### PR TITLE
HOTT-1206 Fix queueing in CI deploy step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
   ruby: circleci/ruby@1.1.2
   cloudfoundry: circleci/cloudfoundry@1.0
   slack: circleci/slack@4.3.0
-  queue: eddiewebb/queue@1.6.1
+  queue: eddiewebb/queue@1.6.4
 
 commands:
   cf_deploy_docker:


### PR DESCRIPTION
### Jira link

[HOTT-1206](https://transformuk.atlassian.net/browse/HOTT-1206)

### What?

I have added/removed/altered:

- [x] Fix for deploy step in CI not queueing correctly

### Why?

I am doing this because:

- CI does not queue and concurrent downloads can result in the deletion of the server being deployed to
