### PR TITLE
Update staging db refresh migrations to not require a deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,17 @@ commands:
             sentry-cli releases set-commits $SENTRY_RELEASE --auto
             sentry-cli releases finalize $SENTRY_RELEASE
             sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT
+  run_migrations:
+    parameters:
+      service:
+        type: string
+      environment_key:
+        type: string
+    steps:
+      - run:
+          name: "Run Migrations"
+          command: |
+            cf run-task "tariff-<< parameters.service >>-backend-worker-<< parameters.environment_key >>" --command "cd app && bundle exec rails db:migrate" --name "db-migrate" --wait
 
 jobs:
   refresh_staging_db:
@@ -256,8 +267,7 @@ jobs:
           name: "Restore the production database into staging"
           command: |
             cf conduit tariff-"<< parameters.service >>"-staging-postgres -- psql $PGDATABASE < tariff-"<< parameters.service >>"-production-postgres.psql
-      - cf_deploy_docker_tasks:
-          space: staging
+      - run_migrations:
           service: << parameters.service >>
           environment_key: staging
 
@@ -480,13 +490,6 @@ workflows:
               only:
                 - main
     jobs:
-      - build:
-          name: build_live
-          context: trade-tariff
-          filters:
-            branches:
-              only:
-                - main
       - refresh_staging_db:
           context: trade-tariff
           matrix:
@@ -498,8 +501,6 @@ workflows:
             branches:
               only:
                 - main
-          requires: # TODO: Make build_live only run if there is not an image for the current sha
-            - build_live
   ci:
     jobs:
       - linters:


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Create a new migration command to enable running migrations without deploy
- [x] Update the refresh staging workflow to no longer use the deploy migrations step and instead use the run migrations step
- [x] Update the refresh staging workflow to no longer build the live docker image

### Why?

I am doing this because:

- Deploying is unnecessary when just running migrations
