### PR TITLE
Handle number indents reloads more wholly

### DIFF
--- a/app/lib/goods_nomenclature_mapper.rb
+++ b/app/lib/goods_nomenclature_mapper.rb
@@ -70,9 +70,6 @@ class GoodsNomenclatureMapper
   end
 
   def map_goods_nomenclatures(primary, secondary)
-    reload_if_stale(primary)
-    reload_if_stale(secondary)
-
     if (heading_map?(primary, secondary) &&
        (primary.producline_suffix < secondary.producline_suffix)) ||
         (primary.number_indents < secondary.number_indents)
@@ -129,11 +126,5 @@ class GoodsNomenclatureMapper
 
   def heading_map?(primary, secondary)
     primary.is_a?(Heading) && secondary.is_a?(Heading)
-  end
-
-  def reload_if_stale(goods_nomenclature)
-    return if goods_nomenclature.number_indents
-
-    goods_nomenclature.reload
   end
 end

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -53,7 +53,14 @@ class GoodsNomenclature < Sequel::Model
 
   delegate :national_measurement_unit_set_units, to: :national_measurement_unit_set, allow_nil: true
 
-  delegate :number_indents, to: :goods_nomenclature_indent, allow_nil: true
+  def number_indents
+    if goods_nomenclature_indent.present?
+      goods_nomenclature_indent.number_indents
+    else
+      reload && goods_nomenclature_indent&.number_indents
+    end
+  end
+
   delegate :description, :formatted_description, to: :goods_nomenclature_description, allow_nil: true
 
   one_to_one :goods_nomenclature_origin, key: %i[goods_nomenclature_item_id


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

This was prompted by https://sentry.io/organizations/engine-le/issues/3079683885/?project=5557005&referrer=slack

I have added/removed/altered:

- [x] Added number_indents override to goods nomenclature that reloads when the goods_nomenclature_indents aren't loaded properly
- [x] Removed reload_if_stale calls and method implementation

### Why?

I am doing this because:

- The reload_if_stale was a patch on a problem that was identified in a specific area of the code base.
- This problem is common to all calls to this relationship so I'm patching it globally

### Not covered

- The relationship that drives this should be a many to one that limits and orders on the dataset - I'm not touching this problem here.
- I'm not understanding/resolving the core issue that leads to this. I've had a look a couple of times and I am unable to reproduce the circumstances that lead to this - it requires a deep dive on our orm infrastructure.
