### PR TITLE
HOTT-811 Adds the field declarable to the search serializers

### DIFF
--- a/app/elastic_search_indexes/search/chapter_index.rb
+++ b/app/elastic_search_indexes/search/chapter_index.rb
@@ -20,7 +20,8 @@ module Search
                 title: { type: 'text' },
                 numeral: { type: 'keyword' }
               }
-            }
+            },
+            declarable: { type: 'boolean' },
           }
         }
       }

--- a/app/elastic_search_indexes/search/commodity_index.rb
+++ b/app/elastic_search_indexes/search/commodity_index.rb
@@ -16,8 +16,8 @@ module Search
                 validity_start_date: { type: 'date', format: 'date_optional_time' },
                 producline_suffix: { type: 'keyword' },
                 goods_nomenclature_sid: { type: 'long' },
-                goods_nomenclature_item_id: { type: 'keyword' }
-              }
+                goods_nomenclature_item_id: { type: 'keyword' },
+              },
             },
             validity_end_date: { format: 'date_optional_time', type: 'date' },
             number_indents: { type: 'long' },
@@ -30,8 +30,8 @@ module Search
               properties: {
                 position: { type: 'long' },
                 title: { type: 'text' },
-                numeral: { type: 'keyword' }
-              }
+                numeral: { type: 'keyword' },
+              },
             },
             heading: {
               dynamic: true,
@@ -42,11 +42,12 @@ module Search
                 validity_start_date: { type: 'date', format: 'date_optional_time' },
                 producline_suffix: { type: 'keyword' },
                 goods_nomenclature_sid: { type: 'long' },
-                goods_nomenclature_item_id: { type: 'keyword' }
-              }
-            }
-          }
-        }
+                goods_nomenclature_item_id: { type: 'keyword' },
+              },
+            },
+            declarable: { type: 'boolean' },
+          },
+        },
       }
     end
   end

--- a/app/elastic_search_indexes/search/heading_index.rb
+++ b/app/elastic_search_indexes/search/heading_index.rb
@@ -16,8 +16,8 @@ module Search
                 validity_start_date: { type: 'date', format: 'date_optional_time' },
                 producline_suffix: { type: 'keyword' },
                 goods_nomenclature_sid: { type: 'long' },
-                goods_nomenclature_item_id: { type: 'keyword' }
-              }
+                goods_nomenclature_item_id: { type: 'keyword' },
+              },
             },
             validity_end_date: { type: 'date', format: 'date_optional_time' },
             number_indents: { type: 'long' },
@@ -30,11 +30,12 @@ module Search
               properties: {
                 position: { type: 'long' },
                 title: { type: 'text' },
-                numeral: { type: 'keyword' }
-              }
-            }
-          }
-        }
+                numeral: { type: 'keyword' },
+              },
+            },
+            declarable: { type: 'boolean' },
+          },
+        },
       }
     end
   end

--- a/app/elastic_search_indexes/search/section_index.rb
+++ b/app/elastic_search_indexes/search/section_index.rb
@@ -11,7 +11,8 @@ module Search
             position: { type: 'long' },
             id: { type: 'long' },
             title: { type: 'text', analyzer: 'snowball' },
-            numeral: { type: 'keyword' }
+            numeral: { type: 'keyword' },
+            declarable: { type: 'boolean' },
           }
         }
       }

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -11,18 +11,18 @@ class Commodity < GoodsNomenclature
 
   set_primary_key [:goods_nomenclature_sid]
 
-  one_to_one :heading, dataset: -> {
+  one_to_one :heading, dataset: lambda {
     actual_or_relevant(Heading)
            .filter('goods_nomenclatures.goods_nomenclature_item_id LIKE ?', heading_id)
            .filter(producline_suffix: '80')
   }
 
-  one_to_one :chapter, dataset: -> {
+  one_to_one :chapter, dataset: lambda {
     actual_or_relevant(Chapter)
            .filter('goods_nomenclatures.goods_nomenclature_item_id LIKE ?', chapter_id)
   }
 
-  one_to_many :overview_measures, key: {}, primary_key: {}, dataset: -> {
+  one_to_many :overview_measures, key: {}, primary_key: {}, dataset: lambda {
     measures_dataset
         .filter(measures__measure_type_id: MeasureType::VAT_TYPES + MeasureType::SUPPLEMENTARY_TYPES + Array.wrap(MeasureType::THIRD_COUNTRY))
   }, class_name: 'Measure'
@@ -45,8 +45,8 @@ class Commodity < GoodsNomenclature
   end
 
   # See oplog sequel plugin
-  def operation=(op)
-    self[:operation] = op.to_s.first.upcase
+  def operation=(operation)
+    self[:operation] = operation.to_s.first.upcase
   end
 
   def ancestors
@@ -88,20 +88,22 @@ class Commodity < GoodsNomenclature
   end
 
   def uptree
-    @_uptree ||= [ancestors, heading, chapter, self].flatten.compact
+    @uptree ||= [ancestors, heading, chapter, self].flatten.compact
   end
 
   def children
-    func = Proc.new {
+    return [] unless heading
+
+    func = proc do
       GoodsNomenclatureMapper.new(
         heading.commodities_dataset
                 .eager(:goods_nomenclature_indents, :goods_nomenclature_descriptions)
-                .all
+                .all,
       ).all
-        .detect do |item|
+        .detect { |item|
         item.goods_nomenclature_sid == goods_nomenclature_sid
-      end.try(:children) || []
-    }
+      }.try(:children) || []
+    end
 
     func.call
   end
@@ -120,7 +122,7 @@ class Commodity < GoodsNomenclature
       :oid,
       :operation_date,
       :operation,
-      Sequel.as(depth, :depth)
+      Sequel.as(depth, :depth),
     ).where(conditions)
      .where(Sequel.~(operation_date: nil))
      .limit(TradeTariffBackend.change_count)
@@ -133,20 +135,20 @@ class Commodity < GoodsNomenclature
       :oid,
       :operation_date,
       :operation,
-      Sequel.as(depth, :depth)
+      Sequel.as(depth, :depth),
     ).where(pk_hash)
      .union(
        Measure.changes_for(
          depth + 1,
-         Sequel.qualify(:measures_oplog, :goods_nomenclature_item_id) => goods_nomenclature_item_id
-       )
+         Sequel.qualify(:measures_oplog, :goods_nomenclature_item_id) => goods_nomenclature_item_id,
+       ),
      )
      .from_self
      .where(Sequel.~(operation_date: nil))
      .tap! { |criteria|
       # if Commodity did not come from initial seed, filter by its
       # create/update date
-      criteria.where { |o| o.>=(:operation_date, operation_date) } unless operation_date.blank?
+      criteria.where { |o| o.>=(:operation_date, operation_date) } if operation_date.present?
     }
      .limit(TradeTariffBackend.change_count)
      .order(Sequel.desc(:operation_date, nulls: :last), Sequel.desc(:depth))

--- a/app/models/hidden_goods_nomenclature.rb
+++ b/app/models/hidden_goods_nomenclature.rb
@@ -10,8 +10,6 @@ class HiddenGoodsNomenclature < Sequel::Model
   end
 
   def self.codes
-    Rails.cache.fetch('hidden_goods_nomenclature_codes', expires_in: 1.hours) do
-      all.map(&:goods_nomenclature_item_id)
-    end
+    all.map(&:goods_nomenclature_item_id)
   end
 end

--- a/app/serializers/search/chapter_serializer.rb
+++ b/app/serializers/search/chapter_serializer.rb
@@ -11,16 +11,17 @@ module Search
         guides: guides.map do |guide|
           {
             title: guide.title,
-            url: guide.url
+            url: guide.url,
           }
-        end
+        end,
+        declarable: false,
       }
 
       if section.present?
         chapter_attributes[:section] = {
           numeral: section.numeral,
           title: section.title,
-          position: section.position
+          position: section.position,
         }
       end
 

--- a/app/serializers/search/commodity_serializer.rb
+++ b/app/serializers/search/commodity_serializer.rb
@@ -9,6 +9,7 @@ module Search
         validity_end_date: validity_end_date,
         description: formatted_description,
         number_indents: number_indents,
+        declarable: declarable?,
       }
 
       if heading.present?
@@ -19,7 +20,7 @@ module Search
           validity_start_date: heading.validity_start_date,
           validity_end_date: heading.validity_end_date,
           description: heading.formatted_description,
-          number_indents: heading.number_indents
+          number_indents: heading.number_indents,
         }
 
         if chapter.present?
@@ -33,16 +34,16 @@ module Search
             guides: chapter.guides.map do |guide|
               {
                 title: guide.title,
-                url: guide.url
+                url: guide.url,
               }
-            end
+            end,
           }
 
           if section.present?
             commodity_attributes[:section] = {
               numeral: section.numeral,
               title: section.title,
-              position: section.position
+              position: section.position,
             }
           end
         end

--- a/app/serializers/search/heading_serializer.rb
+++ b/app/serializers/search/heading_serializer.rb
@@ -9,6 +9,7 @@ module Search
         validity_end_date: validity_end_date,
         description: formatted_description,
         number_indents: number_indents,
+        declarable: declarable,
       }
 
       if chapter.present?
@@ -22,16 +23,16 @@ module Search
           guides: chapter.guides.map do |guide|
             {
               title: guide.title,
-              url: guide.url
+              url: guide.url,
             }
-          end
+          end,
         }
 
         if section.present?
           heading_attributes[:section] = {
             numeral: section.numeral,
             title: section.title,
-            position: section.position
+            position: section.position,
           }
         end
       end

--- a/app/serializers/search/section_serializer.rb
+++ b/app/serializers/search/section_serializer.rb
@@ -5,7 +5,8 @@ module Search
         id: id,
         numeral: numeral,
         title: title,
-        position: position
+        declarable: false,
+        position: position,
       }
     end
   end

--- a/app/serializers/search/section_serializer.rb
+++ b/app/serializers/search/section_serializer.rb
@@ -5,8 +5,8 @@ module Search
         id: id,
         numeral: numeral,
         title: title,
-        declarable: false,
         position: position,
+        declarable: false,
       }
     end
   end

--- a/lib/trade_tariff_backend/search_client.rb
+++ b/lib/trade_tariff_backend/search_client.rb
@@ -15,12 +15,9 @@ module TradeTariffBackend
       end
     end
 
-    attr_reader :indexed_models
-    attr_reader :index_page_size
-    attr_reader :search_operation_options
-    attr_reader :namespace
+    attr_reader :indexed_models, :index_page_size, :search_operation_options, :namespace
 
-    delegate :search_index_for, to: TradeTariffBackend
+    delegate :search_index_for, :model_serializer_for, to: TradeTariffBackend
 
     def initialize(search_client, options = {})
       @indexed_models = options.fetch(:indexed_models, [])
@@ -78,7 +75,7 @@ module TradeTariffBackend
         super({
           index: model_index.name,
           id: model.id,
-          body: TradeTariffBackend.model_serializer_for(namespace, model_index.model).new(model).as_json
+          body: model_serializer_for(namespace, model_index.model).new(model).as_json,
         }.merge(search_operation_options))
       end
     end
@@ -87,7 +84,7 @@ module TradeTariffBackend
       search_index_for(namespace, model.class).tap do |model_index|
         super({
           index: model_index.name,
-          id: model.id
+          id: model.id,
         }.merge(search_operation_options))
       end
     end

--- a/spec/factories/goods_nomenclature_factory.rb
+++ b/spec/factories/goods_nomenclature_factory.rb
@@ -129,7 +129,6 @@ FactoryBot.define do
     end
   end
 
-  # WIP
   factory :heading, parent: :goods_nomenclature, class: 'Heading' do
     # +1 is needed to avoid creating heading with gono id in form of
     # xx00xxxxxx which is a Chapter

--- a/spec/factories/goods_nomenclature_factory.rb
+++ b/spec/factories/goods_nomenclature_factory.rb
@@ -129,6 +129,7 @@ FactoryBot.define do
     end
   end
 
+  # WIP
   factory :heading, parent: :goods_nomenclature, class: 'Heading' do
     # +1 is needed to avoid creating heading with gono id in form of
     # xx00xxxxxx which is a Chapter

--- a/spec/serializers/search/chapter_serializer_spec.rb
+++ b/spec/serializers/search/chapter_serializer_spec.rb
@@ -1,6 +1,7 @@
 describe Search::ChapterSerializer do
+  subject(:serializer) { described_class.new(chapter) }
+
   describe '#to_json' do
-    let(:serializer) { described_class.new(chapter) }
     let(:chapter) { create(:chapter, :with_section, :with_description) }
 
     let(:pattern) do

--- a/spec/serializers/search/chapter_serializer_spec.rb
+++ b/spec/serializers/search/chapter_serializer_spec.rb
@@ -1,10 +1,8 @@
 describe Search::ChapterSerializer do
   describe '#to_json' do
-    let!(:chapter) do
-      described_class.new(
-        create(:chapter, :with_section, :with_description),
-      )
-    end
+    let(:serializer) { described_class.new(chapter) }
+    let(:chapter) { create(:chapter, :with_section, :with_description) }
+
     let(:pattern) do
       {
         goods_nomenclature_item_id: chapter.goods_nomenclature_item_id,
@@ -13,7 +11,7 @@ describe Search::ChapterSerializer do
     end
 
     it 'returns json representation for ElasticSearch' do
-      expect(chapter.to_json).to match_json_expression pattern
+      expect(serializer.to_json).to match_json_expression pattern
     end
   end
 end

--- a/spec/serializers/search/chapter_serializer_spec.rb
+++ b/spec/serializers/search/chapter_serializer_spec.rb
@@ -7,6 +7,7 @@ describe Search::ChapterSerializer do
     let(:pattern) do
       {
         goods_nomenclature_item_id: chapter.goods_nomenclature_item_id,
+        declarable: false,
         section: Hash,
       }.ignore_extra_keys!
     end

--- a/spec/serializers/search/commodity_serializer_spec.rb
+++ b/spec/serializers/search/commodity_serializer_spec.rb
@@ -1,0 +1,37 @@
+describe Search::CommoditySerializer do
+  describe '#to_json' do
+    let(:serializer) { described_class.new(commodity) }
+
+    context 'when commodity is declarable' do
+      let(:commodity) { build :commodity, :declarable, :with_children, :with_heading }
+
+      let(:pattern) do
+        {
+          goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+          producline_suffix: '80',
+          declarable: true,
+        }.ignore_extra_keys!
+      end
+
+      it 'returns json representation for ElasticSearch' do
+        expect(serializer.to_json).to match_json_expression pattern
+      end
+    end
+
+    context 'when commodity is NOT declarable' do
+      let(:commodity) { build :commodity, :non_declarable, :with_children, :with_heading }
+
+      let(:pattern) do
+        {
+          goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+          producline_suffix: '10',
+          declarable: false,
+        }.ignore_extra_keys!
+      end
+
+      it 'returns json representation for ElasticSearch' do
+        expect(serializer.to_json).to match_json_expression pattern
+      end
+    end
+  end
+end

--- a/spec/serializers/search/commodity_serializer_spec.rb
+++ b/spec/serializers/search/commodity_serializer_spec.rb
@@ -1,7 +1,7 @@
 describe Search::CommoditySerializer do
-  describe '#to_json' do
-    let(:serializer) { described_class.new(commodity) }
+  subject(:serializer) { described_class.new(commodity) }
 
+  describe '#to_json' do
     context 'when commodity is declarable' do
       let(:commodity) { build :commodity, :declarable, :with_children, :with_heading }
 

--- a/spec/serializers/search/commodity_serializer_spec.rb
+++ b/spec/serializers/search/commodity_serializer_spec.rb
@@ -13,9 +13,7 @@ describe Search::CommoditySerializer do
         }.ignore_extra_keys!
       end
 
-      it 'returns json representation for ElasticSearch' do
-        expect(serializer.to_json).to match_json_expression pattern
-      end
+      it { expect(serializer.to_json).to match_json_expression pattern }
     end
 
     context 'when commodity is NOT declarable' do
@@ -29,9 +27,7 @@ describe Search::CommoditySerializer do
         }.ignore_extra_keys!
       end
 
-      it 'returns json representation for ElasticSearch' do
-        expect(serializer.to_json).to match_json_expression pattern
-      end
+      it { expect(serializer.to_json).to match_json_expression pattern }
     end
   end
 end

--- a/spec/serializers/search/heading_serializer_spec.rb
+++ b/spec/serializers/search/heading_serializer_spec.rb
@@ -1,0 +1,37 @@
+describe Search::HeadingSerializer do
+  describe '#to_json' do
+    let(:serializer) { described_class.new(heading) }
+
+    context 'when heading is declarable' do
+      let(:heading) { create :heading, :declarable }
+
+      let(:pattern) do
+        {
+          goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
+          producline_suffix: '80',
+          declarable: true,
+        }.ignore_extra_keys!
+      end
+
+      it 'returns json representation for ElasticSearch' do
+        expect(serializer.to_json).to match_json_expression pattern
+      end
+    end
+
+    context 'when heading is NOT declarable' do
+      let(:heading) { create :heading, :non_declarable }
+
+      let(:pattern) do
+        {
+          goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
+          producline_suffix: heading.producline_suffix,
+          declarable: false,
+        }.ignore_extra_keys!
+      end
+
+      it 'returns json representation for ElasticSearch' do
+        expect(serializer.to_json).to match_json_expression pattern
+      end
+    end
+  end
+end

--- a/spec/serializers/search/heading_serializer_spec.rb
+++ b/spec/serializers/search/heading_serializer_spec.rb
@@ -29,9 +29,7 @@ describe Search::HeadingSerializer do
         }.ignore_extra_keys!
       end
 
-      it 'returns json representation for ElasticSearch' do
-        expect(serializer.to_json).to match_json_expression pattern
-      end
+      it { expect(serializer.to_json).to match_json_expression pattern }
     end
   end
 end

--- a/spec/serializers/search/heading_serializer_spec.rb
+++ b/spec/serializers/search/heading_serializer_spec.rb
@@ -1,7 +1,7 @@
 describe Search::HeadingSerializer do
-  describe '#to_json' do
-    let(:serializer) { described_class.new(heading) }
+  subject(:serializer) { described_class.new(heading) }
 
+  describe '#to_json' do
     context 'when heading is declarable' do
       let(:heading) { create :heading, :declarable }
 

--- a/spec/serializers/search/section_serializer_spec.rb
+++ b/spec/serializers/search/section_serializer_spec.rb
@@ -1,0 +1,19 @@
+describe Search::SectionSerializer do
+  subject(:serializer) { described_class.new(section) }
+
+  describe '#to_json' do
+    let(:section) { create(:section) }
+
+    let(:pattern) do
+      {
+        id: section.id,
+        numeral: section.numeral,
+        title: section.title,
+        position: section.position,
+        declarable: false,
+      }
+    end
+
+    it { expect(serializer.to_json).to match_json_expression pattern }
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-811

### What?
The reason is that we need to keep declarable in case of fuzzy search too,
which came from elasticsearch.


I have added/removed/altered:
- [x] Added declarable in the search heading and commodities serializers
- [x] Add the missing tests for those

### Why?

I am doing this because:
to help the SWT to check if an entity is declarable.

### Have you? (optional)

- [ ] Added documentation for new apis
not yet!


### Deployment risks (optional)
Risk should be low, since we are adding a new field (and not removing any)
