### PR TITLE
Notify when there are failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,10 @@ jobs:
           - network.host: 127.0.0.1
           - http.port: 9200
           - discovery.type: single-node
+      - slack/notify:
+          channel: deployments
+          event: fail
+          template: basic_fail_1
     resource_class: medium
     steps:
       - checkout


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Notify slack when we have failures in CI

### Why?

I am doing this because:

- Real time feedback is helpful
