### PR TITLE
HOTT-1342: Adjust balance to initial volume when no balance events

### DIFF
--- a/app/models/quota_definition.rb
+++ b/app/models/quota_definition.rb
@@ -58,7 +58,7 @@ class QuotaDefinition < Sequel::Model
   end
 
   def balance
-    last_balance_event.present? ? last_balance_event.new_balance : volume
+    last_balance_event.present? ? last_balance_event.new_balance : initial_volume
   end
 
   def last_suspension_period

--- a/spec/factories/quota_factory.rb
+++ b/spec/factories/quota_factory.rb
@@ -74,8 +74,10 @@ FactoryBot.define do
     end
 
     trait :with_quota_balance_events do
-      after(:create) do |quota_definition, _evaluator|
-        create(:quota_balance_event, quota_definition: quota_definition)
+      transient { event_new_balance { 100 } }
+
+      after(:create) do |quota_definition, evaluator|
+        create(:quota_balance_event, quota_definition:, new_balance: evaluator.event_new_balance)
       end
     end
 

--- a/spec/models/quota_definition_spec.rb
+++ b/spec/models/quota_definition_spec.rb
@@ -28,4 +28,42 @@ RSpec.describe QuotaDefinition do
       end
     end
   end
+
+  describe '#balance' do
+    around do |example|
+      TimeMachine.at(Time.zone.today) do
+        example.run
+      end
+    end
+
+    context 'when there are quota balance events' do
+      subject(:quota_definition) do
+        create(
+          :quota_definition,
+          :with_quota_balance_events,
+          event_new_balance: 6500,
+          volume: 6501,
+          initial_volume: 6502,
+        )
+      end
+
+      it 'returns the new balance of the quota balance event' do
+        expect(quota_definition.balance).to eq(6500)
+      end
+    end
+
+    context 'when there are no quota balance events' do
+      subject(:quota_definition) do
+        create(
+          :quota_definition,
+          volume: 6501,
+          initial_volume: 6502,
+        )
+      end
+
+      it 'returns initial volume' do
+        expect(quota_definition.balance).to eq(6502)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1342

### What?

I have added/removed/altered:

- [x] Altered QuotaDefinition#balance such that it uses the initial_volume when there are no balance events

### Why?

I am doing this because:

- This is the correct behaviour
