### PR TITLE
Notify when smoke tests fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,6 +280,11 @@ jobs:
       - run:
           name: "Cypress Smoke tests"
           command: 'cd trade-tariff-testing && yarn install && yarn run cypress run --spec "/*/**/HOTT-Shared/smokeTestCI.spec.js"'
+      - slack/notify:
+          channel: deployments
+          event: fail
+          template: basic_fail_1
+
 
   smoketest_staging:
     <<: *smoketest


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Notify slack when smoke tests fail

### Why?

I am doing this because:

- We got a bunch of failures recently that would have been better to have been discovered early
