### PR TITLE
Push updates back a bit and chain the reindex when the updates actually happen

### DIFF
--- a/app/workers/updates_synchronizer_worker.rb
+++ b/app/workers/updates_synchronizer_worker.rb
@@ -11,11 +11,11 @@ class UpdatesSynchronizerWorker
     if TradeTariffBackend.use_cds?
       TariffSynchronizer.download_cds
       logger.info 'Applying...'
-      TariffSynchronizer.apply_cds
+      TariffSynchronizer.apply_cds(reindex_all_indexes: true)
     elsif TradeTariffBackend.xi?
       TariffSynchronizer.download
       logger.info 'Applying...'
-      TariffSynchronizer.apply
+      TariffSynchronizer.apply(reindex_all_indexes: true)
     end
   end
 end

--- a/app/workers/updates_synchronizer_worker.rb
+++ b/app/workers/updates_synchronizer_worker.rb
@@ -7,8 +7,7 @@ class UpdatesSynchronizerWorker
     logger.info 'Running UpdatesSynchronizerWorker'
     logger.info 'Downloading...'
 
-    # TODO: this check can be removed when we switch to CDS data.
-    if TradeTariffBackend.use_cds?
+    if TradeTariffBackend.uk?
       TariffSynchronizer.download_cds
       logger.info 'Applying...'
       TariffSynchronizer.apply_cds(reindex_all_indexes: true)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -19,14 +19,11 @@
   # Online converter: https://crontab.guru/#0_22_*_*_*
   #
   UpdatesSynchronizerWorker:
-    cron: "30 4 * * *"
+    cron: "0 5 * * *"
     description: "UpdatesSynchronizerWorker"
   TaricSequenceCheckWorker:
     cron: "0 14 * * 6" 
     description: "TaricSequenceCheckWorker"
-  ClearCacheWorker:
-    cron: "0 5 * * *" 
-    description: "Clear Rails cache"
   PopulateChangesTableWorker:
     cron: "30 4 * * *" 
     description: "Populates the changes table"

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -19,7 +19,7 @@
   # Online converter: https://crontab.guru/#0_22_*_*_*
   #
   UpdatesSynchronizerWorker:
-    cron: "0 5 * * *"
+    cron: "30 5 * * *"
     description: "UpdatesSynchronizerWorker"
   TaricSequenceCheckWorker:
     cron: "0 14 * * 6" 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1203

### What?

I have added/removed/altered:

- [x] Updated sidekiq schedule by 30 minutes for the update synchronizer worker
- [x] Removed the sidekiq schedule for the cache clearing
- [x] Added an optional parameter to the worker which kicks off the relevant worker after the update has finished and only when there are no pending or failed updates
- [x] Linted the specs to reflect better_specs principles https://www.betterspecs.org/
- [x] Replaced the now-defunct use_cds? business method with the uk? service method and removed additional specs
- [x] Added specs for the tariff synchronizer apply_cds and apply methods which now kick off the sidekiq client with the cache clear worker

### Why?

I am doing this because:

- The extra 30 minutes enables us to better capture slow to drop api files on the cds files
- Only running when all updates are applied  and there are no failed updates will catch extra work which doesn't add value
- Chaining the Update and Cache workers will reduce the arbitrary latency/schedules we have setup for these two related jobs and should speed up the process overall