### PR TITLE
HOTT-1396 Fix migrations on staging refresh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,7 @@ jobs:
             cf conduit tariff-"<< parameters.service >>"-staging-postgres -- psql $PGDATABASE < tariff-"<< parameters.service >>"-production-postgres.psql
             cf conduit tariff-"<< parameters.service >>"-staging-postgres -- psql $PGDATABASE < db/seeds/staging.sql
       - run_migrations:
-          service: staging
+          service: << parameters.service >>
           environment_key: staging
 
   linters:


### PR DESCRIPTION
### Jira link

[HOTT-1396](https://transformuk.atlassian.net/browse/HOTT-1396)

### What?

I have added/removed/altered:

- [x] Corrected the service passed into the migrations command


### Why?

I am doing this because:

- The wrong service value was being passed into the migrations command, preventing the weekly staging refresh from running the migrations

