### PR TITLE
HOTT-1244: Update downloads to handle long rollbacks in XI

### DIFF
--- a/app/lib/tariff_synchronizer.rb
+++ b/app/lib/tariff_synchronizer.rb
@@ -69,7 +69,7 @@ module TariffSynchronizer
 
     TradeTariffBackend.with_redis_lock do
       instrument('download.tariff_synchronizer') do
-        TaricUpdate.sync
+        TradeTariffBackend.patch_broken_taric_downloads? ? TaricUpdate.sync_patched : TaricUpdate.sync
       rescue TariffUpdatesRequester::DownloadException => e
         instrument('failed_download.tariff_synchronizer', exception: e)
         raise e.original

--- a/app/lib/tariff_synchronizer/taric_update_downloader_patched.rb
+++ b/app/lib/tariff_synchronizer/taric_update_downloader_patched.rb
@@ -2,33 +2,46 @@ module TariffSynchronizer
   # Download pending updates TARIC files
   #
   # This behaves slighlty differently from the TaricUpdateDownloader in that it downloads updates based off of the
-  # most recent update filename sequence.
+  # most recent update filename sequence and continues trying new updates until the api responds with not found.
   #
   # This should be removed once the Taric api responds correctly
   class TaricUpdateDownloaderPatched
     def initialize(update)
-      @local_filename = update.filename
-      @issue_date = update.issue_date
-      @url_filename = update.url_filename
+      @update = update
     end
 
     def perform
-      return if check_file_already_downloaded?
+      return if update_exists?
 
-      TariffDownloader.new(@local_filename, url, @issue_date, TariffSynchronizer::TaricUpdate).perform
+      downloader = download(@update)
+
+      while downloader.success?
+        @update = @update.next_update
+
+        downloader = download(@update)
+      end
     end
 
     private
 
-    def check_file_already_downloaded?
-      TaricUpdate.find(filename: @local_filename).present?
+    def download(update)
+      TariffDownloader.new(
+        update.filename,
+        url_for(update),
+        update.issue_date,
+        TariffSynchronizer::TaricUpdate,
+      ).tap(&:perform)
     end
 
-    def url
+    def update_exists?
+      TaricUpdate.find(filename: @update.filename).present?
+    end
+
+    def url_for(update)
       sprintf(
         TariffSynchronizer.taric_update_url_template,
         host: TariffSynchronizer.host,
-        filename: @url_filename,
+        filename: update.url_filename,
       )
     end
   end

--- a/app/lib/tariff_synchronizer/tariff_downloader.rb
+++ b/app/lib/tariff_synchronizer/tariff_downloader.rb
@@ -3,13 +3,15 @@ module TariffSynchronizer
   class TariffDownloader
     delegate :instrument, :subscribe, to: ActiveSupport::Notifications
 
-    attr_reader :filename, :url, :date, :update_klass
+    attr_reader :filename, :url, :date, :update_klass, :success
+    alias_method :success?, :success
 
     def initialize(filename, url, date, update_klass)
       @filename = filename
       @url = url
       @date = date
       @update_klass = update_klass
+      @success = false
     end
 
     def perform
@@ -24,6 +26,8 @@ module TariffSynchronizer
 
     def create_entry
       return if tariff_update.present?
+
+      @success = true
 
       update_or_create(filename, BaseUpdate::PENDING_STATE, filesize)
       instrument('created_tariff.tariff_synchronizer', date: date, filename: filename, type: update_klass.update_type)
@@ -60,12 +64,14 @@ module TariffSynchronizer
     end
 
     # We do not create records for missing updates
-    def create_record_for_not_found_response; end
+    def create_record_for_not_found_response
+    end
 
     def create_record_for_successful_response
       update_klass.validate_file!(response.content) # Validate response
       update_or_create(filename, BaseUpdate::PENDING_STATE, response.content.size)
       write_update_file(response.content)
+      @success = true
     rescue BaseUpdate::InvalidContents => e
       persist_exception_for_review(e)
     end

--- a/spec/unit/tariff_synchronizer_spec.rb
+++ b/spec/unit/tariff_synchronizer_spec.rb
@@ -30,6 +30,20 @@ RSpec.describe TariffSynchronizer, truncation: true do
         allow(described_class::TaricUpdate).to receive(:sync).and_return(true)
         described_class.download
       end
+
+      context 'when patch_broken_taric_downloads is set to true' do
+        before do
+          allow(TradeTariffBackend).to receive(:patch_broken_taric_downloads?).and_return(true)
+        end
+
+        it 'invokes update downloading/syncing on all update types' do
+          allow(described_class::TaricUpdate).to receive(:sync_patched).and_return(true)
+
+          described_class.download
+
+          expect(described_class::TaricUpdate).to have_received(:sync_patched)
+        end
+      end
     end
 
     context 'when sync variables are not set' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1244

### What?

I have added/removed/altered:

- [x] Altered patch download behaviour to continue downloading until we stop finding files
- [x] Altered existing tests for the new patched download behaviour

### Why?

I am doing this because:

- We are about to do a long rollback and whilst we can't distinguish between an actual 404 and a new year/or a genuinely non present file we can bail at the point the next increment isn't there. This will enable me to rollback a long way and bring us up-to-date with the patched downloader a year at a time.
