### PR TITLE
[HOTT-463] Surface exchange rates for the duty calculator

### DIFF
--- a/app/controllers/api/v2/exchange_rates_controller.rb
+++ b/app/controllers/api/v2/exchange_rates_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V2
+    class ExchangeRatesController < ApiController
+      def index
+        render json: Api::V2::ExchangeRateSerializer.new(exchange_rates).serializable_hash
+      end
+
+      def exchange_rates
+        ExchangeRate.build_collection
+      end
+    end
+  end
+end

--- a/app/models/exchange_rate.rb
+++ b/app/models/exchange_rate.rb
@@ -1,0 +1,24 @@
+class ExchangeRate
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :id, :string
+  attribute :rate, :float
+  attribute :base_currency, :string
+  attribute :applicable_date, :date
+
+  def self.build_collection
+    rates           = ExchangeRateService.new.call
+    base_currency   = rates['base']
+    applicable_date = rates['date']
+
+    rates['rates'].map do |id, rate|
+      new(
+        id: id,
+        rate: rate,
+        base_currency: base_currency,
+        applicable_date: applicable_date,
+      )
+    end
+  end
+end

--- a/app/serializers/api/v2/exchange_rate_serializer.rb
+++ b/app/serializers/api/v2/exchange_rate_serializer.rb
@@ -1,0 +1,13 @@
+module Api
+  module V2
+    class ExchangeRateSerializer
+      include JSONAPI::Serializer
+
+      set_type :exchange_rate
+
+      attributes :rate,
+                 :base_currency,
+                 :applicable_date
+    end
+  end
+end

--- a/app/services/exchange_rate_service.rb
+++ b/app/services/exchange_rate_service.rb
@@ -1,0 +1,61 @@
+class ExchangeRateService
+  API_URL = 'https://api.exchangeratesapi.io/latest'.freeze
+  EXCHANGE_RATES_UTC_REFRESH_HOUR = 15
+  EXCHANGE_RATES_UTC_REFRESH_MIN  = 15
+  REDIS_KEY = 'trade-tariff-exchange-rates'.freeze
+
+  def call
+    cached_exchange_rates || fetched_exchange_rates
+  end
+
+  private
+
+  def cached_exchange_rates(ignore_expiry: false)
+    response = TradeTariffBackend.redis.get(REDIS_KEY)
+
+    if response.present?
+      exchange_rates = JSON.parse(response)
+      exchange_rates['expires_at'] = Time.zone.parse(exchange_rates['expires_at'])
+
+      return exchange_rates if ignore_expiry
+      return exchange_rates if exchange_rates['expires_at'] > now
+
+      false
+    end
+  end
+
+  def fetched_exchange_rates
+    response = Faraday.new(API_URL).get
+
+    if response.success?
+      exchange_rates = JSON.parse(response.body)
+      exchange_rates['expires_at'] = expires_at.iso8601
+
+      TradeTariffBackend.redis.set(REDIS_KEY, exchange_rates.to_json)
+
+      exchange_rates['expires_at'] = Time.zone.parse(exchange_rates['expires_at'])
+      exchange_rates
+    else
+      cached_exchange_rates(ignore_expiry: true)
+    end
+  end
+
+  def expires_at
+    relative_day.change(
+      hour: EXCHANGE_RATES_UTC_REFRESH_HOUR,
+      min: EXCHANGE_RATES_UTC_REFRESH_MIN,
+    )
+  end
+
+  def relative_day
+    if now.hour > EXCHANGE_RATES_UTC_REFRESH_HOUR
+      now.tomorrow
+    else
+      now
+    end
+  end
+
+  def now
+    Time.zone.now
+  end
+end

--- a/app/services/exchange_rate_service.rb
+++ b/app/services/exchange_rate_service.rb
@@ -19,9 +19,9 @@ class ExchangeRateService
 
       return exchange_rates if ignore_expiry
       return exchange_rates if exchange_rates['expires_at'] > now
-
-      false
     end
+
+    nil
   end
 
   def fetched_exchange_rates
@@ -48,11 +48,9 @@ class ExchangeRateService
   end
 
   def relative_day
-    if now.hour > EXCHANGE_RATES_UTC_REFRESH_HOUR
-      now.tomorrow
-    else
-      now
-    end
+    return now.tomorrow if now.hour > EXCHANGE_RATES_UTC_REFRESH_HOUR
+
+    now
   end
 
   def now

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,70 +5,70 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: { format: 'json' }, path: '/admin' do
     scope module: :admin do
-      resources :sections, only: [:index, :show], constraints: { id: /\d{1,2}/ } do
+      resources :sections, only: %i[index show], constraints: { id: /\d{1,2}/ } do
         scope module: 'sections', constraints: { section_id: /\d{1,2}/, id: /\d+/ } do
-          resource :section_note, only: [:show, :create, :update, :destroy]
-          resources :search_references, only: [:show, :index, :destroy, :create, :update]
+          resource :section_note, only: %i[show create update destroy]
+          resources :search_references, only: %i[show index destroy create update]
         end
       end
 
       resources :updates, only: [:index]
-      resources :rollbacks, only: [:create, :index]
-      resources :footnotes, only: [:index, :show, :update]
-      resources :measure_types, only: [:index, :show, :update]
+      resources :rollbacks, only: %i[create index]
+      resources :footnotes, only: %i[index show update]
+      resources :measure_types, only: %i[index show update]
       resources :search_references, only: [:index]
-      
-      resources :chapters, only: [:index, :show], constraints: { id: /\d{2}/ } do
+
+      resources :chapters, only: %i[index show], constraints: { id: /\d{2}/ } do
         scope module: 'chapters', constraints: { chapter_id: /\d{2}/, id: /\d+/ } do
-          resource :chapter_note, only: [:show, :create, :update, :destroy]
-          resources :search_references, only: [:show, :index, :destroy, :create, :update]
+          resource :chapter_note, only: %i[show create update destroy]
+          resources :search_references, only: %i[show index destroy create update]
         end
       end
 
       resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
         scope module: 'headings', constraints: { heading_id: /\d{4}/, id: /\d+/ } do
-          resources :search_references, only: [:show, :index, :destroy, :create, :update]
+          resources :search_references, only: %i[show index destroy create update]
         end
       end
 
       resources :commodities, only: [:show], constraints: { id: /\d{10}/ } do
         scope module: 'commodities', constraints: { commodity_id: /\d{10}/, id: /\d+/ } do
-          resources :search_references, only: [:show, :index, :destroy, :create, :update]
+          resources :search_references, only: %i[show index destroy create update]
         end
       end
     end
   end
 
-  namespace :api, defaults: {format: 'json'}, path: '/' do
+  namespace :api, defaults: { format: 'json' }, path: '/' do
     # How (or even if) API versioning will be implemented is still an open question. We can defer
     # the choice until we need to expose the API to clients which we don't control.
 
     scope module: :v2, constraints: ApiConstraints.new(version: 2, default: false) do
-      resources :sections, only: [:index, :show], constraints: { id: /\d{1,2}/ } do
+      resources :sections, only: %i[index show], constraints: { id: /\d{1,2}/ } do
         collection do
           get :tree
         end
       end
 
-      resources :chapters, only: [:index, :show], constraints: { id: /\d{2}/ } do
-        member {
+      resources :chapters, only: %i[index show], constraints: { id: /\d{2}/ } do
+        member do
           get :changes
-        }
+        end
       end
 
       resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
-        member {
+        member do
           get :changes
-        }
+        end
       end
 
       resources :commodities, only: [:show], constraints: { id: /\d{10}/ } do
-        member {
+        member do
           get :changes
-        }
+        end
       end
 
-      resources :geographical_areas, only: [:index, :countries] do
+      resources :geographical_areas, only: %i[index countries] do
         collection { get :countries }
       end
 
@@ -99,9 +99,11 @@ Rails.application.routes.draw do
       end
       resources :footnote_types, only: [:index]
 
-      resources :chemicals, only: [:index, :show] do
+      resources :chemicals, only: %i[index show] do
         collection { get :search }
       end
+
+      resources :exchange_rates, only: [:index]
 
       post 'search' => 'search#search'
       get 'search_suggestions' => 'search#suggestions'
@@ -117,44 +119,44 @@ Rails.application.routes.draw do
     end
 
     scope module: :v1, constraints: ApiConstraints.new(version: 1, default: true) do
-      resources :sections, only: [:index, :show], constraints: { id: /\d{1,2}/ } do
+      resources :sections, only: %i[index show], constraints: { id: /\d{1,2}/ } do
         collection do
           get :tree
         end
         scope module: 'sections', constraints: { section_id: /\d{1,2}/, id: /\d+/ } do
-          resource :section_note, only: [:show, :create, :update, :destroy]
-          resources :search_references, only: [:show, :index, :destroy, :create, :update]
+          resource :section_note, only: %i[show create update destroy]
+          resources :search_references, only: %i[show index destroy create update]
         end
       end
 
-      resources :chapters, only: [:index, :show], constraints: { id: /\d{2}/ } do
-        member {
+      resources :chapters, only: %i[index show], constraints: { id: /\d{2}/ } do
+        member do
           get :changes
-        }
+        end
 
         scope module: 'chapters', constraints: { chapter_id: /\d{2}/, id: /\d+/ } do
-          resource :chapter_note, only: [:show, :create, :update, :destroy]
-          resources :search_references, only: [:show, :index, :destroy, :create, :update]
+          resource :chapter_note, only: %i[show create update destroy]
+          resources :search_references, only: %i[show index destroy create update]
         end
       end
 
       resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
-        member {
+        member do
           get :changes
-        }
+        end
 
         scope module: 'headings', constraints: { heading_id: /\d{4}/, id: /\d+/ } do
-          resources :search_references, only: [:show, :index, :destroy, :create, :update]
+          resources :search_references, only: %i[show index destroy create update]
         end
       end
 
       resources :commodities, only: [:show], constraints: { id: /\d{10}/, as_of: /.*/ } do
-        member {
+        member do
           get :changes
-        }
+        end
 
         scope module: 'commodities', constraints: { commodity_id: /\d{10}/, id: /\d+/ } do
-          resources :search_references, only: [:show, :index, :destroy, :create, :update]
+          resources :search_references, only: %i[show index destroy create update]
         end
       end
 
@@ -174,9 +176,9 @@ Rails.application.routes.draw do
       get 'search_suggestions' => 'search#suggestions'
       get '/headings/:id/tree' => 'headings#tree'
 
-      resources :rollbacks, only: [:create, :index]
-      resources :footnotes, only: [:index, :show, :update]
-      resources :measure_types, only: [:index, :show, :update]
+      resources :rollbacks, only: %i[create index]
+      resources :footnotes, only: %i[index show update]
+      resources :measure_types, only: %i[index show update]
     end
   end
 

--- a/lib/trade_tariff_backend.rb
+++ b/lib/trade_tariff_backend.rb
@@ -88,6 +88,10 @@ module TradeTariffBackend
       lock.lock!(lock_name, 5000, &block)
     end
 
+    def redis
+      @redis ||= Redis.new(PaasConfig.redis)
+    end
+
     def reindex(indexer = search_client)
       TimeMachine.with_relevant_validity_periods do
         begin

--- a/spec/controllers/api/v2/exchange_rates_controller_spec.rb
+++ b/spec/controllers/api/v2/exchange_rates_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Api::V2::ExchangeRatesController do
+  describe 'GET #index' do
+    subject(:response) { get :index }
+
+    before do
+      allow(ExchangeRateService).to receive(:new).and_return(service)
+    end
+
+    let(:service) { instance_double(ExchangeRateService, call: api_result) }
+
+    let(:api_result) do
+      {
+        'rates' => {
+          'CAD' => 1.5051,
+        },
+        'base' => 'EUR',
+        'date' => '2021-03-11',
+        'expires_at' => Time.zone.parse('2021-03-11T18:10:44Z'),
+      }
+    end
+
+    let(:expected) do
+      {
+        'data' => [
+          {
+            'id' => 'CAD',
+            'type' => 'exchange_rate',
+            'attributes' => {
+              'rate' => 1.5051,
+              'base_currency' => 'EUR',
+              'applicable_date' => '2021-03-11',
+            },
+          },
+        ],
+      }
+    end
+
+    it { expect(JSON.parse(response.body)).to eq(expected) }
+    it { expect(response).to have_http_status(:ok) }
+  end
+end

--- a/spec/factories/exchange_rate_factory.rb
+++ b/spec/factories/exchange_rate_factory.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :exchange_rate do
+    id { 'CAD' }
+    rate { Forgery(:monetary).money.to_f }
+    base_currency { 'EUR' }
+    applicable_date { Date.current.iso8601 }
+
+    initialize_with do
+      new(
+        id: id,
+        rate: rate,
+        base_currency: base_currency,
+        applicable_date: applicable_date,
+      )
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,13 +18,13 @@ require 'sidekiq/testing'
 require 'elasticsearch/extensions/test/cluster'
 
 require Rails.root.join('spec/support/tariff_validation_matcher.rb')
-Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
 
 # require models and serializers
 require 'clearable'
-Dir[Rails.root.join('app/models/*.rb')].each { |f| require f }
+Dir[Rails.root.join('app/models/*.rb')].sort.each { |f| require f }
 # Dir[Rails.root.join('app/models/concerns/*rb')].each { |f| require concern }
-Dir[Rails.root.join('app/serializers/*.rb')].each { |f| require f }
+Dir[Rails.root.join('app/serializers/*.rb')].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = false

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -46,10 +46,12 @@ RSpec.configure do |config|
   RedisLockDb.redis = redis
 
   config.before(:suite) do
+    TradeTariffBackend.redis.flushdb
     redis.flushdb
   end
 
   config.after(:suite) do
+    TradeTariffBackend.redis.flushdb
     redis.flushdb
   end
 

--- a/spec/serializers/api/v2/exchange_rate_serializer_spec.rb
+++ b/spec/serializers/api/v2/exchange_rate_serializer_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Api::V2::Measures::ExchangeRateSerializer do
+  subject(:serializer) { described_class.new(serializable) }
+
+  let(:serializable) { build(:exchange_rate) }
+
+  let(:expected_pattern) do
+    {
+      data: {
+        id: 'CAD',
+        type: :exchange_rate,
+        attributes: {
+          rate: serializable.rate,
+          base_currency: serializable.base_currency,
+          applicable_date: serializable.applicable_date,
+        },
+      },
+    }
+  end
+
+  describe '#serializable_hash' do
+    it { is_expected.to include(expected_pattern) }
+  end
+end

--- a/spec/services/exchange_rate_service_spec.rb
+++ b/spec/services/exchange_rate_service_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+RSpec.describe ExchangeRateService do
+  subject(:service) { described_class.new }
+
+  let(:now) { Time.zone.parse('2021-03-11T18:10:44Z') }
+
+  before do
+    TradeTariffBackend.redis.flushdb
+    allow(Time.zone).to receive(:now).and_return(now)
+  end
+
+  describe '#call' do
+    let(:expected_cache) do
+      expected = expected_result.dup
+      expected['expires_at'] = expected['expires_at'].iso8601
+      expected.to_json
+    end
+
+    context 'when fetching for the first time' do
+      before do
+        stub_request(:get, 'https://api.exchangeratesapi.io/latest')
+          .to_return(status: 200, body: '{"foo":"bar"}')
+      end
+
+      let(:expected_result) do
+        {
+          'foo' => 'bar',
+          'expires_at' => Time.zone.parse('2021-03-12T15:15:0Z'),
+        }
+      end
+
+      it 'returns newly fetched exchange rates' do
+        expect(service.call).to eq(expected_result)
+      end
+
+      it 'caches the newly fetched exchange rates' do
+        expect { service.call }
+          .to change { TradeTariffBackend.redis.get(described_class::REDIS_KEY) }
+          .from(nil)
+          .to(expected_cache)
+      end
+    end
+
+    context 'when the exchange rates are expired' do
+      before do
+        TradeTariffBackend.redis.set(described_class::REDIS_KEY, previously_cached_result)
+        stub_request(:get, 'https://api.exchangeratesapi.io/latest')
+          .to_return(status: 200, body: '{"baz":"qux"}')
+      end
+
+      let(:expected_result) do
+        {
+          'baz' => 'qux',
+          'expires_at' => Time.zone.parse('2021-03-12T15:15:0Z'),
+        }
+      end
+      let(:previously_cached_result) do
+        {
+          'foo' => 'bar',
+          'expires_at' => (now - 1.second).iso8601,
+        }.to_json
+      end
+
+      it 'returns the fetched exchange rates' do
+        expect(service.call).to eq(expected_result)
+      end
+
+      it 'caches the newly fetched exchange rates' do
+        expect { service.call }
+          .to change { TradeTariffBackend.redis.get(described_class::REDIS_KEY) }
+          .from(previously_cached_result)
+          .to(expected_cache)
+      end
+    end
+
+    context 'when the exchange rates are current' do
+      before do
+        TradeTariffBackend.redis.set(described_class::REDIS_KEY, previously_cached_result)
+        stub_request(:get, 'https://api.exchangeratesapi.io/latest')
+          .to_return(status: 200, body: '{"baz":"qux"}')
+      end
+
+      let(:expected_result) do
+        {
+          'foo' => 'bar',
+          'expires_at' => Time.zone.parse('2021-03-12T15:14:0Z'),
+        }
+      end
+      let(:previously_cached_result) do
+        expected = expected_result.dup
+        expected['expires_at'] = expected['expires_at'].iso8601
+        expected.to_json
+      end
+
+      it 'returns the cached exchange rates' do
+        expect(service.call).to eq(expected_result)
+      end
+
+      it 'does not update the cache' do
+        expect { service.call }
+          .not_to change { TradeTariffBackend.redis.get(described_class::REDIS_KEY) }
+          .from(previously_cached_result)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-463

### What?

I have added/removed/altered:

- [x] Adds exchange rate lookup service that expires the cache lazily at 15:15 each day.
- [x] Expose the response from this service behind a v2 json:api endpoint

### Why?

I am doing this because:

- This is needed for the duty calculator and (we expect) other things in the backend.

### AC

- Must be encapsulated and portable
- Must refresh when the api data refreshes