### PR TITLE
Use separate Redis database for tests

### DIFF
--- a/app/lib/paas_config.rb
+++ b/app/lib/paas_config.rb
@@ -10,7 +10,7 @@ module PaasConfig
       ENV['REDIS_URL']
     end
 
-    { url: url, db: 0, id: nil } # rubocop:disable Style/HashSyntax
+    { url: url, db: Rails.env.test? ? 1 : 0, id: nil } # rubocop:disable Style/HashSyntax
   end
 
   def elasticsearch

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,12 +40,8 @@ RSpec.configure do |config|
 
   config.include_context 'with fake global rules of origin data'
 
-  redis = Redis.new(db: 15)
-  RedisLockDb.redis = redis
-
   config.before(:suite) do
     TradeTariffBackend.redis.flushdb
-    redis.flushdb
 
     MeasureTypeExclusion.load_from_file \
       Rails.root.join('spec/fixtures/measure_type_exclusions.csv')
@@ -53,7 +49,6 @@ RSpec.configure do |config|
 
   config.after(:suite) do
     TradeTariffBackend.redis.flushdb
-    redis.flushdb
   end
 
   config.before do


### PR DESCRIPTION
### Jira link

HOTT-???

### What?

I have added/removed/altered:

- [x] Use a separate Redis DB for tests
- [x] Dropped using an entirely separate redis config for RedLockDb in tests

### Why?

I am doing this because:

- The tests run flushdb before and after the suite, this means you can run the tests at the same time as meaningfully using Redis in development, eg running a re-cache.
- The separate db for RedLockDb should no longer be necessary because we handle connection pooling correctly - it looks like this was a historical attempt to solve the test suite from locking up. 

