### PR TITLE
HOTT-1252: Fix new scopes for update model

### DIFF
--- a/app/lib/tariff_synchronizer.rb
+++ b/app/lib/tariff_synchronizer.rb
@@ -106,7 +106,7 @@ module TariffSynchronizer
       # Updates could be modifying primary keys so unrestricted it for all models.
       sequel_models.each(&:unrestrict_primary_key)
 
-      date_range = date_range_since_last_pending_update
+      date_range = date_range_since_oldest_pending_update
       date_range.each do |day|
         applied_updates << perform_update(TaricUpdate, day)
       end
@@ -145,7 +145,7 @@ module TariffSynchronizer
         import_warnings << event.payload
       end
 
-      date_range = date_range_since_last_pending_update
+      date_range = date_range_since_oldest_pending_update
       date_range.each do |day|
         applied_updates << perform_update(CdsUpdate, day)
       end
@@ -279,11 +279,11 @@ module TariffSynchronizer
     updates
   end
 
-  def date_range_since_last_pending_update
-    last_pending_update = BaseUpdate.last_pending
-    return [] if last_pending_update.blank?
+  def date_range_since_oldest_pending_update
+    oldest_pending_update = BaseUpdate.oldest_pending
+    return [] if oldest_pending_update.blank?
 
-    (last_pending_update.issue_date..update_to)
+    (oldest_pending_update.issue_date..update_to)
   end
 
   def update_to

--- a/app/lib/tariff_synchronizer/base_update.rb
+++ b/app/lib/tariff_synchronizer/base_update.rb
@@ -77,15 +77,19 @@ module TariffSynchronizer
       end
 
       def last_pending
-        pending.order(:issue_date).first
+        pending.ascending.first
       end
 
-      def last_applied
-        applied.order(:issue_date).first
+      def most_recent_applied
+        applied.descending.first
       end
 
-      def last_failed
-        failed.order(:issue_date).first
+      def most_recent_failed
+        failed.descending.first
+      end
+
+      def ascending
+        order(Sequel.asc(:issue_date))
       end
 
       def descending
@@ -173,7 +177,7 @@ module TariffSynchronizer
         if pending_applied_or_failed.count.zero?
           TariffSynchronizer.initial_update_date_for(update_type)
         else
-          last_download = (last_pending || last_applied || last_failed)
+          last_download = (last_pending || most_recent_applied || most_recent_failed)
 
           [last_download.issue_date, DOWNLOAD_FROM.ago.to_date].min
         end

--- a/app/lib/tariff_synchronizer/base_update.rb
+++ b/app/lib/tariff_synchronizer/base_update.rb
@@ -76,7 +76,7 @@ module TariffSynchronizer
         where(state: [APPLIED_STATE, FAILED_STATE])
       end
 
-      def last_pending
+      def oldest_pending
         pending.ascending.first
       end
 
@@ -177,7 +177,7 @@ module TariffSynchronizer
         if pending_applied_or_failed.count.zero?
           TariffSynchronizer.initial_update_date_for(update_type)
         else
-          last_download = (last_pending || most_recent_applied || most_recent_failed)
+          last_download = (oldest_pending || most_recent_applied || most_recent_failed)
 
           [last_download.issue_date, DOWNLOAD_FROM.ago.to_date].min
         end

--- a/app/lib/tariff_synchronizer/cds_update.rb
+++ b/app/lib/tariff_synchronizer/cds_update.rb
@@ -5,7 +5,7 @@ module TariffSynchronizer
 
     class << self
       def correct_filename_sequence?
-        pending_seq = last_pending&.filename_sequence
+        pending_seq = oldest_pending&.filename_sequence
         applied_seq = most_recent_applied&.filename_sequence
 
         return true if pending_seq.blank? || applied_seq.blank?

--- a/app/lib/tariff_synchronizer/cds_update.rb
+++ b/app/lib/tariff_synchronizer/cds_update.rb
@@ -6,7 +6,7 @@ module TariffSynchronizer
     class << self
       def correct_filename_sequence?
         pending_seq = last_pending&.filename_sequence
-        applied_seq = last_applied&.filename_sequence
+        applied_seq = most_recent_applied&.filename_sequence
 
         return true if pending_seq.blank? || applied_seq.blank?
 

--- a/spec/unit/tariff_synchronizer/base_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/base_update_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe TariffSynchronizer::BaseUpdate do
     stub_holidays_gem_between_call
   end
 
+  let(:today) { Time.zone.today }
+  let(:yesterday) { Time.zone.yesterday }
+
   describe '#file_path' do
     before do
       allow(TariffSynchronizer).to receive(:root_path).and_return('data')
@@ -169,19 +172,19 @@ RSpec.describe TariffSynchronizer::BaseUpdate do
     end
   end
 
-  describe '.last_pending' do
-    subject(:last_pending) { described_class.last_pending }
+  describe '.oldest_pending' do
+    subject(:oldest_pending) { described_class.oldest_pending }
 
     context 'when there are updates' do
       before do
-        create(:cds_update, :pending, issue_date:  Time.zone.yesterday) # Target
-        create(:cds_update, :pending, issue_date:  Time.zone.today) # Control
-        create(:cds_update, :failed, issue_date: Time.zone.yesterday) # Control
-        create(:cds_update, :applied, issue_date:  Time.zone.yesterday) # Control
-        create(:cds_update, :missing, issue_date:  Time.zone.yesterday) # Control
+        create(:cds_update, :pending, issue_date:  yesterday) # Target
+        create(:cds_update, :pending, issue_date:  today) # Control
+        create(:cds_update, :failed, issue_date: yesterday) # Control
+        create(:cds_update, :applied, issue_date:  yesterday) # Control
+        create(:cds_update, :missing, issue_date:  yesterday) # Control
       end
 
-      it { is_expected.to have_attributes(state: 'P', issue_date: Time.zone.yesterday) }
+      it { is_expected.to have_attributes(state: 'P', issue_date: yesterday) }
     end
 
     context 'when there are no updates' do
@@ -194,14 +197,14 @@ RSpec.describe TariffSynchronizer::BaseUpdate do
 
     context 'when there are updates' do
       before do
-        create(:cds_update, :applied, issue_date:  Time.zone.today) # Target
-        create(:cds_update, :applied, issue_date:  Time.zone.yesterday) # Control
-        create(:cds_update, :failed, issue_date: Time.zone.today) # Control
-        create(:cds_update, :missing, issue_date:  Time.zone.today) # Control
-        create(:cds_update, :pending, issue_date:  Time.zone.today) # Control
+        create(:cds_update, :applied, issue_date:  today) # Target
+        create(:cds_update, :applied, issue_date:  yesterday) # Control
+        create(:cds_update, :failed, issue_date: today) # Control
+        create(:cds_update, :missing, issue_date:  today) # Control
+        create(:cds_update, :pending, issue_date:  today) # Control
       end
 
-      it { is_expected.to have_attributes(state: 'A', issue_date: Time.zone.today) }
+      it { is_expected.to have_attributes(state: 'A', issue_date: today) }
     end
 
     context 'when there are no updates' do
@@ -214,15 +217,15 @@ RSpec.describe TariffSynchronizer::BaseUpdate do
 
     context 'when there are updates' do
       before do
-        create(:cds_update, :failed, issue_date: Time.zone.today) # Target
-        create(:cds_update, :failed, issue_date: Time.zone.yesterday) # Control
-        create(:cds_update, :applied, issue_date:  Time.zone.today) # Control
-        create(:cds_update, :applied, issue_date:  Time.zone.yesterday) # Control
-        create(:cds_update, :missing, issue_date:  Time.zone.today) # Control
-        create(:cds_update, :pending, issue_date:  Time.zone.today) # Control
+        create(:cds_update, :failed, issue_date: today) # Target
+        create(:cds_update, :failed, issue_date: yesterday) # Control
+        create(:cds_update, :applied, issue_date:  today) # Control
+        create(:cds_update, :applied, issue_date:  yesterday) # Control
+        create(:cds_update, :missing, issue_date:  today) # Control
+        create(:cds_update, :pending, issue_date:  today) # Control
       end
 
-      it { is_expected.to have_attributes(state: 'F', issue_date: Time.zone.today) }
+      it { is_expected.to have_attributes(state: 'F', issue_date: today) }
     end
 
     context 'when there are no updates' do

--- a/spec/unit/tariff_synchronizer/base_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/base_update_spec.rb
@@ -168,4 +168,65 @@ RSpec.describe TariffSynchronizer::BaseUpdate do
       end
     end
   end
+
+  describe '.last_pending' do
+    subject(:last_pending) { described_class.last_pending }
+
+    context 'when there are updates' do
+      before do
+        create(:cds_update, :pending, issue_date:  Time.zone.yesterday) # Target
+        create(:cds_update, :pending, issue_date:  Time.zone.today) # Control
+        create(:cds_update, :failed, issue_date: Time.zone.yesterday) # Control
+        create(:cds_update, :applied, issue_date:  Time.zone.yesterday) # Control
+        create(:cds_update, :missing, issue_date:  Time.zone.yesterday) # Control
+      end
+
+      it { is_expected.to have_attributes(state: 'P', issue_date: Time.zone.yesterday) }
+    end
+
+    context 'when there are no updates' do
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '.most_recent_applied' do
+    subject(:most_recent_applied) { described_class.most_recent_applied }
+
+    context 'when there are updates' do
+      before do
+        create(:cds_update, :applied, issue_date:  Time.zone.today) # Target
+        create(:cds_update, :applied, issue_date:  Time.zone.yesterday) # Control
+        create(:cds_update, :failed, issue_date: Time.zone.today) # Control
+        create(:cds_update, :missing, issue_date:  Time.zone.today) # Control
+        create(:cds_update, :pending, issue_date:  Time.zone.today) # Control
+      end
+
+      it { is_expected.to have_attributes(state: 'A', issue_date: Time.zone.today) }
+    end
+
+    context 'when there are no updates' do
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '.most_recent_failed' do
+    subject(:most_recent_failed) { described_class.most_recent_failed }
+
+    context 'when there are updates' do
+      before do
+        create(:cds_update, :failed, issue_date: Time.zone.today) # Target
+        create(:cds_update, :failed, issue_date: Time.zone.yesterday) # Control
+        create(:cds_update, :applied, issue_date:  Time.zone.today) # Control
+        create(:cds_update, :applied, issue_date:  Time.zone.yesterday) # Control
+        create(:cds_update, :missing, issue_date:  Time.zone.today) # Control
+        create(:cds_update, :pending, issue_date:  Time.zone.today) # Control
+      end
+
+      it { is_expected.to have_attributes(state: 'F', issue_date: Time.zone.today) }
+    end
+
+    context 'when there are no updates' do
+      it { is_expected.to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1252

### What?

I have added/removed/altered:

- [x] Added coverage for existing used base update model scopes
- [x] Tweaked scope naming to reflect chronology rather than couple to order
- [x] Tweaked scope behaviour to reflect pulling out earliest updates

### Why?

I am doing this because:

- These break the cds sequence checker and therefore are holding up applies
