### PR TITLE
HOTT-1308: Adds leaf column to search references

### DIFF
--- a/db/migrate/20220131140324_add_leaf_to_search_references.rb
+++ b/db/migrate/20220131140324_add_leaf_to_search_references.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table :search_references do
+      add_column :leaf, FalseClass, null: true
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6554,7 +6554,8 @@ CREATE TABLE public.search_references (
     title text,
     referenced_id character varying(10),
     referenced_class character varying(10),
-    productline_suffix text DEFAULT '80'::text NOT NULL
+    productline_suffix text DEFAULT '80'::text NOT NULL,
+    leaf boolean
 );
 
 
@@ -10832,3 +10833,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20210610150945_create_chan
 INSERT INTO "schema_migrations" ("filename") VALUES ('20210628165555_add_unique_constraint_to_changes.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20210915112121_add_news_items.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20220107134210_add_productline_suffix_to_search_references.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20220131140324_add_leaf_to_search_references.rb');


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1308

### What?

I have added/removed/altered:

- [x] Added leaf boolean column to search references

### Why?

I am doing this because:

- This will enable us to pick the Commodity/Subheading model in an exact
match and therefore enable the frontend to be redirected to the
subheadings page
