### PR TITLE
Removes unused and misleading relationship on goods_nomenclature

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,13 +32,13 @@ RSpec/ContextWording:
     - for
 RSpec/ExampleLength:
   Enabled: false
+RSpec/FilePath:
+  Enabled: false
 RSpec/NestedGroups:
   Enabled: false
 Rails/SaveBang:
   Enabled: false
 Rails/UniqueValidationWithoutIndex:
-  Enabled: false
-Rails/FilePath:
   Enabled: false
 Style/Documentation:
   Enabled: false

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -6,6 +6,7 @@ class GoodsNomenclature < Sequel::Model
 
   plugin :time_machine, period_start_column: Sequel.qualify(:goods_nomenclatures, :validity_start_date),
                         period_end_column: Sequel.qualify(:goods_nomenclatures, :validity_end_date)
+
   plugin :oplog, primary_key: :goods_nomenclature_sid
   plugin :nullable
   plugin :active_model
@@ -69,9 +70,6 @@ class GoodsNomenclature < Sequel::Model
                                             primary_key: :goods_nomenclature_sid do |ds|
     ds.with_actual(ExportRefundNomenclature)
   end
-
-  one_to_many :measures, key: :goods_nomenclature_sid,
-                         foreign_key: :goods_nomenclature_sid
 
   many_to_many :chemicals, join_table: :chemicals_goods_nomenclatures, left_key: :goods_nomenclature_sid, right_key: :chemical_id
 


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Removes measures relationship from goods nomenclature
- [x] Fix rubocop namespacing

### Why?

This made us think that the time machine functionality wasn't being used on the declarable goods nomenclature types (Heading and Commodity) and led to some confusion

The reality is that this relationship is defined in the Declarable concern
