### PR TITLE
HOTT-866 extend legal act node

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,12 @@ Metrics/BlockLength:
   Enabled: false
 Metrics/ModuleLength:
   Enabled: false
+RSpec/ContextWording:
+  Prefixes:
+    - when
+    - with
+    - without
+    - for
 RSpec/ExampleLength:
   Enabled: false
 RSpec/NestedGroups:

--- a/app/presenters/api/v2/measures/measure_legal_act_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_legal_act_presenter.rb
@@ -3,6 +3,7 @@ module Api
     module Measures
       class MeasureLegalActPresenter < SimpleDelegator
         attr_reader :regulation, :measure
+
         delegate :regulation_url, :regulation_code, :description,
                  to: :uk_regulation_data, prefix: :uk
 
@@ -48,7 +49,7 @@ module Api
 
         def uk?
           TradeTariffBackend.uk? &&
-            regulation.officialjournal_number == "1" &&
+            regulation.officialjournal_number == '1' &&
             regulation.officialjournal_page == 1
         end
 

--- a/app/presenters/api/v2/measures/measure_legal_act_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_legal_act_presenter.rb
@@ -3,10 +3,17 @@ module Api
     module Measures
       class MeasureLegalActPresenter < SimpleDelegator
         alias_method :regulation, :__getobj__
+        attr_reader :measure
         delegate :regulation_url, :regulation_code, :description,
                  to: :uk_regulation_data, prefix: :uk
 
         EXCLUDED_REGULATION_IDS = %w[IYY99990].freeze
+        EXCLUDED_MEASURE_TYPE_IDS = %w[305 306].freeze
+
+        def initialize(regulation, measure)
+          @measure = measure
+          super(regulation)
+        end
 
         def published_date
           regulation&.published_date
@@ -39,11 +46,15 @@ module Api
         end
 
         def show_reduced_info?
-          excluded_regulation?
+          excluded_regulation? || excluded_measure?
         end
 
         def excluded_regulation?
           EXCLUDED_REGULATION_IDS.include? regulation.regulation_id
+        end
+
+        def excluded_measure?
+          EXCLUDED_MEASURE_TYPE_IDS.include? measure.measure_type_id
         end
 
         def eu_regulation_code

--- a/app/presenters/api/v2/measures/measure_legal_act_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_legal_act_presenter.rb
@@ -23,18 +23,24 @@ module Api
           return '' if show_reduced_info?
 
           uk? ? uk_regulation_code : eu_regulation_code
+        rescue UkRegulationParser::InvalidUkRegulationText
+          eu_regulation_code
         end
 
         def regulation_url
           return '' if show_reduced_info?
 
           uk? ? uk_regulation_url : eu_regulation_url
+        rescue UkRegulationParser::InvalidUkRegulationText
+          ''
         end
 
         def description
           return nil if show_reduced_info?
 
           uk? ? uk_description : information_text
+        rescue UkRegulationParser::InvalidUkRegulationText
+          nil
         end
 
       private

--- a/app/presenters/api/v2/measures/measure_legal_act_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_legal_act_presenter.rb
@@ -4,20 +4,32 @@ module Api
       class MeasureLegalActPresenter < SimpleDelegator
         alias_method :regulation, :__getobj__
 
+        EXCLUDED_REGULATION_IDS = %w[IYY99990].freeze
+
         def published_date
           regulation&.published_date
         end
 
         def regulation_code
-          ApplicationHelper.regulation_code(regulation)
+          show_full_info? ? ApplicationHelper.regulation_code(regulation) : ''
         end
 
         def regulation_url
-          ApplicationHelper.regulation_url(regulation)
+          show_full_info? ? ApplicationHelper.regulation_url(regulation) : ''
         end
 
         def description
-          information_text
+          show_full_info? ? information_text : nil
+        end
+
+      private
+
+        def show_full_info?
+          !excluded_regulation?
+        end
+
+        def excluded_regulation?
+          EXCLUDED_REGULATION_IDS.include? regulation.regulation_id
         end
       end
     end

--- a/app/presenters/api/v2/measures/measure_legal_act_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_legal_act_presenter.rb
@@ -1,0 +1,25 @@
+module Api
+  module V2
+    module Measures
+      class MeasureLegalActPresenter < SimpleDelegator
+        alias_method :regulation, :__getobj__
+
+        def published_date
+          regulation&.published_date
+        end
+
+        def regulation_code
+          ApplicationHelper.regulation_code(regulation)
+        end
+
+        def regulation_url
+          ApplicationHelper.regulation_url(regulation)
+        end
+
+        def description
+          information_text
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/api/v2/measures/measure_legal_act_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_legal_act_presenter.rb
@@ -2,8 +2,7 @@ module Api
   module V2
     module Measures
       class MeasureLegalActPresenter < SimpleDelegator
-        alias_method :regulation, :__getobj__
-        attr_reader :measure
+        attr_reader :regulation, :measure
         delegate :regulation_url, :regulation_code, :description,
                  to: :uk_regulation_data, prefix: :uk
 
@@ -11,7 +10,9 @@ module Api
         EXCLUDED_MEASURE_TYPE_IDS = %w[305 306].freeze
 
         def initialize(regulation, measure)
+          @regulation = regulation
           @measure = measure
+
           super(regulation)
         end
 

--- a/app/presenters/api/v2/measures/measure_legal_act_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_legal_act_presenter.rb
@@ -3,9 +3,8 @@ module Api
     module Measures
       class MeasureLegalActPresenter < SimpleDelegator
         alias_method :regulation, :__getobj__
-        delegate :uk?, to: TradeTariffBackend
         delegate :regulation_url, :regulation_code, :description,
-                 to: :uk_regulation, prefix: :uk
+                 to: :uk_regulation_data, prefix: :uk
 
         EXCLUDED_REGULATION_IDS = %w[IYY99990].freeze
 
@@ -16,13 +15,13 @@ module Api
         def regulation_code
           return '' if show_reduced_info?
 
-          uk? ? uk_regulation_code : xi_regulation_code
+          uk? ? uk_regulation_code : eu_regulation_code
         end
 
         def regulation_url
           return '' if show_reduced_info?
 
-          uk? ? uk_regulation_url : xi_regulation_url
+          uk? ? uk_regulation_url : eu_regulation_url
         end
 
         def description
@@ -33,6 +32,12 @@ module Api
 
       private
 
+        def uk?
+          TradeTariffBackend.uk? &&
+            regulation.officialjournal_number == "1" &&
+            regulation.officialjournal_page == 1
+        end
+
         def show_reduced_info?
           excluded_regulation?
         end
@@ -41,16 +46,16 @@ module Api
           EXCLUDED_REGULATION_IDS.include? regulation.regulation_id
         end
 
-        def xi_regulation_code
+        def eu_regulation_code
           ApplicationHelper.regulation_code(regulation)
         end
 
-        def xi_regulation_url
+        def eu_regulation_url
           ApplicationHelper.regulation_url(regulation)
         end
 
-        def uk_regulation
-          @uk_regulation ||= UkRegulationParser.new(regulation.information_text)
+        def uk_regulation_data
+          @uk_regulation_data ||= UkRegulationParser.new(regulation.information_text)
         end
       end
     end

--- a/app/presenters/api/v2/measures/measure_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_presenter.rb
@@ -68,7 +68,9 @@ module Api
         end
 
         def legal_acts
-          measure.legal_acts.map(&Api::V2::Measures::MeasureLegalActPresenter.method(:new))
+          measure.legal_acts.map do |legal_act|
+            Api::V2::Measures::MeasureLegalActPresenter.new legal_act, @measure
+          end
         end
 
         def order_number_id

--- a/app/presenters/api/v2/measures/measure_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_presenter.rb
@@ -67,6 +67,10 @@ module Api
           measure.legal_acts.map(&:regulation_id)
         end
 
+        def legal_acts
+          measure.legal_acts.map(&Api::V2::Measures::MeasureLegalActPresenter.method(:new))
+        end
+
         def order_number_id
           measure.order_number&.quota_order_number_id
         end

--- a/app/presenters/api/v2/measures/measure_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_presenter.rb
@@ -4,6 +4,9 @@ module Api
       class MeasurePresenter < SimpleDelegator
         attr_reader :measure, :duty_expression, :geographical_areas, :national_measurement_units
 
+        delegate :id, to: :duty_expression, prefix: true
+        delegate :geographical_area, :geographical_area_id, to: :measure
+
         def initialize(measure, declarable, geographical_areas = [])
           super(measure)
           @measure = measure
@@ -21,18 +24,6 @@ module Api
 
         def vat
           measure.vat?
-        end
-
-        def duty_expression_id
-          duty_expression.id
-        end
-
-        def geographical_area
-          measure.geographical_area
-        end
-
-        def geographical_area_id
-          measure.geographical_area_id
         end
 
         def additional_code

--- a/app/serializers/api/v2/measures/measure_legal_act_serializer.rb
+++ b/app/serializers/api/v2/measures/measure_legal_act_serializer.rb
@@ -9,23 +9,8 @@ module Api
         set_id :regulation_id
 
         attributes :validity_start_date, :validity_end_date, :officialjournal_number,
-                   :officialjournal_page
-
-        attribute :published_date do |regulation|
-          regulation.try(:published_date)
-        end
-        
-        attribute :regulation_code do |regulation|
-          ApplicationHelper.regulation_code(regulation)
-        end
-
-        attribute :regulation_url do |regulation|
-          ApplicationHelper.regulation_url(regulation)
-        end
-
-        attribute :description do |regulation|
-          regulation.information_text
-        end
+                   :officialjournal_page, :published_date, :regulation_code,
+                   :regulation_url, :description
       end
     end
   end

--- a/app/serializers/api/v2/measures/measure_legal_act_serializer.rb
+++ b/app/serializers/api/v2/measures/measure_legal_act_serializer.rb
@@ -22,6 +22,10 @@ module Api
         attribute :regulation_url do |regulation|
           ApplicationHelper.regulation_url(regulation)
         end
+
+        attribute :description do |regulation|
+          regulation.information_text
+        end
       end
     end
   end

--- a/lib/uk_regulation_parser.rb
+++ b/lib/uk_regulation_parser.rb
@@ -1,0 +1,25 @@
+class UkRegulationParser
+  DELIMITER = "\xC2\xA0".freeze
+
+  def initialize(information_text)
+    @original_text = information_text
+  end
+
+  def regulation_code
+    parsed[1]
+  end
+
+  def regulation_url
+    parsed[2]
+  end
+
+  def description
+    parsed[0]
+  end
+
+private
+
+  def parsed
+    @parsed ||= @original_text.split(DELIMITER)
+  end
+end

--- a/lib/uk_regulation_parser.rb
+++ b/lib/uk_regulation_parser.rb
@@ -7,13 +7,13 @@ class UkRegulationParser
     @description, @regulation_code, @regulation_url = parse_information_text
   end
 
-  class NonUkRegulationText < ::RuntimeError; end
+  class InvalidUkRegulationText < ::RuntimeError; end
 
 private
 
   def parse_information_text
     @original_text&.split(DELIMITER).tap do |parts|
-      raise NonUkRegulationText unless parts&.length == 3
+      raise InvalidUkRegulationText unless parts&.length == 3
     end
   end
 end

--- a/lib/uk_regulation_parser.rb
+++ b/lib/uk_regulation_parser.rb
@@ -1,25 +1,19 @@
 class UkRegulationParser
   DELIMITER = "\xC2\xA0".freeze
+  attr_reader :regulation_code, :regulation_url, :description
 
   def initialize(information_text)
     @original_text = information_text
+    @description, @regulation_code, @regulation_url = parse_information_text
   end
 
-  def regulation_code
-    parsed[1]
-  end
-
-  def regulation_url
-    parsed[2]
-  end
-
-  def description
-    parsed[0]
-  end
+  class NonUkRegulationText < ::RuntimeError; end
 
 private
 
-  def parsed
-    @parsed ||= @original_text.split(DELIMITER)
+  def parse_information_text
+    @original_text&.split(DELIMITER).tap do |parts|
+      raise NonUkRegulationText unless parts&.length == 3
+    end
   end
 end

--- a/spec/factories/base_regulation_factory.rb
+++ b/spec/factories/base_regulation_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     validity_start_date { Date.current.ago(3.years) }
     validity_end_date   { nil }
     effective_end_date  { nil }
-    information_text { "This is some explanatory information text" }
+    information_text { 'This is some explanatory information text' }
 
     trait :abrogated do
       after(:build) do |br, _evaluator|
@@ -17,7 +17,7 @@ FactoryBot.define do
     end
 
     trait :uk_concatenated_regulation do
-      officialjournal_number { "1" }
+      officialjournal_number { '1' }
       officialjournal_page { 1 }
 
       transient do

--- a/spec/factories/base_regulation_factory.rb
+++ b/spec/factories/base_regulation_factory.rb
@@ -17,6 +17,9 @@ FactoryBot.define do
     end
 
     trait :uk_concatenated_regulation do
+      officialjournal_number { "1" }
+      officialjournal_page { 1 }
+
       transient do
         uk_regulation_code { 'S.I. 2019/16' }
         uk_regulation_url { 'https://www.legislation.gov.uk/uksi/2019/16' }

--- a/spec/factories/base_regulation_factory.rb
+++ b/spec/factories/base_regulation_factory.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
         end
       end
 
-      information_text { [uk_description, uk_regulation_code, uk_regulation_url].join("\xC2\xA0") }
+      information_text { [uk_description, uk_regulation_code, uk_regulation_url].compact.join("\xC2\xA0") }
     end
   end
 end

--- a/spec/factories/base_regulation_factory.rb
+++ b/spec/factories/base_regulation_factory.rb
@@ -7,12 +7,25 @@ FactoryBot.define do
     validity_start_date { Date.current.ago(3.years) }
     validity_end_date   { nil }
     effective_end_date  { nil }
+    information_text { "This is some explanatory information text" }
 
     trait :abrogated do
       after(:build) do |br, _evaluator|
         FactoryBot.create(:complete_abrogation_regulation, complete_abrogation_regulation_id: br.base_regulation_id,
                                                            complete_abrogation_regulation_role: br.base_regulation_role)
       end
+    end
+
+    trait :uk_concatenated_regulation do
+      transient do
+        uk_regulation_code { 'S.I. 2019/16' }
+        uk_regulation_url { 'https://www.legislation.gov.uk/uksi/2019/16' }
+        uk_description do
+          'The Leghold Trap and Pelt Imports (Amendment etc.) (EU Exit) Regulations 2019'
+        end
+      end
+
+      information_text { [uk_description, uk_regulation_code, uk_regulation_url].join("\xC2\xA0") }
     end
   end
 end

--- a/spec/lib/uk_regulation_parser_spec.rb
+++ b/spec/lib/uk_regulation_parser_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe UkRegulationParser do
 
     it "should raise an exception" do
       expect { parser }.to \
-        raise_exception(UkRegulationParser::NonUkRegulationText)
+        raise_exception(described_class::InvalidUkRegulationText)
     end
   end
 
@@ -39,7 +39,7 @@ RSpec.describe UkRegulationParser do
 
     it "should raise an exception" do
       expect { parser }.to \
-        raise_exception(UkRegulationParser::NonUkRegulationText)
+        raise_exception(described_class::InvalidUkRegulationText)
     end
   end
 
@@ -48,7 +48,7 @@ RSpec.describe UkRegulationParser do
 
     it "should raise an exception" do
       expect { parser }.to \
-        raise_exception(UkRegulationParser::NonUkRegulationText)
+        raise_exception(described_class::InvalidUkRegulationText)
     end
   end
 end

--- a/spec/lib/uk_regulation_parser_spec.rb
+++ b/spec/lib/uk_regulation_parser_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe UkRegulationParser do
+  subject(:parser) { described_class.new(information_text) }
+
+  let(:information_text) do
+    "The Leghold Trap and Pelt Imports (Amendment etc.) (EU Exit) Regulations 2019\xC2\xA0S.I. 2019/16\xC2\xA0https://www.legislation.gov.uk/uksi/2019/16"
+  end
+
+  describe "#regulation_code" do
+    subject { parser.regulation_code }
+
+    it { is_expected.to eql('S.I. 2019/16') }
+  end
+
+  describe "#regulation_url" do
+    subject { parser.regulation_url }
+
+    it { is_expected.to eql('https://www.legislation.gov.uk/uksi/2019/16') }
+  end
+
+  describe "#description" do
+    subject { parser.description }
+
+    it { is_expected.to eql('The Leghold Trap and Pelt Imports (Amendment etc.) (EU Exit) Regulations 2019') }
+  end
+end

--- a/spec/lib/uk_regulation_parser_spec.rb
+++ b/spec/lib/uk_regulation_parser_spec.rb
@@ -24,4 +24,31 @@ RSpec.describe UkRegulationParser do
 
     it { is_expected.to eql('The Leghold Trap and Pelt Imports (Amendment etc.) (EU Exit) Regulations 2019') }
   end
+
+  context "with null text" do
+    let(:information_text) { nil }
+
+    it "should raise an exception" do
+      expect { parser }.to \
+        raise_exception(UkRegulationParser::NonUkRegulationText)
+    end
+  end
+
+  context "with incomplete text" do
+    let(:information_text) { "First\xC2\xA0Second" }
+
+    it "should raise an exception" do
+      expect { parser }.to \
+        raise_exception(UkRegulationParser::NonUkRegulationText)
+    end
+  end
+
+  context "with unexpected text format" do
+    let(:information_text) { "First\xC2\xA0Second\xC2\xA0Third\xC2\xA0Fourth" }
+
+    it "should raise an exception" do
+      expect { parser }.to \
+        raise_exception(UkRegulationParser::NonUkRegulationText)
+    end
+  end
 end

--- a/spec/lib/uk_regulation_parser_spec.rb
+++ b/spec/lib/uk_regulation_parser_spec.rb
@@ -7,46 +7,46 @@ RSpec.describe UkRegulationParser do
     "The Leghold Trap and Pelt Imports (Amendment etc.) (EU Exit) Regulations 2019\xC2\xA0S.I. 2019/16\xC2\xA0https://www.legislation.gov.uk/uksi/2019/16"
   end
 
-  describe "#regulation_code" do
+  describe '#regulation_code' do
     subject { parser.regulation_code }
 
     it { is_expected.to eql('S.I. 2019/16') }
   end
 
-  describe "#regulation_url" do
+  describe '#regulation_url' do
     subject { parser.regulation_url }
 
     it { is_expected.to eql('https://www.legislation.gov.uk/uksi/2019/16') }
   end
 
-  describe "#description" do
+  describe '#description' do
     subject { parser.description }
 
     it { is_expected.to eql('The Leghold Trap and Pelt Imports (Amendment etc.) (EU Exit) Regulations 2019') }
   end
 
-  context "with null text" do
+  context 'with null text' do
     let(:information_text) { nil }
 
-    it "should raise an exception" do
+    it 'will raise an exception' do
       expect { parser }.to \
         raise_exception(described_class::InvalidUkRegulationText)
     end
   end
 
-  context "with incomplete text" do
+  context 'with incomplete text' do
     let(:information_text) { "First\xC2\xA0Second" }
 
-    it "should raise an exception" do
+    it 'will raise an exception' do
       expect { parser }.to \
         raise_exception(described_class::InvalidUkRegulationText)
     end
   end
 
-  context "with unexpected text format" do
+  context 'with unexpected text format' do
     let(:information_text) { "First\xC2\xA0Second\xC2\xA0Third\xC2\xA0Fourth" }
 
-    it "should raise an exception" do
+    it 'will raise an exception' do
       expect { parser }.to \
         raise_exception(described_class::InvalidUkRegulationText)
     end

--- a/spec/presenters/api/v2/measures/measure_legal_act_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_legal_act_presenter_spec.rb
@@ -50,22 +50,44 @@ describe Api::V2::Measures::MeasureLegalActPresenter do
   context "for UK service" do
     before { allow(TradeTariffBackend).to receive(:service).and_return('uk') }
 
-    let(:regulation) { create(:base_regulation, :uk_concatenated_regulation) }
+    context "if before 01 Jan 2021" do
+      describe "#regulation_code" do
+        let(:formatted_regulation_code) { "14567/23" }
 
-    describe "#regulation_code" do
-      it { expect(presenter.regulation_code).to eql('S.I. 2019/16') }
+        it { expect(presenter.regulation_code).to eql(formatted_regulation_code) }
+      end
+
+      describe "regulation_url" do
+        let(:eu_regulation_url) { "http://eur-lex.europa.eu/search.html?" }
+
+        it { expect(presenter.regulation_url).to start_with(eu_regulation_url) }
+      end
+
+      describe "#description" do
+        it "should map to the regulations information text" do
+          expect(presenter.description).to eql(regulation.information_text)
+        end
+      end
     end
 
-    describe "#regulation_url" do
-      let(:uk_regulation_url) { 'https://www.legislation.gov.uk/uksi/2019/16' }
+    context "if after 01 Jan 2021" do
+      let(:regulation) { create(:base_regulation, :uk_concatenated_regulation) }
 
-      it { expect(presenter.regulation_url).to eql(uk_regulation_url) }
-    end
+      describe "#regulation_code" do
+        it { expect(presenter.regulation_code).to eql('S.I. 2019/16') }
+      end
 
-    describe "#description" do
-      let(:uk_description) { 'The Leghold Trap and Pelt Imports (Amendment etc.) (EU Exit) Regulations 2019' }
+      describe "#regulation_url" do
+        let(:uk_regulation_url) { 'https://www.legislation.gov.uk/uksi/2019/16' }
 
-      it { expect(presenter.description).to eql(uk_description) }
+        it { expect(presenter.regulation_url).to eql(uk_regulation_url) }
+      end
+
+      describe "#description" do
+        let(:uk_description) { 'The Leghold Trap and Pelt Imports (Amendment etc.) (EU Exit) Regulations 2019' }
+
+        it { expect(presenter.description).to eql(uk_description) }
+      end
     end
   end
 

--- a/spec/presenters/api/v2/measures/measure_legal_act_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_legal_act_presenter_spec.rb
@@ -6,128 +6,135 @@ describe Api::V2::Measures::MeasureLegalActPresenter do
   let(:regulation) { create(:base_regulation, base_regulation_id: '1234567') }
   let(:measure) { create(:measure) }
 
-  let(:eu_regulation_code) { '14567/23' }
-  let(:eu_regulation_url) { 'http://eur-lex.europa.eu/search.html?' }
-  let(:eu_description) { regulation.information_text }
-
-  let(:uk_regulation_code) { 'S.I. 2019/16' }
-  let(:uk_regulation_url) { 'https://www.legislation.gov.uk/uksi/2019/16' }
-  let(:uk_description) do
-    'The Leghold Trap and Pelt Imports (Amendment etc.) (EU Exit) Regulations 2019'
+  let(:eu_regulation) do
+    {
+      code: '14567/23',
+      url: 'http://eur-lex.europa.eu/search.html?',
+      description: regulation.information_text,
+    }
   end
 
-  describe "#regulation_id" do
-    it "should map to the models internal id" do
+  let(:uk_regulation) do
+    {
+      code: 'S.I. 2019/16',
+      url: 'https://www.legislation.gov.uk/uksi/2019/16',
+      description:
+        'The Leghold Trap and Pelt Imports (Amendment etc.) (EU Exit) Regulations 2019',
+    }
+  end
+
+  describe '#regulation_id' do
+    it 'maps to the models internal id' do
       expect(presenter.regulation_id).to eql(regulation.base_regulation_id)
     end
   end
 
-  describe "published_date" do
+  describe 'published_date' do
     subject { presenter.published_date }
 
-    context "without regulation present" do
+    context 'without regulation present' do
       let(:legal_act) { nil }
 
       it { is_expected.to be_nil }
     end
 
-    context "with legal act" do
+    context 'with legal act' do
       it { is_expected.to eql(regulation.published_date) }
     end
   end
 
-  context "for XI service" do
+  context 'for XI service' do
     before { allow(TradeTariffBackend).to receive(:service).and_return('xi') }
 
-    describe "#regulation_code" do
-      it { expect(presenter.regulation_code).to eql(eu_regulation_code) }
+    describe '#regulation_code' do
+      it { expect(presenter.regulation_code).to eql(eu_regulation[:code]) }
     end
 
-    describe "#regulation_url" do
-      it { expect(presenter.regulation_url).to start_with(eu_regulation_url) }
+    describe '#regulation_url' do
+      it { expect(presenter.regulation_url).to start_with(eu_regulation[:url]) }
     end
 
-    describe "#description" do
-      it { expect(presenter.description).to eql(eu_description) }
+    describe '#description' do
+      it { expect(presenter.description).to eql(eu_regulation[:description]) }
     end
   end
 
-  context "for UK service" do
+  context 'for UK service' do
     before { allow(TradeTariffBackend).to receive(:service).and_return('uk') }
 
-    context "if before 01 Jan 2021" do
-      describe "#regulation_code" do
-        it { expect(presenter.regulation_code).to eql(eu_regulation_code) }
+    context 'when before 01 Jan 2021' do
+      describe '#regulation_code' do
+        it { expect(presenter.regulation_code).to eql(eu_regulation[:code]) }
       end
 
-      describe "#regulation_url" do
-        it { expect(presenter.regulation_url).to start_with(eu_regulation_url) }
+      describe '#regulation_url' do
+        it { expect(presenter.regulation_url).to start_with(eu_regulation[:url]) }
       end
 
-      describe "#description" do
-        it { expect(presenter.description).to eql(eu_description) }
+      describe '#description' do
+        it { expect(presenter.description).to eql(eu_regulation[:description]) }
       end
     end
 
-    context "if after 01 Jan 2021" do
+    context 'when after 01 Jan 2021' do
       let(:regulation) { create(:base_regulation, :uk_concatenated_regulation) }
 
-      describe "#regulation_code" do
-        it { expect(presenter.regulation_code).to eql(uk_regulation_code) }
+      describe '#regulation_code' do
+        it { expect(presenter.regulation_code).to eql(uk_regulation[:code]) }
       end
 
-      describe "#regulation_url" do
-        it { expect(presenter.regulation_url).to eql(uk_regulation_url) }
+      describe '#regulation_url' do
+        it { expect(presenter.regulation_url).to eql(uk_regulation[:url]) }
       end
 
-      describe "#description" do
-        it { expect(presenter.description).to eql(uk_description) }
+      describe '#description' do
+        it { expect(presenter.description).to eql(uk_regulation[:description]) }
       end
     end
 
-    context "if after 01 Jan 2021 with null information_text field" do
+    context 'when after 01 Jan 2021 with null information_text field' do
       let(:regulation) do
         create(:base_regulation, :uk_concatenated_regulation,
-                                  base_regulation_id: "1234567",
-                                  information_text: nil)
+               base_regulation_id: '1234567',
+               information_text: nil)
       end
 
-      describe "#regulation_code" do
-        it { expect(presenter.regulation_code).to eql(eu_regulation_code) }
+      describe '#regulation_code' do
+        it { expect(presenter.regulation_code).to eql(eu_regulation[:code]) }
       end
 
-      describe "#regulation_url" do
-        it { expect(presenter.regulation_url).to eql("") }
+      describe '#regulation_url' do
+        it { expect(presenter.regulation_url).to eql('') }
       end
 
-      describe "#description" do
+      describe '#description' do
         it { expect(presenter.description).to be_nil }
       end
     end
 
-    context "if after 01 Jan 2021 with invalid information_text field" do
+    context 'when after 01 Jan 2021 with invalid information_text field' do
       let(:regulation) do
         create(:base_regulation, :uk_concatenated_regulation,
-                                  base_regulation_id: "1234567",
-                                  uk_regulation_code: nil )
+               base_regulation_id: '1234567',
+               uk_regulation_code: nil)
       end
 
-      describe "#regulation_code" do
-        it { expect(presenter.regulation_code).to eql(eu_regulation_code) }
+      describe '#regulation_code' do
+        it { expect(presenter.regulation_code).to eql(eu_regulation[:code]) }
       end
 
-      describe "#regulation_url" do
-        it { expect(presenter.regulation_url).to eql("") }
+      describe '#regulation_url' do
+        it { expect(presenter.regulation_url).to eql('') }
       end
 
-      describe "#description" do
+      describe '#description' do
         it { expect(presenter.description).to be_nil }
       end
     end
   end
 
-  context "when showing reduced information" do
-    context "with regulation id of IVY99990" do
+  context 'when showing reduced information' do
+    context 'with regulation id of IVY99990' do
       let(:regulation) { create(:base_regulation, base_regulation_id: 'IYY99990') }
 
       it { is_expected.to have_attributes(regulation_code: '') }
@@ -135,7 +142,7 @@ describe Api::V2::Measures::MeasureLegalActPresenter do
       it { is_expected.to have_attributes(description: nil) }
     end
 
-    context "with measure type 305" do
+    context 'with measure type 305' do
       let(:measure) { create(:measure, measure_type_id: '305') }
 
       it { is_expected.to have_attributes(regulation_code: '') }
@@ -143,7 +150,7 @@ describe Api::V2::Measures::MeasureLegalActPresenter do
       it { is_expected.to have_attributes(description: nil) }
     end
 
-    context "with measure type 306" do
+    context 'with measure type 306' do
       let(:measure) { create(:measure, measure_type_id: '306') }
 
       it { is_expected.to have_attributes(regulation_code: '') }

--- a/spec/presenters/api/v2/measures/measure_legal_act_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_legal_act_presenter_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Api::V2::Measures::MeasureLegalActPresenter do
   subject(:presenter) { described_class.new(regulation, measure) }
 
-  let(:regulation) { create(:base_regulation, base_regulation_id: "1234567") }
+  let(:regulation) { create(:base_regulation, base_regulation_id: '1234567') }
   let(:measure) { create(:measure) }
 
   let(:eu_regulation_code) { '14567/23' }
@@ -87,7 +87,9 @@ describe Api::V2::Measures::MeasureLegalActPresenter do
 
     context "if after 01 Jan 2021 with null information_text field" do
       let(:regulation) do
-        create(:base_regulation, :uk_concatenated_regulation, information_text: nil)
+        create(:base_regulation, :uk_concatenated_regulation,
+                                  base_regulation_id: "1234567",
+                                  information_text: nil)
       end
 
       describe "#regulation_code" do
@@ -105,7 +107,9 @@ describe Api::V2::Measures::MeasureLegalActPresenter do
 
     context "if after 01 Jan 2021 with invalid information_text field" do
       let(:regulation) do
-        create(:base_regulation, :uk_concatenated_regulation, uk_regulation_code: nil )
+        create(:base_regulation, :uk_concatenated_regulation,
+                                  base_regulation_id: "1234567",
+                                  uk_regulation_code: nil )
       end
 
       describe "#regulation_code" do

--- a/spec/presenters/api/v2/measures/measure_legal_act_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_legal_act_presenter_spec.rb
@@ -6,6 +6,16 @@ describe Api::V2::Measures::MeasureLegalActPresenter do
   let(:regulation) { create(:base_regulation, base_regulation_id: "1234567") }
   let(:measure) { create(:measure) }
 
+  let(:eu_regulation_code) { '14567/23' }
+  let(:eu_regulation_url) { 'http://eur-lex.europa.eu/search.html?' }
+  let(:eu_description) { regulation.information_text }
+
+  let(:uk_regulation_code) { 'S.I. 2019/16' }
+  let(:uk_regulation_url) { 'https://www.legislation.gov.uk/uksi/2019/16' }
+  let(:uk_description) do
+    'The Leghold Trap and Pelt Imports (Amendment etc.) (EU Exit) Regulations 2019'
+  end
+
   describe "#regulation_id" do
     it "should map to the models internal id" do
       expect(presenter.regulation_id).to eql(regulation.base_regulation_id)
@@ -30,21 +40,15 @@ describe Api::V2::Measures::MeasureLegalActPresenter do
     before { allow(TradeTariffBackend).to receive(:service).and_return('xi') }
 
     describe "#regulation_code" do
-      let(:formatted_regulation_code) { "14567/23" }
-
-      it { expect(presenter.regulation_code).to eql(formatted_regulation_code) }
+      it { expect(presenter.regulation_code).to eql(eu_regulation_code) }
     end
 
-    describe "regulation_url" do
-      let(:eu_regulation_url) { "http://eur-lex.europa.eu/search.html?" }
-
+    describe "#regulation_url" do
       it { expect(presenter.regulation_url).to start_with(eu_regulation_url) }
     end
 
     describe "#description" do
-      it "should map to the regulations information text" do
-        expect(presenter.description).to eql(regulation.information_text)
-      end
+      it { expect(presenter.description).to eql(eu_description) }
     end
   end
 
@@ -53,21 +57,15 @@ describe Api::V2::Measures::MeasureLegalActPresenter do
 
     context "if before 01 Jan 2021" do
       describe "#regulation_code" do
-        let(:formatted_regulation_code) { "14567/23" }
-
-        it { expect(presenter.regulation_code).to eql(formatted_regulation_code) }
+        it { expect(presenter.regulation_code).to eql(eu_regulation_code) }
       end
 
-      describe "regulation_url" do
-        let(:eu_regulation_url) { "http://eur-lex.europa.eu/search.html?" }
-
+      describe "#regulation_url" do
         it { expect(presenter.regulation_url).to start_with(eu_regulation_url) }
       end
 
       describe "#description" do
-        it "should map to the regulations information text" do
-          expect(presenter.description).to eql(regulation.information_text)
-        end
+        it { expect(presenter.description).to eql(eu_description) }
       end
     end
 
@@ -75,19 +73,51 @@ describe Api::V2::Measures::MeasureLegalActPresenter do
       let(:regulation) { create(:base_regulation, :uk_concatenated_regulation) }
 
       describe "#regulation_code" do
-        it { expect(presenter.regulation_code).to eql('S.I. 2019/16') }
+        it { expect(presenter.regulation_code).to eql(uk_regulation_code) }
       end
 
       describe "#regulation_url" do
-        let(:uk_regulation_url) { 'https://www.legislation.gov.uk/uksi/2019/16' }
-
         it { expect(presenter.regulation_url).to eql(uk_regulation_url) }
       end
 
       describe "#description" do
-        let(:uk_description) { 'The Leghold Trap and Pelt Imports (Amendment etc.) (EU Exit) Regulations 2019' }
-
         it { expect(presenter.description).to eql(uk_description) }
+      end
+    end
+
+    context "if after 01 Jan 2021 with null information_text field" do
+      let(:regulation) do
+        create(:base_regulation, :uk_concatenated_regulation, information_text: nil)
+      end
+
+      describe "#regulation_code" do
+        it { expect(presenter.regulation_code).to eql(eu_regulation_code) }
+      end
+
+      describe "#regulation_url" do
+        it { expect(presenter.regulation_url).to eql("") }
+      end
+
+      describe "#description" do
+        it { expect(presenter.description).to be_nil }
+      end
+    end
+
+    context "if after 01 Jan 2021 with invalid information_text field" do
+      let(:regulation) do
+        create(:base_regulation, :uk_concatenated_regulation, uk_regulation_code: nil )
+      end
+
+      describe "#regulation_code" do
+        it { expect(presenter.regulation_code).to eql(eu_regulation_code) }
+      end
+
+      describe "#regulation_url" do
+        it { expect(presenter.regulation_url).to eql("") }
+      end
+
+      describe "#description" do
+        it { expect(presenter.description).to be_nil }
       end
     end
   end

--- a/spec/presenters/api/v2/measures/measure_legal_act_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_legal_act_presenter_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 describe Api::V2::Measures::MeasureLegalActPresenter do
-  subject(:presenter) { described_class.new(regulation) }
+  subject(:presenter) { described_class.new(regulation, measure) }
 
   let(:regulation) { create(:base_regulation, base_regulation_id: "1234567") }
+  let(:measure) { create(:measure) }
 
   describe "#regulation_id" do
     it "should map to the models internal id" do
@@ -92,10 +93,28 @@ describe Api::V2::Measures::MeasureLegalActPresenter do
   end
 
   context "when showing reduced information" do
-    let(:regulation) { create(:base_regulation, base_regulation_id: 'IYY99990') }
+    context "with regulation id of IVY99990" do
+      let(:regulation) { create(:base_regulation, base_regulation_id: 'IYY99990') }
 
-    it { is_expected.to have_attributes(regulation_code: '') }
-    it { is_expected.to have_attributes(regulation_url: '') }
-    it { is_expected.to have_attributes(description: nil) }
+      it { is_expected.to have_attributes(regulation_code: '') }
+      it { is_expected.to have_attributes(regulation_url: '') }
+      it { is_expected.to have_attributes(description: nil) }
+    end
+
+    context "with measure type 305" do
+      let(:measure) { create(:measure, measure_type_id: '305') }
+
+      it { is_expected.to have_attributes(regulation_code: '') }
+      it { is_expected.to have_attributes(regulation_url: '') }
+      it { is_expected.to have_attributes(description: nil) }
+    end
+
+    context "with measure type 306" do
+      let(:measure) { create(:measure, measure_type_id: '306') }
+
+      it { is_expected.to have_attributes(regulation_code: '') }
+      it { is_expected.to have_attributes(regulation_url: '') }
+      it { is_expected.to have_attributes(description: nil) }
+    end
   end
 end

--- a/spec/presenters/api/v2/measures/measure_legal_act_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_legal_act_presenter_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe Api::V2::Measures::MeasureLegalActPresenter do
+  subject(:presenter) { described_class.new(regulation) }
+
+  let(:regulation) { create(:base_regulation, base_regulation_id: "1234567") }
+
+  describe "#regulation_id" do
+    it "should map to the models internal id" do
+      expect(presenter.regulation_id).to eql(regulation.base_regulation_id)
+    end
+  end
+
+  describe "published_date" do
+    subject { presenter.published_date }
+
+    context "without regulation present" do
+      let(:legal_act) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "with legal act" do
+      it { is_expected.to eql(regulation.published_date) }
+    end
+  end
+
+  describe "#regulation_code" do
+    let(:formatted_regulation_code) { "14567/23" }
+
+    it { expect(presenter.regulation_code).to eql(formatted_regulation_code) }
+  end
+
+  describe "regulation_url" do
+    let(:eu_regulation_url) { "http://eur-lex.europa.eu/search.html?" }
+
+    it { expect(presenter.regulation_url).to start_with(eu_regulation_url) }
+  end
+
+  describe "#description" do
+    it "should map to the regulations information text" do
+      expect(presenter.description).to eql(regulation.information_text)
+    end
+  end
+end

--- a/spec/presenters/api/v2/measures/measure_legal_act_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_legal_act_presenter_spec.rb
@@ -42,4 +42,12 @@ describe Api::V2::Measures::MeasureLegalActPresenter do
       expect(presenter.description).to eql(regulation.information_text)
     end
   end
+
+  context "when showing reduced information" do
+    let(:regulation) { create(:base_regulation, base_regulation_id: 'IYY99990') }
+
+    it { is_expected.to have_attributes(regulation_code: '') }
+    it { is_expected.to have_attributes(regulation_url: '') }
+    it { is_expected.to have_attributes(description: nil) }
+  end
 end

--- a/spec/presenters/api/v2/measures/measure_legal_act_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_legal_act_presenter_spec.rb
@@ -25,21 +25,47 @@ describe Api::V2::Measures::MeasureLegalActPresenter do
     end
   end
 
-  describe "#regulation_code" do
-    let(:formatted_regulation_code) { "14567/23" }
+  context "for XI service" do
+    before { allow(TradeTariffBackend).to receive(:service).and_return('xi') }
 
-    it { expect(presenter.regulation_code).to eql(formatted_regulation_code) }
+    describe "#regulation_code" do
+      let(:formatted_regulation_code) { "14567/23" }
+
+      it { expect(presenter.regulation_code).to eql(formatted_regulation_code) }
+    end
+
+    describe "regulation_url" do
+      let(:eu_regulation_url) { "http://eur-lex.europa.eu/search.html?" }
+
+      it { expect(presenter.regulation_url).to start_with(eu_regulation_url) }
+    end
+
+    describe "#description" do
+      it "should map to the regulations information text" do
+        expect(presenter.description).to eql(regulation.information_text)
+      end
+    end
   end
 
-  describe "regulation_url" do
-    let(:eu_regulation_url) { "http://eur-lex.europa.eu/search.html?" }
+  context "for UK service" do
+    before { allow(TradeTariffBackend).to receive(:service).and_return('uk') }
 
-    it { expect(presenter.regulation_url).to start_with(eu_regulation_url) }
-  end
+    let(:regulation) { create(:base_regulation, :uk_concatenated_regulation) }
 
-  describe "#description" do
-    it "should map to the regulations information text" do
-      expect(presenter.description).to eql(regulation.information_text)
+    describe "#regulation_code" do
+      it { expect(presenter.regulation_code).to eql('S.I. 2019/16') }
+    end
+
+    describe "#regulation_url" do
+      let(:uk_regulation_url) { 'https://www.legislation.gov.uk/uksi/2019/16' }
+
+      it { expect(presenter.regulation_url).to eql(uk_regulation_url) }
+    end
+
+    describe "#description" do
+      let(:uk_description) { 'The Leghold Trap and Pelt Imports (Amendment etc.) (EU Exit) Regulations 2019' }
+
+      it { expect(presenter.description).to eql(uk_description) }
     end
   end
 

--- a/spec/presenters/api/v2/measures/measure_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_presenter_spec.rb
@@ -5,8 +5,8 @@ describe Api::V2::Measures::MeasurePresenter do
 
   let(:measure) { create(:measure) }
 
-  describe "#legal_acts" do
-    it "will be mapped through the MeasureLegalActPresenter" do
+  describe '#legal_acts' do
+    it 'will be mapped through the MeasureLegalActPresenter' do
       expect(presenter.legal_acts.first).to \
         be_instance_of(Api::V2::Measures::MeasureLegalActPresenter)
     end

--- a/spec/presenters/api/v2/measures/measure_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_presenter_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe Api::V2::Measures::MeasurePresenter do
+  subject(:presenter) { described_class.new(measure, measure.goods_nomenclature) }
+
+  let(:measure) { create(:measure) }
+
+  describe "#legal_acts" do
+    it "will be mapped through the MeasureLegalActPresenter" do
+      expect(presenter.legal_acts.first).to \
+        be_instance_of(Api::V2::Measures::MeasureLegalActPresenter)
+    end
+  end
+end

--- a/spec/serializers/api/v2/measures/measure_legal_act_serializer_spec.rb
+++ b/spec/serializers/api/v2/measures/measure_legal_act_serializer_spec.rb
@@ -3,8 +3,9 @@ require 'rails_helper'
 RSpec.describe Api::V2::Measures::MeasureLegalActSerializer do
   subject(:serializer) { described_class.new(serializable).serializable_hash.as_json }
 
-  let(:serializable) { Api::V2::Measures::MeasureLegalActPresenter.new(regulation) }
+  let(:serializable) { Api::V2::Measures::MeasureLegalActPresenter.new(regulation, measure) }
   let(:regulation) { create(:base_regulation, base_regulation_id: "1234567") }
+  let(:measure) { create(:measure) }
 
   let(:generated_url) do
     MeasureService::CouncilRegulationUrlGenerator.new(regulation).generate

--- a/spec/serializers/api/v2/measures/measure_legal_act_serializer_spec.rb
+++ b/spec/serializers/api/v2/measures/measure_legal_act_serializer_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V2::Measures::MeasureLegalActSerializer do
   subject(:serializer) { described_class.new(serializable).serializable_hash.as_json }
 
-  let(:serializable) { regulation }
+  let(:serializable) { Api::V2::Measures::MeasureLegalActPresenter.new(regulation) }
   let(:regulation) { create(:base_regulation, base_regulation_id: "1234567") }
 
   let(:generated_url) do

--- a/spec/serializers/api/v2/measures/measure_legal_act_serializer_spec.rb
+++ b/spec/serializers/api/v2/measures/measure_legal_act_serializer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Api::V2::Measures::MeasureLegalActSerializer do
   subject(:serializer) { described_class.new(serializable).serializable_hash.as_json }
 
   let(:serializable) { Api::V2::Measures::MeasureLegalActPresenter.new(regulation, measure) }
-  let(:regulation) { create(:base_regulation, base_regulation_id: "1234567") }
+  let(:regulation) { create(:base_regulation, base_regulation_id: '1234567') }
   let(:measure) { create(:measure) }
 
   let(:generated_url) do
@@ -21,7 +21,7 @@ RSpec.describe Api::V2::Measures::MeasureLegalActSerializer do
           'validity_end_date' => regulation.validity_end_date,
           'officialjournal_number' => regulation.officialjournal_number,
           'officialjournal_page' => regulation.officialjournal_page,
-          'regulation_code' => "14567/23",
+          'regulation_code' => '14567/23',
           'regulation_url' => generated_url,
           'description' => regulation.information_text,
         }

--- a/spec/serializers/api/v2/measures/measure_legal_act_serializer_spec.rb
+++ b/spec/serializers/api/v2/measures/measure_legal_act_serializer_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Api::V2::Measures::MeasureLegalActSerializer do
           'officialjournal_page' => regulation.officialjournal_page,
           'regulation_code' => "14567/23",
           'regulation_url' => generated_url,
+          'description' => regulation.information_text,
         }
       },
     }.as_json

--- a/spec/serializers/api/v2/measures/measure_legal_act_serializer_spec.rb
+++ b/spec/serializers/api/v2/measures/measure_legal_act_serializer_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Api::V2::Measures::MeasureLegalActSerializer do
+  subject(:serializer) { described_class.new(serializable).serializable_hash.as_json }
+
+  let(:serializable) { regulation }
+  let(:regulation) { create(:base_regulation, base_regulation_id: "1234567") }
+
+  let(:generated_url) do
+    MeasureService::CouncilRegulationUrlGenerator.new(regulation).generate
+  end
+
+  let(:expected_pattern) do
+    {
+      'data' => {
+        'id' => regulation.regulation_id.to_s,
+        'type' => 'legal_act',
+        'attributes' => {
+          'validity_start_date' => regulation.validity_start_date,
+          'validity_end_date' => regulation.validity_end_date,
+          'officialjournal_number' => regulation.officialjournal_number,
+          'officialjournal_page' => regulation.officialjournal_page,
+          'regulation_code' => "14567/23",
+          'regulation_url' => generated_url,
+        }
+      },
+    }.as_json
+  end
+
+  describe '#serializable_hash' do
+    it { is_expected.to include_json(expected_pattern) }
+  end
+end


### PR DESCRIPTION
### Jira link

[HOTT-866](https://transformuk.atlassian.net/jira/software/projects/HOTT/boards/96?selectedIssue=HOTT-866)

### What?

I have added/removed/altered:

- [x] Added a spec for `MeasuresLegalActSerializer` to check for regressions to existing behaviour
- [x] Added a `MeasureLegalActPresenter` to allow manipulating the legal act data before serializing it
- [x] Changed the `MeasurePresenter` to utilise the MeasureLegalActPresenter for legal acts
- [x] Added a `UkRegulationParser` class to parse the concatenated `information_text` for uk legal acts applying after 01 Jan 2021
- [x] Changed the `MeasureLegalActPresenter` to use `UkRegulationParser` to extract uk descriptions, urls and codes for the UK dataset, when the `officialjournal_number` == '1' and the `officialjournal_page` == 1
- [x] Added fallback handling for the above when the `information_text` field doesn't comply with the new concatenated format
- [x] Change the `MeasureLegalActPresenter` to return blank fields for regulation_url, regulation_code and description when either the regulation id is `IYY99990` or the measure type id is either `305` or `306`

### Why?

I am doing this because:

- Uk regulations after 01 Jan 2021 will be holding their regulation code, regulation url and description in a concatenated format inside of the `information_text` field instead of using the existing fields

### Deployment risks (optional)

This changes the format of the legal act API nodes in 3 ways
- for uk regulations after 01 Jan 2021 changes from the existing fields, to extracting regulation code/url/description from the information text
- it hides the code/url/description for all regulations with an id of `IYY99990` or measure type id of 305 or 306
- it adds a description attribute for all other regulations with the contents of the information text database field
