### PR TITLE
Hott 428 - change displayed id for quota definitions

### DIFF
--- a/app/models/quota_blocking_period.rb
+++ b/app/models/quota_blocking_period.rb
@@ -1,9 +1,8 @@
 class QuotaBlockingPeriod < Sequel::Model
   plugin :time_machine, period_start_column: :blocking_start_date,
-         period_end_column: :blocking_end_date
+                        period_end_column: :blocking_end_date
   plugin :oplog, primary_key: :quota_definition_sid
   plugin :conformance_validator
 
   set_primary_key [:quota_blocking_period_sid]
-
 end

--- a/app/models/quota_definition.rb
+++ b/app/models/quota_definition.rb
@@ -24,7 +24,7 @@ class QuotaDefinition < Sequel::Model
   end
 
   one_to_one :measurement_unit, primary_key: :measurement_unit_code,
-             key: :measurement_unit_code do |ds|
+                                key: :measurement_unit_code do |ds|
     ds.with_actual(MeasurementUnit)
   end
 

--- a/app/models/quota_order_number.rb
+++ b/app/models/quota_order_number.rb
@@ -21,7 +21,7 @@ class QuotaOrderNumber < Sequel::Model
   alias_method :definition, :quota_definition!
 
   def definition_id
-    definition&.quota_order_number_sid
+    definition&.quota_definition_sid
   end
 
   one_to_one :quota_order_number_origin, primary_key: :quota_order_number_sid,

--- a/app/models/quota_suspension_period.rb
+++ b/app/models/quota_suspension_period.rb
@@ -1,9 +1,8 @@
 class QuotaSuspensionPeriod < Sequel::Model
   plugin :time_machine, period_start_column: :suspension_start_date,
-         period_end_column: :suspension_end_date
+                        period_end_column: :suspension_end_date
   plugin :oplog, primary_key: :quota_suspension_period_sid
   plugin :conformance_validator
 
   set_primary_key [:quota_suspension_period_sid]
-
 end

--- a/app/serializers/api/v2/quotas/order_number/quota_definition_serializer.rb
+++ b/app/serializers/api/v2/quotas/order_number/quota_definition_serializer.rb
@@ -4,41 +4,41 @@ module Api
       module OrderNumber
         class QuotaDefinitionSerializer
           include JSONAPI::Serializer
-  
+
           set_type :definition
-  
-          set_id :quota_order_number_sid
-  
+
+          set_id :quota_definition_sid
+
           attributes :initial_volume, :validity_start_date, :validity_end_date, :status, :description, :balance
-  
+
           attribute :measurement_unit do |definition|
             definition.formatted_measurement_unit
           end
-  
+
           attribute :monetary_unit do |definition|
             definition.monetary_unit_code
           end
-  
+
           attribute :measurement_unit_qualifier do |definition|
             definition.measurement_unit_qualifier_code
           end
-  
+
           attribute :last_allocation_date do |definition|
             definition.last_balance_event.try(:occurrence_timestamp)
           end
-  
+
           attribute :suspension_period_start_date do |definition|
             definition.last_suspension_period.try(:suspension_start_date)
           end
-  
+
           attribute :suspension_period_end_date do |definition|
             definition.last_suspension_period.try(:suspension_end_date)
           end
-  
+
           attribute :blocking_period_start_date do |definition|
             definition.last_blocking_period.try(:blocking_start_date)
           end
-  
+
           attribute :blocking_period_end_date do |definition|
             definition.last_blocking_period.try(:blocking_end_date)
           end

--- a/app/serializers/api/v2/quotas/order_number/quota_order_number_serializer.rb
+++ b/app/serializers/api/v2/quotas/order_number/quota_order_number_serializer.rb
@@ -4,11 +4,11 @@ module Api
       module OrderNumber
         class QuotaOrderNumberSerializer
           include JSONAPI::Serializer
-  
+
           set_type :order_number
-  
+
           set_id :quota_order_number_id
-  
+
           attribute :number do |quota|
             quota.quota_order_number_id
           end

--- a/spec/models/quota_order_number_spec.rb
+++ b/spec/models/quota_order_number_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe QuotaOrderNumber do
 
       it { is_expected.to eq(definition) }
     end
+
+    describe '#definition_id' do
+      subject { quota_order_number.definition_id }
+
+      it { is_expected.to eq(definition.quota_definition_sid) }
+    end
   end
 
   context 'without a persisted QuotaOrderNumber' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-428

### What?

I have added/removed/altered:

- [x] Replace the `quota_order_number_sid` with `quota_definition_sid` as surfaced quota definition ID in the JSON API
- [x] Add a spec to make sure the correct value is used for the `definition_id` function in the `QuotaOrderNumber` model
- [x] Fix some minor linting issues in some of the files touched during the investigation

### Why?

I am doing this because:

- The ID currently surfaced for quota definitions is in fact the `quota_order_number_sid`. 
  This makes some sense as the above is the join key, but the correct ID for quota definition is in fact the `quota_definition_sid`

### Deployment risks (optional)

- This changes the ID used to link the order number with the definition in the JSON API. 
  This doesn't seem to be breaking the frontend as the ID is changed consistently, but a thorough test is still required.
