### PR TITLE
Make sure all MFN measures are zero duty

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,12 +279,12 @@ workflows:
     jobs:
       - linters:
           context: trade-tariff
-      - test:
-           context: trade-tariff
-           filters:
-             branches:
-               ignore:
-                 - master
+      # - test:
+      #      context: trade-tariff
+      #      filters:
+      #        branches:
+      #          ignore:
+      #            - master
       - deploy_dev:
            matrix:
              parameters:
@@ -296,8 +296,8 @@ workflows:
              branches:
                ignore:
                  - master
-           requires:
-             - test
+           # requires:
+           #   - test
       - deploy_staging:
            matrix:
              parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,12 +279,12 @@ workflows:
     jobs:
       - linters:
           context: trade-tariff
-      # - test:
-      #      context: trade-tariff
-      #      filters:
-      #        branches:
-      #          ignore:
-      #            - master
+      - test:
+           context: trade-tariff
+           filters:
+             branches:
+               ignore:
+                 - master
       - deploy_dev:
            matrix:
              parameters:
@@ -296,8 +296,8 @@ workflows:
              branches:
                ignore:
                  - master
-           # requires:
-           #   - test
+           requires:
+             - test
       - deploy_staging:
            matrix:
              parameters:

--- a/app/presenters/api/v2/commodities/commodity_presenter.rb
+++ b/app/presenters/api/v2/commodities/commodity_presenter.rb
@@ -51,7 +51,11 @@ module Api
         alias_method :meursing_code, :meursing_code?
 
         def zero_mfn_duty?
-          import_measures.select(&:third_country?).all?(&:zero_mfn?)
+          third_country_measures.size.positive? && third_country_measures.all?(&:zero_mfn?)
+        end
+
+        def third_country_measures
+          import_measures.select(&:third_country?)
         end
 
         def trade_remedies?

--- a/app/presenters/api/v2/commodities/commodity_presenter.rb
+++ b/app/presenters/api/v2/commodities/commodity_presenter.rb
@@ -51,7 +51,7 @@ module Api
         alias_method :meursing_code, :meursing_code?
 
         def zero_mfn_duty?
-          import_measures.any?(&:zero_mfn?)
+          import_measures.select(&:third_country?).all?(&:zero_mfn?)
         end
 
         def trade_remedies?

--- a/spec/factories/goods_nomenclature_factory.rb
+++ b/spec/factories/goods_nomenclature_factory.rb
@@ -29,14 +29,6 @@ FactoryBot.define do
       validity_end_date   { nil }
     end
 
-    trait :fifteen_years do
-      validity_start_date { Date.current.ago(15.years) }
-    end
-
-    trait :twenty_years do
-      validity_start_date { Date.current.ago(20.years) }
-    end
-
     trait :declarable do
       producline_suffix { '80' }
     end

--- a/spec/presenters/api/v2/commodities/commodity_presenter_spec.rb
+++ b/spec/presenters/api/v2/commodities/commodity_presenter_spec.rb
@@ -34,6 +34,20 @@ describe Api::V2::Commodities::CommodityPresenter do
     )
   end
 
+  let(:non_mfn_measure) do
+    create(
+      :measure,
+      :with_measure_components,
+      :with_measure_type,
+    )
+  end
+
+  describe '#third_country_measures' do
+    let(:measures) { [non_mfn_measure, zero_mfn_measure] }
+
+    it { expect(presenter.third_country_measures).to eq([zero_mfn_measure]) }
+  end
+
   describe '#zero_mfn_duty?' do
     context 'when all mfn duties are zero' do
       let(:measures) { [zero_mfn_measure, zero_mfn_measure] }
@@ -49,6 +63,12 @@ describe Api::V2::Commodities::CommodityPresenter do
 
     context 'when no mfn duty is zero' do
       let(:measures) { [non_zero_mfn_measure, non_zero_mfn_measure] }
+
+      it { is_expected.not_to be_zero_mfn_duty }
+    end
+
+    context 'when no mfn duties are passed' do
+      let(:measures) { [] }
 
       it { is_expected.not_to be_zero_mfn_duty }
     end

--- a/spec/presenters/api/v2/commodities/commodity_presenter_spec.rb
+++ b/spec/presenters/api/v2/commodities/commodity_presenter_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe Api::V2::Commodities::CommodityPresenter do
+  subject(:presenter) { described_class.new(commodity.reload, measures) }
+
+  let(:commodity) do
+    create(
+      :commodity,
+      :with_indent,
+      :with_chapter,
+      :with_heading,
+      :with_description,
+      :declarable,
+    )
+  end
+
+  let(:zero_mfn_measure) do
+    create(
+      :measure,
+      :with_measure_components,
+      :with_measure_type,
+      :third_country,
+      duty_amount: 0,
+    )
+  end
+
+  let(:non_zero_mfn_measure) do
+    create(
+      :measure,
+      :with_measure_components,
+      :with_measure_type,
+      :third_country,
+      duty_amount: 1,
+    )
+  end
+
+  describe '#zero_mfn_duty?' do
+    context 'when all mfn duties are zero' do
+      let(:measures) { [zero_mfn_measure, zero_mfn_measure] }
+
+      it { is_expected.to be_zero_mfn_duty }
+    end
+
+    context 'when at least one mfn duty is non-zero' do
+      let(:measures) { [zero_mfn_measure, non_zero_mfn_measure] }
+
+      it { is_expected.not_to be_zero_mfn_duty }
+    end
+
+    context 'when no mfn duty is zero' do
+      let(:measures) { [non_zero_mfn_measure, non_zero_mfn_measure] }
+
+      it { is_expected.not_to be_zero_mfn_duty }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-784

### What?

In the situation where we have multiple third country duties with additional codes (e.g. covid-related commodities) we want the backend to flag the commodity as having a non-zero amount on the third country duty if and only if _all_ the third country duties have components that are 0.

I have added/removed/altered:

- [x] Make sure MFN duties are _all_ zero for mfn zero check
- [x] Adds a presenter spec to more easily test the behaviour of the presenter without needing to do a full integration

### Why?

I am doing this because:

- We need to make sure we're returning true only when all the mfn measures are zero in the xi service for the duty calculator

