### PR TITLE
HOTT-1224 fix v1 api with v2 default

### DIFF
--- a/app/lib/api_constraints.rb
+++ b/app/lib/api_constraints.rb
@@ -1,19 +1,35 @@
 class ApiConstraints
+  VERSION_HEADER_MATCHER = %r{application/vnd\.uktt\.v\d}
+
+  class << self
+    def default_version
+      ENV.fetch('DEFAULT_API_VERSION', '1')
+    end
+  end
+
   def initialize(version:)
     @version = version.to_s
   end
 
   def matches?(req)
-    default? || req.headers['Accept'].include?("application/vnd.uktt.v#{@version}")
+    if uktt_version_header_present?(req)
+      requested_version?(req)
+    else
+      default?
+    end
   end
 
   private
 
   def default?
-    @version == default
+    @version == self.class.default_version
   end
 
-  def default
-    ENV.fetch('DEFAULT_API_VERSION', '1')
+  def uktt_version_header_present?(req)
+    req.headers['Accept'].to_s.match? VERSION_HEADER_MATCHER
+  end
+
+  def requested_version?(req)
+    req.headers['Accept'].to_s.include?("application/vnd.uktt.v#{@version}")
   end
 end

--- a/spec/lib/api_constraints_spec.rb
+++ b/spec/lib/api_constraints_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ApiConstraints do
     subject(:constraint) { described_class.new(version: constraint_version) }
 
     before do
-      allow_any_instance_of(described_class).to receive(:default)
+      allow(described_class).to receive(:default_version)
                                 .and_return(default_version)
     end
 

--- a/spec/lib/api_constraints_spec.rb
+++ b/spec/lib/api_constraints_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe ApiConstraints do
+  describe '#matches?' do
+    subject(:constraint) { described_class.new(version: constraint_version) }
+
+    before do
+      allow_any_instance_of(described_class).to receive(:default)
+                                .and_return(default_version)
+    end
+
+    # rubocop:disable RSpec/MultipleMemoizedHelpers
+    let(:bare_req) { OpenStruct.new(headers: {}) }
+    let(:no_v_req) { OpenStruct.new(headers: { 'Accept' => 'application/json' }) }
+    let(:v1_req) { OpenStruct.new(headers: { 'Accept' => 'application/vnd.uktt.v1' }) }
+    let(:v2_req) { OpenStruct.new(headers: { 'Accept' => 'application/vnd.uktt.v2' }) }
+    let(:v9_req) { OpenStruct.new(headers: { 'Accept' => 'application/vnd.uktt.v9' }) }
+
+    context 'with v1 default version' do
+      let(:default_version) { '1' }
+
+      context 'for v1 constraint' do
+        let(:constraint_version) { 1 }
+
+        it { expect(constraint.matches?(bare_req)).to be true }
+        it { expect(constraint.matches?(no_v_req)).to be true }
+        it { expect(constraint.matches?(v1_req)).to be true }
+        it { expect(constraint.matches?(v2_req)).to be false }
+        it { expect(constraint.matches?(v9_req)).to be false }
+      end
+
+      context 'for v2 constraint' do
+        let(:constraint_version) { 2 }
+
+        it { expect(constraint.matches?(bare_req)).to be false }
+        it { expect(constraint.matches?(no_v_req)).to be false }
+        it { expect(constraint.matches?(v1_req)).to be false }
+        it { expect(constraint.matches?(v2_req)).to be true }
+        it { expect(constraint.matches?(v9_req)).to be false }
+      end
+    end
+
+    context 'with v2 default version' do
+      let(:default_version) { '2' }
+
+      context 'for v1 constraint' do
+        let(:constraint_version) { 1 }
+
+        it { expect(constraint.matches?(bare_req)).to be false }
+        it { expect(constraint.matches?(no_v_req)).to be false }
+        it { expect(constraint.matches?(v1_req)).to be true }
+        it { expect(constraint.matches?(v2_req)).to be false }
+        it { expect(constraint.matches?(v9_req)).to be false }
+      end
+
+      context 'for v2 constraint' do
+        let(:constraint_version) { 2 }
+
+        it { expect(constraint.matches?(bare_req)).to be true }
+        it { expect(constraint.matches?(no_v_req)).to be true }
+        it { expect(constraint.matches?(v1_req)).to be false }
+        it { expect(constraint.matches?(v2_req)).to be true }
+        it { expect(constraint.matches?(v9_req)).to be false }
+      end
+    end
+    # rubocop:enable RSpec/MultipleMemoizedHelpers
+  end
+end

--- a/spec/requests/api/v2/commodities_controller_spec.rb
+++ b/spec/requests/api/v2/commodities_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Api::V2::CommoditiesController do
     end
 
     before do
-      allow_any_instance_of(ApiConstraints).to receive(:default).and_return default_version
+      allow(ApiConstraints).to receive(:default_version).and_return default_version
     end
 
     context 'with v1 api default' do

--- a/spec/requests/api/v2/commodities_controller_spec.rb
+++ b/spec/requests/api/v2/commodities_controller_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe Api::V2::CommoditiesController do
+  let!(:commodity) do
+    create(
+      :commodity,
+      :with_indent,
+      :with_chapter,
+      :with_heading,
+      :with_description,
+      :declarable,
+    )
+  end
+
+  let(:v1_header) { { 'Accept' => 'application/vnd.uktt.v1' } }
+  let(:v2_header) { { 'Accept' => 'application/vnd.uktt.v2' } }
+
+  describe 'GET #show' do
+    subject(:page_response) do
+      get "/commodities/#{commodity.to_param}", headers: api_header
+      response
+    end
+
+    before do
+      allow_any_instance_of(ApiConstraints).to receive(:default).and_return default_version
+    end
+
+    context 'with v1 api default' do
+      let(:default_version) { '1' }
+
+      context 'with v1 api request' do
+        let(:api_header) { v1_header }
+
+        it_behaves_like 'a successful plain json response'
+
+        it 'does include the objects data at the top level' do
+          expect(JSON.parse(page_response.body)).to include 'goods_nomenclature_item_id'
+        end
+      end
+
+      context 'with v2 api request' do
+        let(:api_header) { v2_header }
+
+        it_behaves_like 'a successful jsonapi response'
+
+        it 'does not include the objects data at the top level' do
+          expect(JSON.parse(page_response.body)).not_to include 'goods_nomenclature_item_id'
+        end
+      end
+    end
+
+    context 'with v2 api default' do
+      let(:default_version) { '2' }
+
+      context 'with v1 api request' do
+        let(:api_header) { v1_header }
+
+        it_behaves_like 'a successful plain json response'
+
+        it 'does include the objects data at the top level' do
+          expect(JSON.parse(page_response.body)).to include 'goods_nomenclature_item_id'
+        end
+      end
+
+      context 'with v2 api request' do
+        let(:api_header) { v2_header }
+
+        it_behaves_like 'a successful jsonapi response'
+
+        it 'does not include the objects data at the top level' do
+          expect(JSON.parse(page_response.body)).not_to include 'goods_nomenclature_item_id'
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/api_request_examples.rb
+++ b/spec/support/shared_examples/api_request_examples.rb
@@ -3,3 +3,9 @@ RSpec.shared_examples 'a successful jsonapi response' do
   it { is_expected.to have_attributes media_type: /json/ }
   it { expect(JSON.parse(subject.body)).to include 'data' }
 end
+
+RSpec.shared_examples 'a successful plain json response' do
+  it { is_expected.to have_http_status :success }
+  it { is_expected.to have_attributes media_type: /json/ }
+  it { expect(JSON.parse(subject.body)).not_to include 'data' }
+end


### PR DESCRIPTION
### Jira link

[HOTT-1224](https://transformuk.atlassian.net/browse/HOTT-1224)

### What?

I have added/removed/altered:

- [x] Added a request spec for the commodities controller which checks the API responses for both v1 and v2
- [x] Added a spec for the ApiConstraints class which verifies the behaviour with v1 and v2 defaults
- [x] Made changes to the ApiConstraints to not rely on ordering of usage in the routes file

### Why?

I am doing this because:

- The ApiConstraints class is always returns true if the default api version is the same as the instance of ApiConstraints is configured for. This works at present because the V1 routes come after the v2 routes, so provided the default is v1, the router has already determined the route is not a v2 route at the point it selects a v1 api controller. If the default is v2, this means the v2 routes (which are processed before the v1 routes) get matched to the v1 request and return an incorrect API response.

### Deployment risks (optional)

- This corrects a bug in the Api routing - it _shouldn't_ affect the routing.
