### PR TITLE
Handle units that belong to measure condition components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,12 +279,12 @@ workflows:
     jobs:
       - linters:
           context: trade-tariff
-      - test:
-           context: trade-tariff
-           filters:
-             branches:
-               ignore:
-                 - master
+      # - test:
+      #      context: trade-tariff
+      #      filters:
+      #        branches:
+      #          ignore:
+      #            - master
       - deploy_dev:
            matrix:
              parameters:
@@ -296,8 +296,8 @@ workflows:
              branches:
                ignore:
                  - master
-           requires:
-             - test
+           # requires:
+           #   - test
       - deploy_staging:
            matrix:
              parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,12 +279,12 @@ workflows:
     jobs:
       - linters:
           context: trade-tariff
-      # - test:
-      #      context: trade-tariff
-      #      filters:
-      #        branches:
-      #          ignore:
-      #            - master
+      - test:
+           context: trade-tariff
+           filters:
+             branches:
+               ignore:
+                 - master
       - deploy_dev:
            matrix:
              parameters:
@@ -296,8 +296,8 @@ workflows:
              branches:
                ignore:
                  - master
-           # requires:
-           #   - test
+           requires:
+             - test
       - deploy_staging:
            matrix:
              parameters:

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -467,15 +467,9 @@ class Measure < Sequel::Model
 
   def condition_units
     measure_conditions.each_with_object([]) do |condition, acc|
-      next unless condition.condition_measurement_unit_code
+      next unless condition.expresses_unit?
 
-      unit = {
-        measure_sid: measure_sid,
-        measurement_unit_code: condition.condition_measurement_unit_code,
-        measurement_unit_qualifier_code: condition.condition_measurement_unit_qualifier_code,
-      }
-
-      acc << unit
+      acc.concat(condition.units)
     end
   end
 end

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -72,7 +72,7 @@ class MeasureCondition < Sequel::Model
     measure_condition_components.map { |mcc| mcc.pk.join('-') }
   end
 
-  # TODO presenter?
+  # TODO: presenter?
   def requirement
     case requirement_type
     when :document
@@ -90,7 +90,7 @@ class MeasureCondition < Sequel::Model
       measurement_unit: measurement_unit,
       formatted_measurement_unit_qualifier: formatted_measurement_unit_qualifier,
       currency: TradeTariffBackend.currency,
-      formatted: true
+      formatted: true,
     )
   end
 
@@ -120,5 +120,25 @@ class MeasureCondition < Sequel::Model
 
   def entry_price_system?
     condition_code == MeasureConditionCode::ENTRY_PRICE_SYSTEM_CODE
+  end
+
+  def expresses_unit?
+    condition_measurement_unit_code || measure_condition_components.any?(&:expresses_unit?)
+  end
+
+  def units
+    if condition_measurement_unit_code
+      [
+        {
+          measure_sid: measure_sid,
+          measurement_unit_code: condition_measurement_unit_code,
+          measurement_unit_qualifier_code: condition_measurement_unit_qualifier_code,
+        },
+      ]
+    else
+      measure_condition_components.map do |measure_condition_component|
+        measure_condition_component.unit(measure_sid: measure_sid)
+      end
+    end
   end
 end

--- a/app/models/measure_condition_component.rb
+++ b/app/models/measure_condition_component.rb
@@ -53,4 +53,16 @@ class MeasureConditionComponent < Sequel::Model
       excise: measure_condition.measure.excise?,
     )
   end
+
+  def expresses_unit?
+    measurement_unit_code
+  end
+
+  def unit(measure_sid:)
+    {
+      measure_sid: measure_sid,
+      measurement_unit_code: measurement_unit_code,
+      measurement_unit_qualifier_code: measurement_unit_qualifier_code,
+    }
+  end
 end

--- a/spec/factories/measure_condition_factory.rb
+++ b/spec/factories/measure_condition_factory.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :measure_condition do
     transient do
       measurement_unit_code {}
+      measurement_unit_qualifier_code {}
     end
 
     measure_condition_sid { generate(:measure_condition_sid) }
@@ -25,6 +26,7 @@ FactoryBot.define do
         :measure_condition_component,
         measure_condition_sid: measure_condition.measure_condition_sid,
         measurement_unit_code: evaluator.measurement_unit_code,
+        measurement_unit_qualifier_code: evaluator.measurement_unit_qualifier_code,
       )
 
       measure_condition.reload

--- a/spec/factories/measure_condition_factory.rb
+++ b/spec/factories/measure_condition_factory.rb
@@ -1,0 +1,33 @@
+FactoryBot.define do
+  sequence(:measure_condition_sid) { |n| n }
+
+  factory :measure_condition do
+    transient do
+      measurement_unit_code {}
+    end
+
+    measure_condition_sid { generate(:measure_condition_sid) }
+    measure_sid { generate(:measure_sid) }
+    condition_code { Forgery(:basic).text(exactly: 2) }
+    component_sequence_number { Forgery(:basic).number }
+    condition_duty_amount { Forgery(:basic).number }
+    condition_monetary_unit_code { Forgery(:basic).text(exactly: 3) }
+    condition_measurement_unit_code { Forgery(:basic).text(exactly: 3) }
+    sequence(:condition_measurement_unit_qualifier_code, LoopingSequence.lower_a_to_upper_z, &:value)
+    sequence(:action_code, LoopingSequence.lower_a_to_upper_z, &:value)
+    sequence(:certificate_type_code, LoopingSequence.lower_a_to_upper_z, &:value)
+    certificate_code { Forgery(:basic).text(exactly: 3) }
+  end
+
+  trait :with_measure_condition_components do
+    after(:create) do |measure_condition, evaluator|
+      create(
+        :measure_condition_component,
+        measure_condition_sid: measure_condition.measure_condition_sid,
+        measurement_unit_code: evaluator.measurement_unit_code,
+      )
+
+      measure_condition.reload
+    end
+  end
+end

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   sequence(:measure_sid) { |n| n }
   sequence(:measure_type_id) { |n| n }
-  sequence(:measure_condition_sid) { |n| n }
 
   factory :measure do |f|
     transient do
@@ -117,7 +116,7 @@ FactoryBot.define do
 
     trait :with_measure_components do
       after(:build) do |measure, evaluator|
-        FactoryBot.create_list(
+        create_list(
           :measure_component,
           evaluator.measure_components_count,
           measure_sid: measure.measure_sid,
@@ -132,14 +131,14 @@ FactoryBot.define do
 
     trait :with_measure_conditions do
       after(:build) do |measure, evaluator|
-        condition = FactoryBot.create(
+        condition = create(
           :measure_condition,
           measure_sid: measure.measure_sid,
           condition_measurement_unit_code: evaluator.measurement_unit_code,
           condition_measurement_unit_qualifier_code: evaluator.measurement_unit_qualifier_code,
         )
 
-        FactoryBot.create(
+        create(
           :measure_condition_component,
           measure_condition_sid: condition.measure_condition_sid,
           duty_amount: evaluator.duty_amount,
@@ -155,7 +154,7 @@ FactoryBot.define do
       measure_generating_regulation_role { 4 }
 
       after(:build) do |measure, _evaluator|
-        FactoryBot.create(:modification_regulation, modification_regulation_id: measure.measure_generating_regulation_id)
+        create(:modification_regulation, modification_regulation_id: measure.measure_generating_regulation_id)
       end
     end
 
@@ -163,8 +162,8 @@ FactoryBot.define do
       measure_generating_regulation_role { 4 }
 
       after(:build) do |measure, _evaluator|
-        base_regulation = FactoryBot.create(:base_regulation, :abrogated)
-        FactoryBot.create(:modification_regulation,
+        base_regulation = create(:base_regulation, :abrogated)
+        create(:modification_regulation,
                           modification_regulation_id: measure.measure_generating_regulation_id,
                           modification_regulation_role: measure.measure_generating_regulation_role,
                           base_regulation_id: base_regulation.base_regulation_id,
@@ -183,7 +182,7 @@ FactoryBot.define do
       end
 
       after(:build) do |measure, evaluator|
-        adco = FactoryBot.create(
+        adco = create(
           :additional_code,
           :with_description,
           additional_code_type_id: measure.additional_code_type_id,
@@ -199,20 +198,20 @@ FactoryBot.define do
 
     trait :with_additional_code_type do
       after(:build) do |measure, _evaluator|
-        FactoryBot.create(:additional_code_type, additional_code_type_id: measure.additional_code_type_id)
+        create(:additional_code_type, additional_code_type_id: measure.additional_code_type_id)
       end
     end
 
     trait :with_related_additional_code_type do
       after(:build) do |measure, _evaluator|
-        FactoryBot.create(:additional_code_type_measure_type, additional_code_type_id: measure.additional_code_type_id,
+        create(:additional_code_type_measure_type, additional_code_type_id: measure.additional_code_type_id,
                                                               measure_type_id: measure.measure_type_id)
       end
     end
 
     trait :with_quota_order_number do
       after(:build) do |measure, _evaluator|
-        FactoryBot.create(:quota_order_number, quota_order_number_id: measure.ordernumber)
+        create(:quota_order_number, quota_order_number_id: measure.ordernumber)
       end
     end
   end
@@ -251,11 +250,11 @@ FactoryBot.define do
     end
 
     after(:build) do |measure_type, _evaluator|
-      FactoryBot.create(:measure_type_series, measure_type_series_id: measure_type.measure_type_series_id)
+      create(:measure_type_series, measure_type_series_id: measure_type.measure_type_series_id)
     end
 
     after(:build) do |measure_type, evaluator|
-      FactoryBot.create(
+      create(
         :measure_type_description,
         measure_type_id: measure_type.measure_type_id,
         description: evaluator.measure_type_description,
@@ -266,19 +265,5 @@ FactoryBot.define do
   factory :measure_type_description do
     measure_type_id { generate(:measure_type_id) }
     description { Forgery(:basic).text }
-  end
-
-  factory :measure_condition do
-    measure_condition_sid { generate(:measure_condition_sid) }
-    measure_sid { generate(:measure_sid) }
-    condition_code { Forgery(:basic).text(exactly: 2) }
-    component_sequence_number { Forgery(:basic).number }
-    condition_duty_amount { Forgery(:basic).number }
-    condition_monetary_unit_code { Forgery(:basic).text(exactly: 3) }
-    condition_measurement_unit_code { Forgery(:basic).text(exactly: 3) }
-    sequence(:condition_measurement_unit_qualifier_code, LoopingSequence.lower_a_to_upper_z, &:value)
-    sequence(:action_code, LoopingSequence.lower_a_to_upper_z, &:value)
-    sequence(:certificate_type_code, LoopingSequence.lower_a_to_upper_z, &:value)
-    certificate_code { Forgery(:basic).text(exactly: 3) }
   end
 end

--- a/spec/models/measure_condition_component_spec.rb
+++ b/spec/models/measure_condition_component_spec.rb
@@ -40,4 +40,20 @@ describe MeasureConditionComponent do
       it { is_expected.not_to be_ad_valorem }
     end
   end
+
+  describe '#expresses_unit?' do
+    subject(:measure_condition_component) { build(:measure_condition_component, measurement_unit_code: measurement_unit_code) }
+
+    context 'when the measure condition component specifies a measurement unit code' do
+      let(:measurement_unit_code) { 'TNE' }
+
+      it { is_expected.to be_expresses_unit }
+    end
+
+    context 'when the measure condition component does not specify a measurement unit code' do
+      let(:measurement_unit_code) { nil }
+
+      it { is_expected.not_to be_expresses_unit }
+    end
+  end
 end

--- a/spec/models/measure_condition_component_spec.rb
+++ b/spec/models/measure_condition_component_spec.rb
@@ -56,4 +56,26 @@ describe MeasureConditionComponent do
       it { is_expected.not_to be_expresses_unit }
     end
   end
+
+  describe '#unit' do
+    subject(:measure_condition_component) do
+      build(
+        :measure_condition_component,
+        measurement_unit_code: 'TNE',
+        measurement_unit_qualifier_code: 'I',
+      )
+    end
+
+    let(:measure_sid) { 'foo' }
+
+    it 'returns the properly formatted unit' do
+      actual = measure_condition_component.unit(measure_sid: measure_sid)
+
+      expect(actual).to eq(
+        measure_sid: 'foo',
+        measurement_unit_code: 'TNE',
+        measurement_unit_qualifier_code: 'I',
+      )
+    end
+  end
 end

--- a/spec/models/measure_condition_spec.rb
+++ b/spec/models/measure_condition_spec.rb
@@ -212,4 +212,54 @@ describe MeasureCondition do
       it { is_expected.not_to be_entry_price_system }
     end
   end
+
+  describe '#expresses_unit?' do
+    context 'when the measure condition has a condition measurement unit code' do
+      subject(:measure_condition) do
+        create(
+          :measure_condition,
+          condition_measurement_unit_code: 'TNE',
+        )
+      end
+
+      it { is_expected.to be_expresses_unit }
+    end
+
+    context 'when the measure condition has no condition measurement unit code' do
+      subject(:measure_condition) do
+        create(
+          :measure_condition,
+          condition_measurement_unit_code: nil,
+        )
+      end
+
+      it { is_expected.not_to be_expresses_unit }
+    end
+
+    context 'when the measure condition has measure condition components that express units' do
+      subject(:measure_condition) do
+        create(
+          :measure_condition,
+          :with_measure_condition_components,
+          condition_measurement_unit_code: nil,
+          measurement_unit_code: 'TNE',
+        )
+      end
+
+      it { is_expected.to be_expresses_unit }
+    end
+
+    context 'when the measure condition has measure condition components that do not express units' do
+      subject(:measure_condition) do
+        create(
+          :measure_condition,
+          :with_measure_condition_components,
+          condition_measurement_unit_code: nil,
+          measurement_unit_code: nil,
+        )
+      end
+
+      it { is_expected.not_to be_expresses_unit }
+    end
+  end
 end

--- a/spec/models/measure_condition_spec.rb
+++ b/spec/models/measure_condition_spec.rb
@@ -262,4 +262,52 @@ describe MeasureCondition do
       it { is_expected.not_to be_expresses_unit }
     end
   end
+
+  describe '#units' do
+    context 'when the condition defines the unit' do
+      subject(:measure_condition) do
+        build(
+          :measure_condition,
+          condition_measurement_unit_code: 'TNE',
+          condition_measurement_unit_qualifier_code: 'I',
+        )
+      end
+
+      it 'returns the properly formatted unit' do
+        expect(measure_condition.units).to eq(
+          [
+            {
+              measure_sid: measure_condition.measure_sid,
+              measurement_unit_code: 'TNE',
+              measurement_unit_qualifier_code: 'I',
+            },
+          ],
+        )
+      end
+    end
+
+    context 'when the condition component defines the unit' do
+      subject(:measure_condition) do
+        create(
+          :measure_condition,
+          :with_measure_condition_components,
+          condition_measurement_unit_code: nil,
+          measurement_unit_code: 'TNE',
+          measurement_unit_qualifier_code: 'R',
+        )
+      end
+
+      it 'returns the properly formatted unit' do
+        expect(measure_condition.units).to eq(
+          [
+            {
+              measure_sid: measure_condition.measure_sid,
+              measurement_unit_code: 'TNE',
+              measurement_unit_qualifier_code: 'R',
+            },
+          ],
+        )
+      end
+    end
+  end
 end

--- a/spec/models/measure_type_spec.rb
+++ b/spec/models/measure_type_spec.rb
@@ -99,7 +99,7 @@ describe MeasureType do
   end
 
   describe '#expresses_unit?' do
-    shared_examples "an expressable measure" do |type_series_id|
+    shared_examples 'an expressable measure' do |type_series_id|
       context "when measure_type has measure_type_series_id of #{type_series_id}" do
         let(:measure_type) { build :measure_type, measure_type_series_id: type_series_id }
 
@@ -109,10 +109,10 @@ describe MeasureType do
       end
     end
 
-    it_behaves_like "an expressable measure", "C"
-    it_behaves_like "an expressable measure", "D"
-    it_behaves_like "an expressable measure", "J"
-    it_behaves_like "an expressable measure", "Q"
+    it_behaves_like 'an expressable measure', 'C'
+    it_behaves_like 'an expressable measure', 'D'
+    it_behaves_like 'an expressable measure', 'J'
+    it_behaves_like 'an expressable measure', 'Q'
 
     context 'when measure_type has measure_type_series_id that does not express units' do
       let(:measure_type) { build :measure_type, measure_type_series_id: 'X' }


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Units can come from either the measure conditions or the measure
condition components

### Why?

I am doing this because:

- This is needed when generating duty calculations against measure condition components
