### PR TITLE
HOTT-844: 

### DIFF
--- a/app/controllers/api/v1/chapters/chapter_notes_controller.rb
+++ b/app/controllers/api/v1/chapters/chapter_notes_controller.rb
@@ -6,12 +6,12 @@ module Api
         skip_before_action :authenticate_user!, only: [:show]
 
         rescue_from Sequel::RecordNotFound do |exception|
-          render json: {}, status: 404
+          render json: { error: '404 - Not Found' }, status: :not_found
         end
 
         def show
           @chapter = chapter
-          @chapter_note = chapter.chapter_note
+          @chapter_note = chapter&.chapter_note
 
           raise Sequel::RecordNotFound if @chapter_note.blank?
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-844

### What?

I have added/removed/altered:

- [ ] Guard against the empty chapter, so that when the chapter is missing it will render a 404 response instead of throwing an exception
- [ ] Change the error message so that it will align with the 404 response for the parent chapter

### Why?

I am doing this because of this error:
https://sentry.io/organizations/engine-le/issues/2515546107/?project=5557005

In this specific case (chapter "732"), the chapter itself doesn't exist, so when trying to fetch the chapter note, the controller used to throw an exception instead of answering with a more reasonable 404 - not found.
