### PR TITLE
HOTT-781: Add reduction indicator to the commodities API

### DIFF
--- a/app/serializers/api/v2/measures/measure_serializer.rb
+++ b/app/serializers/api/v2/measures/measure_serializer.rb
@@ -9,7 +9,7 @@ module Api
         set_id :measure_sid
 
         attributes :id, :origin, :effective_start_date, :effective_end_date, :import,
-                   :excise, :vat
+                   :excise, :vat, :reduction_indicator
 
         has_one :duty_expression, serializer: Api::V2::Measures::DutyExpressionSerializer
         has_one :measure_type, serializer: Api::V2::Measures::MeasureTypeSerializer

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -29,6 +29,7 @@ FactoryBot.define do
     f.geographical_area_id { generate(:geographical_area_id) }
     f.validity_start_date { Date.current.ago(3.years) }
     f.validity_end_date   { nil }
+    f.reduction_indicator { [nil, 1, 2, 3][Random.rand(4)] }
 
     # mandatory valid associations
     f.goods_nomenclature do

--- a/spec/serializers/api/v2/measures/measure_serializer_spec.rb
+++ b/spec/serializers/api/v2/measures/measure_serializer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Api::V2::Measures::MeasureSerializer do
   subject(:serializer) { described_class.new(serializable).serializable_hash.as_json }
 
   let(:serializable) { Api::V2::Measures::MeasurePresenter.new(measure, measure.goods_nomenclature) }
-  let(:measure) { create(:measure) }
+  let(:measure) { create(:measure, reduction_indicator: 1) }
 
   let(:expected_pattern) do
     {
@@ -19,6 +19,7 @@ RSpec.describe Api::V2::Measures::MeasureSerializer do
           'import' => true,
           'excise' => false,
           'vat' => false,
+          'reduction_indicator' => 1
         },
         'relationships' => {
           'duty_expression' => {


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-781

### What?

I have added/removed/altered:

- [ ] Add reduction_indicator field to the measures attributes in the commodities endpoint
- [ ] Add a spec to check that the reduction_indicator is exposed by the serialiser

### Why?

I am doing this because it's required in order to properly calculate Meursing duties on the commodity code page

### Have you? (optional)

- [ ] Added documentation for new apis
- [ ] Added new environment variables with correct values to all apps in all spaces
