### PR TITLE
HOTT-1240: Adds productline suffix to search references

### DIFF
--- a/db/migrate/20220107134210_add_productline_suffix_to_search_references.rb
+++ b/db/migrate/20220107134210_add_productline_suffix_to_search_references.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table :search_references do
+      add_column :productline_suffix, String, null: false, default: '80'
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6553,7 +6553,8 @@ CREATE TABLE public.search_references (
     id integer NOT NULL,
     title text,
     referenced_id character varying(10),
-    referenced_class character varying(10)
+    referenced_class character varying(10),
+    productline_suffix text DEFAULT '80'::text NOT NULL
 );
 
 
@@ -10830,3 +10831,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20210112160504_add_fields_
 INSERT INTO "schema_migrations" ("filename") VALUES ('20210610150945_create_changes.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20210628165555_add_unique_constraint_to_changes.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20210915112121_add_news_items.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20220107134210_add_productline_suffix_to_search_references.rb');


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1240

### What?

I have added/removed/altered:

- [x] Added migration to add productline_suffix to search references

### Why?

I am doing this because:

- This is required to differentiate commodity subheadings
