### PR TITLE
HOTT-868 - Rules of origin queries

### DIFF
--- a/app/models/rules_of_origin/data_set.rb
+++ b/app/models/rules_of_origin/data_set.rb
@@ -1,0 +1,33 @@
+module RulesOfOrigin
+  class DataSet
+    attr_reader :scheme_set, :rule_set, :heading_mappings
+
+    class << self
+      def load_default
+        new default_scheme_set, default_rule_set, default_heading_mappings
+      end
+
+    private
+
+      def default_scheme_set
+        RulesOfOrigin::SchemeSet.from_default_file(TradeTariffBackend.service)
+      end
+
+      def default_rule_set
+        RulesOfOrigin::RuleSet.from_default_file.tap(&:import)
+      end
+
+      def default_heading_mappings
+        RulesOfOrigin::HeadingMappings.from_default_file.tap do |importer|
+          importer.import(skip_invalid_rows: true)
+        end
+      end
+    end
+
+    def initialize(scheme_set, rule_set, heading_mappings)
+      @scheme_set = scheme_set
+      @rule_set = rule_set
+      @heading_mappings = heading_mappings
+    end
+  end
+end

--- a/app/models/rules_of_origin/explainer.rb
+++ b/app/models/rules_of_origin/explainer.rb
@@ -8,6 +8,7 @@ module RulesOfOrigin
 
     class << self
       def new_with_check(attrs = {})
+        attrs = attrs.stringify_keys
         return unless attrs['text'].present? && attrs['url'].present?
 
         new(attrs)

--- a/app/models/rules_of_origin/heading_mappings.rb
+++ b/app/models/rules_of_origin/heading_mappings.rb
@@ -53,9 +53,13 @@ module RulesOfOrigin
       @mappings[sub_heading][scheme_code] << id_rule.to_i
     end
 
+    def heading_codes
+      @mappings.keys
+    end
+
     def for_heading_and_schemes(heading, scheme_codes)
       schemes = @mappings[heading]
-      return [] if schemes.nil?
+      return {} if schemes.nil?
 
       schemes.slice(*scheme_codes)
     end

--- a/app/models/rules_of_origin/heading_mappings.rb
+++ b/app/models/rules_of_origin/heading_mappings.rb
@@ -40,12 +40,17 @@ module RulesOfOrigin
           raise InvalidFile, "Row #{count} is invalid - sub_heading, scheme_code or id_rule are blank"
         end
 
-        @mappings[row['sub_heading']] ||= {}
-        @mappings[row['sub_heading']][row['scheme_code']] ||= []
-        @mappings[row['sub_heading']][row['scheme_code']] << row['id_rule'].to_i
+        add_mapping row['sub_heading'], row['scheme_code'], row['id_rule']
       end
 
       @mappings.values.map(&:length).sum
+    end
+
+    def add_mapping(sub_heading, scheme_code, id_rule)
+      @mappings ||= {}
+      @mappings[sub_heading] ||= {}
+      @mappings[sub_heading][scheme_code] ||= []
+      @mappings[sub_heading][scheme_code] << id_rule.to_i
     end
 
     def for_heading_and_schemes(heading, scheme_codes)

--- a/app/models/rules_of_origin/link.rb
+++ b/app/models/rules_of_origin/link.rb
@@ -8,6 +8,7 @@ module RulesOfOrigin
 
     class << self
       def new_with_check(attrs = {})
+        attrs = attrs.stringify_keys
         return unless attrs['text'].present? && attrs['url'].present?
 
         new(attrs)

--- a/app/models/rules_of_origin/query.rb
+++ b/app/models/rules_of_origin/query.rb
@@ -1,0 +1,40 @@
+module RulesOfOrigin
+  class Query
+    attr_reader :heading_code, :country_code
+
+    delegate :scheme_set, :rule_set, :heading_mappings, to: :@data_set
+
+    def initialize(data_set, heading_code, country_code)
+      @data_set = data_set
+      @heading_code = heading_code
+      @country_code = country_code
+    end
+
+    def rules
+      id_rules.map(&rule_set.method(:rule))
+    end
+
+    def schemes
+      @schemes ||= scheme_set.schemes_for_country(country_code)
+    end
+
+    def scheme_codes
+      schemes.map(&:scheme_code)
+    end
+
+    def links
+      scheme_set.links + schemes.map(&:links).flatten
+    end
+
+    private
+
+    def id_rules
+      schemes_and_their_id_rules.values.flatten.uniq
+    end
+
+    def schemes_and_their_id_rules
+      @schemes_and_their_id_rules ||=
+        heading_mappings.for_heading_and_schemes(heading_code, scheme_codes)
+    end
+  end
+end

--- a/app/models/rules_of_origin/rule.rb
+++ b/app/models/rules_of_origin/rule.rb
@@ -21,5 +21,11 @@ module RulesOfOrigin
     validates :scheme_code, presence: true, format: SCHEME_CODE_FORMAT
     validates :heading, presence: true
     validates :rule, presence: true
+
+    def ==(other)
+      id_rule.present? &&
+        other.respond_to?(:id_rule) &&
+        other.id_rule == id_rule
+    end
   end
 end

--- a/app/models/rules_of_origin/rule.rb
+++ b/app/models/rules_of_origin/rule.rb
@@ -3,12 +3,19 @@
 module RulesOfOrigin
   class Rule
     include ActiveModel::Model
+    include ActiveModel::Attributes
 
     ID_RULE_FORMAT = %r{\A\d+\z}.freeze
     SCHEME_CODE_FORMAT = %r{\A[a-zA-Z\-]+\z}.freeze
 
-    attr_accessor :id_rule, :scheme_code, :heading, :description,
-                  :quota_amount, :quota_unit, :rule, :alternate_rule
+    attribute :id_rule
+    attribute :scheme_code
+    attribute :heading
+    attribute :description
+    attribute :quota_amount
+    attribute :quota_unit
+    attribute :rule
+    attribute :alternate_rule
 
     validates :id_rule, presence: true, format: ID_RULE_FORMAT
     validates :scheme_code, presence: true, format: SCHEME_CODE_FORMAT

--- a/app/models/rules_of_origin/rule_set.rb
+++ b/app/models/rules_of_origin/rule_set.rb
@@ -41,6 +41,10 @@ module RulesOfOrigin
       @rules[id_rule] = rule_data
     end
 
+    def id_rules
+      @rules.keys
+    end
+
     def rule(id_rule)
       rule = @rules[id_rule.to_i]
 

--- a/app/models/rules_of_origin/rule_set.rb
+++ b/app/models/rules_of_origin/rule_set.rb
@@ -25,15 +25,20 @@ module RulesOfOrigin
     def import
       raise AlreadyImported if @rules
 
-      @rules = {}
+      @rules ||= {}
 
       CSV.foreach(@source_file, headers: true) do |row|
         next unless row['scope'] == TradeTariffBackend.service
 
-        @rules[row['id_rule'].to_i] = row.to_h.without('scope', 'id_rule')
+        add_rule row['id_rule'].to_i, row.to_h.without('scope', 'id_rule')
       end
 
       @rules.length
+    end
+
+    def add_rule(id_rule, rule_data)
+      @rules ||= {}
+      @rules[id_rule] = rule_data
     end
 
     def rule(id_rule)

--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -7,8 +7,6 @@ module RulesOfOrigin
     attr_accessor :scheme_code, :title, :introductory_notes_file, :fta_intro_file,
                   :countries, :rule_offset, :footnote
 
-    attr_reader :links, :explainers
-
     def links=(links_data)
       @links = Array.wrap(links_data)
                     .map(&Link.method(:new_with_check))
@@ -16,11 +14,19 @@ module RulesOfOrigin
                     .freeze
     end
 
+    def links
+      @links || []
+    end
+
     def explainers=(explainers_data)
       @explainers = Array.wrap(explainers_data)
                          .map(&Explainer.method(:new_with_check))
                          .compact
                          .freeze
+    end
+
+    def explainers
+      @explainers || []
     end
   end
 end

--- a/config/initializers/rules_of_origin.rb
+++ b/config/initializers/rules_of_origin.rb
@@ -1,8 +1,6 @@
 if TradeTariffBackend.rules_of_origin_enabled? && !Rails.env.test?
   Rails.application.reloader.to_prepare do
     # trigger loading at boot
-    TradeTariffBackend.rules_of_origin_schemes
-    TradeTariffBackend.rules_of_origin_rules
-    TradeTariffBackend.rules_of_origin_mappings
+    TradeTariffBackend.rules_of_origin
   end
 end

--- a/lib/trade_tariff_backend.rb
+++ b/lib/trade_tariff_backend.rb
@@ -194,21 +194,8 @@ module TradeTariffBackend
       ENV['ENABLE_RULES_OF_ORIGIN'].to_s == 'true'
     end
 
-    def rules_of_origin_schemes
-      @rules_of_origin_schemes ||=
-        RulesOfOrigin::SchemeSet.from_default_file(service)
-    end
-
-    def rules_of_origin_rules
-      @rules_of_origin_rules ||=
-        RulesOfOrigin::RuleSet.from_default_file.tap(&:import)
-    end
-
-    def rules_of_origin_mappings
-      @rules_of_origin_mappings ||=
-        RulesOfOrigin::HeadingMappings.from_default_file.tap do |importer|
-          importer.import(skip_invalid_rows: true)
-        end
+    def rules_of_origin
+      @rules_of_origin ||= RulesOfOrigin::DataSet.load_default
     end
   end
 end

--- a/spec/factories/rules_of_origin/data_set_factory.rb
+++ b/spec/factories/rules_of_origin/data_set_factory.rb
@@ -1,0 +1,20 @@
+FactoryBot.define do
+  factory :rules_of_origin_data_set, class: 'RulesOfOrigin::DataSet' do
+    initialize_with { new scheme_set, rule_set, heading_mappings }
+
+    scheme_set { build :rules_of_origin_scheme_set }
+    rule_set { build :rules_of_origin_rule_set, rules: rules }
+
+    heading_mappings do
+      build :rules_of_origin_heading_mappings,
+            rule: rules.first,
+            sub_heading: heading_code
+    end
+
+    transient do
+      scheme_code { scheme_set.schemes.first }
+      rules { build_list :rules_of_origin_rule, 2, scheme_code: scheme_code }
+      sequence(:heading_code, 1000) { |n| sprintf '%6d', n }
+    end
+  end
+end

--- a/spec/factories/rules_of_origin/heading_mappings_factory.rb
+++ b/spec/factories/rules_of_origin/heading_mappings_factory.rb
@@ -1,0 +1,24 @@
+FactoryBot.define do
+  factory :rules_of_origin_heading_mappings, class: 'RulesOfOrigin::HeadingMappings' do
+    initialize_with do
+      new(source_file).tap do |heading_mappings|
+        mappings.each do |mapping|
+          heading_mappings.add_mapping(*mapping)
+        end
+      end
+    end
+
+    transient do
+      mappings do
+        [
+          [sub_heading, scheme_code, id_rule],
+        ]
+      end
+      source_file { 'spec/fixtures/rules_of_origin/rules_to_commodities.csv' }
+      sub_heading { '010101' }
+      rule { build :rules_of_origin_rule }
+      scheme_code { rule.scheme_code }
+      id_rule { rule.id_rule }
+    end
+  end
+end

--- a/spec/factories/rules_of_origin/link_factory.rb
+++ b/spec/factories/rules_of_origin/link_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :rules_of_origin_link, class: 'RulesOfOrigin::Link' do
-    sequence(:text) { |n| "Explainer #{n}" }
-    sequence(:url)  { |n| "explainer#{n}.md" }
+    sequence(:text) { |n| "Link #{n}" }
+    sequence(:url)  { |n| "https://gov.uk/some-external-link-#{n}" }
   end
 end

--- a/spec/factories/rules_of_origin/rule_set_factory.rb
+++ b/spec/factories/rules_of_origin/rule_set_factory.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :rules_of_origin_rule_set, class: 'RulesOfOrigin::RuleSet' do
+    initialize_with do
+      new(source_file).tap do |rule_set|
+        rules.each do |rule|
+          rule_set.add_rule rule.id_rule, rule.attributes.without(:id_rule)
+        end
+      end
+    end
+
+    transient do
+      source_file { 'spec/fixtures/rules_of_origin/rules_of_origin_210728.csv' }
+      rules { build_list(:rules_of_origin_rule, 2) }
+    end
+  end
+end

--- a/spec/factories/rules_of_origin/scheme_set_factory.rb
+++ b/spec/factories/rules_of_origin/scheme_set_factory.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
       base_path { Rails.root.join('spec/fixtures/rules_of_origin') }
       scope { 'uk' }
       links { [attributes_for(:rules_of_origin_link)] }
-      schemes { [attributes_for(:rules_of_origin_scheme)] }
+      schemes { [attributes_for(:rules_of_origin_scheme, :with_links)] }
 
       scheme_data do
         {

--- a/spec/models/rules_of_origin/data_set_spec.rb
+++ b/spec/models/rules_of_origin/data_set_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe RulesOfOrigin::DataSet do
+  subject { described_class.new scheme_set, rule_set, mappings }
+
+  let(:rules) do
+    build_list :rules_of_origin_rule, 2, scheme_code: scheme_set.schemes.first
+  end
+
+  let(:scheme_set) { build :rules_of_origin_scheme_set }
+  let(:rule_set) { build :rules_of_origin_rule_set, rules: rules }
+  let(:mappings) { build :rules_of_origin_heading_mappings, rule: rules.first }
+
+  it { is_expected.to respond_to :scheme_set }
+  it { is_expected.to respond_to :rule_set }
+  it { is_expected.to respond_to :heading_mappings }
+
+  it { is_expected.to have_attributes scheme_set: scheme_set }
+  it { is_expected.to have_attributes rule_set: rule_set }
+  it { is_expected.to have_attributes heading_mappings: mappings }
+end

--- a/spec/models/rules_of_origin/heading_mappings_spec.rb
+++ b/spec/models/rules_of_origin/heading_mappings_spec.rb
@@ -61,13 +61,13 @@ RSpec.describe RulesOfOrigin::HeadingMappings do
     context 'with unknown scheme code' do
       let(:scheme_code) { 'unknown' }
 
-      it { is_expected.to be_empty }
+      it { is_expected.to eq({}) }
     end
 
     context 'with unknown heading' do
       let(:heading) { '111111' }
 
-      it { is_expected.to be_empty }
+      it { is_expected.to eq({}) }
     end
   end
 

--- a/spec/models/rules_of_origin/query_spec.rb
+++ b/spec/models/rules_of_origin/query_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe RulesOfOrigin::Query do
+  subject(:query) { described_class.new data_set, heading_code, country_code }
+
+  let(:scheme_code) { data_set.scheme_set.schemes.first }
+  let(:country_code) { data_set.scheme_set.scheme(scheme_code).countries.first }
+  let(:heading_code) { data_set.heading_mappings.heading_codes.first }
+  let(:data_set) { build :rules_of_origin_data_set }
+
+  describe '#rules' do
+    subject { query.rules }
+
+    let(:rule) { data_set.rule_set.rule data_set.rule_set.id_rules.first }
+
+    context 'with matching heading and country code' do
+      it { is_expected.to include rule }
+      it { is_expected.to have_attributes length: 1 }
+    end
+
+    context 'with unmatched country code' do
+      let(:country_code) { 'RA' }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'with unmatched heading' do
+      let(:heading_code) { '011111' }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
+  describe '#schemes' do
+    subject { query.schemes }
+
+    context 'with schemes matching supplied country code' do
+      it { is_expected.to include data_set.scheme_set.scheme(scheme_code) }
+    end
+
+    context 'without schemes matching supplied country code' do
+      let(:country_code) { 'RA' }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
+  describe '#links' do
+    subject { query.links }
+
+    let(:scheme_link) { data_set.scheme_set.scheme(scheme_code).links.first }
+
+    it { is_expected.to have_attributes length: 3 }
+    it { is_expected.to include data_set.scheme_set.links.first }
+    it { is_expected.to include scheme_link }
+  end
+end

--- a/spec/models/rules_of_origin/rule_spec.rb
+++ b/spec/models/rules_of_origin/rule_spec.rb
@@ -26,4 +26,14 @@ RSpec.describe RulesOfOrigin::Rule do
     it { is_expected.to have_attributes rule: attrs[:rule] }
     it { is_expected.to have_attributes alternate_rule: attrs[:alternate_rule] }
   end
+
+  describe '#==' do
+    subject(:rule) { build :rules_of_origin_rule }
+
+    let(:matching) { build :rules_of_origin_rule, id_rule: rule.id_rule }
+    let(:different) { build :rules_of_origin_rule }
+
+    it { is_expected.to eq matching }
+    it { is_expected.not_to eq different }
+  end
 end

--- a/spec/models/rules_of_origin/scheme_spec.rb
+++ b/spec/models/rules_of_origin/scheme_spec.rb
@@ -34,6 +34,22 @@ RSpec.describe RulesOfOrigin::Scheme do
     it { expect(links.first).to have_attributes url: 'https://www.hmrc.gov.uk' }
   end
 
+  describe '#links' do
+    subject { scheme.links }
+
+    context 'with links' do
+      let(:scheme) { build :rules_of_origin_scheme, :with_links }
+
+      it { is_expected.to have_attributes length: 2 }
+    end
+
+    context 'without links' do
+      let(:scheme) { build :rules_of_origin_scheme }
+
+      it { is_expected.to have_attributes length: 0 }
+    end
+  end
+
   describe '#explainers=' do
     subject(:explainers) { instance.explainers }
 
@@ -53,5 +69,21 @@ RSpec.describe RulesOfOrigin::Scheme do
     it { is_expected.to all be_instance_of RulesOfOrigin::Explainer }
     it { expect(explainers.first).to have_attributes text: 'HMRC' }
     it { expect(explainers.first).to have_attributes url: 'hmrc.md' }
+  end
+
+  describe '#explainers' do
+    subject { scheme.explainers }
+
+    context 'with explainers' do
+      let(:scheme) { build :rules_of_origin_scheme, :with_explainers }
+
+      it { is_expected.to have_attributes length: 2 }
+    end
+
+    context 'without explainers' do
+      let(:scheme) { build :rules_of_origin_scheme }
+
+      it { is_expected.to have_attributes length: 0 }
+    end
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-868](https://transformuk.atlassian.net/browse/HOTT-868)

### What?

I have added/removed/altered:

- [x] Added a `RulesOfOrigin::DataSet` model to group the various file based data sources together
- [x] Added a `RulesOfOrigin::Query` model to query the data set model
- [x] Fixed several edge case bugs in the other RoO data models
- [x] Added various factories to make it easier to generate data for testing

### Why?

I am doing this because:

- We need a way to query our file based data so that we can return the Rules of Origin data in the API

