### PR TITLE
Updates schedule and triggers reindexing of es models after clearing redis

### DIFF
--- a/app/workers/clear_cache_worker.rb
+++ b/app/workers/clear_cache_worker.rb
@@ -7,5 +7,8 @@ class ClearCacheWorker
     logger.info 'Clearing Rails cache'
     Rails.cache.clear
     logger.info 'Clearing Rails cache completed'
+
+    Sidekiq::Client.enqueue(RecacheModelsWorker)
+    Sidekiq::Client.enqueue(ReindexModelsWorker)
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -19,20 +19,14 @@
   # Online converter: https://crontab.guru/#0_22_*_*_*
   #
   UpdatesSynchronizerWorker:
-    cron: "0 2 * * *" # 2AM every day
-    description: "UpdatesSynchronizerWorker will run every day at 2am."
+    cron: "30 4 * * *"
+    description: "UpdatesSynchronizerWorker"
   TaricSequenceCheckWorker:
-    cron: "0 14 * * 6" # 14:00 every Saturday
-    description: "TaricSequenceCheckWorker will run every Saturday at 14:00."
+    cron: "0 14 * * 6" 
+    description: "TaricSequenceCheckWorker"
   ClearCacheWorker:
-    cron: "30 2 * * *" # 02:30 every day
-    description: "Clear Rails cache at 02:30"
-  RecacheModelsWorker:
-    cron: "30 2 * * *" # 02:30 every day
-    description: "RecacheModelsWorker will run every day at 02:30."
-  ReindexModelsWorker:
-    cron: "30 2 * * *" # 02:30 every day
-    description: "ReindexModelsWorker will run every day at 02:30."
+    cron: "0 5 * * *" 
+    description: "Clear Rails cache"
   PopulateChangesTableWorker:
-    cron: "30 4 * * *" # 04:30 every day
-    description: "Populates the changes table, will run every day at 04:30"
+    cron: "30 4 * * *" 
+    description: "Populates the changes table"


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-889

### What?

I have added/removed/altered:

- [x] After we've cleared the redis cache trigger TradeTariffBackend.reindex and TradeTariffBackend.recache
- [x] Updates UpdateSynchronizerWorker to reflect CDS changes of file availability

### Why?

I am doing this because:

- We only want to recache after a UpdateSynchronizerWorker has triggered but I felt that was too much of a change (affecting both sets of workers)
- This reduces the number of schedules we have to manage
