### PR TITLE
HOTT-1434 Search finds subheadings

### DIFF
--- a/app/services/search_service/exact_search.rb
+++ b/app/services/search_service/exact_search.rb
@@ -58,7 +58,13 @@ class SearchService
 
       # NOTE: at the moment scope .declarable is not enough to
       # determine if it is really declarable or not
-      commodity.present? && commodity.declarable? ? commodity : nil
+      if commodity.blank?
+        nil
+      elsif commodity.declarable?
+        commodity
+      else
+        Subheading.actual.by_code(query).declarable.non_hidden.first
+      end
     end
 
     def find_chapter(query)

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -244,12 +244,12 @@ RSpec.describe SearchService do
                  validity_start_date: Date.new(2011, 1, 1)
         end
 
-        let(:heading_pattern) do
+        let(:subheading_pattern) do
           {
             type: 'exact_match',
             entry: {
-              endpoint: 'headings',
-              id: heading.goods_nomenclature_item_id.first(4),
+              endpoint: 'subheadings',
+              id: "8418213100-80",
             },
           }
         end
@@ -259,7 +259,7 @@ RSpec.describe SearchService do
           result = described_class.new(data_serializer, q: commodity1.goods_nomenclature_item_id,
                                                         as_of: Time.zone.today).to_json
 
-          expect(result).to match_json_expression heading_pattern
+          expect(result).to match_json_expression subheading_pattern
         end
       end
 


### PR DESCRIPTION
Previously it would not find the commodity and fall back to returning the heading

### Jira link

[HOTT-1434](https://transformuk.atlassian.net/browse/HOTT-1434)

### What?

I have added/removed/altered:

- [x] Changed the Search exact search to return the subheading model for non-declarable commodities instead of returning the parent Heading

### Why?

I am doing this because:

- This means Search in the frontend takes the user to the subheading page, rather then the Commodities page which then incorrectly fallsback to the history page even though its non declarable

### Deployment risks (optional)

- This changes the behaviour of the Search API - we don't actually document this _but_ it is publicly accessible - I would argue it changes to make it more useful but one to consider prior to merging.

Previously: undeclarable commodity = return ExactMatch for heading
Now: undeclarable commodity = return ExactMatch for subheading
