### PR TITLE
HOTT-1276: Tidy up search references

### DIFF
--- a/app/elastic_search_indexes/search/search_reference_index.rb
+++ b/app/elastic_search_indexes/search/search_reference_index.rb
@@ -19,8 +19,8 @@ module Search
                   properties: {
                     position: { type: 'long' },
                     title: { type: 'text' },
-                    numeral: { type: 'keyword' }
-                  }
+                    numeral: { type: 'keyword' },
+                  },
                 },
                 id: { type: 'long' },
                 chapter: {
@@ -30,8 +30,8 @@ module Search
                     validity_start_date: { type: 'date', format: 'date_optional_time' },
                     producline_suffix: { type: 'keyword' },
                     goods_nomenclature_sid: { type: 'long' },
-                    goods_nomenclature_item_id: { type: 'keyword' }
-                  }
+                    goods_nomenclature_item_id: { type: 'keyword' },
+                  },
                 },
                 title: { type: 'text' },
                 description: { type: 'text' },
@@ -45,14 +45,14 @@ module Search
                     validity_start_date: { type: 'date', format: 'date_optional_time' },
                     producline_suffix: { type: 'keyword' },
                     goods_nomenclature_sid: { type: 'long' },
-                    goods_nomenclature_item_id: { type: 'keyword' }
-                  }
-                }
+                    goods_nomenclature_item_id: { type: 'keyword' },
+                  },
+                },
               },
-              type: 'nested'
-            }
-          }
-        }
+              type: 'nested',
+            },
+          },
+        },
       }
     end
   end

--- a/app/serializers/cache/heading_serializer.rb
+++ b/app/serializers/cache/heading_serializer.rb
@@ -42,9 +42,9 @@ module Cache
               {
                 id: guide.id,
                 title: guide.title,
-                url: guide.url
+                url: guide.url,
               }
-            end
+            end,
           }
         end
 
@@ -55,7 +55,7 @@ module Cache
             numeral: heading.section.numeral,
             title: heading.section.title,
             position: heading.section.position,
-            section_note: heading.section.section_note&.content
+            section_note: heading.section.section_note&.content,
           }
         end
 
@@ -66,7 +66,7 @@ module Cache
             validity_end_date: footnote.validity_end_date,
             code: footnote.code,
             description: footnote.description,
-            formatted_description: footnote.formatted_description
+            formatted_description: footnote.formatted_description,
           }
         end
 
@@ -111,13 +111,13 @@ module Cache
               duty_expression: {
                 id: "#{measure.measure_sid}-duty_expression",
                 base: measure.duty_expression_with_national_measurement_units_for(commodity),
-                formatted_base: measure.formatted_duty_expression_with_national_measurement_units_for(commodity)
+                formatted_base: measure.formatted_duty_expression_with_national_measurement_units_for(commodity),
               },
               measure_type_id: measure.measure_type.measure_type_id,
               measure_type: {
                 measure_type_id: measure.measure_type.measure_type_id,
-                description: measure.measure_type.description
-              }
+                description: measure.measure_type.description,
+              },
             }
           end
           commodity_attributes

--- a/app/services/heading_service/cached_heading_service.rb
+++ b/app/services/heading_service/cached_heading_service.rb
@@ -56,14 +56,7 @@ module HeadingService
     end
 
     def filter_commodity_relations
-      search_references = SearchReference.where(
-        referenced_id: result.commodity_ids.map(&:to_s),
-        referenced_class: 'Commodity'
-      ).all.group_by(&:referenced_id)
-
       result.commodities.each do |commodity|
-        commodity.search_references = search_references[commodity.id.to_s] || []
-
         commodity.overview_measures.keep_if do |measure|
           has_valid_dates(measure, :effective_start_date, :effective_end_date)
         end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1276

### What?

I have added/removed/altered:

- [x] Removed unused scope filtering methods
- [x] Removed search references being preloaded and associated with serialized commodities in the CachedHeadingService
- [x] Removed eager loading custom behaviour

### Why?

I am doing this because:

- The cached headings do not even serialize the commodity search references and this is just overhead: https://github.com/trade-tariff/trade-tariff-backend/blob/main/app/serializers/cache/heading_serializer.rb#L73-L123. I believe these were put in place as part of the V2 api previously being used for admin ui purposes before the separation: https://github.com/trade-tariff/trade-tariff-backend/commit/0c9f7a120a75c4cf31be6f7649372733ae93f602.
- The scope filtering methods just are not used
- The eager loading is also not used - I suspect it would have been part of enabling eager loading of search references as part of the CachedHeadingService
