### PR TITLE
Upgraded circleci provisioned remote docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.2
+          version: 20.10.11
           docker_layer_caching: false
       - aws-cli/install
       - run:


### PR DESCRIPTION
### Jira link

HOTT-???

### What?

I have added/removed/altered:

- [x] Upgraded the version of the remote docker provisioned by Circle

### Why?

I am doing this because:

- its taking a long time to provision and I suspect this is because we're using a version falling into disuse
- later versions may also potentially help us avoid any already fixed bugs in docker

