### PR TITLE
Tighten validation on Rules of Origin query

### DIFF
--- a/app/models/rules_of_origin/query.rb
+++ b/app/models/rules_of_origin/query.rb
@@ -36,7 +36,7 @@ module RulesOfOrigin
       scheme_set.links + schemes.map(&:links).flatten
     end
 
-    class InvalidParams < StandardError; end
+    class InvalidParams < ArgumentError; end
 
     private
 

--- a/app/models/rules_of_origin/query.rb
+++ b/app/models/rules_of_origin/query.rb
@@ -1,13 +1,19 @@
+# frozen_string_literal: true
+
 module RulesOfOrigin
   class Query
+    HEADING_CHECKER = /\A\d{6}\z/
+    COUNTRY_CHECKER = /\A[A-Z]{2}\z/
+
     attr_reader :heading_code, :country_code
 
     delegate :scheme_set, :rule_set, :heading_mappings, to: :@data_set
 
     def initialize(data_set, heading_code, country_code)
       @data_set = data_set
-      @heading_code = heading_code
-      @country_code = country_code
+      @heading_code = heading_code.to_s
+      @country_code = country_code.to_s.upcase
+      validate!
     end
 
     def rules
@@ -30,11 +36,18 @@ module RulesOfOrigin
       scheme_set.links + schemes.map(&:links).flatten
     end
 
+    class InvalidParams < StandardError; end
+
     private
 
     def schemes_and_their_id_rules
       @schemes_and_their_id_rules ||=
         heading_mappings.for_heading_and_schemes(heading_code, scheme_codes)
+    end
+
+    def validate!
+      raise InvalidParams unless HEADING_CHECKER.match?(heading_code)
+      raise InvalidParams unless COUNTRY_CHECKER.match?(country_code)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,9 @@ Rails.application.routes.draw do
       resources :rules_of_origin_schemes,
                 controller: 'rules_of_origin',
                 only: %i[index]
+      get '/rules_of_origin_schemes/:heading_code/:country_code',
+          to: 'rules_of_origin#index',
+          as: :rules_of_origin
 
       if TradeTariffBackend.uk?
         get '/news_items/:id', constraints: { id: /\d+/ }, to: 'news_items#show', as: :news_item

--- a/spec/factories/rules_of_origin/data_set_factory.rb
+++ b/spec/factories/rules_of_origin/data_set_factory.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
     transient do
       scheme_code { scheme_set.schemes.first }
       rules { build_list :rules_of_origin_rule, 2, scheme_code: scheme_code }
-      sequence(:heading_code, 1000) { |n| sprintf '%6d', n }
+      sequence(:heading_code, 1000) { |n| sprintf '%06d', n }
     end
   end
 end

--- a/spec/models/rules_of_origin/query_spec.rb
+++ b/spec/models/rules_of_origin/query_spec.rb
@@ -5,10 +5,26 @@ RSpec.describe RulesOfOrigin::Query do
     described_class.new roo_data_set, heading_code, country_code
   end
 
+  include_context 'with fake rules of origin data'
+
   let(:heading_code) { roo_heading_code }
   let(:country_code) { roo_country_code }
 
-  include_context 'with fake rules of origin data'
+  describe '.new' do
+    it { is_expected.to be_instance_of described_class }
+
+    context 'with invalid heading code' do
+      let(:heading_code) { '1000' }
+
+      it { expect { query }.to raise_exception described_class::InvalidParams }
+    end
+
+    context 'with invalid country code' do
+      let(:country_code) { 'USA' }
+
+      it { expect { query }.to raise_exception described_class::InvalidParams }
+    end
+  end
 
   describe '#rules' do
     subject { query.rules[roo_scheme_code] }

--- a/spec/requests/api/v2/rules_of_origin_controller_spec.rb
+++ b/spec/requests/api/v2/rules_of_origin_controller_spec.rb
@@ -26,5 +26,16 @@ RSpec.describe Api::V2::RulesOfOriginController do
 
       it_behaves_like 'a successful jsonapi response'
     end
+
+    context 'with path params' do
+      let :make_request do
+        get api_rules_of_origin_path(heading_code: heading_code,
+                                     country_code: country_code,
+                                     format: :json),
+            headers: { 'Accept' => 'application/vnd.uktt.v2' }
+      end
+
+      it_behaves_like 'a successful jsonapi response'
+    end
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-1001](https://transformuk.atlassian.net/browse/HOTT-1001)

### What?

I have added/removed/altered:

- [x] Added parameter checks to the RulesOfOrigin::Query

### Why?

I am doing this because:

- Because we are going to publicly expose the Rules of Origin api
