### PR TITLE
[HOTT-356] Decorate zero duties for third countries on commodity response

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -392,7 +392,7 @@ class Measure < Sequel::Model
   def zero_mfn?
     third_country? &&
       measure_components.count == 1 &&
-      measure_components.first.zero_duty
+      measure_components.first.zero_duty?
   end
 
   def order_number

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -389,6 +389,12 @@ class Measure < Sequel::Model
     measure_components.any?(&:meursing?)
   end
 
+  def zero_mfn?
+    third_country? &&
+      measure_components.count == 1 &&
+      measure_components.any?(&:zero_duty?)
+  end
+
   def order_number
     if quota_order_number.present?
       quota_order_number

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -392,7 +392,7 @@ class Measure < Sequel::Model
   def zero_mfn?
     third_country? &&
       measure_components.count == 1 &&
-      measure_components.any?(&:zero_duty?)
+      measure_components.first.zero_duty
   end
 
   def order_number

--- a/app/models/measure_component.rb
+++ b/app/models/measure_component.rb
@@ -48,6 +48,10 @@ class MeasureComponent < Sequel::Model
     duty_expression_id.in?(DutyExpression::MEURSING_DUTY_EXPRESSION_IDS)
   end
 
+  def zero_duty?
+    duty_amount&.zero?
+  end
+
   private
 
   def duty_expression_formatter_options

--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -5,7 +5,7 @@
 class MeasureType < Sequel::Model
   IMPORT_MOVEMENT_CODES = [0, 2].freeze
   EXPORT_MOVEMENT_CODES = [1, 2].freeze
-  THIRD_COUNTRY = '103'.freeze
+  THIRD_COUNTRY = %w[103 105].freeze # 105 measure types are for end use Third Country duties. 103 are for everything else
   VAT_TYPES = %w[VTA VTE VTS VTZ 305].freeze
   SUPPLEMENTARY_TYPES = %w[109 110 111].freeze
   QUOTA_TYPES = %w[046 122 123 143 146 147 653 654].freeze
@@ -42,7 +42,7 @@ class MeasureType < Sequel::Model
   end
 
   def third_country?
-    measure_type_id == THIRD_COUNTRY
+    measure_type_id.in?(THIRD_COUNTRY)
   end
 
   # 306

--- a/app/presenters/api/v2/commodities/commodity_presenter.rb
+++ b/app/presenters/api/v2/commodities/commodity_presenter.rb
@@ -48,6 +48,10 @@ module Api
           import_measures.any?(&:meursing?) || export_measures.any?(&:meursing?)
         end
         alias meursing_code meursing_code?
+
+        def zero_mfn_duty?
+          import_measures.any?(&:zero_mfn?)
+        end
       end
     end
   end

--- a/app/serializers/api/v2/commodities/commodity_serializer.rb
+++ b/app/serializers/api/v2/commodities/commodity_serializer.rb
@@ -12,6 +12,7 @@ module Api
                    :goods_nomenclature_item_id, :bti_url, :formatted_description,
                    :description_plain, :consigned, :consigned_from, :basic_duty_rate,
                    :meursing_code
+
         attribute :declarable do
           true
         end
@@ -23,6 +24,14 @@ module Api
         has_many :ancestors, record_type: :commodity, serializer: Api::V2::Commodities::AncestorsSerializer
         has_many :import_measures, record_type: :measure, serializer: Api::V2::Measures::MeasureSerializer
         has_many :export_measures, record_type: :measure, serializer: Api::V2::Measures::MeasureSerializer
+
+        meta do |commodity|
+          {
+            duty_calculator: {
+              zero_mfn_duty: commodity.zero_mfn_duty?,
+            },
+          }
+        end
       end
     end
   end

--- a/spec/controllers/api/v2/commodities_controller_spec.rb
+++ b/spec/controllers/api/v2/commodities_controller_spec.rb
@@ -23,6 +23,9 @@ describe Api::V2::CommoditiesController, 'GET #show' do
           import_measures: Hash,
           export_measures: Hash,
         },
+        meta: {
+          duty_calculator: Hash,
+        },
       },
       included: [
         {

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -9,6 +9,8 @@ FactoryBot.define do
       gono_number_indents { 1 }
       gono_producline_suffix { '80' }
       order_number_capture_code { 2 }
+      duty_amount { Forgery(:basic).number }
+      measure_components_count { 1 }
     end
 
     f.measure_sid { generate(:measure_sid) }
@@ -65,6 +67,21 @@ FactoryBot.define do
 
     trait :with_measure_type do
       # noop
+    end
+
+    trait :third_country do
+      measure_type_id { MeasureType::THIRD_COUNTRY.sample }
+    end
+
+    trait :with_measure_components do
+      after(:build) do |measure, evaluator|
+        FactoryBot.create_list(
+          :measure_component,
+          evaluator.measure_components_count,
+          measure_sid: measure.measure_sid,
+          duty_amount: evaluator.duty_amount,
+        )
+      end
     end
 
     trait :with_modification_regulation do

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -1237,4 +1237,52 @@ describe Measure do
       end
     end
   end
+
+  describe '#zero_mfn?' do
+    context 'when the measure type is a third country' do
+      subject(:measure) { create(:measure, :third_country, :with_measure_components, duty_amount: duty_amount, measure_components_count: measure_components_count) }
+
+      let(:measure_components_count) { 1 }
+
+      context 'when measure components have zero duty amount' do
+        let(:duty_amount) { 0.0 }
+
+        it 'returns true' do
+          expect(measure).to be_zero_mfn
+        end
+
+        context 'when there are more than one measure components' do
+          let(:measure_components_count) { 2 }
+
+          it 'returns false' do
+            expect(measure).not_to be_zero_mfn
+          end
+        end
+      end
+
+      context 'when measure components have a non zero duty amount' do
+        let(:duty_amount) { 67.45 }
+
+        it 'returns false when measure components have non zero duty amount' do
+          expect(measure).not_to be_zero_mfn
+        end
+      end
+
+      context 'when measure components have a nil duty amount' do
+        let(:duty_amount) { nil }
+
+        it 'returns false when measure components have non zero duty amount' do
+          expect(measure).not_to be_zero_mfn
+        end
+      end
+    end
+
+    context 'when the measure type is not a third country' do
+      subject(:measure) { create(:measure, measure_type_id: 'foo') }
+
+      it 'returns false' do
+        expect(measure).not_to be_zero_mfn
+      end
+    end
+  end
 end

--- a/spec/models/measure_type_spec.rb
+++ b/spec/models/measure_type_spec.rb
@@ -55,16 +55,24 @@ describe MeasureType do
   end
 
   describe '#third_country?' do
-    context 'measure_type is third country' do
-      let(:measure_type) { build :measure_type, measure_type_id: MeasureType::THIRD_COUNTRY }
+    context 'measure_type has measure_type_id of 103' do
+      let(:measure_type) { build :measure_type, measure_type_id: '103' }
 
       it 'returns true' do
         expect(measure_type).to be_third_country
       end
     end
 
-    context 'measure_type is not third country' do
-      let(:measure_type) { build :measure_type, measure_type_id: 'aaa' }
+    context 'measure_type is a 105 third country' do
+      let(:measure_type) { build :measure_type, measure_type_id: '105' }
+
+      it 'returns true' do
+        expect(measure_type).to be_third_country
+      end
+    end
+
+    context 'measure_type is non-third-country measure_type_id' do
+      let(:measure_type) { build :measure_type, measure_type_id: 'foo' }
 
       it 'returns false' do
         expect(measure_type).not_to be_third_country

--- a/spec/models/measure_type_spec.rb
+++ b/spec/models/measure_type_spec.rb
@@ -63,7 +63,7 @@ describe MeasureType do
       end
     end
 
-    context 'measure_type is a 105 third country' do
+    context 'measure_type has measure_type_id of 105' do
       let(:measure_type) { build :measure_type, measure_type_id: '105' }
 
       it 'returns true' do

--- a/spec/services/cached_commodity_service_spec.rb
+++ b/spec/services/cached_commodity_service_spec.rb
@@ -33,6 +33,9 @@ describe CachedCommodityService do
             import_measures: Hash,
             export_measures: Hash,
           },
+          meta: {
+            duty_calculator: Hash,
+          },
         },
         included: [
           {


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-356

### What?

I have added/removed/altered:

- [x] Adds `zero_mfn_duty` key to metadata of commodity response
- [x] Fixes broken bitzesty logic

### Why?

I am doing this because:

- We need this question answered for the duty calculator flow