### PR TITLE
HOTT-1143-sentry-rails: Migrate to sentry-rails and sentry-sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,8 @@ gem 'nokogiri'
 gem 'omniauth-rails_csrf_protection'
 gem 'ox'
 gem 'plek'
-gem 'sentry-raven'
+gem 'sentry-rails'
+gem "sentry-sidekiq"
 
 # API related
 gem 'ansi'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,8 +368,15 @@ GEM
     rubyzip (2.3.2)
     rufus-scheduler (3.8.0)
       fugit (~> 1.1, >= 1.1.6)
-    sentry-raven (3.1.2)
-      faraday (>= 1.0)
+    sentry-rails (4.8.1)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 4.8.1)
+    sentry-ruby-core (4.8.1)
+      concurrent-ruby
+      faraday
+    sentry-sidekiq (4.8.1)
+      sentry-ruby-core (~> 4.8.1)
+      sidekiq (>= 3.0)
     sequel (5.52.0)
     sequel-rails (1.1.1)
       actionpack (>= 4.0.0)
@@ -466,7 +473,8 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop-govuk
   rubyzip
-  sentry-raven
+  sentry-rails
+  sentry-sidekiq
   sequel
   sequel-rails
   sidekiq

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::Base
   def render_bad_request(exception)
     logger.error exception
     logger.error exception.backtrace
-    ::Raven.capture_exception(exception)
+    ::Sentry.capture_exception(exception)
 
     respond_to do |format|
       format.any do
@@ -41,7 +41,7 @@ class ApplicationController < ActionController::Base
   def render_internal_server_error(exception)
     logger.error exception
     logger.error exception.backtrace
-    ::Raven.capture_exception(exception)
+    ::Sentry.capture_exception(exception)
 
     respond_to do |format|
       format.any do

--- a/app/lib/tariff_synchronizer/cds_update.rb
+++ b/app/lib/tariff_synchronizer/cds_update.rb
@@ -35,7 +35,7 @@ module TariffSynchronizer
     end
 
     def alert_potential_failed_import
-      Raven.capture_message \
+      Sentry.capture_message \
         "Empty CDS update - Issue Date: #{issue_date}: Applied: #{Time.zone.today}"
     end
   end

--- a/app/models/measurement_unit.rb
+++ b/app/models/measurement_unit.rb
@@ -47,9 +47,9 @@ class MeasurementUnit < Sequel::Model
       qualifier_code = unit_key.length == 4 ? unit_key[3..] : ''
 
       if unit.present?
-        Raven.capture_message("Missing measurement unit in database for measurement unit key: #{unit_key}")
+        Sentry.capture_message("Missing measurement unit in database for measurement unit key: #{unit_key}")
       else
-        Raven.capture_message("Missing measurement unit in measurement_units.yml: #{unit_key}")
+        Sentry.capture_message("Missing measurement unit in measurement_units.yml: #{unit_key}")
       end
 
       {

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,8 +1,0 @@
-if defined?(Raven) && ENV['VCAP_APPLICATION'].present?
-  tags = JSON.parse(ENV['VCAP_APPLICATION'])
-             .except('application_uris', 'host', 'application_name', 'space_id', 'port', 'uris', 'application_version')
-             .merge({ server_name: ENV['GOVUK_APP_DOMAIN'] })
-  Raven.configure do |config|
-    config.tags = tags
-  end
-end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,5 @@
+Sentry.init do |config|
+  config.rails.report_rescued_exceptions = false
+
+  config.breadcrumbs_logger = [:active_support_logger]
+end

--- a/lib/sentry/rails/background_worker.rb
+++ b/lib/sentry/rails/background_worker.rb
@@ -1,0 +1,7 @@
+module Sentry
+  class BackgroundWorker
+    def _perform(&block)
+      block.call
+    end
+  end
+end

--- a/spec/models/measurement_unit_spec.rb
+++ b/spec/models/measurement_unit_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe MeasurementUnit do
 
       before do
         measurement_unit
-        allow(Raven).to receive(:capture_message).and_call_original
+        allow(Sentry).to receive(:capture_message).and_call_original
         allow(described_class).to receive(:measurement_units).and_return({})
         result
       end
@@ -66,14 +66,14 @@ RSpec.describe MeasurementUnit do
       end
 
       it { is_expected.to eq(expected_units) }
-      it { expect(Raven).to have_received(:capture_message) }
+      it { expect(Sentry).to have_received(:capture_message) }
     end
 
     context 'with measurement unit not in the database' do
       subject(:result) { described_class.units('FC1', 'FC1X') }
 
       before do
-        allow(Raven).to receive(:capture_message).and_call_original
+        allow(Sentry).to receive(:capture_message).and_call_original
         allow(described_class).to receive(:measurement_units).and_return({})
         result
       end
@@ -92,7 +92,7 @@ RSpec.describe MeasurementUnit do
       end
 
       it { is_expected.to eq(expected_units) }
-      it { expect(Raven).to have_received(:capture_message) }
+      it { expect(Sentry).to have_received(:capture_message) }
     end
   end
 end

--- a/spec/unit/tariff_synchronizer/cds_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/cds_update_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe TariffSynchronizer::CdsUpdate do
       before do
         allow(CdsImporter).to receive(:new).with(cds_update).and_return importer
         allow(importer).to receive(:import).and_return inserted_oplog_records
-        allow(Raven).to receive(:capture_message)
+        allow(Sentry).to receive(:capture_message)
         allow(cds_update).to receive(:check_oplog_inserts).and_call_original
 
         cds_update.import!
@@ -71,7 +71,7 @@ RSpec.describe TariffSynchronizer::CdsUpdate do
         end
 
         it 'will not alert' do
-          expect(Raven).not_to have_received(:capture_message)
+          expect(Sentry).not_to have_received(:capture_message)
         end
       end
 
@@ -90,7 +90,7 @@ RSpec.describe TariffSynchronizer::CdsUpdate do
         end
 
         it 'will not alert' do
-          expect(Raven).not_to have_received(:capture_message)
+          expect(Sentry).not_to have_received(:capture_message)
         end
       end
 
@@ -107,7 +107,7 @@ RSpec.describe TariffSynchronizer::CdsUpdate do
         end
 
         it 'will alert' do
-          expect(Raven).to have_received(:capture_message)
+          expect(Sentry).to have_received(:capture_message)
                              .with(/Empty CDS update - Issue Date: \d{4}-\d\d-\d\d: Applied: #{Time.zone.today}/)
         end
       end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1143

### What?

I have added/removed/altered:

- [x] Added sentry-rails and sentry-sidekiq gem
- [x] Added monkey patch for hard dependency on ActiveRecord
- [x] Fixed references in specs and code from `Raven` to `Sentry`

### Why?

I am doing this because:

- sentry-raven is out of support
