### PR TITLE
HOTT-1230 Fix backend PRs breaking review apps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,17 @@ commands:
             cf add-network-policy "$CF_ADMIN_APP-<< parameters.environment_key >>" "tariff-<< parameters.service >>-backend-<< parameters.environment_key >>-dark" --protocol tcp --port 8080
             cf add-network-policy "$CF_DUTYCALCULATOR_APP-<< parameters.environment_key >>" "tariff-<< parameters.service >>-backend-<< parameters.environment_key >>-dark" --protocol tcp --port 8080
 
+      - when:
+          condition:
+            equal: [ 'development', << parameters.space >> ]
+          steps:
+          - run:
+              name: "Recreate review app network policies"
+              command: |
+                for REVIEW_APP in $(cf apps | grep 'tariff-frontend-pr' | cut -d ' ' -f 1)
+                do
+                  cf add-network-policy $REVIEW_APP tariff-<<parameters.service >>-backend-dev-dark --protocol tcp --port 8080
+                done
       - run:
           name: "Verify new version is working on dark URL."
           command: |


### PR DESCRIPTION
### Jira link

[HOTT-1230](https://transformuk.atlassian.net/browse/HOTT-1230)

### What?

I have added/removed/altered:

- [x] Added CI step to recreate network policies required for review apps, only runs when cf space is `development`

### Why?

I am doing this because:

- When a new backend dev PR is pushed - the old app is removed and a new one is created in its place. This new backend will lack the necessary network policies to allow review apps to connect to the new backend.
- This fixes the issue where pushing a backend PR breaks the frontend review apps

### Deployment risks (optional)

- This changes the CI pipeline so is probably one to merge in the New Year - I've tested the `when:`  clause with both 'development' and 'ignore' - the step skips when its 'ignore' as expected. There will also be an opportunity to verify that step does not get run for staging when the PR is merged.
