### PR TITLE
HOTT-1364: Populate oplog inserts in tariff update table

### DIFF
--- a/app/lib/tariff_synchronizer/cds_update.rb
+++ b/app/lib/tariff_synchronizer/cds_update.rb
@@ -31,8 +31,10 @@ module TariffSynchronizer
     def import!
       instrument('apply_cds.tariff_synchronizer', filename: filename) do
         @oplog_inserts = CdsImporter.new(self).import
+
         check_oplog_inserts
         mark_as_applied
+        store_oplog_inserts
       end
     end
 
@@ -56,6 +58,12 @@ module TariffSynchronizer
       return if oplog_inserts.values.sum > 0
 
       alert_potential_failed_import
+    end
+
+    def store_oplog_inserts
+      self.inserts = oplog_inserts.to_json
+
+      save
     end
 
     def alert_potential_failed_import

--- a/app/serializers/api/admin/tariff_update_serializer.rb
+++ b/app/serializers/api/admin/tariff_update_serializer.rb
@@ -7,8 +7,20 @@ module Api
 
       set_id :filename
 
-      attributes :update_type, :state, :issue_date, :created_at, :updated_at, :filename, :applied_at, :filesize, :exception_backtrace,
-                 :exception_queries, :exception_class, :file_presigned_url
+      attributes :update_type,
+                 :state,
+                 :issue_date,
+                 :inserts,
+                 :created_at,
+                 :updated_at,
+                 :filename,
+                 :applied_at,
+                 :filesize,
+                 :exception_backtrace,
+                 :issue_date,
+                 :exception_queries,
+                 :exception_class,
+                 :file_presigned_url
 
       has_many :presence_errors, serializer: Api::Admin::PresenceErrorSerializer
     end

--- a/spec/controllers/api/admin/updates_controller_spec.rb
+++ b/spec/controllers/api/admin/updates_controller_spec.rb
@@ -1,54 +1,45 @@
-RSpec.describe Api::Admin::UpdatesController, 'GET #index' do
-  let(:pattern) do
-    {
-      data: [
-        {
-          id: String,
-          type: 'tariff_update',
-          attributes: {
-            update_type: 'TariffSynchronizer::TaricUpdate',
-            state: String,
-            filename: String,
-            created_at: String,
+RSpec.describe Api::Admin::UpdatesController do
+  describe 'GET #index' do
+    let(:pattern) do
+      {
+        data: [
+          {
+            id: String,
+            type: 'tariff_update',
+            attributes: {
+              update_type: 'TariffSynchronizer::TaricUpdate',
+              state: String,
+              filename: String,
+              created_at: String,
+            }.ignore_extra_keys!,
           }.ignore_extra_keys!,
-        }.ignore_extra_keys!,
-        {
-          id: String,
-          type: 'tariff_update',
-          attributes: {
-            update_type: 'TariffSynchronizer::TaricUpdate',
-            state: String,
-            filename: String,
-            created_at: String,
-          }.ignore_extra_keys!,
-        }.ignore_extra_keys!,
-      ],
-      meta: {
-        pagination: {
-          page: Integer,
-          per_page: Integer,
-          total_count: Integer,
+        ],
+        meta: {
+          pagination: {
+            page: Integer,
+            per_page: Integer,
+            total_count: Integer,
+          },
         },
-      },
-    }
-  end
-
-  context 'when records are present' do
-    let!(:taric_update1) { create :taric_update, :applied, issue_date: Time.zone.yesterday }
-    let!(:taric_update2) { create :taric_update, :pending, issue_date: Time.zone.today }
-
-    it 'returns rendered records' do
-      get :index, format: :json
-
-      expect(response.body).to match_json_expression pattern
+      }
     end
-  end
 
-  context 'when records are not present' do
-    it 'returns blank array' do
-      get :index, format: :json
+    context 'when records are present' do
+      before { create :taric_update }
 
-      expect(JSON.parse(response.body)['data']).to eq []
+      it 'returns rendered records' do
+        get :index, format: :json
+
+        expect(response.body).to match_json_expression pattern
+      end
+    end
+
+    context 'when records are not present' do
+      it 'returns blank array' do
+        get :index, format: :json
+
+        expect(JSON.parse(response.body)['data']).to eq []
+      end
     end
   end
 end

--- a/spec/unit/tariff_synchronizer/cds_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/cds_update_spec.rb
@@ -87,7 +87,18 @@ RSpec.describe TariffSynchronizer::CdsUpdate do
 
       let(:importer) { CdsImporter.new(cds_update) }
 
+      let(:inserted_oplog_records) do
+        {
+          'AdditionalCode::Operation' => 1,
+          'Measure::Operation' => 5,
+        }
+      end
+
       context 'with valid upload' do
+        it 'will store the inserts on the update' do
+          expect(cds_update.reload.inserts).to eq('{"AdditionalCode::Operation":1,"Measure::Operation":5}')
+        end
+
         it 'will check the import' do
           expect(cds_update).to have_received(:check_oplog_inserts)
         end
@@ -160,7 +171,7 @@ RSpec.describe TariffSynchronizer::CdsUpdate do
   end
 
   describe '#filename_sequence' do
-    subject(:cds_update) { create(:cds_update, filename: filename) }
+    subject(:cds_update) { create(:cds_update, filename:) }
 
     let(:filename) { 'tariff_dailyExtract_v1_20220118T235959.gzip' }
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1364

### What?

I have added/removed/altered:

- [x] Alters cds import process to populate the inserts in the update table

### Why?

I am doing this because:

- This will be used for the admin UI

### See also

https://github.com/trade-tariff/trade-tariff-backend/pull/434
https://github.com/trade-tariff/trade-tariff-admin/pull/125
