### PR TITLE
Removes mimemagic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 ruby File.read('.ruby-version')
 
 # Server
-gem 'mimemagic'
 gem 'puma', '~> 5.3.1'
 gem 'rails', '>= 6.0.3.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,9 +237,6 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
     method_source (1.0.0)
-    mimemagic (0.3.9)
-      nokogiri (~> 1)
-      rake
     mini_mime (1.1.0)
     mini_portile2 (2.6.1)
     minitest (5.14.4)
@@ -490,7 +487,6 @@ DEPENDENCIES
   letter_opener
   lograge (>= 0.3.6)
   logstash-event
-  mimemagic
   newrelic_rpm
   nokogiri (>= 1.10.9)
   ox (>= 2.8.1)

--- a/lib/cds_importer.rb
+++ b/lib/cds_importer.rb
@@ -1,4 +1,3 @@
-require 'mimemagic'
 require 'zip'
 # It's important to require mappers before xml_parser and entity_mapper to load all descendants
 Dir[File.join(Rails.root, 'lib', 'cds_importer/entity_mapper/*.rb')].each { |f| require f }
@@ -9,7 +8,7 @@ class CdsImporter
   class ImportException < StandardError
     attr_reader :original
 
-    def initialize(msg = 'CdsImporter::ImportException', original=$!)
+    def initialize(msg = 'CdsImporter::ImportException', original = $!)
       super(msg)
       @original = original
     end
@@ -24,26 +23,16 @@ class CdsImporter
 
   def import
     handler = XmlProcessor.new(@cds_update.filename)
-    gzip_file = TariffSynchronizer::FileService.file_as_stringio(@cds_update)
+    zip_file = TariffSynchronizer::FileService.file_as_stringio(@cds_update)
 
-    # The api https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/secure-data-exchange-bulk-download/1.0
-    # returns zip files for daily and monthly updates and gzip for annual files.
-    if MimeMagic.by_magic(gzip_file).subtype == 'gzip'
-      xml_stream = Zlib::GzipReader.wrap(gzip_file)
+    Zip::File.open_buffer(zip_file) do |archive|
+      archive.entries.each do |entry|
+        # Read into memory
+        xml_stream = entry.get_input_stream
+        # do the xml parsing depending on records root depth
+        CdsImporter::XmlParser::Reader.new(xml_stream.read, handler).parse
 
-      CdsImporter::XmlParser::Reader.new(xml_stream, handler).parse
-
-      ActiveSupport::Notifications.instrument('cds_imported.tariff_importer', filename: @cds_update.filename)
-    else
-      Zip::File.open_buffer(gzip_file) do |archive|
-        archive.entries.each do |entry|
-          # Read into memory
-          xml_stream = entry.get_input_stream
-          # do the xml parsing depending on records root depth
-          CdsImporter::XmlParser::Reader.new(xml_stream.read, handler).parse
-
-          ActiveSupport::Notifications.instrument('cds_imported.tariff_importer', filename: @cds_update.filename)
-        end
+        ActiveSupport::Notifications.instrument('cds_imported.tariff_importer', filename: @cds_update.filename)
       end
     end
   end
@@ -54,16 +43,14 @@ class CdsImporter
     end
 
     def process_xml_node(key, hash_from_node)
-      begin
-        hash_from_node['filename'] = @filename
-        CdsImporter::EntityMapper.new(key, hash_from_node).import
-      rescue StandardError => exception
-        ActiveSupport::Notifications.instrument(
-          'cds_failed.tariff_importer',
-          exception: exception, hash: hash_from_node, key: key
-        )
-        raise ImportException.new
-      end
+      hash_from_node['filename'] = @filename
+      CdsImporter::EntityMapper.new(key, hash_from_node).import
+    rescue StandardError => e
+      ActiveSupport::Notifications.instrument(
+        'cds_failed.tariff_importer',
+        exception: e, hash: hash_from_node, key: key,
+      )
+      raise ImportException
     end
   end
 end

--- a/lib/cds_importer.rb
+++ b/lib/cds_importer.rb
@@ -1,6 +1,6 @@
 require 'zip'
 # It's important to require mappers before xml_parser and entity_mapper to load all descendants
-Dir[File.join(Rails.root, 'lib', 'cds_importer/entity_mapper/*.rb')].each { |f| require f }
+Dir[Rails.root.join('lib/cds_importer/entity_mapper/*.rb')].sort.each { |f| require f }
 require 'cds_importer/xml_parser'
 require 'cds_importer/entity_mapper'
 
@@ -8,7 +8,7 @@ class CdsImporter
   class ImportException < StandardError
     attr_reader :original
 
-    def initialize(msg = 'CdsImporter::ImportException', original = $!)
+    def initialize(msg = 'CdsImporter::ImportException', original = $ERROR_INFO)
       super(msg)
       @original = original
     end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Removes the mimemagic gem

### Why?

I am doing this because:

- This was only required to magically handle/understand gzipped annual files. We never download these and can manually gunzip them if necessary by passing the correct flags
- mimemagic was requiring extra files to be provided as part of dockerising this application
