### PR TITLE
HOTT-1295: Pin rails to 7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby File.read('.ruby-version')
 
 # Server
 gem 'puma'
-gem 'rails'
+gem 'rails', '~> 7.0'
 
 # DB
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -487,7 +487,7 @@ DEPENDENCIES
   puma
   rabl
   rack-timeout
-  rails
+  rails (~> 7.0)
   redis-rails
   redlock
   responders


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1295

### What?

I have added/removed/altered:

- [x] Pin rails to 7.0

### Why?

I am doing this because:

- We should control more closely breaking versions of rails
- Rails do not use semver and minor versions are breaking
