### PR TITLE
HOTT-334 Avoid duplicates in comm code suggestions

### DIFF
--- a/app/services/base_suggestions_service.rb
+++ b/app/services/base_suggestions_service.rb
@@ -9,7 +9,8 @@ class BaseSuggestionsService
           .actual
           .distinct
           .order(Sequel.desc(:goods_nomenclature_item_id))
-          .map { |commodity| handle_commodity_record(commodity) }
+          .index_by(&:goods_nomenclature_item_id)
+          .map { |_commodity_code, commodity| handle_commodity_record(commodity) }
 
     search_references = SearchReference
           .select(:id, :title)


### PR DESCRIPTION
### Jira link

[HOTT-334](https://transformuk.atlassian.net/browse/HOTT-334)

### What?

I have added/removed/altered:

- [x] Changed the search suggestions in the V2 api (at `/search/suggestions`) to remove duplicate commodity codes

### Why?

I am doing this because:

- These are caused by multiple current goods nomenclature records with the same commodity code but with different product line suffixes. We do not want these showing up multiple times in the search results on the frontend.

### Notes

This does change the output from `/search/suggestions` previously with multiple production line suffixes we would return all the commodity codes, each with a different OID. Now we only return 1 commodity code with the last matched OID.