### PR TITLE
HOTT-1332: Reload stale goods nomenclature

### DIFF
--- a/app/lib/goods_nomenclature_mapper.rb
+++ b/app/lib/goods_nomenclature_mapper.rb
@@ -70,6 +70,7 @@ class GoodsNomenclatureMapper
   end
 
   def map_goods_nomenclatures(primary, secondary)
+    reload_if_stale(primary)
     reload_if_stale(secondary)
 
     if (heading_map?(primary, secondary) &&


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1332

### What?

I have added/removed/altered:

- [x] Added reload of goods nomenclature to the primary

See https://sentry.io/organizations/engine-le/issues/3015912710/?project=5557005&referrer=slac

### Why?

I am doing this because:

- See linked open sentry issue
