### PR TITLE
HOTT-1064: Also mark GSP under XI as unilateral

### DIFF
--- a/db/rules_of_origin/roo_schemes_xi.json
+++ b/db/rules_of_origin/roo_schemes_xi.json
@@ -885,6 +885,7 @@
             "title": "Generalised Scheme of Preferences (GSP)",
             "introductory_notes_file": "gsp_intro.md",
             "fta_intro_file": "gsp.md",
+            "unilateral": true,
             "links": [
                 {
                     "text": "GSP - Least Developed Countries Framework",


### PR DESCRIPTION
### Jira link

[HOTT-1064](https://transformuk.atlassian.net/browse/HOTT-1064)

### What?

I have added/removed/altered:

- [x] Mark GSP scheme under XI as unilateral

### Why?

I am doing this because:

- it got missed in the original PR
