### PR TITLE
Refactor the applicable_measure_units returned for the Duty Calculator

### DIFF
--- a/app/models/measure_component.rb
+++ b/app/models/measure_component.rb
@@ -64,7 +64,6 @@ class MeasureComponent < Sequel::Model
 
   def unit
     {
-      component_id: pk.join('-'),
       measurement_unit_code: measurement_unit_code,
       measurement_unit_qualifier_code: measurement_unit_qualifier_code,
     }

--- a/app/models/measure_condition_component.rb
+++ b/app/models/measure_condition_component.rb
@@ -62,7 +62,6 @@ class MeasureConditionComponent < Sequel::Model
 
   def unit
     {
-      condition_component_id: pk.join('-'),
       measurement_unit_code: measurement_unit_code,
       measurement_unit_qualifier_code: measurement_unit_qualifier_code,
     }

--- a/app/services/measure_unit_service.rb
+++ b/app/services/measure_unit_service.rb
@@ -6,17 +6,10 @@ class MeasureUnitService
   def call
     units.each_with_object({}) do |unit, acc|
       unit_key = "#{unit[:measurement_unit_code]}#{unit[:measurement_unit_qualifier_code]}"
-      component_id = unit[:component_id]
-      condition_component_id = unit[:condition_component_id]
 
-      if acc[unit_key].present?
-        acc[unit_key]['component_ids'].add(component_id) if component_id
-        acc[unit_key]['condition_component_ids'].add(condition_component_id) if condition_component_id
-      else
+      if acc[unit_key].blank?
         acc[unit_key] = {}
         acc[unit_key] = MeasurementUnit.measurement_unit(unit_key)
-        acc[unit_key]['component_ids'] = Set.new([component_id].compact)
-        acc[unit_key]['condition_component_ids'] = Set.new([condition_component_id].compact)
       end
     end
   end

--- a/spec/models/measure_condition_spec.rb
+++ b/spec/models/measure_condition_spec.rb
@@ -188,7 +188,6 @@ describe MeasureCondition do
         expect(measure_condition.units).to eq(
           [
             {
-              condition_component_id: measure_condition.measure_condition_components.first.pk.join('-'),
               measurement_unit_code: 'TNE',
               measurement_unit_qualifier_code: 'R',
             },

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -997,11 +997,8 @@ describe Measure do
       subject(:measure) { create(:measure, :with_measure_conditions) }
 
       let(:expected_units) do
-        condition_component_id = measure.measure_conditions.flat_map(&:measure_condition_components).first.pk.join('-')
-
         [
           {
-            condition_component_id: condition_component_id,
             measurement_unit_code: 'DTN',
             measurement_unit_qualifier_code: 'R',
           },

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -959,17 +959,12 @@ describe Measure do
       subject(:measure) { create(:measure, :with_measure_components, :with_measure_conditions) }
 
       let(:expected_units) do
-        condition_component_id = measure.measure_conditions.flat_map(&:measure_condition_components).first.pk.join('-')
-        component_id = measure.measure_components.first.pk.join('-')
-
         [
           {
-            condition_component_id: condition_component_id,
             measurement_unit_code: 'DTN',
             measurement_unit_qualifier_code: 'R',
           },
           {
-            component_id: component_id,
             measurement_unit_code: 'DTN',
             measurement_unit_qualifier_code: 'R',
           },
@@ -985,11 +980,8 @@ describe Measure do
       subject(:measure) { create(:measure, :with_measure_components) }
 
       let(:expected_units) do
-        component_id = measure.measure_components.first.pk.join('-')
-
         [
           {
-            component_id: component_id,
             measurement_unit_code: 'DTN',
             measurement_unit_qualifier_code: 'R',
           },

--- a/spec/services/measure_unit_service_spec.rb
+++ b/spec/services/measure_unit_service_spec.rb
@@ -22,8 +22,6 @@ RSpec.describe MeasureUnitService do
         )
       end
       let(:expected_applicable_units) do
-        condition_component_id = measure.measure_conditions.flat_map(&:measure_condition_components).first.pk.join('-')
-        component_id = measure.measure_components.first.pk.join('-')
         {
           'DTNR' => {
             'measurement_unit_code' => 'DTN',
@@ -32,8 +30,6 @@ RSpec.describe MeasureUnitService do
             'unit_question' => 'What is the weight net of the standard quality of the goods you will be importing?',
             'unit_hint' => 'Enter the value in decitonnes (100kg)',
             'unit' => 'x 100 kg',
-            'component_ids' => Set.new([component_id]),
-            'condition_component_ids' => Set.new([condition_component_id]),
           },
         }
       end

--- a/spec/support/shared_examples/a_component.rb
+++ b/spec/support/shared_examples/a_component.rb
@@ -41,10 +41,7 @@ shared_examples_for 'a component' do |type|
     end
 
     it 'returns the properly formatted unit' do
-      identifier_key = type == :measure_condition_component ? :condition_component_id : :component_id
-
       expect(component.unit).to eq(
-        identifier_key => component.pk.join('-'),
         measurement_unit_code: 'TNE',
         measurement_unit_qualifier_code: 'I',
       )


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Removes id references from measure units

### Why?

I am doing this because:

- These aren't needed anymore
