### PR TITLE
Lazy load all measure v2 relationships

### DIFF
--- a/app/serializers/api/v2/measures/measure_serializer.rb
+++ b/app/serializers/api/v2/measures/measure_serializer.rb
@@ -11,20 +11,20 @@ module Api
         attributes :id, :origin, :effective_start_date, :effective_end_date, :import,
                    :excise, :vat, :reduction_indicator
 
-        has_one :duty_expression, serializer: Api::V2::Measures::DutyExpressionSerializer
-        has_one :measure_type, serializer: Api::V2::Measures::MeasureTypeSerializer
-        has_many :legal_acts, serializer: Api::V2::Measures::MeasureLegalActSerializer
+        has_one :duty_expression, serializer: Api::V2::Measures::DutyExpressionSerializer, lazy_load_data: true
+        has_one :measure_type, serializer: Api::V2::Measures::MeasureTypeSerializer, lazy_load_data: true
+        has_many :legal_acts, serializer: Api::V2::Measures::MeasureLegalActSerializer, lazy_load_data: true
         has_one :suspending_regulation, key: :suspension_legal_act,
                                         record_type: :suspension_legal_act, serializer: Api::V2::Measures::MeasureSuspensionLegalActSerializer,
-                                        if: proc { |measure| !measure.national && measure.suspended? }
-        has_many :measure_conditions, serializer: Api::V2::Measures::MeasureConditionSerializer
-        has_many :measure_components, serializer: Api::V2::Measures::MeasureComponentSerializer
-        has_many :national_measurement_units, serializer: Api::V2::Measures::NationalMeasurementUnitSerializer
-        has_one :geographical_area, serializer: Api::V2::Measures::GeographicalAreaSerializer
-        has_many :excluded_countries, record_type: :geographical_area, serializer: Api::V2::GeographicalAreaSerializer
-        has_many :footnotes, serializer: Api::V2::Measures::FootnoteSerializer
-        has_one :additional_code, if: proc { |measure| measure.additional_code.present? }, serializer: Api::V2::AdditionalCodeSerializer
-        has_one :order_number, serializer: Api::V2::Quotas::OrderNumber::QuotaOrderNumberSerializer
+                                        if: proc { |measure| !measure.national && measure.suspended? }, lazy_load_data: true
+        has_many :measure_conditions, serializer: Api::V2::Measures::MeasureConditionSerializer, lazy_load_data: true
+        has_many :measure_components, serializer: Api::V2::Measures::MeasureComponentSerializer, lazy_load_data: true
+        has_many :national_measurement_units, serializer: Api::V2::Measures::NationalMeasurementUnitSerializer, lazy_load_data: true
+        has_one :geographical_area, serializer: Api::V2::Measures::GeographicalAreaSerializer, lazy_load_data: true
+        has_many :excluded_countries, record_type: :geographical_area, serializer: Api::V2::GeographicalAreaSerializer, lazy_load_data: true
+        has_many :footnotes, serializer: Api::V2::Measures::FootnoteSerializer, lazy_load_data: true
+        has_one :additional_code, if: proc { |measure| measure.additional_code.present? }, serializer: Api::V2::AdditionalCodeSerializer, lazy_load_data: true
+        has_one :order_number, serializer: Api::V2::Quotas::OrderNumber::QuotaOrderNumberSerializer, lazy_load_data: true
 
         meta do |_measure|
           {

--- a/spec/serializers/api/v2/measures/measure_serializer_spec.rb
+++ b/spec/serializers/api/v2/measures/measure_serializer_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Api::V2::Measures::MeasureSerializer do
   subject(:serializer) { described_class.new(serializable).serializable_hash.as_json }
 
   let(:serializable) { Api::V2::Measures::MeasurePresenter.new(measure, measure.goods_nomenclature) }
-  let(:measure) { create(:measure, reduction_indicator: 1) }
+  let(:measure) { create(:measure, :with_goods_nomenclature, reduction_indicator: 1) }
 
   let(:expected_pattern) do
     {
@@ -20,31 +20,16 @@ RSpec.describe Api::V2::Measures::MeasureSerializer do
           'reduction_indicator' => 1,
         },
         'relationships' => {
-          'duty_expression' => {
-            'data' => {
-              'id' => "#{measure.id}-duty_expression",
-              'type' => 'duty_expression',
-            },
-          },
-          'measure_type' => {
-            'data' => {
-              'id' => measure.measure_type_id,
-              'type' => 'measure_type',
-            },
-          },
-          'legal_acts' => { 'data' => [] },
-          'measure_conditions' => { 'data' => [] },
-          'measure_components' => { 'data' => [] },
-          'national_measurement_units' => { 'data' => [] },
-          'geographical_area' => {
-            'data' => {
-              'id' => measure.geographical_area_id,
-              'type' => 'geographical_area',
-            },
-          },
-          'excluded_countries' => { 'data' => [] },
-          'footnotes' => { 'data' => [] },
-          'order_number' => { 'data' => nil },
+          'duty_expression' => {},
+          'measure_type' => {},
+          'legal_acts' => {},
+          'measure_conditions' => {},
+          'measure_components' => {},
+          'national_measurement_units' => {},
+          'geographical_area' => {},
+          'excluded_countries' => {},
+          'footnotes' => {},
+          'order_number' => {},
         },
         'meta' => {
           'duty_calculator' => {


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-801

### What?

I have added/removed/altered:

- [x] Added lazy_load_data: true to all v2 measure serializer relationships

### Why?

I am doing this because:

- This change means that other users of the serializer do not have to load the entire world of un-eager loaded resources just to return a subset of the targeted relationships.
- This will make the meursing index endpoints which serialize meursing measures as measures signficantly faster and should not affect existing implementations
