### PR TITLE
HOTT-1286: Remove creation of missing updates

### DIFF
--- a/app/lib/tariff_synchronizer/taric_update_downloader.rb
+++ b/app/lib/tariff_synchronizer/taric_update_downloader.rb
@@ -46,13 +46,8 @@ module TariffSynchronizer
       instrument('retry_exceeded.tariff_synchronizer', date: date, url: url)
     end
 
-    def create_record_for_not_found_response
-      # Do not create missing record until we are sure until the next day
-      return if date >= Date.current
-
-      update_or_create(BaseUpdate::MISSING_STATE, missing_filename)
-      instrument('not_found.tariff_synchronizer', date: date, url: url)
-    end
+    # We do not create records for missing updates (see dynamic send method in perform)
+    def create_record_for_not_found_response; end
 
     def missing_filename
       "#{date}_taric"

--- a/spec/unit/tariff_synchronizer/logger_spec.rb
+++ b/spec/unit/tariff_synchronizer/logger_spec.rb
@@ -7,30 +7,6 @@ RSpec.describe TariffSynchronizer::Logger, truncation: true do
 
   before { tariff_synchronizer_logger_listener }
 
-  describe '#missing_updates' do
-    let(:not_found_response) { build :response, :not_found }
-
-    before do
-      stub_holidays_gem_between_call
-      create :taric_update, :missing, issue_date: Date.current.ago(2.days)
-      create :taric_update, :missing, issue_date: Date.current.ago(3.days)
-      allow(TariffSynchronizer::TariffUpdatesRequester).to receive(:perform)
-                                            .and_return(not_found_response)
-      TariffSynchronizer::TaricUpdate.sync
-    end
-
-    it 'logs a warn event' do
-      expect(@logger.logged(:warn).size).to be > 1
-      expect(@logger.logged(:warn).to_s).to match(/Missing/)
-    end
-
-    it 'sends a warning email' do
-      expect(ActionMailer::Base.deliveries).not_to be_empty
-      email = ActionMailer::Base.deliveries.last
-      expect(email.encoded).to match(/missing/)
-    end
-  end
-
   describe '#rollback_lock_error' do
     before do
       expect(TradeTariffBackend).to receive(

--- a/spec/unit/tariff_synchronizer/taric_update_downloader_spec.rb
+++ b/spec/unit/tariff_synchronizer/taric_update_downloader_spec.rb
@@ -44,32 +44,7 @@ RSpec.describe TariffSynchronizer::TaricUpdateDownloader do
           .with(generator.url).and_return(build(:response, :not_found))
       end
 
-      it 'Creates a record with a missing state if the date has passed' do
-        expect {
-          described_class.new(example_date).perform
-        }.to change(TariffSynchronizer::TaricUpdate, :count).by(1)
-
-        taric_update = TariffSynchronizer::TaricUpdate.last
-        expect(taric_update.filename).to eq('2010-01-01_taric')
-        expect(taric_update.filesize).to be_nil
-        expect(taric_update.issue_date).to eq(example_date)
-        expect(taric_update.state).to eq(TariffSynchronizer::BaseUpdate::MISSING_STATE)
-      end
-
-      it "Doesn't create a record if the date is the same" do
-        expect {
-          travel_to example_date do
-            described_class.new(example_date).perform
-          end
-        }.not_to change(TariffSynchronizer::TaricUpdate, :count)
-      end
-
-      it 'Logs the creating of the TaricUpdate record with missing state' do
-        tariff_synchronizer_logger_listener
-        described_class.new(example_date).perform
-        expect(@logger.logged(:warn).size).to eq 1
-        expect(@logger.logged(:warn).last).to eq('Update NOT found for 2010-01-01 at http://example.com/taric/TARIC320100101')
-      end
+      it { expect { described_class.new(example_date).perform }.not_to change(TariffSynchronizer::TaricUpdate, :count) }
     end
 
     context 'Retries Exceeded Response' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1286

### What?

I have added/removed/altered:

- [x] Removed creating missing updates when downloading Taric files

### Why?

I am doing this because:

- This isn't helpful and in fact creates noise in the process of
reviewing files which haven't been downloaded correctly.
