### PR TITLE
hotfix docker-compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
         - discovery.type=single-node
         - "OPENSEARCH_JAVA_OPTS=-Xms2g -Xmx2g"
         - cluster.routing.allocation.disk.threshold_enabled=false
+        - plugins.security.disabled=true
     ulimits:
         memlock:
             soft: -1


### PR DESCRIPTION
For some reason I'd excluded a change which disabled security for
opensearch as opensearch is 'better' than elasticsearch when it comes to
defaults choices. However, this gets in the way when we want to run
something locally quickly without messing about too much.

I've updated the file so that we can run the backend with docker-compose
without too much faffing around.

Signed-off-by: Chris Mills <7100370+chriscoffee@users.noreply.github.com>