### PR TITLE
HOTT-1414: Adds necessary attributes to ES-backed goods nomenclature

### DIFF
--- a/app/serializers/cache/additional_code_serializer.rb
+++ b/app/serializers/cache/additional_code_serializer.rb
@@ -34,7 +34,10 @@ module Cache
             validity_end_date: measure.validity_end_date,
             goods_nomenclature_item_id: measure.goods_nomenclature_item_id,
             goods_nomenclature_sid: measure.goods_nomenclature_sid,
+            goods_nomenclature_id: measure.goods_nomenclature_sid,
             goods_nomenclature: goods_nomenclature_attributes(measure.goods_nomenclature),
+            geographical_area_id: measure.geographical_area_id,
+            geographical_area: geographical_area_attributes(measure.geographical_area),
           }
         end,
       }

--- a/app/serializers/cache/certificate_serializer.rb
+++ b/app/serializers/cache/certificate_serializer.rb
@@ -30,7 +30,9 @@ module Cache
             validity_end_date: measure.validity_end_date,
             goods_nomenclature_item_id: measure.goods_nomenclature_item_id,
             goods_nomenclature_sid: measure.goods_nomenclature_sid,
-            goods_nomenclature: goods_nomenclature_attributes(measure.goods_nomenclature)
+            goods_nomenclature: goods_nomenclature_attributes(measure.goods_nomenclature),
+            geographical_area_id: measure.geographical_area_id,
+            geographical_area: geographical_area_attributes(measure.geographical_area),
           }
         end
       }

--- a/app/serializers/cache/certificate_serializer.rb
+++ b/app/serializers/cache/certificate_serializer.rb
@@ -30,11 +30,12 @@ module Cache
             validity_end_date: measure.validity_end_date,
             goods_nomenclature_item_id: measure.goods_nomenclature_item_id,
             goods_nomenclature_sid: measure.goods_nomenclature_sid,
+            goods_nomenclature_id: measure.goods_nomenclature_sid,
             goods_nomenclature: goods_nomenclature_attributes(measure.goods_nomenclature),
             geographical_area_id: measure.geographical_area_id,
             geographical_area: geographical_area_attributes(measure.geographical_area),
           }
-        end
+        end,
       }
     end
   end

--- a/app/serializers/cache/footnote_serializer.rb
+++ b/app/serializers/cache/footnote_serializer.rb
@@ -41,7 +41,10 @@ module Cache
             validity_end_date: measure.validity_end_date,
             goods_nomenclature_item_id: measure.goods_nomenclature_item_id,
             goods_nomenclature_sid: measure.goods_nomenclature_sid,
-            goods_nomenclature: goods_nomenclature_attributes(measure.goods_nomenclature)
+            goods_nomenclature: goods_nomenclature_attributes(measure.goods_nomenclature),
+            goods_nomenclature_id: measure.goods_nomenclature.goods_nomenclature_sid,
+            geographical_area_id: measure.geographical_area_id,
+            geographical_area: geographical_area_attributes(measure.geographical_area),
           }
         end
       end

--- a/app/serializers/cache/search_cache_methods.rb
+++ b/app/serializers/cache/search_cache_methods.rb
@@ -1,21 +1,34 @@
 module Cache
   module SearchCacheMethods
-    def has_valid_dates(hash, start_key = :validity_start_date, end_key = :validity_end_date)
-      hash[start_key].to_date <= as_of &&
-        (hash[end_key].nil? || hash[end_key].to_date >= as_of)
+    def has_valid_dates(hash)
+      hash[:validity_start_date].to_date <= as_of &&
+        (hash[:validity_end_date].nil? || hash[:validity_end_date].to_date >= as_of)
     end
 
     def goods_nomenclature_attributes(goods_nomenclature)
-      return nil unless goods_nomenclature.present?
+      return nil if goods_nomenclature.blank?
 
       {
+        id: goods_nomenclature.goods_nomenclature_sid,
+        goods_nomenclature_class: goods_nomenclature.goods_nomenclature_class,
         goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
         goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
         number_indents: goods_nomenclature.number_indents,
+        description: goods_nomenclature.description,
         formatted_description: goods_nomenclature.formatted_description,
         producline_suffix: goods_nomenclature.producline_suffix,
         validity_start_date: goods_nomenclature.validity_start_date,
-        validity_end_date: goods_nomenclature.validity_end_date
+        validity_end_date: goods_nomenclature.validity_end_date,
+      }
+    end
+
+    def geographical_area_attributes(geographical_area)
+      return nil if geographical_area.blank?
+
+      {
+        id: geographical_area.geographical_area_id,
+        geographical_area_id: geographical_area.geographical_area_id,
+        description: geographical_area.description,
       }
     end
   end

--- a/spec/serializers/cache/search_cache_methods_spec.rb
+++ b/spec/serializers/cache/search_cache_methods_spec.rb
@@ -1,0 +1,106 @@
+class TestSearchCacheSerializer
+  include Cache::SearchCacheMethods
+
+  attr_reader :as_of
+
+  def initialize(as_of)
+    @as_of = as_of
+  end
+end
+
+RSpec.describe Cache::SearchCacheMethods do
+  let(:serializer) { TestSearchCacheSerializer.new(Date.parse(as_of)) }
+  let(:as_of) { '2021-01-01' }
+
+  describe '#has_valid_dates' do
+    subject(:has_valid_dates) { serializer.has_valid_dates(record_hash) }
+
+    let(:record_hash) do
+      {
+        validity_start_date: '2021-01-01',
+        validity_end_date: '2021-01-03',
+      }
+    end
+
+    context 'when the as of date is before the range' do
+      let(:as_of) { '2020-12-31' }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when the as of date is on the start of the range' do
+      let(:as_of) { '2021-01-01' }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when the as of date is on the end of the range' do
+      let(:as_of) { '2021-01-03' }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when the as of date is after the range' do
+      let(:as_of) { '2021-01-04' }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe '#goods_nomenclature_attributes' do
+    subject(:goods_nomenclature_attributes) { serializer.goods_nomenclature_attributes(goods_nomenclature) }
+
+    context 'when the goods nomenclature is present' do
+      let(:goods_nomenclature) { create(:heading) }
+
+      let(:expected_pattern) do
+        {
+          id: goods_nomenclature.goods_nomenclature_sid,
+          goods_nomenclature_class: 'Heading',
+          goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
+          goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
+          number_indents: 0,
+          description: '',
+          formatted_description: '',
+          producline_suffix: '80',
+          validity_start_date: '2020-03-22T00:00:00.000Z',
+          validity_end_date: nil,
+        }
+      end
+
+      it { expect(goods_nomenclature_attributes).to eq(expected_pattern) }
+    end
+
+    context 'when the goods nomenclature is blank' do
+      let(:goods_nomenclature) { nil }
+      let(:expected_pattern) { nil }
+
+      it { expect(goods_nomenclature_attributes).to eq(expected_pattern) }
+    end
+  end
+
+  describe '#geographical_area_attributes' do
+    subject(:geographical_area_attributes) { serializer.geographical_area_attributes(geographical_area) }
+
+    context 'when the geographical area is present' do
+      let(:geographical_area) { create(:geographical_area) }
+
+      let(:expected_pattern) do
+        {
+          id: geographical_area.geographical_area_id,
+          description: 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit.',
+          geographical_area_id: geographical_area.geographical_area_id,
+        }
+      end
+
+      it { expect(geographical_area_attributes).to eq(expected_pattern) }
+    end
+
+    context 'when the geographical area is blank' do
+      let(:geographical_area) { nil }
+      let(:expected_pattern) { nil }
+
+      it { expect(geographical_area_attributes).to eq(expected_pattern) }
+    end
+  end
+end

--- a/spec/serializers/cache/search_cache_methods_spec.rb
+++ b/spec/serializers/cache/search_cache_methods_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Cache::SearchCacheMethods do
           description: '',
           formatted_description: '',
           producline_suffix: '80',
-          validity_start_date: '2020-03-22T00:00:00.000Z',
+          validity_start_date: goods_nomenclature.validity_start_date,
           validity_end_date: nil,
         }
       end

--- a/spec/services/additional_code_search_service_spec.rb
+++ b/spec/services/additional_code_search_service_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe AdditionalCodeSearchService do
 
     let!(:additional_code_1) { create :additional_code }
     let!(:additional_code_description_1) { create :additional_code_description, :with_period, additional_code_sid: additional_code_1.additional_code_sid }
-    let!(:measure_1) { create :measure, additional_code_sid: additional_code_1.additional_code_sid }
+    let!(:measure_1) { create :measure, additional_code_sid: additional_code_1.additional_code_sid, goods_nomenclature: create(:chapter) }
     let!(:goods_nomenclature_1) { measure_1.goods_nomenclature }
 
     let!(:additional_code_2) { create :additional_code }
     let!(:additional_code_description_2) { create :additional_code_description, :with_period, additional_code_sid: additional_code_2.additional_code_sid }
-    let!(:measure_2) { create :measure, additional_code_sid: additional_code_2.additional_code_sid }
+    let!(:measure_2) { create :measure, additional_code_sid: additional_code_2.additional_code_sid, goods_nomenclature: create(:heading) }
     let!(:goods_nomenclature_2) { measure_2.goods_nomenclature }
     let(:current_page) { 1 }
     let(:per_page) { 20 }

--- a/spec/services/certificate_search_service_spec.rb
+++ b/spec/services/certificate_search_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CertificateSearchService do
              certificate_type_code: certificate_1.certificate_type_code,
              certificate_code: certificate_1.certificate_code
     end
-    let!(:measure_1) { create :measure }
+    let!(:measure_1) { create :measure, goods_nomenclature: create(:heading) }
     let!(:goods_nomenclature_1) { measure_1.goods_nomenclature }
     let!(:measure_condition_1) do
       create :measure_condition,
@@ -27,7 +27,7 @@ RSpec.describe CertificateSearchService do
              certificate_type_code: certificate_2.certificate_type_code,
              certificate_code: certificate_2.certificate_code
     end
-    let!(:measure_2) { create :measure }
+    let!(:measure_2) { create :measure, goods_nomenclature: create(:chapter) }
     let!(:goods_nomenclature_2) { measure_2.goods_nomenclature }
     let!(:measure_condition_2) do
       create :measure_condition,


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1414

### What?

I have added/removed/altered:

- [x] Added attributes to serialize ES-backed goods nomenclature with new shared jsonapi serializers
- [x] Added geographical area helper to enable storing geographical areas in ES
- [x] Added spec coverage for existing functionality

### Why?

I am doing this because:

- This is required so that ES-backed search results can be serialized using the new shared serializers
- We were missing coverage
