### PR TITLE
Fix subheading footnotes

### DIFF
--- a/app/models/footnote.rb
+++ b/app/models/footnote.rb
@@ -60,24 +60,9 @@ class Footnote < Sequel::Model
     end
   end
 
-  # FO4
-  # length_of :footnote_description_periods, minimum: 1
-  # # FO4
-  # associated :footnote_description_periods, ensure: :first_footnote_description_period_is_valid
-  # # FO5, FO6, FO7, FO9, FO10
-  # associated [:measures,
-  #             :goods_nomenclatures,
-  #             :export_refund_nomenclatures,
-  #             :additional_codes,
-  #             :meursing_headings], ensure: :spans_validity_period_of_associations
-  # # FO17
-  # associated :footnote_type, ensure: :footnote_type_validity_period_spans_validity_periods
-
   def code
     "#{footnote_type_id}#{footnote_id}"
   end
 
-  def id
-    code
-  end
+  alias_method :id, :code
 end

--- a/app/serializers/api/v2/subheadings/footnote_serializer.rb
+++ b/app/serializers/api/v2/subheadings/footnote_serializer.rb
@@ -6,7 +6,7 @@ module Api
 
         set_type :footnote
 
-        set_id :footnote_id
+        set_id :id
 
         attributes :code, :description, :formatted_description
       end

--- a/app/serializers/cache/heading_serializer.rb
+++ b/app/serializers/cache/heading_serializer.rb
@@ -71,6 +71,7 @@ module Cache
 
       heading_attributes[:footnotes] = heading.footnotes.map do |footnote|
         {
+          id: footnote.id,
           footnote_id: footnote.footnote_id,
           validity_start_date: footnote.validity_start_date&.strftime('%FT%T.%LZ'),
           validity_end_date: footnote.validity_end_date,

--- a/spec/serializers/api/v2/subheadings/footnote_serializer_spec.rb
+++ b/spec/serializers/api/v2/subheadings/footnote_serializer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Api::V2::Subheadings::FootnoteSerializer do
   let(:expected_pattern) do
     {
       data: {
-        id: serializable.footnote_id,
+        id: 'TR037',
         type: 'footnote',
         attributes: {
           code: 'TR037',

--- a/spec/serializers/cache/heading_serializer_spec.rb
+++ b/spec/serializers/cache/heading_serializer_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe Cache::HeadingSerializer do
         },
         footnotes: [
           {
+            id: String,
             footnote_id: String,
             validity_start_date: String,
             validity_end_date: nil,


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?
 
When there are footnotes for a subheading we want to present them under the footnotes in the UI. In the current implementation we were returning footnotes but the ids were never matching up/were using the wrong id.

I have added/removed/altered:

- [x] Altered the footnote serializers and presenters to consistently use the composite primary key that uniquely identifies the current footnote

### Why?

I am doing this because:

- We were getting a garbled jsonapi result which was breaking the frontend integration on subheadings with their own footnotes
