### PR TITLE
Exit brakeman gracefully after parser errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,7 +294,7 @@ jobs:
       - run:
           name: Inspecting with Brakeman
           when: always
-          command: 'bundle exec brakeman -o test-results/brakeman/brakeman.junit -o brakeman.html --no-progress --separate-models --no-exit-on-warn'
+          command: 'bundle exec brakeman -o test-results/brakeman/brakeman.junit -o brakeman.html --no-progress --separate-models --no-exit-on-error'
       - store_test_results:
           path: test-results/brakeman/
       - store_artifacts:


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Fixed typo in brakeman config

### Why?

I am doing this because:

- ruby 6 syntax brakes the brakeman sexpression tokeniser and propagates errors since brakeman 4
