### PR TITLE
[HOTT-355] Surface trade remedies in commodity response meta

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -94,7 +94,7 @@ class Measure < Sequel::Model
                                                    ds.with_actual(FullTemporaryStopRegulation)
                                                  end
 
-  delegate :third_country?, :excise?, :vat?, to: :measure_type, allow_nil: true
+  delegate :third_country?, :excise?, :vat?, :trade_remedy?, to: :measure_type, allow_nil: true
 
   def full_temporary_stop_regulation
     full_temporary_stop_regulations.first

--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -14,6 +14,16 @@ class MeasureType < Sequel::Model
   XI_EXCLUDED_TYPES = DEFAULT_EXCLUDED_TYPES + NATIONAL_PR_TYPES + QUOTA_TYPES
   UK_EXCLUDED_TYPES = DEFAULT_EXCLUDED_TYPES
 
+  DEFENSE_MEASURES = [
+    '551', # Provisional anti-dumping duty
+    '552', # Definitive anti-dumping duty
+    '553', # Provisional countervailing duty
+    '554', # Definitive countervailing duty
+    '555', # Anti-dumping/countervailing duty - Pending collection
+    '695', # Additional duties - these are the retaliatory duties
+    '696', # Additional duties (safeguard)
+  ].freeze
+
   plugin :time_machine, period_start_column: :measure_types__validity_start_date,
                         period_end_column: :measure_types__validity_end_date
   plugin :oplog, primary_key: :measure_type_id
@@ -43,6 +53,10 @@ class MeasureType < Sequel::Model
 
   def third_country?
     measure_type_id.in?(THIRD_COUNTRY)
+  end
+
+  def trade_remedy?
+    measure_type_id.in?(DEFENSE_MEASURES)
   end
 
   # 306

--- a/app/presenters/api/v2/commodities/commodity_presenter.rb
+++ b/app/presenters/api/v2/commodities/commodity_presenter.rb
@@ -45,7 +45,7 @@ module Api
         end
 
         def meursing_code?
-          import_measures.any?(&:meursing?) || export_measures.any?(&:meursing?)
+          import_measures.any?(&:meursing?)
         end
         alias_method :meursing_code, :meursing_code?
 

--- a/app/presenters/api/v2/commodities/commodity_presenter.rb
+++ b/app/presenters/api/v2/commodities/commodity_presenter.rb
@@ -47,10 +47,14 @@ module Api
         def meursing_code?
           import_measures.any?(&:meursing?) || export_measures.any?(&:meursing?)
         end
-        alias meursing_code meursing_code?
+        alias_method :meursing_code, :meursing_code?
 
         def zero_mfn_duty?
           import_measures.any?(&:zero_mfn?)
+        end
+
+        def trade_remedies?
+          import_measures.any?(&:trade_remedy?)
         end
       end
     end

--- a/app/serializers/api/v2/commodities/commodity_serializer.rb
+++ b/app/serializers/api/v2/commodities/commodity_serializer.rb
@@ -29,6 +29,7 @@ module Api
           {
             duty_calculator: {
               zero_mfn_duty: commodity.zero_mfn_duty?,
+              trade_defence: commodity.trade_remedies?,
             },
           }
         end

--- a/spec/models/measure_type_spec.rb
+++ b/spec/models/measure_type_spec.rb
@@ -79,4 +79,22 @@ describe MeasureType do
       end
     end
   end
+
+  describe '#trade_remedy?' do
+    context 'measure_type has measure_type_id that is a defense measure type' do
+      let(:measure_type) { build :measure_type, measure_type_id: MeasureType::DEFENSE_MEASURES.sample }
+
+      it 'returns true' do
+        expect(measure_type).to be_trade_remedy
+      end
+    end
+
+    context 'measure_type does not have a measure_type_id that is a defense measure type' do
+      let(:measure_type) { build :measure_type, measure_type_id: 'foo' }
+
+      it 'returns false' do
+        expect(measure_type).not_to be_trade_remedy
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-355

### What?

I have added/removed/altered:

- [x] Adds whether there are any trade remedies in place to the commodity response

### Why?

I am doing this because:

- This is needed to make decisions in the duty calculator