### PR TITLE
Annotate commodity response when there are no components

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -446,6 +446,10 @@ class Measure < Sequel::Model
     ad_valorem_resource?(:measure_components) || ad_valorem_resource?(:measure_conditions)
   end
 
+  def only_measure_conditions?
+    measure_components.blank?
+  end
+
   def units
     component_units + condition_units
   end

--- a/app/presenters/api/v2/commodities/commodity_presenter.rb
+++ b/app/presenters/api/v2/commodities/commodity_presenter.rb
@@ -61,6 +61,10 @@ module Api
         def applicable_measure_units
           MeasureUnitService.new(unit_measures).call
         end
+
+        def only_measure_conditions?
+          import_measures.all?(&:only_measure_conditions?)
+        end
       end
     end
   end

--- a/app/serializers/api/v2/commodities/commodity_serializer.rb
+++ b/app/serializers/api/v2/commodities/commodity_serializer.rb
@@ -11,7 +11,8 @@ module Api
         attributes :producline_suffix, :description, :number_indents,
                    :goods_nomenclature_item_id, :bti_url, :formatted_description,
                    :description_plain, :consigned, :consigned_from, :basic_duty_rate,
-                   :meursing_code
+                   :meursing_code,
+                   :only_measure_conditions
 
         attribute :declarable do
           true
@@ -32,6 +33,7 @@ module Api
               trade_defence: commodity.trade_remedies?,
               applicable_measure_units: commodity.applicable_measure_units,
               meursing_code: commodity.meursing_code,
+              only_measure_conditions: commodity.only_measure_conditions?,
             },
           }
         end

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -1352,6 +1352,20 @@ describe Measure do
     end
   end
 
+  describe '#only_measure_conditions?' do
+    describe 'when there are measure components' do
+      subject(:measure) { create(:measure, :with_measure_components) }
+
+      it { is_expected.not_to be_only_measure_conditions }
+    end
+
+    describe 'when there are no measure components' do
+      subject(:measure) { create(:measure, :with_measure_conditions) }
+
+      it { is_expected.to be_only_measure_conditions }
+    end
+  end
+
   describe '#units' do
     context 'when there are measure components and measure components' do
       subject(:measure) { create(:measure, :with_measure_components, :with_measure_conditions) }


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Adds only_measure_conditions for commodities without measure components

### Why?

I am doing this because:

- We want to handle this case in the frontend and skip displaying the link to calculate duties
