### PR TITLE
Make quotas conform to time machine functionality

### DIFF
--- a/app/controllers/api/v2/quotas_controller.rb
+++ b/app/controllers/api/v2/quotas_controller.rb
@@ -1,20 +1,17 @@
 module Api
   module V2
     class QuotasController < ApiController
-      before_action :find_quotas
-
       def search
-        options = {}
-        options[:include] = [:quota_order_number, 'quota_order_number.geographical_areas', :measures, 'measures.geographical_area']
-        render json: Api::V2::Quotas::Definition::QuotaDefinitionSerializer.new(@quotas, options.merge(serialization_meta)).serializable_hash
+        render json: serializable_hash
       end
 
       private
 
-      def find_quotas
-        TimeMachine.now do
-          @quotas = search_service.perform
-        end
+      def serializable_hash
+        Api::V2::Quotas::Definition::QuotaDefinitionSerializer.new(
+          search_service.perform,
+          options,
+        ).serializable_hash
       end
 
       def search_service
@@ -25,15 +22,22 @@ module Api
         5
       end
 
-      def serialization_meta
+      def actual_date
+        Date.parse([params['year'], params['month'], params['day']].join('-'))
+      rescue DateError # empty date param means today
+        Date.current
+      end
+
+      def options
         {
+          include: [:quota_order_number, 'quota_order_number.geographical_areas', :measures, 'measures.geographical_area'],
           meta: {
             pagination: {
               page: current_page,
               per_page: per_page,
-              total_count: search_service.pagination_record_count
-            }
-          }
+              total_count: search_service.pagination_record_count,
+            },
+          },
         }
       end
     end

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -12,8 +12,8 @@ class Measure < Sequel::Model
   ].freeze
 
   set_primary_key [:measure_sid]
-  plugin :time_machine, period_start_column: :effective_start_date,
-                        period_end_column: :effective_end_date
+  plugin :time_machine, period_start_column: :validity_start_date,
+                        period_end_column: :validity_end_date
   plugin :oplog, primary_key: :measure_sid
   plugin :conformance_validator
   plugin :national

--- a/app/services/quota_search_service.rb
+++ b/app/services/quota_search_service.rb
@@ -3,24 +3,25 @@ class QuotaSearchService
 
   attr_accessor :scope
   attr_reader :goods_nomenclature_item_id, :geographical_area_id, :order_number,
-    :critical, :years, :status, :current_page, :per_page, :date
+              :critical, :years, :status, :current_page, :per_page
 
   delegate :pagination_record_count, to: :scope
 
   def initialize(attributes, current_page, per_page)
-    self.scope = Measure.
-      eager(quota_definition: [:measures, :quota_exhaustion_events, :quota_blocking_periods, quota_order_number: [quota_order_number_origins: :geographical_area]]).
-      join(:quota_definitions, [%i[measures__ordernumber quota_definitions__quota_order_number_id], %i[measures__validity_start_date quota_definitions__validity_start_date]]).
-      distinct(:measures__ordernumber, :measures__validity_start_date).
-      select(Sequel.expr(:measures).*).
-      exclude(measures__ordernumber: nil).
-      order(:measures__ordernumber)
+    self.scope = Measure
+      .eager(quota_definition: [:measures, :quota_exhaustion_events, :quota_blocking_periods, quota_order_number: [quota_order_number_origins: :geographical_area]])
+      .join(:quota_definitions, [%i[measures__ordernumber quota_definitions__quota_order_number_id], %i[measures__validity_start_date quota_definitions__validity_start_date]])
+      .distinct(:measures__ordernumber, :measures__validity_start_date)
+      .select(Sequel.expr(:measures).*)
+      .exclude(measures__ordernumber: nil)
+      .order(:measures__ordernumber)
+      .with_actual(Measure)
 
     @goods_nomenclature_item_id = attributes['goods_nomenclature_item_id']
     @geographical_area_id = attributes['geographical_area_id']
     @order_number = attributes['order_number']
     @critical = attributes['critical']
-    extract_date_or_years(attributes)
+    @years = Array.wrap(attributes['years']).join(', ')
     status_value = attributes['status']&.gsub(/[+ ]/, '_')
     @status = status_value if STATUS_VALUES.include?(status_value)
     @current_page = current_page
@@ -33,7 +34,6 @@ class QuotaSearchService
     apply_order_number_filter if order_number.present?
     apply_critical_filter if critical.present?
     apply_years_filter if years.present?
-    apply_date_filter if date.present?
     apply_status_filters if status.present?
 
     self.scope = scope.paginate(current_page, per_page)
@@ -41,13 +41,6 @@ class QuotaSearchService
   end
 
   private
-
-  def extract_date_or_years(attributes)
-    date = Date.parse([attributes['year'], attributes['month'], attributes['day']].join('-'))
-    @date = date
-  rescue Date::Error
-    @years = Array.wrap(attributes['years']).concat(Array.wrap(attributes['year'])).compact.join(', ')
-  end
 
   def apply_goods_nomenclature_item_id_filter
     self.scope = scope.where(Sequel.like(:measures__goods_nomenclature_item_id, "#{goods_nomenclature_item_id}%"))
@@ -62,18 +55,13 @@ class QuotaSearchService
   end
 
   def apply_critical_filter
-    self.scope = scope.
-      where(quota_definitions__critical_state: critical)
+    self.scope = scope.where(quota_definitions__critical_state: critical)
   end
 
   def apply_years_filter
+    # TODO: This doesn't propagate to the validity start/end date of related resources
+    #       Really we should use the time machine to work this out
     @scope = scope.where("EXTRACT(YEAR FROM measures.validity_start_date) IN (#{years})")
-  end
-
-  def apply_date_filter
-    @scope = scope.where('(measures.validity_start_date IS NULL OR measures.validity_start_date <= ?)' \
-                         'AND (measures.validity_end_date IS NULL OR measures.validity_end_date >= ?)',
-                          date, date)
   end
 
   def apply_status_filters
@@ -81,46 +69,14 @@ class QuotaSearchService
   end
 
   def apply_exhausted_filter
-    @scope = scope.
-      where(
-        <<~SQL
+    @scope = scope
+      .where(
+        <<~SQL,
           EXISTS (
           SELECT *
             FROM "quota_exhaustion_events"
            WHERE "quota_exhaustion_events"."quota_definition_sid" = "quota_definitions"."quota_definition_sid" AND
                  "quota_exhaustion_events"."occurrence_timestamp" <= '#{QuotaDefinition.point_in_time}'
-           LIMIT 1
-          )
-        SQL
-      )
-  end
-
-  def apply_not_exhausted_filter
-    @scope = scope.
-      where(
-        <<~SQL
-          NOT EXISTS (
-          SELECT *
-            FROM "quota_exhaustion_events"
-           WHERE "quota_exhaustion_events"."quota_definition_sid" = "quota_definitions"."quota_definition_sid" AND
-                 "quota_exhaustion_events"."occurrence_timestamp" <= '#{QuotaDefinition.point_in_time}'
-           LIMIT 1
-          )
-        SQL
-      )
-  end
-
-  def apply_blocked_filter
-    @scope = scope.
-      where(
-        <<~SQL
-          EXISTS (
-          SELECT *
-            FROM "quota_blocking_periods"
-           WHERE "quota_blocking_periods"."quota_definition_sid" = "quota_definitions"."quota_definition_sid" AND
-                 ("quota_blocking_periods"."blocking_start_date" <= '#{QuotaDefinition.point_in_time}' AND
-                 ("quota_blocking_periods"."blocking_end_date" >= '#{QuotaDefinition.point_in_time}' OR
-                  "quota_blocking_periods"."blocking_end_date" IS NULL))
            LIMIT 1
           )
         SQL
@@ -128,9 +84,9 @@ class QuotaSearchService
   end
 
   def apply_not_blocked_filter
-    @scope = scope.
-      where(
-        <<~SQL
+    @scope = scope
+      .where(
+        <<~SQL,
           NOT EXISTS (
           SELECT *
             FROM "quota_blocking_periods"

--- a/spec/services/quota_search_service_spec.rb
+++ b/spec/services/quota_search_service_spec.rb
@@ -89,6 +89,26 @@ describe QuotaSearchService do
     end
 
     context 'by order_number' do
+      context 'when the order number is current' do
+        context 'when the definition and measure have expired' do
+          it 'returns an empty result'
+        end
+
+        context 'when the definition and measure have not expired' do
+          it 'returns an the non-expired result'
+        end
+      end
+
+      context 'when the order number is non-current' do
+        context 'when the definition and measure have expired' do
+          it 'returns an empty result'
+        end
+
+        context 'when the definition and measure have not expired' do
+          it 'returns an the non-expired result'
+        end
+      end
+
       it 'finds quota definition by order number' do
         result = described_class.new(
           {


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

The quota search service enables searching for quota definitions for measures that are valid according to the current year. We've recently changed the service to use a specific date (e.g. precise to the day)

We noticed an issue with the service when pulling quotas for certain order numbers not returning the related resources.

We previously were using a custom implementation of a date filter that was not propagating to related resources (e.g. quota definitions) because we were using whole year/years as the filter. We were only filtering in related measures based on, say, the current year that was passed and filtering in the definitions that are valid on today's date.

When we moved to a more specific filter of the full date we were able to rely on the actual time machine functionality which would have fixed the broken year filter implementation - but importantly not the year implementation.

This PR fixes this by:

- [ ] Removing the enforced time machine for today filter (which is actually the default, anyway without an as_of query param)
- [ ] Overriding the time machine actual_date to be the date parsed into the query for the given day, month and year coming from the quotas form in the quota search controller
- [ ] Adding unit tests of the quota order service to make sure that it returns related resources using the same date range filter

### Why?

I am doing this because:

- The quota search service is broken in confusing ways
