### PR TITLE
Reenable current git revision healthcheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,12 @@ commands:
       - run:
           name: "Push new app in dark mode"
           command: |
+            # Enables /healthcheck to show the current deployed git sha
+            export GIT_NEW_REVISION=$(git rev-parse --short HEAD)
+            echo $GIT_NEW_REVISION >REVISION
+
             export BUILDPACK="https://github.com/cloudfoundry/ruby-buildpack.git#<< parameters.buildpack_version >>"
+
             # Push as "dark" instance
             cf push "tariff-<< parameters.service >>-backend-<< parameters.domain_prefix >>-dark" -f deploy_manifest.yml --no-route --buildpack $BUILDPACK
 

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,6 +1,6 @@
 class HealthcheckController < ApplicationController
   def index
     Section.all
-    render json: { git_sha1: CURRENT_RELEASE_SHA }
+    render json: { git_sha1: CURRENT_REVISION }
   end
 end

--- a/config/initializers/revision.rb
+++ b/config/initializers/revision.rb
@@ -1,0 +1,7 @@
+revision = if File.exist?(Rails.root.join('REVISION'))
+             system('cat', Rails.root.join('REVISION')).chomp
+           else
+             Rails.env
+           end
+
+CURRENT_REVISION = revision

--- a/config/initializers/revision.rb
+++ b/config/initializers/revision.rb
@@ -1,5 +1,10 @@
-revision = if File.exist?(Rails.root.join('REVISION'))
-             system('cat', Rails.root.join('REVISION')).chomp
+require 'open3'
+
+revision_file = Rails.root.join('REVISION').to_s
+
+revision = if File.exist?(revision_file)
+             stdout, _status = Open3.capture2e('cat', revision_file)
+             stdout.chomp
            else
              Rails.env
            end

--- a/config/initializers/sha.rb
+++ b/config/initializers/sha.rb
@@ -1,6 +1,0 @@
-if File.exists?("#{Rails.root}/REVISION")
-  revision = `cat #{Rails.root}/REVISION`.chomp
-  CURRENT_RELEASE_SHA = revision[0..10] # Just get the short SHA
-else
-  CURRENT_RELEASE_SHA = 'development'
-end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-717

### What?

I have added/removed/altered:

- [x] Enable /healthcheck endpoint to reveal git revision

### Why?

I am doing this because:

- We use this to debug

### Working on dev

```shell
cf ssh tariff-xi-backend-dev  -t -c "/tmp/lifecycle/launcher /home/vcap/app 'curl http://localhost:8080/healthcheck' ''"
{"git_sha1":"539635e0"}
```
