### PR TITLE
HOTT-1120: Fixes null measurement units

### DIFF
--- a/app/serializers/api/v2/measures/measure_component_serializer.rb
+++ b/app/serializers/api/v2/measures/measure_component_serializer.rb
@@ -15,7 +15,7 @@ module Api
                    :duty_expression_description,
                    :duty_expression_abbreviation
 
-        has_one :measurement_unit, serializer: Api::V2::Measures::MeasurementUnitSerializer
+        has_one :measurement_unit, serializer: Api::V2::Measures::MeasurementUnitSerializer, if: proc { |measure_component| measure_component.measurement_unit_code.present? }
       end
     end
   end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1120

### What?

The newly-surfaced measurement unit relationships were being
populated with garbage data:

```json
"relationships": {
  "measurement_unit": {
    "data": null
  }
}
```

Now the measurement units do not get populated if they are missing an id

I have added/removed/altered:

- [x] Fix bug with newly-surfaced measurement unit relationships
