### PR TITLE
Fixes ExchangeRateService

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+EXCHANGE_RATE_ACCESS_KEY=flibble

--- a/.env.test
+++ b/.env.test
@@ -1,15 +1,16 @@
-TARIFF_SYNC_USERNAME=username
-TARIFF_SYNC_PASSWORD=password
-TARIFF_SYNC_HOST=http://example.com
-TARIFF_SYNC_EMAIL=user@example.com
-HMRC_SYNC_HOST: http://example.com
+AWS_ACCESS_KEY_ID=xxxxxxxxxxxxxxxxxxxx
+AWS_BUCKET_NAME=trade-tariff-backend
+AWS_REGION=us-east-1
+AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+EXCHANGE_RATE_ACCESS_KEY=flibble
 HMRC_CLIENT_ID: 123456789
 HMRC_CLIENT_SECRET: 123456789
-TARIFF_MEASURES_LOGGER=0
-TARIFF_IGNORE_PRESENCE_ERRORS=0
+HMRC_SYNC_HOST: http://example.com
 TARIFF_CDS_LOGGER=0
 TARIFF_FROM_EMAIL=no-reply@example.com
-AWS_ACCESS_KEY_ID=xxxxxxxxxxxxxxxxxxxx
-AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-AWS_REGION=us-east-1
-AWS_BUCKET_NAME=trade-tariff-backend
+TARIFF_IGNORE_PRESENCE_ERRORS=0
+TARIFF_MEASURES_LOGGER=0
+TARIFF_SYNC_EMAIL=user@example.com
+TARIFF_SYNC_HOST=http://example.com
+TARIFF_SYNC_PASSWORD=password
+TARIFF_SYNC_USERNAME=username

--- a/app/services/exchange_rate_service.rb
+++ b/app/services/exchange_rate_service.rb
@@ -1,5 +1,6 @@
 class ExchangeRateService
-  API_URL = 'https://api.exchangeratesapi.io/latest'.freeze
+  ACCESS_KEY = ENV['EXCHANGE_RATE_ACCESS_KEY']
+  API_URL = "http://api.exchangeratesapi.io/v1/latest?access_key=#{ACCESS_KEY}".freeze
   EXCHANGE_RATES_UTC_REFRESH_HOUR = 15
   EXCHANGE_RATES_UTC_REFRESH_MIN  = 15
   REDIS_KEY = 'trade-tariff-exchange-rates'.freeze

--- a/spec/services/exchange_rate_service_spec.rb
+++ b/spec/services/exchange_rate_service_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ExchangeRateService do
 
     context 'when fetching for the first time' do
       before do
-        stub_request(:get, 'https://api.exchangeratesapi.io/latest')
+        stub_request(:get, 'http://api.exchangeratesapi.io/v1/latest?access_key=flibble')
           .to_return(status: 200, body: '{"foo":"bar"}')
       end
 
@@ -45,7 +45,7 @@ RSpec.describe ExchangeRateService do
     context 'when the exchange rates are expired' do
       before do
         TradeTariffBackend.redis.set(described_class::REDIS_KEY, previously_cached_result)
-        stub_request(:get, 'https://api.exchangeratesapi.io/latest')
+        stub_request(:get, 'http://api.exchangeratesapi.io/v1/latest?access_key=flibble')
           .to_return(status: 200, body: '{"baz":"qux"}')
       end
 
@@ -77,7 +77,7 @@ RSpec.describe ExchangeRateService do
     context 'when the exchange rates are current' do
       before do
         TradeTariffBackend.redis.set(described_class::REDIS_KEY, previously_cached_result)
-        stub_request(:get, 'https://api.exchangeratesapi.io/latest')
+        stub_request(:get, 'http://api.exchangeratesapi.io/v1/latest?access_key=flibble')
           .to_return(status: 200, body: '{"baz":"qux"}')
       end
 


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Adds access key query to `ExchangeRateService`
- [x] Move from https -> http

### Why?

I am doing this because:

- We can't pull out exchange rates in the duty calculator
- The api changed to requiring an access key and disabling requests over
https
