### PR TITLE
HOTT-1295: Ruby 3.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@2.0.3
-  ruby: circleci/ruby@1.1.2
+  ruby: circleci/ruby@1.4.0
   cloudfoundry: circleci/cloudfoundry@1.0
   slack: circleci/slack@4.3.0
   queue: eddiewebb/queue@1.6.4
@@ -196,7 +196,7 @@ commands:
 jobs:
   linters:
     docker:
-      - image: cimg/ruby:3.0.3
+      - image: cimg/ruby:3.1.0
     resource_class: small
     steps:
       - checkout
@@ -257,7 +257,7 @@ jobs:
 
   test:
     docker:
-      - image: cimg/ruby:3.0.3
+      - image: cimg/ruby:3.1.0
         environment:
           BUNDLE_JOBS: "3"
           BUNDLE_RETRY: "3"
@@ -320,7 +320,7 @@ jobs:
 
   deploy_dev:
     docker:
-      - image: cimg/ruby:3.0.3
+      - image: cimg/ruby:3.1.0
     environment:
       SENTRY_ENVIRONMENT: "development"
     parameters:
@@ -345,7 +345,7 @@ jobs:
 
   deploy_staging:
     docker:
-      - image: cimg/ruby:3.0.3
+      - image: cimg/ruby:3.1.0
     environment:
       SENTRY_ENVIRONMENT: "staging"
     parameters:
@@ -367,7 +367,7 @@ jobs:
 
   deploy_production:
     docker:
-      - image: cimg/ruby:3.0.3
+      - image: cimg/ruby:3.1.0
     environment:
       SENTRY_ENVIRONMENT: "production"
     parameters:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ inherit_gem:
 require: rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 3.0.2
+  TargetRubyVersion: 3.1.0
   Exclude:
     - 'db/schema.rb'
     - 'vendor/**/*'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build compilation image
-FROM ruby:3.0.3-alpine3.15 as builder
+FROM ruby:3.1.0-alpine3.15 as builder
 
 # The application runs from /app
 WORKDIR /app
@@ -34,7 +34,7 @@ RUN rm -rf node_modules log tmp && \
       find /usr/local/bundle/gems -name "*.html" -delete
 
 # Build runtime image
-FROM ruby:3.0.3-alpine3.15 as production
+FROM ruby:3.1.0-alpine3.15 as production
 
 RUN apk add --update --no-cache postgresql-dev curl curl-dev shared-mime-info tzdata && \
   cp /usr/share/zoneinfo/Europe/London /etc/localtime && \


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1295

### What?

I have added/removed/altered:

- [x] Bump ruby to 3.1.0

### Why?

I am doing this because:

- We get performance, debugging and error feedback improvements in this release
