### PR TITLE
HOTT-1337: Obfuscate errors to clients of the backend apis

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,11 +6,13 @@ class ApplicationController < ActionController::Base
   before_action :clear_association_queries
   around_action :configure_time_machine
 
-  rescue_from Exception,                          with: :render_internal_server_error
-  rescue_from ArgumentError,                      with: :render_bad_request
-  rescue_from Sequel::RecordNotFound,             with: :render_not_found
-  rescue_from ActionController::RoutingError,     with: :render_not_found
-  rescue_from AbstractController::ActionNotFound, with: :render_not_found
+  unless Rails.application.config.consider_all_requests_local
+    rescue_from Exception,                          with: :render_internal_server_error
+    rescue_from ArgumentError,                      with: :render_bad_request
+    rescue_from Sequel::RecordNotFound,             with: :render_not_found
+    rescue_from ActionController::RoutingError,     with: :render_not_found
+    rescue_from AbstractController::ActionNotFound, with: :render_not_found
+  end
 
   def render_not_found
     respond_to do |format|

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,13 +6,11 @@ class ApplicationController < ActionController::Base
   before_action :clear_association_queries
   around_action :configure_time_machine
 
-  unless Rails.application.config.consider_all_requests_local
-    rescue_from Exception,                          with: :render_internal_server_error
-    rescue_from ArgumentError,                      with: :render_bad_request
-    rescue_from Sequel::RecordNotFound,             with: :render_not_found
-    rescue_from ActionController::RoutingError,     with: :render_not_found
-    rescue_from AbstractController::ActionNotFound, with: :render_not_found
-  end
+  rescue_from Exception,                          with: :render_internal_server_error
+  rescue_from ArgumentError,                      with: :render_bad_request
+  rescue_from Sequel::RecordNotFound,             with: :render_not_found
+  rescue_from ActionController::RoutingError,     with: :render_not_found
+  rescue_from AbstractController::ActionNotFound, with: :render_not_found
 
   def render_not_found
     respond_to do |format|
@@ -47,7 +45,7 @@ class ApplicationController < ActionController::Base
       format.any do
         response.headers['Content-Type'] = 'application/json'
         serializer = TradeTariffBackend.error_serializer(request)
-        render json: serializer.serialized_errors(error: "500 - Internal Server Error: #{exception.message}"), status: :internal_server_error
+        render json: serializer.serialized_errors(error: '500 - Internal Server Error: Please contact the Tariff team for help with this issue.'), status: :internal_server_error
       end
     end
   end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -17,7 +17,8 @@ Rails.application.configure do
   config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  # TODO: This is only really necessary to make the application controller rescue behaviour testable.
+  config.consider_all_requests_local       = false
   config.action_controller.perform_caching = false
 
   config.cache_store = :null_store

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1,19 +1,44 @@
-RSpec.describe 'get a 404 response (in JSON) from unmatched route', type: :request do
-  it 'when the request is for HTML' do
-    get '/foo'
-    expect(response.body).to eq('{"error":"404 - Not Found"}')
-    expect(response).to have_http_status(:not_found)
+class NullService
+  def self.call; end
+end
+
+RSpec.describe ApplicationController, type: :controller do
+  controller do
+    def index
+      render plain: NullService.call
+    end
   end
 
-  it 'when the request is for CSV' do
-    get '/foo', headers: { "Content-Type": 'text/csv' }
-    expect(response.body).to eq('{"error":"404 - Not Found"}')
-    expect(response).to have_http_status(:not_found)
-  end
+  describe 'GET #index' do
+    subject(:do_response) { get :index }
 
-  it 'when the request is for JSON' do
-    get '/foo', headers: { "Content-Type": 'application/vnd.uktt.v2' }
-    expect(response.body).to eq('{"error":"404 - Not Found"}')
-    expect(response).to have_http_status(:not_found)
+    before do
+      allow(NullService).to receive(:call).and_raise(exception, 'foo')
+    end
+
+    context 'when the request propagates a server generated error' do
+      let(:exception) { StandardError }
+
+      it { is_expected.to have_http_status(:internal_server_error) }
+      it { expect(do_response.body).to eq('{"error":"500 - Internal Server Error: Please contact the Tariff team for help with this issue."}') }
+    end
+
+    context 'when the request propagates an argument error' do
+      let(:exception) { ArgumentError }
+
+      it { is_expected.to have_http_status(:bad_request) }
+      it { expect(do_response.body).to eq('{"error":"400 - Bad request: foo"}') }
+    end
+
+    shared_examples_for 'a not found request' do |error|
+      let(:exception) { error }
+
+      it { is_expected.to have_http_status(:not_found) }
+      it { expect(do_response.body).to eq('{"error":"404 - Not Found"}') }
+    end
+
+    it_behaves_like 'a not found request', Sequel::RecordNotFound
+    it_behaves_like 'a not found request', ActionController::RoutingError
+    it_behaves_like 'a not found request', AbstractController::ActionNotFound
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1337

### What?

I have added/removed/altered:

- [x] Added specs of current error propagation behaviour
- [x] Altered the internal server error behaviour to not include the exception body

### Why?

I am doing this because:

- We were missing coverage of this
- We need to make sure that internal details of the service do not leak to clients
