### PR TITLE
Refactor quota search service

### DIFF
--- a/app/controllers/api/v2/quotas_controller.rb
+++ b/app/controllers/api/v2/quotas_controller.rb
@@ -52,8 +52,8 @@ module Api
 
       def actual_date
         Date.parse([params['year'], params['month'], params['day']].join('-'))
-      rescue ArgumentError # empty date, month and year params means today
-        Date.current
+      rescue ArgumentError # empty date, default to as_of in ApplicationController
+        super
       end
     end
   end

--- a/app/controllers/api/v2/quotas_controller.rb
+++ b/app/controllers/api/v2/quotas_controller.rb
@@ -11,15 +11,12 @@ module Api
 
       def serialized_quota_definitions
         Api::V2::Quotas::Definition::QuotaDefinitionSerializer.new(
-          quotas, serializer_options
+          quota_definitions, serializer_options
         ).serializable_hash
       end
 
-      def quotas
-        # TODO: We've added a filter that does not propagate to related resources (e.g. the definition validity time window). We need to make sure that the as_of functionality we've added propagates to related resources.
-        TimeMachine.now do
-          @quotas = search_service.perform
-        end
+      def quota_definitions
+        search_service.call
       end
 
       def serializer_options
@@ -51,6 +48,12 @@ module Api
 
       def provided_includes
         include_params.presence || []
+      end
+
+      def actual_date
+        Date.parse([params['year'], params['month'], params['day']].join('-'))
+      rescue ArgumentError # empty date, month and year params means today
+        Date.current
       end
     end
   end

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -396,16 +396,6 @@ class Measure < Sequel::Model
     end
   end
 
-  def quota_definition_or_nil
-    if quota_definition.present?
-      quota_definition
-    elsif ordernumber.present?
-      definition = QuotaDefinition.new(quota_order_number_id: ordernumber, validity_start_date: validity_start_date)
-      definition[:quota_definition_sid] = -rand(100000)
-      definition
-    end
-  end
-
   def relevant_for_country?(country_id)
     return false if measure_excluded_geographical_areas.map(&:excluded_geographical_area).include?(country_id)
     return true if geographical_area_id == GeographicalArea::ERGA_OMNES_ID && national?

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -12,8 +12,8 @@ class Measure < Sequel::Model
   ].freeze
 
   set_primary_key [:measure_sid]
-  plugin :time_machine, period_start_column: :effective_start_date,
-                        period_end_column: :effective_end_date
+
+  plugin :time_machine
   plugin :oplog, primary_key: :measure_sid
   plugin :conformance_validator
   plugin :national

--- a/app/services/quota_search_service.rb
+++ b/app/services/quota_search_service.rb
@@ -44,7 +44,8 @@ class QuotaSearchService
     apply_status_filters if status.present?
 
     @scope = scope.paginate(current_page, per_page)
-    scope.map(&:quota_definition_or_nil)
+
+    scope.map(&:quota_definition).compact
   end
 
   private

--- a/spec/services/quota_search_service_spec.rb
+++ b/spec/services/quota_search_service_spec.rb
@@ -1,425 +1,142 @@
 require 'rails_helper'
 
 describe QuotaSearchService do
-  describe 'quota search' do
-    around do |example|
-      TimeMachine.now { example.run }
-    end
+  subject(:service) { described_class.new(filter, current_page, per_page) }
 
-    let(:validity_start_date) { Date.new(Date.current.year, 1, 1) }
-    let(:quota_order_number1) { create :quota_order_number }
-    let!(:measure1) { create :measure, ordernumber: quota_order_number1.quota_order_number_id, validity_start_date: validity_start_date }
-    let!(:quota_definition1) do
-      create :quota_definition,
-             quota_order_number_sid: quota_order_number1.quota_order_number_sid,
-             quota_order_number_id: quota_order_number1.quota_order_number_id,
-             critical_state: 'Y',
-             validity_start_date: validity_start_date
-    end
-    let!(:quota_order_number_origin1) do
-      create :quota_order_number_origin,
-             :with_geographical_area,
-             quota_order_number_sid: quota_order_number1.quota_order_number_sid
-    end
+  around do |example|
+    TimeMachine.now { example.run }
+  end
 
-    let(:quota_order_number2) { create :quota_order_number }
-    let!(:measure2) { create :measure, ordernumber: quota_order_number2.quota_order_number_id, validity_start_date: validity_start_date }
-    let!(:quota_definition2) do
-      create :quota_definition,
-             quota_order_number_sid: quota_order_number2.quota_order_number_sid,
-             quota_order_number_id: quota_order_number2.quota_order_number_id,
-             critical_state: 'N',
-             validity_start_date: validity_start_date
+  let(:validity_start_date) { Date.yesterday }
+  let(:quota_order_number1) { create :quota_order_number }
+  let!(:measure1) { create :measure, ordernumber: quota_order_number1.quota_order_number_id, validity_start_date: validity_start_date }
+  let!(:quota_definition1) do
+    create :quota_definition,
+           quota_order_number_sid: quota_order_number1.quota_order_number_sid,
+           quota_order_number_id: quota_order_number1.quota_order_number_id,
+           critical_state: 'Y',
+           validity_start_date: validity_start_date
+  end
+  let!(:quota_order_number_origin1) do
+    create :quota_order_number_origin,
+           :with_geographical_area,
+           quota_order_number_sid: quota_order_number1.quota_order_number_sid
+  end
+
+  let(:quota_order_number2) { create :quota_order_number }
+  let!(:measure2) { create :measure, ordernumber: quota_order_number2.quota_order_number_id, validity_start_date: validity_start_date }
+  let!(:quota_definition2) do
+    create :quota_definition,
+           quota_order_number_sid: quota_order_number2.quota_order_number_sid,
+           quota_order_number_id: quota_order_number2.quota_order_number_id,
+           critical_state: 'N',
+           validity_start_date: validity_start_date
+  end
+  let!(:quota_order_number_origin2) do
+    create :quota_order_number_origin,
+           :with_geographical_area,
+           quota_order_number_sid: quota_order_number2.quota_order_number_sid
+  end
+  let(:current_page) { 1 }
+  let(:per_page) { 20 }
+
+  before do
+    measure1.update(geographical_area_id: quota_order_number_origin1.geographical_area_id)
+    measure2.update(geographical_area_id: quota_order_number_origin2.geographical_area_id)
+  end
+
+  describe '#status' do
+    let(:filter) { { 'status' => 'not+exhausted' } }
+
+    it 'unescapes status values' do
+      expect(service.status).to eq('not_exhausted')
     end
-    let!(:quota_order_number_origin2) do
-      create :quota_order_number_origin,
-             :with_geographical_area,
-             quota_order_number_sid: quota_order_number2.quota_order_number_sid
-    end
-    let(:current_page) { 1 }
-    let(:per_page) { 20 }
+  end
 
-    before do
-      measure1.update(geographical_area_id: quota_order_number_origin1.geographical_area_id)
-      measure2.update(geographical_area_id: quota_order_number_origin2.geographical_area_id)
-    end
+  describe '#call' do
+    context 'when filtering by the goods_nomenclature_item_id' do
+      let(:filter) { { 'goods_nomenclature_item_id' => measure1.goods_nomenclature_item_id } }
 
-    describe '#status' do
-      subject(:service) do
-        described_class.new(
-          {
-            'status' => status,
-            'year' => Date.current.year.to_s,
-          },
-          current_page,
-          per_page,
-        )
-      end
-
-      context 'when the status is url encoded' do
-        let(:status) { 'not+exhausted' }
-
-        it 'unescapes status values' do
-          expect(service.status).to eq('not_exhausted')
-        end
+      it 'returns the correct quota definition' do
+        expect(service.call).to eq([quota_definition1])
       end
     end
 
-    context 'by goods_nomenclature_item_id' do
-      it 'finds quota definition by goods nomenclature' do
-        result = described_class.new(
-          {
-            'goods_nomenclature_item_id' => measure1.goods_nomenclature_item_id,
-            'year' => Date.current.year.to_s,
-          }, current_page, per_page
-        ).perform
-        expect(result).to include(quota_definition1)
-      end
+    context 'when filtering by the geographical_area_id' do
+      let(:filter) { { 'geographical_area_id' => quota_order_number_origin1.geographical_area_id } }
 
-      it 'does not find quota definition by wrong goods nomenclature' do
-        result = described_class.new(
-          {
-            'goods_nomenclature_item_id' => measure1.goods_nomenclature_item_id,
-            'year' => Date.current.year.to_s,
-          }, current_page, per_page
-        ).perform
-        expect(result).not_to include(quota_definition2)
+      it 'returns the correct quota definition' do
+        expect(service.call).to eq([quota_definition1])
       end
     end
 
-    context 'by geographical_area_id' do
-      it 'finds quota definition by geographical area' do
-        result = described_class.new(
-          {
-            'geographical_area_id' => quota_order_number_origin1.geographical_area_id,
-            'year' => Date.current.year.to_s,
-          }, current_page, per_page
-        ).perform
-        expect(result).to include(quota_definition1)
-      end
+    context 'when filtering by the order number' do
+      let(:filter) { { 'order_number' => quota_order_number1.quota_order_number_id } }
 
-      it 'does not find quota definition by wrong geographical area' do
-        result = described_class.new(
-          {
-            'geographical_area_id' => quota_order_number_origin1.geographical_area_id,
-            'year' => Date.current.year.to_s,
-          }, current_page, per_page
-        ).perform
-        expect(result).not_to include(quota_definition2)
+      it 'returns the correct quota definition' do
+        expect(service.call).to eq([quota_definition1])
       end
     end
 
-    context 'by order_number' do
-      it 'finds quota definition by order number' do
-        result = described_class.new(
-          {
-            'order_number' => quota_order_number1.quota_order_number_id,
-            'year' => Date.current.year.to_s,
-          }, current_page, per_page
-        ).perform
-        expect(result).to include(quota_definition1)
-      end
+    context 'when filtering by the quota definition critical state' do
+      let(:filter) { { 'critical' => 'Y' } }
 
-      it 'does not find quota definition by wrong order number' do
-        result = described_class.new(
-          {
-            'order_number' => quota_order_number1.quota_order_number_id,
-            'year' => Date.current.year.to_s,
-          }, current_page, per_page
-        ).perform
-        expect(result).not_to include(quota_definition2)
+      it 'returns the correct quota definition' do
+        expect(service.call).to eq([quota_definition1])
       end
     end
 
-    context 'by critical' do
-      it 'finds quota definition by critical state' do
-        result = described_class.new(
-          {
-            'critical' => quota_definition1.critical_state,
-            'year' => Date.current.year.to_s,
-          }, current_page, per_page
-        ).perform
-        expect(result).to include(quota_definition1)
+    context 'when filtering by status exhausted' do
+      let(:filter) { { 'status' => 'exhausted' } }
+
+      let!(:quota_exhaustion_event) do
+        create :quota_exhaustion_event, quota_definition: quota_definition1
       end
 
-      it 'does not find quota definition by wrong critical state' do
-        result = described_class.new(
-          {
-            'critical' => quota_definition1.critical_state,
-            'year' => Date.current.year.to_s,
-          }, current_page, per_page
-        ).perform
-        expect(result).not_to include(quota_definition2)
+      it 'returns the correct quota definition' do
+        expect(service.call).to eq([quota_definition1])
       end
     end
 
-    context 'by years' do
-      let(:past_validity_start_date) { Date.new(Date.current.year - 1, 1, 1) }
-      let(:quota_order_number3) { create :quota_order_number }
-      let!(:measure3) { create :measure, ordernumber: quota_order_number3.quota_order_number_id, validity_start_date: past_validity_start_date }
-      let!(:quota_definition3) do
-        create :quota_definition,
-               quota_order_number_sid: quota_order_number3.quota_order_number_sid,
-               quota_order_number_id: quota_order_number3.quota_order_number_id,
-               critical_state: 'N',
-               validity_start_date: past_validity_start_date
-      end
-      let!(:quota_order_number_origin3) do
-        create :quota_order_number_origin,
-               :with_geographical_area,
-               quota_order_number_sid: quota_order_number3.quota_order_number_sid
+    context 'when filtering by status not exhausted' do
+      let(:filter) { { 'status' => 'not_exhausted' } }
+
+      let!(:quota_exhaustion_event) do
+        create :quota_exhaustion_event, quota_definition: quota_definition1
       end
 
-      it 'finds quota definition by year' do
-        result = described_class.new(
-          {
-            'years' => Date.current.year.to_s,
-          }, current_page, per_page
-        ).perform
-        expect(result).to include(quota_definition1)
-      end
-
-      it 'finds quota definition by multiple years' do
-        result = described_class.new(
-          {
-            'years' => [Date.current.year.to_s, (Date.current.year - 1).to_s],
-          }, current_page, per_page
-        ).perform
-        expect(result).to include(quota_definition1)
-        expect(result).to include(quota_definition3)
-      end
-
-      it 'does not find quota definition by wrong year' do
-        result = described_class.new(
-          {
-            'years' => Date.current.year.to_s,
-          }, current_page, per_page
-        ).perform
-        expect(result).not_to include(quota_definition3)
+      it 'returns the correct quota definition' do
+        expect(service.call).to eq([quota_definition2])
       end
     end
 
-    context 'by date' do
-      let(:past_validity_start_date) { Date.new(Date.current.year - 1, 1, 1) }
-      let(:quota_order_number3) { create :quota_order_number }
-      let!(:measure3) { create :measure, ordernumber: quota_order_number3.quota_order_number_id, validity_start_date: past_validity_start_date }
-      let!(:quota_definition3) do
-        create :quota_definition,
-               quota_order_number_sid: quota_order_number3.quota_order_number_sid,
-               quota_order_number_id: quota_order_number3.quota_order_number_id,
-               critical_state: 'N',
-               validity_start_date: past_validity_start_date
-      end
-      let!(:quota_order_number_origin3) do
-        create :quota_order_number_origin,
-               :with_geographical_area,
-               quota_order_number_sid: quota_order_number3.quota_order_number_sid
+    context 'when filtering by status blocked' do
+      let(:filter) { { 'status' => 'blocked' } }
+
+      let!(:quota_blocking_period) do
+        create :quota_blocking_period,
+               quota_definition_sid: quota_definition1.quota_definition_sid,
+               blocking_start_date: Date.current,
+               blocking_end_date: 1.year.from_now
       end
 
-      it 'finds quota definition by year only' do
-        result = described_class.new(
-          {
-            'year' => (Date.current.year - 1).to_s,
-          }, current_page, per_page
-        ).perform
-        expect(result).not_to include(quota_definition1)
-      end
-
-      it 'doesn\'t filter quota definition by month only' do
-        result = described_class.new(
-          {
-            'month' => Date.current.month.to_s,
-          }, current_page, per_page
-        ).perform
-        expect(result).to include(quota_definition1, quota_definition2, quota_definition3)
-      end
-
-      it 'doesn\'t filter quota definition by day only' do
-        result = described_class.new(
-          {
-            'day' => Date.current.day.to_s,
-          }, current_page, per_page
-        ).perform
-        expect(result).to include(quota_definition1, quota_definition2, quota_definition3)
-      end
-
-      it 'finds quota definition by full date' do
-        result = described_class.new(
-          {
-            'year' => Date.current.year.to_s,
-            'month' => Date.current.month.to_s,
-            'day' => Date.current.day.to_s,
-          }, current_page, per_page
-        ).perform
-        expect(result).to include(quota_definition1, quota_definition2, quota_definition3)
-      end
-
-      it 'does not find quota definition by wrong date' do
-        result = described_class.new(
-          {
-            'year' => (Date.current.year - 1).to_s,
-            'month' => Date.current.month.to_s,
-            'day' => Date.current.day.to_s,
-          }, current_page, per_page
-        ).perform
-        expect(result).not_to include(quota_definition1)
+      it 'returns the correct quota definition' do
+        expect(service.call).to eq([quota_definition1])
       end
     end
 
-    context 'by status' do
-      context 'exhausted' do
-        let!(:quota_exhaustion_event) do
-          create :quota_exhaustion_event,
-                 quota_definition: quota_definition1
-        end
+    context 'when filtering by status not blocked' do
+      let(:filter) { { 'status' => 'not_blocked' } }
 
-        it 'finds quota definition by exhausted status' do
-          result = described_class.new(
-            {
-              'status' => 'exhausted',
-              'year' => Date.current.year.to_s,
-            }, current_page, per_page
-          ).perform
-          expect(result).to include(quota_definition1)
-        end
-
-        it 'does not find quota definition by wrong exhausted status' do
-          result = described_class.new(
-            {
-              'status' => 'exhausted',
-              'year' => Date.current.year.to_s,
-            }, current_page, per_page
-          ).perform
-          expect(result).not_to include(quota_definition2)
-        end
+      let!(:quota_blocking_period) do
+        create :quota_blocking_period,
+               quota_definition_sid: quota_definition1.quota_definition_sid,
+               blocking_start_date: Date.current,
+               blocking_end_date: 1.year.from_now
       end
 
-      context 'not exhausted' do
-        let!(:quota_exhaustion_event) do
-          create :quota_exhaustion_event,
-                 quota_definition: quota_definition1
-        end
-
-        it 'finds quota definition by not exhausted status' do
-          result = described_class.new(
-            {
-              'status' => 'not_exhausted',
-              'year' => Date.current.year.to_s,
-            }, current_page, per_page
-          ).perform
-          expect(result).to include(quota_definition2)
-        end
-
-        it 'does not find quota definition by wrong not exhausted status' do
-          result = described_class.new(
-            {
-              'status' => 'not_exhausted',
-              'year' => Date.current.year.to_s,
-            }, current_page, per_page
-          ).perform
-          expect(result).not_to include(quota_definition1)
-        end
-      end
-
-      context 'blocked' do
-        let!(:quota_blocking_period) do
-          create :quota_blocking_period,
-                 quota_definition_sid: quota_definition1.quota_definition_sid,
-                 blocking_start_date: Date.current,
-                 blocking_end_date: 1.year.from_now
-        end
-
-        it 'finds quota definition by blocked status' do
-          result = described_class.new(
-            {
-              'status' => 'blocked',
-              'year' => Date.current.year.to_s,
-            }, current_page, per_page
-          ).perform
-          expect(result).to include(quota_definition1)
-        end
-
-        it 'does not find quota definition by wrong blocked status' do
-          result = described_class.new(
-            {
-              'status' => 'blocked',
-              'year' => Date.current.year.to_s,
-            }, current_page, per_page
-          ).perform
-          expect(result).not_to include(quota_definition2)
-        end
-      end
-
-      context 'not blocked' do
-        let!(:quota_blocking_period) do
-          create :quota_blocking_period,
-                 quota_definition_sid: quota_definition1.quota_definition_sid,
-                 blocking_start_date: Date.current,
-                 blocking_end_date: 1.year.from_now
-        end
-
-        it 'finds quota definition by not blocked status' do
-          result = described_class.new(
-            {
-              'status' => 'not_blocked',
-              'year' => Date.current.year.to_s,
-            }, current_page, per_page
-          ).perform
-          expect(result).to include(quota_definition2)
-        end
-
-        it 'finds quota definition by not blocked status with encoded values' do
-          result = described_class.new(
-            {
-              'status' => 'not+blocked',
-              'year' => Date.current.year.to_s,
-            }, current_page, per_page
-          ).perform
-          expect(result).to include(quota_definition2)
-          result = described_class.new(
-            {
-              'status' => 'not%2bblocked',
-              'year' => Date.current.year.to_s,
-            }, current_page, per_page
-          ).perform
-          expect(result).to include(quota_definition2)
-        end
-
-        it 'does not find quota definition by wrong not blocked status' do
-          result = described_class.new(
-            {
-              'status' => 'not_blocked',
-              'year' => Date.current.year.to_s,
-            }, current_page, per_page
-          ).perform
-          expect(result).not_to include(quota_definition1)
-        end
-      end
-
-      context '094 quotas' do
-        let!(:measure_094) do
-          create :measure,
-                 ordernumber: "094#{3.times.map { Random.rand(9) }.join}",
-                 validity_start_date: validity_start_date
-        end
-        let!(:quota_order_number_094) { create :quota_order_number, quota_order_number_id: measure_094.ordernumber }
-        let!(:quota_definition_094) do
-          create :quota_definition,
-                 quota_order_number_sid: quota_order_number_094.quota_order_number_sid,
-                 quota_order_number_id: quota_order_number_094.quota_order_number_id,
-                 critical_state: 'Y',
-                 validity_start_date: validity_start_date
-        end
-
-        it 'searches 094 quotas' do
-          result = described_class.new(
-            {
-              'order_number' => measure_094.ordernumber,
-              'year' => Date.current.year.to_s,
-            }, current_page, per_page
-          ).perform
-          expect(result.first.quota_order_number_id).to eq(measure_094.ordernumber)
-        end
+      it 'returns the correct quota definition' do
+        expect(service.call).to eq([quota_definition2])
       end
     end
   end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-689

### What?

I have added/removed/altered:

- [x] Consolidated TimeMachine functionality by overriding the
  actual_date that is used around the action
- [x] Removed the years filtering since all time filtering is managed by
  the time machine - this is more idiomatic with the rest of the
  application - this may break integrations (but we believe we're the
  only ones using this. We need to investigate api usage to see before
  we go live with this change.
- [x] Shake out and refactor the tests
  - Remove duplication
  - Fix naming of contexts and examples
  - Use subject and filter with lets properly
  - Remove redundant specs (especially of day, month, year and years
    filtering)
  - Tests necessary and sufficient behaviour
- [x] Handle join without requiring an exact match on the
  validity_start_date (this is an overlap with the TimeMachine
  functionality and excludes the wrong records). These start dates are
  handled by different processes and needed removing
- [x] Force the service to conform to rails service api


### Why?

I am doing this because:

- The service TimeMachine functionality was just broken and not idiomatic

### AC

- [ ] Review https://github.com/trade-tariff/trade-tariff-frontend/issues/117
- [ ] Madhu does a manual test of the quota search service

### What's not covered

- Handling geographical area filtering in a way that works with exclusions, groups, etc
- Handling goods_nomenclature_item_id filtering properly according to the hierarchy of the tree
- Does not remove filters we suspect we do not use



