### PR TITLE
HOTT-930: Spec to catch when the CDS import failed

### DIFF
--- a/spec/integration/cds_importer/entity_mapper_spec.rb
+++ b/spec/integration/cds_importer/entity_mapper_spec.rb
@@ -18,21 +18,25 @@ RSpec.describe CdsImporter::EntityMapper do
   end
   let(:mapper) { described_class.new('AdditionalCode', xml_node) }
 
-  before do
-    stub_const(
-      'CdsImporter::EntityMapper::ALL_MAPPERS',
-      [
-        CdsImporter::EntityMapper::MeasureMapper,
-        CdsImporter::EntityMapper::MeasureExcludedGeographicalAreaMapper,
-        CdsImporter::EntityMapper::AdditionalCodeMapper,
-        CdsImporter::EntityMapper::GeographicalAreaMapper,
-        CdsImporter::EntityMapper::GeographicalAreaMembershipMapper,
-      ],
-    )
+  describe '::ALL_MAPPERS' do
+    subject { described_class::ALL_MAPPERS }
+
+    it { is_expected.not_to be_empty }
   end
 
   describe '#import' do
     before do
+      stub_const(
+        'CdsImporter::EntityMapper::ALL_MAPPERS',
+        [
+          CdsImporter::EntityMapper::MeasureMapper,
+          CdsImporter::EntityMapper::MeasureExcludedGeographicalAreaMapper,
+          CdsImporter::EntityMapper::AdditionalCodeMapper,
+          CdsImporter::EntityMapper::GeographicalAreaMapper,
+          CdsImporter::EntityMapper::GeographicalAreaMembershipMapper,
+        ],
+      )
+
       create(:geographical_area, hjid: 23_590, geographical_area_sid: 331)
     end
 


### PR DESCRIPTION
Failure was caused by missing load of entities by entity mapper. Check to ensure the list of MAPPERS is not empty.

### Jira link

[HOTT-930](https://transformuk.atlassian.net/browse/HOTT-930)

### What?

I have added/removed/altered:

- [x] Added a spec to ensure the CDS importer has some entities to map

### Why?

I am doing this because:

- When the zeitwerk autoloader was enabled it broke autoloading of the entity mappers. This was not picked up because the specs mocked the list of entity mappers to use.
- So I've added a spec to ensure when the list isn't mocked, it is still not empty.