### PR TITLE
Hott 854 add fallback for missing measurement units

### DIFF
--- a/app/models/measurement_unit.rb
+++ b/app/models/measurement_unit.rb
@@ -13,6 +13,20 @@ class MeasurementUnit < Sequel::Model
 
   delegate :description, to: :measurement_unit_description
 
+  class << self
+    def measurement_units
+      @measurement_units ||=
+        begin
+          file = File.join(::Rails.root, 'db', 'measurement_units.json').freeze
+          JSON.parse(File.read(file))
+        end
+    end
+
+    def measurement_unit(unit_key)
+      measurement_units[unit_key]
+    end
+  end
+
   def to_s
     description
   end
@@ -26,13 +40,5 @@ class MeasurementUnit < Sequel::Model
     measurement_unit_abbreviations.find do |abbreviation|
       abbreviation.measurement_unit_qualifier == measurement_unit_qualifier.try(:measurement_unit_qualifier_code)
     end
-  end
-
-  def self.measurement_units
-    @measurement_units ||=
-      begin
-        file = File.join(::Rails.root, 'db', 'measurement_units.json').freeze
-        JSON.parse(File.read(file))
-      end
   end
 end

--- a/app/models/measurement_unit.rb
+++ b/app/models/measurement_unit.rb
@@ -23,7 +23,18 @@ class MeasurementUnit < Sequel::Model
     end
 
     def measurement_unit(unit_key)
-      measurement_units[unit_key]
+      measurement_units.fetch(unit_key)
+    rescue KeyError => e
+      Raven.capture_exception(e)
+
+      {
+        'measurement_unit_code' => unit_key,
+        'measurement_unit_qualifier_code' => '',
+        'abbreviation' => '',
+        'unit_question' => '',
+        'unit_hint' => '',
+        'unit' => '',
+      }
     end
   end
 

--- a/app/models/measurement_unit.rb
+++ b/app/models/measurement_unit.rb
@@ -20,6 +20,12 @@ class MeasurementUnit < Sequel::Model
   delegate :description, to: :measurement_unit_description
 
   class << self
+    def measurement_unit(unit_key)
+      measurement_units[unit_key] ||= build_missing_measurement_unit(unit_key)
+    end
+
+    private
+
     def measurement_units
       @measurement_units ||=
         begin
@@ -27,12 +33,6 @@ class MeasurementUnit < Sequel::Model
           JSON.parse(File.read(file))
         end
     end
-
-    def measurement_unit(unit_key)
-      measurement_units[unit_key] ||= build_missing_measurement_unit(unit_key)
-    end
-
-    private
 
     def build_missing_measurement_unit(unit_key)
       raise InvalidMeasurementUnit, unit_key unless unit = self[unit_key]

--- a/app/services/measure_unit_service.rb
+++ b/app/services/measure_unit_service.rb
@@ -11,7 +11,7 @@ class MeasureUnitService
         acc[unit_key]['measure_sids'].add(unit[:measure_sid])
       else
         acc[unit_key] = {}
-        acc[unit_key] = MeasurementUnit.measurement_units[unit_key]
+        acc[unit_key] = MeasurementUnit.measurement_unit(unit_key)
         acc[unit_key]['measure_sids'] = Set.new([unit[:measure_sid]])
       end
     end

--- a/spec/models/measurement_unit_spec.rb
+++ b/spec/models/measurement_unit_spec.rb
@@ -52,7 +52,15 @@ describe MeasurementUnit do
     end
 
     context 'with unknown measurement unit' do
-      it { expect(MeasurementUnit.measurement_unit('UNKNOWN')).to be_nil }
+      before { allow(Raven).to receive(:capture_exception).and_return(true) }
+
+      subject! { MeasurementUnit.measurement_unit('UNKNOWN') }
+
+      it { is_expected.to include('measurement_unit_code' => 'UNKNOWN') }
+      it { is_expected.to include('unit' => '') }
+      it { is_expected.to include('abbreviation' => '') }
+      it { is_expected.to include('unit_question' => '') }
+      it { expect(Raven).to have_received(:capture_exception) }
     end
 
     context 'without specifying a unit' do

--- a/spec/models/measurement_unit_spec.rb
+++ b/spec/models/measurement_unit_spec.rb
@@ -35,7 +35,7 @@ describe MeasurementUnit do
   end
 
   describe '.measurement_units' do
-    let(:units) { described_class.measurement_units }
+    let(:units) { described_class.send(:measurement_units) }
 
     it "will return the hash of all measurement units" do
       expect(units).to be_instance_of Hash

--- a/spec/models/measurement_unit_spec.rb
+++ b/spec/models/measurement_unit_spec.rb
@@ -33,4 +33,30 @@ describe MeasurementUnit do
       }
     end
   end
+
+  describe '.measurement_units' do
+    let(:units) { described_class.measurement_units }
+
+    it "will return the hash of all measurement units" do
+      expect(units).to be_instance_of Hash
+    end
+
+    it "will include individual units indexed by key" do
+      expect(units).to include("ASV")
+    end
+  end
+
+  describe '.measurement_unit' do
+    context 'with valid measurement unit' do
+      it { expect(MeasurementUnit.measurement_unit('ASV')).to include('unit' => 'percent') }
+    end
+
+    context 'with unknown measurement unit' do
+      it { expect(MeasurementUnit.measurement_unit('UNKNOWN')).to be_nil }
+    end
+
+    context 'without specifying a unit' do
+      it { expect { MeasurementUnit.measurement_unit }.to raise_exception ArgumentError }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/jira/software/projects/HOTT/boards/96?selectedIssue=HOTT-854

### What?

I have added a fallback for when a Measurement Unit is requested which is not listed in the YML:

- [x] Added an `#measurement_unit` method to access a specific unit, rather than going to the units hash directly
- [x] `#measurement_unit` will now query the DB and create 'stubbed measurement unit' in the units hash if found in the DB
- [x] `#measurement_unit` will log to Sentry with the unit code of the missing measurement unit
- [x] made `#measurement_units` private - any public access should go via the new singular method with appropriate fallback handling

### Why?

I am doing this because:

- The commodities listed in ticket `HOTT-825` were triggering a key error because whilst they were valid and present in the database, they had no corresponding entries in the YML file of questions (`db/measurement_units.yml`)

### Points for discussion? (optional)

- I've left the existing `#measurement_units` method public _but_ there are no consumers of this method now and it would make sense to make it private since that will force consumers down the path with fallback handling (ie `MeasurementUnit#measurement_unit`)

![Screenshot from 2021-07-21 12-21-37](https://user-images.githubusercontent.com/10818/126480985-ceff4345-fa30-467b-bcab-b5eab603dbc5.png)
