### PR TITLE
HOTT-1261: Fix sequencing of transforms during CDS ETL

### DIFF
--- a/app/lib/cds_importer/entity_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper.rb
@@ -119,6 +119,8 @@ class CdsImporter
                            .sort_by { |m| m.mapping_path ? m.mapping_path.length : 0 }
 
       mappers.each.with_object({}) do |mapper, oplog_inserts_performed|
+        mapper.before_building_model_callbacks.each { |callback| callback.call(xml_node) }
+
         instances = mapper.new(xml_node).parse
 
         mapper.before_oplog_inserts_callbacks.each { |callback| callback.call(xml_node) }

--- a/app/lib/cds_importer/entity_mapper/base_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/base_mapper.rb
@@ -16,6 +16,10 @@ class CdsImporter
           @before_oplog_inserts_callbacks ||= []
         end
 
+        def before_building_model_callbacks
+          @before_building_model_callbacks ||= []
+        end
+
         def base_mapping
           BASE_MAPPING.except(*exclude_mapping).keys.inject({}) do |memo, key|
             mapped_key = mapping_path.present? ? "#{mapping_path}.#{key}" : key
@@ -50,6 +54,10 @@ class CdsImporter
 
         def before_oplog_inserts(&block)
           before_oplog_inserts_callbacks << block
+        end
+
+        def before_building_model(&block)
+          before_building_model_callbacks << block
         end
       end
 

--- a/app/lib/cds_importer/entity_mapper/geographical_area_membership_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/geographical_area_membership_mapper.rb
@@ -17,7 +17,7 @@ class CdsImporter
 
       self.entity_mapping_keys_to_parse = mapping_keys_to_parse.freeze
 
-      before_oplog_inserts do |xml_node|
+      before_building_model do |xml_node|
         unless xml_node['geographicalAreaMembership'].is_a?(Array)
           xml_node['geographicalAreaMembership'] = [xml_node['geographicalAreaMembership']]
         end

--- a/spec/integration/cds_importer/entity_mapper_spec.rb
+++ b/spec/integration/cds_importer/entity_mapper_spec.rb
@@ -187,6 +187,12 @@ RSpec.describe CdsImporter::EntityMapper do
         expect(xml_node).to eq(expected_hash)
       end
 
+      it 'creates the correct memberships' do
+        expect { entity_mapper.import }
+          .to change { GeographicalAreaMembership.where(geographical_area_sid: [331, 112], geographical_area_group_sid: [114]).count }
+          .by(2)
+      end
+
       context 'when the xml node is missing a membership group sid' do
         before do
           allow(ActiveSupport::Notifications).to receive(:instrument).and_call_original


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1261

### What?

I have added/removed/altered:

- [x] Added spec to avoid regressions in ETL callback sequencing.
- [x] Added new callback on CDS ETL which enables transforms to be passed to the model.
- [x] Altered the sequencing of the TaricSynchronizer::EntityMapper code such that transformed attributes take.

### Why?

I am doing this because:

- When we moved to callbacks I missed the sequencing mattered and broke imports of memberships from CDS
- We want to make sure there's coverage to avoid this happening in future
