### PR TITLE
Fixes filter for stopping deploys on dependabot branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -464,6 +464,7 @@ workflows:
             branches:
               ignore:
                 - master
+                - /^dependabot\/.*/
           requires:
             - test
       - deploy_dev:


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Stop deploying dependabot branches

### Why?

I am doing this because:

- We don't want to spam dev with deploys of dependabot upgrades
