### PR TITLE
Allow duty-calculator to reach backend internal endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,7 @@ commands:
             # Enable routing from this frontend to backend applications which are private
             cf add-network-policy "$CF_FRONTEND_APP-<< parameters.domain_prefix >>" "tariff-<< parameters.service >>-backend-<< parameters.domain_prefix >>-dark" --protocol tcp --port 8080
             cf add-network-policy "$CF_ADMIN_APP-<< parameters.domain_prefix >>" "tariff-<< parameters.service >>-backend-<< parameters.domain_prefix >>-dark" --protocol tcp --port 8080
+            cf add-network-policy "$CF_DUTYCALCULATOR_APP-<< parameters.domain_prefix >>" "tariff-<< parameters.service >>-backend-<< parameters.domain_prefix >>-dark" --protocol tcp --port 8080
 
       - run:
           name: "Verify new version is working on dark URL."


### PR DESCRIPTION
### Jira link

n/a

### What?

I have added/removed/altered:

- [ ] Allow **duty-calculator** instance to reach the backend instance via internal network.


### Why?

I am doing this because:

- We don't want the request to go in and out via the public internet (and CDN)


