### PR TITLE
Fix n + 1 issue due to inverse load of measure via the measure condition

### DIFF
--- a/app/formatters/duty_expression_formatter.rb
+++ b/app/formatters/duty_expression_formatter.rb
@@ -5,7 +5,7 @@ class DutyExpressionFormatter
         float,
         minimum_decimal_points: 2,
         precision: 4,
-        strip_insignificant_zeros: true
+        strip_insignificant_zeros: true,
       )
     end
 
@@ -19,22 +19,6 @@ class DutyExpressionFormatter
       measurement_unit_qualifier = opts[:measurement_unit_qualifier]
       measurement_unit_abbreviation = measurement_unit.try :abbreviation,
                                                            measurement_unit_qualifier: measurement_unit_qualifier
-      if TradeTariffBackend.currency_conversion_enabled?
-        currency = opts[:currency] || TradeTariffBackend.currency
-        excise = opts[:excise]
-
-        if !excise && duty_amount.present? && currency.present? && monetary_unit.present? && monetary_unit != currency
-          period = MonetaryExchangePeriod.actual.last(parent_monetary_unit_code: 'EUR')
-          if period.present?
-            rate = MonetaryExchangeRate.last(monetary_exchange_period_sid: period.monetary_exchange_period_sid, child_monetary_unit_code: monetary_unit == 'EUR' ? currency : monetary_unit)
-            if rate.present?
-              duty_amount = (monetary_unit == 'EUR' ? (rate.exchange_rate * duty_amount.to_d).to_f : (duty_amount.to_d / rate.exchange_rate).to_f).round(2)
-              monetary_unit = currency
-            end
-          end
-        end
-      end
-
       output = []
       case duty_expression_id
       when '99'
@@ -62,11 +46,7 @@ class DutyExpressionFormatter
                       prettify(duty_amount).to_s
                     end
         end
-        output << if monetary_unit.present?
-                    monetary_unit
-                  else
-                    '%'
-                  end
+        output << monetary_unit.presence || '%'
         if measurement_unit_abbreviation.present?
           output << if opts[:formatted]
                       "/ <abbr title='#{measurement_unit.description}'>#{measurement_unit_abbreviation}</abbr>"

--- a/app/formatters/duty_expression_formatter.rb
+++ b/app/formatters/duty_expression_formatter.rb
@@ -46,7 +46,11 @@ class DutyExpressionFormatter
                       prettify(duty_amount).to_s
                     end
         end
-        output << monetary_unit.presence || '%'
+        output << if monetary_unit.present?
+                    monetary_unit
+                  else
+                    '%'
+                  end
         if measurement_unit_abbreviation.present?
           output << if opts[:formatted]
                       "/ <abbr title='#{measurement_unit.description}'>#{measurement_unit_abbreviation}</abbr>"

--- a/app/formatters/requirement_duty_expression_formatter.rb
+++ b/app/formatters/requirement_duty_expression_formatter.rb
@@ -5,7 +5,7 @@ class RequirementDutyExpressionFormatter
         float,
         precision: 4,
         minimum_decimal_points: 2,
-        strip_insignificant_zeros: true
+        strip_insignificant_zeros: true,
       )
     end
 
@@ -16,24 +16,6 @@ class RequirementDutyExpressionFormatter
       measurement_unit_qualifier = opts[:formatted_measurement_unit_qualifier]
       measurement_unit_abbreviation = measurement_unit.try :abbreviation,
                                                            measurement_unit_qualifier: measurement_unit_qualifier
-
-      if TradeTariffBackend.currency_conversion_enabled?
-        currency = opts[:currency] || TradeTariffBackend.currency
-
-        old_duty_amount = duty_amount
-        old_monetary_unit = monetary_unit
-
-        if duty_amount.present? && currency.present? && monetary_unit.present? && monetary_unit != currency
-          period = MonetaryExchangePeriod.actual.last(parent_monetary_unit_code: 'EUR')
-          if period.present?
-            rate = MonetaryExchangeRate.last(monetary_exchange_period_sid: period.monetary_exchange_period_sid, child_monetary_unit_code: monetary_unit == 'EUR' ? currency : monetary_unit)
-            if rate.present?
-              duty_amount = (monetary_unit == 'EUR' ? (rate.exchange_rate * duty_amount.to_d).to_f : (duty_amount.to_d / rate.exchange_rate).to_f).round(2)
-              monetary_unit = currency
-            end
-          end
-        end
-      end
 
       output = []
 

--- a/app/models/measure_component.rb
+++ b/app/models/measure_component.rb
@@ -72,7 +72,6 @@ class MeasureComponent < Sequel::Model
       measurement_unit: measurement_unit,
       measurement_unit_qualifier: measurement_unit_qualifier,
       currency: TradeTariffBackend.currency,
-      excise: measure.excise?,
     }
   end
 end

--- a/app/models/measure_condition_component.rb
+++ b/app/models/measure_condition_component.rb
@@ -50,7 +50,6 @@ class MeasureConditionComponent < Sequel::Model
       measurement_unit_qualifier: measurement_unit_qualifier,
       currency: TradeTariffBackend.currency,
       formatted: true,
-      excise: measure_condition.measure.excise?,
     )
   end
 end

--- a/lib/trade_tariff_backend.rb
+++ b/lib/trade_tariff_backend.rb
@@ -71,10 +71,6 @@ module TradeTariffBackend
       SERVICE_CURRENCIES.fetch(service, 'GBP')
     end
 
-    def currency_conversion_enabled?
-      ENV.fetch('CURRENCY_CONVERSION_ENABLED', 'false') == 'true'
-    end
-
     def data_migration_path
       File.join(Rails.root, 'db', 'data_migrations')
     end

--- a/spec/formatters/duty_expression_formatter_spec.rb
+++ b/spec/formatters/duty_expression_formatter_spec.rb
@@ -15,11 +15,6 @@ describe DutyExpressionFormatter do
     let!(:measurement_unit_qualifier) do
       create(:measurement_unit_qualifier, measurement_unit_qualifier_code: measurement_unit_abbreviation.measurement_unit_qualifier)
     end
-    let(:currency_conversion_enabled) { true }
-
-    before do
-      allow(TradeTariffBackend).to receive(:currency_conversion_enabled?).and_return(currency_conversion_enabled)
-    end
 
     context 'for excise measure' do
       it 'does not fetch exchange rates' do
@@ -105,22 +100,6 @@ describe DutyExpressionFormatter do
                                    duty_expression_description: 'abc',
                                    monetary_unit: 'EUR'),
           ).to match(/EUR/)
-        end
-
-        context 'when currency conversion is disabled' do
-          let(:currency_conversion_enabled) { false }
-
-          it 'does not check the currency' do
-            allow(TradeTariffBackend).to receive(:currency)
-
-            described_class.format(
-              duty_expression_id: '15',
-              duty_expression_description: 'abc',
-              monetary_unit: 'EUR',
-            )
-
-            expect(TradeTariffBackend).not_to have_received(:currency)
-          end
         end
       end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-879

### What?

I have added/removed/altered:

- [x] Fixes inverse load n + 1 issue where the measure condition component was loading the measure condition and the measure to pull out the measure type over and over just to avoid doing currency conversion on excise measure types.
- [x] Removed unused/disabled currency conversion feature from the DutyExpressionFormatter

### Why?

I am doing this because:

- The currency conversion feature isn't being used.
- The n + 1 inverse load was creating a ton of SQL queries that are slowing down calls to the commodity api
