### PR TITLE
HOTT-1084: Migrate to using callbacks for specific behaviours on specific mappers

### DIFF
--- a/lib/cds_importer/entity_mapper/geographical_area_membership_mapper.rb
+++ b/lib/cds_importer/entity_mapper/geographical_area_membership_mapper.rb
@@ -16,6 +16,28 @@ class CdsImporter
       self.entity_mapping_key_as_array = mapping_with_key_as_array.freeze
 
       self.entity_mapping_keys_to_parse = mapping_keys_to_parse.freeze
+
+      before_oplog_inserts do |xml_node|
+        unless xml_node['geographicalAreaMembership'].is_a?(Array)
+          xml_node['geographicalAreaMembership'] = [xml_node['geographicalAreaMembership']]
+        end
+
+        xml_node['geographicalAreaMembership'] = xml_node['geographicalAreaMembership'].each_with_object([]) do |geographical_area_membership, array|
+          unless geographical_area_membership.key?('geographicalAreaGroupSid')
+            message = "Skipping membership import due to missing geographical area group sid. hjid is #{geographical_area_membership['hjid']}\n"
+
+            instrument_warning(message, xml_node)
+            next
+          end
+
+          geographical_area = GeographicalArea[hjid: geographical_area_membership['geographicalAreaGroupSid']]
+
+          geographical_area_membership['geographicalAreaSid'] = geographical_area&.geographical_area_sid
+          geographical_area_membership['geographicalAreaGroupSid'] = xml_node['sid'].to_i
+
+          array << geographical_area_membership
+        end
+      end
     end
   end
 end

--- a/lib/cds_importer/entity_mapper/measure_mapper.rb
+++ b/lib/cds_importer/entity_mapper/measure_mapper.rb
@@ -22,15 +22,22 @@ class CdsImporter
         'additionalCode.additionalCodeCode' => :additional_code_id,
         'additionalCode.sid' => :additional_code_sid,
         'reductionIndicator' => :reduction_indicator,
-        'exportRefundNomenclature.sid' => :export_refund_nomenclature_sid
-        # "" => :tariff_measure_number,
-        # "" => :invalidated_by,
-        # "" => :invalidated_at
+        'exportRefundNomenclature.sid' => :export_refund_nomenclature_sid,
       ).freeze
 
       self.entity_mapping_key_as_array = mapping_with_key_as_array.freeze
 
       self.entity_mapping_keys_to_parse = mapping_keys_to_parse.freeze
+
+      before_oplog_inserts do |xml_node|
+        if xml_node['sid'].blank?
+          message = 'Skipping removal of measure geographical exclusions due to missing measure sid.'
+
+          instrument_warning(message, xml_node)
+        else
+          MeasureExcludedGeographicalArea.operation_klass.where(measure_sid: xml_node['sid']).delete
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1084

### What?

We are in a situation where, because of CDS non-compliance with
taric data structure and processing standards we need to special
snowflake a bunch of behaviour when specific kinds of entity are
imported.

This change makes this whole process a bit neater by supplying a before
insert callback mechanism which (as the name suggests) enables us to
implement root- and branch- specific behaviour before a given entity  has an operation row created.

Following this specific change will be more changes to the MeasureMapper
around FootnoteAssociationMeasures


I have added/removed/altered:

- [x] Added a callback mechanism for executing arbitrary callbacks before we insert a given mapped node

### Why?

I am doing this because:

- This is significantly neater than putting the callback code inline with the orchestrating layer and requires less logic
