### PR TITLE
HOTT-1414: Cache Commodity#declarable? result

### DIFF
--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -93,7 +93,9 @@ class Commodity < GoodsNomenclature
   end
 
   def declarable?
-    producline_suffix == '80' && children.none?
+    Rails.cache.fetch("_declarable_#{goods_nomenclature_sid}") do
+      producline_suffix == '80' && children.none?
+    end
   end
 
   def uptree

--- a/app/models/goods_nomenclature_indent.rb
+++ b/app/models/goods_nomenclature_indent.rb
@@ -1,4 +1,6 @@
 class GoodsNomenclatureIndent < Sequel::Model
+  NON_GROUPING_PRODUCTLINE_SUFFIX = '80'.freeze
+
   set_dataset order(Sequel.desc(:goods_nomenclature_indents__validity_end_date))
 
   plugin :oplog, primary_key: :goods_nomenclature_indent_sid

--- a/spec/factories/goods_nomenclature_factory.rb
+++ b/spec/factories/goods_nomenclature_factory.rb
@@ -38,7 +38,6 @@ FactoryBot.define do
       producline_suffix { '80' }
     end
 
-
     trait :with_indent do
       # TODO: Populate this trait
     end

--- a/spec/factories/goods_nomenclature_factory.rb
+++ b/spec/factories/goods_nomenclature_factory.rb
@@ -30,6 +30,15 @@ FactoryBot.define do
       )
     end
 
+    trait :grouping do
+      producline_suffix { '10' }
+    end
+
+    trait :non_grouping do
+      producline_suffix { '80' }
+    end
+
+
     trait :with_indent do
       # TODO: Populate this trait
     end
@@ -205,20 +214,16 @@ FactoryBot.define do
     end
   end
 
+  trait :without_children do
+    # This is just a labelling trait
+  end
+
   factory :heading, parent: :goods_nomenclature, class: 'Heading' do
     # +1 is needed to avoid creating heading with gono id in form of
     # xx00xxxxxx which is a Chapter
     goods_nomenclature_item_id { "#{4.times.map { Random.rand(1..8) }.join}000000" }
 
     trait :declarable do
-      producline_suffix { '80' }
-    end
-
-    trait :grouping do
-      producline_suffix { '10' }
-    end
-
-    trait :non_grouping do
       producline_suffix { '80' }
     end
 

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -668,7 +668,7 @@ RSpec.describe Commodity do
       it 'caches the result' do
         commodity.declarable?
 
-        expect(Rails.cache).to have_received(:fetch).with("_declarable_#{commodity.goods_nomenclature_sid}")
+        expect(Rails.cache).to have_received(:fetch).with("commodity-#{commodity.goods_nomenclature_sid}--is-declarable?")
       end
     end
 
@@ -678,7 +678,7 @@ RSpec.describe Commodity do
       it 'caches the result' do
         commodity.declarable?
 
-        expect(Rails.cache).to have_received(:fetch).with("_declarable_#{commodity.goods_nomenclature_sid}")
+        expect(Rails.cache).to have_received(:fetch).with("commodity-#{commodity.goods_nomenclature_sid}--is-declarable?")
       end
     end
 

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -695,6 +695,34 @@ RSpec.describe Commodity do
     end
   end
 
+  describe '#non_grouping?' do
+    context 'when the commodity has a non-grouping producline_suffix' do
+      subject(:commodity) { create(:commodity, :non_grouping) }
+
+      it { is_expected.to be_non_grouping }
+    end
+
+    context 'when the commodity has a grouping producline_suffix' do
+      subject(:commodity) { create(:commodity, :grouping) }
+
+      it { is_expected.not_to be_non_grouping }
+    end
+  end
+
+  describe '#grouping?' do
+    context 'when the commodity has a grouping producline_suffix' do
+      subject(:commodity) { create(:commodity, :grouping) }
+
+      it { is_expected.to be_grouping }
+    end
+
+    context 'when the commodity has a non-grouping producline_suffix' do
+      subject(:commodity) { create(:commodity, :non_grouping) }
+
+      it { is_expected.not_to be_grouping }
+    end
+  end
+
   describe '.declarable' do
     let(:commodity_80) { create(:commodity, producline_suffix: '80') }
     let(:commodity_10) { create(:commodity, producline_suffix: '10') }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1414

### What?

I have added/removed/altered:

- [x] Added caching to the result of the current Commodity being declarable
- [x] Added method/constant to define formally what grouping and non grouping productline suffixes are
- [x] Added specs for new and updated methods

### Why?

I am doing this because:

- This method is called a lot and is very expensive (we have to enumerate children and related indents. This will optimise other places we ask this question.
