### PR TITLE
HOTT-1343: Filter regulation measures correctly

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -2,6 +2,19 @@ module Declarable
   extend ActiveSupport::Concern
   include Formatter
 
+  COMMON_UNION_MEASURE_ORDER = [
+    Sequel.desc(:measures__measure_generating_regulation_id),
+    Sequel.desc(:measures__measure_generating_regulation_role),
+    Sequel.desc(:measures__measure_type_id),
+    Sequel.desc(:measures__goods_nomenclature_sid),
+    Sequel.desc(:measures__geographical_area_id),
+    Sequel.desc(:measures__geographical_area_sid),
+    Sequel.desc(:measures__additional_code_type_id),
+    Sequel.desc(:measures__additional_code_id),
+    Sequel.desc(:measures__ordernumber),
+    Sequel.desc(:effective_start_date),
+  ].freeze
+
   included do
     one_to_many :measures, primary_key: {}, key: {}, dataset: -> {
       Measure.join(
@@ -9,14 +22,14 @@ module Declarable
                .with_actual(BaseRegulation)
                .where({ measures__goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid) })
                .where { Sequel.~(measures__measure_type_id: MeasureType.excluded_measure_types) }
-               .order(Sequel.desc(:measures__measure_generating_regulation_id), Sequel.desc(:measures__measure_type_id), Sequel.desc(:measures__goods_nomenclature_sid), Sequel.desc(:measures__geographical_area_id), Sequel.desc(:measures__geographical_area_sid), Sequel.desc(:measures__additional_code_type_id), Sequel.desc(:measures__additional_code_id), Sequel.desc(:measures__ordernumber), Sequel.desc(:effective_start_date))
+               .order(*COMMON_UNION_MEASURE_ORDER)
                .tap! { |query|
                  query.union(
                    Measure.with_base_regulations
                      .with_actual(BaseRegulation)
                      .where({ measures__export_refund_nomenclature_sid: export_refund_uptree.map(&:export_refund_nomenclature_sid) })
                      .where { Sequel.~(measures__measure_type_id: MeasureType.excluded_measure_types) }
-                     .order(Sequel.desc(:measures__measure_generating_regulation_id), Sequel.desc(:measures__measure_type_id), Sequel.desc(:measures__goods_nomenclature_sid), Sequel.desc(:measures__geographical_area_id), Sequel.desc(:measures__geographical_area_sid), Sequel.desc(:measures__additional_code_type_id), Sequel.desc(:measures__additional_code_id), Sequel.desc(:measures__ordernumber), Sequel.desc(:effective_start_date))
+                     .order(*COMMON_UNION_MEASURE_ORDER)
                  ) if export_refund_uptree.present?
                }
        .union(
@@ -24,14 +37,14 @@ module Declarable
                 .with_actual(ModificationRegulation)
                 .where({ measures__goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid) })
                 .where { Sequel.~(measures__measure_type_id: MeasureType.excluded_measure_types) }
-                .order(Sequel.desc(:measures__measure_generating_regulation_id), Sequel.desc(:measures__measure_type_id), Sequel.desc(:measures__goods_nomenclature_sid), Sequel.desc(:measures__geographical_area_id), Sequel.desc(:measures__geographical_area_sid), Sequel.desc(:measures__additional_code_type_id), Sequel.desc(:measures__additional_code_id), Sequel.desc(:measures__ordernumber), Sequel.desc(:effective_start_date))
+                .order(*COMMON_UNION_MEASURE_ORDER)
                 .tap! { |query|
                   query.union(
                     Measure.with_modification_regulations
                            .with_actual(ModificationRegulation)
                            .where({ measures__export_refund_nomenclature_sid: export_refund_uptree.map(&:export_refund_nomenclature_sid) })
                            .where { Sequel.~(measures__measure_type_id: MeasureType.excluded_measure_types) }
-                           .order(Sequel.desc(:measures__measure_generating_regulation_id), Sequel.desc(:measures__measure_type_id), Sequel.desc(:measures__goods_nomenclature_sid), Sequel.desc(:measures__geographical_area_id), Sequel.desc(:measures__geographical_area_sid), Sequel.desc(:measures__additional_code_type_id), Sequel.desc(:measures__additional_code_id), Sequel.desc(:measures__ordernumber), Sequel.desc(:effective_start_date))
+                           .order(*COMMON_UNION_MEASURE_ORDER)
                   ) if export_refund_uptree.present?
                 },
          alias: :measures

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -320,7 +320,8 @@ RSpec.describe Commodity do
       let!(:measure_type) { create :measure_type }
       let!(:modification_regulation) { create :modification_regulation, effective_end_date: Time.zone.now.ago(1.month) }
       let!(:measure1) do
-        create :measure, measure_generating_regulation_id: modification_regulation.modification_regulation_id,
+        create :measure, :with_base_regulation,
+                         measure_generating_regulation_id: modification_regulation.modification_regulation_id,
                          validity_end_date: Time.zone.now.ago(30.months),
                          goods_nomenclature_sid: commodity.goods_nomenclature_sid,
                          validity_start_date: Time.zone.now.ago(10.years),
@@ -328,7 +329,8 @@ RSpec.describe Commodity do
                          geographical_area_sid: 1
       end
       let!(:measure2) do
-        create :measure, measure_generating_regulation_id: modification_regulation.modification_regulation_id,
+        create :measure, :with_base_regulation,
+                         measure_generating_regulation_id: modification_regulation.modification_regulation_id,
                          goods_nomenclature_sid: commodity.goods_nomenclature_sid,
                          measure_type_id: measure_type.measure_type_id,
                          validity_start_date: Time.zone.now.ago(10.years),
@@ -336,7 +338,8 @@ RSpec.describe Commodity do
                          geographical_area_sid: 2
       end
       let!(:measure3) do
-        create :measure, measure_generating_regulation_id: modification_regulation.modification_regulation_id,
+        create :measure, :with_base_regulation,
+                         measure_generating_regulation_id: modification_regulation.modification_regulation_id,
                          goods_nomenclature_sid: commodity.goods_nomenclature_sid,
                          measure_type_id: measure_type.measure_type_id,
                          validity_start_date: Time.zone.now.ago(10.years),
@@ -344,7 +347,7 @@ RSpec.describe Commodity do
                          geographical_area_sid: 3
       end
 
-      it 'measure validity date superseeds regulation validity date' do
+      it 'measure validity date supercedes regulation validity date' do
         measures = TimeMachine.at(Time.zone.now.ago(1.year)) { described_class.actual.first.measures }.map(&:measure_sid)
         expect(measures).to     include measure3.measure_sid
         expect(measures).not_to include measure2.measure_sid


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1343

### What?

I have added/removed/altered:

- [x] Extended distinct regulation filters to actual filter based off of the role/roles that the generating regulation for each union should have
- [x] Adds specs to cover the case where we have multiple base regulations with different roles as well as filtering on modification regulations
- [x] Tidied the ordering of the unioned measures in the declarable implementation

### Why?

I am doing this because:

- We currently show measures that should be end dated because we're not filtering on regulation role and are picking the wrong regulation effective end date
- We need to make sure the base regulation filter includes all possible role ids (this caught us out recently)

## AC

- [x] Representative price no longer pulls back the base_regulation for the effective end date (effectively its gone from the UK data) https://www.trade-tariff.service.gov.uk/commodities/1703100000
- [x] Trade remedies display properly https://www.trade-tariff.service.gov.uk/commodities/1516209821
