### PR TITLE
HOTT-1252 Check the correctness of sequence for the CDS and Taric updates.

### DIFF
--- a/app/lib/tariff_synchronizer.rb
+++ b/app/lib/tariff_synchronizer.rb
@@ -93,9 +93,9 @@ module TariffSynchronizer
   end
 
   def apply(reindex_all_indexes: false)
-    return unless correct_sequence_for_pending_taric_file?
-
     check_tariff_updates_failures
+
+    return unless correct_sequence_for_pending_taric_file?
 
     applied_updates = []
     import_warnings = []
@@ -114,6 +114,7 @@ module TariffSynchronizer
       applied_updates.flatten!
 
       if applied_updates.any? && BaseUpdate.pending_or_failed.none?
+
         instrument(
           'apply.tariff_synchronizer',
           update_names: applied_updates.map(&:filename),

--- a/app/lib/tariff_synchronizer/base_update.rb
+++ b/app/lib/tariff_synchronizer/base_update.rb
@@ -74,6 +74,10 @@ module TariffSynchronizer
         pending.order(:issue_date).first
       end
 
+      def last_applied
+        applied.order(:issue_date).first
+      end
+
       def descending
         order(Sequel.desc(:issue_date))
       end

--- a/app/lib/tariff_synchronizer/taric_update.rb
+++ b/app/lib/tariff_synchronizer/taric_update.rb
@@ -1,6 +1,26 @@
 module TariffSynchronizer
   class TaricUpdate < BaseUpdate
+    REGEX_TARIC_SEQUENCE = /^\d{4}-\d{2}-\d{2}_TGB(?<year>\d{2})(?<sequence>\d+).xml$/
+    NEW_YEAR_STARTING_SEQUENCE_NUMBER = 1
+
     class << self
+      def correct_filename_sequence?
+        pending_seq = last_pending&.filename_sequence
+        applied_seq = last_applied&.filename_sequence
+
+        return true if pending_seq.blank? || applied_seq.blank?
+
+        current_sequence_number = pending_seq[:sequence].to_i
+
+        expected_new_sequence_number = if pending_seq[:year].to_i == applied_seq[:year].to_i
+                                         applied_seq[:sequence].to_i + 1
+                                       else
+                                         NEW_YEAR_STARTING_SEQUENCE_NUMBER
+                                       end
+
+        current_sequence_number == expected_new_sequence_number
+      end
+
       def download(date)
         TaricUpdateDownloader.new(date).perform
       end
@@ -17,7 +37,9 @@ module TariffSynchronizer
       end
     end
 
-  private
+    def filename_sequence
+      filename.match(REGEX_TARIC_SEQUENCE)
+    end
 
     def self.validate_file!(xml_string)
       Ox.parse(xml_string)

--- a/spec/factories/cds_update_factory.rb
+++ b/spec/factories/cds_update_factory.rb
@@ -1,8 +1,14 @@
 FactoryBot.define do
   factory :cds_update, parent: :base_update, class: 'TariffSynchronizer::CdsUpdate' do
     issue_date { example_date }
-    filename { 'tariff_dailyExtract_v1_20201004T235959.gzip' }
+
+    filename { "tariff_dailyExtract_v1_#{example_date.strftime('%Y%m%d')}T235959.gzip" }
+
     update_type { 'TariffSynchronizer::CdsUpdate' }
+
+    trait :pending do
+      state { 'P' }
+    end
 
     trait :applied do
       state { 'A' }

--- a/spec/factories/cds_update_factory.rb
+++ b/spec/factories/cds_update_factory.rb
@@ -3,5 +3,9 @@ FactoryBot.define do
     issue_date { example_date }
     filename { 'tariff_dailyExtract_v1_20201004T235959.gzip' }
     update_type { 'TariffSynchronizer::CdsUpdate' }
+
+    trait :applied do
+      state { 'A' }
+    end
   end
 end

--- a/spec/factories/taric_update_factory.rb
+++ b/spec/factories/taric_update_factory.rb
@@ -1,7 +1,22 @@
 FactoryBot.define do
   factory :taric_update, parent: :base_update, class: 'TariffSynchronizer::TaricUpdate' do
+    transient do
+      sequence_number { example_date.yday }
+    end
+
     issue_date { example_date }
-    filename { "#{example_date}_TGB#{example_date.strftime('%y')}#{example_date.yday}.xml" }
+
+    # Example: 2015-04-15_TGB15072.xml
+    filename { "#{example_date}_TGB#{example_date.strftime('%y')}#{sequence_number}.xml" }
+
     update_type { 'TariffSynchronizer::TaricUpdate' }
+
+    trait :applied do
+      state { 'A' }
+    end
+
+    trait :pending do
+      state { 'P' }
+    end
   end
 end

--- a/spec/factories/taric_update_factory.rb
+++ b/spec/factories/taric_update_factory.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
       sequence_number { example_date.yday }
     end
 
+    # TODO: try to remove example_date and use issue_date
     issue_date { example_date }
 
     # Example: 2015-04-15_TGB15072.xml

--- a/spec/integration/tariff_synchronizer_spec.rb
+++ b/spec/integration/tariff_synchronizer_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe TariffSynchronizer do
   describe '#apply', truncation: true do
-    let!(:taric_update) { create :taric_update, example_date: example_date }
+    let!(:taric_update_applied) { create :taric_update, :applied, example_date: example_date - 1.day }
+    let!(:taric_update) { create :taric_update, :pending, example_date: example_date }
 
     before(:context) do
       prepare_synchronizer_folders

--- a/spec/unit/tariff_synchronizer/cds_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/cds_update_spec.rb
@@ -113,4 +113,37 @@ RSpec.describe TariffSynchronizer::CdsUpdate do
       end
     end
   end
+
+  describe '.correct_filename_sequence?' do
+    subject(:cds_update) { described_class }
+
+    before do
+      create(:cds_update, :applied, example_date: applied_date)
+      create(:cds_update, :pending, example_date: pending_date)
+    end
+
+    let(:applied_date) { Date.yesterday }
+
+    context 'when the sequence date is correct' do
+      let(:pending_date) { applied_date + 1.day }
+
+      it { is_expected.to be_correct_filename_sequence }
+    end
+
+    context 'when the sequence date is incorrect' do
+      let(:pending_date) { applied_date + 2.days }
+
+      it { is_expected.not_to be_correct_filename_sequence }
+    end
+  end
+
+  describe '#filename_sequence' do
+    subject(:cds_update) { create(:cds_update, filename: filename) }
+
+    let(:filename) { 'tariff_dailyExtract_v1_20220118T235959.gzip' }
+
+    it 'returns the sequence date' do
+      expect(cds_update.filename_sequence).to eq Date.new(2022, 0o1, 18)
+    end
+  end
 end

--- a/spec/unit/tariff_synchronizer/taric_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/taric_update_spec.rb
@@ -42,4 +42,54 @@ RSpec.describe TariffSynchronizer::TaricUpdate do
       expect(@logger.logged(:info).last).to match(/Applied TARIC update/)
     end
   end
+
+  describe '.correct_filename_sequence?' do
+    subject(:taric_update) { described_class }
+
+    before do
+      create(:taric_update, :applied, example_date: applied_date, sequence_number: applied_sequence_number)
+      create(:taric_update, :pending, example_date: pending_date, sequence_number: pending_sequence_number)
+    end
+
+    let(:applied_date) { Date.parse('2021-12-01') }
+    let(:applied_sequence_number) { '002' }
+
+    context 'when the pending year is the same and the pending sequence is the next valid sequence' do
+      let(:pending_date) {  Date.parse('2021-12-02') } # Same year
+      let(:pending_sequence_number) { '003' } # Correct sequence
+
+      it { is_expected.to be_correct_filename_sequence }
+    end
+
+    context 'when the pending year is the same and the pending sequence is NOT the next valid sequence' do
+      let(:pending_date) { Date.parse('2021-12-02') } # Same year
+      let(:pending_sequence_number) { '004' } # Incorrect sequence
+
+      it { is_expected.not_to be_correct_filename_sequence }
+    end
+
+    context 'when the pending year is the following year and the pending sequence is 001' do
+      let(:pending_date) { Date.parse('2022-12-02') } # Following year
+      let(:pending_sequence_number) { '001' } # Correct sequence
+
+      it { is_expected.to be_correct_filename_sequence }
+    end
+
+    context 'when the pending year is the following year and the pending sequence is NOT the next valid sequence' do
+      let(:pending_date) { Date.parse('2022-12-02') } # Following year
+      let(:pending_sequence_number) { '002' }           # Incorrect sequence
+
+      it { is_expected.not_to be_correct_filename_sequence }
+    end
+  end
+
+  describe '#filename_sequence' do
+    subject(:taric_update) { create(:taric_update, filename: filename) }
+
+    let(:filename) { '2021-12-30_TGB21257.xml' }
+
+    it 'returns the year and sequence number' do
+      expect(taric_update.filename_sequence.named_captures).to eq('year' => '21', 'sequence' => '257')
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

[HOTT-1252](https://transformuk.atlassian.net/browse/HOTT-1252)

### What?
We want to identify whether the current update is the next increment for the sequence based on its filename. In case it is not the expected update in sequence, it should not be run, and an alert must be sent to an appropriate channel.

### Why?
To avoid data inconsistency.
