### PR TITLE
HOTT-1414: Tweak tariff mash to work with polymorphic serializers

### DIFF
--- a/app/lib/hashie/tariff_mash.rb
+++ b/app/lib/hashie/tariff_mash.rb
@@ -14,7 +14,7 @@ module Hashie
     #
     # TODO: Replace Hashie::Mash with models and presenters since it does not play friendly with jsonapi-serializer
     def respond_to?(method)
-      return false if method == :map
+      return false if method.to_sym == :map
 
       super
     end

--- a/app/lib/hashie/tariff_mash.rb
+++ b/app/lib/hashie/tariff_mash.rb
@@ -7,5 +7,16 @@ module Hashie
     def to_a
       Array.wrap(self)
     end
+
+    # When using non-static serializers we need to avoid the jsonapi-serializer gem from treating a TariffMash like
+    # an Array which it internally maps over to pull out ids and types from each record
+    # when in fact each Mash should be treated like a single record.
+    #
+    # TODO: Replace Hashie::Mash with models and presenters since it does not play friendly with jsonapi-serializer
+    def respond_to?(method)
+      return false if method == :map
+
+      super
+    end
   end
 end

--- a/spec/lib/hashie/tariff_mash_spec.rb
+++ b/spec/lib/hashie/tariff_mash_spec.rb
@@ -1,10 +1,36 @@
 RSpec.describe Hashie::TariffMash do
-  describe '#to_a' do
-    subject(:mash) { described_class.new(foo: :bar) }
+  subject(:mash) { described_class.new(foo: :bar) }
 
+  describe '#to_a' do
     # NOTE: The to_a method is used in internal comparisons in matchers so to verify the resulting
     #       Array I need to directly call the == method. Ideally we'd not have to override this method/stop being clever
     #       in using Mashie in place of the presenter pattern.
     it { expect(mash.to_a == [{ 'foo' => :bar }]).to eq(true) }
+  end
+
+  describe '#respond_to?' do
+    context 'when passed :map' do
+      let(:respond_to_method) { :map }
+
+      it { expect(mash.respond_to?(respond_to_method)).to eq(false) }
+    end
+
+    context 'when passed "map"' do
+      let(:respond_to_method) { 'map' }
+
+      it { expect(mash.respond_to?(respond_to_method)).to eq(false) }
+    end
+
+    context 'when passed something Mashie implements' do
+      let(:respond_to_method) { 'foo' }
+
+      it { expect(mash.respond_to?(respond_to_method)).to eq(true) }
+    end
+
+    context 'when passed something Mashie does not implement' do
+      let(:respond_to_method) { 'bar' }
+
+      it { expect(mash.respond_to?(respond_to_method)).to eq(false) }
+    end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1414

### What?

The relationship method calls map for a TariffMash for non-static serializers: https://github.com/jsonapi-serializer/jsonapi-serializer/blob/master/lib/fast_jsonapi/relationship.rb#L110-L114. We want Mash to be treated like a non-enumerable object.

I have added/removed/altered:

- [x] Altered Hashie::TariffMash so that it works with polymorphic serializers

### Why?

I am doing this because:

- This is required so we can serialize ES-backed search results polymorphically

### AC

- This does not affect when An Array/Hashie::Mash::Array is encountered by the jsonapi-serializer.
