### PR TITLE
Allow developers to assign log_levels locally

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,8 +19,8 @@ Rails.application.configure do
   # config.cache_store = :memory_store, { size: 20.megabytes }
   config.cache_store = [:null_store]
 
-  # enable sequel transaction logs by switching this to :debug
-  config.log_level = :info
+  # enable sequel transaction logs by setting RAILS_LOG_LEVEL=debug
+  config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info').to_sym
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [x] Added an env var to control log levels in the development environment

### Why?

I am doing this because:

- So that I can have query logging on by default without requiring other developers to do so

