### PR TITLE
HOTT-1184 Handle when no published date

### DIFF
--- a/app/services/measure_service/council_regulation_url_generator.rb
+++ b/app/services/measure_service/council_regulation_url_generator.rb
@@ -36,7 +36,7 @@ module MeasureService
                                  .to_s
                                  .rjust(4, '0')
 
-      url_ops = if target_regulation.is_a?(MeasurePartialTemporaryStop)
+      url_ops = if target_regulation.is_a?(MeasurePartialTemporaryStop) || target_regulation.published_date.nil?
                   #
                   # If MeasurePartialTemporaryStop, we do not pass year into the search params
                   # as there are no published_date for partial stop


### PR DESCRIPTION
### Jira link

[HOTT-1184](https://transformuk.atlassian.net/browse/HOTT-1184)

### What?

I have added/removed/altered:

- [x] Change the url generation to include the published date if one is set

### Why?

I am doing this because:

- We now have other regulation types without published dates

