### PR TITLE
Changed spec_helper to allow assigning seed

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,4 +11,10 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
 
   config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
 end


### PR DESCRIPTION
Useful for debugging flaky specs (this is why using rspec --seed doesn't work at the moment)
