### PR TITLE
Clear CertificateDescription and CertificateDescriptionPeriods

### DIFF
--- a/lib/trade_tariff_backend.rb
+++ b/lib/trade_tariff_backend.rb
@@ -176,6 +176,8 @@ module TradeTariffBackend
     def clearable_models
       [
         Certificate,
+        CertificateDescription,
+        CertificateDescriptionPeriod,
         Chief::Tamf,
         ExportRefundNomenclature,
         Footnote,


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Clear certificate description cache

### Why?

I am doing this because:

- We think this might cause some issues when returning certificate descriptions
