### PR TITLE
Adds measure type descriptions to the applicable additional codes

### DIFF
--- a/app/services/applicable_additional_code_service.rb
+++ b/app/services/applicable_additional_code_service.rb
@@ -8,6 +8,7 @@ class ApplicableAdditionalCodeService
       measure_type_id = measure.measure_type_id
 
       acc[measure_type_id] = {} if acc[measure_type_id].blank?
+      acc[measure_type_id]['measure_type_description'] = measure&.measure_type&.description
       acc[measure_type_id]['heading'] = heading_annotations_for(measure.additional_code.type)
       acc[measure_type_id]['additional_codes'] = [] if acc[measure_type_id]['additional_codes'].blank?
       acc[measure_type_id]['additional_codes'] << code_annotations_for(measure)

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -72,7 +72,15 @@ FactoryBot.define do
     end
 
     trait :with_measure_type do
-      # noop
+      after(:build) do |measure, evaluator|
+        create :measure_type,
+               measure_type_id: measure.measure_type_id,
+               validity_start_date: measure.validity_start_date - 1.day,
+               measure_explosion_level: evaluator.type_explosion_level,
+               order_number_capture_code: evaluator.order_number_capture_code,
+               trade_movement_code: MeasureType::IMPORT_MOVEMENT_CODES.sample,
+               measure_type_series_id: evaluator.measure_type_series_id
+      end
     end
 
     trait :ad_valorem do

--- a/spec/services/applicable_additional_code_service_spec.rb
+++ b/spec/services/applicable_additional_code_service_spec.rb
@@ -19,6 +19,7 @@ describe ApplicableAdditionalCodeService do
         create(
           :measure,
           :with_additional_code,
+          :with_measure_type,
           measure_type_id: '105',
           additional_code_type_id: '2',
           additional_code: '550',
@@ -28,6 +29,7 @@ describe ApplicableAdditionalCodeService do
         create(
           :measure,
           :with_additional_code,
+          :with_measure_type,
           measure_type_id: '105',
           additional_code_type_id: '2',
           additional_code: '550',
@@ -38,6 +40,7 @@ describe ApplicableAdditionalCodeService do
         create(
           :measure,
           :with_additional_code,
+          :with_measure_type,
           measure_type_id: '105',
           additional_code_type_id: '2',
           additional_code: '551',
@@ -47,17 +50,23 @@ describe ApplicableAdditionalCodeService do
         create(
           :measure,
           :with_additional_code,
+          :with_measure_type,
           measure_type_id: '103',
           additional_code_type_id: '8',
         )
       end
       let(:measure_without_additional_code) do
-        create(:measure, measure_type_id: '103')
+        create(
+          :measure,
+          :with_measure_type,
+          measure_type_id: '103',
+        )
       end
 
       let(:expected_additional_codes) do
         {
           '105' => {
+            'measure_type_description' => be_a(String),
             'heading' => {
               'overlay' => 'Describe your goods in more detail',
               'hint' => 'To trade this commodity, you need to specify an additional 4 digits, known as an additional code',
@@ -78,6 +87,7 @@ describe ApplicableAdditionalCodeService do
             ],
           },
           '103' => {
+            'measure_type_description' => be_a(String),
             'heading' => {
               'overlay' => 'From which company are you buying these goods?',
               'hint' => 'Additional duties are levied against imports from certain companies in the form of anti-dumping or anti-subsidy duties.',


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Surface measure_type_description to applicable additional codes

### Why?

I am doing this because:

- This is needed for richer information in the duty calculator
