### PR TITLE
Adds excise type to the applicable additional codes

### DIFF
--- a/app/models/additional_code.rb
+++ b/app/models/additional_code.rb
@@ -1,10 +1,12 @@
 class AdditionalCode < Sequel::Model
+  EXCISE_TYPE = 'excise'.freeze
   PREFERENCE_TYPE = 'preference'.freeze
   REMEDY_TYPE = 'remedy'.freeze
   UNKNOWN_TYPE = 'unknown'.freeze
 
   PREFERENCE_TYPE_IDS = %w[2].freeze
   REMEDY_TYPE_IDS = %w[8 A B C].freeze
+  EXCISE_TYPE_IDS = %w[X].freeze
 
   plugin :time_machine
   plugin :oplog, primary_key: :additional_code_sid
@@ -52,8 +54,9 @@ class AdditionalCode < Sequel::Model
   end
 
   def type
+    return EXCISE_TYPE if additional_code_type_id.in?(EXCISE_TYPE_IDS)
     return PREFERENCE_TYPE if additional_code_type_id.in?(PREFERENCE_TYPE_IDS)
-    return REMEDY_TYPE if  additional_code_type_id.in?(REMEDY_TYPE_IDS)
+    return REMEDY_TYPE if additional_code_type_id.in?(REMEDY_TYPE_IDS)
 
     UNKNOWN_TYPE
   end

--- a/app/services/applicable_additional_code_service.rb
+++ b/app/services/applicable_additional_code_service.rb
@@ -18,7 +18,7 @@ class ApplicableAdditionalCodeService
   private
 
   def unique_applicable_measures
-    applicable_measures.uniq { |measure| measure.measure_sid }
+    applicable_measures.uniq(&:measure_sid)
   end
 
   def applicable_measures

--- a/spec/models/additional_code_spec.rb
+++ b/spec/models/additional_code_spec.rb
@@ -108,16 +108,22 @@ describe AdditionalCode do
       it { expect(additional_code.type).to eq('remedy') }
     end
 
-    context 'when the type id is not a remedy or a preference' do
-      let(:additional_code_type_id) { 'X' }
+    context 'when the type id is not currently handled' do
+      let(:additional_code_type_id) { 'Z' }
 
       it { expect(additional_code.type).to eq('unknown') }
+    end
+
+    context 'when the type id is of a excise type' do
+      let(:additional_code_type_id) { 'X' }
+
+      it { expect(additional_code.type).to eq('excise') }
     end
   end
 
   describe '#applicable?' do
     context 'when the type is unknown' do
-      let(:additional_code_type_id) { 'X' }
+      let(:additional_code_type_id) { 'Z' }
 
       it { is_expected.not_to be_applicable }
     end

--- a/spec/services/applicable_additional_code_service_spec.rb
+++ b/spec/services/applicable_additional_code_service_spec.rb
@@ -114,7 +114,7 @@ describe ApplicableAdditionalCodeService do
           :measure,
           :with_additional_code,
           measure_type_id: '105',
-          additional_code_type_id: 'X',
+          additional_code_type_id: 'Z',
         )
       end
 


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

We have plumbed together a list of applicable additional codes via the ApplicableAdditionalCodeService that we use to enumerate the additional codes the trader might select for a given measure type id. This has a filtering effect on the measures with additional codes that match the trader's answer in the duty calculation.

This PR extends this functionality to also return the excise type of additional codes so we can plumb together a step for excise.

- [x] Adds excise 'X' to the list of additional code types  that we infer from the additional_code_type_id
- [x] Cover the new type with a spec

### Why?

I am doing this because:

- We need to extend the list of the additional code types we return so we can build the additional code step for excise.
