### PR TITLE
Bump mimemagic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.2)


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Bump mimemagic gem

### Why

- The existing version has been yanked. Whole explanation here:

https://www.altusintel.com/public-yy2r88/
https://github.com/mimemagicrb/mimemagic/commit/c0f7b6b21a192629839db87612794d08f9ff7e88

- Other gov projects have opted out from mimemagic - it has licensing issues:
  https://ukgovernmentdfe.slack.com/archives/CAGBHB4JV/p1616668662022200
  
  Rationale for rails dep changes here: rails/rails#41750 (comment)
 Relevant govuk-component changes: DFE-Digital/govuk-components#124

However, we explicitly need this in our importers (CDS importer):

```ruby
def import
    handler = XmlProcessor.new(@cds_update.filename)
    gzip_file = TariffSynchronizer::FileService.file_as_stringio(@cds_update)

    # The api https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/secure-data-exchange-bulk-download/1.0
    # returns zip files for daily and monthly updates and gzip for annual files.
    if MimeMagic.by_magic(gzip_file).subtype == 'gzip'
      xml_stream = Zlib::GzipReader.wrap(gzip_file)

      CdsImporter::XmlParser::Reader.new(xml_stream, handler).parse

      ActiveSupport::Notifications.instrument('cds_imported.tariff_importer', filename: @cds_update.filename)
    else
      Zip::File.open_buffer(gzip_file) do |archive|
        archive.entries.each do |entry|
          # Read into memory
          xml_stream = entry.get_input_stream
          # do the xml parsing depending on records root depth
          CdsImporter::XmlParser::Reader.new(xml_stream.read, handler).parse

          ActiveSupport::Notifications.instrument('cds_imported.tariff_importer', filename: @cds_update.filename)
        end
      end
    end
  end
```

This does however mean we fall under GPL-V2 licence.