### PR TITLE
HOTT-1233: Updates cron schedule for synchronizer worker

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -19,7 +19,7 @@
   # Online converter: https://crontab.guru/#0_22_*_*_*
   #
   UpdatesSynchronizerWorker:
-    cron: "30 5 * * *"
+    cron: "0 6 * * *"
     description: "UpdatesSynchronizerWorker"
   TaricSequenceCheckWorker:
     cron: "0 14 * * 6" 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1233

### What?

I have added/removed/altered:

- [x] Updates cron schedule for synchronizer worker

### Why?

I am doing this because:

- The update files are available later than we currently think they should be there so we need to push back a bit
