### PR TITLE
Remove the cache for hidden_goods_nomenclature_codes

### DIFF
--- a/app/models/hidden_goods_nomenclature.rb
+++ b/app/models/hidden_goods_nomenclature.rb
@@ -10,8 +10,6 @@ class HiddenGoodsNomenclature < Sequel::Model
   end
 
   def self.codes
-    Rails.cache.fetch('hidden_goods_nomenclature_codes', expires_in: 1.hours) do
-      all.map(&:goods_nomenclature_item_id)
-    end
+    all.map(&:goods_nomenclature_item_id)
   end
 end


### PR DESCRIPTION
This PR remove the cache for hidden_goods_nomenclature_codes,
which do no provide any valuable performance improvement (the number of entries are very low),
and is cause of a nasty bug that was hard to spot.

### Jira link
No ticket for this, but that is to prevent a bug spotted working on the HOTT-811

### What?
This PR remove the cache for hidden_goods_nomenclature_codes,
which do no provide any valuable performance improvement (the number of entries are very low),
and is cause of a nasty bug that was hard to spot.

