### PR TITLE
HOTT-1104 Run database migrations on own tasks app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,10 +145,40 @@ commands:
             export DOCKER_IMAGE=tariff-backend
             export DOCKER_TAG=<<# parameters.dev-release >>dev-<</ parameters.dev-release >>${CIRCLE_SHA1}
             CF_DOCKER_PASSWORD=$AWS_SECRET_ACCESS_KEY cf push "tariff-<< parameters.service >>-backend-worker-<< parameters.environment_key >>" -f deploy_manifest.yml --no-route --docker-image "$ECR_REPO/$DOCKER_IMAGE:$DOCKER_TAG" --docker-username "$AWS_ACCESS_KEY_ID"
+  cf_deploy_docker_tasks:
+    parameters:
+      dev-release:
+        default: false
+        type: boolean
+      space:
+        type: string
+      service:
+        type: string
+      environment_key:
+        type: string
+    steps:
+      - checkout
+      - cf_install:
+          space: << parameters.space >>
+      - run:
+          name: "Create tasks app manifest"
+          command: |
+            cf create-app-manifest "tariff-<< parameters.service >>-backend-worker-<< parameters.environment_key >>" -p tasks_deploy_manifest.yml
+      - run:
+          name: "Push Tasks app"
+          command: |
+            export DOCKER_IMAGE=tariff-backend
+            export DOCKER_TAG=<<# parameters.dev-release >>dev-<</ parameters.dev-release >>${CIRCLE_SHA1}
+            CF_DOCKER_PASSWORD=$AWS_SECRET_ACCESS_KEY cf push "tariff-<< parameters.service >>-backend-tasks-<< parameters.environment_key >>" \
+                                                               -f tasks_deploy_manifest.yml \
+                                                               --no-route \
+                                                               --task \
+                                                               --docker-image "$ECR_REPO/$DOCKER_IMAGE:$DOCKER_TAG" \
+                                                               --docker-username "$AWS_ACCESS_KEY_ID"
       - run:
           name: "Run Migrations"
           command: |
-            cf run-task "tariff-<< parameters.service >>-backend-worker-<< parameters.environment_key >>" --command "cd app && bundle exec rails db:migrate" --name "db-migrate" --wait
+            cf run-task "tariff-<< parameters.service >>-backend-tasks-<< parameters.environment_key >>" --command "cd app && bundle exec rails db:migrate" --name "db-migrate" --wait
 
   smoketest:
     parameters:
@@ -331,6 +361,11 @@ jobs:
           time: '10'
           consider-branch: false
           dont-quit: true
+      - cf_deploy_docker_tasks:
+          dev-release: true
+          space: "development"
+          environment_key: "dev"
+          service: << parameters.service >>
       - cf_deploy_docker_worker:
           dev-release: true
           space: "development"
@@ -355,6 +390,10 @@ jobs:
       - queue/until_front_of_line:
           time: '10'
           dont-quit: true
+      - cf_deploy_docker_tasks:
+          space: "staging"
+          environment_key: "staging"
+          service: << parameters.service >>
       - cf_deploy_docker_worker:
           space: "staging"
           environment_key: "staging"
@@ -377,6 +416,10 @@ jobs:
       - queue/until_front_of_line:
           time: '10'
           dont-quit: true
+      - cf_deploy_docker_tasks:
+          space: "production"
+          environment_key: "production"
+          service: << parameters.service >>
       - cf_deploy_docker_worker:
           space: "production"
           environment_key: "production"


### PR DESCRIPTION
### Jira link

[HOTT-1104](https://transformuk.atlassian.net/browse/HOTT-1104)

### What?

I have added/removed/altered:

- [x] Added a dedicated 'tasks' app to both XI and UK backends 
- [x] moved the `rails db:migrate` step to use the tasks app

### Why?

This avoids the current 'race' scenario triggered by a newly deployed app reading the database structure on boot.

In order to perform database migrations, we need an 'app' running the latest image. _BUT_ if that app starts, it will start with the old database structure because migration has not yet happened. Best case scenario is sidekiq boots but with an old structure, worst case is we've added a new db model and the missing table prevents sidekiq from booting.

This change introduces a new app, the same size as the sidekiq worker app but without it ever starting (the `--task` option to cf push). This app can be updated, then used to migrate the database before updating the worker and web apps which will boot, but by that point migrations have happened and there should be no errors.

This 'tasks' app can also be used for running things like rake tasks if necessary.

### Deployment risks (optional)

- This changes our deployment setup - adding another app into the mix - changes should obviously be the same to staging and dev steps before hand so should be well tested by the point of reaching production
- Should not be deployed alongside already merged migrations because they will have already been run on staging using the old process and we want any deploy to production to follow the same path as to staging
