### PR TITLE
HOTT-1294: Fix Alpine docker updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.2
+          version: 20.10.11
           docker_layer_caching: false
       - aws-cli/install
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build compilation image
-FROM ruby:3.0.3-alpine3.13 as builder
+FROM ruby:3.0.3-alpine3.15 as builder
 
 # The application runs from /app
 WORKDIR /app
@@ -34,7 +34,7 @@ RUN rm -rf node_modules log tmp && \
       find /usr/local/bundle/gems -name "*.html" -delete
 
 # Build runtime image
-FROM ruby:3.0.3-alpine3.13 as production
+FROM ruby:3.0.3-alpine3.15 as production
 
 RUN apk add --update --no-cache postgresql-dev curl curl-dev shared-mime-info tzdata && \
   cp /usr/share/zoneinfo/Europe/London /etc/localtime && \


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1294

### What?

I have added/removed/altered:

- [x] Bumps Alpine docker image
- [x] Bumps docker engine we use to build the image

### Why?

I am doing this because:

- So that we can keep up-to-date with the latest official ruby images
