### PR TITLE
HOTT-1064: Mark GSP RoO schemes as unilateral

### DIFF
--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -6,7 +6,7 @@ module RulesOfOrigin
 
     attr_accessor :scheme_set, :scheme_code, :title, :introductory_notes_file,
                   :fta_intro_file, :countries, :rule_offset, :footnote,
-                  :adopted_by_uk, :country_code, :notes
+                  :adopted_by_uk, :country_code, :notes, :unilateral
 
     delegate :read_referenced_file, to: :scheme_set
 

--- a/app/serializers/api/v2/rules_of_origin/scheme_serializer.rb
+++ b/app/serializers/api/v2/rules_of_origin/scheme_serializer.rb
@@ -8,8 +8,8 @@ module Api
 
         set_id :scheme_code
 
-        attributes :scheme_code, :title, :countries, :footnote, :fta_intro,
-                   :introductory_notes
+        attributes :scheme_code, :title, :countries, :footnote, :unilateral,
+                   :fta_intro, :introductory_notes
 
         has_many :rules, serializer: Api::V2::RulesOfOrigin::RuleSerializer
         has_many :links, serializer: Api::V2::RulesOfOrigin::LinkSerializer

--- a/db/rules_of_origin/roo_schemes_uk.json
+++ b/db/rules_of_origin/roo_schemes_uk.json
@@ -1340,6 +1340,7 @@
             "footnote": "Scheme incorporates:</p><ul class='govuk-list govuk-list--bullet govuk-body-s'><li>the GSP Least Developed Countries Framework</li><li>the GSP General Framework</li><li>the GSP Enhanced Framework</li></ul>",
             "introductory_notes_file": "gsp_intro.md",
             "fta_intro_file": "gsp.md",
+            "unilateral": true,
             "links": [
                 {
                     "text": "GSP - Least Developed Countries Framework",

--- a/spec/factories/rules_of_origin/scheme_factory.rb
+++ b/spec/factories/rules_of_origin/scheme_factory.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     fta_intro_file          { 'fta_intro.md' }
     countries               { %w[FR ES IT DE] }
     footnote                { 'This scheme may be expanded in the future' }
+    unilateral              { nil }
 
     trait :with_links do
       links { attributes_for_list :rules_of_origin_link, 2 }

--- a/spec/models/rules_of_origin/scheme_spec.rb
+++ b/spec/models/rules_of_origin/scheme_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe RulesOfOrigin::Scheme do
     it { is_expected.to respond_to :rule_offset }
     it { is_expected.to respond_to :footnote }
     it { is_expected.to respond_to :adopted_by_uk }
+    it { is_expected.to respond_to :unilateral }
     it { is_expected.to respond_to :country_code }
     it { is_expected.to respond_to :notes }
     it { is_expected.to respond_to :proofs }

--- a/spec/serializers/api/v2/rules_of_origin/scheme_serializer_spec.rb
+++ b/spec/serializers/api/v2/rules_of_origin/scheme_serializer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemeSerializer do
 
   let :scheme do
     build :rules_of_origin_scheme, :with_links, :with_proofs,
-          scheme_set: scheme_set
+          scheme_set: scheme_set, unilateral: true
   end
 
   let :rules do
@@ -28,6 +28,7 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemeSerializer do
           title: scheme.title,
           countries: scheme.countries,
           footnote: scheme.footnote,
+          unilateral: true,
           fta_intro: scheme.fta_intro,
           introductory_notes: scheme.introductory_notes,
         },


### PR DESCRIPTION
### Jira link

[HOTT-1064](https://transformuk.atlassian.net/browse/HOTT-1064)

### What?

I have added/removed/altered:

- [x] Added the `unilateral` field to the schemes
- [x] Expose this in the Rules of Origin API
- [x] Mark the GSP scheme as unilateral

### Why?

I am doing this because:

- The GSP schemes operate differently to others and we need to show different intro text on the frontend.

