### PR TITLE
Hott 720 eager loading fixes

### DIFF
--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -77,7 +77,6 @@ class CachedCommodityService
     { geographical_area: [:geographical_area_descriptions,
                           { contained_geographical_areas: :geographical_area_descriptions }] },
     { additional_code: :additional_code_descriptions },
-    :footnotes,
     :base_regulation,
     :modification_regulation,
     :full_temporary_stop_regulations,

--- a/app/services/cached_geographical_area_service.rb
+++ b/app/services/cached_geographical_area_service.rb
@@ -24,7 +24,10 @@ class CachedGeographicalAreaService
   ].freeze
 
   DEFAULT_INCLUDES = [:contained_geographical_areas].freeze
-  GEOGRAPHICAL_AREAS_EAGER_GRAPH = :geographical_area_descriptions
+  GEOGRAPHICAL_AREAS_EAGER_GRAPH = [
+    :geographical_area_descriptions,
+    :contained_geographical_areas,
+  ].freeze
   TTL = 24.hours
 
   def initialize(actual_date, countries = false)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,6 +46,5 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  config.log_level = :info
   config.logger = ActiveSupport::Logger.new($stdout)
 end


### PR DESCRIPTION
### Jira link

[HOTT-720](https://transformuk.atlassian.net/jira/software/projects/HOTT/boards/96?selectedIssue=HOTT-720)

### What?

I have added/removed/altered:

- [x] Changed the log level in Dev - this enables SQL query logging and will help surface N+1 queries
- [x] Fixed an N+1 on `/api/v2/geographical_areas/countries` - see `CachedGeograpicalAreaService`
- [x] Fixed an N+1 for `FootnoteDescription`'s on `/api/v2/commodities`


### Why?

I am doing this because:

- We were generating a lot of N+1 queries on the `/commodities/:id` endpoint on the frontend - this is a common end point and this code path will be used frequently
