### PR TITLE
[HOTT-1312] Elasticsearch migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,14 +271,14 @@ jobs:
       - image: circleci/redis:4.0.9
         environment:
           - REDIS_URL: "redis://localhost:6379/"
-      - image: docker.elastic.co/elasticsearch/elasticsearch:7.9.3
+      - image: opensearchproject/opensearch:1.2.4
         environment:
           - cluster.name: elasticsearch
-          - xpack.security.enabled: false
           - transport.host: localhost
           - network.host: 127.0.0.1
           - http.port: 9200
           - discovery.type: single-node
+          - plugins.security.disabled: true
     resource_class: medium
     steps:
       - checkout

--- a/app/lib/paas_config.rb
+++ b/app/lib/paas_config.rb
@@ -6,28 +6,28 @@ module PaasConfig
       # TODO: !Important
       # need to fetch by service name if we use multiple redis services
       JSON.parse(ENV['VCAP_SERVICES'])['redis'][0]['credentials']['uri']
-    rescue
+    rescue StandardError
       ENV['REDIS_URL']
     end
 
-    { url: url, db: 0, id: nil }
+    { url: url, db: 0, id: nil } # rubocop:disable Style/HashSyntax
   end
 
   def elasticsearch
     url = begin
       # TODO: !Important
       # need to fetch by service name if we use multiple elasticsearch services
-      JSON.parse(ENV['VCAP_SERVICES'])['elasticsearch'][0]['credentials']['uri']
-    rescue
+      JSON.parse(ENV['VCAP_SERVICES'])['opensearch'][0]['credentials']['uri']
+    rescue StandardError
       ENV['ELASTICSEARCH_URL']
     end
 
-    { url: url }
+    { url: url } # rubocop:disable Style/HashSyntax
   end
 
   def space
     JSON.parse(ENV['VCAP_APPLICATION'])['space_name']
-  rescue
+  rescue StandardError
     Rails.env
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,27 +20,30 @@ services:
       - 127.0.0.1:5432:5432
     volumes:
       - hmrc-postgres:/var/lib/postgresql/data
-  hmrc-elasticsearch:
-    container_name: hmrc-elasticsearch
-    image: elasticsearch:7.9.3
+  hmrc-opensearch:
+    container_name: hmrc-opensearch
+    image: opensearchproject/opensearch:1.2.4
     ports:
       - 127.0.0.1:9200:9200
       - 127.0.0.1:9300:9300
     environment:
         - bootstrap.memory_lock=true
         - discovery.type=single-node
-        - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
+        - "OPENSEARCH_JAVA_OPTS=-Xms2g -Xmx2g"
         - cluster.routing.allocation.disk.threshold_enabled=false
     ulimits:
         memlock:
             soft: -1
             hard: -1
+        nofile:
+          soft: 65536
+          hard: 65536
     healthcheck:
       interval: 60s
       retries: 10
       test: curl -s http://localhost:9200/_cluster/health | grep -vq '"status":"red"'
     volumes:
-    - hmrc-es:/usr/share/elasticsearch/data
+    - hmrc-os:/usr/share/opensearch/data
 
 volumes:
   dev-env-redis-volume:
@@ -49,7 +52,7 @@ volumes:
     driver: local
   hmrc-postgres:
     driver: local
-  hmrc-es:
+  hmrc-os:
     driver: local
 
 


### PR DESCRIPTION
In order to migrate our elasticsearch nodes to opensearch we need to move the connection information to the newly created opensearch nodes. They work correctly with the current elasticsearch gem and have been tested. I will be providing a follow up PR to normalize some of the references of 'elasticsearch' where possible and provide some comment around the move from an infrastructure perspective in confluence.

- Removed disabling of xpack plugin and added `plugins.security.disabled` which disables TLS that's enabled by default (ES did not have this feature enabled by default). We require this in CI.
- Corrected issues with rubocop linting.
- Moved docker-compose to use opensearch.
- Disabled Style/HashSyntax due to a problem with ruby_parser and 3.1 syntax when interacting with Brakeman
- Moved rescue to use elasticsearch vs environment variable of elasticsearch URL for some resiliency whilst we're migrating

Due to the blocking nature of binding/unbinding services and the endpoint changes this'll be done out of hours and won't incur downtime as the applications swap over, it's more that it would get in the way of development processes.

As there's no 'automated' rollback I'll also create another PR for ```s/JSON.parse(ENV['VCAP_SERVICES'])['opensearch'][0]['credentials']['uri']/JSON.parse(ENV['VCAP_SERVICES'])['elasticsearch'][0]['credentials']['uri']``` should the rescue not be enough.