### PR TITLE
Ignore duty expression ids for ad valorem

### DIFF
--- a/app/models/duty_expression.rb
+++ b/app/models/duty_expression.rb
@@ -1,5 +1,4 @@
 class DutyExpression < Sequel::Model
-  AD_VALOREM_DUTY_EXPRESSION_ID = '01'.freeze
   MEURSING_DUTY_EXPRESSION_IDS  = %w[12 14 21 25 27 29].freeze
 
   plugin :time_machine

--- a/app/models/measure_component.rb
+++ b/app/models/measure_component.rb
@@ -56,8 +56,7 @@ class MeasureComponent < Sequel::Model
 
   def ad_valorem?
     measurement_unit_code.nil? &&
-      monetary_unit_code.nil? &&
-      duty_expression_id == DutyExpression::AD_VALOREM_DUTY_EXPRESSION_ID
+      monetary_unit_code.nil?
   end
 
   private

--- a/app/models/measure_condition_component.rb
+++ b/app/models/measure_condition_component.rb
@@ -35,8 +35,7 @@ class MeasureConditionComponent < Sequel::Model
 
   def ad_valorem?
     monetary_unit_code.nil? &&
-      measurement_unit_code.nil? &&
-      duty_expression_id == DutyExpression::AD_VALOREM_DUTY_EXPRESSION_ID
+      measurement_unit_code.nil?
   end
 
   def formatted_duty_expression

--- a/spec/factories/measure_component_factory.rb
+++ b/spec/factories/measure_component_factory.rb
@@ -11,6 +11,5 @@ FactoryBot.define do
   trait :ad_valorem do
     monetary_unit_code { nil }
     measurement_unit_code { nil }
-    duty_expression_id { DutyExpression::AD_VALOREM_DUTY_EXPRESSION_ID }
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Ignore duty expression ids when understanding whether a component is ad valorem

### Why?

I am doing this because:

- We only care about the id for sequencing duty expressions that we need to evaluate
