### PR TITLE
Deduplicate third country measures with additional codes

### DIFF
--- a/app/services/applicable_additional_code_service.rb
+++ b/app/services/applicable_additional_code_service.rb
@@ -4,7 +4,7 @@ class ApplicableAdditionalCodeService
   end
 
   def call
-    unique_applicable_measures.each_with_object({}) do |measure, acc|
+    applicable_measures.each_with_object({}) do |measure, acc|
       measure_type_id = measure.measure_type_id
 
       acc[measure_type_id] = {} if acc[measure_type_id].blank?
@@ -15,10 +15,6 @@ class ApplicableAdditionalCodeService
   end
 
   private
-
-  def unique_applicable_measures
-    applicable_measures.uniq { |measure| measure.measure_sid }
-  end
 
   def applicable_measures
     @measures.select { |measure| measure.additional_code&.applicable? }

--- a/spec/services/applicable_additional_code_service_spec.rb
+++ b/spec/services/applicable_additional_code_service_spec.rb
@@ -9,7 +9,6 @@ describe ApplicableAdditionalCodeService do
       let(:measures) do
         [
           measure,
-          duplicate_measure,
           measure_with_same_measure_and_code_type,
           measure_with_different_measure_and_code_type,
           measure_without_additional_code,
@@ -22,16 +21,6 @@ describe ApplicableAdditionalCodeService do
           measure_type_id: '105',
           additional_code_type_id: '2',
           additional_code: '550',
-        )
-      end
-      let(:duplicate_measure) do
-        create(
-          :measure,
-          :with_additional_code,
-          measure_type_id: '105',
-          additional_code_type_id: '2',
-          additional_code: '550',
-          measure_sid: measure.measure_sid,
         )
       end
       let(:measure_with_same_measure_and_code_type) do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-666

### What?

I have added/removed/altered:

1. Preserve the behaviour to deduplicate third country measures where there are more than one in the list of import measures
2. Consolidate the behaviour to unique additional code measures by the measure_sid for those third country measures with additional codes
3. Remove unused measure deduplication in the ApplicableAdditionalCodeService since this is handled in a consolidated manner
4. Updates specs to reflect removal of uniqueness from the service

### Why?

I am doing this because:

- We currently show duplicate measures in the uk backend and need to hide these.
