### PR TITLE
HOTT-1318: Fix broken measure filtering

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -164,12 +164,7 @@ class Measure < Sequel::Model
 
   dataset_module do
     def with_base_regulations
-      query = if model.point_in_time.present?
-                distinct(:measure_generating_regulation_id, :measure_type_id, :goods_nomenclature_sid, :geographical_area_id, :geographical_area_sid, :additional_code_type_id, :additional_code_id, :ordernumber).select(Sequel.expr(:measures).*)
-              else
-                select(Sequel.expr(:measures).*)
-              end
-      query
+      distinct_measure_regulation_query(role: BASE_REGULATION_ROLE)
         .select_append(Sequel.as(Sequel.case({ { Sequel.qualify(:measures, :validity_start_date) => nil } => Sequel.lit('base_regulations.validity_start_date') }, Sequel.lit('measures.validity_start_date')), :effective_start_date))
         .select_append(Sequel.as(Sequel.case({ { Sequel.qualify(:measures, :validity_end_date) => nil } => Sequel.lit('base_regulations.effective_end_date') }, Sequel.lit('measures.validity_end_date')), :effective_end_date))
         .join_table(:inner, :base_regulations, base_regulations__base_regulation_id: :measures__measure_generating_regulation_id)
@@ -177,12 +172,7 @@ class Measure < Sequel::Model
     end
 
     def with_modification_regulations
-      query = if model.point_in_time.present?
-                distinct(:measure_generating_regulation_id, :measure_type_id, :goods_nomenclature_sid, :geographical_area_id, :geographical_area_sid, :additional_code_type_id, :additional_code_id, :ordernumber).select(Sequel.expr(:measures).*)
-              else
-                select(Sequel.expr(:measures).*)
-              end
-      query
+      distinct_measure_regulation_query(role: MODIFICATION_REGULATION_ROLE)
         .select_append(Sequel.as(Sequel.case({ { Sequel.qualify(:measures, :validity_start_date) => nil } => Sequel.lit('modification_regulations.validity_start_date') }, Sequel.lit('measures.validity_start_date')), :effective_start_date))
         .select_append(Sequel.as(Sequel.case({ { Sequel.qualify(:measures, :validity_end_date) => nil } => Sequel.lit('modification_regulations.effective_end_date') }, Sequel.lit('measures.validity_end_date')), :effective_end_date))
         .join_table(:inner, :modification_regulations, modification_regulations__modification_regulation_id: :measures__measure_generating_regulation_id)
@@ -279,6 +269,27 @@ class Measure < Sequel::Model
 
     def non_invalidated
       where(measures__invalidated_at: nil)
+    end
+
+    private
+
+    def distinct_measure_regulation_query(role:)
+      query = if model.point_in_time.present?
+                distinct(
+                  :measure_generating_regulation_id,
+                  :measure_type_id,
+                  :goods_nomenclature_sid,
+                  :geographical_area_id,
+                  :geographical_area_sid,
+                  :additional_code_type_id,
+                  :additional_code_id,
+                  :ordernumber,
+                ).select(Sequel.expr(:measures).*)
+              else
+                select(Sequel.expr(:measures).*)
+              end
+
+      query.where(measure_generating_regulation_role: role)
     end
   end
 

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -320,7 +320,8 @@ RSpec.describe Commodity do
       let!(:measure_type) { create :measure_type }
       let!(:modification_regulation) { create :modification_regulation, effective_end_date: Time.zone.now.ago(1.month) }
       let!(:measure1) do
-        create :measure, measure_generating_regulation_id: modification_regulation.modification_regulation_id,
+        create :measure, :with_base_regulation,
+                         measure_generating_regulation_id: modification_regulation.modification_regulation_id,
                          validity_end_date: Time.zone.now.ago(30.months),
                          goods_nomenclature_sid: commodity.goods_nomenclature_sid,
                          validity_start_date: Time.zone.now.ago(10.years),
@@ -328,7 +329,8 @@ RSpec.describe Commodity do
                          geographical_area_sid: 1
       end
       let!(:measure2) do
-        create :measure, measure_generating_regulation_id: modification_regulation.modification_regulation_id,
+        create :measure, :with_base_regulation,
+                         measure_generating_regulation_id: modification_regulation.modification_regulation_id,
                          goods_nomenclature_sid: commodity.goods_nomenclature_sid,
                          measure_type_id: measure_type.measure_type_id,
                          validity_start_date: Time.zone.now.ago(10.years),
@@ -336,7 +338,8 @@ RSpec.describe Commodity do
                          geographical_area_sid: 2
       end
       let!(:measure3) do
-        create :measure, measure_generating_regulation_id: modification_regulation.modification_regulation_id,
+        create :measure, :with_base_regulation,
+                         measure_generating_regulation_id: modification_regulation.modification_regulation_id,
                          goods_nomenclature_sid: commodity.goods_nomenclature_sid,
                          measure_type_id: measure_type.measure_type_id,
                          validity_start_date: Time.zone.now.ago(10.years),
@@ -344,7 +347,7 @@ RSpec.describe Commodity do
                          geographical_area_sid: 3
       end
 
-      it 'measure validity date superseeds regulation validity date' do
+      it 'measure validity date supercedes regulation validity date' do
         measures = TimeMachine.at(Time.zone.now.ago(1.year)) { described_class.actual.first.measures }.map(&:measure_sid)
         expect(measures).to     include measure3.measure_sid
         expect(measures).not_to include measure2.measure_sid

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -1224,4 +1224,36 @@ RSpec.describe Measure do
 
     it { expect(measure.meursing_measures).to eq(meursing_measures) }
   end
+
+  shared_context 'with regulation measures' do
+    before do
+      create(:base_regulation, base_regulation_id: 'R9726580')
+      create(:modification_regulation, modification_regulation_id: 'R9726580')
+
+      # Base regulation measure
+      create(:measure, measure_sid: 1, goods_nomenclature_sid: 1, measure_generating_regulation_role: 1, measure_generating_regulation_id: 'R9726580')
+
+      # Modification regulation measure
+      create(:measure, measure_sid: 2, goods_nomenclature_sid: 1, measure_generating_regulation_role: 4, measure_generating_regulation_id: 'R9726580')
+
+      # No regulation measure - control
+      create(:measure, measure_sid: 3, goods_nomenclature_sid: 1)
+    end
+  end
+
+  describe '.with_base_regulations' do
+    subject(:with_base_regulations) { described_class.with_base_regulations.pluck(:measure_sid) }
+
+    include_context 'with regulation measures'
+
+    it { is_expected.to eq([1]) } # Base regulation measure
+  end
+
+  describe '.with_modification_regulations' do
+    subject(:with_modification_regulations) { described_class.with_modification_regulations.pluck(:measure_sid) }
+
+    include_context 'with regulation measures'
+
+    it { is_expected.to eq([2]) } # Modification regulation measure
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1318

### What?

The distinct measure regulation query needs to take account of the
regulation role in order to uniquely identify the modification or the
base regulation measures.

This is then used downstream to pull out the correct measures that are
applicable based on the TimeMachine as applied to a worked-out effective end
date.

This was subtle and unnoticed because for the most part regulation ids
are unique between the base_regulations and modification_regulations
views and we were getting the correct joined measures bac.

I have added/removed/altered:

- [x] Altered the with_modification_regulations and with_base_regulation scope so that they only return modification and base regulations, respectively
- [x] Added tests of these scopes

### Why?

I am doing this because:

- Fixes some presentational issues where the regulation id is the same between two regulations with different validity periods
