### PR TITLE
Rename format -> custom_format

### DIFF
--- a/app/models/additional_code_description.rb
+++ b/app/models/additional_code_description.rb
@@ -6,7 +6,7 @@ class AdditionalCodeDescription < Sequel::Model
 
   set_primary_key %i[additional_code_description_period_sid additional_code_sid]
 
-  format :formatted_description, with: DescriptionFormatter,
+  custom_format :formatted_description, with: DescriptionFormatter,
                                  using: :description
 
   # one_to_one :additional_code_description_period, key: [:additional_code_description_period_sid, :additional_code_sid, :additional_code_type_id]

--- a/app/models/certificate_description.rb
+++ b/app/models/certificate_description.rb
@@ -6,7 +6,7 @@ class CertificateDescription < Sequel::Model
 
   set_primary_key [:certificate_description_period_sid]
 
-  format :formatted_description, with: DescriptionFormatter,
+  custom_format :formatted_description, with: DescriptionFormatter,
                                  using: :description
 
   def to_s

--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -61,9 +61,9 @@ module Declarable
       MeasureComponent.where(measure: import_measures_dataset.where(measures__measure_type_id: MeasureType::THIRD_COUNTRY).all)
     }
 
-    format :description_plain, with: DescriptionTrimFormatter,
+    custom_format :description_plain, with: DescriptionTrimFormatter,
                                using: :description
-    format :formatted_description, with: DescriptionFormatter,
+    custom_format :formatted_description, with: DescriptionFormatter,
                                    using: :description
   end
 

--- a/app/models/concerns/formatter.rb
+++ b/app/models/concerns/formatter.rb
@@ -2,19 +2,21 @@ module Formatter
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def format(attribute, options)
+    def custom_format(attribute, options)
       options.assert_valid_keys :with, :using, :defaults
 
-      formatter, using, defaults = options.values_at(:with,
-                                                     :using,
-                                                     :defaults)
+      formatter = options[:with]
+      using = options[:using]
+
       mod = Module.new do
         define_method(attribute) do
           opts = {}
 
-          [using].flatten.each do |field|
-            opts[field] = result_of_attribute_or_method_call(field)
-          end if using.present?
+          if using.present?
+            [using].flatten.each do |field|
+              opts[field] = result_of_attribute_or_method_call(field)
+            end
+          end
 
           formatter.format(opts)
         end

--- a/app/models/footnote_description.rb
+++ b/app/models/footnote_description.rb
@@ -8,6 +8,6 @@ class FootnoteDescription < Sequel::Model
 
   set_primary_key %i[footnote_description_period_sid footnote_id footnote_type_id]
 
-  format :formatted_description, with: DescriptionFormatter,
+  custom_format :formatted_description, with: DescriptionFormatter,
                                  using: :description
 end

--- a/app/models/goods_nomenclature_description.rb
+++ b/app/models/goods_nomenclature_description.rb
@@ -14,9 +14,9 @@ class GoodsNomenclatureDescription < Sequel::Model
 
   delegate :validity_start_date, :validity_end_date, to: :goods_nomenclature_description_period
 
-  format :description_plain, with: DescriptionTrimFormatter,
+  custom_format :description_plain, with: DescriptionTrimFormatter,
                              using: :description
-  format :formatted_description, with: DescriptionFormatter,
+  custom_format :formatted_description, with: DescriptionFormatter,
                                  using: :description
 
   def description

--- a/app/models/measure_component.rb
+++ b/app/models/measure_component.rb
@@ -1,6 +1,4 @@
 class MeasureComponent < Sequel::Model
-  include Formatter
-
   plugin :time_machine
   plugin :oplog, primary_key: %i[measure_sid duty_expression_id]
 

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -1,6 +1,4 @@
 class MeasureCondition < Sequel::Model
-  include Formatter
-
   plugin :time_machine
   plugin :national
   plugin :oplog, primary_key: :measure_condition_sid

--- a/app/models/measurement_unit_qualifier_description.rb
+++ b/app/models/measurement_unit_qualifier_description.rb
@@ -5,6 +5,6 @@ class MeasurementUnitQualifierDescription < Sequel::Model
 
   set_primary_key [:measurement_unit_qualifier_code]
 
-  format :formatted_measurement_unit_qualifier, with: DescriptionFormatter,
+  custom_format :formatted_measurement_unit_qualifier, with: DescriptionFormatter,
                                                 using: :description
 end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Rename format -> custom_format in Formatter

### Why?

I am doing this because:

- We don't want to override a ruby or rails core methods that aren't attached clearly
to a constant (e.g. DescriptionFormatter.format)
