### PR TITLE
HOTT-1082: Expose resolved measure component units

### DIFF
--- a/app/controllers/api/v2/commodities_controller.rb
+++ b/app/controllers/api/v2/commodities_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V2
     class CommoditiesController < ApiController
       before_action :find_commodity, only: %i[show changes]
+      before_action :set_meursing_additional_code, only: :show
 
       def show
         render json: cached_commodity
@@ -35,7 +36,10 @@ module Api
       end
 
       def filter_params
-        params.require(:filter).permit(:geographical_area_id, :meursing_additional_code_id) if params[:filter].present?
+        params.fetch(:filter, {}).permit(
+          :geographical_area_id,
+          :meursing_additional_code_id,
+        )
       end
 
       def commodity_has_children?
@@ -44,6 +48,10 @@ module Api
         Rails.cache.fetch(cache_key, expires_in: CachedCommodityService::TTL) do
           @commodity.children.any?
         end
+      end
+
+      def set_meursing_additional_code
+        Thread.current[:meursing_additional_code_id] = filter_params[:meursing_additional_code_id]
       end
     end
   end

--- a/app/models/measure_component.rb
+++ b/app/models/measure_component.rb
@@ -56,12 +56,11 @@ class MeasureComponent < Sequel::Model
   end
 
   def ad_valorem?
-    measurement_unit_code.nil? &&
-      monetary_unit_code.nil?
+    measurement_unit_code.blank?
   end
 
   def expresses_unit?
-    measurement_unit_code
+    measurement_unit_code.present?
   end
 
   def unit

--- a/app/presenters/api/v2/measures/measure_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_presenter.rb
@@ -39,7 +39,11 @@ module Api
         end
 
         def measure_component_ids
-          measure.measure_components.map { |component| component.pk.join('-') }
+          measure_components.map(&:id)
+        end
+
+        def resolved_measure_component_ids
+          resolved_measure_components.map(&:id)
         end
 
         def national_measurement_unit_ids

--- a/app/serializers/api/v2/measures/measure_serializer.rb
+++ b/app/serializers/api/v2/measures/measure_serializer.rb
@@ -16,15 +16,8 @@ module Api
                    :excise,
                    :vat,
                    :reduction_indicator,
-                   :meursing
-
-        attribute :resolved_duty_expression do |measure, params|
-          measure.resolved_duty_expression_for(params[:meursing_additional_code_id])
-        end
-
-        has_many :resolved_measure_components, serializer: Api::V2::Measures::MeasureComponentSerializer do |measure, params|
-          measure.resolved_components_for(params[:meursing_additional_code_id])
-        end
+                   :meursing,
+                   :resolved_duty_expression
 
         has_one :duty_expression, serializer: Api::V2::Measures::DutyExpressionSerializer
         has_one :measure_type, serializer: Api::V2::Measures::MeasureTypeSerializer
@@ -34,6 +27,7 @@ module Api
                                         if: proc { |measure| !measure.national && measure.suspended? }
         has_many :measure_conditions, serializer: Api::V2::Measures::MeasureConditionSerializer
         has_many :measure_components, serializer: Api::V2::Measures::MeasureComponentSerializer
+        has_many :resolved_measure_components, serializer: Api::V2::Measures::MeasureComponentSerializer
 
         has_many :national_measurement_units, serializer: Api::V2::Measures::NationalMeasurementUnitSerializer
         has_one :geographical_area, serializer: Api::V2::Measures::GeographicalAreaSerializer

--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -117,9 +117,6 @@ class CachedCommodityService
     {}.tap do |opts|
       opts[:is_collection] = false
       opts[:include] = DEFAULT_INCLUDES
-      opts[:params] = {}
-
-      opts[:params][:meursing_additional_code_id] = meursing_additional_code_id if meursing_additional_code_id.present?
     end
   end
 
@@ -135,7 +132,7 @@ class CachedCommodityService
   end
 
   def meursing_additional_code_id
-    filter_params[:meursing_additional_code_id]
+    Thread.current[:meursing_additional_code_id]
   end
 
   def cache_key

--- a/spec/factories/measure_component_factory.rb
+++ b/spec/factories/measure_component_factory.rb
@@ -13,6 +13,10 @@ FactoryBot.define do
     measurement_unit_code { nil }
   end
 
+  trait :with_measure_unit do
+    measurement_unit_code { 'DTN' }
+  end
+
   trait :with_duty_expression do
     after(:build) do |measure_component, _evaluator|
       create(

--- a/spec/serializers/api/v2/measures/measure_serializer_spec.rb
+++ b/spec/serializers/api/v2/measures/measure_serializer_spec.rb
@@ -59,8 +59,10 @@ RSpec.describe Api::V2::Measures::MeasureSerializer do
   describe '#serializable_hash' do
     it { is_expected.to include_json(expected_pattern) }
 
-    context 'when passing a meursing additional code' do
-      let(:options) { { params: { meursing_additional_code_id: '000' }, include: %w[measure_components] } }
+    context 'when a meursing additional code is specified' do
+      include_context 'with meursing additional code id', '000'
+
+      let(:options) { { include: %w[measure_components] } }
       let(:meursing_agricultural_measure) { create(:measure, :agricultural) }
 
       let(:expected_pattern) do

--- a/spec/services/cached_commodity_service_spec.rb
+++ b/spec/services/cached_commodity_service_spec.rb
@@ -140,15 +140,11 @@ RSpec.describe CachedCommodityService do
       end
     end
 
-    context 'when the filter specifies a meursing_additional_code_id' do
-      let(:filter_params) do
-        ActionController::Parameters.new(
-          meursing_additional_code_id: 'foo',
-        ).permit!
-      end
+    context 'when the current Thread specifies a meursing_additional_code_id' do
+      include_context 'with meursing additional code id', 'foo'
 
       it 'uses a cache key with an area filter in it' do
-        expected_key = "_commodity-#{commodity.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}--foo"
+        expected_key = "_commodity-#{commodity.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}-RO-foo"
         service.call
         expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 24.hours)
       end

--- a/spec/support/shared_contexts/with_meursing_additional_code_id.rb
+++ b/spec/support/shared_contexts/with_meursing_additional_code_id.rb
@@ -1,0 +1,7 @@
+RSpec.shared_context 'with meursing additional code id' do |meursing_additional_code_id|
+  around do |example|
+    Thread.current[:meursing_additional_code_id] = meursing_additional_code_id
+    example.run
+    Thread.current[:meursing_additional_code_id] = nil
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1082

### What?

I have added/removed/altered:

- [x] Added resolved measure components to the list of components that express units
- [x] Made the logic of whether a component expresses units simpler
- [x] Added a request-global Thread variable for the meursing additional code that is accessible to serializers and presenters when trying to fetch measure units

### Why?

I am doing this because:

- This is required to make sure the user is asked the proper questions about resolved measure component units in the duty calculator
