### PR TITLE
HOTT-1352: Move to consistent Date/Time api usage

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -68,7 +68,7 @@ class ApplicationController < ActionController::Base
   def actual_date
     Date.parse(params[:as_of].to_s)
   rescue ArgumentError # empty as_of param means today
-    Date.current
+    Time.zone.today
   end
   helper_method :actual_date
 

--- a/app/lib/bank_holidays.rb
+++ b/app/lib/bank_holidays.rb
@@ -9,11 +9,11 @@ module BankHolidays
   private
 
   def self.weekends(n)
-    ((Date.current - n + 1)..Date.current).to_a.select { |d| d.saturday? || d.sunday? }
+    ((Time.zone.today - n + 1)..Time.zone.today).to_a.select { |d| d.saturday? || d.sunday? }
   end
 
   def self.holidays(n)
-    Holidays.between(Date.current - n, Date.current, :be_nl, :gb)
+    Holidays.between(Time.zone.today - n, Time.zone.today, :be_nl, :gb)
             .map { |h| h[:date] }
   end
 end

--- a/app/lib/changes_table_populator.rb
+++ b/app/lib/changes_table_populator.rb
@@ -5,7 +5,7 @@ require 'active_support/log_subscriber'
 
 module ChangesTablePopulator
   # Starts the generation of the changes data.
-  def self.populate(day: Date.current)
+  def self.populate(day: Time.zone.today)
     ActiveSupport::Notifications.instrument('populate.changes_table_populator', day: day) do
       [
         CommodityCodeEndDated,
@@ -25,7 +25,7 @@ module ChangesTablePopulator
     end
   end
 
-  def self.populate_backlog(from: Date.current.ago(3.months), to: Date.current)
+  def self.populate_backlog(from: 3.months.ago.beginning_of_day, to: Time.zone.today)
     ActiveSupport::Notifications.instrument('populate_backlog.changes_table_populator', from: from, to: to) do
       [
         CommodityCodeEndDated,
@@ -45,7 +45,7 @@ module ChangesTablePopulator
     end
   end
 
-  def self.cleanup_outdated(older_than: Date.current.ago(3.months))
+  def self.cleanup_outdated(older_than: 3.months.ago.beginning_of_day)
     ActiveSupport::Notifications.instrument('cleanup_outdated.changes_table_populator', older_than: older_than) do
       Change.cleanup(older_than: older_than)
       return nil

--- a/app/lib/changes_table_populator/commodity_code_description_changed.rb
+++ b/app/lib/changes_table_populator/commodity_code_description_changed.rb
@@ -9,11 +9,11 @@ module ChangesTablePopulator
         -> { [goods_nomenclature_item_id, goods_nomenclature_sid, productline_suffix] }
       end
 
-      def where_condition(day: Date.current)
+      def where_condition(day: Time.zone.today)
         { validity_start_date: day }
       end
 
-      def import_records(elements:, day: Date.current)
+      def import_records(elements:, day: Time.zone.today)
         elements.map { |element| integrate_element(row: element, day: day) }
       end
 

--- a/app/lib/changes_table_populator/commodity_code_end_dated.rb
+++ b/app/lib/changes_table_populator/commodity_code_end_dated.rb
@@ -9,11 +9,11 @@ module ChangesTablePopulator
         -> { [goods_nomenclature_item_id, goods_nomenclature_sid, producline_suffix] }
       end
 
-      def where_condition(day: Date.current)
+      def where_condition(day: Time.zone.today)
         { validity_end_date: day - 1.day }
       end
 
-      def import_records(elements:, day: Date.current)
+      def import_records(elements:, day: Time.zone.today)
         elements.map { |element| integrate_element(row: element, day: day) }
       end
 

--- a/app/lib/changes_table_populator/commodity_code_started.rb
+++ b/app/lib/changes_table_populator/commodity_code_started.rb
@@ -9,11 +9,11 @@ module ChangesTablePopulator
         -> { [goods_nomenclature_item_id, goods_nomenclature_sid, producline_suffix] }
       end
 
-      def where_condition(day: Date.current)
+      def where_condition(day: Time.zone.today)
         { validity_start_date: day }
       end
 
-      def import_records(elements:, day: Date.current)
+      def import_records(elements:, day: Time.zone.today)
         elements.map { |element| integrate_element(row: element, day: day) }
       end
 

--- a/app/lib/changes_table_populator/importer.rb
+++ b/app/lib/changes_table_populator/importer.rb
@@ -11,7 +11,7 @@ module ChangesTablePopulator
       ].freeze
       DB = Sequel::Model.db
 
-      def populate(day: Date.current)
+      def populate(day: Time.zone.today)
         elements = DB[source_table]
           .where(where_condition(day: day))
           .select &select_condition
@@ -21,7 +21,7 @@ module ChangesTablePopulator
           .import IMPORT_FIELDS, import_records(elements: elements, day: day)
       end
 
-      def populate_backlog(from: Date.current - 3.months, to: Date.current)
+      def populate_backlog(from: Time.zone.today - 3.months, to: Time.zone.today)
         from = from.to_date
         to = to.to_date
         (from..to).each do |day|
@@ -37,7 +37,7 @@ module ChangesTablePopulator
         raise NotImplementedError, 'Implement this method in the subclasses'
       end
 
-      def where_condition(day: Date.current) # rubocop:disable Lint/UnusedMethodArgument
+      def where_condition(day: Time.zone.today) # rubocop:disable Lint/UnusedMethodArgument
         raise NotImplementedError, 'Implement this method in the subclasses'
       end
 
@@ -45,7 +45,7 @@ module ChangesTablePopulator
         raise NotImplementedError, 'Implement this method in the subclasses'
       end
 
-      def integrate_element(row:, day: Date.current, is_end_line: nil, siblings: nil)
+      def integrate_element(row:, day: Time.zone.today, is_end_line: nil, siblings: nil)
         [
           row[:goods_nomenclature_item_id],
           row[:goods_nomenclature_sid],
@@ -56,7 +56,7 @@ module ChangesTablePopulator
         ]
       end
 
-      def end_line?(row:, day: Date.current, siblings: [])
+      def end_line?(row:, day: Time.zone.today, siblings: [])
         TimeMachine.at(day) do
           item_id = row[:goods_nomenclature_item_id]
           return false if chapter?(item_id) || heading?(item_id)
@@ -73,7 +73,7 @@ module ChangesTablePopulator
         end
       end
 
-      def integrate_and_find_children(row:, day: Date.current)
+      def integrate_and_find_children(row:, day: Time.zone.today)
         suffix = row[:producline_suffix] || row[:productline_suffix]
         children = find_children(row: row, day: day)
         is_end_line = suffix.nil? || suffix == '80' ? children.none? : false
@@ -109,7 +109,7 @@ module ChangesTablePopulator
         children
       end
 
-      def find_children(row:, day: Date.current)
+      def find_children(row:, day: Time.zone.today)
         TimeMachine.at(day) do
           item_id = row[:goods_nomenclature_item_id]
 
@@ -133,7 +133,7 @@ module ChangesTablePopulator
         item_id.ends_with?('000000') && !chapter?(item_id)
       end
 
-      def chapter_children(row:, day: Date.current)
+      def chapter_children(row:, day: Time.zone.today)
         item_id = row[:goods_nomenclature_item_id]
         chapter_id_regex = "#{item_id[0, 2]}________"
 
@@ -160,7 +160,7 @@ module ChangesTablePopulator
         # rubocop:enable all
       end
 
-      def heading_children(row:, day: Date.current)
+      def heading_children(row:, day: Time.zone.today)
         item_id = row[:goods_nomenclature_item_id]
         heading_id_regex = "#{item_id[0, 4]}______"
 
@@ -187,7 +187,7 @@ module ChangesTablePopulator
         # rubocop:enable all
       end
 
-      def commodity_children(row:, day: Date.current)
+      def commodity_children(row:, day: Time.zone.today)
         item_id = row[:goods_nomenclature_item_id]
         heading_id_regex = "#{item_id[0, 4]}______"
 

--- a/app/lib/changes_table_populator/measure_created_or_updated.rb
+++ b/app/lib/changes_table_populator/measure_created_or_updated.rb
@@ -9,14 +9,14 @@ module ChangesTablePopulator
         -> { [goods_nomenclature_item_id, goods_nomenclature_sid] }
       end
 
-      def where_condition(day: Date.current)
+      def where_condition(day: Time.zone.today)
         Sequel.lit('validity_start_date <= ? AND ' \
                    '(validity_end_date IS NULL OR validity_end_date > ?) AND ' \
                    'operation IN (\'C\', \'U\') AND ' \
                    'operation_date = ?', day, day, day)
       end
 
-      def import_records(elements:, day: Date.current)
+      def import_records(elements:, day: Time.zone.today)
         elements
           .uniq { |element| element[:goods_nomenclature_sid] }
           .collect_concat { |element| integrate_and_find_children(row: element, day: day) }

--- a/app/lib/changes_table_populator/measure_deleted.rb
+++ b/app/lib/changes_table_populator/measure_deleted.rb
@@ -9,11 +9,11 @@ module ChangesTablePopulator
         -> { [goods_nomenclature_item_id, goods_nomenclature_sid] }
       end
 
-      def where_condition(day: Date.current)
+      def where_condition(day: Time.zone.today)
         { operation: 'D', operation_date: day }
       end
 
-      def import_records(elements:, day: Date.current)
+      def import_records(elements:, day: Time.zone.today)
         elements
           .uniq { |element| element[:goods_nomenclature_sid] }
           .collect_concat { |element| integrate_and_find_children(row: element, day: day) }

--- a/app/lib/changes_table_populator/measure_end_dated.rb
+++ b/app/lib/changes_table_populator/measure_end_dated.rb
@@ -9,11 +9,11 @@ module ChangesTablePopulator
         -> { [goods_nomenclature_item_id, goods_nomenclature_sid] }
       end
 
-      def where_condition(day: Date.current)
+      def where_condition(day: Time.zone.today)
         { validity_end_date: day - 1 }
       end
 
-      def import_records(elements:, day: Date.current)
+      def import_records(elements:, day: Time.zone.today)
         elements
           .uniq { |element| element[:goods_nomenclature_sid] }
           .collect_concat { |element| integrate_and_find_children(row: element, day: day) }

--- a/app/lib/changes_table_populator/measure_started.rb
+++ b/app/lib/changes_table_populator/measure_started.rb
@@ -9,11 +9,11 @@ module ChangesTablePopulator
         -> { [goods_nomenclature_item_id, goods_nomenclature_sid] }
       end
 
-      def where_condition(day: Date.current)
+      def where_condition(day: Time.zone.today)
         { validity_start_date: day }
       end
 
-      def import_records(elements:, day: Date.current)
+      def import_records(elements:, day: Time.zone.today)
         elements
           .uniq { |element| element[:goods_nomenclature_sid] }
           .collect_concat { |element| integrate_and_find_children(row: element, day: day) }

--- a/app/lib/tariff_synchronizer.rb
+++ b/app/lib/tariff_synchronizer.rb
@@ -170,7 +170,7 @@ module TariffSynchronizer
     TradeTariffBackend.with_redis_lock do
       date = Date.parse(rollback_date.to_s)
 
-      (date..Date.current).to_a.reverse.each do |date_for_rollback|
+      (date..Time.zone.today).to_a.reverse.each do |date_for_rollback|
         Sequel::Model.db.transaction do
           # Delete actual data
           oplog_based_models.each do |model|
@@ -216,7 +216,7 @@ module TariffSynchronizer
     TradeTariffBackend.with_redis_lock do
       date = Date.parse(rollback_date.to_s)
 
-      (date..Date.current).to_a.reverse.each do |date_for_rollback|
+      (date..Time.zone.today).to_a.reverse.each do |date_for_rollback|
         Sequel::Model.db.transaction do
           if keep
             TariffSynchronizer::CdsUpdate.applied_or_failed.where { issue_date > date_for_rollback }.each do |cds_update|
@@ -287,7 +287,7 @@ module TariffSynchronizer
   end
 
   def update_to
-    ENV['DATE'] ? Date.parse(ENV['DATE']) : Date.current
+    ENV['DATE'] ? Date.parse(ENV['DATE']) : Time.zone.today
   end
 
   def sync_variables_set?

--- a/app/lib/trade_tariff_backend/data_migration/helpers/vat_measures/manual_addition.rb
+++ b/app/lib/trade_tariff_backend/data_migration/helpers/vat_measures/manual_addition.rb
@@ -133,7 +133,7 @@ module TradeTariffBackend
                     mfcm: mfcm,
                     tame: mfcm.tame,
                     operation: :create,
-                    operation_date: Date.current
+                    operation_date: Time.zone.today
                   )
 
                   added_list << measure_candidate_ops[0]

--- a/app/models/change.rb
+++ b/app/models/change.rb
@@ -1,7 +1,7 @@
 class Change < Sequel::Model
   plugin :time_machine
 
-  def self.cleanup(older_than: Date.current.ago(3.months))
+  def self.cleanup(older_than: 3.months.ago.beginning_of_day)
     where('change_date < ?', older_than).delete
   end
 end

--- a/app/serializers/cache/additional_code_serializer.rb
+++ b/app/serializers/cache/additional_code_serializer.rb
@@ -6,7 +6,7 @@ module Cache
 
     def initialize(additional_code)
       @additional_code = additional_code
-      @as_of = Date.current.midnight
+      @as_of = Time.zone.today.midnight
     end
 
     def as_json

--- a/app/serializers/cache/certificate_serializer.rb
+++ b/app/serializers/cache/certificate_serializer.rb
@@ -6,7 +6,7 @@ module Cache
 
     def initialize(certificate)
       @certificate = certificate
-      @as_of = Date.current.midnight
+      @as_of = Time.zone.today.midnight
     end
 
     def as_json

--- a/app/serializers/cache/footnote_serializer.rb
+++ b/app/serializers/cache/footnote_serializer.rb
@@ -6,7 +6,7 @@ module Cache
 
     def initialize(footnote)
       @footnote = footnote
-      @as_of = Date.current.midnight
+      @as_of = Time.zone.today.midnight
     end
 
     def as_json

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -38,11 +38,11 @@ class SearchService
   end
 
   def as_of=(date)
-    date ||= Date.current.to_s
+    date ||= Time.zone.today.to_s
     @as_of = begin
       Date.parse(date)
     rescue StandardError
-      Date.current
+      Time.zone.today
     end
   end
 

--- a/db/data_migrations/20160926155015_switch_footnotes_from_commodity_to_measures.rb
+++ b/db/data_migrations/20160926155015_switch_footnotes_from_commodity_to_measures.rb
@@ -50,7 +50,7 @@ TradeTariffBackend::DataMigrator.migration do
       delete_old_footnotes_associations
       FootnoteAssociationMeasure.unrestrict_primary_key
 
-      TimeMachine.at(Date.current) do
+      TimeMachine.at(Time.zone.today) do
         Commodity.where(goods_nomenclature_item_id: GOODS_NOMENCLATURE_ITEM_IDS).each do |commodity|
           measures = commodity.measures.select{ |m| m.measure_type_id == "103" }
 

--- a/spec/controllers/api/admin/rollbacks_controller_spec.rb
+++ b/spec/controllers/api/admin/rollbacks_controller_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Api::Admin::RollbacksController, 'POST to #create' do
 
   let(:rollback_attributes) { attributes_for :rollback }
   let(:record) do
-    create :measure, operation_date: Date.yesterday.to_date
+    create :measure, operation_date: Time.zone.yesterday.to_date
   end
 
   context 'when rollback is valid' do
@@ -19,7 +19,7 @@ RSpec.describe Api::Admin::RollbacksController, 'POST to #create' do
     it 'performs a rollback' do
       Sidekiq::Testing.inline! do
         expect {
-          create(:rollback, date: Date.current.ago(1.month).to_date)
+          create(:rollback, date: 1.month.ago.beginning_of_day)
         }.to change(Measure, :count).from(1).to(0)
       end
     end

--- a/spec/controllers/api/admin/updates_controller_spec.rb
+++ b/spec/controllers/api/admin/updates_controller_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe Api::Admin::UpdatesController, 'GET #index' do
   end
 
   context 'when records are present' do
-    let!(:taric_update1) { create :taric_update, :applied, issue_date: Date.yesterday }
-    let!(:taric_update2) { create :taric_update, :pending, issue_date: Date.current }
+    let!(:taric_update1) { create :taric_update, :applied, issue_date: Time.zone.yesterday }
+    let!(:taric_update2) { create :taric_update, :pending, issue_date: Time.zone.today }
 
     it 'returns rendered records' do
       get :index, format: :json

--- a/spec/controllers/api/v1/chapters_controller_spec.rb
+++ b/spec/controllers/api/v1/chapters_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Api::V1::ChaptersController, 'GET #changes' do
   context 'changes happened after chapter creation' do
     let(:chapter) do
       create :chapter, :with_section, :with_note,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
 
     let(:heading) { create :heading, goods_nomenclature_item_id: "#{chapter.goods_nomenclature_item_id.first(2)}20000000" }
@@ -80,7 +80,7 @@ RSpec.describe Api::V1::ChaptersController, 'GET #changes' do
              goods_nomenclature: heading,
              goods_nomenclature_sid: heading.goods_nomenclature_sid,
              goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
 
     let(:pattern) do
@@ -119,7 +119,7 @@ RSpec.describe Api::V1::ChaptersController, 'GET #changes' do
   context 'changes happened before requested date' do
     let(:chapter) do
       create :chapter, :with_section, :with_note,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
     let(:heading) { create :heading, goods_nomenclature_item_id: "#{chapter.goods_nomenclature_item_id.first(2)}20000000" }
     let!(:measure) do
@@ -128,11 +128,11 @@ RSpec.describe Api::V1::ChaptersController, 'GET #changes' do
              goods_nomenclature: heading,
              goods_nomenclature_sid: heading.goods_nomenclature_sid,
              goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
 
     it 'does not include change records' do
-      get :changes, params: { id: chapter, as_of: Date.yesterday }, format: :json
+      get :changes, params: { id: chapter, as_of: Time.zone.yesterday }, format: :json
 
       expect(response.body).to match_json_expression []
     end
@@ -141,7 +141,7 @@ RSpec.describe Api::V1::ChaptersController, 'GET #changes' do
   context 'changes include deleted record' do
     let(:chapter) do
       create :chapter, :with_section, :with_note,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
 
     let(:heading) { create :heading, goods_nomenclature_item_id: "#{chapter.goods_nomenclature_item_id.first(2)}20000000" }
@@ -151,7 +151,7 @@ RSpec.describe Api::V1::ChaptersController, 'GET #changes' do
              goods_nomenclature: heading,
              goods_nomenclature_sid: heading.goods_nomenclature_sid,
              goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
 
     let(:pattern) do

--- a/spec/controllers/api/v1/commodities_controller_spec.rb
+++ b/spec/controllers/api/v1/commodities_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Api::V1::CommoditiesController, 'GET #changes' do
              :with_heading,
              :with_description,
              :declarable,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
 
     let(:pattern) do
@@ -119,11 +119,11 @@ RSpec.describe Api::V1::CommoditiesController, 'GET #changes' do
              :with_heading,
              :with_description,
              :declarable,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
 
     it 'does not include change records' do
-      get :changes, params: { id: commodity, as_of: Date.yesterday }, format: :json
+      get :changes, params: { id: commodity, as_of: Time.zone.yesterday }, format: :json
 
       expect(response.body).to match_json_expression []
     end
@@ -136,7 +136,7 @@ RSpec.describe Api::V1::CommoditiesController, 'GET #changes' do
              :with_heading,
              :with_description,
              :declarable,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
     let!(:measure) do
       create :measure,
@@ -144,7 +144,7 @@ RSpec.describe Api::V1::CommoditiesController, 'GET #changes' do
              goods_nomenclature: commodity,
              goods_nomenclature_sid: commodity.goods_nomenclature_sid,
              goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
 
     let(:pattern) do

--- a/spec/controllers/api/v1/headings_controller_spec.rb
+++ b/spec/controllers/api/v1/headings_controller_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Api::V1::HeadingsController, 'GET #changes' do
              :non_declarable,
              :with_description,
              :with_chapter,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
 
     let(:pattern) do
@@ -153,11 +153,11 @@ RSpec.describe Api::V1::HeadingsController, 'GET #changes' do
              :non_declarable,
              :with_description,
              :with_chapter,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
 
     it 'does not include change records' do
-      get :changes, params: { id: heading, as_of: Date.yesterday }, format: :json
+      get :changes, params: { id: heading, as_of: Time.zone.yesterday }, format: :json
 
       expect(response.body).to match_json_expression []
     end
@@ -169,7 +169,7 @@ RSpec.describe Api::V1::HeadingsController, 'GET #changes' do
              :non_declarable,
              :with_description,
              :with_chapter,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
     let!(:measure) do
       create :measure,
@@ -177,7 +177,7 @@ RSpec.describe Api::V1::HeadingsController, 'GET #changes' do
              goods_nomenclature: heading,
              goods_nomenclature_sid: heading.goods_nomenclature_sid,
              goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
     let(:pattern) do
       [

--- a/spec/controllers/api/v2/changes_controller_spec.rb
+++ b/spec/controllers/api/v2/changes_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Api::V2::ChangesController do
   let(:productline_suffix) { nil }
   let(:end_line) { nil }
   let(:change_type) { nil }
-  let(:change_date) { Date.current.strftime('%Y-%m-%d') }
+  let(:change_date) { Time.zone.today.strftime('%Y-%m-%d') }
 
   let(:expected_change_response) do
     {
@@ -43,7 +43,7 @@ RSpec.describe Api::V2::ChangesController do
     end
 
     context 'when a commodity change exists for the day' do
-      let!(:change) { create :change, change_date: Date.current }
+      let!(:change) { create :change, change_date: Time.zone.today }
       let(:goods_nomenclature_item_id) { change.goods_nomenclature_item_id }
       let(:goods_nomenclature_sid) { change.goods_nomenclature_sid }
       let(:productline_suffix) { change.productline_suffix }
@@ -61,7 +61,7 @@ RSpec.describe Api::V2::ChangesController do
       end
 
       context 'on the previous day' do
-        before { get :index, params: { as_of: (Date.current - 1.day) }, format: :json }
+        before { get :index, params: { as_of: (Time.zone.today - 1.day) }, format: :json }
 
         let(:json) { JSON.parse(response.body) }
 
@@ -72,7 +72,7 @@ RSpec.describe Api::V2::ChangesController do
     end
 
     context 'when a measure change exists for the day' do
-      let!(:change) { create :change_measure, change_date: Date.current }
+      let!(:change) { create :change_measure, change_date: Time.zone.today }
       let(:goods_nomenclature_item_id) { change.goods_nomenclature_item_id }
       let(:goods_nomenclature_sid) { change.goods_nomenclature_sid }
       let(:productline_suffix) { change.productline_suffix }
@@ -90,7 +90,7 @@ RSpec.describe Api::V2::ChangesController do
       end
 
       context 'on the previous day' do
-        before { get :index, params: { as_of: (Date.current - 1.day) }, format: :json }
+        before { get :index, params: { as_of: (Time.zone.today - 1.day) }, format: :json }
 
         let(:json) { JSON.parse(response.body) }
 

--- a/spec/controllers/api/v2/chapters_controller_spec.rb
+++ b/spec/controllers/api/v2/chapters_controller_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Api::V2::ChaptersController, 'GET #changes' do
   context 'changes happened after chapter creation' do
     let(:chapter) do
       create :chapter, :with_section, :with_note,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
 
     let(:heading) { create :heading, goods_nomenclature_item_id: "#{chapter.goods_nomenclature_item_id.first(2)}20000000" }
@@ -166,7 +166,7 @@ RSpec.describe Api::V2::ChaptersController, 'GET #changes' do
              goods_nomenclature: heading,
              goods_nomenclature_sid: heading.goods_nomenclature_sid,
              goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
 
     let(:pattern) do
@@ -292,7 +292,7 @@ RSpec.describe Api::V2::ChaptersController, 'GET #changes' do
   context 'changes happened before requested date' do
     let(:chapter) do
       create :chapter, :with_section, :with_note,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
     let(:heading) { create :heading, goods_nomenclature_item_id: "#{chapter.goods_nomenclature_item_id.first(2)}20000000" }
     let!(:measure) do
@@ -301,7 +301,7 @@ RSpec.describe Api::V2::ChaptersController, 'GET #changes' do
              goods_nomenclature: heading,
              goods_nomenclature_sid: heading.goods_nomenclature_sid,
              goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
 
     let!(:pattern) do
@@ -312,7 +312,7 @@ RSpec.describe Api::V2::ChaptersController, 'GET #changes' do
     end
 
     it 'does not include change records' do
-      get :changes, params: { id: chapter, as_of: Date.yesterday }, format: :json
+      get :changes, params: { id: chapter, as_of: Time.zone.yesterday }, format: :json
 
       expect(response.body).to match_json_expression pattern
     end
@@ -321,7 +321,7 @@ RSpec.describe Api::V2::ChaptersController, 'GET #changes' do
   context 'changes include deleted record' do
     let(:chapter) do
       create :chapter, :with_section, :with_note,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
 
     let(:heading) { create :heading, goods_nomenclature_item_id: "#{chapter.goods_nomenclature_item_id.first(2)}20000000" }
@@ -331,7 +331,7 @@ RSpec.describe Api::V2::ChaptersController, 'GET #changes' do
              goods_nomenclature: heading,
              goods_nomenclature_sid: heading.goods_nomenclature_sid,
              goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
 
     let(:pattern) do

--- a/spec/controllers/api/v2/commodities_controller_spec.rb
+++ b/spec/controllers/api/v2/commodities_controller_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Api::V2::CommoditiesController, 'GET #changes' do
              :with_heading,
              :with_description,
              :declarable,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
 
     let(:pattern) do
@@ -224,7 +224,7 @@ RSpec.describe Api::V2::CommoditiesController, 'GET #changes' do
              :with_heading,
              :with_description,
              :declarable,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
 
     let!(:pattern) do
@@ -235,7 +235,7 @@ RSpec.describe Api::V2::CommoditiesController, 'GET #changes' do
     end
 
     it 'does not include change records' do
-      get :changes, params: { id: commodity, as_of: Date.yesterday }, format: :json
+      get :changes, params: { id: commodity, as_of: Time.zone.yesterday }, format: :json
 
       expect(response.body).to match_json_expression pattern
     end
@@ -248,7 +248,7 @@ RSpec.describe Api::V2::CommoditiesController, 'GET #changes' do
              :with_heading,
              :with_description,
              :declarable,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
     let!(:measure) do
       create :measure,
@@ -256,7 +256,7 @@ RSpec.describe Api::V2::CommoditiesController, 'GET #changes' do
              goods_nomenclature: commodity,
              goods_nomenclature_sid: commodity.goods_nomenclature_sid,
              goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
-             operation_date: Date.current
+             operation_date: Time.zone.today
     end
 
     let(:pattern) do

--- a/spec/controllers/api/v2/measure_actions_controller_spec.rb
+++ b/spec/controllers/api/v2/measure_actions_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Api::V2::MeasureActionsController, type: :controller do
             'attributes' => {
               'description' => 'Import/export not allowed after control',
               'validity_end_date' => nil,
-              'validity_start_date' => Date.current.ago(3.years).as_json,
+              'validity_start_date' => 3.years.ago.beginning_of_day.as_json,
             },
             'id' => '01',
             'type' => 'measure_action',

--- a/spec/controllers/api/v2/measure_condition_codes_controller_spec.rb
+++ b/spec/controllers/api/v2/measure_condition_codes_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Api::V2::MeasureConditionCodesController, type: :controller do
             'type' => 'measure_condition_code',
             'attributes' => {
               'description' => 'Presentation of a certificate/licence/document',
-              'validity_start_date' => Date.current.ago(3.years).as_json,
+              'validity_start_date' => 3.years.ago.beginning_of_day.as_json,
               'validity_end_date' => nil,
             },
           },

--- a/spec/controllers/api/v2/monetary_exchange_rates_controller_spec.rb
+++ b/spec/controllers/api/v2/monetary_exchange_rates_controller_spec.rb
@@ -1,11 +1,11 @@
 RSpec.describe Api::V2::MonetaryExchangeRatesController, 'GET to #index' do
   context 'Expected results' do
-    let!(:gbp_unit) { create(:monetary_unit, monetary_unit_code: 'GBP', validity_start_date: Date.current.ago(10.years)) }
-    let!(:eur_unit) { create(:monetary_unit, monetary_unit_code: 'EUR', validity_start_date: Date.current.ago(10.years)) }
+    let!(:gbp_unit) { create(:monetary_unit, monetary_unit_code: 'GBP', validity_start_date: 10.years.ago.beginning_of_day) }
+    let!(:eur_unit) { create(:monetary_unit, monetary_unit_code: 'EUR', validity_start_date: 10.years.ago.beginning_of_day) }
     let!(:monetary_exchange_period) { create :monetary_exchange_period }
     let!(:monetary_exchange_rate) { create :monetary_exchange_rate, monetary_exchange_period_sid: monetary_exchange_period.monetary_exchange_period_sid }
 
-    let!(:five_year_old_period) { create :monetary_exchange_period, validity_start_date: Date.current.ago(5.years) }
+    let!(:five_year_old_period) { create :monetary_exchange_period, validity_start_date: 5.years.ago.beginning_of_day }
     let!(:five_year_old_rate) { create :monetary_exchange_rate, monetary_exchange_period_sid: five_year_old_period.monetary_exchange_period_sid }
 
     it 'returns exchange rates for the last 5 years' do
@@ -23,8 +23,8 @@ RSpec.describe Api::V2::MonetaryExchangeRatesController, 'GET to #index' do
   end
 
   context 'Constraints' do
-    let!(:gbp_unit) { create :monetary_unit, monetary_unit_code: 'GBP', validity_start_date: Date.current - 10.years }
-    let!(:eur_unit) { create :monetary_unit, monetary_unit_code: 'EUR', validity_start_date: Date.current - 10.years }
+    let!(:gbp_unit) { create :monetary_unit, monetary_unit_code: 'GBP', validity_start_date: Time.zone.today - 10.years }
+    let!(:eur_unit) { create :monetary_unit, monetary_unit_code: 'EUR', validity_start_date: Time.zone.today - 10.years }
     let!(:monetary_exchange_period) { create :monetary_exchange_period }
     let!(:old_period) { create :monetary_exchange_period, :old }
     let!(:hkn_rate) { create :monetary_exchange_rate, child_monetary_unit_code: 'HKN' }

--- a/spec/controllers/api/v2/quota_order_numbers_controller_spec.rb
+++ b/spec/controllers/api/v2/quota_order_numbers_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Api::V2::QuotaOrderNumbersController, type: :controller do
             'type' => 'quota_order_number',
             'attributes' => {
               'quota_order_number_sid' => 5,
-              'validity_start_date' => Date.current.ago(4.years).as_json,
+              'validity_start_date' => 4.years.ago.beginning_of_day.as_json,
               'validity_end_date' => nil,
             },
             'relationships' => {

--- a/spec/controllers/api/v2/quotas_controller_spec.rb
+++ b/spec/controllers/api/v2/quotas_controller_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Api::V2::QuotasController, type: :controller do
   describe 'GET /quotas/search.json' do
-    let(:validity_start_date) { Date.new(Date.current.year, 1, 1) }
+    let(:validity_start_date) { Date.new(Time.zone.today.year, 1, 1) }
     let(:quota_order_number) { create :quota_order_number }
     let!(:measure) { create :measure, ordernumber: quota_order_number.quota_order_number_id, validity_start_date: validity_start_date }
     let!(:quota_definition) do
@@ -27,7 +27,7 @@ RSpec.describe Api::V2::QuotasController, type: :controller do
     end
 
     context 'when not specifying an includes list in the query params' do
-      let(:params) { { year: [Date.current.year.to_s] } }
+      let(:params) { { year: [Time.zone.today.year.to_s] } }
 
       let(:pattern) do
         {
@@ -136,7 +136,7 @@ RSpec.describe Api::V2::QuotasController, type: :controller do
       let(:params) do
         {
           year: [
-            Date.current.year.to_s,
+            Time.zone.today.year.to_s,
           ],
           include: 'quota_balance_events,measures,measures.geographical_area',
         }

--- a/spec/controllers/api/v2/search_controller_search_spec.rb
+++ b/spec/controllers/api/v2/search_controller_search_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Api::V2::SearchController do
         post :search, params: { q: chapter.description, as_of: chapter.validity_start_date }
       end
 
-      let(:chapter) { create :chapter, :with_description, description: 'horse', validity_start_date: Date.current }
+      let(:chapter) { create :chapter, :with_description, description: 'horse', validity_start_date: Time.zone.today }
 
       let(:pattern) do
         {

--- a/spec/factories/additional_code_factory.rb
+++ b/spec/factories/additional_code_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     additional_code_sid     { generate(:additional_code_sid) }
     additional_code_type_id { generate(:additional_code_type_id) }
     additional_code         { Forgery(:basic).text(exactly: 3) }
-    validity_start_date     { Date.current.ago(2.years) }
+    validity_start_date     { 2.years.ago.beginning_of_day }
     validity_end_date       { nil }
 
     trait :with_export_refund_nomenclature do
@@ -32,13 +32,13 @@ FactoryBot.define do
     additional_code_sid                    { generate(:additional_code_sid) }
     additional_code_type_id                { generate(:additional_code_type_id) }
     additional_code                        { Forgery(:basic).text(exactly: 3) }
-    validity_start_date                    { Date.current.ago(2.years) }
+    validity_start_date                    { 2.years.ago.beginning_of_day }
     validity_end_date                      { nil }
   end
 
   factory :additional_code_description do
     transient do
-      valid_at { Date.current.ago(2.years) }
+      valid_at { 2.years.ago.beginning_of_day }
       valid_to { nil }
     end
 
@@ -63,7 +63,7 @@ FactoryBot.define do
   factory :additional_code_type do
     additional_code_type_id { generate(:additional_code_type_id) }
     application_code        { '1' }
-    validity_start_date     { Date.current.ago(2.years) }
+    validity_start_date     { 2.years.ago.beginning_of_day }
     validity_end_date       { nil }
 
     trait :ern do
@@ -91,7 +91,7 @@ FactoryBot.define do
     end
 
     trait :xml do
-      validity_end_date { Date.current.ago(1.year) }
+      validity_end_date { 1.year.ago.beginning_of_day }
     end
   end
 
@@ -107,14 +107,14 @@ FactoryBot.define do
   factory :meursing_additional_code do
     meursing_additional_code_sid { generate(:meursing_additional_code_sid) }
     additional_code         { Forgery(:basic).text(exactly: 3) }
-    validity_start_date     { Date.current.ago(2.years) }
+    validity_start_date     { 2.years.ago.beginning_of_day }
     validity_end_date       { nil }
   end
 
   factory :additional_code_type_measure_type do |f|
     f.measure_type_id { Forgery(:basic).text(exactly: 3) }
     f.additional_code_type_id { generate(:additional_code_type_id) }
-    f.validity_start_date     { Date.current.ago(2.years) }
+    f.validity_start_date     { 2.years.ago.beginning_of_day }
     f.validity_end_date       { nil }
 
     f.measure_type         { create :measure_type, measure_type_id: measure_type_id }

--- a/spec/factories/base_regulation_factory.rb
+++ b/spec/factories/base_regulation_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :base_regulation do
     base_regulation_id   { generate(:sid) }
     base_regulation_role { 1 }
-    validity_start_date { Date.current.ago(3.years) }
+    validity_start_date { 3.years.ago.beginning_of_day }
     validity_end_date   { nil }
     effective_end_date  { nil }
     information_text { 'This is some explanatory information text' }

--- a/spec/factories/certificate_factory.rb
+++ b/spec/factories/certificate_factory.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
 
     certificate_type_code { generate(:certificate_type_code) }
     certificate_code      { Forgery(:basic).text(exactly: 3) }
-    validity_start_date   { Date.current.ago(2.years) }
+    validity_start_date   { 2.years.ago.beginning_of_day }
     validity_end_date     { nil }
   end
 
@@ -17,13 +17,13 @@ FactoryBot.define do
     certificate_description_period_sid { generate(:certificate_sid) }
     certificate_type_code              { generate(:certificate_type_code) }
     certificate_code                   { Forgery(:basic).text(exactly: 3) }
-    validity_start_date                { Date.current.ago(2.years) }
+    validity_start_date                { 2.years.ago.beginning_of_day }
     validity_end_date                  { nil }
   end
 
   factory :certificate_description do
     transient do
-      valid_at { Date.current.ago(2.years) }
+      valid_at { 2.years.ago.beginning_of_day }
       valid_to { nil }
     end
 
@@ -49,7 +49,7 @@ FactoryBot.define do
     end
 
     certificate_type_code              { generate(:certificate_type_code) }
-    validity_start_date                { Date.current.ago(2.years) }
+    validity_start_date                { 2.years.ago.beginning_of_day }
     validity_end_date                  { nil }
 
     trait :with_description do

--- a/spec/factories/duty_expression_factory.rb
+++ b/spec/factories/duty_expression_factory.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
 
   factory :duty_expression do
     duty_expression_id  { generate(:duty_expression_description) }
-    validity_start_date { Date.current.ago(3.years) }
+    validity_start_date { 3.years.ago.beginning_of_day }
     validity_end_date   { nil }
 
     trait :with_description do

--- a/spec/factories/export_refund_nomenclature_factory.rb
+++ b/spec/factories/export_refund_nomenclature_factory.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     export_refund_code   { 3.times.map { Random.rand(9) }.join }
     additional_code_type { Random.rand(9) }
     productline_suffix   { [10, 20, 80].sample }
-    validity_start_date  { Date.current.ago(2.years) }
+    validity_start_date  { 2.years.ago.beginning_of_day }
     validity_end_date    { nil }
 
     trait :with_indent do
@@ -26,20 +26,20 @@ FactoryBot.define do
     export_refund_nomenclature_sid { generate(:export_refund_nomenclature_sid) }
     export_refund_nomenclature_indents_sid { generate(:export_refund_nomenclature_sid) }
     number_export_refund_nomenclature_indents { Forgery(:basic).number }
-    validity_start_date { Date.current.ago(3.years) }
+    validity_start_date { 3.years.ago.beginning_of_day }
     validity_end_date   { nil }
   end
 
   factory :export_refund_nomenclature_description_period do
     export_refund_nomenclature_sid { generate(:sid) }
     export_refund_nomenclature_description_period_sid { generate(:sid) }
-    validity_start_date { Date.current.ago(3.years) }
+    validity_start_date { 3.years.ago.beginning_of_day }
     validity_end_date   { nil }
   end
 
   factory :export_refund_nomenclature_description do
     transient do
-      validity_start_date { Date.current.ago(3.years) }
+      validity_start_date { 3.years.ago.beginning_of_day }
       validity_end_date { nil }
       valid_at { Time.zone.now.ago(2.years) }
       valid_to { nil }

--- a/spec/factories/footnote_factory.rb
+++ b/spec/factories/footnote_factory.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
 
   factory :footnote do
     transient do
-      valid_at { Date.current.ago(2.years) }
+      valid_at { 2.years.ago.beginning_of_day }
       valid_to { nil }
       goods_nomenclature_sid { generate(:goods_nomenclature_sid) }
       measure_sid { generate(:measure_sid) }
@@ -11,7 +11,7 @@ FactoryBot.define do
 
     footnote_id      { Forgery(:basic).text(exactly: 3) }
     footnote_type_id { Forgery(:basic).text(exactly: 2) }
-    validity_start_date     { Date.current.ago(2.years).localtime }
+    validity_start_date     { 2.years.ago.beginning_of_day }
     validity_end_date       { nil }
 
     after(:build) do |ftn, _evaluator|
@@ -59,13 +59,13 @@ FactoryBot.define do
     footnote_description_period_sid { generate(:footnote_sid) }
     footnote_id      { Forgery(:basic).text(exactly: 3) }
     footnote_type_id { Forgery(:basic).text(exactly: 2) }
-    validity_start_date                    { Date.current.ago(2.years) }
+    validity_start_date                    { 2.years.ago.beginning_of_day }
     validity_end_date                      { nil }
   end
 
   factory :footnote_description do
     transient do
-      valid_at { Date.current.ago(2.years) }
+      valid_at { 2.years.ago.beginning_of_day }
       valid_to { nil }
     end
 
@@ -89,7 +89,7 @@ FactoryBot.define do
     goods_nomenclature_sid          { generate(:goods_nomenclature_sid) }
     footnote_id                     { Forgery(:basic).text(exactly: 3) }
     footnote_type                   { Forgery(:basic).text(exactly: 2) }
-    validity_start_date             { Date.current.ago(3.years) }
+    validity_start_date             { 3.years.ago.beginning_of_day }
     validity_end_date               { nil }
   end
 
@@ -97,7 +97,7 @@ FactoryBot.define do
     export_refund_nomenclature_sid  { generate(:export_refund_nomenclature_sid) }
     footnote_id                     { Forgery(:basic).text(exactly: 3) }
     footnote_type                   { Forgery(:basic).text(exactly: 2) }
-    validity_start_date             { Date.current.ago(2.years) }
+    validity_start_date             { 2.years.ago.beginning_of_day }
     validity_end_date               { nil }
   end
 
@@ -111,7 +111,7 @@ FactoryBot.define do
     additional_code_sid             { generate(:additional_code_sid) }
     footnote_id                     { Forgery(:basic).text(exactly: 3) }
     footnote_type_id                { Forgery(:basic).text(exactly: 2) }
-    validity_start_date             { Date.current.ago(2.years) }
+    validity_start_date             { 2.years.ago.beginning_of_day }
     validity_end_date               { nil }
   end
 
@@ -120,13 +120,13 @@ FactoryBot.define do
     meursing_heading_number         { Forgery(:basic).number }
     footnote_id                     { Forgery(:basic).text(exactly: 3) }
     footnote_type                   { Forgery(:basic).text(exactly: 2) }
-    validity_start_date             { Date.current.ago(2.years) }
+    validity_start_date             { 2.years.ago.beginning_of_day }
     validity_end_date               { nil }
   end
 
   factory :footnote_type do
     footnote_type_id { Forgery(:basic).text(exactly: 2) }
-    validity_start_date { Date.current.ago(2.years) }
+    validity_start_date { 2.years.ago.beginning_of_day }
     validity_end_date   { nil }
   end
 

--- a/spec/factories/geographical_area_factory.rb
+++ b/spec/factories/geographical_area_factory.rb
@@ -5,15 +5,15 @@ FactoryBot.define do
   factory :geographical_area do
     geographical_area_sid { generate(:geographical_area_sid) }
     geographical_area_id  { Forgery(:basic).text(exactly: 2) }
-    validity_start_date   { Date.current.ago(3.years) }
+    validity_start_date   { 3.years.ago.beginning_of_day }
     validity_end_date     { nil }
 
     trait :fifteen_years do
-      validity_start_date { Date.current.ago(15.years) }
+      validity_start_date { 15.years.ago.beginning_of_day }
     end
 
     trait :twenty_years do
-      validity_start_date { Date.current.ago(20.years) }
+      validity_start_date { 20.years.ago.beginning_of_day }
     end
 
     trait :erga_omnes do
@@ -49,7 +49,7 @@ FactoryBot.define do
     geographical_area_description_period_sid { generate(:geographical_area_sid) }
     geographical_area_sid                    { generate(:geographical_area_sid) }
     geographical_area_id                     { Forgery(:basic).text(exactly: 3) }
-    validity_start_date                      { Date.current.ago(2.years) }
+    validity_start_date                      { 2.years.ago.beginning_of_day }
     validity_end_date                        { nil }
   end
 
@@ -78,7 +78,7 @@ FactoryBot.define do
   factory :geographical_area_membership do
     geographical_area_sid                    { generate(:geographical_area_sid) }
     geographical_area_group_sid              { generate(:geographical_area_sid) }
-    validity_start_date                      { Date.current.ago(2.years) }
+    validity_start_date                      { 2.years.ago.beginning_of_day }
     validity_end_date                        { nil }
   end
 end

--- a/spec/factories/goods_nomenclature_factory.rb
+++ b/spec/factories/goods_nomenclature_factory.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
     # results
     goods_nomenclature_item_id { 10.times.map { Random.rand(1..9) }.join }
     producline_suffix   { '80' }
-    validity_start_date { Date.current.ago(2.years) }
+    validity_start_date { 2.years.ago.beginning_of_day }
     validity_end_date   { nil }
 
     # TODO: Put this in a trait. This forces indents on all nomenclature regardless of
@@ -91,7 +91,7 @@ FactoryBot.define do
     end
 
     trait :actual do
-      validity_start_date { Date.current.ago(3.years) }
+      validity_start_date { 3.years.ago.beginning_of_day }
       validity_end_date   { nil }
     end
 
@@ -100,8 +100,8 @@ FactoryBot.define do
     end
 
     trait :expired do
-      validity_start_date { Date.current.ago(3.years) }
-      validity_end_date   { Date.current.ago(1.year)  }
+      validity_start_date { 3.years.ago.beginning_of_day }
+      validity_end_date   { 1.year.ago.beginning_of_day  }
     end
 
     trait :with_description do
@@ -115,7 +115,7 @@ FactoryBot.define do
     end
 
     trait :xml do
-      validity_end_date           { Date.current.ago(1.year) }
+      validity_end_date           { 1.year.ago.beginning_of_day }
       statistical_indicator       { 1 }
     end
   end
@@ -231,32 +231,32 @@ FactoryBot.define do
     goods_nomenclature_sid { generate(:sid) }
     goods_nomenclature_indent_sid { generate(:sid) }
     number_indents { Forgery(:basic).number }
-    validity_start_date { Date.current.ago(3.years) }
+    validity_start_date { 3.years.ago.beginning_of_day }
     validity_end_date   { nil }
 
     trait :xml do
       goods_nomenclature_item_id     { Forgery(:basic).text(exactly: 2) }
       productline_suffix             { Forgery(:basic).text(exactly: 2) }
-      validity_end_date              { Date.current.ago(1.year) }
+      validity_end_date              { 1.year.ago.beginning_of_day }
     end
   end
 
   factory :goods_nomenclature_description_period do
     goods_nomenclature_sid { generate(:sid) }
     goods_nomenclature_description_period_sid { generate(:sid) }
-    validity_start_date { Date.current.ago(3.years) }
+    validity_start_date { 3.years.ago.beginning_of_day }
     validity_end_date   { nil }
 
     trait :xml do
       goods_nomenclature_item_id                 { Forgery(:basic).text(exactly: 2) }
       productline_suffix                         { Forgery(:basic).text(exactly: 2) }
-      validity_end_date                          { Date.current.ago(1.year) }
+      validity_end_date                          { 1.year.ago.beginning_of_day }
     end
   end
 
   factory :goods_nomenclature_description do
     transient do
-      validity_start_date { Date.current.ago(3.years) }
+      validity_start_date { 3.years.ago.beginning_of_day }
       validity_end_date { nil }
     end
 
@@ -280,14 +280,14 @@ FactoryBot.define do
   end
 
   factory :goods_nomenclature_group do
-    validity_start_date                  { Date.current.ago(3.years) }
+    validity_start_date                  { 3.years.ago.beginning_of_day }
     validity_end_date                    { nil }
     goods_nomenclature_group_type        { generate(:goods_nomenclature_group_type) }
     goods_nomenclature_group_id          { Forgery(:basic).text(exactly: 2) }
     nomenclature_group_facility_code     { 0 }
 
     trait :xml do
-      validity_end_date { Date.current.ago(1.year) }
+      validity_end_date { 1.year.ago.beginning_of_day }
     end
   end
 
@@ -323,11 +323,11 @@ FactoryBot.define do
     goods_nomenclature_group_id    { Forgery(:basic).text(exactly: 2) }
     goods_nomenclature_item_id     { Forgery(:basic).text(exactly: 2) }
     productline_suffix             { Forgery(:basic).text(exactly: 2) }
-    validity_start_date            { Date.current.ago(3.years) }
+    validity_start_date            { 3.years.ago.beginning_of_day }
     validity_end_date              { nil }
 
     trait :xml do
-      validity_end_date            { Date.current.ago(1.year) }
+      validity_end_date            { 1.year.ago.beginning_of_day }
     end
   end
 end

--- a/spec/factories/measure_action_factory.rb
+++ b/spec/factories/measure_action_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :measure_action do
     action_code         { Forgery(:basic).text(exactly: 2) }
-    validity_start_date { Date.current.ago(3.years) }
+    validity_start_date { 3.years.ago.beginning_of_day }
     validity_end_date   { nil }
 
     trait :with_description do

--- a/spec/factories/measure_condition_code_factory.rb
+++ b/spec/factories/measure_condition_code_factory.rb
@@ -7,11 +7,11 @@ FactoryBot.define do
     end
 
     condition_code { generate(:condition_code) }
-    validity_start_date { Date.current.ago(3.years) }
+    validity_start_date { 3.years.ago.beginning_of_day }
     validity_end_date   { nil }
 
     trait :xml do
-      validity_end_date { Date.current.ago(1.year) }
+      validity_end_date { 1.year.ago.beginning_of_day }
     end
 
     trait :with_description do

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -29,7 +29,7 @@ FactoryBot.define do
     f.goods_nomenclature_item_id { 10.times.map { Random.rand(9) }.join }
     f.geographical_area_sid { generate(:geographical_area_sid) }
     f.geographical_area_id { generate(:geographical_area_id) }
-    f.validity_start_date { Date.current.ago(3.years) }
+    f.validity_start_date { 3.years.ago.beginning_of_day }
     f.validity_end_date   { nil }
     f.reduction_indicator { [nil, 1, 2, 3].sample }
 
@@ -64,7 +64,7 @@ FactoryBot.define do
           :base_regulation,
           base_regulation_id: measure.measure_generating_regulation_id,
           base_regulation_role: measure.measure_generating_regulation_role,
-          effective_end_date: evaluator.base_regulation_effective_end_date || Date.current.in(10.years),
+          effective_end_date: evaluator.base_regulation_effective_end_date || Time.zone.today.in(10.years),
         )
       end
     end
@@ -309,7 +309,7 @@ FactoryBot.define do
 
     measure_type_id { generate(:measure_type_id) }
     sequence(:measure_type_series_id, LoopingSequence.lower_a_to_upper_z, &:value)
-    validity_start_date    { Date.current.ago(3.years) }
+    validity_start_date    { 3.years.ago.beginning_of_day }
     validity_end_date      { nil }
     measure_explosion_level { 10 }
     order_number_capture_code { 10 }

--- a/spec/factories/measure_type_series_factory.rb
+++ b/spec/factories/measure_type_series_factory.rb
@@ -3,12 +3,12 @@ FactoryBot.define do
 
   factory :measure_type_series do
     measure_type_series_id   { generate(:measure_type_series_id) }
-    validity_start_date      { Date.current.ago(3.years) }
+    validity_start_date      { 3.years.ago.beginning_of_day }
     validity_end_date        { nil }
 
     trait :xml do
       measure_type_combination { 0 }
-      validity_end_date        { Date.current.ago(1.year) }
+      validity_end_date        { 1.year.ago.beginning_of_day }
     end
   end
 

--- a/spec/factories/measurement_factory.rb
+++ b/spec/factories/measurement_factory.rb
@@ -2,11 +2,11 @@ FactoryBot.define do
   factory :measurement do
     measurement_unit_code           { Forgery(:basic).text(exactly: 2) }
     measurement_unit_qualifier_code { generate(:measurement_unit_qualifier_code) }
-    validity_start_date             { Date.current.ago(3.years) }
+    validity_start_date             { 3.years.ago.beginning_of_day }
     validity_end_date               { nil }
 
     trait :xml do
-      validity_end_date { Date.current.ago(1.year) }
+      validity_end_date { 1.year.ago.beginning_of_day }
     end
   end
 end

--- a/spec/factories/measurement_unit_factory.rb
+++ b/spec/factories/measurement_unit_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     end
 
     measurement_unit_code { generate(:measurement_unit_code) }
-    validity_start_date { Date.current.ago(3.years) }
+    validity_start_date { 3.years.ago.beginning_of_day }
     validity_end_date   { nil }
 
     trait :with_description do

--- a/spec/factories/measurement_unit_qualifier_factory.rb
+++ b/spec/factories/measurement_unit_qualifier_factory.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :measurement_unit_qualifier do
     measurement_unit_qualifier_code { generate(:measurement_unit_qualifier_code) }
-    validity_start_date { Date.current.ago(3.years) }
+    validity_start_date { 3.years.ago.beginning_of_day }
     validity_end_date   { nil }
 
     trait :xml do
-      validity_end_date { Date.current.ago(1.year) }
+      validity_end_date { 1.year.ago.beginning_of_day }
     end
   end
 

--- a/spec/factories/meursing_heading_factory.rb
+++ b/spec/factories/meursing_heading_factory.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     meursing_table_plan_id          { Forgery(:basic).text(exactly: 2) }
     meursing_heading_number         { Forgery(:basic).number }
     row_column_code                 { Forgery(:basic).number }
-    validity_start_date             { Date.current.ago(2.years) }
+    validity_start_date             { 2.years.ago.beginning_of_day }
     validity_end_date               { nil }
   end
 end

--- a/spec/factories/meursing_table_plan_factory.rb
+++ b/spec/factories/meursing_table_plan_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :meursing_table_plan do
     meursing_table_plan_id          { Forgery(:basic).text(exactly: 2) }
-    validity_start_date             { Date.current.ago(2.years) }
+    validity_start_date             { 2.years.ago.beginning_of_day }
     validity_end_date               { nil }
   end
 end

--- a/spec/factories/modification_regulation_factory.rb
+++ b/spec/factories/modification_regulation_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :modification_regulation do
     modification_regulation_id   { generate(:sid) }
     modification_regulation_role { 4 }
-    validity_start_date { Date.current.ago(3.years) }
+    validity_start_date { 3.years.ago.beginning_of_day }
     validity_end_date   { nil }
   end
 end

--- a/spec/factories/monetary_exchange_period.rb
+++ b/spec/factories/monetary_exchange_period.rb
@@ -4,11 +4,11 @@ FactoryBot.define do
   factory :monetary_exchange_period do
     monetary_exchange_period_sid { generate(:monetary_exchange_sid) }
     parent_monetary_unit_code { 'EUR' }
-    validity_start_date { Date.current.at_beginning_of_month }
+    validity_start_date { Time.zone.today.at_beginning_of_month }
     operation_date { validity_start_date - 4.days }
 
     trait :old do
-      validity_start_date { Date.current.at_beginning_of_month - 6.years }
+      validity_start_date { Time.zone.today.at_beginning_of_month - 6.years }
     end
   end
 end

--- a/spec/factories/monetary_exchange_rate_factory.rb
+++ b/spec/factories/monetary_exchange_rate_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :monetary_exchange_rate do
     child_monetary_unit_code { 'GBP' }
     exchange_rate { Random.rand.to_d.truncate(9) }
-    operation_date { Date.current.at_beginning_of_month - 5.days }
+    operation_date { Time.zone.today.at_beginning_of_month - 5.days }
     monetary_exchange_period
   end
 end

--- a/spec/factories/monetary_unit_factory.rb
+++ b/spec/factories/monetary_unit_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :monetary_unit do
     monetary_unit_code { Forgery(:basic).text(exactly: 3) }
-    validity_start_date { Date.current.ago(3.years) }
+    validity_start_date { 3.years.ago.beginning_of_day }
     validity_end_date   { nil }
 
     trait :with_description do

--- a/spec/factories/publication_sigle_factory.rb
+++ b/spec/factories/publication_sigle_factory.rb
@@ -4,11 +4,11 @@ FactoryBot.define do
     code               { Forgery(:basic).text(exactly: 2) }
     sequence(:publication_code, LoopingSequence.lower_a_to_upper_z, &:value)
     publication_sigle { Forgery(:basic).text(exactly: 2) }
-    validity_start_date   { Date.current.ago(2.years) }
+    validity_start_date   { 2.years.ago.beginning_of_day }
     validity_end_date     { nil }
 
     trait :xml do
-      validity_end_date { Date.current.ago(1.year) }
+      validity_end_date { 1.year.ago.beginning_of_day }
     end
   end
 end

--- a/spec/factories/quota_factory.rb
+++ b/spec/factories/quota_factory.rb
@@ -19,11 +19,11 @@ FactoryBot.define do
 
     quota_order_number_sid { generate(:quota_order_number_sid) }
     quota_order_number_id  { generate(:quota_order_number_id) }
-    validity_start_date { Date.current.ago(4.years) }
+    validity_start_date { 4.years.ago.beginning_of_day }
     validity_end_date   { nil }
 
     trait :xml do
-      validity_end_date { Date.current.ago(1.year) }
+      validity_end_date { 1.year.ago.beginning_of_day }
     end
 
     trait :current do
@@ -61,11 +61,11 @@ FactoryBot.define do
     quota_order_number_sid         { generate(:sid) }
     geographical_area_id           { Forgery(:basic).text(exactly: 2) }
     geographical_area_sid          { generate(:sid) }
-    validity_start_date            { Date.current.ago(4.years) }
+    validity_start_date            { 4.years.ago.beginning_of_day }
     validity_end_date              { nil }
 
     trait :xml do
-      validity_end_date { Date.current.ago(1.year) }
+      validity_end_date { 1.year.ago.beginning_of_day }
     end
 
     trait :with_geographical_area do
@@ -91,7 +91,7 @@ FactoryBot.define do
   factory :quota_reopening_event do
     quota_definition_sid  { generate(:sid) }
     occurrence_timestamp  { 24.hours.ago }
-    reopening_date        { Date.current.ago(1.year) }
+    reopening_date        { 1.year.ago.beginning_of_day }
   end
 
   factory :quota_definition do
@@ -101,11 +101,11 @@ FactoryBot.define do
     monetary_unit_code              { Forgery(:basic).text(exactly: 3) }
     measurement_unit_code           { Forgery(:basic).text(exactly: 3) }
     measurement_unit_qualifier_code { generate(:measurement_unit_qualifier_code) }
-    validity_start_date             { Date.current.ago(4.years) }
+    validity_start_date             { 4.years.ago.beginning_of_day }
     validity_end_date               { nil }
 
     trait :actual do
-      validity_start_date { Date.current.ago(3.years) }
+      validity_start_date { 3.years.ago.beginning_of_day }
       validity_end_date   { nil }
     end
 
@@ -118,8 +118,8 @@ FactoryBot.define do
     end
 
     trait :xml do
-      validity_start_date             { Date.current.ago(3.years) }
-      validity_end_date               { Date.current.ago(1.year) }
+      validity_start_date             { 3.years.ago.beginning_of_day }
+      validity_end_date               { 1.year.ago.beginning_of_day }
       volume                          { Forgery(:basic).number }
       initial_volume                  { Forgery(:basic).number }
       measurement_unit_code           { Forgery(:basic).text(exactly: 2) }
@@ -144,21 +144,21 @@ FactoryBot.define do
   factory :quota_blocking_period do
     quota_blocking_period_sid  { Forgery(:basic).number }
     quota_definition_sid       { Forgery(:basic).number }
-    blocking_start_date        { Date.current.ago(1.year) }
-    blocking_end_date          { Date.current.ago(1.year) }
+    blocking_start_date        { 1.year.ago.beginning_of_day }
+    blocking_end_date          { 1.year.ago.beginning_of_day }
     blocking_period_type       { Forgery(:basic).number }
     description                { Forgery(:lorem_ipsum).sentence }
   end
 
   factory :quota_exhaustion_event do
     quota_definition
-    exhaustion_date { Date.current }
+    exhaustion_date { Time.zone.today }
     occurrence_timestamp { 24.hours.ago }
   end
 
   factory :quota_critical_event do
     quota_definition
-    critical_state_change_date { Date.current }
+    critical_state_change_date { Time.zone.today }
     occurrence_timestamp       { 24.hours.ago }
 
     trait :xml do
@@ -169,20 +169,20 @@ FactoryBot.define do
   factory :quota_suspension_period do
     quota_suspension_period_sid  { generate(:sid) }
     quota_definition_sid         { generate(:sid) }
-    suspension_start_date        { Date.current.ago(1.year) }
-    suspension_end_date          { Date.current.ago(1.year) }
+    suspension_start_date        { 1.year.ago.beginning_of_day }
+    suspension_end_date          { 1.year.ago.beginning_of_day }
     description                  { Forgery(:lorem_ipsum).sentence }
   end
 
   factory :quota_unblocking_event do
     quota_definition_sid  { generate(:sid) }
     occurrence_timestamp  { 24.hours.ago }
-    unblocking_date       { Date.current.ago(1.year) }
+    unblocking_date       { 1.year.ago.beginning_of_day }
   end
 
   factory :quota_unsuspension_event do
     quota_definition_sid  { generate(:sid) }
     occurrence_timestamp  { 24.hours.ago }
-    unsuspension_date     { Date.current.ago(1.year) }
+    unsuspension_date     { 1.year.ago.beginning_of_day }
   end
 end

--- a/spec/factories/regulation_group_factory.rb
+++ b/spec/factories/regulation_group_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :regulation_group do
     regulation_group_id     { Forgery(:basic).text(exactly: 3) }
-    validity_start_date     { Date.current.ago(2.years) }
+    validity_start_date     { 2.years.ago.beginning_of_day }
     validity_end_date       { nil }
   end
 end

--- a/spec/factories/rollbacks.rb
+++ b/spec/factories/rollbacks.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :rollback do
-    date { Date.current }
+    date { Time.zone.today }
     reason { SecureRandom.hex }
     user_id { create(:user).id }
   end

--- a/spec/integration/tariff_synchronizer_spec.rb
+++ b/spec/integration/tariff_synchronizer_spec.rb
@@ -63,12 +63,12 @@ RSpec.describe TariffSynchronizer do
   end
 
   describe '.rollback' do
-    let!(:measure) { create :measure, operation_date: Date.current }
-    let!(:update)  { create :taric_update, :applied, issue_date: Date.current }
+    let!(:measure) { create :measure, operation_date: Time.zone.today }
+    let!(:update)  { create :taric_update, :applied, issue_date: Time.zone.today }
 
     context 'successful run' do
       before do
-        described_class.rollback(Date.yesterday, keep: true)
+        described_class.rollback(Time.zone.yesterday, keep: true)
       end
 
       it 'removes entries from oplog tables' do
@@ -84,7 +84,7 @@ RSpec.describe TariffSynchronizer do
       before do
         expect(Measure).to receive(:operation_klass).and_raise(StandardError)
 
-        rescuing { described_class.rollback(Date.yesterday, keep: true) }
+        rescuing { described_class.rollback(Time.zone.yesterday, keep: true) }
       end
 
       it 'does not remove entries from oplog derived tables' do
@@ -98,7 +98,7 @@ RSpec.describe TariffSynchronizer do
 
     context 'forced to redownload by default' do
       before do
-        described_class.rollback(Date.yesterday)
+        described_class.rollback(Time.zone.yesterday)
       end
 
       it 'removes entries from oplog derived tables' do
@@ -116,7 +116,7 @@ RSpec.describe TariffSynchronizer do
       end
 
       before do
-        described_class.rollback(Date.yesterday)
+        described_class.rollback(Time.zone.yesterday)
       end
 
       it 'removes entries from oplog derived tables' do
@@ -134,6 +134,6 @@ RSpec.describe TariffSynchronizer do
   end
 
   def example_date
-    @example_date ||= Date.current
+    @example_date ||= Time.zone.today
   end
 end

--- a/spec/models/additional_code_spec.rb
+++ b/spec/models/additional_code_spec.rb
@@ -14,20 +14,20 @@ RSpec.describe AdditionalCode do
       let!(:additional_code_description1)   do
         create :additional_code_description, :with_period,
                additional_code_sid: additional_code.additional_code_sid,
-               valid_at: Date.current.ago(2.years),
+               valid_at: 2.years.ago.beginning_of_day,
                valid_to: nil
       end
       let!(:additional_code_description2) do
         create :additional_code_description, :with_period,
                additional_code_sid: additional_code.additional_code_sid,
-               valid_at: Date.current.ago(5.years),
-               valid_to: Date.current.ago(3.years)
+               valid_at: 5.years.ago.beginning_of_day,
+               valid_to: 3.years.ago.beginning_of_day
       end
       let!(:additional_code_description3) do
         create :additional_code_description, :with_period,
                additional_code_sid: additional_code.additional_code_sid,
-               valid_at: Date.current.ago(6.years),
-               valid_to: Date.current.ago(1.year)
+               valid_at: 6.years.ago.beginning_of_day,
+               valid_to: 1.year.ago.beginning_of_day
       end
 
       context 'direct loading' do

--- a/spec/models/change_spec.rb
+++ b/spec/models/change_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Change do
     context 'when there are outdated changes' do
       before do
         create :change
-        create :change, change_date: Date.current.ago(4.months)
+        create :change, change_date: 4.months.ago.beginning_of_day
         create :change_measure
       end
 

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Chapter do
     end
 
     context 'with Chapter changes' do
-      let!(:chapter) { create :chapter, operation_date: Date.current }
+      let!(:chapter) { create :chapter, operation_date: Time.zone.today }
 
       it 'includes Chapter changes' do
         expect(
@@ -86,7 +86,7 @@ RSpec.describe Chapter do
       context 'with Heading changes' do
         let!(:heading) do
           create :heading,
-                 operation_date: Date.current,
+                 operation_date: Time.zone.today,
                  goods_nomenclature_item_id: "#{chapter.short_code}01000000"
         end
 
@@ -102,7 +102,7 @@ RSpec.describe Chapter do
         context 'with associated Commodity changes' do
           let!(:commodity) do
             create :commodity,
-                   operation_date: Date.current,
+                   operation_date: Time.zone.today,
                    goods_nomenclature_item_id: "#{heading.short_code}000001"
           end
 
@@ -120,7 +120,7 @@ RSpec.describe Chapter do
               create :measure,
                      goods_nomenclature: commodity,
                      goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
-                     operation_date: Date.current
+                     operation_date: Time.zone.today
             end
 
             it 'includes Measure changes' do

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -185,13 +185,13 @@ RSpec.describe Commodity do
       # validity_start date
       # need to group and choose the latest one
       let(:measure_type) { create :measure_type }
-      let(:commodity)    { create :commodity, :with_indent, validity_start_date: Date.current.ago(3.years) }
+      let(:commodity)    { create :commodity, :with_indent, validity_start_date: 3.years.ago.beginning_of_day }
       let!(:measure1)    do
         create :measure, :with_base_regulation, measure_sid: 1,
                          measure_type_id: measure_type.measure_type_id,
                          additional_code_type_id: nil,
                          goods_nomenclature_sid: commodity.goods_nomenclature_sid,
-                         validity_start_date: Date.current.ago(1.year)
+                         validity_start_date: 1.year.ago.beginning_of_day
       end
       let!(:measure2) do
         create :measure, :with_base_regulation, measure_sid: 2,
@@ -202,11 +202,11 @@ RSpec.describe Commodity do
                          goods_nomenclature_sid: commodity.goods_nomenclature_sid,
                          additional_code_type_id: measure1.additional_code_type_id,
                          additional_code_id: measure1.additional_code_id,
-                         validity_start_date: Date.current.ago(2.years)
+                         validity_start_date: 2.years.ago.beginning_of_day
       end
 
       it 'groups measures by measure_generating_regulation_id and picks latest one' do
-        TimeMachine.at(Date.current) do
+        TimeMachine.at(Time.zone.today) do
           expect(commodity.measures.map(&:measure_sid)).to     include measure1.measure_sid
           expect(commodity.measures.map(&:measure_sid)).not_to include measure2.measure_sid
         end
@@ -388,7 +388,7 @@ RSpec.describe Commodity do
 
     context 'when in TimeMachine block' do
       it 'fetches commodities that are actual on specified Date' do
-        TimeMachine.at(Date.current.ago(2.years)) do
+        TimeMachine.at(2.years.ago.beginning_of_day) do
           commodities = described_class.actual.all
           expect(commodities).to include actual_commodity
           expect(commodities).to include expired_commodity
@@ -623,7 +623,7 @@ RSpec.describe Commodity do
     end
 
     context 'with commodity changes' do
-      let!(:commodity) { create :commodity, operation_date: Date.current }
+      let!(:commodity) { create :commodity, operation_date: Time.zone.today }
 
       it 'includes commodity changes' do
         expect(
@@ -636,12 +636,12 @@ RSpec.describe Commodity do
     end
 
     context 'with associated measure changes' do
-      let!(:commodity) { create :commodity, operation_date: Date.yesterday }
+      let!(:commodity) { create :commodity, operation_date: Time.zone.yesterday }
       let!(:measure)   do
         create :measure,
                goods_nomenclature: commodity,
                goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
-               operation_date: Date.current
+               operation_date: Time.zone.today
       end
 
       it 'includes measure changes' do

--- a/spec/models/full_temporary_stop_regulation_spec.rb
+++ b/spec/models/full_temporary_stop_regulation_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe FullTemporaryStopRegulation do
-  let(:fts_regulation) { build :fts_regulation, effective_enddate: Date.current }
+  let(:fts_regulation) { build :fts_regulation, effective_enddate: Time.zone.today }
 
   describe '#regulation_id' do
     it 'is an alias for full temporary stop regulation id' do

--- a/spec/models/geographical_area_spec.rb
+++ b/spec/models/geographical_area_spec.rb
@@ -69,24 +69,24 @@ RSpec.describe GeographicalArea do
       let!(:geographical_area)                { create :geographical_area, geographical_area_id: 'xx' }
       let!(:contained_area_present)           do
         create :geographical_area, geographical_area_id: 'ab',
-                                   validity_start_date: Date.current.ago(2.years),
-                                   validity_end_date: Date.current.ago(2.years)
+                                   validity_start_date: 2.years.ago.beginning_of_day,
+                                   validity_end_date: 2.years.ago.beginning_of_day
       end
       let!(:contained_area_past) do
         create :geographical_area, geographical_area_id: 'de',
-                                   validity_start_date: Date.current.ago(5.years),
+                                   validity_start_date: 5.years.ago.beginning_of_day,
                                    validity_end_date: 3.years.ago
       end
       let!(:geographical_area_membership1) do
         create :geographical_area_membership, geographical_area_sid: contained_area_present.geographical_area_sid,
                                               geographical_area_group_sid: geographical_area.geographical_area_sid,
-                                              validity_start_date: Date.current.ago(2.years),
+                                              validity_start_date: 2.years.ago.beginning_of_day,
                                               validity_end_date: nil
       end
       let!(:geographical_area_membership2) do
         create :geographical_area_membership, geographical_area_sid: contained_area_past.geographical_area_sid,
                                               geographical_area_group_sid: geographical_area.geographical_area_sid,
-                                              validity_start_date: Date.current.ago(5.years),
+                                              validity_start_date: 5.years.ago.beginning_of_day,
                                               validity_end_date: 3.years.ago
       end
 

--- a/spec/models/heading_spec.rb
+++ b/spec/models/heading_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe Heading do
 
   describe '#declarable' do
     context 'different points in time' do
-      today = Date.current
+      today = Time.zone.today
       t1 = today.ago(2.years)
       t2 = today.ago(1.year)
       let!(:declarable_heading) { create :heading, :declarable, goods_nomenclature_item_id: '0102000000', validity_start_date: t1, validity_end_date: nil }
@@ -275,7 +275,7 @@ RSpec.describe Heading do
     end
 
     context 'with Heading changes' do
-      let!(:heading) { create :heading, operation_date: Date.current }
+      let!(:heading) { create :heading, operation_date: Time.zone.today }
 
       it 'includes Heading changes' do
         expect(
@@ -288,10 +288,10 @@ RSpec.describe Heading do
     end
 
     context 'with associated Commodity changes' do
-      let!(:heading)   { create :heading, operation_date: Date.yesterday }
+      let!(:heading)   { create :heading, operation_date: Time.zone.yesterday }
       let!(:commodity) do
         create :commodity,
-               operation_date: Date.yesterday,
+               operation_date: Time.zone.yesterday,
                goods_nomenclature_item_id: "#{heading.short_code}000001"
       end
 
@@ -305,17 +305,17 @@ RSpec.describe Heading do
       end
 
       context 'with associated Measure (through Commodity) changes' do
-        let!(:heading)   { create :heading, operation_date: Date.yesterday }
+        let!(:heading)   { create :heading, operation_date: Time.zone.yesterday }
         let!(:commodity) do
           create :commodity,
-                 operation_date: Date.yesterday,
+                 operation_date: Time.zone.yesterday,
                  goods_nomenclature_item_id: "#{heading.short_code}000001"
         end
         let!(:measure) do
           create :measure,
                  goods_nomenclature: commodity,
                  goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
-                 operation_date: Date.yesterday
+                 operation_date: Time.zone.yesterday
         end
 
         it 'includes Measure changes' do

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -56,11 +56,11 @@ RSpec.describe Measure do
 
   # According to Taric guide
   describe '#validity_end_date' do
-    let(:base_regulation) { create :base_regulation, effective_end_date: Date.yesterday }
+    let(:base_regulation) { create :base_regulation, effective_end_date: Time.zone.yesterday }
     let(:measure) do
       create :measure, measure_generating_regulation_role: 1,
                        base_regulation: base_regulation,
-                       validity_end_date: Date.current
+                       validity_end_date: Time.zone.today
     end
 
     context 'measure end date greater than generating regulation end date' do
@@ -70,11 +70,11 @@ RSpec.describe Measure do
     end
 
     context 'measure end date lesser than generating regulation end date' do
-      let(:base_regulation) { create :base_regulation, effective_end_date: Date.current }
+      let(:base_regulation) { create :base_regulation, effective_end_date: Time.zone.today }
       let(:measure) do
         create :measure, measure_generating_regulation_role: 1,
                          base_regulation: base_regulation,
-                         validity_end_date: Date.yesterday
+                         validity_end_date: Time.zone.yesterday
       end
 
       it 'returns validity end date of the measure' do
@@ -100,7 +100,7 @@ RSpec.describe Measure do
       let(:measure) do
         create :measure, measure_generating_regulation_role: 1,
                          base_regulation: base_regulation,
-                         validity_end_date: Date.current
+                         validity_end_date: Time.zone.today
       end
 
       it 'returns validity end date of the measure' do
@@ -109,7 +109,7 @@ RSpec.describe Measure do
     end
 
     context 'generating regulation effective end date present, measure end date blank' do
-      let(:base_regulation) { create :base_regulation, effective_end_date: Date.current }
+      let(:base_regulation) { create :base_regulation, effective_end_date: Time.zone.today }
       let(:measure) do
         create :measure, measure_generating_regulation_role: 1,
                          base_regulation: base_regulation,
@@ -117,21 +117,21 @@ RSpec.describe Measure do
       end
 
       it 'returns validity end date of the measure' do
-        expect(measure.validity_end_date.to_date).to eq Date.current
+        expect(measure.validity_end_date.to_date).to eq Time.zone.today
       end
     end
 
     context 'measure is national' do
-      let(:base_regulation) { create :base_regulation, effective_end_date: Date.yesterday }
+      let(:base_regulation) { create :base_regulation, effective_end_date: Time.zone.yesterday }
       let(:measure) do
         create :measure, measure_generating_regulation_role: 1,
                          base_regulation: base_regulation,
-                         validity_end_date: Date.current,
+                         validity_end_date: Time.zone.today,
                          national: true
       end
 
       it 'returns validity end date of the measure' do
-        expect(measure.validity_end_date.to_date).to eq Date.current
+        expect(measure.validity_end_date.to_date).to eq Time.zone.today
       end
     end
   end
@@ -143,7 +143,7 @@ RSpec.describe Measure do
         create :measure_type, measure_type_id: measure.measure_type_id,
                               validity_start_date: 5.years.ago,
                               validity_end_date: 3.years.ago,
-                              operation_date: Date.yesterday
+                              operation_date: Time.zone.yesterday
       end
       let!(:measure_type2) do
         create :measure_type, measure_type_id: measure.measure_type_id,
@@ -420,8 +420,8 @@ RSpec.describe Measure do
     end
 
     describe 'additional code' do
-      let!(:additional_code1)     { create :additional_code, validity_start_date: Date.current.ago(3.years) }
-      let!(:additional_code2)     { create :additional_code, validity_start_date: Date.current.ago(5.years) }
+      let!(:additional_code1)     { create :additional_code, validity_start_date: 3.years.ago.beginning_of_day }
+      let!(:additional_code2)     { create :additional_code, validity_start_date: 5.years.ago.beginning_of_day }
       let!(:measure)              { create :measure, additional_code_sid: additional_code1.additional_code_sid }
 
       context 'direct loading' do
@@ -458,8 +458,8 @@ RSpec.describe Measure do
     end
 
     describe 'quota order number' do
-      let!(:quota_order_number1)     { create :quota_order_number, validity_start_date: Date.current.ago(3.years) }
-      let!(:quota_order_number2)     { create :quota_order_number, validity_start_date: Date.current.ago(5.years) }
+      let!(:quota_order_number1)     { create :quota_order_number, validity_start_date: 3.years.ago.beginning_of_day }
+      let!(:quota_order_number2)     { create :quota_order_number, validity_start_date: 5.years.ago.beginning_of_day }
       let!(:measure)                 { create :measure, ordernumber: quota_order_number1.quota_order_number_id }
 
       context 'direct loading' do
@@ -496,8 +496,8 @@ RSpec.describe Measure do
     end
 
     describe 'full temporary stop regulation' do
-      let!(:fts_regulation1)        { create :fts_regulation, validity_start_date: Date.current.ago(3.years) }
-      let!(:fts_regulation2)        { create :fts_regulation, validity_start_date: Date.current.ago(5.years) }
+      let!(:fts_regulation1)        { create :fts_regulation, validity_start_date: 3.years.ago.beginning_of_day }
+      let!(:fts_regulation2)        { create :fts_regulation, validity_start_date: 5.years.ago.beginning_of_day }
       let!(:fts_regulation_action1) { create :fts_regulation_action, fts_regulation_id: fts_regulation1.full_temporary_stop_regulation_id }
       let!(:fts_regulation_action2) { create :fts_regulation_action, fts_regulation_id: fts_regulation2.full_temporary_stop_regulation_id }
       let!(:measure)                { create :measure, measure_generating_regulation_id: fts_regulation_action1.stopped_regulation_id }
@@ -536,8 +536,8 @@ RSpec.describe Measure do
     end
 
     describe 'measure partial temporary stop' do
-      let!(:mpt_stop1)        { create :measure_partial_temporary_stop, validity_start_date: Date.current.ago(3.years) }
-      let!(:mpt_stop2)        { create :measure_partial_temporary_stop, validity_start_date: Date.current.ago(5.years) }
+      let!(:mpt_stop1)        { create :measure_partial_temporary_stop, validity_start_date: 3.years.ago.beginning_of_day }
+      let!(:mpt_stop2)        { create :measure_partial_temporary_stop, validity_start_date: 5.years.ago.beginning_of_day }
       let!(:measure)          { create :measure, measure_generating_regulation_id: mpt_stop1.partial_temporary_stop_regulation_id, measure_sid: mpt_stop1.measure_sid }
 
       context 'direct loading' do

--- a/spec/models/quota_event_spec.rb
+++ b/spec/models/quota_event_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe QuotaEvent do
 
   describe '.for_quota_definition' do
     it 'returns all quota events for specified quota_definition_sid' do
-      events = described_class.for_quota_definition(quota_definition.quota_definition_sid, Date.current).all
+      events = described_class.for_quota_definition(quota_definition.quota_definition_sid, Time.zone.today).all
       expect(
         events.select { |ev| ev[:event_type] == 'balance' },
       ).not_to be_blank
@@ -28,7 +28,7 @@ RSpec.describe QuotaEvent do
   describe '.last_for' do
     it 'returns last quota event type (as class) for provided quota_definition_sid value' do
       expect(
-        described_class.last_for(quota_definition.quota_definition_sid, Date.current),
+        described_class.last_for(quota_definition.quota_definition_sid, Time.zone.today),
       ).to eq QuotaExhaustionEvent
     end
   end

--- a/spec/presenters/api/v2/measures/measure_legal_act_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_legal_act_presenter_spec.rb
@@ -38,10 +38,10 @@ RSpec.describe Api::V2::Measures::MeasureLegalActPresenter do
 
     context 'with legal act' do
       let(:regulation) do
-        create(:base_regulation, published_date: Date.yesterday)
+        create(:base_regulation, published_date: Time.zone.yesterday)
       end
 
-      it { is_expected.to eql(Date.yesterday) }
+      it { is_expected.to eql(Time.zone.yesterday) }
     end
 
     context 'with legal act without published_date field' do

--- a/spec/serializers/api/v2/quota_definition_serializer_spec.rb
+++ b/spec/serializers/api/v2/quota_definition_serializer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Api::V2::QuotaDefinitionSerializer do
             measurement_unit_qualifier_code: serializable.measurement_unit_qualifier_code,
             quota_order_number_id: serializable.quota_order_number_id,
             validity_end_date: nil,
-            validity_start_date: Date.current.ago(4.years),
+            validity_start_date: 4.years.ago.beginning_of_day,
           },
         },
       }

--- a/spec/serializers/api/v2/quota_order_number_serializer_spec.rb
+++ b/spec/serializers/api/v2/quota_order_number_serializer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::V2::QuotaOrderNumberSerializer do
           attributes: {
             quota_order_number_sid: serializable.quota_order_number_sid,
             validity_end_date: nil,
-            validity_start_date: Date.current.ago(4.years),
+            validity_start_date: 4.years.ago.beginning_of_day,
           },
           relationships: {
             quota_definition: { data: { id: serializable.quota_definition_id.to_s, type: :quota_definition } },

--- a/spec/serializers/api/v2/quotas/definition/quota_definition_serializer_spec.rb
+++ b/spec/serializers/api/v2/quotas/definition/quota_definition_serializer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::V2::Quotas::Definition::QuotaDefinitionSerializer do
           quota_definition_sid: be_a(Numeric),
           quota_order_number_id: match(/09\d{4}/),
           initial_volume: nil,
-          validity_start_date: Date.current.ago(4.years).as_json,
+          validity_start_date: 4.years.ago.beginning_of_day.as_json,
           validity_end_date: nil,
           status: 'Open',
           description: nil,

--- a/spec/serializers/search/monetary_exchange_rate_serializer_spec.rb
+++ b/spec/serializers/search/monetary_exchange_rate_serializer_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Search::MonetaryExchangeRateSerializer do
   describe '#to_json' do
-    let!(:gbp_unit) { create(:monetary_unit, monetary_unit_code: 'GBP', validity_start_date: Date.current.ago(10.years)) }
-    let!(:eur_unit) { create(:monetary_unit, monetary_unit_code: 'EUR', validity_start_date: Date.current.ago(10.years)) }
+    let!(:gbp_unit) { create(:monetary_unit, monetary_unit_code: 'GBP', validity_start_date: 10.years.ago.beginning_of_day) }
+    let!(:eur_unit) { create(:monetary_unit, monetary_unit_code: 'EUR', validity_start_date: 10.years.ago.beginning_of_day) }
     let!(:monetary_exchange_period) { create :monetary_exchange_period }
     let!(:monetary_exchange_rate) { create :monetary_exchange_rate, monetary_exchange_period_sid: monetary_exchange_period.monetary_exchange_period_sid }
     let(:pattern) do

--- a/spec/services/heading_service/cached_heading_service_spec.rb
+++ b/spec/services/heading_service/cached_heading_service_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe HeadingService::CachedHeadingService do
            :with_description
   end
   let(:measure_type) { create :measure_type, measure_type_id: '103' }
-  let(:actual_date) { Date.current }
+  let(:actual_date) { Time.zone.today }
 
   describe '#serializable_hash' do
     describe 'applying time machine to footnotes, chapter, commodities and overview measures' do
@@ -43,8 +43,8 @@ RSpec.describe HeadingService::CachedHeadingService do
         let!(:footnote) do
           create :footnote,
                  :with_gono_association,
-                 validity_start_date: Date.current.ago(1.week),
-                 validity_end_date: Date.yesterday,
+                 validity_start_date: 1.week.ago.beginning_of_day,
+                 validity_end_date: Time.zone.yesterday,
                  goods_nomenclature_sid: heading.goods_nomenclature_sid
         end
         let!(:chapter) do
@@ -76,8 +76,8 @@ RSpec.describe HeadingService::CachedHeadingService do
         let!(:chapter) do
           create :chapter,
                  :with_section, :with_description,
-                 validity_start_date: Date.current.ago(1.week),
-                 validity_end_date: Date.yesterday,
+                 validity_start_date: 1.week.ago.beginning_of_day,
+                 validity_end_date: Time.zone.yesterday,
                  goods_nomenclature_item_id: heading.chapter_id
         end
         let!(:commodity) do
@@ -111,8 +111,8 @@ RSpec.describe HeadingService::CachedHeadingService do
           create :goods_nomenclature,
                  :with_description,
                  :with_indent,
-                 validity_start_date: Date.current.ago(1.week),
-                 validity_end_date: Date.yesterday,
+                 validity_start_date: 1.week.ago.beginning_of_day,
+                 validity_end_date: Time.zone.yesterday,
                  goods_nomenclature_item_id: "#{heading.short_code}#{6.times.map { Random.rand(9) }.join}"
         end
         let!(:measure) do
@@ -143,8 +143,8 @@ RSpec.describe HeadingService::CachedHeadingService do
         end
         let!(:measure) do
           create :measure,
-                 validity_start_date: Date.current.ago(1.week),
-                 validity_end_date: Date.yesterday,
+                 validity_start_date: 1.week.ago.beginning_of_day,
+                 validity_end_date: Time.zone.yesterday,
                  measure_type_id: measure_type.measure_type_id,
                  goods_nomenclature: commodity,
                  goods_nomenclature_sid: commodity.goods_nomenclature_sid

--- a/spec/services/quota_search_service_spec.rb
+++ b/spec/services/quota_search_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe QuotaSearchService do
     TimeMachine.now { example.run }
   end
 
-  let(:validity_start_date) { Date.yesterday }
+  let(:validity_start_date) { Time.zone.yesterday }
   let(:quota_order_number1) { create :quota_order_number }
   let!(:measure1) { create :measure, ordernumber: quota_order_number1.quota_order_number_id, validity_start_date: validity_start_date }
   let!(:quota_definition1) do
@@ -123,7 +123,7 @@ RSpec.describe QuotaSearchService do
       before do
         create :quota_blocking_period,
                quota_definition_sid: quota_definition1.quota_definition_sid,
-               blocking_start_date: Date.current,
+               blocking_start_date: Time.zone.today,
                blocking_end_date: 1.year.from_now
       end
 
@@ -138,7 +138,7 @@ RSpec.describe QuotaSearchService do
       before do
         create :quota_blocking_period,
                quota_definition_sid: quota_definition1.quota_definition_sid,
-               blocking_start_date: Date.current,
+               blocking_start_date: Time.zone.today,
                blocking_end_date: 1.year.from_now
       end
 

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe SearchService do
 
     it 'is valid if has both t and as_of params provided' do
       expect(
-        described_class.new(data_serializer, q: 'value', as_of: Date.current),
+        described_class.new(data_serializer, q: 'value', as_of: Time.zone.today),
       ).to be_valid
     end
   end
@@ -69,7 +69,7 @@ RSpec.describe SearchService do
         it 'returns endpoint and identifier if provided with 2 digit chapter code' do
           result = described_class.new(data_serializer,
                                        q: chapter.goods_nomenclature_item_id.first(2),
-                                       as_of: Date.current).to_json
+                                       as_of: Time.zone.today).to_json
 
           expect(result).to match_json_expression pattern
         end
@@ -77,7 +77,7 @@ RSpec.describe SearchService do
         it 'returns endpoint and identifier if provided with matching 3 digit chapter code' do
           result = described_class.new(data_serializer,
                                        q: chapter.goods_nomenclature_item_id.first(2),
-                                       as_of: Date.current).to_json
+                                       as_of: Time.zone.today).to_json
 
           expect(result).to match_json_expression pattern
         end
@@ -98,7 +98,7 @@ RSpec.describe SearchService do
         it 'returns endpoint and identifier if provided with 1 digit chapter code' do
           result = described_class.new(data_serializer,
                                        q: chapter.goods_nomenclature_item_id.first(2),
-                                       as_of: Date.current).to_json
+                                       as_of: Time.zone.today).to_json
 
           expect(result).to match_json_expression pattern
         end
@@ -120,7 +120,7 @@ RSpec.describe SearchService do
       it 'returns endpoint and identifier if provided with 4 symbol heading code' do
         result = described_class.new(data_serializer,
                                      q: heading.goods_nomenclature_item_id.first(4),
-                                     as_of: Date.current).to_json
+                                     as_of: Time.zone.today).to_json
 
         expect(result).to match_json_expression pattern
       end
@@ -128,7 +128,7 @@ RSpec.describe SearchService do
       it 'returns endpoint and identifier if provided with matching 6 (or any between length of 4 to 9) symbol heading code' do
         result = described_class.new(data_serializer,
                                      q: heading.goods_nomenclature_item_id.first(6),
-                                     as_of: Date.current).to_json
+                                     as_of: Time.zone.today).to_json
 
         expect(result).to match_json_expression pattern
       end
@@ -136,7 +136,7 @@ RSpec.describe SearchService do
       it 'returns endpoint and identifier if provided with matching 10 symbol declarable heading code' do
         result = described_class.new(data_serializer,
                                      q: heading.goods_nomenclature_item_id,
-                                     as_of: Date.current).to_json
+                                     as_of: Time.zone.today).to_json
 
         expect(result).to match_json_expression pattern
       end
@@ -161,7 +161,7 @@ RSpec.describe SearchService do
         it 'returns endpoint and identifier if provided with 10 symbol commodity code' do
           result = described_class.new(data_serializer,
                                        q: commodity.goods_nomenclature_item_id.first(10),
-                                       as_of: Date.current).to_json
+                                       as_of: Time.zone.today).to_json
 
           expect(result).to match_json_expression commodity_pattern(commodity)
         end
@@ -173,7 +173,7 @@ RSpec.describe SearchService do
                   commodity.goods_nomenclature_item_id[6..7],
                   commodity.goods_nomenclature_item_id[8..9]].join('')
           result = described_class.new(data_serializer, q: code,
-                                                        as_of: Date.current).to_json
+                                                        as_of: Time.zone.today).to_json
 
           expect(result).to match_json_expression commodity_pattern(commodity)
         end
@@ -186,7 +186,7 @@ RSpec.describe SearchService do
           code << '  ' << commodity.goods_nomenclature_item_id[8..9]
 
           result = described_class.new(data_serializer, q: code,
-                                                        as_of: Date.current).to_json
+                                                        as_of: Time.zone.today).to_json
 
           expect(result).to match_json_expression commodity_pattern(commodity)
         end
@@ -198,7 +198,7 @@ RSpec.describe SearchService do
                   commodity.goods_nomenclature_item_id[6..7],
                   commodity.goods_nomenclature_item_id[8..9]].join('.')
           result = described_class.new(data_serializer, q: code,
-                                                        as_of: Date.current).to_json
+                                                        as_of: Time.zone.today).to_json
 
           expect(result).to match_json_expression commodity_pattern(commodity)
         end
@@ -211,14 +211,14 @@ RSpec.describe SearchService do
           code << '  ' << commodity.goods_nomenclature_item_id[8..9]
 
           result = described_class.new(data_serializer, q: code,
-                                                        as_of: Date.current).to_json
+                                                        as_of: Time.zone.today).to_json
 
           expect(result).to match_json_expression commodity_pattern(commodity)
         end
 
         it 'returns endpoint and identifier if provided with matching 12 symbol commodity code' do
           result = described_class.new(data_serializer, q: commodity.goods_nomenclature_item_id + commodity.producline_suffix,
-                                                        as_of: Date.current).to_json
+                                                        as_of: Time.zone.today).to_json
 
           expect(result).to match_json_expression commodity_pattern(commodity)
         end
@@ -257,7 +257,7 @@ RSpec.describe SearchService do
         it 'does not exact match commodity with children' do
           # even though productline suffix (80) suggests that it is declarable
           result = described_class.new(data_serializer, q: commodity1.goods_nomenclature_item_id,
-                                                        as_of: Date.current).to_json
+                                                        as_of: Time.zone.today).to_json
 
           expect(result).to match_json_expression heading_pattern
         end
@@ -269,7 +269,7 @@ RSpec.describe SearchService do
 
         it 'returns mapped commodity' do
           result = described_class.new(data_serializer, q: '1010111255',
-                                                        as_of: Date.current).to_json
+                                                        as_of: Time.zone.today).to_json
 
           expect(result).to match_json_expression commodity_pattern(commodity2)
         end
@@ -287,7 +287,7 @@ RSpec.describe SearchService do
         result = described_class.new(
           data_serializer,
           q: "cas #{chemical.cas}",
-          as_of: Date.current,
+          as_of: Time.zone.today,
         ).to_json
 
         expect(result).to match_json_expression commodity_pattern(commodity)
@@ -297,7 +297,7 @@ RSpec.describe SearchService do
         result = described_class.new(
           data_serializer,
           q: chemical.cas,
-          as_of: Date.current,
+          as_of: Time.zone.today,
         ).to_json
 
         expect(result).to match_json_expression commodity_pattern(commodity)
@@ -310,7 +310,7 @@ RSpec.describe SearchService do
 
       before do
         @result = described_class.new(data_serializer, q: commodity.goods_nomenclature_item_id.first(10),
-                                                       as_of: Date.current).to_json
+                                                       as_of: Time.zone.today).to_json
       end
 
       it 'does not return hidden commodity as exact match' do
@@ -319,7 +319,7 @@ RSpec.describe SearchService do
     end
 
     context 'search references' do
-      subject(:result) { described_class.new(data_serializer, q: 'Foo Bar', as_of: Date.current).to_json }
+      subject(:result) { described_class.new(data_serializer, q: 'Foo Bar', as_of: Time.zone.today).to_json }
 
       let!(:search_reference) { create(:search_reference, title: 'Foo Bar') }
 
@@ -470,7 +470,7 @@ RSpec.describe SearchService do
       let(:synonym) { 'synonym 1' }
       let(:resources) { %w[section chapter heading commodity] }
       let(:exact_match) do
-        described_class.new(data_serializer, q: synonym, as_of: Date.current).send(:perform).results
+        described_class.new(data_serializer, q: synonym, as_of: Time.zone.today).send(:perform).results
       end
 
       before do
@@ -573,7 +573,7 @@ RSpec.describe SearchService do
 
       it 'only matches exact phrases' do
         @result = described_class.new(data_serializer, q: 'acid oil',
-                                                       as_of: Date.current).to_json
+                                                       as_of: Time.zone.today).to_json
 
         expect(@result).to match_json_expression heading_pattern
       end

--- a/spec/support/shared_examples/association_shared_examples.rb
+++ b/spec/support/shared_examples/association_shared_examples.rb
@@ -22,8 +22,8 @@ shared_examples_for 'one to one to' do |associated_object, eager_load_associatio
     end
   end
   let!(:source_record)             { :"#{described_class.to_s.underscore}" }
-  let!(:"#{associated_object}1")   { create associated_object, { validity_start_date: Date.current.ago(3.years) }.merge(right_association) }
-  let!(:"#{associated_object}2")   { create associated_object, { validity_start_date: Date.current.ago(5.years) }.merge(right_association) }
+  let!(:"#{associated_object}1")   { create associated_object, { validity_start_date: 3.years.ago.beginning_of_day }.merge(right_association) }
+  let!(:"#{associated_object}2")   { create associated_object, { validity_start_date: 5.years.ago.beginning_of_day }.merge(right_association) }
   let!(@source_record)             { create source_record, left_association }
 
   context 'direct loading' do

--- a/spec/support/shared_examples/base_update_shared_examples.rb
+++ b/spec/support/shared_examples/base_update_shared_examples.rb
@@ -7,7 +7,7 @@ shared_examples_for 'Base Update' do
     end
 
     context 'when last update is out of date' do
-      let!(:example_taric_update) { create :taric_update, example_date: Date.yesterday }
+      let!(:example_taric_update) { create :taric_update, example_date: Time.zone.yesterday }
 
       it 'should_receive download to be invoked' do
         expect(described_class).to receive(:download).at_least(1)

--- a/spec/support/synchronizer_helper.rb
+++ b/spec/support/synchronizer_helper.rb
@@ -1,5 +1,5 @@
 module SynchronizerHelper
-  def create_taric_file(date = Date.current)
+  def create_taric_file(date = Time.zone.today)
     date = Date.parse(date.to_s)
 
     content = %(<?xml version="1.0" encoding="UTF-8"?>
@@ -29,7 +29,7 @@ module SynchronizerHelper
     create_file taric_file_path, content
   end
 
-  def create_chief_file(date = Date.current)
+  def create_chief_file(date = Time.zone.today)
     date = Date.parse(date.to_s)
 
     content =

--- a/spec/unit/bank_holidays_spec.rb
+++ b/spec/unit/bank_holidays_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe BankHolidays do
       expect(described_class.last(2)).to be_a(Array)
     end
 
-    it 'returns max date less or equal Date.current' do
-      expect(described_class.last(3).last).to be <= Date.current
+    it 'returns max date less or equal Time.zone.today' do
+      expect(described_class.last(3).last).to be <= Time.zone.today
     end
 
     it 'returns Date type records' do

--- a/spec/unit/changes_table_populator/commodity_code_description_changed_spec.rb
+++ b/spec/unit/changes_table_populator/commodity_code_description_changed_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ChangesTablePopulator::CommodityCodeDescriptionChanged do
         commodity = create :goods_nomenclature, :with_description
 
         period = commodity.goods_nomenclature_description.goods_nomenclature_description_period
-        period.validity_start_date = Date.current
+        period.validity_start_date = Time.zone.today
         period.save
       end
 
@@ -53,7 +53,7 @@ RSpec.describe ChangesTablePopulator::CommodityCodeDescriptionChanged do
         create(:goods_nomenclature_description,
                goods_nomenclature_sid: heading.goods_nomenclature_sid,
                goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
-               validity_start_date: Date.current,
+               validity_start_date: Time.zone.today,
                validity_end_date: heading.validity_end_date,
                description: 'Description')
       end
@@ -80,7 +80,7 @@ RSpec.describe ChangesTablePopulator::CommodityCodeDescriptionChanged do
         create(:goods_nomenclature_description,
                goods_nomenclature_sid: heading.goods_nomenclature_sid,
                goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
-               validity_start_date: Date.current,
+               validity_start_date: Time.zone.today,
                validity_end_date: heading.validity_end_date,
                description: 'Description')
       end

--- a/spec/unit/changes_table_populator/commodity_code_end_dated_spec.rb
+++ b/spec/unit/changes_table_populator/commodity_code_end_dated_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ChangesTablePopulator::CommodityCodeEndDated do
 
     context 'when there are commodities that ended on the previous day' do
       before do
-        create :goods_nomenclature, validity_end_date: Date.current - 1.day
+        create :goods_nomenclature, validity_end_date: Time.zone.today - 1.day
       end
 
       it 'extracts changes' do
@@ -47,7 +47,7 @@ RSpec.describe ChangesTablePopulator::CommodityCodeEndDated do
         commodity = create :commodity, :with_heading
 
         heading = commodity.heading
-        heading.validity_end_date = Date.current - 1.day
+        heading.validity_end_date = Time.zone.today - 1.day
         heading.save
       end
 

--- a/spec/unit/changes_table_populator/commodity_code_started_spec.rb
+++ b/spec/unit/changes_table_populator/commodity_code_started_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ChangesTablePopulator::CommodityCodeStarted do
 
     context 'when there are commodities that started on the same day' do
       before do
-        create :goods_nomenclature, validity_start_date: Date.current
+        create :goods_nomenclature, validity_start_date: Time.zone.today
       end
 
       it 'extracts changes' do
@@ -47,7 +47,7 @@ RSpec.describe ChangesTablePopulator::CommodityCodeStarted do
         commodity = create :commodity, :with_heading
 
         heading = commodity.heading
-        heading.validity_start_date = Date.current
+        heading.validity_start_date = Time.zone.today
         heading.save
       end
 

--- a/spec/unit/changes_table_populator/measure_created_or_updated_spec.rb
+++ b/spec/unit/changes_table_populator/measure_created_or_updated_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ChangesTablePopulator::MeasureCreatedOrUpdated do
       before do
         measure = create :measure
 
-        db.run("UPDATE measures_oplog SET operation = 'C', operation_date = '#{Date.current}' " \
+        db.run("UPDATE measures_oplog SET operation = 'C', operation_date = '#{Time.zone.today}' " \
                "WHERE measure_sid = '#{measure.measure_sid}'")
       end
 
@@ -39,7 +39,7 @@ RSpec.describe ChangesTablePopulator::MeasureCreatedOrUpdated do
       before do
         measure = create :measure
 
-        db.run("UPDATE measures_oplog SET operation = 'U', operation_date = '#{Date.current}' " \
+        db.run("UPDATE measures_oplog SET operation = 'U', operation_date = '#{Time.zone.today}' " \
                "WHERE measure_sid = '#{measure.measure_sid}'")
       end
 
@@ -66,7 +66,7 @@ RSpec.describe ChangesTablePopulator::MeasureCreatedOrUpdated do
                          goods_nomenclature_sid: commodity.goods_nomenclature_sid,
                          goods_nomenclature: commodity
 
-        db.run("UPDATE measures_oplog SET operation = 'U', operation_date = '#{Date.current}' " \
+        db.run("UPDATE measures_oplog SET operation = 'U', operation_date = '#{Time.zone.today}' " \
                "WHERE measure_sid = '#{measure.measure_sid}'")
       end
 
@@ -94,7 +94,7 @@ RSpec.describe ChangesTablePopulator::MeasureCreatedOrUpdated do
                          goods_nomenclature_sid: heading.goods_nomenclature_sid,
                          goods_nomenclature: heading
 
-        db.run("UPDATE measures_oplog SET operation = 'U', operation_date = '#{Date.current}' " \
+        db.run("UPDATE measures_oplog SET operation = 'U', operation_date = '#{Time.zone.today}' " \
                "WHERE measure_sid = '#{measure.measure_sid}'")
       end
 

--- a/spec/unit/changes_table_populator/measure_deleted_spec.rb
+++ b/spec/unit/changes_table_populator/measure_deleted_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ChangesTablePopulator::MeasureDeleted do
       before do
         measure = create :measure
 
-        db.run("UPDATE measures_oplog SET operation = 'D', operation_date = '#{Date.current}' " \
+        db.run("UPDATE measures_oplog SET operation = 'D', operation_date = '#{Time.zone.today}' " \
                "WHERE measure_sid = '#{measure.measure_sid}'")
       end
 
@@ -53,7 +53,7 @@ RSpec.describe ChangesTablePopulator::MeasureDeleted do
                          goods_nomenclature_sid: commodity.goods_nomenclature_sid,
                          goods_nomenclature: commodity
 
-        db.run("UPDATE measures_oplog SET operation = 'D', operation_date = '#{Date.current}' " \
+        db.run("UPDATE measures_oplog SET operation = 'D', operation_date = '#{Time.zone.today}' " \
                "WHERE measure_sid = '#{measure.measure_sid}'")
       end
 
@@ -81,7 +81,7 @@ RSpec.describe ChangesTablePopulator::MeasureDeleted do
                          goods_nomenclature_sid: heading.goods_nomenclature_sid,
                          goods_nomenclature: heading
 
-        db.run("UPDATE measures_oplog SET operation = 'D', operation_date = '#{Date.current}' " \
+        db.run("UPDATE measures_oplog SET operation = 'D', operation_date = '#{Time.zone.today}' " \
                "WHERE measure_sid = '#{measure.measure_sid}'")
       end
 

--- a/spec/unit/changes_table_populator/measure_end_dated_spec.rb
+++ b/spec/unit/changes_table_populator/measure_end_dated_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ChangesTablePopulator::MeasureEndDated do
 
     context 'when there are measures that ended on the previous day' do
       before do
-        create :measure, validity_end_date: Date.current - 1.day
+        create :measure, validity_end_date: Time.zone.today - 1.day
       end
 
       it 'extracts changes' do
@@ -49,7 +49,7 @@ RSpec.describe ChangesTablePopulator::MeasureEndDated do
                goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
                goods_nomenclature_sid: commodity.goods_nomenclature_sid,
                goods_nomenclature: commodity,
-               validity_end_date: Date.current - 1.day
+               validity_end_date: Time.zone.today - 1.day
       end
 
       it 'extracts the commodity and the child commodity as change' do
@@ -75,7 +75,7 @@ RSpec.describe ChangesTablePopulator::MeasureEndDated do
                goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
                goods_nomenclature_sid: heading.goods_nomenclature_sid,
                goods_nomenclature: heading,
-               validity_end_date: Date.current - 1.day
+               validity_end_date: Time.zone.today - 1.day
       end
 
       it 'extracts the commodity and the child commodity as change' do

--- a/spec/unit/changes_table_populator/measure_started_spec.rb
+++ b/spec/unit/changes_table_populator/measure_started_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ChangesTablePopulator::MeasureStarted do
 
     context 'when there are measures that started on the same day' do
       before do
-        create :measure, validity_start_date: Date.current
+        create :measure, validity_start_date: Time.zone.today
       end
 
       it 'extracts changes' do
@@ -49,7 +49,7 @@ RSpec.describe ChangesTablePopulator::MeasureStarted do
                goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
                goods_nomenclature_sid: commodity.goods_nomenclature_sid,
                goods_nomenclature: commodity,
-               validity_start_date: Date.current
+               validity_start_date: Time.zone.today
       end
 
       it 'extracts the commodity and the child commodity as change' do
@@ -75,7 +75,7 @@ RSpec.describe ChangesTablePopulator::MeasureStarted do
                goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
                goods_nomenclature_sid: heading.goods_nomenclature_sid,
                goods_nomenclature: heading,
-               validity_start_date: Date.current
+               validity_start_date: Time.zone.today
       end
 
       it 'extracts the commodity and the child commodity as change' do

--- a/spec/unit/taric_importer/record_processor/destroy_operation_spec.rb
+++ b/spec/unit/taric_importer/record_processor/destroy_operation_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe TaricImporter::RecordProcessor::DestroyOperation do
   end
 
   let(:operation) do
-    described_class.new(record, Date.current)
+    described_class.new(record, Time.zone.today)
   end
 
   describe '#to_oplog_operation' do

--- a/spec/unit/taric_importer/transaction_spec.rb
+++ b/spec/unit/taric_importer/transaction_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe TaricImporter::Transaction do
         'language_id' => 'EN',
         'description' => 'French' } }
   end
-  let(:transaction_date) { Date.current }
+  let(:transaction_date) { Time.zone.today }
 
   describe 'initialization' do
     context 'invalid record structure provided' do

--- a/spec/unit/tariff_synchronizer/base_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/base_update_spec.rb
@@ -107,9 +107,9 @@ RSpec.describe TariffSynchronizer::BaseUpdate do
 
   describe '.sync' do
     it 'calls the download method for each date for the last 20 days to the current date' do
-      create :cds_update, :applied, issue_date: 1.day.ago
+      create :cds_update, :applied, issue_date: 1.day.ago.to_date
 
-      (20.days.ago.to_date..Date.current).each do |download_date|
+      (20.days.ago.to_date..Time.zone.today).each do |download_date|
         expect(TariffSynchronizer::CdsUpdateDownloader).to receive(:new).with(download_date).and_return(instance_double('TariffSynchronizer::CdsUpdateDownloader', perform: nil))
       end
 
@@ -127,8 +127,8 @@ RSpec.describe TariffSynchronizer::BaseUpdate do
         travel_back
       end
 
-      let!(:update1) { create :taric_update, :missing, example_date: Date.current }
-      let!(:update2) { create :taric_update, example_date: Date.yesterday }
+      let!(:update1) { create :taric_update, :missing, example_date: Time.zone.today }
+      let!(:update2) { create :taric_update, example_date: Time.zone.yesterday }
 
       it 'returns false' do
         expect(described_class.send(:last_updates_are_missing?)).to be_falsey
@@ -144,8 +144,8 @@ RSpec.describe TariffSynchronizer::BaseUpdate do
         travel_back
       end
 
-      let!(:update1) { create :taric_update, :missing, example_date: Date.current }
-      let!(:update2) { create :taric_update, example_date: Date.yesterday }
+      let!(:update1) { create :taric_update, :missing, example_date: Time.zone.today }
+      let!(:update2) { create :taric_update, example_date: Time.zone.yesterday }
 
       it 'returns true' do
         expect(described_class.send(:last_updates_are_missing?)).to be_truthy

--- a/spec/unit/tariff_synchronizer/cds_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/cds_update_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe TariffSynchronizer::CdsUpdate do
       create(:cds_update, :pending, example_date: pending_date)
     end
 
-    let(:applied_date) { Date.yesterday }
+    let(:applied_date) { Time.zone.yesterday }
 
     context 'when the sequence date is correct' do
       let(:pending_date) { applied_date + 1.day }

--- a/spec/unit/tariff_synchronizer/logger_spec.rb
+++ b/spec/unit/tariff_synchronizer/logger_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe TariffSynchronizer::Logger, truncation: true do
         :with_redis_lock,
       ).and_raise(Redlock::LockError, 'foo')
 
-      TariffSynchronizer.rollback(Date.current, keep: true)
+      TariffSynchronizer.rollback(Time.zone.today, keep: true)
     end
 
     it 'logs a warn event' do
@@ -24,7 +24,7 @@ RSpec.describe TariffSynchronizer::Logger, truncation: true do
 
   describe '#apply_lock_error' do
     before do
-      create(:taric_update, :applied, example_date: Date.yesterday)
+      create(:taric_update, :applied, example_date: Time.zone.yesterday)
       create(:taric_update, :pending, example_date: Date.today)
 
       expect(TradeTariffBackend).to receive(:with_redis_lock).and_raise(Redlock::LockError, 'foo')

--- a/spec/unit/tariff_synchronizer/taric_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/taric_update_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe TariffSynchronizer::TaricUpdate do
     end
 
     it 'calls the downloader with the correct args' do
-      create :taric_update, :applied, issue_date: 1.day.ago
+      create :taric_update, :applied, issue_date: 1.day.ago.to_date
 
       described_class.sync
 
-      (20.days.ago.to_date..Date.current).each do |download_date|
+      (20.days.ago.to_date..Time.zone.today).each do |download_date|
         expect(TariffSynchronizer::TaricUpdateDownloader).to have_received(:new).with(download_date)
       end
     end

--- a/spec/unit/tariff_synchronizer_spec.rb
+++ b/spec/unit/tariff_synchronizer_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe TariffSynchronizer, truncation: true do
   end
 
   describe '.apply' do
-    let(:applied_update) { create(:taric_update, :applied, example_date: Date.yesterday) }
+    let(:applied_update) { create(:taric_update, :applied, example_date: Time.zone.yesterday) }
     let(:pending_update) { create(:taric_update, :pending, example_date: Date.today) }
 
     context 'when successful' do
@@ -186,7 +186,7 @@ RSpec.describe TariffSynchronizer, truncation: true do
     end
 
     context 'with failed updates present' do
-      let(:failed_update) { create(:taric_update, :failed, example_date: Date.yesterday) }
+      let(:failed_update) { create(:taric_update, :failed, example_date: Time.zone.yesterday) }
 
       before do
         failed_update
@@ -298,7 +298,7 @@ RSpec.describe TariffSynchronizer, truncation: true do
   end
 
   describe '.apply_cds' do
-    let(:applied_update) { create(:cds_update, :applied, example_date: Date.yesterday) }
+    let(:applied_update) { create(:cds_update, :applied, example_date: Time.zone.yesterday) }
     let(:pending_update) { create(:cds_update, :pending, example_date: Date.today) }
 
     before do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1352

### What?

I have added/removed/altered:

- [x] Move from using Date.current to Time.zone.today
- [x] Move from using Date.yesterday to Time.zone.yesterday
- [x] Move from using Date.current.ago(3.years) to 3.years.ago.beginning_of_day

### Why?

I am doing this because:

- For consistency
- For clarity on the result
- To follow community standards
