### PR TITLE
Drop the max autoscale value for Staging

### DIFF
--- a/config/autoscaling/staging-policy.json
+++ b/config/autoscaling/staging-policy.json
@@ -1,6 +1,6 @@
 {
   "instance_min_count": 2,
-  "instance_max_count": 12,
+  "instance_max_count": 8,
   "scaling_rules": [
     {
       "metric_type": "memoryutil",


### PR DESCRIPTION
### Jira link

HOTT-???

### What?

I have added/removed/altered:

- [ ] Drop the max autoscale value in the staging environment

### Why?

I am doing this because:

- Max DB connections allowed in Staging is 200
- Previously we were running with a max of 12 instances, 6 process per instance, 6 connections per process = 432
- Now its max 8 processes, 4 processes per instance, 6 connections per process = 192
