### PR TITLE
HOTT-1318: Adds a trait for base regulation and avoid forced coupling

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,17 +10,17 @@ module ApplicationHelper
   end
 
   def regulation_url(regulation)
-    ApplicationHelper::regulation_url(regulation)
+    ApplicationHelper.regulation_url(regulation)
   end
 
   def self.regulation_url(regulation)
     MeasureService::CouncilRegulationUrlGenerator.new(
-      regulation
+      regulation,
     ).generate
   end
 
   def regulation_code(regulation)
-    ApplicationHelper::regulation_code(regulation)
+    ApplicationHelper.regulation_code(regulation)
   end
 
   def self.regulation_code(regulation)

--- a/spec/controllers/api/v2/additional_codes_controller_spec.rb
+++ b/spec/controllers/api/v2/additional_codes_controller_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Api::V2::AdditionalCodesController, type: :controller do
   context 'additional codes search' do
     let!(:additional_code) { create :additional_code }
     let!(:additional_code_description) { create :additional_code_description, :with_period, additional_code_sid: additional_code.additional_code_sid }
-    let!(:measure) { create :measure, additional_code_sid: additional_code.additional_code_sid }
+    let!(:measure) { create :measure, :with_base_regulation, additional_code_sid: additional_code.additional_code_sid }
     let!(:goods_nomenclature) { measure.goods_nomenclature }
     let!(:goods_nomenclature_description) { create :goods_nomenclature_description, goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid }
 

--- a/spec/controllers/api/v2/footnotes_controller_spec.rb
+++ b/spec/controllers/api/v2/footnotes_controller_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Api::V2::FootnotesController, type: :controller do
   context 'footnotes search' do
     let!(:footnote) { create :footnote, :national }
     let!(:footnote_description) { create :footnote_description, :with_period, footnote_type_id: footnote.footnote_type_id, footnote_id: footnote.footnote_id }
-    let!(:measure) { create :measure }
+    let!(:measure) { create :measure, :with_base_regulation }
     let!(:footnote_association_measure) { create :footnote_association_measure, footnote_type_id: footnote.footnote_type_id, footnote_id: footnote.footnote_id, measure_sid: measure.measure_sid }
     let!(:goods_nomenclature) { measure.goods_nomenclature }
     let!(:goods_nomenclature2) { create :goods_nomenclature }

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -57,10 +57,16 @@ FactoryBot.define do
                                  geographical_area_id: geographical_area_id,
                                  validity_start_date: validity_start_date - 1.day)
     end
-    f.base_regulation do
-      create(:base_regulation, base_regulation_id: measure_generating_regulation_id,
-                               base_regulation_role: measure_generating_regulation_role,
-                               effective_end_date: base_regulation_effective_end_date || Date.current.in(10.years))
+
+    trait :with_base_regulation do
+      after(:create) do |measure, evaluator|
+        create(
+          :base_regulation,
+          base_regulation_id: measure.measure_generating_regulation_id,
+          base_regulation_role: measure.measure_generating_regulation_role,
+          effective_end_date: evaluator.base_regulation_effective_end_date || Date.current.in(10.years),
+        )
+      end
     end
 
     trait :national do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -121,7 +121,8 @@ RSpec.describe ApplicationHelper do
 
   describe '#regulation_code' do
     let(:measure) do
-      build :measure,
+      create :measure,
+            :with_base_regulation,
             measure_generating_regulation_id: '1234567'
     end
 

--- a/spec/models/heading_spec.rb
+++ b/spec/models/heading_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Heading do
       end
     end
 
-    describe 'measures' do
+    describe '#measures' do
       let(:heading) { create :commodity, :with_indent }
       let(:excluded_for_both_uk_xi) { '442' }
       let(:excluded_quota_for_xi) { '653' }
@@ -72,21 +72,21 @@ RSpec.describe Heading do
 
         it 'does not include measures that are excluded for the UK service' do
           measure_type = create(:measure_type, measure_type_id: excluded_for_both_uk_xi)
-          measure = create(:measure, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: heading.goods_nomenclature_sid)
+          measure = create(:measure, :with_base_regulation, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: heading.goods_nomenclature_sid)
 
           expect(heading.measures.map(&:measure_sid)).not_to include measure.measure_sid
         end
 
         it 'does include quota measures that are only excluded for the XI service' do
           measure_type = create(:measure_type, measure_type_id: excluded_quota_for_xi)
-          measure = create(:measure, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: heading.goods_nomenclature_sid)
+          measure = create(:measure, :with_base_regulation, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: heading.goods_nomenclature_sid)
 
           expect(heading.measures.map(&:measure_sid)).to include measure.measure_sid
         end
 
         it 'does include P&R national measures that are only excluded for the XI service' do
           measure_type = create(:measure_type, measure_type_id: excluded_pr_for_xi)
-          measure = create(:measure, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: heading.goods_nomenclature_sid)
+          measure = create(:measure, :with_base_regulation, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: heading.goods_nomenclature_sid)
 
           expect(heading.measures.map(&:measure_sid)).to include measure.measure_sid
         end
@@ -97,21 +97,21 @@ RSpec.describe Heading do
 
         it 'does not include measures that were also excluded for the UK service' do
           measure_type = create(:measure_type, measure_type_id: excluded_for_both_uk_xi)
-          measure = create(:measure, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: heading.goods_nomenclature_sid)
+          measure = create(:measure, :with_base_regulation, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: heading.goods_nomenclature_sid)
 
           expect(heading.measures.map(&:measure_sid)).not_to include measure.measure_sid
         end
 
         it 'does not include quota measures that are only excluded for the XI service' do
           measure_type = create(:measure_type, measure_type_id: excluded_quota_for_xi)
-          measure = create(:measure, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: heading.goods_nomenclature_sid)
+          measure = create(:measure, :with_base_regulation, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: heading.goods_nomenclature_sid)
 
           expect(heading.measures.map(&:measure_sid)).not_to include measure.measure_sid
         end
 
         it 'does not include national P&R national measures that are only excluded for the XI service' do
           measure_type = create(:measure_type, measure_type_id: excluded_pr_for_xi)
-          measure = create(:measure, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: heading.goods_nomenclature_sid)
+          measure = create(:measure, :with_base_regulation, measure_type_id: measure_type.measure_type_id, goods_nomenclature_sid: heading.goods_nomenclature_sid)
 
           expect(heading.measures.map(&:measure_sid)).not_to include measure.measure_sid
         end

--- a/spec/models/meursing_measure_spec.rb
+++ b/spec/models/meursing_measure_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe MeursingMeasure do
     let(:meursing_measure) do
       create(
         :measure,
+        :with_base_regulation,
         additional_code_id: '000',
         additional_code_type_id: '7',
         goods_nomenclature: nil,
@@ -17,7 +18,7 @@ RSpec.describe MeursingMeasure do
       )
     end
 
-    let(:regular_measure) { create(:measure) }
+    let(:regular_measure) { create(:measure, :with_base_regulation) }
 
     context 'when there are meursing measures' do
       let(:measures) { [regular_measure, meursing_measure] }
@@ -37,7 +38,7 @@ RSpec.describe MeursingMeasure do
   end
 
   describe '#current?' do
-    subject(:meursing_measure) { build(:meursing_measure, validity_end_date: validity_end_date, base_regulation_effective_end_date: validity_end_date) }
+    subject(:meursing_measure) { create(:meursing_measure, :with_base_regulation, validity_end_date: validity_end_date, base_regulation_effective_end_date: validity_end_date) }
 
     around { |example| TimeMachine.now { example.run } }
 

--- a/spec/presenters/api/v2/measures/measure_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_presenter_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Api::V2::Measures::MeasurePresenter do
   subject(:presenter) { described_class.new(measure, measure.goods_nomenclature) }
 
-  let(:measure) { create(:measure) }
+  let(:measure) { create(:measure, :with_base_regulation) }
 
   describe '#legal_acts' do
     it 'will be mapped through the MeasureLegalActPresenter' do

--- a/spec/serializers/cache/heading_serializer_spec.rb
+++ b/spec/serializers/cache/heading_serializer_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Cache::HeadingSerializer do
     create(
       :measure,
       :with_measure_type,
+      :with_base_regulation,
       :third_country,
       goods_nomenclature: commodity,
       goods_nomenclature_sid: commodity.goods_nomenclature_sid,

--- a/spec/services/cached_commodity_service_spec.rb
+++ b/spec/services/cached_commodity_service_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe CachedCommodityService do
       allow(Rails.cache).to receive(:fetch).and_call_original
       measure = create(
         :measure,
+        :with_base_regulation,
         goods_nomenclature: commodity,
         goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
         goods_nomenclature_sid: commodity.goods_nomenclature_sid,

--- a/spec/services/heading_service/cached_heading_service_spec.rb
+++ b/spec/services/heading_service/cached_heading_service_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe HeadingService::CachedHeadingService do
         end
         let!(:measure) do
           create :measure,
+                :with_base_regulation,
                  measure_type_id: measure_type.measure_type_id,
                  goods_nomenclature: commodity,
                  goods_nomenclature_sid: commodity.goods_nomenclature_sid


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1318

### What?

I have added/removed/altered:

- [x] Added trait for the default/implicit behaviour of creating a base regulation on every measure create
- [x] Updated consumers that need the base regulation to be there

### Why?

I am doing this because:

- To avoid coupling
- To enable tests of the base regulation filtering on a measure
