### PR TITLE
Handle broken goods_nomenclature_description values

### DIFF
--- a/app/models/goods_nomenclature_description.rb
+++ b/app/models/goods_nomenclature_description.rb
@@ -15,16 +15,16 @@ class GoodsNomenclatureDescription < Sequel::Model
   delegate :validity_start_date, :validity_end_date, to: :goods_nomenclature_description_period
 
   custom_format :description_plain, with: DescriptionTrimFormatter,
-                             using: :description
+                                    using: :description
   custom_format :formatted_description, with: DescriptionFormatter,
-                                 using: :description
+                                        using: :description
 
   def description
-    super.gsub(%r/( ?<br> ?){2,}/, '<br>')
+    super.try(:gsub, %r/( ?<br> ?){2,}/, '<br>') || ''
   end
 
   def formatted_description
-    super.mb_chars.downcase.to_s.gsub(/^(.)/) { $1.capitalize }
+    super.mb_chars.downcase.to_s.gsub(/^(.)/) { Regexp.last_match(1).capitalize }
   end
 
   def to_s

--- a/spec/models/goods_nomenclature_description_spec.rb
+++ b/spec/models/goods_nomenclature_description_spec.rb
@@ -2,6 +2,12 @@ RSpec.describe GoodsNomenclatureDescription do
   describe '#description' do
     subject(:goods_nomenclature_description) { build :goods_nomenclature_description, description: description }
 
+    context 'when the description value is nil' do
+      let(:description) { nil }
+
+      it { expect(goods_nomenclature_description.description).to eq('') }
+    end
+
     context 'when the description value has multiple chained <br><br><br>tags' do
       let(:description) do
         'Additives containing<br> <br><br><br>- overbased magnesium (C20-C24) alkylbenzenesulphonates (CAS RN 231297-75-9) and<br> <br><br><br>- by weight more than 25 % but not more than 50 % of mineral oils,<br>having a total base number of more than 350, but not more than 450, for use in the manufacture of lubricating oils'


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1070

### What?

I have added/removed/altered:

- [x] Handle nil values on goods_nomenclature_descriptions table rows

### Why?

I am doing this because:

- We've recently received some broken data which affects quite a few commodities and still want to return a working api response
