### PR TITLE
Extend list of globally-excluded geographical area ids

### DIFF
--- a/app/services/cached_geographical_area_service.rb
+++ b/app/services/cached_geographical_area_service.rb
@@ -1,4 +1,28 @@
 class CachedGeographicalAreaService
+  GLOBALLY_EXCLUDED_GEOGRAPHICAL_AREA_IDS = %w[
+    EU
+    GG
+    JE
+    QP
+    QQ
+    QR
+    QS
+    QU
+    QV
+    QW
+    QX
+    QY
+    QZ
+    ZB
+    ZD
+    ZE
+    ZF
+    ZG
+    ZH
+    ZN
+    ZU
+  ].freeze
+
   DEFAULT_INCLUDES = [:contained_geographical_areas].freeze
   GEOGRAPHICAL_AREAS_EAGER_GRAPH = :geographical_area_descriptions
   TTL = 24.hours
@@ -23,7 +47,7 @@ class CachedGeographicalAreaService
 
   def sorted_areas
     areas.exclude(
-      geographical_area_id: excluded_geographical_area_ids,
+      geographical_area_id: excluded_geographical_area_ids + GLOBALLY_EXCLUDED_GEOGRAPHICAL_AREA_IDS,
     ).order(
       Sequel.asc(:geographical_area_id),
     )

--- a/spec/services/cached_geographical_area_service_spec.rb
+++ b/spec/services/cached_geographical_area_service_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe CachedGeographicalAreaService do
   let(:actual_date) { Time.zone.today }
   let(:countries) { false }
   let(:xi_service) { false }
+  let(:geographical_area) { create(:geographical_area, :country, geographical_area_id: 'RO') }
+  let(:excluded_geographical_area) { create(:geographical_area, :country, geographical_area_id: 'JE') }
 
   describe '#call' do
     let(:pattern) do
@@ -30,6 +32,12 @@ RSpec.describe CachedGeographicalAreaService do
       allow(TradeTariffBackend).to receive(:xi?).and_return(xi_service)
 
       geographical_area
+    end
+
+    it 'excludes globally excluded geographical area ids' do
+      excluded_geographical_area
+      no_je = service.call[:data].select { |country| country[:id] == 'JE' }.empty?
+      expect(no_je).to be(true)
     end
 
     context 'when fetching geographical area countries' do


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Extend the list of exclusions for geographical areas

### Why?

I am doing this because:

- There are some places you just won't import from and that aren't useful in both the frontend and the duty calculator
