### PR TITLE
HOTT-943: Allow missing migration files

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -41,5 +41,8 @@ module TradeTariffBackend
       Sequel::Model.db.extension :server_block
       Sequel::Model.db.extension :auto_literal_strings
     end
+
+    config.sequel.allow_missing_migration_files = \
+      (ENV['ALLOW_MISSING_MIGRATION_FILES'].to_s == 'true')
   end
 end


### PR DESCRIPTION
Requires Env var setting - will only be set on DEV environment

### Jira link

[HOTT-943](https://transformuk.atlassian.net/browse/HOTT-943)

### What?

I have added/removed/altered:

- [x] Added a configurable option to ignore the check for migration files existing

### Why?

I am doing this because:

- the DEV environment flip flops between different branches so sometimes migration files will 'disappear' but we don't want this to prevent the `rake db:migrate` task from running