### PR TITLE
HOTT-1400 Exclude hidden commodities from suggestions

### DIFF
--- a/app/services/base_suggestions_service.rb
+++ b/app/services/base_suggestions_service.rb
@@ -10,6 +10,7 @@ class BaseSuggestionsService
           .distinct
           .order(Sequel.desc(:goods_nomenclature_item_id))
           .index_by(&:goods_nomenclature_item_id)
+          .without(*hidden_goods_nomenclature_ids)
           .map { |_commodity_code, commodity| handle_commodity_record(commodity) }
 
     search_references = SearchReference
@@ -34,5 +35,9 @@ class BaseSuggestionsService
 
   def handle_search_reference_record(_search_reference)
     nil
+  end
+
+  def hidden_goods_nomenclature_ids
+    @hidden_goods_nomenclature_ids ||= HiddenGoodsNomenclature.codes
   end
 end

--- a/spec/services/api/v2/suggestions_service_spec.rb
+++ b/spec/services/api/v2/suggestions_service_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe Api::V2::SuggestionsService do
+  describe '#perform' do
+    subject(:suggestions) do
+      commodities && described_class.new.perform
+    end
+
+    let(:commodities) { create_list :commodity, 3 }
+    let(:commodity_ids) { commodities.map(&:goods_nomenclature_item_id) }
+
+    it { is_expected.to have_attributes length: commodities.length }
+    it { is_expected.to all be_instance_of Api::V2::SuggestionPresenter }
+
+    describe 'suggestions' do
+      subject { suggestions.map(&:value) }
+
+      it { is_expected.to match_array commodity_ids }
+
+      context 'with hidden_goods_nomenclature_item_ids' do
+        before do
+          create :hidden_goods_nomenclature,
+                 goods_nomenclature_item_id: commodities.first.goods_nomenclature_item_id
+        end
+
+        it { is_expected.to have_attributes length: 2 }
+        it { is_expected.not_to include commodities.first.goods_nomenclature_item_id }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-1400

### What?

I have added/removed/altered:

- [x] Changed SuggestionsService to exclude directly hidden goods nomenclatures

### Why?

I am doing this because:

- they should not be showing up in search suggestions

