### PR TITLE
HOTT-1364: Adds inserts to the tariff_updates table

### DIFF
--- a/db/migrate/20220223091956_add_oplog_inserts_to_tariff_updates.rb
+++ b/db/migrate/20220223091956_add_oplog_inserts_to_tariff_updates.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table :tariff_updates do
+      add_column :inserts, String
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6747,7 +6747,8 @@ CREATE TABLE public.tariff_updates (
     last_error_at timestamp without time zone,
     exception_backtrace text,
     exception_queries text,
-    exception_class text
+    exception_class text,
+    inserts text
 );
 
 
@@ -10832,3 +10833,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20210610150945_create_chan
 INSERT INTO "schema_migrations" ("filename") VALUES ('20210628165555_add_unique_constraint_to_changes.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20210915112121_add_news_items.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20220107134210_add_productline_suffix_to_search_references.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20220223091956_add_oplog_inserts_to_tariff_updates.rb');


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1364

### What?

I have added/removed/altered:

- [x] Added inserts to the tariff_updates table

### Why?

I am doing this because:

- This is required to store that oplog inserts in the updates for presentation in the admin UI https://github.com/trade-tariff/trade-tariff-admin/pull/125
