### PR TITLE
Handle generation of missing taric updates on the uk service

### DIFF
--- a/app/workers/taric_sequence_check_worker.rb
+++ b/app/workers/taric_sequence_check_worker.rb
@@ -4,7 +4,9 @@ class TaricSequenceCheckWorker
   sidekiq_options queue: :sync, retry: false
 
   def perform
+    return if TradeTariffBackend.uk?
+
     logger.info 'Running TARIC files sequence check'
-    TariffSynchronizer::TaricSequenceChecker.new(true).perform
+    TariffSynchronizer::TaricSequenceChecker.new(with_email: true).perform
   end
 end

--- a/app/workers/taric_sequence_check_worker.rb
+++ b/app/workers/taric_sequence_check_worker.rb
@@ -7,6 +7,6 @@ class TaricSequenceCheckWorker
     return if TradeTariffBackend.uk?
 
     logger.info 'Running TARIC files sequence check'
-    TariffSynchronizer::TaricSequenceChecker.new(with_email: true).perform
+    TariffSynchronizer::TaricSequenceChecker.new.perform
   end
 end

--- a/lib/tariff_synchronizer/taric_file_name_generator.rb
+++ b/lib/tariff_synchronizer/taric_file_name_generator.rb
@@ -1,6 +1,7 @@
 module TariffSynchronizer
   class TaricFileNameGenerator
     attr_reader :date
+
     delegate :taric_query_url_template, :taric_update_url_template, :host, to: TariffSynchronizer
 
     def initialize(date)
@@ -8,7 +9,7 @@ module TariffSynchronizer
     end
 
     def url
-      format(taric_query_url_template, host: host, date: date.strftime('%Y%m%d'))
+      sprintf(taric_query_url_template, host: host, date: date.strftime('%Y%m%d'))
     end
 
     def get_info_from_response(string)
@@ -21,7 +22,7 @@ module TariffSynchronizer
   private
 
     def update_url(name)
-      format(taric_update_url_template, host: host, filename: name)
+      sprintf(taric_update_url_template, host: host, filename: name)
     end
 
     def local_filename(name)
@@ -29,7 +30,7 @@ module TariffSynchronizer
     end
 
     def remove_invalid_characters(name)
-      name.gsub(/[^0-9a-zA-Z\.]/i, '')
+      name.gsub(/[^0-9a-zA-Z.]/i, '')
     end
   end
 end

--- a/lib/tariff_synchronizer/taric_sequence_checker.rb
+++ b/lib/tariff_synchronizer/taric_sequence_checker.rb
@@ -1,8 +1,7 @@
 module TariffSynchronizer
-  # Class checks tarif update files for current and previous year
+  # Class checks tariff update files for current and previous year
   class TaricSequenceChecker
-    def initialize(with_email: false)
-      @with_email = with_email
+    def initialize
       @old_retry = TariffSynchronizer.retry_count
       @old_exception_retry = TariffSynchronizer.exception_retry_count
       @missing_updates = []
@@ -24,7 +23,7 @@ module TariffSynchronizer
 
       @missing_updates.select! { |file| file.include?('.xml') }
 
-      if @with_email && @missing_updates.any?
+      if @missing_updates.any?
         Mailer.failed_taric_sequence(@missing_updates).deliver_now
       end
 
@@ -38,9 +37,9 @@ module TariffSynchronizer
     private
 
     def interval
-      today = Time.zone.today
-      end_date = today
-      start_date = Date.new(today.year - 1, 1, 1)
+      end_date = Time.zone.today
+      start_date = end_date - 2.years
+
       start_date..end_date
     end
 

--- a/lib/tariff_synchronizer/taric_sequence_checker.rb
+++ b/lib/tariff_synchronizer/taric_sequence_checker.rb
@@ -1,7 +1,7 @@
 module TariffSynchronizer
   # Class checks tarif update files for current and previous year
   class TaricSequenceChecker
-    def initialize(with_email = false)
+    def initialize(with_email: false)
       @with_email = with_email
       @old_retry = TariffSynchronizer.retry_count
       @old_exception_retry = TariffSynchronizer.exception_retry_count
@@ -38,7 +38,7 @@ module TariffSynchronizer
     private
 
     def interval
-      today = Date.today
+      today = Time.zone.today
       end_date = today
       start_date = Date.new(today.year - 1, 1, 1)
       start_date..end_date

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,3 +62,19 @@ RSpec.configure do |config|
     TradeTariffBackend.clearable_models.map(&:clear_association_cache)
   end
 end
+
+def silence
+  # Store the original stderr and stdout in order to restore them later
+  @original_stderr = $stderr
+  @original_stdout = $stdout
+
+  # Redirect stderr and stdout
+  $stderr = $stdout = StringIO.new
+
+  yield
+
+  $stderr = @original_stderr
+  $stdout = @original_stdout
+  @original_stderr = nil
+  @original_stdout = nil
+end

--- a/spec/workers/taric_sequence_check_worker_spec.rb
+++ b/spec/workers/taric_sequence_check_worker_spec.rb
@@ -1,20 +1,30 @@
 describe TaricSequenceCheckWorker, type: :worker do
   before do
-    allow($stdout).to receive(:write)
-    allow_any_instance_of(TariffSynchronizer::TaricSequenceChecker).to receive(:perform)
+    allow(TariffSynchronizer::TaricSequenceChecker).to receive(:new).and_return(taric_sequence_checker)
+    allow(TradeTariffBackend).to receive(:service).and_return(service)
   end
 
-  describe '#perfomr' do
-    it 'creates an instance of TaricSequenceCheck' do
-      expect(TariffSynchronizer::TaricSequenceChecker).to receive(:new).with(true).and_call_original
+  let(:taric_sequence_checker) { instance_double(TariffSynchronizer::TaricSequenceChecker, perform: 'foo') }
 
-      described_class.new.perform
+  describe '#perform' do
+    context 'when on the uk service' do
+      let(:service) { 'uk' }
+
+      it 'does not call perform on the instance of TaricSequenceChecker' do
+        silence { described_class.new.perform }
+
+        expect(taric_sequence_checker).not_to have_received(:perform)
+      end
     end
 
-    it 'calls perform for the instance of TaricSequenceCheck' do
-      expect_any_instance_of(TariffSynchronizer::TaricSequenceChecker).to receive(:perform)
+    context 'when on the xi service' do
+      let(:service) { 'xi' }
 
-      described_class.new.perform
+      it 'calls perform on the instance of TaricSequenceChecker' do
+        silence { described_class.new.perform }
+
+        expect(taric_sequence_checker).to have_received(:perform)
+      end
     end
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Stop running the sequence worker on the uk service
- [x] Lint

### Why?

I am doing this because:

- That this is happening was noticed because we failed to do a deploy when a queued worker was getting failed responses from the Taric api
- It seemed simple enough to just stop this from running
