### PR TITLE
Handle meursing measures that are erga omnes

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -394,6 +394,7 @@ class Measure < Sequel::Model
   def relevant_for_country?(country_id)
     return false if measure_excluded_geographical_areas.map(&:excluded_geographical_area).include?(country_id)
     return true if geographical_area_id == GeographicalArea::ERGA_OMNES_ID && national?
+    return true if geographical_area_id == GeographicalArea::ERGA_OMNES_ID && measure_type.meursing?
     return true if geographical_area_id.blank? || geographical_area_id == country_id
 
     geographical_area.contained_geographical_areas.map(&:geographical_area_id).include?(country_id)

--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -82,6 +82,10 @@ class MeasureType < Sequel::Model
     measure_type_series_id == 'Q'
   end
 
+  def meursing?
+    measure_type_id.in?(MEURSING_MEASURES)
+  end
+
   # The VAT standard rate has measure type 305 and no additional code.
   # The VAT zero rate has measure type 305 and  VATZ additional code.
   # The VAT exempt has measure type 305 and  VATE additional code.

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -810,6 +810,14 @@ RSpec.describe Measure do
       end
     end
 
+    context 'when the measure has a meursing measure type and its geographical area is the world' do
+      subject(:measure) { create(:measure, :flour, geographical_area_id: '1011') }
+
+      it 'returns true' do
+        expect(measure.relevant_for_country?('foo')).to eq(true)
+      end
+    end
+
     context 'when the measure has no geographical area' do
       subject(:measure) { create(:measure, geographical_area_sid: nil, geographical_area_id: nil) }
 

--- a/spec/models/measure_type_spec.rb
+++ b/spec/models/measure_type_spec.rb
@@ -43,6 +43,24 @@ RSpec.describe MeasureType do
     end
   end
 
+  describe '#meursing?' do
+    shared_examples_for 'a meursing measure type' do |measure_type_id|
+      subject(:measure_type) { build(:measure_type, measure_type_id: measure_type_id) }
+
+      it { is_expected.to be_meursing }
+    end
+
+    it_behaves_like 'a meursing measure type', '672'
+    it_behaves_like 'a meursing measure type', '673'
+    it_behaves_like 'a meursing measure type', '674'
+
+    context 'when not a meursing measure type' do
+      subject(:measure_type) { build(:measure_type, measure_type_id: '142') }
+
+      it { is_expected.not_to be_meursing }
+    end
+  end
+
   describe '#third_country?' do
     context 'when measure_type has measure_type_id of 103' do
       let(:measure_type) { build :measure_type, measure_type_id: '103' }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-801

### What?

I have added/removed/altered:

- [x] Handle meursing measures that are erga omnes
- [x] Adds test coverage

### Why?

I am doing this because:

- We have meursing measures that are erga omnes and the business logic around whether the measure is relevant only applies to national measures
