### PR TITLE
Exclude geographical areas by service

### DIFF
--- a/app/controllers/api/v2/geographical_areas_controller.rb
+++ b/app/controllers/api/v2/geographical_areas_controller.rb
@@ -1,35 +1,12 @@
 module Api
   module V2
     class GeographicalAreasController < ApiController
-      TTL = 24.hours
-
       def index
-        render json: cached_serialized_geographical_areas
+        render json: CachedGeographicalAreaService.new(actual_date).call
       end
 
       def countries
-        render json: cached_serialized_geographical_areas
-      end
-
-      private
-
-      def cached_serialized_geographical_areas(countries: false)
-        @serialized = Rails.cache.fetch(cache_key, expires_in: TTL) do
-          geographical_areas = if countries
-                                 GeographicalArea.eager(:geographical_area_descriptions).actual.countries.all
-                               else
-                                 GeographicalArea.eager(:geographical_area_descriptions).actual.areas.all
-                               end
-
-          Api::V2::GeographicalAreaTreeSerializer.new(
-            geographical_areas,
-            include: [:contained_geographical_areas],
-          ).serializable_hash
-        end
-      end
-
-      def cache_key
-        "_geographical-areas-#{action_name}-#{actual_date}"
+        render json: CachedGeographicalAreaService.new(actual_date, true).call
       end
     end
   end

--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -1,5 +1,5 @@
 class CachedCommodityService
-  DEFAULT_COMMODITY_INCLUDES = [
+  DEFAULT_INCLUDES = [
     'section',
     'chapter',
     'chapter.guides',
@@ -115,7 +115,7 @@ class CachedCommodityService
   def options
     {
       is_collection: false,
-      include: DEFAULT_COMMODITY_INCLUDES,
+      include: DEFAULT_INCLUDES,
     }
   end
 

--- a/app/services/cached_geographical_area_service.rb
+++ b/app/services/cached_geographical_area_service.rb
@@ -10,11 +10,12 @@ class CachedGeographicalAreaService
 
   def call
     Rails.cache.fetch(cache_key, expires_in: TTL) do
-      Api::V2::GeographicalAreaTreeSerializer.new(areas.all, include: DEFAULT_INCLUDES).serializable_hash
+      Api::V2::GeographicalAreaTreeSerializer.new(
+        areas.exclude(geographical_area_id: excluded_geographical_area_ids).all,
+        include: DEFAULT_INCLUDES,
+      ).serializable_hash
     end
   end
-
-  def cached_serialized_geographical_areas(countries: false); end
 
   private
 
@@ -38,5 +39,11 @@ class CachedGeographicalAreaService
 
   def geographical_areas
     GeographicalArea.eager(GEOGRAPHICAL_AREAS_EAGER_GRAPH).actual.areas
+  end
+
+  def excluded_geographical_area_ids
+    return %w[XU] if TradeTariffBackend.xi?
+
+    %w[GB XU XI]
   end
 end

--- a/app/services/cached_geographical_area_service.rb
+++ b/app/services/cached_geographical_area_service.rb
@@ -11,7 +11,7 @@ class CachedGeographicalAreaService
   def call
     Rails.cache.fetch(cache_key, expires_in: TTL) do
       Api::V2::GeographicalAreaTreeSerializer.new(
-        areas.exclude(geographical_area_id: excluded_geographical_area_ids).all,
+        sorted_areas.all,
         include: DEFAULT_INCLUDES,
       ).serializable_hash
     end
@@ -20,6 +20,14 @@ class CachedGeographicalAreaService
   private
 
   attr_reader :countries, :actual_date
+
+  def sorted_areas
+    areas.exclude(
+      geographical_area_id: excluded_geographical_area_ids,
+    ).order(
+      Sequel.asc(:geographical_area_id),
+    )
+  end
 
   def areas
     return country_geographical_areas if countries

--- a/app/services/cached_geographical_area_service.rb
+++ b/app/services/cached_geographical_area_service.rb
@@ -1,0 +1,42 @@
+class CachedGeographicalAreaService
+  DEFAULT_INCLUDES = [:contained_geographical_areas].freeze
+  GEOGRAPHICAL_AREAS_EAGER_GRAPH = :geographical_area_descriptions
+  TTL = 24.hours
+
+  def initialize(actual_date, countries = false)
+    @countries = countries
+    @actual_date = actual_date
+  end
+
+  def call
+    Rails.cache.fetch(cache_key, expires_in: TTL) do
+      Api::V2::GeographicalAreaTreeSerializer.new(areas.all, include: DEFAULT_INCLUDES).serializable_hash
+    end
+  end
+
+  def cached_serialized_geographical_areas(countries: false); end
+
+  private
+
+  attr_reader :countries, :actual_date
+
+  def areas
+    return country_geographical_areas if countries
+
+    geographical_areas
+  end
+
+  def cache_key
+    return "_geographical-areas-countries-#{actual_date}" if countries
+
+    "_geographical-areas-index-#{actual_date}"
+  end
+
+  def country_geographical_areas
+    GeographicalArea.eager(GEOGRAPHICAL_AREAS_EAGER_GRAPH).actual.countries
+  end
+
+  def geographical_areas
+    GeographicalArea.eager(GEOGRAPHICAL_AREAS_EAGER_GRAPH).actual.areas
+  end
+end

--- a/spec/controllers/api/v2/geographical_areas_controller_spec.rb
+++ b/spec/controllers/api/v2/geographical_areas_controller_spec.rb
@@ -28,10 +28,17 @@ describe Api::V2::GeographicalAreasController, 'GET #countries' do
     }
   end
 
-  let(:actual_date) { Time.zone.today.iso8601 }
+  let(:actual_date) { Time.zone.today }
 
   before do
     allow(Rails.cache).to receive(:fetch).and_call_original
+    allow(CachedGeographicalAreaService).to receive(:new).and_call_original
+  end
+
+  it 'calls the CachedGeographicalAreaService' do
+    get :countries, format: :json
+
+    expect(CachedGeographicalAreaService).to have_received(:new).with(actual_date, true)
   end
 
   it 'caches the serialized countries' do

--- a/spec/services/cached_geographical_area_service_spec.rb
+++ b/spec/services/cached_geographical_area_service_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe CachedGeographicalAreaService do
+  subject(:service) { described_class.new(actual_date, countries) }
+
+  let(:actual_date) { Time.zone.today }
+  let(:countries) { false }
+
+  describe '#call' do
+    let(:pattern) do
+      {
+        data: [
+          {
+            id: String,
+            type: 'geographical_area',
+            attributes: Hash,
+            relationships: {
+              children_geographical_areas: Hash,
+            },
+          },
+        ],
+        included: [],
+      }
+    end
+
+    before do
+      allow(Rails.cache).to receive(:fetch).and_call_original
+      geographical_area
+    end
+
+    context 'when fetching geographical area countries' do
+      let(:geographical_area) { create(:geographical_area, :country) }
+      let(:countries) { true }
+
+      it 'returns a correctly serialized hash' do
+        expect(service.call.to_json).to match_json_expression pattern
+      end
+
+      it 'uses the correct cache key' do
+        expected_key = "_geographical-areas-countries-#{actual_date}"
+        service.call
+        expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 24.hours)
+      end
+    end
+
+    context 'when fetching geographical areas' do
+      let(:geographical_area) { create(:geographical_area, :group) }
+      let(:countries) { false }
+
+      it 'returns a correctly serialized hash' do
+        expect(service.call.to_json).to match_json_expression pattern
+      end
+
+      it 'uses the correct cache key' do
+        expected_key = "_geographical-areas-index-#{actual_date}"
+        service.call
+        expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 24.hours)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Adds cached_geographical_area_service and spec
- [x] Exclude geographical areas depending on the service following the same logic as the frontend change we made

### Why?

I am doing this because:

- These areas aren't needed in each of these services.
- This avoids duplication in both of our frontends
