### PR TITLE
Replacing constantize with sti_load

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -128,15 +128,4 @@ class GoodsNomenclature < Sequel::Model
   def bti_url
     'https://www.gov.uk/guidance/check-what-youll-need-to-get-a-legally-binding-decision-on-a-commodity-code'
   end
-
-  # This method is safer than `constantize`
-  # which is considered dangeros by `brakeman` (a static analyzer)
-  def self.constantize_class_name(klass_name)
-    [
-      Commodity,
-      Heading,
-      Chapter,
-      GoodsNomenclature,
-    ].find { |klass| klass.to_s == klass_name }
-  end
 end

--- a/app/services/find_ancestors_service.rb
+++ b/app/services/find_ancestors_service.rb
@@ -16,10 +16,7 @@ class FindAncestorsService
   end
 
   def goods_nomenclature_class
-    klass_name = GoodsNomenclature.class_determinator
-                                  .call(goods_nomenclature_item_id: goods_nomenclature_item_id)
-
-    GoodsNomenclature.constantize_class_name(klass_name)
+    GoodsNomenclature.sti_load(goods_nomenclature_item_id: goods_nomenclature_item_id).class
   end
 
   def goods_nomenclature_item_id


### PR DESCRIPTION
 Make use of sti_load to constantize the good nomenclature class name.

Why?
The method String#constantize is considered unsafe by Brakeman.
