### PR TITLE
Fix rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,3 +5,5 @@
 require_relative 'config/application'
 
 Rails.application.load_tasks
+
+Rake.add_rakelib 'app/lib/tasks'

--- a/app/lib/tasks/data_migrations.rake
+++ b/app/lib/tasks/data_migrations.rake
@@ -1,40 +1,43 @@
-TradeTariffBackend::DataMigrator.reporter = TradeTariffBackend::DataMigrator::ConsoleReporter
-
 namespace :db do
   namespace :data do
+    desc 'Set reporter class variable after the environment has loaded'
+    task load_reporter: :environment do
+      TradeTariffBackend::DataMigrator.reporter = TradeTariffBackend::DataMigrator::ConsoleReporter
+    end
+
     desc 'Applies all pending data migrations'
-    task migrate: :environment do
+    task migrate: :load_reporter do
       TradeTariffBackend::DataMigrator.migrate
     end
 
     desc 'Rollbacks last applied data migration'
-    task rollback: :environment do
+    task rollback: :load_reporter do
       TradeTariffBackend::DataMigrator.rollback
     end
 
     desc 'Prints data migration application status'
-    task status: :environment do
+    task status: :load_reporter do
       TradeTariffBackend::DataMigrator.status
     end
 
     desc 'Rollbacks last data migration and applies it'
-    task redo: :environment do
+    task redo: :load_reporter do
       TradeTariffBackend::DataMigrator.redo
     end
 
     desc 'Applies data migration one more time by timestamp'
-    task :repeat, [:timestamp] => :environment do |_task, args|
+    task :repeat, [:timestamp] => :load_reporter do |_task, args|
       TradeTariffBackend::DataMigrator.repeat(args[:timestamp])
     end
 
     desc 'Load old data migrations (run this task once)'
-    task init_migrations_table: :environment do
+    task init_migrations_table: :load_reporter do
       TradeTariffBackend::DataMigrator.send(:migration_files).each do |file|
-        if TradeTariffBackend::DataMigration::LogEntry.where(filename: file).none?
-          l = TradeTariffBackend::DataMigration::LogEntry.new
-          l.filename = file
-          l.save
-        end
+        next unless TradeTariffBackend::DataMigration::LogEntry.where(filename: file).none?
+
+        l = TradeTariffBackend::DataMigration::LogEntry.new
+        l.filename = file
+        l.save
       end
     end
   end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

We depend on a bunch of models being loaded and haven't got explicit
requires that do this to enable doing various things with these models.

This includes things like unrestricting the primary key of each model so
the import process can update them or enumerating the models that are backed by oplogs
so we can clean oplog tables of rolled back files.

I've also updated a rake task not to try and load a constant and assign
a class variable to it before we've had a chance to load the environment


I have added/removed/altered:

- [x] Fix loading data migration rake tasks before the environment has loaded and the autoloaders are ready
- [x] Make it so that the Rakefile knows about the rake tasks under app/lib
- [x] When running tasks in development, make sure we're eager loading constants if we need them

### Why?

I am doing this because:

- So we can follow the common rails/zeitwerk idioms and not get confusing behaviour around rollbacks (I was getting confusing behaviour)
- So we can list rake tasks that - a bug I introduced when we moved to making lib work with zeitwerk under app/lib
- So we actually rollback successfully when debugging/testing ETL changes locally
- The main changes in this PR bring us up-to-date with how production is run
