### PR TITLE
Use :null_store for caching when Rails.env.test?

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  config.cache_store = :memory_store
+  config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false


### PR DESCRIPTION
Currently using :memory_store which _may_ result in data leaking between tests. Tests probably still pass because we use factories so are generating new IDs but this could trip someone up in the future.

Using :null_store brings this inline with rails defaults.
