### PR TITLE
Handle extra qualifier in unit code key.

### DIFF
--- a/app/services/measure_unit_service.rb
+++ b/app/services/measure_unit_service.rb
@@ -5,11 +5,13 @@ class MeasureUnitService
 
   def call
     units.each_with_object({}) do |unit, acc|
-      unit_key = "#{unit[:measurement_unit_code]}#{unit[:measurement_unit_qualifier_code]}"
+      unit_code = unit[:measurement_unit_code]
+      unit_qualifier_code = unit[:measurement_unit_qualifier_code]
+      unit_key = "#{unit_code}#{unit_qualifier_code}"
 
       if acc[unit_key].blank?
         acc[unit_key] = {}
-        acc[unit_key] = MeasurementUnit.measurement_unit(unit_key)
+        acc[unit_key] = MeasurementUnit.measurement_unit(unit_code, unit_key)
       end
     end
   end

--- a/spec/models/measurement_unit_spec.rb
+++ b/spec/models/measurement_unit_spec.rb
@@ -1,5 +1,5 @@
 describe MeasurementUnit do
-  let(:measurement_unit) { create :measurement_unit, :with_description }
+  subject(:measurement_unit) { create :measurement_unit, :with_description }
 
   describe '#to_s' do
     it 'is an alias for description' do
@@ -8,9 +8,7 @@ describe MeasurementUnit do
   end
 
   describe '#abbreviation' do
-    it {
-      expect(measurement_unit.abbreviation).to eq(measurement_unit.description)
-    }
+    it { expect(measurement_unit.abbreviation).to eq(measurement_unit.description) }
   end
 
   describe '#measurement_unit_abbreviation' do
@@ -19,56 +17,56 @@ describe MeasurementUnit do
         create(:measurement_unit_abbreviation, measurement_unit_code: measurement_unit.measurement_unit_code)
       end
 
-      it {
-        expect(measurement_unit.measurement_unit_abbreviation).to eq(measurement_unit_abbreviation)
-      }
-    end
-  end
-
-  describe '.measurement_units' do
-    let(:units) { described_class.send(:measurement_units) }
-
-    it "will return the hash of all measurement units" do
-      expect(units).to be_instance_of Hash
-    end
-
-    it "will include individual units indexed by key" do
-      expect(units).to include("ASV")
+      it { expect(measurement_unit.measurement_unit_abbreviation).to eq(measurement_unit_abbreviation) }
     end
   end
 
   describe '.measurement_unit' do
+    let(:measurement_unit) do
+      create(
+        :measurement_unit,
+        :with_description,
+        measurement_unit_code: measurement_unit_code,
+      )
+    end
+
+    let(:measurement_unit_code) { 'ASV' }
+
     context 'with valid measurement unit' do
-      it { expect(MeasurementUnit.measurement_unit('ASV')).to include('unit' => 'percent') }
+      let(:unit_code) { 'ASV' }
+      let(:unit_key) { 'ASV' }
+
+      it { expect(described_class.measurement_unit(unit_code, unit_key)).to include('unit' => 'percent') }
     end
 
     context 'with missing measurement unit present in database' do
-      before { allow(Raven).to receive(:capture_message).and_return(true) }
-      before { allow(MeasurementUnit).to receive(:measurement_units).and_return({}) }
+      subject { described_class.measurement_unit(unit_code, unit_key) }
 
-      subject! { MeasurementUnit.measurement_unit(unit_code) }
+      before do
+        measurement_unit
+        allow(Raven).to receive(:capture_message).and_return(true)
+        allow(described_class).to receive(:measurement_units).and_return({})
+      end
 
-      let(:unit_code) { measurement_unit.measurement_unit_code }
+      let(:unit_code) { 'ASV' }
+      let(:unit_key) { 'ASVX' }
       let(:unit_description) { measurement_unit.description }
 
       it { is_expected.to include('measurement_unit_code' => unit_code) }
+      it { is_expected.to include('measurement_unit_qualifier_code' => 'X') }
       it { is_expected.to include('unit' => nil) }
-      it { is_expected.to include('abbreviation' => '') }
+      it { is_expected.to include('abbreviation' => measurement_unit.abbreviation) }
       it { is_expected.to include('unit_question' => "Please enter unit: #{unit_description}") }
-      it { is_expected.to include('unit_hint' => nil) }
+      it { is_expected.to include('unit_hint' =>  "Please correctly enter unit: #{unit_description}") }
       it { expect(Raven).to have_received(:capture_message) }
     end
 
     context 'with measurement unit not in the database' do
-      let(:unit) { MeasurementUnit.measurement_unit('UNKNOWN') }
+      let(:unit) { described_class.measurement_unit('UNKNOWN', 'UNKNOWN') }
 
-      it "will raise an InvalidMeasurementUnit exception" do
+      it 'will raise an InvalidMeasurementUnit exception' do
         expect { unit }.to raise_exception(MeasurementUnit::InvalidMeasurementUnit)
       end
-    end
-
-    context 'without specifying a unit' do
-      it { expect { MeasurementUnit.measurement_unit }.to raise_exception ArgumentError }
     end
   end
 end

--- a/spec/models/measurement_unit_spec.rb
+++ b/spec/models/measurement_unit_spec.rb
@@ -40,7 +40,7 @@ describe MeasurementUnit do
     end
 
     context 'with missing measurement unit present in database' do
-      subject { described_class.measurement_unit(unit_code, unit_key) }
+      subject(:result) { described_class.measurement_unit(unit_code, unit_key) }
 
       before do
         measurement_unit
@@ -58,7 +58,11 @@ describe MeasurementUnit do
       it { is_expected.to include('abbreviation' => measurement_unit.abbreviation) }
       it { is_expected.to include('unit_question' => "Please enter unit: #{unit_description}") }
       it { is_expected.to include('unit_hint' =>  "Please correctly enter unit: #{unit_description}") }
-      it { expect(Raven).to have_received(:capture_message) }
+
+      it 'sends a message to Sentry' do
+        result
+        expect(Raven).to have_received(:capture_message)
+      end
     end
 
     context 'with measurement unit not in the database' do


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

In the wild we retrieve the unit from the measure units file using the
code and the qualifier concatenated. This enables us to enrich the
descriptions a bit as they relate to the specific measure
component/measure condition component.

Our specific example `Factor` exists in the database but does not match
because it's code is FC1 and we were passing in the full key FC1X

```
"500 - Internal Server Error: Requested invalid measurement unit: FC1X"
```

There are only **18** measure condition components active in the database that have the unit key `FC1X`

I have added/removed/altered:

- [x] Changes the key that we use to look up the measurement unit
code in fallback scenarios to exclude the qualifier
- [x] Lint according to rubocop rules

### Why?

I am doing this because:

- This is needed for us to be able to present commodities with unsupported units
