### PR TITLE
HOTT-1270 Use a connection pool for RedLock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'aws-sdk-s3'
 gem 'rubyzip'
 
 # Background jobs
+gem 'connection_pool'
 gem 'redis-rails'
 gem 'redlock'
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,6 +458,7 @@ DEPENDENCIES
   aws-sdk-s3
   bootsnap
   brakeman
+  connection_pool
   curb
   database_cleaner-sequel
   dotenv-rails

--- a/config/initializers/redis_lock_db.rb
+++ b/config/initializers/redis_lock_db.rb
@@ -1,11 +1,30 @@
 module RedisLockDb
+  DEFAULT_POOL_SIZE = 10
+
   class << self
-    def redis= redis
-      @redis = redis
-    end
+    delegate :logger, to: Rails
+    attr_writer :redis
 
     def redis
-      @redis ||= Sidekiq.redis { |conn| conn }
+      @redis ||= build_connection_pool
+    end
+
+  private
+
+    def pool_size
+      if Sidekiq.server?
+        Sidekiq.options[:concurrency] || DEFAULT_POOL_SIZE
+      else
+        Integer(ENV['RAILS_MAX_THREADS'].presence || ENV['MAX_THREADS'].presence || DEFAULT_POOL_SIZE)
+      end
+    end
+
+    def build_connection_pool
+      logger.info "Initialising Redlock connection pool with #{pool_size} connections"
+
+      ConnectionPool.new(size: pool_size) do
+        Redis.new PaasConfig.redis
+      end
     end
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-1270](https://transformuk.atlassian.net/browse/HOTT-1270)

### What?

I have added/removed/altered:

- [x] Added a connection pool for Redlock

### Why?

I am doing this because:

Whilst working on the CDS rollback and reapply a few weeks ago we observed that scheduling a rollback didn't work, but did then subsequently ran much later on. I had observed similar behaviour whilst dealing with another CDS rollback some months prior but I'd only just started on the project and assumed I was doing something wrong.

The issue turns out to be redlock hanging waiting to acquire a lock - I can reliably reproduce this by scheduling a rollback, then a roll forward. This will result in hang between 1 and 3 iterations - killing sidekiq then causes the job to run on shutdown. Potentially much later then expected.

I believe this is caused by our Redlock configuration which is not thread safe but being used in a Sidekiq environment which is threaded. We use the Sidekiq redis client - but that is a single client, not a pool of clients. Redlock can work with a pool if provided with one (and if given a single redis client it actually monkey patches it to behave like its a connection pool).

### Deployment risks (optional)

- This impacts the critical nightly sync job so should be well tested prior to roll out to production - plan is to leave it on DEV over the weekend and see how it fairs.

### Notes

I believe this is also the underlying issue affecting the CDS sync retry code.
