### PR TITLE
HOTT-1080 Add frontend news api

### DIFF
--- a/app/controllers/api/v2/news_items_controller.rb
+++ b/app/controllers/api/v2/news_items_controller.rb
@@ -4,6 +4,7 @@ module Api
       def index
         news_items = NewsItem.for_service(params[:service])
                              .for_target(params[:target])
+                             .for_today
                              .paginate(current_page, per_page)
                              .descending
 

--- a/app/controllers/api/v2/news_items_controller.rb
+++ b/app/controllers/api/v2/news_items_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  module V2
+    class NewsItemsController < ApiController
+      def index
+        news_items = NewsItem.for_service(params[:service])
+                             .for_target(params[:target])
+                             .paginate(current_page, per_page)
+                             .descending
+
+        serializer = Api::V2::NewsItemSerializer.new(news_items)
+
+        render json: serializer.serializable_hash
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/news_items_controller.rb
+++ b/app/controllers/api/v2/news_items_controller.rb
@@ -12,6 +12,14 @@ module Api
 
         render json: serializer.serializable_hash
       end
+
+      def show
+        news_item = NewsItem.for_today.with_pk!(params[:id])
+
+        serializer = Api::V2::NewsItemSerializer.new(news_item)
+
+        render json: serializer.serializable_hash
+      end
     end
   end
 end

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -8,6 +8,24 @@ class NewsItem < Sequel::Model
     def descending
       order(Sequel.desc(:id))
     end
+
+    def for_service(service_name)
+      case service_name.to_s
+      when 'uk' then where(show_on_uk: true)
+      when 'xi' then where(show_on_xi: true)
+      when '' then self
+      else raise Sequel::RecordNotFound
+      end
+    end
+
+    def for_target(target_name)
+      case target_name.to_s
+      when 'home' then where(show_on_home_page: true)
+      when 'updates' then where(show_on_updates_page: true)
+      when '' then self
+      else raise Sequel::RecordNotFound
+      end
+    end
   end
 
   def validate

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -9,6 +9,11 @@ class NewsItem < Sequel::Model
       order(Sequel.desc(:id))
     end
 
+    def for_today
+      where { start_date <= Time.zone.today }
+      .where { (end_date >= Time.zone.today) | { end_date: nil } }
+    end
+
     def for_service(service_name)
       case service_name.to_s
       when 'uk' then where(show_on_uk: true)

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -6,7 +6,7 @@ class NewsItem < Sequel::Model
 
   dataset_module do
     def descending
-      order(Sequel.desc(:id))
+      order(Sequel.desc(:start_date), Sequel.desc(:id))
     end
 
     def for_today

--- a/app/serializers/api/v2/news_item_serializer.rb
+++ b/app/serializers/api/v2/news_item_serializer.rb
@@ -5,7 +5,7 @@ module Api
 
       set_type :news_item
 
-      attributes :title, :content, :display_style, :show_on_xi, :show_on_uk,
+      attributes :id, :title, :content, :display_style, :show_on_xi, :show_on_uk,
                  :show_on_updates_page, :show_on_home_page, :start_date,
                  :end_date, :created_at, :updated_at
     end

--- a/app/serializers/api/v2/news_item_serializer.rb
+++ b/app/serializers/api/v2/news_item_serializer.rb
@@ -1,0 +1,13 @@
+module Api
+  module V2
+    class NewsItemSerializer
+      include JSONAPI::Serializer
+
+      set_type :news_item
+
+      attributes :title, :content, :display_style, :show_on_xi, :show_on_uk,
+                 :show_on_updates_page, :show_on_home_page, :start_date,
+                 :end_date, :created_at, :updated_at
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,6 +114,10 @@ Rails.application.routes.draw do
                 controller: 'rules_of_origin',
                 only: %i[index]
 
+      if TradeTariffBackend.uk?
+        get '/news_items(/:service(/:target))', to: 'news_items#index', as: :news_items
+      end
+
       get '/changes(/:as_of)', to: 'changes#index', as: :changes, constraints: { as_of: /\d{4}-\d{1,2}-\d{1,2}/ }
 
       post 'search' => 'search#search'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,6 +115,7 @@ Rails.application.routes.draw do
                 only: %i[index]
 
       if TradeTariffBackend.uk?
+        get '/news_items/:id', constraints: { id: /\d+/ }, to: 'news_items#show', as: :news_item
         get '/news_items(/:service(/:target))', to: 'news_items#index', as: :news_items
       end
 

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -156,5 +156,14 @@ RSpec.describe NewsItem do
       it { is_expected.not_to include tomorrows }
       it { is_expected.to include indefinite }
     end
+
+    describe '#descending' do
+      subject { described_class.descending.to_a }
+
+      let!(:published_today) { create :news_item, start_date: Time.zone.today }
+      let!(:published_yesterday) { create :news_item, start_date: Time.zone.yesterday }
+
+      it { is_expected.to eql [published_today, published_yesterday] }
+    end
   end
 end

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -35,4 +35,101 @@ RSpec.describe NewsItem do
       it { is_expected.to include(content: ['is not present']) }
     end
   end
+
+  describe 'scopes' do
+    describe 'for_service' do
+      subject(:results) { described_class.for_service(service_name) }
+
+      let(:uk_page) { create :news_item, show_on_uk: true, show_on_xi: false }
+      let(:xi_page) { create :news_item, show_on_uk: false, show_on_xi: true }
+      let(:both_page) { create :news_item, show_on_uk: true, show_on_xi: true }
+      let(:neither_page) { create :news_item, show_on_uk: false, show_on_xi: false }
+
+      context 'without service name' do
+        let(:service_name) { nil }
+
+        it { is_expected.to include uk_page }
+        it { is_expected.to include xi_page }
+        it { is_expected.to include both_page }
+        it { is_expected.to include neither_page }
+      end
+
+      context 'with uk' do
+        let(:service_name) { 'uk' }
+
+        it { is_expected.to include uk_page }
+        it { is_expected.not_to include xi_page }
+        it { is_expected.to include both_page }
+        it { is_expected.not_to include neither_page }
+      end
+
+      context 'with xi' do
+        let(:service_name) { 'xi' }
+
+        it { is_expected.to include xi_page }
+        it { is_expected.not_to include uk_page }
+        it { is_expected.to include both_page }
+        it { is_expected.not_to include neither_page }
+      end
+
+      context 'with an invalid service' do
+        let(:service_name) { 'invalid' }
+
+        it { expect { results }.to raise_exception Sequel::RecordNotFound }
+      end
+    end
+
+    describe 'for target' do
+      subject(:results) { described_class.for_target(target) }
+
+      let :home_page do
+        create :news_item, show_on_home_page: true, show_on_updates_page: false
+      end
+
+      let :updates_page do
+        create :news_item, show_on_home_page: false, show_on_updates_page: true
+      end
+
+      let :both_page do
+        create :news_item, show_on_home_page: true, show_on_updates_page: true
+      end
+
+      let :neither_page do
+        create :news_item, show_on_home_page: false, show_on_updates_page: false
+      end
+
+      context 'without target' do
+        let(:target) { nil }
+
+        it { is_expected.to include home_page }
+        it { is_expected.to include updates_page }
+        it { is_expected.to include both_page }
+        it { is_expected.to include neither_page }
+      end
+
+      context 'with home' do
+        let(:target) { 'home' }
+
+        it { is_expected.to include home_page }
+        it { is_expected.not_to include updates_page }
+        it { is_expected.to include both_page }
+        it { is_expected.not_to include neither_page }
+      end
+
+      context 'with updates' do
+        let(:target) { 'updates' }
+
+        it { is_expected.to include updates_page }
+        it { is_expected.not_to include home_page }
+        it { is_expected.to include both_page }
+        it { is_expected.not_to include neither_page }
+      end
+
+      context 'with an invalid target' do
+        let(:target) { 'invalid' }
+
+        it { expect { results }.to raise_exception Sequel::RecordNotFound }
+      end
+    end
+  end
 end

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe NewsItem do
   end
 
   describe 'scopes' do
-    describe 'for_service' do
+    describe '#for_service' do
       subject(:results) { described_class.for_service(service_name) }
 
       let(:uk_page) { create :news_item, show_on_uk: true, show_on_xi: false }
@@ -79,7 +79,7 @@ RSpec.describe NewsItem do
       end
     end
 
-    describe 'for target' do
+    describe '#for_target' do
       subject(:results) { described_class.for_target(target) }
 
       let :home_page do
@@ -130,6 +130,31 @@ RSpec.describe NewsItem do
 
         it { expect { results }.to raise_exception Sequel::RecordNotFound }
       end
+    end
+
+    describe '#for_today' do
+      subject { described_class.for_today }
+
+      let :yesterdays do
+        create :news_item, start_date: Time.zone.yesterday, end_date: Time.zone.yesterday
+      end
+
+      let :todays do
+        create :news_item, start_date: Time.zone.today, end_date: Time.zone.today
+      end
+
+      let :tomorrows do
+        create :news_item, start_date: Time.zone.tomorrow, end_date: Time.zone.tomorrow
+      end
+
+      let :indefinite do
+        create :news_item, start_date: Time.zone.today, end_date: nil
+      end
+
+      it { is_expected.not_to include yesterdays }
+      it { is_expected.to include todays }
+      it { is_expected.not_to include tomorrows }
+      it { is_expected.to include indefinite }
     end
   end
 end

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe NewsItem do
   end
 
   describe 'scopes' do
-    describe '#for_service' do
+    describe '.for_service' do
       subject(:results) { described_class.for_service(service_name) }
 
       let(:uk_page) { create :news_item, show_on_uk: true, show_on_xi: false }
@@ -79,7 +79,7 @@ RSpec.describe NewsItem do
       end
     end
 
-    describe '#for_target' do
+    describe '.for_target' do
       subject(:results) { described_class.for_target(target) }
 
       let :home_page do
@@ -132,7 +132,7 @@ RSpec.describe NewsItem do
       end
     end
 
-    describe '#for_today' do
+    describe '.for_today' do
       subject { described_class.for_today }
 
       let :yesterdays do
@@ -157,7 +157,7 @@ RSpec.describe NewsItem do
       it { is_expected.to include indefinite }
     end
 
-    describe '#descending' do
+    describe '.descending' do
       subject { described_class.descending.to_a }
 
       let!(:published_today) { create :news_item, start_date: Time.zone.today }

--- a/spec/requests/api/v2/news_items_controller_spec.rb
+++ b/spec/requests/api/v2/news_items_controller_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe Api::V2::NewsItemsController do
+  describe 'GET #index' do
+    subject(:rendered) { make_request && response }
+
+    let :make_request do
+      get api_news_items_path(format: :json),
+          headers: { 'Accept' => 'application/vnd.uktt.v2' }
+    end
+
+    it_behaves_like 'a successful jsonapi response'
+
+    context 'for uk pages' do
+      let :make_request do
+        get api_news_items_path(service: 'uk', format: :json),
+            headers: { 'Accept' => 'application/vnd.uktt.v2' }
+      end
+
+      it_behaves_like 'a successful jsonapi response'
+
+      context 'with only items for home page' do
+        let :make_request do
+          get api_news_items_path(service: 'uk', target: 'home', format: :json),
+              headers: { 'Accept' => 'application/vnd.uktt.v2' }
+        end
+
+        it_behaves_like 'a successful jsonapi response'
+      end
+
+      context 'with only items for updates page' do
+        let :make_request do
+          get api_news_items_path(service: 'uk', target: 'updates', format: :json),
+              headers: { 'Accept' => 'application/vnd.uktt.v2' }
+        end
+
+        it_behaves_like 'a successful jsonapi response'
+      end
+
+      context 'with unknown target' do
+        let :make_request do
+          get api_news_items_path(service: 'uk', target: 'unknown', format: :json),
+              headers: { 'Accept' => 'application/vnd.uktt.v2' }
+        end
+
+        it { is_expected.to have_http_status :not_found }
+      end
+    end
+
+    context 'for xi pages' do
+      let :make_request do
+        get api_news_items_path(service: 'xi', format: :json),
+            headers: { 'Accept' => 'application/vnd.uktt.v2' }
+      end
+
+      it_behaves_like 'a successful jsonapi response'
+    end
+
+    context 'for unknown service pages' do
+      let :make_request do
+        get api_news_items_path(service: 'uk', format: :json),
+            headers: { 'Accept' => 'application/vnd.uktt.v2' }
+
+        it { is_expected.to have_http_status :not_found }
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/news_items_controller_spec.rb
+++ b/spec/requests/api/v2/news_items_controller_spec.rb
@@ -65,4 +65,17 @@ RSpec.describe Api::V2::NewsItemsController do
       end
     end
   end
+
+  describe 'GET #show' do
+    subject(:rendered) { make_request && response }
+
+    let(:news_item) { create :news_item }
+
+    let :make_request do
+      get api_news_item_path(news_item.id, format: :json),
+          headers: { 'Accept' => 'application/vnd.uktt.v2' }
+    end
+
+    it_behaves_like 'a successful jsonapi response'
+  end
 end

--- a/spec/requests/api/v2/rules_of_origin_controller_spec.rb
+++ b/spec/requests/api/v2/rules_of_origin_controller_spec.rb
@@ -13,28 +13,18 @@ RSpec.describe Api::V2::RulesOfOriginController do
           headers: { 'Accept' => 'application/vnd.uktt.v2' }
     end
 
-    it { is_expected.to have_http_status :success }
-    it { is_expected.to have_attributes media_type: /json/ }
-
-    context 'with respond json' do
-      subject { JSON.parse rendered.body }
-
-      it { is_expected.to include 'data' }
-      it { is_expected.to include 'included' }
-    end
+    it_behaves_like 'a successful jsonapi response'
 
     context 'without match heading' do
       let(:heading_code) { '010101' }
 
-      it { is_expected.to have_http_status :success }
-      it { is_expected.to have_attributes media_type: /json/ }
+      it_behaves_like 'a successful jsonapi response'
     end
 
     context 'without matching country' do
       let(:country_code) { 'ES' }
 
-      it { is_expected.to have_http_status :success }
-      it { is_expected.to have_attributes media_type: /json/ }
+      it_behaves_like 'a successful jsonapi response'
     end
   end
 end

--- a/spec/serializers/api/v2/news_item_serializer_spec.rb
+++ b/spec/serializers/api/v2/news_item_serializer_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Api::V2::NewsItemSerializer do
         id: news_item.id.to_s,
         type: :news_item,
         attributes: {
+          id: news_item.id,
           title: news_item.title,
           content: news_item.content,
           display_style: news_item.display_style,

--- a/spec/serializers/api/v2/news_item_serializer_spec.rb
+++ b/spec/serializers/api/v2/news_item_serializer_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe Api::V2::NewsItemSerializer do
+  subject(:serializable) { described_class.new(news_item).serializable_hash }
+
+  let(:news_item) { create :news_item }
+
+  let :expected do
+    {
+      data: {
+        id: news_item.id.to_s,
+        type: :news_item,
+        attributes: {
+          title: news_item.title,
+          content: news_item.content,
+          display_style: news_item.display_style,
+          show_on_xi: news_item.show_on_xi,
+          show_on_uk: news_item.show_on_uk,
+          show_on_updates_page: news_item.show_on_updates_page,
+          show_on_home_page: news_item.show_on_home_page,
+          start_date: news_item.start_date,
+          end_date: news_item.end_date,
+          created_at: news_item.created_at,
+          updated_at: news_item.updated_at,
+        },
+      },
+    }
+  end
+
+  describe '#serializable_hash' do
+    it 'matches the expected hash' do
+      expect(serializable).to eql expected
+    end
+  end
+end

--- a/spec/support/shared_examples/api_request_examples.rb
+++ b/spec/support/shared_examples/api_request_examples.rb
@@ -1,0 +1,5 @@
+RSpec.shared_examples 'a successful jsonapi response' do
+  it { is_expected.to have_http_status :success }
+  it { is_expected.to have_attributes media_type: /json/ }
+  it { expect(JSON.parse(subject.body)).to include 'data' }
+end


### PR DESCRIPTION
### Jira link

[HOTT-1080](https://transformuk.atlassian.net/browse/HOTT-1080)

### What?

I have added/removed/altered:

- [x] Added filtering News Items by todays date
- [x] Added filtering News Items by service (xi or uk)
- [x] Added filtering News Items by target page (home or updates)
- [x] Added a Api::V2 serializer for the News Items
- [x] Added an `/api/v2/news_items/:service/:target` api endpoint which the frontend can use to retrieve the stories
- [x] Added an '/api/v2/news_items/:id` api endpoint which the frontend can use to retrieve specific news stories

### Why?

I am doing this because:

- We wish to show news items on the frontend
