### PR TITLE
Adjust autoscaling policy for all environments

### DIFF
--- a/config/autoscaling/development-policy.json
+++ b/config/autoscaling/development-policy.json
@@ -1,22 +1,14 @@
 {
-  "instance_min_count": 1,
-  "instance_max_count": 3,
+  "instance_min_count": 2,
+  "instance_max_count": 6,
   "scaling_rules": [
     {
-      "metric_type": "throughput",
-      "breach_duration_secs": 120,
-      "threshold": 5,
-      "operator": "<",
-      "cool_down_secs": 120,
-      "adjustment": "-1"
-    },
-    {
-      "metric_type": "throughput",
-      "breach_duration_secs": 120,
-      "threshold": 5,
+      "metric_type": "memoryutil",
+      "breach_duration_secs": 60,
+      "threshold": 50,
       "operator": ">=",
-      "cool_down_secs": 120,
-      "adjustment": "+1"
+      "cool_down_secs": 60,
+      "adjustment": "+2"
     },
     {
       "metric_type": "memoryutil",
@@ -27,28 +19,20 @@
       "adjustment": "-1"
     },
     {
-      "metric_type": "memoryutil",
-      "breach_duration_secs": 120,
+      "metric_type": "cpu",
+      "breach_duration_secs": 60,
       "threshold": 50,
       "operator": ">=",
       "cool_down_secs": 120,
-      "adjustment": "+1"
+      "adjustment": "+2"
     },
     {
       "metric_type": "cpu",
-      "breach_duration_secs": 120,
-      "threshold": 60,
+      "breach_duration_secs": 60,
+      "threshold": 5,
       "operator": "<",
-      "cool_down_secs": 120,
+      "cool_down_secs": 60,
       "adjustment": "-1"
-    },
-    {
-      "metric_type": "cpu",
-      "breach_duration_secs": 120,
-      "threshold": 60,
-      "operator": ">=",
-      "cool_down_secs": 120,
-      "adjustment": "+1"
     }
   ]
 }

--- a/config/autoscaling/production-policy.json
+++ b/config/autoscaling/production-policy.json
@@ -1,54 +1,38 @@
 {
-  "instance_min_count": 5,
+  "instance_min_count": 8,
   "instance_max_count": 12,
   "scaling_rules": [
     {
-      "metric_type": "throughput",
+      "metric_type": "memoryutil",
       "breach_duration_secs": 60,
+      "threshold": 50,
+      "operator": ">=",
+      "cool_down_secs": 60,
+      "adjustment": "+2"
+    },
+    {
+      "metric_type": "memoryutil",
+      "breach_duration_secs": 120,
+      "threshold": 50,
+      "operator": "<",
+      "cool_down_secs": 120,
+      "adjustment": "-1"
+    },
+    {
+      "metric_type": "cpu",
+      "breach_duration_secs": 60,
+      "threshold": 50,
+      "operator": ">=",
+      "cool_down_secs": 60,
+      "adjustment": "+2"
+    },
+    {
+      "metric_type": "cpu",
+      "breach_duration_secs": 120,
       "threshold": 10,
       "operator": "<",
-      "cool_down_secs": 60,
+      "cool_down_secs": 120,
       "adjustment": "-1"
-    },
-    {
-      "metric_type": "throughput",
-      "breach_duration_secs": 60,
-      "threshold": 3,
-      "operator": ">=",
-      "cool_down_secs": 60,
-      "adjustment": "+1"
-    },
-    {
-      "metric_type": "memoryutil",
-      "breach_duration_secs": 60,
-      "threshold": 40,
-      "operator": "<",
-      "cool_down_secs": 60,
-      "adjustment": "-1"
-    },
-    {
-      "metric_type": "memoryutil",
-      "breach_duration_secs": 60,
-      "threshold": 40,
-      "operator": ">=",
-      "cool_down_secs": 60,
-      "adjustment": "+1"
-    },
-    {
-      "metric_type": "cpu",
-      "breach_duration_secs": 60,
-      "threshold": 40,
-      "operator": "<",
-      "cool_down_secs": 60,
-      "adjustment": "-1"
-    },
-    {
-      "metric_type": "cpu",
-      "breach_duration_secs": 60,
-      "threshold": 40,
-      "operator": ">=",
-      "cool_down_secs": 60,
-      "adjustment": "+1"
     }
   ]
 }

--- a/config/autoscaling/staging-policy.json
+++ b/config/autoscaling/staging-policy.json
@@ -1,22 +1,14 @@
 {
-  "instance_min_count": 1,
-  "instance_max_count": 3,
+  "instance_min_count": 2,
+  "instance_max_count": 12,
   "scaling_rules": [
     {
-      "metric_type": "throughput",
-      "breach_duration_secs": 120,
-      "threshold": 5,
-      "operator": "<",
-      "cool_down_secs": 120,
-      "adjustment": "-1"
-    },
-    {
-      "metric_type": "throughput",
-      "breach_duration_secs": 120,
-      "threshold": 5,
+      "metric_type": "memoryutil",
+      "breach_duration_secs": 60,
+      "threshold": 50,
       "operator": ">=",
-      "cool_down_secs": 120,
-      "adjustment": "+1"
+      "cool_down_secs": 60,
+      "adjustment": "+2"
     },
     {
       "metric_type": "memoryutil",
@@ -27,28 +19,20 @@
       "adjustment": "-1"
     },
     {
-      "metric_type": "memoryutil",
-      "breach_duration_secs": 120,
+      "metric_type": "cpu",
+      "breach_duration_secs": 60,
       "threshold": 50,
       "operator": ">=",
-      "cool_down_secs": 120,
-      "adjustment": "+1"
+      "cool_down_secs": 60,
+      "adjustment": "+2"
     },
     {
       "metric_type": "cpu",
       "breach_duration_secs": 120,
-      "threshold": 60,
+      "threshold": 5,
       "operator": "<",
       "cool_down_secs": 120,
       "adjustment": "-1"
-    },
-    {
-      "metric_type": "cpu",
-      "breach_duration_secs": 120,
-      "threshold": 60,
-      "operator": ">=",
-      "cool_down_secs": 120,
-      "adjustment": "+1"
     }
   ]
 }


### PR DESCRIPTION
### Jira link

HOTT-957

### What?

I have added/removed/altered:

- [ ] Adjusted the auto-scaler settings for all environments

In general the changes were:
-  scale up aggressively, and scale down in a softer way after the spike is gone.
- Drop the `throughput` metric, as it was useless (no data for it)


### Why?

I am doing this because:

- This morning's [blip](https://transformuk.atlassian.net/browse/HOTT-957) was likely caused but lack of resources on a flash spike in traffic. 
- This prompted an investigation, amongst other things, on the scaling policy. 

### Have you? 

- [x] Added new environment variables with correct values to all apps in all spaces

We also want to adjust the memory footprint of each instance as we have it oversized. We want to be able to have more discrete instances with less memory each, and re-balance toward CPU usage instead. 



**Note: The autoscaler was actually already enabled for the backend in all environments, so this PR just adjusts it's settings.** 