### PR TITLE
Handle when a measure has no matching goods nomenclature

### DIFF
--- a/app/serializers/cache/footnote_serializer.rb
+++ b/app/serializers/cache/footnote_serializer.rb
@@ -42,7 +42,7 @@ module Cache
             goods_nomenclature_item_id: measure.goods_nomenclature_item_id,
             goods_nomenclature_sid: measure.goods_nomenclature_sid,
             goods_nomenclature: goods_nomenclature_attributes(measure.goods_nomenclature),
-            goods_nomenclature_id: measure.goods_nomenclature.goods_nomenclature_sid,
+            goods_nomenclature_id: measure.goods_nomenclature_sid,
             geographical_area_id: measure.geographical_area_id,
             geographical_area: geographical_area_attributes(measure.geographical_area),
           }


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Added handling for footnote measures that have no goods nomenclature

### Why?

I am doing this because:

- This fails to update some footnotes in ES
