### PR TITLE
Removed eager loading of models in specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,9 +22,6 @@ Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
 
 # require models and serializers
 require 'clearable'
-Dir[Rails.root.join('app/models/*.rb')].sort.each { |f| require f }
-# Dir[Rails.root.join('app/models/concerns/*rb')].each { |f| require concern }
-Dir[Rails.root.join('app/serializers/*.rb')].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = false


### PR DESCRIPTION
### Jira link

????

### What?

I have added/removed/altered:

- [x] Removed eager loading of models in specs

### Why?

I am doing this because:

- This doesn't appear to be serving any purpose and slows down starting the test suite when testing individual specs - I assume its a fix for an old autoloading issue thats now resolved. I've run every spec individually and they all still pass.

