### PR TITLE
HOTT-1298: Surface quota order numbers.

### DIFF
--- a/app/controllers/api/v2/quota_order_numbers_controller.rb
+++ b/app/controllers/api/v2/quota_order_numbers_controller.rb
@@ -1,11 +1,26 @@
 module Api
   module V2
     class QuotaOrderNumbersController < ApiController
+      TTL = 1.day
+
       def index
-        render json: Api::V2::QuotaOrderNumberSerializer.new(quota_order_numbers, include: [:quota_definition]).serializable_hash
+        render json: serialized_quota_order_numbers
       end
 
       private
+
+      def serialized_quota_order_numbers
+        Rails.cache.fetch(cache_key, expires_in: TTL) do
+          Api::V2::QuotaOrderNumberSerializer.new(
+            quota_order_numbers,
+            include: [:quota_definition],
+          ).serializable_hash
+        end
+      end
+
+      def cache_key
+        "_quota-order-numbers-#{actual_date.iso8601}"
+      end
 
       def quota_order_numbers
         QuotaOrderNumber.with_quota_definitions

--- a/app/controllers/api/v2/quota_order_numbers_controller.rb
+++ b/app/controllers/api/v2/quota_order_numbers_controller.rb
@@ -1,0 +1,15 @@
+module Api
+  module V2
+    class QuotaOrderNumbersController < ApiController
+      def index
+        render json: Api::V2::QuotaOrderNumberSerializer.new(quota_order_numbers, include: [:quota_definition]).serializable_hash
+      end
+
+      private
+
+      def quota_order_numbers
+        QuotaOrderNumber.with_quota_definitions
+      end
+    end
+  end
+end

--- a/app/models/quota_order_number.rb
+++ b/app/models/quota_order_number.rb
@@ -4,9 +4,17 @@ class QuotaOrderNumber < Sequel::Model
 
   set_primary_key [:quota_order_number_sid]
 
-  one_to_one :quota_definition, key: :quota_order_number_sid,
-                                primary_key: :quota_order_number_sid do |ds|
+  one_to_one :quota_definition, key: :quota_order_number_sid, primary_key: :quota_order_number_sid do |ds|
     ds.with_actual(QuotaDefinition)
+  end
+
+  dataset_module do
+    def with_quota_definitions
+      inner_join(:quota_definitions, quota_order_numbers__quota_order_number_sid: :quota_definitions__quota_order_number_sid)
+        .actual
+        .with_actual(QuotaDefinition)
+        .eager(:quota_definition)
+    end
   end
 
   LICENSED_QUOTA_PREFIXES = %w[094 084 074 064 054 044 034 024 014].freeze
@@ -22,6 +30,8 @@ class QuotaOrderNumber < Sequel::Model
   def definition_id
     definition&.quota_definition_sid
   end
+
+  alias_method :quota_definition_id, :definition_id
 
   one_to_one :quota_order_number_origin, primary_key: :quota_order_number_sid,
                                          key: :quota_order_number_sid do |ds|

--- a/app/serializers/api/v2/quota_definition_serializer.rb
+++ b/app/serializers/api/v2/quota_definition_serializer.rb
@@ -1,0 +1,20 @@
+module Api
+  module V2
+    class QuotaDefinitionSerializer
+      include JSONAPI::Serializer
+
+      set_type :quota_definition
+
+      set_id :quota_definition_sid
+
+      attributes :quota_order_number_id,
+                 :validity_start_date,
+                 :validity_end_date,
+                 :initial_volume,
+                 :measurement_unit_code,
+                 :measurement_unit_qualifier_code,
+                 :maximum_precision,
+                 :critical_threshold
+    end
+  end
+end

--- a/app/serializers/api/v2/quota_order_number_serializer.rb
+++ b/app/serializers/api/v2/quota_order_number_serializer.rb
@@ -5,9 +5,9 @@ module Api
 
       set_type :quota_order_number
 
-      set_id :quota_order_number_sid
+      set_id :quota_order_number_id
 
-      attributes :quota_order_number_id,
+      attributes :quota_order_number_sid,
                  :validity_start_date,
                  :validity_end_date
 

--- a/app/serializers/api/v2/quota_order_number_serializer.rb
+++ b/app/serializers/api/v2/quota_order_number_serializer.rb
@@ -1,0 +1,17 @@
+module Api
+  module V2
+    class QuotaOrderNumberSerializer
+      include JSONAPI::Serializer
+
+      set_type :quota_order_number
+
+      set_id :quota_order_number_sid
+
+      attributes :quota_order_number_id,
+                 :validity_start_date,
+                 :validity_end_date
+
+      has_one :quota_definition, serializer: Api::V2::QuotaDefinitionSerializer
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,7 @@ Rails.application.routes.draw do
 
       resources :measure_actions, only: %i[index]
       resources :measure_condition_codes, only: %i[index]
+      resources :quota_order_numbers, only: %i[index]
       resources :measure_types, only: %i[index]
 
       resources :additional_codes, only: [] do

--- a/spec/controllers/api/v2/quota_order_numbers_controller_spec.rb
+++ b/spec/controllers/api/v2/quota_order_numbers_controller_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Api::V2::QuotaOrderNumbersController, type: :controller do
       )
 
       allow(TimeMachine).to receive(:at).and_call_original
+      allow(Rails.cache).to receive(:fetch).and_call_original
     end
 
     it { is_expected.to have_http_status(:success) }
@@ -50,6 +51,11 @@ RSpec.describe Api::V2::QuotaOrderNumbersController, type: :controller do
     it 'the TimeMachine receives the correct Date' do
       do_request
       expect(TimeMachine).to have_received(:at).with(Time.zone.today)
+    end
+
+    it 'rails cache receives fetch with the correct key' do
+      do_request
+      expect(Rails.cache).to have_received(:fetch).with("_quota-order-numbers-#{Time.zone.today.iso8601}", expires_in: 1.day)
     end
   end
 end

--- a/spec/controllers/api/v2/quota_order_numbers_controller_spec.rb
+++ b/spec/controllers/api/v2/quota_order_numbers_controller_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe Api::V2::QuotaOrderNumbersController, type: :controller do
       expect(json_body['data']).to eq(
         [
           {
-            'id' => '5',
+            'id' => '000001',
             'type' => 'quota_order_number',
             'attributes' => {
-              'quota_order_number_id' => '000001',
+              'quota_order_number_sid' => 5,
               'validity_start_date' => Date.current.ago(4.years).as_json,
               'validity_end_date' => nil,
             },

--- a/spec/controllers/api/v2/quota_order_numbers_controller_spec.rb
+++ b/spec/controllers/api/v2/quota_order_numbers_controller_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe Api::V2::QuotaOrderNumbersController, type: :controller do
+  describe '#index' do
+    subject(:do_request) { get :index }
+
+    let(:json_body) { JSON.parse(do_request.body) }
+
+    before do
+      create(
+        :quota_order_number,
+        :with_quota_definition,
+        :current,
+        :current_definition,
+        quota_definition_sid: 1,
+        quota_order_number_sid: 5,
+        quota_order_number_id: '000001',
+      )
+
+      allow(TimeMachine).to receive(:at).and_call_original
+    end
+
+    it { is_expected.to have_http_status(:success) }
+
+    it 'returns all the records' do
+      expect(json_body['data']).to eq(
+        [
+          {
+            'id' => '5',
+            'type' => 'quota_order_number',
+            'attributes' => {
+              'quota_order_number_id' => '000001',
+              'validity_start_date' => Date.current.ago(4.years).as_json,
+              'validity_end_date' => nil,
+            },
+            'relationships' => {
+              'quota_definition' => { 'data' => { 'id' => '1', 'type' => 'quota_definition' } },
+            },
+          },
+        ],
+      )
+    end
+
+    it 'returns all the includes' do
+      expect(json_body['included']).to include_json(
+        [
+          { 'id' => '1', 'type' => 'quota_definition' },
+        ],
+      )
+    end
+
+    it 'the TimeMachine receives the correct Date' do
+      do_request
+      expect(TimeMachine).to have_received(:at).with(Time.zone.today)
+    end
+  end
+end

--- a/spec/factories/quota_factory.rb
+++ b/spec/factories/quota_factory.rb
@@ -12,6 +12,11 @@ FactoryBot.define do
   end
 
   factory :quota_order_number do
+    transient do
+      quota_definition_sid { generate(:sid) }
+      quota_definition_validity_end_date { nil }
+    end
+
     quota_order_number_sid { generate(:quota_order_number_sid) }
     quota_order_number_id  { generate(:quota_order_number_id) }
     validity_start_date { Date.current.ago(4.years) }
@@ -19,6 +24,35 @@ FactoryBot.define do
 
     trait :xml do
       validity_end_date { Date.current.ago(1.year) }
+    end
+
+    trait :current do
+      validity_end_date { nil }
+    end
+
+    trait :non_current do
+      validity_end_date { Time.zone.yesterday }
+    end
+
+    trait :current_definition do
+      quota_definition_validity_end_date { nil }
+    end
+
+    trait :non_current_definition do
+      quota_definition_validity_end_date { Time.zone.yesterday }
+    end
+
+    trait :with_quota_definition do
+      after(:create) do |quota_order_number, evaluator|
+        result = create(
+          :quota_definition,
+          quota_order_number_id: quota_order_number.quota_order_number_id,
+          quota_order_number_sid: quota_order_number.quota_order_number_sid,
+          quota_definition_sid: evaluator.quota_definition_sid,
+          validity_end_date: evaluator.quota_definition_validity_end_date,
+        )
+        result
+      end
     end
   end
 
@@ -67,6 +101,8 @@ FactoryBot.define do
     monetary_unit_code              { Forgery(:basic).text(exactly: 3) }
     measurement_unit_code           { Forgery(:basic).text(exactly: 3) }
     measurement_unit_qualifier_code { generate(:measurement_unit_qualifier_code) }
+    validity_start_date             { Date.current.ago(4.years) }
+    validity_end_date               { nil }
 
     trait :actual do
       validity_start_date { Date.current.ago(3.years) }

--- a/spec/factories/quota_factory.rb
+++ b/spec/factories/quota_factory.rb
@@ -30,7 +30,7 @@ FactoryBot.define do
       validity_end_date { nil }
     end
 
-    trait :non_current do
+    trait :expired do
       validity_end_date { Time.zone.yesterday }
     end
 
@@ -38,7 +38,7 @@ FactoryBot.define do
       quota_definition_validity_end_date { nil }
     end
 
-    trait :non_current_definition do
+    trait :expired_definition do
       quota_definition_validity_end_date { Time.zone.yesterday }
     end
 

--- a/spec/models/quota_order_number_spec.rb
+++ b/spec/models/quota_order_number_spec.rb
@@ -56,10 +56,10 @@ RSpec.describe QuotaOrderNumber do
     end
 
     before do
-      create(:quota_order_number, :with_quota_definition, :current, :current_definition, quota_order_number_id: '000001')         # target
-      create(:quota_order_number, :with_quota_definition, :current, :non_current_definition, quota_order_number_id: '000002')     # control
-      create(:quota_order_number, :with_quota_definition, :non_current, :current_definition, quota_order_number_id: '000003')     # control
-      create(:quota_order_number, :with_quota_definition, :non_current, :non_current_definition, quota_order_number_id: '000004') # control
+      create(:quota_order_number, :with_quota_definition, :current, :current_definition, quota_order_number_id: '000001') # target
+      create(:quota_order_number, :with_quota_definition, :current, :expired_definition, quota_order_number_id: '000002') # control
+      create(:quota_order_number, :with_quota_definition, :expired, :current_definition, quota_order_number_id: '000003') # control
+      create(:quota_order_number, :with_quota_definition, :expired, :expired_definition, quota_order_number_id: '000004') # control
     end
 
     it { is_expected.to eq %w[000001] }

--- a/spec/models/quota_order_number_spec.rb
+++ b/spec/models/quota_order_number_spec.rb
@@ -47,4 +47,33 @@ RSpec.describe QuotaOrderNumber do
       end
     end
   end
+
+  describe '.with_quota_definitions' do
+    subject(:with_quota_definitions) { described_class.with_quota_definitions.map(&:quota_order_number_id) }
+
+    around do |example|
+      TimeMachine.now { example.run }
+    end
+
+    before do
+      create(:quota_order_number, :with_quota_definition, :current, :current_definition, quota_order_number_id: '000001')         # target
+      create(:quota_order_number, :with_quota_definition, :current, :non_current_definition, quota_order_number_id: '000002')     # control
+      create(:quota_order_number, :with_quota_definition, :non_current, :current_definition, quota_order_number_id: '000003')     # control
+      create(:quota_order_number, :with_quota_definition, :non_current, :non_current_definition, quota_order_number_id: '000004') # control
+    end
+
+    it { is_expected.to eq %w[000001] }
+  end
+
+  describe '#definition_id' do
+    subject(:definition_id) { create(:quota_order_number, :with_quota_definition, quota_definition_sid: 111).definition_id }
+
+    it { is_expected.to eq(111) }
+  end
+
+  describe '#quota_definition_id' do
+    subject(:quota_order_number) { create(:quota_order_number) }
+
+    it { expect(quota_order_number.method(:quota_definition_id)).to eq(quota_order_number.method(:definition_id)) }
+  end
 end

--- a/spec/serializers/api/v2/quota_definition_serializer_spec.rb
+++ b/spec/serializers/api/v2/quota_definition_serializer_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe Api::V2::QuotaDefinitionSerializer do
+  describe '#serializable_hash' do
+    subject(:serializable_hash) { described_class.new(serializable).serializable_hash }
+
+    let(:serializable) { create(:quota_definition) }
+
+    let(:expected_pattern) do
+      {
+        data: {
+          id: serializable.quota_definition_sid.to_s,
+          type: :quota_definition,
+          attributes: {
+            critical_threshold: nil,
+            initial_volume: nil,
+            maximum_precision: nil,
+            measurement_unit_code: serializable.measurement_unit_code,
+            measurement_unit_qualifier_code: serializable.measurement_unit_qualifier_code,
+            quota_order_number_id: serializable.quota_order_number_id,
+            validity_end_date: nil,
+            validity_start_date: Date.current.ago(4.years),
+          },
+        },
+      }
+    end
+
+    it { is_expected.to eq(expected_pattern) }
+  end
+end

--- a/spec/serializers/api/v2/quota_order_number_serializer_spec.rb
+++ b/spec/serializers/api/v2/quota_order_number_serializer_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe Api::V2::QuotaOrderNumberSerializer do
+  describe '#serializable_hash' do
+    subject(:serializable_hash) { described_class.new(serializable).serializable_hash }
+
+    let(:serializable) { create(:quota_order_number, :with_quota_definition) }
+
+    let(:expected_pattern) do
+      {
+        data: {
+          id: serializable.quota_order_number_sid.to_s,
+          type: :quota_order_number,
+          attributes: {
+            quota_order_number_id: serializable.quota_order_number_id,
+            validity_end_date: nil,
+            validity_start_date: Date.current.ago(4.years),
+          },
+          relationships: {
+            quota_definition: { data: { id: serializable.quota_definition_id.to_s, type: :quota_definition } },
+          },
+        },
+      }
+    end
+
+    it { is_expected.to eq(expected_pattern) }
+  end
+end

--- a/spec/serializers/api/v2/quota_order_number_serializer_spec.rb
+++ b/spec/serializers/api/v2/quota_order_number_serializer_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe Api::V2::QuotaOrderNumberSerializer do
     let(:expected_pattern) do
       {
         data: {
-          id: serializable.quota_order_number_sid.to_s,
+          id: serializable.quota_order_number_id.to_s,
           type: :quota_order_number,
           attributes: {
-            quota_order_number_id: serializable.quota_order_number_id,
+            quota_order_number_sid: serializable.quota_order_number_sid,
             validity_end_date: nil,
             validity_start_date: Date.current.ago(4.years),
           },

--- a/spec/serializers/api/v2/quotas/definition/quota_definition_serializer_spec.rb
+++ b/spec/serializers/api/v2/quotas/definition/quota_definition_serializer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::V2::Quotas::Definition::QuotaDefinitionSerializer do
           quota_definition_sid: be_a(Numeric),
           quota_order_number_id: match(/09\d{4}/),
           initial_volume: nil,
-          validity_start_date: nil,
+          validity_start_date: Date.current.ago(4.years).as_json,
           validity_end_date: nil,
           status: 'Open',
           description: nil,


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1298

### What?

I have added/removed/altered:

- [x] Added api endpoint for surfacing active quota order numbers
- [x] Added coverage for this endpoint and its serializers
- [x] Added dataset module method for returning only active quota order numbers that have a quota definition

### Why?

I am doing this because:

- This is a feature request that will be used by Defra https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs

### AC

- [x] We need to make sure that these are only returned when there is a
corresponding quota definition for the given time machine specified
date.
- [x] We do not care about quota balance events for the moment since these can
be fetched using a different api (to come later)
