### PR TITLE
Set Cache-Control to no-cache in ExchangeRateController

### DIFF
--- a/app/controllers/api/v2/exchange_rates_controller.rb
+++ b/app/controllers/api/v2/exchange_rates_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V2
     class ExchangeRatesController < ApiController
+      before_action :expires_now
+
       def index
         render json: Api::V2::ExchangeRateSerializer.new(exchange_rates).serializable_hash
       end

--- a/spec/controllers/api/v2/exchange_rates_controller_spec.rb
+++ b/spec/controllers/api/v2/exchange_rates_controller_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Api::V2::ExchangeRatesController do
       }
     end
 
+    it { expect(response['Cache-Control']).to eq('no-cache') }
     it { expect(JSON.parse(response.body)).to eq(expected) }
     it { expect(response).to have_http_status(:ok) }
   end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Sets `Cache-Control: no-cache` in `ExchangeRateController`
- [x] Adds spec to prove it

### Why?

I am doing this because:

- Removes an additional layer of caching that really isn't needed
