### PR TITLE
HOTT-1250: Fixes broken heading api

### DIFF
--- a/app/lib/hashie/tariff_mash.rb
+++ b/app/lib/hashie/tariff_mash.rb
@@ -1,0 +1,11 @@
+module Hashie
+  class TariffMash < Hashie::Mash
+    disable_warnings
+
+    # Need to wrap object in array because serializer gem does Array(obj) and it breaks Hashie::Mash object
+    # See changes https://github.com/jsonapi-serializer/jsonapi-serializer/commit/f62a5bf1622fd2da0278e2fef0e8d4342b97e7cc
+    def to_a
+      Array.wrap(self)
+    end
+  end
+end

--- a/app/lib/trade_tariff_backend/search_client.rb
+++ b/app/lib/trade_tariff_backend/search_client.rb
@@ -5,16 +5,6 @@ module TradeTariffBackend
     # Raised if Elasticsearch returns an error from query
     QueryError = Class.new(StandardError)
 
-    class Response < Hashie::Mash
-      disable_warnings
-
-      # Need to wrap object in array because serializer gem does Array(obj) and it breaks Hashie::Mash object
-      # See changes https://github.com/jsonapi-serializer/jsonapi-serializer/commit/f62a5bf1622fd2da0278e2fef0e8d4342b97e7cc
-      def to_a
-        Array.wrap(self)
-      end
-    end
-
     attr_reader :indexed_models
     attr_reader :index_page_size
     attr_reader :search_operation_options
@@ -32,11 +22,11 @@ module TradeTariffBackend
     end
 
     def search(*)
-      Response.new(super)
+      Hashie::TariffMash.new(super)
     end
 
     def msearch(*)
-      Response.new(super)
+      Hashie::TariffMash.new(super)
     end
 
     def reindex

--- a/app/services/heading_service/cached_heading_service.rb
+++ b/app/services/heading_service/cached_heading_service.rb
@@ -22,7 +22,7 @@ module HeadingService
     private
 
     def serialize_result
-      ::Hashie::Mash.new(::Cache::HeadingSerializer.new(heading).as_json)
+      Hashie::TariffMash.new(::Cache::HeadingSerializer.new(heading).as_json)
     end
 
     def fetch_result

--- a/spec/controllers/api/v2/headings_controller_spec.rb
+++ b/spec/controllers/api/v2/headings_controller_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe Api::V2::HeadingsController, type: :controller do
     end
 
     context 'when the heading is not declarable' do
+      before { chapter }
+
       let(:heading) do
         create(
           :heading,

--- a/spec/lib/hashie/tariff_mash_spec.rb
+++ b/spec/lib/hashie/tariff_mash_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Hashie::TariffMash do
+  describe '#to_a' do
+    subject(:mash) { described_class.new(foo: :bar) }
+
+    # NOTE: The to_a method is used in internal comparisons in matchers so to verify the resulting
+    #       Array I need to directly call the == method. Ideally we'd not have to override this method/stop being clever
+    #       in using Mashie in place of the presenter pattern.
+    it { expect(mash.to_a == [{ 'foo' => :bar }]).to eq(true) }
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1305

### What?

When the heading hasn't been preloaded, we try to serialize using the
json api fast serializer a Mash which calls Array(our_mash) on the
intermediate serialized result. We have an intermediate result because
we use a different structure for the ES cache DDL to the JSON API
schema.

We have a special snowflake Mash implementation that was nested in the
SearchClient and generically named Response. This was implemented
because of an incompatibility with the JSON API gem we're using where
Array() implicitly calls to to_a on the Hashie::Mash and creates the
wrong result for includes.

I've moved this Mash implementation, added specs for it and made sure
that we can properly serialize all Mashes we instantiate.

I have added/removed/altered:

- [x] Renamed and added tests for our custom implementation of Hashie::Mash
- [x] Fixed a broken controller test which wasn't properly instantiating a chapter and therefore not implicitly verifying includes

### Why?

I am doing this because:

- So the api works for headings regardless of the state of ES cache
