### PR TITLE
HOTT-940 Fix and extend the Search for quotas

### DIFF
--- a/app/services/find_ancestors_service.rb
+++ b/app/services/find_ancestors_service.rb
@@ -1,0 +1,39 @@
+class FindAncestorsService
+  def initialize(goods_nomenclature_item_id)
+    @goods_nomenclature_item_id = goods_nomenclature_item_id
+  end
+
+  def call
+    return [] if goods_nomenclature_item_id.blank?
+
+    goods_nomenclature.uptree.map(&:goods_nomenclature_item_id)
+  end
+
+  private
+
+  def goods_nomenclature
+    goods_nomenclature_class.by_code(goods_nomenclature_item_id).take
+  end
+
+  def goods_nomenclature_class
+    klass_name = GoodsNomenclature.class_determinator
+                                  .call(goods_nomenclature_item_id: goods_nomenclature_item_id)
+
+    GoodsNomenclature.constantize_class_name(klass_name)
+  end
+
+  def goods_nomenclature_item_id
+    length = @goods_nomenclature_item_id.length
+
+    case length
+    when 2 # chapter
+      "#{@goods_nomenclature_item_id}00000000"
+    when 4 # heading
+      "#{@goods_nomenclature_item_id}000000"
+    when 10 # fully-qualified
+      @goods_nomenclature_item_id.to_s
+    else # ilike
+      ''
+    end
+  end
+end

--- a/app/services/quota_search_service.rb
+++ b/app/services/quota_search_service.rb
@@ -43,9 +43,9 @@ class QuotaSearchService
     apply_critical_filter if critical.present?
     apply_status_filters if status.present?
 
-    @scope = scope.paginate(current_page, per_page)
+    @scope = @scope.paginate(current_page, per_page)
 
-    scope.map(&:quota_definition).compact
+    @scope.map(&:quota_definition).compact
   end
 
   private
@@ -65,7 +65,13 @@ class QuotaSearchService
   end
 
   def apply_goods_nomenclature_item_id_filter
-    @scope = scope.where(Sequel.like(:measures__goods_nomenclature_item_id, "#{goods_nomenclature_item_id}%"))
+    ancestors = FindAncestorsService.new(goods_nomenclature_item_id).call
+
+    @scope = if ancestors.present?
+               @scope.where(goods_nomenclature_item_id: ancestors)
+             else
+               @scope.where(Sequel.like(:measures__goods_nomenclature_item_id, "#{goods_nomenclature_item_id}%"))
+             end
   end
 
   def apply_geographical_area_id_filter

--- a/spec/services/find_ancestors_service_spec.rb
+++ b/spec/services/find_ancestors_service_spec.rb
@@ -1,0 +1,53 @@
+describe FindAncestorsService do
+  subject(:service) { described_class.new(goods_nomenclature_item_id).call }
+
+  context 'when the search term is empty' do
+    let(:goods_nomenclature_item_id) { '' }
+
+    it 'returns no ancestors' do
+      expect(service).to eq([])
+    end
+  end
+
+  context 'when the search term is fully-qualified (10 chars)' do
+    let(:commodity) { create(:commodity) }
+    let(:goods_nomenclature_item_id) { commodity.goods_nomenclature_item_id }
+
+    it 'returns the correct ancestors' do
+      expected_result = commodity.uptree.pluck(:goods_nomenclature_item_id)
+
+      expect(service).to eq(expected_result)
+    end
+  end
+
+  context 'when the search term is a Chapter' do
+    let(:chapter) { create(:chapter) }
+    let(:goods_nomenclature_item_id) { chapter.goods_nomenclature_item_id }
+
+    it 'returns the correct ancestors' do
+      expected_result = chapter.uptree.pluck(:goods_nomenclature_item_id)
+
+      expect(service).to eq(expected_result)
+    end
+  end
+
+  context 'when the search term is a Heading' do
+    let(:heading) { create(:heading) }
+    let(:goods_nomenclature_item_id) { heading.goods_nomenclature_item_id }
+
+    it 'returns the correct ancestors' do
+      expected_result = heading.uptree.pluck(:goods_nomenclature_item_id)
+
+      expect(service).to eq(expected_result)
+    end
+  end
+
+  context 'when the search term is NOT a Chapter, Heading or fully-qualified Commodity' do
+    let(:commodity) { create(:commodity) }
+    let(:goods_nomenclature_item_id) { commodity.goods_nomenclature_item_id[0..6] }
+
+    it 'returns no ancestors' do
+      expect(service).to eq([])
+    end
+  end
+end

--- a/spec/services/quota_search_service_spec.rb
+++ b/spec/services/quota_search_service_spec.rb
@@ -1,4 +1,5 @@
-RSpec.describe QuotaSearchService do
+# rubocop:disable RSpec/MultipleMemoizedHelpers
+describe QuotaSearchService do
   subject(:service) { described_class.new(filter, current_page, per_page) }
 
   around do |example|
@@ -52,8 +53,16 @@ RSpec.describe QuotaSearchService do
   end
 
   describe '#call' do
-    context 'when filtering by the goods_nomenclature_item_id' do
+    context 'when filtering by a fully-qualified goods_nomenclature_item_id' do
       let(:filter) { { 'goods_nomenclature_item_id' => measure1.goods_nomenclature_item_id } }
+
+      it 'returns the correct quota definition' do
+        expect(service.call).to eq([quota_definition1])
+      end
+    end
+
+    context 'when filtering by a NOT fully-qualified goods_nomenclature_item_id' do
+      let(:filter) { { 'goods_nomenclature_item_id' => measure1.goods_nomenclature_item_id[0..6] } }
 
       it 'returns the correct quota definition' do
         expect(service.call).to eq([quota_definition1])
@@ -87,7 +96,7 @@ RSpec.describe QuotaSearchService do
     context 'when filtering by status exhausted' do
       let(:filter) { { 'status' => 'exhausted' } }
 
-      let!(:quota_exhaustion_event) do
+      before do
         create :quota_exhaustion_event, quota_definition: quota_definition1
       end
 
@@ -99,7 +108,7 @@ RSpec.describe QuotaSearchService do
     context 'when filtering by status not exhausted' do
       let(:filter) { { 'status' => 'not_exhausted' } }
 
-      let!(:quota_exhaustion_event) do
+      before do
         create :quota_exhaustion_event, quota_definition: quota_definition1
       end
 
@@ -111,7 +120,7 @@ RSpec.describe QuotaSearchService do
     context 'when filtering by status blocked' do
       let(:filter) { { 'status' => 'blocked' } }
 
-      let!(:quota_blocking_period) do
+      before do
         create :quota_blocking_period,
                quota_definition_sid: quota_definition1.quota_definition_sid,
                blocking_start_date: Date.current,
@@ -126,7 +135,7 @@ RSpec.describe QuotaSearchService do
     context 'when filtering by status not blocked' do
       let(:filter) { { 'status' => 'not_blocked' } }
 
-      let!(:quota_blocking_period) do
+      before do
         create :quota_blocking_period,
                quota_definition_sid: quota_definition1.quota_definition_sid,
                blocking_start_date: Date.current,
@@ -139,3 +148,4 @@ RSpec.describe QuotaSearchService do
     end
   end
 end
+# rubocop:enable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
### What?

This PR Fixes and extends the Search for quotas

The search is smarter now, it supports:
- Chapter
- Heading
- Commodity
using the ancestries,
otherwise - in case the term does not look one of those - it uses a ilike search.

### Why?
I am doing this because:

To allow users to find easily quotas.

### Jira link
https://transformuk.atlassian.net/browse/HOTT-940
