### PR TITLE
HOTT-1240: Populate search references with productline suffix

### DIFF
--- a/app/controllers/api/admin/commodities/search_references_controller.rb
+++ b/app/controllers/api/admin/commodities/search_references_controller.rb
@@ -13,14 +13,14 @@ module Api
         end
 
         def collection_url
-          [:admin, commodity, @search_reference]
+          [:admin, commodity.admin_id, @search_reference]
         end
 
         def commodity
           @commodity ||= begin
             commodity = Commodity.actual
-                   .declarable
                    .by_code(commodity_id)
+                   .by_productline_suffix(productline_suffix)
                    .take
 
             raise Sequel::RecordNotFound if commodity.goods_nomenclature_item_id.in?(HiddenGoodsNomenclature.codes)
@@ -30,7 +30,11 @@ module Api
         end
 
         def commodity_id
-          params[:commodity_id]
+          params[:commodity_id].split('-', 2).first
+        end
+
+        def productline_suffix
+          params[:commodity_id].split('-', 2)[1] || '80'
         end
       end
     end

--- a/app/controllers/api/admin/commodities_controller.rb
+++ b/app/controllers/api/admin/commodities_controller.rb
@@ -11,11 +11,19 @@ module Api
 
       def find_commodity
         @commodity = Commodity.actual
-                              .declarable
-                              .by_code(params[:id])
+                              .by_productline_suffix(productline_suffix)
+                              .by_code(commodity_code)
                               .take
 
         raise Sequel::RecordNotFound if @commodity.goods_nomenclature_item_id.in? HiddenGoodsNomenclature.codes
+      end
+
+      def commodity_code
+        params[:id].split('-', 2).first
+      end
+
+      def productline_suffix
+        params[:id].split('-', 2)[1] || '80'
       end
     end
   end

--- a/app/controllers/api/admin/search_references_base_controller.rb
+++ b/app/controllers/api/admin/search_references_base_controller.rb
@@ -34,7 +34,7 @@ module Api
         if @search_reference.save
           options = { is_collection: false }
           options[:include] = [:referenced, 'referenced.chapter', 'referenced.chapter.guides', 'referenced.section']
-          render json: Api::Admin::SearchReferences::SearchReferenceSerializer.new(@search_reference, options).serializable_hash
+          render json: Api::Admin::SearchReferences::SearchReferenceSerializer.new(@search_reference, options).serializable_hash, status: :created
         else
           data = { errors: [] }
           data[:errors] = @search_reference.errors.full_messages.map do |error|

--- a/app/models/search_reference.rb
+++ b/app/models/search_reference.rb
@@ -1,4 +1,6 @@
 class SearchReference < Sequel::Model
+  DEFAULT_PRODUCTLINE_SUFFIX = '80'.freeze
+
   extend ActiveModel::Naming
 
   plugin :active_model
@@ -10,7 +12,8 @@ class SearchReference < Sequel::Model
                                       if referenced.present?
                                         self.set(
                                           referenced_id: referenced.to_param,
-                                          referenced_class: referenced.class.name
+                                          referenced_class: referenced.class.name,
+                                          productline_suffix: referenced.try(:producline_suffix) || DEFAULT_PRODUCTLINE_SUFFIX
                                         )
                                       end
                                     end),
@@ -30,7 +33,8 @@ class SearchReference < Sequel::Model
                                          )
                                        when 'Commodity'
                                          klass.where(
-                                           Sequel.qualify(:goods_nomenclatures, :goods_nomenclature_item_id) => commodity_id
+                                           Sequel.qualify(:goods_nomenclatures, :goods_nomenclature_item_id) => commodity_id,
+                                           Sequel.qualify(:goods_nomenclatures, :producline_suffix) => productline_suffix,
                                          )
                                        end
                                      end),
@@ -155,6 +159,7 @@ class SearchReference < Sequel::Model
     errors.add(:reference_id, 'has to be associated to Section/Chapter/Heading') if referenced_id.blank?
     errors.add(:reference_class, 'has to be associated to Section/Chapter/Heading') if referenced_id.blank?
     errors.add(:title, 'missing title') if title.blank?
+    errors.add(:productline_suffix, 'missing productline suffix') if productline_suffix.blank?
   end
 
   def section_id

--- a/app/serializers/api/admin/commodities/commodity_serializer.rb
+++ b/app/serializers/api/admin/commodities/commodity_serializer.rb
@@ -6,9 +6,9 @@ module Api
 
         set_type :commodity
 
-        set_id :goods_nomenclature_sid
+        set_id :admin_id
 
-        attributes :description, :goods_nomenclature_item_id
+        attributes :description, :goods_nomenclature_item_id, :producline_suffix
       end
     end
   end

--- a/app/serializers/api/admin/headings/commodity_serializer.rb
+++ b/app/serializers/api/admin/headings/commodity_serializer.rb
@@ -6,16 +6,12 @@ module Api
 
         set_type :commodity
 
-        set_id :goods_nomenclature_sid
+        set_id :admin_id
 
-        attributes :description, :goods_nomenclature_item_id, :goods_nomenclature_sid
+        attributes :description
 
         attribute :search_references_count do |commodity|
           commodity.search_references.count
-        end
-
-        attribute :leaf do |object|
-          object.producline_suffix == '80'
         end
       end
     end

--- a/app/serializers/api/admin/headings/heading_serializer.rb
+++ b/app/serializers/api/admin/headings/heading_serializer.rb
@@ -14,13 +14,9 @@ module Api
           heading.search_references.count
         end
 
-        has_one :chapter, serializer: Api::Admin::Headings::ChapterSerializer, id_method_name: :goods_nomenclature_sid do |heading|
-          heading.chapter
-        end
+        has_one :chapter, serializer: Api::Admin::Headings::ChapterSerializer, id_method_name: :goods_nomenclature_sid, &:chapter
 
-        has_many :commodities, serializer: Api::Admin::Headings::CommoditySerializer, id_method_name: :goods_nomenclature_sid do |heading|
-          heading.commodities
-        end
+        has_many :commodities, serializer: Api::Admin::Headings::CommoditySerializer, id_method_name: :admin_id, &:commodities
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,8 +29,8 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :commodities, only: [:show], constraints: { id: /\d{10}/ } do
-        scope module: 'commodities', constraints: { commodity_id: /\d{10}/, id: /\d+/ } do
+      resources :commodities, only: [:show] do
+        scope module: 'commodities' do
           resources :search_references, only: %i[show index destroy create update]
         end
       end

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -727,4 +727,18 @@ RSpec.describe Commodity do
       expect(commodities).not_to include(commodity2)
     end
   end
+
+  describe '.by_productline_suffix' do
+    subject(:result) { described_class.by_productline_suffix('10').all }
+
+    before do
+      declarable_commodity
+      non_declarable_commodity
+    end
+
+    let(:declarable_commodity) { create(:commodity, producline_suffix: '80') }
+    let(:non_declarable_commodity) { create(:commodity, producline_suffix: '10') }
+
+    it { expect(result).to eq([non_declarable_commodity]) }
+  end
 end

--- a/spec/serializers/api/admin/commodities/commodity_serializer_spec.rb
+++ b/spec/serializers/api/admin/commodities/commodity_serializer_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Api::Admin::Commodities::CommoditySerializer do
+  subject(:serialized) { described_class.new(serializable).serializable_hash }
+
+  let(:serializable) { create(:commodity) }
+
+  let(:expected) do
+    {
+      data: {
+        id: serializable.admin_id,
+        type: :commodity,
+        attributes: {
+          description: serializable.description,
+          goods_nomenclature_item_id: serializable.goods_nomenclature_item_id,
+          producline_suffix: serializable.producline_suffix,
+        },
+      },
+    }
+  end
+
+  describe '#serializable_hash' do
+    it { expect(serialized).to eq(expected) }
+  end
+end

--- a/spec/serializers/api/admin/headings/commodity_serializer_spec.rb
+++ b/spec/serializers/api/admin/headings/commodity_serializer_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe Api::Admin::Headings::CommoditySerializer do
+  subject(:serialized) { described_class.new(serializable).serializable_hash }
+
+  let(:serializable) { create(:commodity) }
+
+  let(:expected) do
+    {
+      data: {
+        id: "#{serializable.goods_nomenclature_item_id}-#{serializable.producline_suffix}",
+        type: :commodity,
+        attributes: {
+          description: serializable.description,
+          search_references_count: 0,
+        },
+      },
+    }
+  end
+
+  describe '#serializable_hash' do
+    it { expect(serialized).to eq(expected) }
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1240

### What?

I have added/removed/altered:

- [x] Surface productline suffix on the admin commodity serializers
- [x] Take the productline suffix as a param when creating commodity search references
- [x] Implicitly populate the productline suffix in the polymorphic `referenced` relationship setter of the SearchReference model
- [x] Extend and refactor SearchReference specs to include validations the implicit callback affects
- [x] Adds coverage for new functionality

### Why?

I am doing this because:

- The productline suffix enables us to differentiate different subheading commodities
