### PR TITLE
HOTT-1357: Remove curb and replace it with Faraday

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 # build-base: compilation tools for bundle
 # git: used to pull gems from git
 # yarn: node package manager
-RUN apk add --update --no-cache build-base git postgresql-dev curl-dev shared-mime-info tzdata && \
+RUN apk add --update --no-cache build-base git postgresql-dev shared-mime-info tzdata && \
   cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
   echo "Europe/London" > /etc/timezone
 
@@ -33,7 +33,7 @@ RUN rm -rf node_modules log tmp && \
 # Build runtime image
 FROM ruby:3.1.1-alpine3.15 as production
 
-RUN apk add --update --no-cache postgresql-dev curl curl-dev shared-mime-info tzdata && \
+RUN apk add --update --no-cache postgresql-dev curl shared-mime-info tzdata && \
   cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
   echo "Europe/London" > /etc/timezone
 

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,6 @@ gem 'slack-notifier'
 
 # API related
 gem 'ansi'
-gem 'curb'
 gem 'jsonapi-serializer'
 gem 'rabl'
 gem 'responders'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,6 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    curb (1.0.0)
     database_cleaner-core (2.0.1)
     database_cleaner-sequel (2.0.0)
       database_cleaner-core (~> 2.0.0)
@@ -459,7 +458,6 @@ DEPENDENCIES
   bootsnap
   brakeman
   connection_pool
-  curb
   database_cleaner-sequel
   dotenv-rails
   elasticsearch (~> 7.9.0)

--- a/spec/unit/tariff_synchronizer/tariff_updates_requester_spec.rb
+++ b/spec/unit/tariff_synchronizer/tariff_updates_requester_spec.rb
@@ -1,50 +1,39 @@
 RSpec.describe TariffSynchronizer::TariffUpdatesRequester do
   describe '.perform' do
+    subject(:response) { described_class.perform('http://example/test') }
+
     let(:url) { 'http://example/test' }
 
-    context 'partial content received' do
-      it 'raises DownloadException' do
-        stub_request(:get, url).to_raise(Curl::Err::PartialFileError)
-        expect { described_class.perform('http://example/test') }.to raise_error TariffSynchronizer::TariffUpdatesRequester::DownloadException
+    context 'when a 200 success response is returned' do
+      before do
+        stub_request(:get, url).to_return(status: 200, body: 'abc')
       end
+
+      it { expect(response.content).to eq('abc') }
+      it { expect(response.response_code).to eq(200) }
     end
 
-    context 'unable to connect' do
-      it 'raises DownloadException' do
-        stub_request(:get, url).to_raise(Curl::Err::ConnectionFailedError)
-        expect { described_class.perform('http://example/test') }.to raise_error TariffSynchronizer::TariffUpdatesRequester::DownloadException
+    context 'when a Faraday:Error is propagated' do
+      before do
+        stub_request(:get, url).to_raise(Faraday::Error)
       end
+
+      it { expect { described_class.perform('http://example/test') }.to raise_error TariffSynchronizer::TariffUpdatesRequester::DownloadException }
     end
 
-    context 'host resolution error' do
-      it 'raises DownloadException' do
-        stub_request(:get, url).to_raise(Curl::Err::HostResolutionError)
-        expect { described_class.perform('http://example/test') }.to raise_error TariffSynchronizer::TariffUpdatesRequester::DownloadException
+    context 'when a 401 response is returned' do
+      before do
+        tariff_synchronizer_logger_listener
+        stub_request(:get, url).to_return(status: 401)
       end
-    end
 
-    context 'not valid request' do
-      before { stub_request(:get, url).to_return(status: 401) }
-
-      it 'returns retry_count_exceeded? as true when not valid request' do
-        response = described_class.perform('http://example/test')
-        expect(response).to be_retry_count_exceeded
-      end
+      it { expect(response).to be_retry_count_exceeded }
+      it { expect { response }.to change { @logger.logged(:info).size }.from(0).to(1) }
 
       it 'logs an info event' do
-        tariff_synchronizer_logger_listener
-        described_class.perform('http://example/test')
-        expect(@logger.logged(:info).size).to be(1)
+        response
         expect(@logger.logged(:info).to_s).to match(/Delaying update fetching/)
       end
-    end
-
-    it 'returns response object if the request is successful' do
-      stub_request(:get, url).to_return(status: 200, body: 'abc')
-
-      response = described_class.perform('http://example/test')
-      expect(response.content).to eq('abc')
-      expect(response.response_code).to eq(200)
     end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1357

### What?

I have added/removed/altered:

- [x] Remove curb
- [x] Remove curl bindings from docker image
- [x] Alter update requester to use Faraday
- [x] Make specs pass with new client implementation

### Why?

I am doing this because:

- This is an additional dependency that adds no value beyond being a bit interesting to developers.

### AC

 - [x] Api of update requester has not changed
 - [ ] Overnight runs still work on both taric and cds endpoints
