### PR TITLE
HOTT-1286: Extend download date range logic to be 20 days ago

### DIFF
--- a/app/lib/tariff_synchronizer/base_update.rb
+++ b/app/lib/tariff_synchronizer/base_update.rb
@@ -1,5 +1,7 @@
 module TariffSynchronizer
   class BaseUpdate < Sequel::Model(:tariff_updates)
+    DOWNLOAD_FROM = 20.days
+
     delegate :instrument, to: ActiveSupport::Notifications
 
     # Used for TARIC updates only.
@@ -62,6 +64,10 @@ module TariffSynchronizer
         where(state: FAILED_STATE)
       end
 
+      def pending_applied_and_failed
+        where(state: [PENDING_STATE, APPLIED_STATE, FAILED_STATE])
+      end
+
       def pending_or_failed
         where(state: [PENDING_STATE, FAILED_STATE])
       end
@@ -76,6 +82,10 @@ module TariffSynchronizer
 
       def last_applied
         applied.order(:issue_date).first
+      end
+
+      def last_failed
+        failed.order(:issue_date).first
       end
 
       def descending
@@ -140,7 +150,8 @@ module TariffSynchronizer
       delegate :instrument, to: ActiveSupport::Notifications
 
       def sync
-        (pending_from..Date.current).each { |date| download(date) }
+        applicable_download_date_range.each { |date| download(date) }
+
         notify_about_missing_updates if last_updates_are_missing?
       end
 
@@ -148,20 +159,30 @@ module TariffSynchronizer
         raise 'Update Type should be specified in inheriting class'
       end
 
-    private
+      def applicable_download_date_range
+        download_start_date..download_end_date
+      end
 
-      def pending_from
-        if last_download = (last_pending || descending.first)
-          last_download.issue_date
-        else
+      private
+
+      def download_end_date
+        Time.zone.today
+      end
+
+      def download_start_date
+        if pending_applied_and_failed.count.zero?
           TariffSynchronizer.initial_update_date_for(update_type)
+        else
+          last_download = (last_pending || last_applied || last_failed)
+
+          [last_download.issue_date, DOWNLOAD_FROM.ago.to_date].min
         end
       end
 
       def last_updates_are_missing?
         holidays = BankHolidays.last(TariffSynchronizer.warning_day_count)
         descending.exclude(issue_date: holidays)
-                  .first.try(:missing?)
+          .first.try(:missing?)
       end
 
       def notify_about_missing_updates

--- a/app/lib/tariff_synchronizer/base_update.rb
+++ b/app/lib/tariff_synchronizer/base_update.rb
@@ -64,7 +64,7 @@ module TariffSynchronizer
         where(state: FAILED_STATE)
       end
 
-      def pending_applied_and_failed
+      def pending_applied_or_failed
         where(state: [PENDING_STATE, APPLIED_STATE, FAILED_STATE])
       end
 
@@ -170,7 +170,7 @@ module TariffSynchronizer
       end
 
       def download_start_date
-        if pending_applied_and_failed.count.zero?
+        if pending_applied_or_failed.count.zero?
           TariffSynchronizer.initial_update_date_for(update_type)
         else
           last_download = (last_pending || last_applied || last_failed)

--- a/spec/factories/cds_update_factory.rb
+++ b/spec/factories/cds_update_factory.rb
@@ -13,5 +13,9 @@ FactoryBot.define do
     trait :applied do
       state { 'A' }
     end
+
+    trait :failed do
+      state { 'F' }
+    end
   end
 end

--- a/spec/factories/taric_update_factory.rb
+++ b/spec/factories/taric_update_factory.rb
@@ -19,5 +19,9 @@ FactoryBot.define do
     trait :pending do
       state { 'P' }
     end
+
+    trait :failed do
+      state { 'F' }
+    end
   end
 end

--- a/spec/unit/tariff_synchronizer/base_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/base_update_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe TariffSynchronizer::BaseUpdate do
   end
 
   describe '.sync' do
-    it 'calls the download method for each date since for the last 20 days to the current date' do
+    it 'calls the download method for each date for the last 20 days to the current date' do
       update = create :taric_update, :applied, issue_date: 1.day.ago
 
       (20.days.ago.to_date..Date.current).each do |download_date|

--- a/spec/unit/tariff_synchronizer/base_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/base_update_spec.rb
@@ -40,12 +40,76 @@ RSpec.describe TariffSynchronizer::BaseUpdate do
     end
   end
 
+  describe '.applicable_download_date_range' do
+    shared_examples_for 'an applicable download date range' do |update_factory|
+      let(:today) { Time.zone.today }
+      let(:pending_issue_date) { today - 21.days }
+      let(:applied_issue_date) { today - 22.days }
+      let(:failed_issue_date) { today - 23.days }
+
+      context 'when choosing a pending update older than the default download from date' do
+        before do
+          create(update_factory, :pending, issue_date: pending_issue_date)
+          create(update_factory, :applied, issue_date: applied_issue_date)
+          create(update_factory, :failed, issue_date: failed_issue_date)
+        end
+
+        it { is_expected.to eq(pending_issue_date..today) }
+      end
+
+      context 'when choosing a applied update older than the default download from date' do
+        before do
+          create(update_factory, :applied, issue_date: applied_issue_date)
+          create(update_factory, :failed, issue_date: failed_issue_date)
+        end
+
+        it { is_expected.to eq(applied_issue_date..today) }
+      end
+
+      context 'when choosing a failed update older than the default download from date' do
+        before do
+          create(update_factory, :failed, issue_date: failed_issue_date)
+        end
+
+        it { is_expected.to eq(failed_issue_date..today) }
+      end
+
+      context 'when there is an update issued 20 days ago or less' do
+        let(:pending_issue_date) { today - 20.days }
+
+        before do
+          create(update_factory, :pending, issue_date: pending_issue_date)
+        end
+
+        it { is_expected.to eq(pending_issue_date..today) }
+      end
+
+      context 'when there are no updates yet' do
+        it { is_expected.to eq(initial_date..today) }
+      end
+    end
+
+    it_behaves_like 'an applicable download date range', :taric_update do
+      subject(:applicable_download_date_range) { TariffSynchronizer::TaricUpdate.applicable_download_date_range }
+
+      let(:initial_date) { Date.new(2012, 6, 6) }
+    end
+
+    it_behaves_like 'an applicable download date range', :cds_update do
+      subject(:applicable_download_date_range) { TariffSynchronizer::CdsUpdate.applicable_download_date_range }
+
+      let(:initial_date) { Date.new(2020, 9, 1) }
+    end
+  end
+
   describe '.sync' do
-    it 'Calls the download method for each date since the last issue_date to the current date' do
+    it 'calls the download method for each date since for the last 20 days to the current date' do
       update = create :taric_update, :applied, issue_date: 1.day.ago
 
-      expect(TariffSynchronizer::TaricUpdate).to receive(:download).with(update.issue_date)
-      expect(TariffSynchronizer::TaricUpdate).to receive(:download).with(Date.current)
+      (20.days.ago.to_date..Date.current).each do |download_date|
+        expect(TariffSynchronizer::TaricUpdate).to receive(:download).with(download_date)
+      end
+
       TariffSynchronizer::TaricUpdate.sync
     end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1286

### What?

I have added/removed/altered:

- [x] Altered the download updates behaviour by defaulting to 20 days as the first date of the files that we try to download.
- [x] Altered the download updates behaviour so that we ignore missing updates and only pay attention to the pending, applied and failed ones

### Why?

I am doing this because:

- Now that we've removed the missing files functionality and we know that the files can come out of order we need to try and download previously unavailable files which now exist. Our tolerance is set to the last 20 days just as a starting point.
- I've applied this behaviour to the CdsUpdate type to keep things
consistent between the implementations.
