### PR TITLE
Adds certificate_description to the measure condition serializer

### DIFF
--- a/app/serializers/api/v2/measures/measure_condition_serializer.rb
+++ b/app/serializers/api/v2/measures/measure_condition_serializer.rb
@@ -8,18 +8,19 @@ module Api
 
         set_id :measure_condition_sid
 
-        attributes :condition_code,
-                   :condition,
-                   :document_code,
-                   :requirement,
-                   :action,
+        attributes :action,
                    :action_code,
-                   :duty_expression,
+                   :certificate_description,
+                   :condition,
+                   :condition_code,
                    :condition_duty_amount,
-                   :condition_monetary_unit_code,
-                   :monetary_unit_abbreviation,
                    :condition_measurement_unit_code,
-                   :condition_measurement_unit_qualifier_code
+                   :condition_measurement_unit_qualifier_code,
+                   :condition_monetary_unit_code,
+                   :document_code,
+                   :duty_expression,
+                   :monetary_unit_abbreviation,
+                   :requirement
 
         has_many :measure_condition_components, serializer: Api::V2::Measures::MeasureConditionComponentSerializer
       end

--- a/spec/serializers/api/v2/measures/measure_condition_serializer_spec.rb
+++ b/spec/serializers/api/v2/measures/measure_condition_serializer_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Api::V2::Measures::MeasureConditionSerializer do
           "condition_code": serializable.condition_code,
           "condition": serializable.condition,
           "document_code": serializable.document_code,
+          "certificate_description": serializable.certificate_description,
           "requirement": serializable.requirement,
           "action": nil,
           "action_code": serializable.action_code,


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Adds the certificate description to the measure condition serializer
- [x] Adds a unit test to verify the change

### Why?

I am doing this because:

- This is needed to annotate the certificates in the duty calculator frontend
