### PR TITLE
HOTT-1225: Make news item target and service optional parameters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'omniauth-rails_csrf_protection'
 gem 'ox'
 gem 'plek'
 gem 'sentry-rails'
-gem "sentry-sidekiq"
+gem 'sentry-sidekiq'
 
 # API related
 gem 'ansi'

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -18,8 +18,7 @@ class NewsItem < Sequel::Model
       case service_name.to_s
       when 'uk' then where(show_on_uk: true)
       when 'xi' then where(show_on_xi: true)
-      when '' then self
-      else raise Sequel::RecordNotFound
+      else self
       end
     end
 
@@ -27,8 +26,7 @@ class NewsItem < Sequel::Model
       case target_name.to_s
       when 'home' then where(show_on_home_page: true)
       when 'updates' then where(show_on_updates_page: true)
-      when '' then self
-      else raise Sequel::RecordNotFound
+      else self
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,7 +117,7 @@ Rails.application.routes.draw do
 
       if TradeTariffBackend.uk?
         get '/news_items/:id', constraints: { id: /\d+/ }, to: 'news_items#show', as: :news_item
-        get '/news_items(/:service(/:target))', to: 'news_items#index', as: :news_items
+        get '/news_items', to: 'news_items#index', as: :news_items
       end
 
       get '/changes(/:as_of)', to: 'changes#index', as: :changes, constraints: { as_of: /\d{4}-\d{1,2}-\d{1,2}/ }

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -45,14 +45,17 @@ RSpec.describe NewsItem do
       let(:both_page) { create :news_item, show_on_uk: true, show_on_xi: true }
       let(:neither_page) { create :news_item, show_on_uk: false, show_on_xi: false }
 
-      context 'without service name' do
-        let(:service_name) { nil }
+      shared_examples_for 'a non-filtering service filter invocation' do |service_name|
+        subject(:results) { described_class.for_service(service_name) }
 
         it { is_expected.to include uk_page }
         it { is_expected.to include xi_page }
         it { is_expected.to include both_page }
         it { is_expected.to include neither_page }
       end
+
+      it_behaves_like 'a non-filtering service filter invocation', ''
+      it_behaves_like 'a non-filtering service filter invocation', nil
 
       context 'with uk' do
         let(:service_name) { 'uk' }
@@ -71,32 +74,27 @@ RSpec.describe NewsItem do
         it { is_expected.to include both_page }
         it { is_expected.not_to include neither_page }
       end
-
-      context 'with an invalid service' do
-        let(:service_name) { 'invalid' }
-
-        it { expect { results }.to raise_exception Sequel::RecordNotFound }
-      end
     end
 
     describe '.for_target' do
       subject(:results) { described_class.for_target(target) }
 
-      let :home_page do
-        create :news_item, show_on_home_page: true, show_on_updates_page: false
+      let(:home_page) { create :news_item, show_on_home_page: true, show_on_updates_page: false }
+      let(:updates_page) { create :news_item, show_on_home_page: false, show_on_updates_page: true }
+      let(:both_page) { create :news_item, show_on_home_page: true, show_on_updates_page: true }
+      let(:neither_page) { create :news_item, show_on_home_page: false, show_on_updates_page: false }
+
+      shared_examples_for 'a non-filtering target filter invocation' do |target|
+        subject(:results) { described_class.for_target(target) }
+
+        it { is_expected.to include home_page }
+        it { is_expected.to include updates_page }
+        it { is_expected.to include both_page }
+        it { is_expected.to include neither_page }
       end
 
-      let :updates_page do
-        create :news_item, show_on_home_page: false, show_on_updates_page: true
-      end
-
-      let :both_page do
-        create :news_item, show_on_home_page: true, show_on_updates_page: true
-      end
-
-      let :neither_page do
-        create :news_item, show_on_home_page: false, show_on_updates_page: false
-      end
+      it_behaves_like 'a non-filtering target filter invocation', ''
+      it_behaves_like 'a non-filtering target filter invocation', nil
 
       context 'without target' do
         let(:target) { nil }
@@ -123,12 +121,6 @@ RSpec.describe NewsItem do
         it { is_expected.not_to include home_page }
         it { is_expected.to include both_page }
         it { is_expected.not_to include neither_page }
-      end
-
-      context 'with an invalid target' do
-        let(:target) { 'invalid' }
-
-        it { expect { results }.to raise_exception Sequel::RecordNotFound }
       end
     end
 

--- a/spec/requests/api/v2/news_items_controller_spec.rb
+++ b/spec/requests/api/v2/news_items_controller_spec.rb
@@ -37,13 +37,13 @@ RSpec.describe Api::V2::NewsItemsController do
         it_behaves_like 'a successful jsonapi response'
       end
 
-      context 'with unknown target' do
+      context 'with items for both updates and home page' do
         let :make_request do
-          get api_news_items_path(service: 'uk', target: 'unknown', format: :json),
+          get api_news_items_path(service: 'uk', target: '', format: :json),
               headers: { 'Accept' => 'application/vnd.uktt.v2' }
         end
 
-        it { is_expected.to have_http_status :not_found }
+        it_behaves_like 'a successful jsonapi response'
       end
     end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1225

### What?

I have added/removed/altered:

- [x] Removed forcing the user to supply a service and target for the v2 new items api
- [x] Removed propagation of not found for targets and services under our own control
- [x] Added shared examples for unfiltered variants of news item target and service

### Why?

I am doing this because:

- We need to be able to return all of the target and service options
- We don't need to be defensive for this internal api
