### PR TITLE
HOTT-1393 Fixed SQL when nil reduction_indicator

### DIFF
--- a/app/services/meursing_measure_finder_service.rb
+++ b/app/services/meursing_measure_finder_service.rb
@@ -7,10 +7,8 @@ class MeursingMeasureFinderService
   def call
     MeursingMeasure
       .where(
-        Sequel.lit('additional_code_id = ?', @additional_code_id),
-      )
-      .where(
-        Sequel.lit('reduction_indicator = ?', @root_measure.reduction_indicator),
+        additional_code_id: @additional_code_id,
+        reduction_indicator: @root_measure.reduction_indicator,
       )
       .actual
       .eager(

--- a/spec/services/meursing_measure_finder_service_spec.rb
+++ b/spec/services/meursing_measure_finder_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe MeursingMeasureFinderService do
         )
       end
 
-      xit { expect(service.call.map(&:pk)).to eq([meursing_measure.pk]) }
+      it { expect(service.call.map(&:pk)).to eq([meursing_measure.pk]) }
     end
 
     context 'when there are no matching meursing measures' do


### PR DESCRIPTION
### Jira link

[HOTT-1393](https://transformuk.atlassian.net/browse/HOTT-1393)

### What?

I have added/removed/altered:

- [x] Corrected the generation of SQL when `reduction_indicator` is NULL

### Why?

I am doing this because:

This solves a flaky spec (and possible real world bug) - it is fairly frequently reproducible (maybe 2 in 3 runs) at 17858ab8 using

`bundle exec rspec --seed=8725 spec/services/meursing_measure_finder_service_spec.rb`

The underlying issue is if reduction_indicator is nil, the finder produces an incorrect SQL query, using `reduction_indicator = NULL` instead of `reduction_indicator IS NULL`

This is triggered intermittently because we are using `.sample` in the `Measure` factory for `reduction_indicator` and one of the possible values is `nil`. When this value (nil) is chosen, the spec fails.

### Notes

Currently this is derived from an older commit (`17858ab8`) to demonstrate it works. I'll rebase prior to merging and update the PR to re-enable the spec which has been disabled in a subsequent commit.


