### PR TITLE
Disable rack-timeout in Dev environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ gem 'logstash-event'
 gem 'nokogiri'
 gem 'ox'
 gem 'plek'
-gem 'rack-timeout'
 gem 'sentry-raven'
 
 # API related
@@ -77,4 +76,8 @@ group :test do
   gem 'rspec-rails'
   gem 'simplecov', require: false
   gem 'webmock'
+end
+
+group :production do
+  gem 'rack-timeout'
 end

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,1 +1,5 @@
-Rails.application.config.middleware.insert_before Rack::Runtime, Rack::Timeout, service_timeout: Integer(ENV.fetch('RACK_TIMEOUT_SERVICE', 6))
+if Rails.env.production?
+  Rails.application.config.middleware.insert_before Rack::Runtime, Rack::Timeout, service_timeout: Integer(ENV.fetch('RACK_TIMEOUT_SERVICE', 6))
+else
+  logger.info 'Rack::Runtime is disabled in Dev env.'
+end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>
No Jira ticket.


### What?
Disable rack-timeout in Dev environment, to allow to pry the BE server.
### Why?

To simplify debugging in local dev env.

