### PR TITLE
Fixes deprecated basic auth api usage

### DIFF
--- a/app/lib/tariff_synchronizer/tariff_updates_requester.rb
+++ b/app/lib/tariff_synchronizer/tariff_updates_requester.rb
@@ -56,7 +56,7 @@ module TariffSynchronizer
 
       client = Faraday.new(uri.host) do |conn|
         if TradeTariffBackend.xi?
-          conn.request :authorization, :basic, TariffSynchronizer.username, TariffSynchronizer.password
+          conn.request :basic_auth, TariffSynchronizer.username, TariffSynchronizer.password
         end
       end
 

--- a/spec/unit/tariff_synchronizer/tariff_updates_requester_spec.rb
+++ b/spec/unit/tariff_synchronizer/tariff_updates_requester_spec.rb
@@ -1,39 +1,49 @@
 RSpec.describe TariffSynchronizer::TariffUpdatesRequester do
   describe '.perform' do
-    subject(:response) { described_class.perform('http://example/test') }
+    shared_examples_for 'a request to download an update' do
+      subject(:response) { described_class.perform('http://example/test') }
 
-    let(:url) { 'http://example/test' }
+      let(:url) { 'http://example/test' }
 
-    context 'when a 200 success response is returned' do
-      before do
-        stub_request(:get, url).to_return(status: 200, body: 'abc')
+      context 'when a 200 success response is returned' do
+        before do
+          stub_request(:get, url).to_return(status: 200, body: 'abc')
+        end
+
+        it { expect(response.content).to eq('abc') }
+        it { expect(response.response_code).to eq(200) }
       end
 
-      it { expect(response.content).to eq('abc') }
-      it { expect(response.response_code).to eq(200) }
+      context 'when a Faraday:Error is propagated' do
+        before do
+          stub_request(:get, url).to_raise(Faraday::Error)
+        end
+
+        it { expect { described_class.perform('http://example/test') }.to raise_error TariffSynchronizer::TariffUpdatesRequester::DownloadException }
+      end
+
+      context 'when a 401 response is returned' do
+        before do
+          tariff_synchronizer_logger_listener
+          stub_request(:get, url).to_return(status: 401)
+        end
+
+        it { expect(response).to be_retry_count_exceeded }
+        it { expect { response }.to change { @logger.logged(:info).size }.from(0).to(1) }
+
+        it 'logs an info event' do
+          response
+          expect(@logger.logged(:info).to_s).to match(/Delaying update fetching/)
+        end
+      end
     end
 
-    context 'when a Faraday:Error is propagated' do
-      before do
-        stub_request(:get, url).to_raise(Faraday::Error)
-      end
-
-      it { expect { described_class.perform('http://example/test') }.to raise_error TariffSynchronizer::TariffUpdatesRequester::DownloadException }
+    it_behaves_like 'a request to download an update' do
+      before { allow(TradeTariffBackend).to receive(:xi?).and_return(true) }
     end
 
-    context 'when a 401 response is returned' do
-      before do
-        tariff_synchronizer_logger_listener
-        stub_request(:get, url).to_return(status: 401)
-      end
-
-      it { expect(response).to be_retry_count_exceeded }
-      it { expect { response }.to change { @logger.logged(:info).size }.from(0).to(1) }
-
-      it 'logs an info event' do
-        response
-        expect(@logger.logged(:info).to_s).to match(/Delaying update fetching/)
-      end
+    it_behaves_like 'a request to download an update' do
+      before { allow(TradeTariffBackend).to receive(:xi?).and_return(false) }
     end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1357

### What?

I have added/removed/altered:

- [x] Alter the api invocation for basic_auth
- [x] Adds missing tests to cover this behaviour through xi

### Why?

I am doing this because:

- We need to make sure the downloads on XI are working
