### PR TITLE
HOTT-1316: Fixes broken ExactSearch behaviour

### DIFF
--- a/app/services/search_service/exact_search.rb
+++ b/app/services/search_service/exact_search.rb
@@ -69,7 +69,7 @@ class SearchService
     end
 
     def find_search_reference(query)
-      item = SearchReference.where(title: singular_and_plural(query)).first.try(:referenced)
+      item = SearchReference.where(Sequel.function(:lower, :title) => singular_and_plural(query)).first.try(:referenced)
 
       return nil if item && item.try(:validity_end_date) && item.validity_end_date < date
 

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -317,6 +317,24 @@ RSpec.describe SearchService do
         expect(@result).not_to match_json_expression commodity_pattern(commodity)
       end
     end
+
+    context 'search references' do
+      subject(:result) { described_class.new(data_serializer, q: 'Foo Bar', as_of: Date.current).to_json }
+
+      let!(:search_reference) { create(:search_reference, title: 'Foo Bar') }
+
+      let(:expected_pattern) do
+        {
+          type: 'exact_match',
+          entry: {
+            endpoint: 'headings',
+            id: search_reference.referenced_id,
+          },
+        }
+      end
+
+      it { is_expected.to match_json_expression(expected_pattern) }
+    end
   end
 
   # Searching in ElasticSearch index


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1316

### What?

Currently, if we have a title value that has any capitals in it we cannot
match the result with an ExactSearch because the input query gets
downcased in the constructor of BaseSearch.

The net effect of this is to prevent us from being able to query search
references until the ES index for search references is repopulated the
following morning. We see the reference in search suggestions but cannot
fetch the result.

After this change we can pull out search results without needing to
touch the ES index rows.


I have added/removed/altered:

- [x] Added lower casing for the filtering on title for search references
- [x] Added a test case of a search reference with a title with capitals in it

### Why?

I am doing this because:

- This is a broken implementation
- This is a bad user experience
- This forces us to always do an ES AND a psql query
