### PR TITLE
Adds id to attributes

### DIFF
--- a/app/serializers/api/v2/exchange_rate_serializer.rb
+++ b/app/serializers/api/v2/exchange_rate_serializer.rb
@@ -5,7 +5,8 @@ module Api
 
       set_type :exchange_rate
 
-      attributes :rate,
+      attributes :id,
+                 :rate,
                  :base_currency,
                  :applicable_date
     end

--- a/spec/controllers/api/v2/exchange_rates_controller_spec.rb
+++ b/spec/controllers/api/v2/exchange_rates_controller_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Api::V2::ExchangeRatesController do
             'id' => 'CAD',
             'type' => 'exchange_rate',
             'attributes' => {
+              'id' => 'CAD',
               'rate' => 1.5051,
               'base_currency' => 'EUR',
               'applicable_date' => '2021-03-11',

--- a/spec/serializers/api/v2/exchange_rate_serializer_spec.rb
+++ b/spec/serializers/api/v2/exchange_rate_serializer_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Api::V2::Measures::ExchangeRateSerializer do
         id: 'CAD',
         type: :exchange_rate,
         attributes: {
+          id: 'CAD',
           rate: serializable.rate,
           base_currency: serializable.base_currency,
           applicable_date: serializable.applicable_date,


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Adds id to attributes in exchange rate serializer

### Why?

I am doing this because:

- This is because the jsonapi parser relies on ids being in the attributes not in the id field :facepalm:
