### PR TITLE
HOTT-1432: Adjust quotas query to remove duplicate definitions

### DIFF
--- a/app/services/quota_search_service.rb
+++ b/app/services/quota_search_service.rb
@@ -33,7 +33,7 @@ class QuotaSearchService
       .actual
       .join(:quota_definitions, [%i[measures__ordernumber quota_definitions__quota_order_number_id]])
       .eager(eager_load_graph)
-      .distinct(:measures__ordernumber, :measures__validity_start_date)
+      .distinct(:measures__ordernumber)
       .select(Sequel.expr(:measures).*)
       .order(:measures__ordernumber)
 

--- a/spec/services/quota_search_service_spec.rb
+++ b/spec/services/quota_search_service_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe QuotaSearchService do
            :with_geographical_area,
            quota_order_number_sid: quota_order_number1.quota_order_number_sid
   end
+  let!(:duplicate_measure) { create :measure, ordernumber: quota_order_number1.quota_order_number_id, validity_start_date: validity_start_date + 1.hour }
 
   let(:quota_order_number2) { create :quota_order_number }
   let!(:measure2) { create :measure, ordernumber: quota_order_number2.quota_order_number_id, validity_start_date: validity_start_date }
@@ -53,6 +54,14 @@ RSpec.describe QuotaSearchService do
   end
 
   describe '#call' do
+    context 'when filtering by a quota order number id' do
+      let(:filter) { { 'order_number' => duplicate_measure.ordernumber } }
+
+      it 'returns the correct quota definition' do
+        expect(service.call).to eq([quota_definition1])
+      end
+    end
+
     context 'when filtering by a fully-qualified goods_nomenclature_item_id' do
       let(:filter) { { 'goods_nomenclature_item_id' => measure1.goods_nomenclature_item_id } }
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1432

### What?

I have added/removed/altered:

- [x] Alter quotas query to return distinct measures by order number, only
- [x] Adds coverage for duplicate measures

### Why?

I am doing this because:

- We use the measure model to find applicable measures and we do not need these to be distinct on the validity start date.
- Its possible/happens in the wild for 2 measures to have a different validity start dates despite having the same order number.
- The order number and definition are one-to-one and we only ever need one active order number measure returned to get the active definition.
