### PR TITLE
HOTT-1341: Avoid collisions in meursing additional code values

### DIFF
--- a/app/controllers/api/v2/commodities_controller.rb
+++ b/app/controllers/api/v2/commodities_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V2
     class CommoditiesController < ApiController
       before_action :find_commodity, only: %i[show changes]
-      before_action :set_meursing_additional_code, only: :show
+      around_action :configure_meursing_additional_code, only: :show
 
       def show
         render json: cached_commodity
@@ -50,8 +50,12 @@ module Api
         end
       end
 
-      def set_meursing_additional_code
+      def configure_meursing_additional_code
         Thread.current[:meursing_additional_code_id] = filter_params[:meursing_additional_code_id]
+
+        yield
+      ensure
+        Thread.current[:meursing_additional_code_id] = nil
       end
     end
   end

--- a/spec/factories/goods_nomenclature_factory.rb
+++ b/spec/factories/goods_nomenclature_factory.rb
@@ -50,6 +50,46 @@ FactoryBot.define do
       end
     end
 
+    trait :with_meursing_measures do
+      after(:create) do |goods_nomenclature, _evaluator|
+        root_measure = create(
+          :measure,
+          :third_country,
+          :with_base_regulation,
+          goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
+          goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
+          geographical_area_id: '1011',
+        )
+
+        # Ad valorem measure component
+        create(
+          :measure_component,
+          :with_duty_expression,
+          measure_sid: root_measure.measure_sid,
+          duty_expression_id: '01',
+        )
+        # Placeholder meursing measure component - agricultural component
+        create(
+          :measure_component,
+          :with_duty_expression,
+          measure_sid: root_measure.measure_sid,
+          duty_expression_id: '12',
+        )
+
+        root_measure.reload
+
+        meursing_agricultural_measure = create(:measure, :agricultural, geographical_area_id: '1011')
+
+        create(
+          :measure_component,
+          duty_amount: 0.0,
+          monetary_unit_code: 'EUR',
+          measurement_unit_code: 'DTN',
+          measure_sid: meursing_agricultural_measure.measure_sid,
+        )
+      end
+    end
+
     trait :actual do
       validity_start_date { Date.current.ago(3.years) }
       validity_end_date   { nil }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1341

### What?

I have added/removed/altered:

- [x] Added around_action hook to safely manage meursing additional codes

### Why?

I am doing this because:

- This is required to avoid colliding meursing additional code behaviour
