### PR TITLE
Disable chief synchronizer

### DIFF
--- a/lib/tariff_synchronizer.rb
+++ b/lib/tariff_synchronizer.rb
@@ -114,7 +114,7 @@ module TariffSynchronizer
     TradeTariffBackend.with_redis_lock do
       instrument('download.tariff_synchronizer') do
         begin
-          [TaricUpdate, ChiefUpdate].map(&:sync)
+          [TaricUpdate].map(&:sync)
         rescue TariffUpdatesRequester::DownloadException => exception
           instrument('failed_download.tariff_synchronizer', exception: exception)
           raise exception.original
@@ -162,10 +162,6 @@ module TariffSynchronizer
       date_range = date_range_since_last_pending_update
       date_range.each do |day|
         applied_updates << perform_update(TaricUpdate, day)
-      end
-
-      date_range.each do |day|
-        applied_updates << perform_update(ChiefUpdate, day)
       end
 
       applied_updates.flatten!

--- a/spec/integration/tariff_synchronizer_spec.rb
+++ b/spec/integration/tariff_synchronizer_spec.rb
@@ -21,7 +21,7 @@ describe TariffSynchronizer do
       it 'applies missing updates' do
         described_class.apply
         expect(taric_update.reload).to be_applied
-        expect(chief_update.reload).to be_applied
+        expect(chief_update.reload).not_to be_applied
       end
     end
 
@@ -34,7 +34,7 @@ describe TariffSynchronizer do
         )
       end
 
-      it 'marks chief update as failed' do
+      xit 'marks chief update as failed' do
         expect(taric_update).to be_pending
         expect(chief_update).to be_pending
         rescuing { described_class.apply }

--- a/spec/unit/tariff_synchronizer_spec.rb
+++ b/spec/unit/tariff_synchronizer_spec.rb
@@ -19,7 +19,6 @@ describe TariffSynchronizer, truncation: true do
 
       it 'invokes update downloading/syncing on all update types' do
         expect(TariffSynchronizer::TaricUpdate).to receive(:sync).and_return(true)
-        expect(TariffSynchronizer::ChiefUpdate).to receive(:sync).and_return(true)
 
         TariffSynchronizer.download
       end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-740

### What?

CHIEF endpoints return Excise and VAT measures and related resources in CSV format. We ETL these into the database via thei ChiefUpdate mechanism. This PR disables CHIEF ETL

I have added/removed/altered:

- [x] Disable chief synchronizer

### Why?

I am doing this because:

- The measures a related resources created by this ETL process are no longer used - UK measures are the source of truth for VAT/Excise duties
