### PR TITLE
Optimize headings

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -3,7 +3,7 @@ module Declarable
   include Formatter
 
   included do
-    one_to_many :measures, primary_key: {}, key: {}, dataset: -> {
+    one_to_many :measures, primary_key: {}, key: {} do |ds|
       Measure.join(
         Measure.with_base_regulations
                .with_actual(BaseRegulation)
@@ -45,7 +45,7 @@ module Declarable
               Sequel.desc(:effective_start_date)),
         t1__measure_sid: :measures__measure_sid
       )
-    }
+    end
 
     one_to_many :import_measures, key: {}, primary_key: {}, dataset: -> {
       measures_dataset.join(:measure_types, measure_types__measure_type_id: :measures__measure_type_id)

--- a/app/presenters/api/v2/headings/chapter_presenter.rb
+++ b/app/presenters/api/v2/headings/chapter_presenter.rb
@@ -1,0 +1,11 @@
+module Api
+  module V2
+    module Headings
+      class ChapterPresenter < SimpleDelegator
+        def guide_ids
+          guides.map(&:id)
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/api/v2/headings/commodity_presenter.rb
+++ b/app/presenters/api/v2/headings/commodity_presenter.rb
@@ -1,0 +1,36 @@
+module Api
+  module V2
+    module Headings
+      class CommodityPresenter < SimpleDelegator
+        def initialize(commodity, overview_measures)
+          @commodity = commodity
+          @overview_measures = overview_measures
+
+          super commodity
+        end
+
+        attr_accessor :leaf, :parent_sid # Managed by the AnnotatedCommodityService
+
+        def overview_measure_ids
+          @overview_measures.map(&:id)
+        end
+
+        def overview_measures
+          @overview_measures.map { |measure| Api::V2::Headings::OverviewMeasurePresenter.new(measure, self) }
+        end
+
+        delegate :number_indents, to: :goods_nomenclature_indent, allow_nil: true
+
+        delegate :description, to: :goods_nomenclature_description, allow_nil: true
+
+        delegate :description_plain, to: :goods_nomenclature_description, allow_nil: true
+
+        delegate :formatted_description, to: :goods_nomenclature_description, allow_nil: true
+
+        def producline_suffix
+          goods_nomenclature_indent.productline_suffix
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/api/v2/headings/heading_presenter.rb
+++ b/app/presenters/api/v2/headings/heading_presenter.rb
@@ -1,0 +1,52 @@
+module Api
+  module V2
+    module Headings
+      class HeadingPresenter < SimpleDelegator
+        delegate :id, to: :section, prefix: true, allow_nil: true
+        delegate :id, to: :chapter, prefix: true, allow_nil: true
+
+        def self.build(heading)
+          presented = new(heading)
+
+          AnnotatedCommodityService.new(presented).call
+
+          presented
+        end
+
+        def commodity_ids
+          commodities.map(&:id)
+        end
+
+        def footnote_ids
+          footnotes.map(&:id)
+        end
+
+        def chapter
+          super ? Api::V2::Headings::ChapterPresenter.new(super) : nil
+        end
+
+        def commodities
+          @commodities ||= begin
+            eager_loaded_commodities = commodities_dataset.eager(
+              :goods_nomenclature_indents,
+              :goods_nomenclature_descriptions,
+            )
+
+            eager_loaded_commodities.map do |commodity|
+              eager_loaded_overview_measures = commodity.overview_measures_dataset.eager(
+                { measure_type: :measure_type_description },
+                {
+                  measure_components: [
+                    { duty_expression: :duty_expression_description },
+                  ],
+                },
+              )
+
+              Api::V2::Headings::CommodityPresenter.new(commodity, eager_loaded_overview_measures)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/api/v2/headings/overview_measure_presenter.rb
+++ b/app/presenters/api/v2/headings/overview_measure_presenter.rb
@@ -1,0 +1,38 @@
+module Api
+  module V2
+    module Headings
+      class OverviewMeasurePresenter < SimpleDelegator
+        def initialize(measure, commodity)
+          @measure = measure
+          @commodity = commodity
+
+          super measure
+        end
+
+        def vat
+          vat?
+        end
+
+        def duty_expression_id
+          "#{measure_sid}-duty_expression"
+        end
+
+        def duty_expression
+          Hashie::TariffMash.new(
+            id: duty_expression_id,
+            base: duty_expression_with_national_measurement_units_for(@commodity),
+            formatted_base: formatted_duty_expression_with_national_measurement_units_for(@commodity),
+          )
+        end
+
+        def effective_start_date
+          super&.strftime('%FT%T.%LZ')
+        end
+
+        def effective_end_date
+          super&.strftime('%FT%T.%LZ')
+        end
+      end
+    end
+  end
+end

--- a/app/services/cached_subheading_service.rb
+++ b/app/services/cached_subheading_service.rb
@@ -28,6 +28,7 @@ class CachedSubheadingService
 
   def presented_subheading
     @presented_subheading ||= begin
+                                Api::V2::Headings::HeadingPresenter.new(@subheading)
       presenter_serialized = Cache::HeadingSerializer.new(@subheading).as_json
 
       # We use Hashie::TariffMash as a proxy for mutating state on something that acts like a Heading and replaces the presenter pattern we use elsewhere

--- a/app/services/heading_service/cached_heading_service.rb
+++ b/app/services/heading_service/cached_heading_service.rb
@@ -1,105 +1,11 @@
 module HeadingService
   class CachedHeadingService
-    attr_reader :heading, :as_of, :result
-
-    def initialize(heading, as_of)
+    def initialize(heading)
       @heading = heading
-      @as_of = as_of
     end
 
-    def serializable_hash
-      @result = fetch_result || serialize_result
-      if result.present? && as_of.present?
-        filter_chapter
-        filter_footnotes
-        filter_commodities
-        filter_commodity_relations
-        build_commodities_tree
-      end
-      result
-    end
-
-    private
-
-    def serialize_result
-      Hashie::TariffMash.new(::Cache::HeadingSerializer.new(heading).as_json)
-    end
-
-    def fetch_result
-      search_client = ::TradeTariffBackend.cache_client
-      index = ::Cache::HeadingIndex.new(TradeTariffBackend.search_namespace).name
-      result = search_client.search index: index, body: { query: { match: { _id: heading.goods_nomenclature_sid } } }
-      result&.hits&.hits&.first&._source
-    end
-
-    def filter_chapter
-      result.delete(:chapter) if result.chapter.present? && !has_valid_dates(result.chapter)
-      result.chapter_id = result.chapter&.goods_nomenclature_sid
-    end
-
-    def filter_footnotes
-      result.footnotes.keep_if do |footnote|
-        has_valid_dates(footnote)
-      end
-      result.footnote_ids = result.footnotes.map do |footnote|
-        footnote.footnote_id
-      end
-    end
-
-    def filter_commodities
-      result.commodities.keep_if do |commodity|
-        has_valid_dates(commodity)
-      end
-      result.commodity_ids = result.commodities.map do |commodity|
-        commodity.goods_nomenclature_sid
-      end
-    end
-
-    def filter_commodity_relations
-      result.commodities.each do |commodity|
-        commodity.overview_measures.keep_if do |measure|
-          has_valid_dates(measure, :effective_start_date, :effective_end_date)
-        end
-
-        commodity.overview_measures = OverviewMeasurePresenter.new(commodity.overview_measures, commodity).validate!
-
-        commodity.overview_measure_ids = commodity.overview_measures.map do |measure|
-          measure.measure_sid
-        end
-
-        commodity.goods_nomenclature_indents.keep_if do |ident|
-          has_valid_dates(ident)
-        end
-
-        indent = commodity.goods_nomenclature_indents.sort_by do |ident|
-          Date.parse ident.validity_start_date
-        end.last
-
-        commodity.number_indents = indent.number_indents
-        commodity.producline_suffix = indent.productline_suffix
-
-        commodity.goods_nomenclature_descriptions.keep_if do |description|
-          has_valid_dates(description)
-        end
-
-        description = commodity.goods_nomenclature_descriptions.sort_by do |description|
-          Date.parse description.validity_start_date
-        end.last
-
-        commodity.description = description.description
-        commodity.formatted_description = description.formatted_description
-        commodity.description_plain = description.description_plain
-      end
-    end
-
-    # TODO: Use the TimeMachine plugin to filter the correct associated entities
-    def has_valid_dates(hash, start_key = :validity_start_date, end_key = :validity_end_date)
-      hash[start_key].to_date <= as_of &&
-        (hash[end_key].nil? || hash[end_key].to_date >= as_of)
-    end
-
-    def build_commodities_tree
-      AnnotatedCommodityService.new(result).call
+    def call
+      Api::V2::Headings::HeadingPresenter.build(@heading)
     end
   end
 end

--- a/app/services/heading_service/heading_serialization_service.rb
+++ b/app/services/heading_service/heading_serialization_service.rb
@@ -78,17 +78,19 @@ module HeadingService
         end
       else
         Rails.cache.fetch("_#{heading_cache_key}", expires_in: 24.hours) do
-          service = HeadingService::CachedHeadingService.new(heading, actual_date)
-          hash = service.serializable_hash
+          service = HeadingService::CachedHeadingService.new(heading)
+          hash = service.call
           options = { is_collection: false }
-          options[:include] = [:section,
-                               :chapter,
-                               'chapter.guides',
-                               :footnotes,
-                               :commodities,
-                               'commodities.overview_measures',
-                               'commodities.overview_measures.duty_expression',
-                               'commodities.overview_measures.measure_type']
+          options[:include] = [
+            :section,
+            :chapter,
+            'chapter.guides',
+            :footnotes,
+            :commodities,
+            'commodities.overview_measures',
+            'commodities.overview_measures.duty_expression',
+            'commodities.overview_measures.measure_type',
+          ]
           Api::V2::Headings::HeadingSerializer.new(hash, options).serializable_hash
         end
       end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   config.cache_store = [:null_store]
 
   # enable sequel transaction logs by setting RAILS_LOG_LEVEL=debug
-  config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info').to_sym
+  config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'debug').to_sym
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/spec/controllers/api/v2/headings_controller_spec.rb
+++ b/spec/controllers/api/v2/headings_controller_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Api::V2::HeadingsController, type: :controller do
       create(
         :heading,
         :non_grouping,
-        :non_declarable,
         :with_description,
       )
     end
@@ -20,22 +19,34 @@ RSpec.describe Api::V2::HeadingsController, type: :controller do
     end
 
     context 'when the heading is not declarable' do
-      before { chapter }
-
-      let(:heading) do
-        create(
-          :heading,
-          :non_grouping,
-          :non_declarable,
-          :with_description,
-        )
+      before do
+        chapter
+        heading
+        commodity
       end
 
       let(:chapter) do
         create(
           :chapter,
           :with_section, :with_description,
-          goods_nomenclature_item_id: heading.chapter_id
+          goods_nomenclature_item_id: '0100000000'
+        )
+      end
+
+      let(:heading) do
+        create(
+          :heading,
+          :with_description,
+          goods_nomenclature_item_id: '0101000000',
+        )
+      end
+
+      let(:commodity) do
+        create(
+          :commodity,
+          :with_description,
+          goods_nomenclature_item_id: '0101290000',
+          producline_suffix: '10',
         )
       end
 

--- a/spec/serializers/api/v2/headings/heading_serializer_spec.rb
+++ b/spec/serializers/api/v2/headings/heading_serializer_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Api::V2::Headings::HeadingSerializer do
   subject(:serializer) { described_class.new(serializable).serializable_hash.as_json }
 
-  let(:serializable) { HeadingService::CachedHeadingService.new(heading, actual_date).serializable_hash }
+  let(:serializable) { Api::V2::Headings::HeadingPresenter.new(heading) }
 
   let(:heading) do
     create(


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Added presenters for the heading endpoint that use eager to preload all of the relationships for each heading commodity
- [ ] Added worker to preload headings into redis as part of our morning ETL

### Why?

I am doing this because:

- We preload all of the heading as part of the morning ETL currently in elastic search. As far as I can see there is no need for this extra layer - we should be able to preload expensive headings in redis
