### PR TITLE
HOTT-1260 Retry data loads

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,5 +67,9 @@ Style/FrozenStringLiteralComment:
 Style/GuardClause:
   MinBodyLength: 2
 
+Style/OptionalBooleanParameter:
+  Exclude:
+    - 'app/workers/**/*.rb' # Sidekiq doesn't support kwargs syntax for jobs
+
 Style/StringLiterals:
   EnforcedStyle: single_quotes

--- a/app/lib/tariff_synchronizer.rb
+++ b/app/lib/tariff_synchronizer.rb
@@ -92,6 +92,10 @@ module TariffSynchronizer
     end
   end
 
+  def downloaded_todays_file_for_cds?
+    CdsUpdate.downloaded_todays_file?
+  end
+
   # Taric
   def apply(reindex_all_indexes: false)
     check_tariff_updates_failures

--- a/app/lib/tariff_synchronizer/cds_update.rb
+++ b/app/lib/tariff_synchronizer/cds_update.rb
@@ -17,6 +17,10 @@ module TariffSynchronizer
         CdsUpdateDownloader.new(date).perform
       end
 
+      def downloaded_todays_file?
+        with_issue_date(Time.zone.yesterday).count.positive?
+      end
+
       def update_type
         :cds
       end

--- a/app/workers/updates_synchronizer_worker.rb
+++ b/app/workers/updates_synchronizer_worker.rb
@@ -1,20 +1,49 @@
 class UpdatesSynchronizerWorker
   include Sidekiq::Worker
 
+  TRY_AGAIN_IN = 20.minutes
+  CUT_OFF_TIME = '07:30'.freeze
+
   sidekiq_options queue: :sync, retry: false
 
-  def perform
+  def perform(check_for_todays_file = true)
     logger.info 'Running UpdatesSynchronizerWorker'
     logger.info 'Downloading...'
 
     if TradeTariffBackend.uk?
       TariffSynchronizer.download_cds
-      logger.info 'Applying...'
-      TariffSynchronizer.apply_cds(reindex_all_indexes: true)
+
+      if check_for_todays_file &&
+          still_time_to_reschedule? &&
+          todays_file_has_not_yet_arrived?
+
+        self.class.perform_in(TRY_AGAIN_IN, true)
+      else
+        logger.info 'Applying...'
+        TariffSynchronizer.apply_cds(reindex_all_indexes: true)
+      end
     elsif TradeTariffBackend.xi?
       TariffSynchronizer.download
       logger.info 'Applying...'
       TariffSynchronizer.apply(reindex_all_indexes: true)
     end
+  end
+
+private
+
+  def cut_off_date_time
+    @cut_off_date_time ||= begin
+      hour, minute = CUT_OFF_TIME.split(':', 2).map(&:to_i)
+
+      Time.zone.now.at_beginning_of_day + hour.hours + minute.minutes
+    end
+  end
+
+  def still_time_to_reschedule?
+    Time.zone.now < cut_off_date_time
+  end
+
+  def todays_file_has_not_yet_arrived?
+    !TariffSynchronizer.downloaded_todays_file_for_cds?
   end
 end

--- a/spec/unit/tariff_synchronizer/cds_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/cds_update_spec.rb
@@ -20,6 +20,28 @@ RSpec.describe TariffSynchronizer::CdsUpdate do
     end
   end
 
+  describe '.downloaded_todays_file?' do
+    subject { described_class.downloaded_todays_file? }
+
+    context 'when todays file is present in table' do
+      # Note published day after file name, so todays file has yesterdays date
+      before { create :cds_update, example_date: Time.zone.yesterday }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when todays file is not present in table' do
+      it { is_expected.to be false }
+    end
+
+    context 'when yesterdays file queued in table' do
+      # Note published day after file name, so yesterdays file is 2 days old
+      before { create :cds_update, example_date: 2.days.ago.to_date }
+
+      it { is_expected.to be false }
+    end
+  end
+
   describe '#import!' do
     let(:cds_update) { create :cds_update }
     let(:filesize) { 57_000 }

--- a/spec/unit/tariff_synchronizer_spec.rb
+++ b/spec/unit/tariff_synchronizer_spec.rb
@@ -283,6 +283,19 @@ RSpec.describe TariffSynchronizer, truncation: true do
     end
   end
 
+  describe '.downloaded_todays_file_for_cds?' do
+    before do
+      allow(described_class::CdsUpdate).to receive(:downloaded_todays_file?)
+                                           .and_return(true)
+    end
+
+    it 'is expected to call through to CdsUpdate#downloaded_todays_file?' do
+      described_class.downloaded_todays_file_for_cds?
+
+      expect(described_class::CdsUpdate).to have_received(:downloaded_todays_file?)
+    end
+  end
+
   describe '.apply_cds' do
     let(:applied_update) { create(:cds_update, :applied, example_date: Date.yesterday) }
     let(:pending_update) { create(:cds_update, :pending, example_date: Date.today) }

--- a/spec/workers/updates_synchronizer_worker_spec.rb
+++ b/spec/workers/updates_synchronizer_worker_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe UpdatesSynchronizerWorker, type: :worker do
       allow(TariffSynchronizer).to receive(:apply_cds)
 
       allow(TradeTariffBackend).to receive(:service).and_return(service)
-
-      perform
     end
 
     context 'when on the xi service' do
+      before { perform }
+
       let(:service) { 'xi' }
 
       it { expect(TariffSynchronizer).to have_received(:download) }
@@ -23,16 +23,87 @@ RSpec.describe UpdatesSynchronizerWorker, type: :worker do
 
       it { expect(TariffSynchronizer).not_to have_received(:download_cds) }
       it { expect(TariffSynchronizer).not_to have_received(:apply_cds) }
+
+      it { expect(described_class.jobs).to be_empty }
     end
 
     context 'when on the uk service' do
+      before do
+        stub_const 'UpdatesSynchronizerWorker::CUT_OFF_TIME',
+                   cut_off_time.strftime('%H:%M')
+      end
+
       let(:service) { 'uk' }
+      let(:cut_off_time) { 1.hour.from_now }
 
-      it { expect(TariffSynchronizer).to have_received(:download_cds) }
-      it { expect(TariffSynchronizer).to have_received(:apply_cds) }
+      context 'with todays file missing' do
+        before do
+          allow(TariffSynchronizer).to receive(:downloaded_todays_file_for_cds?)
+                                       .and_return(false)
+        end
 
-      it { expect(TariffSynchronizer).not_to have_received(:download) }
-      it { expect(TariffSynchronizer).not_to have_received(:apply) }
+        context 'when before cut off time' do
+          before { perform }
+
+          it { expect(TariffSynchronizer).to have_received(:download_cds) }
+          it { expect(TariffSynchronizer).not_to have_received(:apply_cds) }
+
+          it { expect(TariffSynchronizer).not_to have_received(:download) }
+          it { expect(TariffSynchronizer).not_to have_received(:apply) }
+
+          it { expect(described_class.jobs).to have_attributes length: 1 }
+
+          it 'creates a later job to re-attempt download and processing' do
+            expect(described_class.jobs.first).to \
+              include 'at' => be_within(2).of(20.minutes.from_now.to_f),
+                      'args' => [true],
+                      'retry' => false
+          end
+        end
+
+        context 'when after cut off time' do
+          before { perform }
+
+          let(:cut_off_time) { 5.minutes.ago }
+
+          it { expect(TariffSynchronizer).to have_received(:download_cds) }
+          it { expect(TariffSynchronizer).to have_received(:apply_cds) }
+
+          it { expect(TariffSynchronizer).not_to have_received(:download) }
+          it { expect(TariffSynchronizer).not_to have_received(:apply) }
+
+          it { expect(described_class.jobs).to be_empty }
+        end
+
+        context 'when before cut off but check disabled' do
+          before { described_class.new.perform(false) }
+
+          it { expect(TariffSynchronizer).to have_received(:download_cds) }
+          it { expect(TariffSynchronizer).to have_received(:apply_cds) }
+
+          it { expect(TariffSynchronizer).not_to have_received(:download) }
+          it { expect(TariffSynchronizer).not_to have_received(:apply) }
+
+          it { expect(described_class.jobs).to be_empty }
+        end
+      end
+
+      context 'with todays file present' do
+        before do
+          allow(TariffSynchronizer).to receive(:downloaded_todays_file_for_cds?)
+                                       .and_return(true)
+
+          perform
+        end
+
+        it { expect(TariffSynchronizer).to have_received(:download_cds) }
+        it { expect(TariffSynchronizer).to have_received(:apply_cds) }
+
+        it { expect(TariffSynchronizer).not_to have_received(:download) }
+        it { expect(TariffSynchronizer).not_to have_received(:apply) }
+
+        it { expect(described_class.jobs).to be_empty }
+      end
     end
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-1260](https://transformuk.atlassian.net/browse/HOTT-1260)

### What?

I have added/removed/altered:

- [x] Added a reschedule feature to UpdatesSynchronizer

### Why?

I am doing this because:

- Sometimes the CDS update file arrives later then when our synchronizer is scheduled to run. If that is the case - re-schedule every 20 minutes until the cut off time is reached. Once the cut off time is reached, if there still isn't a file for today, the job will continue as per normal.

### Deployment risks (optional)

- Changes the behaviour of the overnight sync job
