### PR TITLE
HOTT-1001 Allow 10 digit comm codes in RoO api

### DIFF
--- a/app/models/rules_of_origin/query.rb
+++ b/app/models/rules_of_origin/query.rb
@@ -11,7 +11,7 @@ module RulesOfOrigin
 
     def initialize(data_set, heading_code, country_code)
       @data_set = data_set
-      @heading_code = heading_code.to_s
+      @heading_code = heading_code.to_s.slice(0, 6)
       @country_code = country_code.to_s.upcase
       validate!
     end

--- a/spec/models/rules_of_origin/query_spec.rb
+++ b/spec/models/rules_of_origin/query_spec.rb
@@ -9,9 +9,16 @@ RSpec.describe RulesOfOrigin::Query do
 
   let(:heading_code) { roo_heading_code }
   let(:country_code) { roo_country_code }
+  let(:commodity_code) { "#{roo_heading_code}1010" }
 
   describe '.new' do
     it { is_expected.to be_instance_of described_class }
+
+    context 'with full commodity code' do
+      let(:heading_code) { commodity_code }
+
+      it { is_expected.to be_instance_of described_class }
+    end
 
     context 'with invalid heading code' do
       let(:heading_code) { '1000' }
@@ -36,6 +43,13 @@ RSpec.describe RulesOfOrigin::Query do
       it { is_expected.to have_attributes length: 1 }
     end
 
+    context 'with matching commodity code and country code' do
+      let(:heading_code) { commodity_code }
+
+      it { is_expected.to include rule_set.rule(rule_set.id_rules.first) }
+      it { is_expected.to have_attributes length: 1 }
+    end
+
     context 'with unmatched country code' do
       let(:country_code) { 'RA' }
 
@@ -51,6 +65,12 @@ RSpec.describe RulesOfOrigin::Query do
 
   describe '#schemes' do
     subject { query.schemes }
+
+    context 'with matching commodity code and country code' do
+      let(:heading_code) { commodity_code }
+
+      it { is_expected.to include roo_scheme }
+    end
 
     context 'with schemes matching supplied country code' do
       it { is_expected.to include roo_scheme }


### PR DESCRIPTION
### Jira link

[HOTT-1001](https://transformuk.atlassian.net/browse/HOTT-1001)

### What?

I have added/removed/altered:

- [x] Allow 10 digit commodity codes in the Rules of Origin api

### Why?

I am doing this because:

- whilst internally the lookups occur using subheadings, the ticket specifies using commodity codes

### Notes

- this is a definite trade off between user convenience and a more optimal API - if users query using 6 digit subheadings, then _any_ commodity under that subheading hits the same CDN cached api endpoint - when using 10 digit codes - this means separate endpoints for every commodity, even though commodities under the same subheadng always end up returning the same JSON payload