### PR TITLE
Add GA server side tracking service

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -14,3 +14,4 @@ AWS_ACCESS_KEY_ID=aws_access_key_id
 AWS_SECRET_ACCESS_KEY=aws_secret_access_key
 AWS_REGION=aws_region
 AWS_BUCKET_NAME=aws_bucket_name
+GOOGLE_ANALYTICS_TRACKING_ID=ga_tracking_id

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 require 'clearable'
 
 class ApplicationController < ActionController::Base
+  include GaTrackingHelper
+  
   respond_to :json, :html
 
   before_action :clear_association_queries

--- a/app/helpers/ga_tracking_helper.rb
+++ b/app/helpers/ga_tracking_helper.rb
@@ -1,0 +1,31 @@
+module GaTrackingHelper
+  def track_event(event_key, event_value, scope = 'events')
+    event_label = I18n.t(event_key, scope: scope)
+
+    track_events(
+      [
+        {
+          key: event_key,
+          label: event_label,
+          value: event_value
+        }
+      ]
+    )
+  end
+
+  def track_events(props = [])
+    TrackingService.new(client_tracking_data: client_tracking_data).track_events(props: props)
+  rescue TrackingService::TrackingServiceError
+    nil
+  end
+
+  private
+
+  def client_tracking_data
+    {
+      ga_cookie: cookies['_ga']&.gsub(/^(.*?\..*?\.)/, ''),
+      ip_address: request.remote_ip,
+      user_agent: request.env['HTTP_USER_AGENT']
+    }
+  end
+end

--- a/app/services/tracking_service.rb
+++ b/app/services/tracking_service.rb
@@ -1,0 +1,86 @@
+class TrackingService
+  TrackingServiceError = Class.new(StandardError)
+  BatchTooBigError = Class.new(StandardError)
+  MissingAttributesError = Class.new(StandardError)
+
+  DEBUG_API_ENDPOINT = 'https://www.google-analytics.com/debug/collect'.freeze
+  BATCH_API_ENDPOINT = 'https://www.google-analytics.com/batch'.freeze
+
+  MAX_BATCH_SIZE = 20
+
+  attr_reader :ga_tracking_id, :client_tracking_data
+
+  def initialize(
+    ga_tracking_id: Rails.configuration.google_analytics_tracking_id,
+    client_tracking_data: {},
+    debug: false
+  )
+    @client_tracking_data = client_tracking_data
+    @ga_tracking_id = ga_tracking_id
+    @debug = debug
+  end
+
+  def track_events(props:)
+    raise MissingAttributesError, 'Event props must be present' unless props.present?
+
+    return unless ga_tracking_id && client_tracking_data[:ga_cookie].present?
+
+    send_events(props)
+  rescue StandardError => e
+    Rails.logger.error("Tracking service error: #{e.message}")
+    raise TrackingServiceError, e.message
+  end
+
+  private
+
+  def debug_uri
+    URI.parse(DEBUG_API_ENDPOINT)
+  end
+
+  def batch_uri
+    URI.parse(BATCH_API_ENDPOINT)
+  end
+
+  def send_events(props)
+    raise BatchTooBigError, "Batch size cannot be over #{MAX_BATCH_SIZE}" if props.size > MAX_BATCH_SIZE
+
+    net_http_post(props).body
+  end
+
+  def debugging_enabled?
+    @debug
+  end
+
+  def client_tracking_info
+    {
+      cid: client_tracking_data[:ga_cookie],
+      uip: client_tracking_data[:ip_address],
+      ua: client_tracking_data[:user_agent]
+    }
+  end
+
+  def build_payload(key, label, value)
+    URI.encode_www_form(
+      {
+        tid: ga_tracking_id,
+        t: 'event',
+        v: 1,
+        ec: key,
+        el: label,
+        ea: value
+      }.merge(client_tracking_info)
+    )
+  end
+
+  def build_batch_payload(props)
+    props.map { |prop| build_payload(prop[:key], prop[:label], prop[:value]) }.join("\n")
+  end
+
+  def net_http_post(props)
+    return ::Net::HTTP.post(batch_uri, build_batch_payload(props)) unless debugging_enabled?
+
+    prop = props.first
+
+    ::Net::HTTP.post(debug_uri, build_payload(prop[:key], prop[:label], prop[:value]))
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,8 @@ module TradeTariffBackend
       Sequel::Model.db.extension :server_block
       Sequel::Model.db.extension :auto_literal_strings
     end
+
+    # GA measurements protocol event tracking
+    config.google_analytics_tracking_id = ENV['GOOGLE_ANALYTICS_TRACKING_ID']
   end
 end

--- a/spec/helpers/ga_tracking_helper_spec.rb
+++ b/spec/helpers/ga_tracking_helper_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe GaTrackingHelper do
+  describe '#track_event' do
+    it 'sends the correct props to the TrackingService' do
+      tracking_service = instance_spy(TrackingService)
+      allow(TrackingService).to receive(:new).and_return(tracking_service)
+      allow(I18n).to receive(:t).with(:commodity, scope: 'events').and_return('Clicked')
+
+      helper.track_event(
+        :commodity,
+        '112300049'
+      )
+
+      expect(tracking_service).to have_received(:track_events).with(
+        props:
+        [
+          {
+            key: :commodity,
+            label: 'Clicked',
+            value: '112300049'
+          }
+        ]
+      )
+    end
+  end
+
+  describe '#track_events' do
+    it 'sends the correct props to the TrackingService' do
+      tracking_service = instance_spy(TrackingService)
+      allow(TrackingService).to receive(:new).and_return(tracking_service)
+      allow(I18n).to receive(:t).with(:commodity, scope: 'events').and_return('Clicked')
+
+      helper.track_events(
+        [
+          {
+            key: :event_key_1,
+            label: 'Commodity clicked',
+            value: '111111'
+          },
+          {
+            key: :event_key_2,
+            label: 'Commodity clicked',
+            value: '2222222'
+          }
+        ]
+      )
+
+      expect(tracking_service).to have_received(:track_events).with(
+        props:
+        [
+          {
+            key: :event_key_1,
+            label: 'Commodity clicked',
+            value: '111111'
+          },
+          {
+            key: :event_key_2,
+            label: 'Commodity clicked',
+            value: '2222222'
+          }
+        ]
+      )
+    end
+  end
+end

--- a/spec/services/tracking_service_spec.rb
+++ b/spec/services/tracking_service_spec.rb
@@ -1,0 +1,260 @@
+require 'rails_helper'
+
+RSpec.describe TrackingService do
+  subject(:service) { described_class.new(client_tracking_data: client_tracking_data, ga_tracking_id: ga_tracking_id) }
+
+  let(:ga_tracking_id) { 'test' }
+
+  let(:ga_response) {
+    'GIF89a\x01\x00\x01\x00\x80\xFF\x00\xFF\xFF\xFF\x00\;'
+  }
+
+  let(:ga_cookie) { 'GA1.1.1652866035.1575886179' }
+
+  let(:ip_address) { '84.17.50.171' }
+
+  let(:user_agent) { 'Mozilla/5.0 (platform; rv:geckoversion) Gecko/geckotrail' }
+
+  let(:client_tracking_data) {
+    {
+      ga_cookie: ga_cookie,
+      ip_address: ip_address,
+      user_agent: user_agent
+    }
+  }
+
+  let(:event_payload) {
+    {
+      tid: ga_tracking_id,
+      t: 'event',
+      v: 1,
+      ec: 'event_category',
+      el: 'Event Label',
+      ea: 'Event action',
+      cid: ga_cookie,
+      uip: ip_address,
+      ua: user_agent
+    }
+  }
+
+  def fake_debug_request_with(payload)
+    stub_request(:post, TrackingService::DEBUG_API_ENDPOINT)
+      .with(body: URI.encode_www_form(payload))
+      .to_return(body: ga_response, status: 200)
+  end
+
+  def fake_batch_request_with(bulk_payload)
+    stub_request(:post, TrackingService::BATCH_API_ENDPOINT)
+      .with(body: bulk_payload)
+      .to_return(body: ga_response, status: 200)
+  end
+
+  describe '.track_events' do
+    context 'without a ga_tracking ID' do
+      subject(:service) { described_class.new }
+
+      it 'does not make a call to GA' do
+        net_http = instance_spy(Net::HTTP)
+
+        service.track_events(props: [{ key: 'key', label: 'label', values: 'value' }])
+
+        expect(net_http).not_to have_received(:start)
+      end
+    end
+
+    context 'without event props' do
+      let(:net_http) { instance_spy(Net::HTTP) }
+
+      it 'raises TrackingServiceError' do
+        expect {
+          service.track_events(
+            props: nil
+          )
+        }.to raise_error(described_class::TrackingServiceError, 'Event props must be present')
+      end
+    end
+
+    context 'without a ga_cookie' do
+      subject(:service) {
+        described_class.new(
+          client_tracking_data: {},
+          ga_tracking_id: ga_tracking_id
+        )
+      }
+
+      before do
+        fake_batch_request_with(URI.encode_www_form(event_payload))
+      end
+
+      it 'does not make a call to GA' do
+        service.track_events(
+          props: [
+            {
+              key: :event_category,
+              label: 'Event Label',
+              value: 'Event action'
+            }
+          ]
+        )
+
+        expect(a_request(:post, /google/)).not_to have_been_made
+      end
+    end
+
+    context 'with a valid ga_tracking ID' do
+      before do
+        fake_batch_request_with(URI.encode_www_form(event_payload))
+      end
+
+      it 'returns the correct response' do
+        expect(
+          service.track_events(
+            props: [
+              {
+                key: :event_category,
+                label: 'Event Label',
+                value: 'Event action'
+              }
+            ]
+          )
+        ).to eq ga_response
+      end
+    end
+
+    context 'with a valid ga_tracking ID and debug mode on' do
+      subject(:service) {
+        described_class.new(
+          client_tracking_data: client_tracking_data,
+          ga_tracking_id: ga_tracking_id,
+          debug: true
+        )
+      }
+
+      let(:ga_response) {
+        {
+          "hitParsingResult": [
+            {
+              "valid": false,
+              "hit": "GET /debug/collect?tid=fake\u0026v=1 HTTP/1.1",
+              "parserMessage": [
+                {
+                  "messageType": 'ERROR',
+                  "description": 'The value provided for parameter \'tid\' is invalid.',
+                  "parameter": 'tid'
+                },
+                {
+                  "messageType": 'ERROR',
+                  "description": 'Tracking Id is a required field for this hit.',
+                  "parameter": 'tid'
+                }
+              ]
+            }
+          ]
+        }.to_json
+      }
+
+      before do
+        fake_debug_request_with(event_payload)
+      end
+
+      it 'returns an actual JSON object' do
+        expect(
+          service.track_events(
+            props: [
+              {
+                key: :event_category,
+                label: 'Event Label',
+                value: 'Event action'
+              }
+            ]
+          )
+        ).to eq ga_response
+      end
+    end
+
+    context 'when the service does experience an error' do
+      it 'raises a TrackingServiceError' do
+        allow(Net::HTTP).to receive(:start).and_raise(RuntimeError)
+
+        expect {
+          service.track_events(
+            props: [
+              {
+                key: :event_category,
+                label: 'Event Label',
+                values: 'Event action'
+              }
+            ]
+          )
+        }.to raise_exception(described_class::TrackingServiceError)
+      end
+    end
+
+    context 'when batch size is exceeded' do
+      let(:tracked_actions) { build_list(:goods_nomenclature, 21) }
+      let(:props) {
+        tracked_actions.map do |value|
+          {
+            label: 'Label',
+            value: value,
+            key: :event_category
+          }
+        end
+      }
+
+      it 'raises a TrackingServiceError' do
+        expect {
+          service.track_events(
+            props: props
+          )
+        }.to raise_error(described_class::TrackingServiceError, 'Batch size cannot be over 20')
+      end
+    end
+
+    context 'when sending multiple values to GA' do
+      let(:bulk_payload) {
+        [
+          URI.encode_www_form(event_payload),
+          URI.encode_www_form(other_event_payload)
+        ].join("\n")
+      }
+
+      let(:other_event_payload) {
+        {
+          tid: ga_tracking_id,
+          t: 'event',
+          v: 1,
+          ec: 'event_category',
+          el: 'Event Label',
+          ea: 'New event action',
+          cid: ga_cookie,
+          uip: ip_address,
+          ua: user_agent
+        }
+      }
+
+      before do
+        fake_batch_request_with(bulk_payload)
+      end
+
+      it 'sends them in batch' do
+        expect(
+          service.track_events(
+            props: [
+              {
+                key: :event_category,
+                label: 'Event Label',
+                value: 'Event action'
+              },
+              {
+                key: :event_category,
+                label: 'Event Label',
+                value: 'New event action'
+              }
+            ]
+          )
+        ).to eq ga_response
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-262

### What?

Using the GA Measurements Protocol,
this service allows server-side event tracking.

The advantage of this approach is that JS can be
disabled on the device and still work.

### Why?

We want to be able to start various events to understand our users' behaviour better.

Resources: https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide