### PR TITLE
HOTT-1036: Don't reload database records in mapper

### DIFF
--- a/lib/goods_nomenclature_mapper.rb
+++ b/lib/goods_nomenclature_mapper.rb
@@ -70,7 +70,7 @@ class GoodsNomenclatureMapper
   end
 
   def map_goods_nomenclatures(primary, secondary)
-    if (heading_map?(primary.reload, secondary.reload) &&
+    if (heading_map?(primary, secondary) &&
        (primary.producline_suffix < secondary.producline_suffix)) ||
         (primary.number_indents < secondary.number_indents)
 


### PR DESCRIPTION
### Jira link

[HOTT-1036](https://transformuk.atlassian.net/browse/HOTT-1036)

### What?

I have added/removed/altered:

- [x] Removed the reloading of records in GoodsNomenclatureMapper

### Why?

I am doing this because:

- It is breaking the eager loading and triggering N+1's when calling Commodity#children - this affects all Commodity pages plus the headings pages

### Notes

This was introduced in 20dd0bdf (PR 259) but it causes an N+1 whenever Commodity#children is requested

It was introduced as part of the Changes work _but_ I can't find
anything to suggest that its ever used as part of that work. Specs
still pass fine without the reloads and we didn't previously have
those reloads so I'm working on the assumption it was accidentally
introduced as part of the development process.

### Deployment risks (optional)

- This removes a previously added `.reload` - I can't find a reason for this to be added but can find problems caused by it, hence removing but the code in this class is opaque at best.
