### PR TITLE
Add a note about the PostgreSQL version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ Other related projects:
 ### Dependencies
 
   - Ruby
-  - Postgresql 10 (won't work with more recent versions)
-  - ElasticSearch
+  - Postgresql v10 (won't work with more recent versions)
+  - ElasticSearch v7 (last tested and working with version 7.12. It may be
+    working with a more recent version, but if you have issues try to downgrade
+    to version 7)
   - Redis
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Other related projects:
 ### Dependencies
 
   - Ruby
-  - Postgresql
+  - Postgresql 10 (won't work with more recent versions)
   - ElasticSearch
   - Redis
 
@@ -34,25 +34,25 @@ Please go through this updated [setup document](https://github.com/trade-tariff/
     c. Check with DevOps to have a cf account created, if you don't have one already
 
     d. Get a data dump of the DB from our DEV/STAGING environment, by running:
-       
+
        cf conduit <target database> -- pg_dump --file <data_dump_file_name>.psql --no-acl --no-owner --clean --verbose
 
     e. Restore the data dump locally, by running:
-       
+
        psql -h localhost tariff_development < <data_dump_file_name>.psql
 
 2. Update `.env` file with valid data. To enable the XI version, add the extra flag `SERVICE=xi`. If not added, it will default to the UK version.
 
 3. Start your services:
-    
+
     a. rails s -p PORT (Rails Server)
-    
+
     b. redis-server (Redis Server)
-    
+
     c. bundle exec sidekiq (Sidekiq)
-    
+
     d. cd to your ElasticSearch folder and run:
-    
+
         ./bin/elasticseach (ElasticSearch - ideally version 7.10.0)
 
 4. Verify that the app is up and running.
@@ -126,7 +126,7 @@ To check autoscaling history run:
 To check autoscaling metrics run:
 
     cf autoscaling-metrics APP_NAME METRIC_NAME
- 
+
 To remove autoscaling policy and disable App Autoscaler run:
 
     cf detach-autoscaling-policy APP_NAME


### PR DESCRIPTION
### Jira link

none

### What?

This PR adds a note in the `README.md` file regarding the required versions for PostgreSQL and ElasticSearch.

### Why?

I am doing this because:

During a first setup of the application, I've been informed that the backend only works with PostgreSQL 10, and the error I was experiencing were due to the fact that I was using a more recent version.

Adding the information in the `README.md`  will hopefully make things easier for the next person that needs to set up the application.