### PR TITLE
HOTT-1225: Surface news items in atom feed

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,4 @@
-EXCHANGE_RATE_ACCESS_KEY=flibble
 DEFAULT_API_VERSION=2
+EXCHANGE_RATE_ACCESS_KEY=flibble
+TARIFF_HOME_URL=http://localhost:3001/find_commodity
+TARIFF_UPDATES_URL=http://localhost:3001/news

--- a/.env.test
+++ b/.env.test
@@ -2,16 +2,18 @@ AWS_ACCESS_KEY_ID=xxxxxxxxxxxxxxxxxxxx
 AWS_BUCKET_NAME=trade-tariff-backend
 AWS_REGION=us-east-1
 AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+DEFAULT_API_VERSION=2
 EXCHANGE_RATE_ACCESS_KEY=flibble
 HMRC_CLIENT_ID: 123456789
 HMRC_CLIENT_SECRET: 123456789
 HMRC_SYNC_HOST: http://example.com
 TARIFF_CDS_LOGGER=0
 TARIFF_FROM_EMAIL=no-reply@example.com
+TARIFF_HOME_URL=http://test.host/find_commodity
+TARIFF_UPDATES_URL=http://test.host/news
 TARIFF_IGNORE_PRESENCE_ERRORS=0
 TARIFF_MEASURES_LOGGER=0
 TARIFF_SYNC_EMAIL=user@example.com
 TARIFF_SYNC_HOST=http://example.com
 TARIFF_SYNC_PASSWORD=password
 TARIFF_SYNC_USERNAME=username
-DEFAULT_API_VERSION=2

--- a/app/controllers/api/feed/news_items_controller.rb
+++ b/app/controllers/api/feed/news_items_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module Feed
+    class NewsItemsController < ApiController
+      def index
+        @news_items = NewsItem
+          .for_service(service)
+          .updates
+          .paginate(current_page, per_page)
+          .descending
+      end
+
+      def service
+        params[:service] || ''
+      end
+    end
+  end
+end

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -33,6 +33,14 @@ module TradeTariffBackend
       ENV['CDS'] == 'true'
     end
 
+    def tariff_home_url
+      ENV.fetch('TARIFF_HOME_URL', 'https://www.trade-tariff.service.gov.uk/find_commodity')
+    end
+
+    def tariff_updates_url
+      ENV.fetch('TARIFF_UPDATES_URL', 'https://www.trade-tariff.service.gov.uk/news')
+    end
+
     def uk?
       service == 'uk'
     end

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -2,9 +2,16 @@ class NewsItem < Sequel::Model
   plugin :timestamps
   plugin :auto_validations
 
+  include ActiveModel::Conversion
+  extend ActiveModel::Naming
+
   DISPLAY_REGULAR = 0
 
   dataset_module do
+    def updates
+      where(show_on_updates_page: true)
+    end
+
     def descending
       order(Sequel.desc(:start_date), Sequel.desc(:id))
     end
@@ -38,5 +45,9 @@ class NewsItem < Sequel::Model
 
     validates_presence :title if title
     validates_presence :content if content
+  end
+
+  def persisted?
+    true
   end
 end

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -1,9 +1,7 @@
 class NewsItem < Sequel::Model
   plugin :timestamps
   plugin :auto_validations
-
-  include ActiveModel::Conversion
-  extend ActiveModel::Naming
+  plugin :active_model
 
   DISPLAY_REGULAR = 0
 
@@ -45,9 +43,5 @@ class NewsItem < Sequel::Model
 
     validates_presence :title if title
     validates_presence :content if content
-  end
-
-  def persisted?
-    true
   end
 end

--- a/app/views/api/feed/news_items/index.atom.builder
+++ b/app/views/api/feed/news_items/index.atom.builder
@@ -1,0 +1,19 @@
+atom_feed do |feed|
+  feed.title 'Online Trade Tariff News Items'
+
+  @news_items.each do |news_item|
+    url = "#{TradeTariffBackend.tariff_updates_url}/#{news_item.id}"
+
+    feed.entry(news_item, url: url) do |entry|
+      entry.id           news_item.id
+      entry.title        news_item.title
+      entry.story_body   news_item.content
+      entry.start_date   news_item.start_date.to_s(:rfc822)
+      entry.end_date     news_item.end_date.to_s(:rfc822) if news_item.end_date.present?
+      entry.uk           news_item.show_on_uk
+      entry.xi           news_item.show_on_xi
+      entry.home_page    TradeTariffBackend.tariff_home_url
+      entry.updates_page TradeTariffBackend.tariff_updates_url
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,12 @@
 Rails.application.routes.draw do
   get 'healthcheck' => 'healthcheck#index'
 
+  namespace :api, defaults: { format: 'atom' }, path: '' do
+    namespace :feed do
+      resources :news_items, only: :index
+    end
+  end
+
   namespace :api, defaults: { format: 'json' }, path: '/admin' do
     scope module: :admin do
       resources :sections, only: %i[index show], constraints: { id: /\d{1,2}/ } do

--- a/spec/factories/news_item_factory.rb
+++ b/spec/factories/news_item_factory.rb
@@ -18,6 +18,14 @@ FactoryBot.define do
       CONTENT
     end
 
+    trait :update_page do
+      show_on_updates_page { true }
+    end
+
+    trait :both_services do
+      # NOOP - inherits defaults from main factory
+    end
+
     trait :uk_only do
       show_on_xi { false }
     end

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -79,6 +79,31 @@ RSpec.describe NewsItem do
       end
     end
 
+    describe '.updates' do
+      subject(:results) { described_class.updates }
+
+      let :home_page do
+        create :news_item, show_on_home_page: true, show_on_updates_page: false
+      end
+
+      let :updates_page do
+        create :news_item, show_on_home_page: false, show_on_updates_page: true
+      end
+
+      let :both_page do
+        create :news_item, show_on_home_page: true, show_on_updates_page: true
+      end
+
+      let :neither_page do
+        create :news_item, show_on_home_page: false, show_on_updates_page: false
+      end
+
+      it { is_expected.to include updates_page }
+      it { is_expected.to include both_page }
+      it { is_expected.not_to include home_page }
+      it { is_expected.not_to include neither_page }
+    end
+
     describe '.for_target' do
       subject(:results) { described_class.for_target(target) }
 

--- a/spec/requests/api/feed/news_items_controller_spec.rb
+++ b/spec/requests/api/feed/news_items_controller_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe Api::Feed::NewsItemsController do
+  describe 'GET #index' do
+    subject(:do_request) do
+      get api_feed_news_items_path(format: :atom, service: service)
+
+      response
+    end
+
+    let(:service) { '' }
+
+    shared_context 'with news items' do
+      before do
+        uk_only_news_item
+        xi_only_news_item
+        both_services_news_item
+      end
+
+      let(:uk_only_news_item) { create(:news_item, :uk_only, :update_page) }
+      let(:xi_only_news_item) { create(:news_item, :xi_only, :update_page) }
+      let(:both_services_news_item) { create(:news_item, :both_services, :update_page) }
+      let(:both_services_no_update_page_news_item) { create(:news_item, :both_services) }
+    end
+
+    context 'when there are news items and the uk service is passed' do
+      let(:service) { 'uk' }
+
+      include_context 'with news items'
+
+      it { is_expected.to have_http_status(:ok) }
+
+      it { expect(do_request.body).to include(uk_only_news_item.title) }
+      it { expect(do_request.body).to include(both_services_news_item.title) }
+
+      it { expect(do_request.body).not_to include(xi_only_news_item.title) }
+      it { expect(do_request.body).not_to include(both_services_no_update_page_news_item.title) }
+    end
+
+    context 'when there are news items and the xi service is passed' do
+      let(:service) { 'xi' }
+
+      include_context 'with news items'
+
+      it { is_expected.to have_http_status(:ok) }
+
+      it { expect(do_request.body).to include(xi_only_news_item.title) }
+      it { expect(do_request.body).to include(both_services_news_item.title) }
+
+      it { expect(do_request.body).not_to include(uk_only_news_item.title) }
+      it { expect(do_request.body).not_to include(both_services_no_update_page_news_item.title) }
+    end
+
+    context 'when there are news items and the service is not passed' do
+      let(:service) { '' }
+
+      include_context 'with news items'
+
+      it { is_expected.to have_http_status(:ok) }
+
+      it { expect(do_request.body).to include(uk_only_news_item.title) }
+      it { expect(do_request.body).to include(both_services_news_item.title) }
+      it { expect(do_request.body).to include(xi_only_news_item.title) }
+      it { expect(do_request.body).not_to include(both_services_no_update_page_news_item.title) }
+    end
+
+    context 'when there are no news items' do
+      let(:expected_news_items) do
+        <<~NEWS_ITEMS
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xml:lang="en-US" xmlns="http://www.w3.org/2005/Atom">
+            <id>tag:www.example.com,2005:/feed/news_items?service=</id>
+            <link rel="alternate" type="text/html" href="http://www.example.com"/>
+            <link rel="self" type="application/atom+xml" href="http://www.example.com/feed/news_items?service="/>
+            <title>Online Trade Tariff News Items</title>
+          </feed>
+        NEWS_ITEMS
+      end
+
+      it { is_expected.to have_http_status(:ok) }
+      it { expect(do_request.body).to eq(expected_news_items) }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1225

### What?

I have added/removed/altered:

- [x] Added atom feed so we can surface news items
- [x] Added specs to cover new behaviour

### Why?

I am doing this because:

- This is required so that our users can remain up-to-date with the news items
