### PR TITLE
Cache geographical areas for 24 hours

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,15 +2,13 @@ version: 2.1
 
 orbs:
   ruby: circleci/ruby@1.1.2
-  node: circleci/node@2
-  browser-tools: circleci/browser-tools@1.1
   cloudfoundry: circleci/cloudfoundry@1.0
   slack: circleci/slack@4.3.0
 
 jobs:
   build:
     docker:
-      - image: cimg/ruby:2.7-node
+      - image: cimg/ruby:2.7
       - image: redis
     resource_class: medium
     steps:
@@ -18,7 +16,7 @@ jobs:
       - ruby/install-deps
   checking:
     docker:
-      - image: 'cimg/ruby:2.7-node'
+      - image: cimg/ruby:2.7
     resource_class: small
     steps:
       - checkout

--- a/app/controllers/api/v2/geographical_areas_controller.rb
+++ b/app/controllers/api/v2/geographical_areas_controller.rb
@@ -1,20 +1,35 @@
 module Api
   module V2
     class GeographicalAreasController < ApiController
-      def index
-        @geographical_areas = GeographicalArea.eager(:geographical_area_descriptions).actual.areas.all
+      TTL = 24.hours
 
-        render json: Api::V2::GeographicalAreaTreeSerializer.new(@geographical_areas, options).serializable_hash
+      def index
+        render json: cached_serialized_geographical_areas
       end
 
       def countries
-        @geographical_areas = GeographicalArea.eager(:geographical_area_descriptions).actual.countries.all
-
-        render json: Api::V2::GeographicalAreaTreeSerializer.new(@geographical_areas, options).serializable_hash
+        render json: cached_serialized_geographical_areas
       end
 
-      def options
-        { include: [:contained_geographical_areas] }
+      private
+
+      def cached_serialized_geographical_areas(countries: false)
+        @serialized = Rails.cache.fetch(cache_key, expires_in: TTL) do
+          geographical_areas = if countries
+                                 GeographicalArea.eager(:geographical_area_descriptions).actual.countries.all
+                               else
+                                 GeographicalArea.eager(:geographical_area_descriptions).actual.areas.all
+                               end
+
+          Api::V2::GeographicalAreaTreeSerializer.new(
+            geographical_areas,
+            include: [:contained_geographical_areas],
+          ).serializable_hash
+        end
+      end
+
+      def cache_key
+        "_geographical_areas-#{action}-#{actual_date}"
       end
     end
   end

--- a/app/controllers/api/v2/geographical_areas_controller.rb
+++ b/app/controllers/api/v2/geographical_areas_controller.rb
@@ -29,7 +29,7 @@ module Api
       end
 
       def cache_key
-        "_geographical_areas-#{action}-#{actual_date}"
+        "_geographical-areas-#{action_name}-#{actual_date}"
       end
     end
   end

--- a/spec/controllers/api/v2/geographical_areas_controller_spec.rb
+++ b/spec/controllers/api/v2/geographical_areas_controller_spec.rb
@@ -28,6 +28,24 @@ describe Api::V2::GeographicalAreasController, 'GET #countries' do
     }
   end
 
+  let(:actual_date) { Time.zone.today.iso8601 }
+
+  before do
+    allow(Rails.cache).to receive(:fetch).and_call_original
+  end
+
+  it 'caches the serialized countries' do
+    get :countries, format: :json
+
+    expect(Rails.cache).to have_received(:fetch).with("_geographical-areas-countries-#{actual_date}", expires_in: 24.hours)
+  end
+
+  it 'caches the serialized geographical_areas' do
+    get :index, format: :json
+
+    expect(Rails.cache).to have_received(:fetch).with("_geographical-areas-index-#{actual_date}", expires_in: 24.hours)
+  end
+
   it 'returns rendered records' do
     get :countries, format: :json
 


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Caches geographical areas for 24 hours

### Why?

I am doing this because:

- There are quite a few geographical areas and fetching/serializing them over the wire is quite slow.

### AC

- [x] Doesn't affect existing fetching behaviour
