### PR TITLE
Rubocop match brakeman

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,7 +295,7 @@ jobs:
       - run:
           name: Inspecting with Brakeman
           when: always
-          command: 'bundle exec brakeman -o test-results/brakeman/brakeman.junit -o brakeman.html --no-progress --separate-models --no-exit-on-error'
+          command: 'bundle exec brakeman -o test-results/brakeman/brakeman.junit -o brakeman.html --no-progress --separate-models --no-exit-on-warn'
       - store_test_results:
           path: test-results/brakeman/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,7 +295,7 @@ jobs:
       - run:
           name: Inspecting with Brakeman
           when: always
-          command: 'bundle exec brakeman -o test-results/brakeman/brakeman.junit -o brakeman.html --no-progress --separate-models --no-exit-on-warn'
+          command: 'bundle exec brakeman -o test-results/brakeman/brakeman.junit -o brakeman.html --no-progress --separate-models'
       - store_test_results:
           path: test-results/brakeman/
       - store_artifacts:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,6 +64,9 @@ Style/Documentation:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Style/HashSyntax:
+  EnforcedShorthandSyntax: never
+
 Style/GuardClause:
   MinBodyLength: 2
 

--- a/app/controllers/api/v2/quotas_controller.rb
+++ b/app/controllers/api/v2/quotas_controller.rb
@@ -25,7 +25,7 @@ module Api
           meta: {
             pagination: {
               page: current_page,
-              per_page:,
+              per_page: per_page,
               total_count: search_service.pagination_record_count,
             },
           },

--- a/app/lib/paas_config.rb
+++ b/app/lib/paas_config.rb
@@ -10,7 +10,7 @@ module PaasConfig
       ENV['REDIS_URL']
     end
 
-    { url: url, db: Rails.env.test? ? 1 : 0, id: nil } # rubocop:disable Style/HashSyntax
+    { url: url, db: Rails.env.test? ? 1 : 0, id: nil }
   end
 
   def elasticsearch
@@ -22,7 +22,7 @@ module PaasConfig
       ENV['ELASTICSEARCH_URL']
     end
 
-    { url: url } # rubocop:disable Style/HashSyntax
+    { url: url }
   end
 
   def space

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -100,9 +100,9 @@ module TradeTariffBackend
     def search_client
       @search_client ||= SearchClient.new(
         Elasticsearch::Client.new,
-        indexed_models:,
+        indexed_models: indexed_models,
         index_page_size: 500,
-        search_operation_options:,
+        search_operation_options: search_operation_options,
       )
     end
 
@@ -112,7 +112,7 @@ module TradeTariffBackend
         namespace: 'cache',
         indexed_models: cached_models,
         index_page_size: 5,
-        search_operation_options:,
+        search_operation_options: search_operation_options,
       )
     end
 

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -100,11 +100,11 @@ class GoodsNomenclature < Sequel::Model
 
   def goods_nomenclature_class
     @goods_nomenclature_class ||= begin
-      class_name = self.class.sti_load(goods_nomenclature_item_id:).class.name
+      class_name = self.class.sti_load(goods_nomenclature_item_id: goods_nomenclature_item_id).class.name
 
       return class_name unless class_name == 'Commodity'
 
-      Commodity.find(goods_nomenclature_sid:).goods_nomenclature_class
+      Commodity.find(goods_nomenclature_sid: goods_nomenclature_sid).goods_nomenclature_class
     end
   end
 

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -87,9 +87,9 @@ class MeasureCondition < Sequel::Model
     RequirementDutyExpressionFormatter.format(
       duty_amount: condition_duty_amount,
       monetary_unit: condition_monetary_unit_code,
-      monetary_unit_abbreviation:,
-      measurement_unit:,
-      formatted_measurement_unit_qualifier:,
+      monetary_unit_abbreviation: monetary_unit_abbreviation,
+      measurement_unit: measurement_unit,
+      formatted_measurement_unit_qualifier: formatted_measurement_unit_qualifier,
       currency: TradeTariffBackend.currency,
       formatted: true,
     )

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -37,8 +37,8 @@ FactoryBot.define do
       create(
         :goods_nomenclature,
         validity_start_date: validity_start_date - 1.day,
-        goods_nomenclature_item_id:,
-        goods_nomenclature_sid:,
+        goods_nomenclature_item_id: goods_nomenclature_item_id,
+        goods_nomenclature_sid: goods_nomenclature_sid,
         producline_suffix: gono_producline_suffix,
         indents: gono_number_indents,
       )
@@ -53,8 +53,8 @@ FactoryBot.define do
                             measure_type_series_id: measure_type_series_id
     end
     f.geographical_area do
-      create(:geographical_area, geographical_area_sid:,
-                                 geographical_area_id:,
+      create(:geographical_area, geographical_area_sid: geographical_area_sid,
+                                 geographical_area_id: geographical_area_id,
                                  validity_start_date: validity_start_date - 1.day)
     end
 
@@ -83,8 +83,8 @@ FactoryBot.define do
         create(
           :goods_nomenclature,
           validity_start_date: validity_start_date - 1.day,
-          goods_nomenclature_item_id:,
-          goods_nomenclature_sid:,
+          goods_nomenclature_item_id: goods_nomenclature_item_id,
+          goods_nomenclature_sid: goods_nomenclature_sid,
           producline_suffix: gono_producline_suffix,
           indents: gono_number_indents,
         )

--- a/spec/factories/quota_factory.rb
+++ b/spec/factories/quota_factory.rb
@@ -113,8 +113,8 @@ FactoryBot.define do
       transient { event_new_balance { 100 } }
 
       after(:create) do |quota_definition, evaluator|
-        create(:quota_balance_event, quota_definition:, new_balance: evaluator.event_new_balance, occurrence_timestamp: Time.zone.today)
-        create(:quota_critical_event, :active, quota_definition:, occurrence_timestamp: Time.zone.yesterday)
+        create(:quota_balance_event, quota_definition: quota_definition, new_balance: evaluator.event_new_balance, occurrence_timestamp: Time.zone.today)
+        create(:quota_critical_event, :active, quota_definition: quota_definition, occurrence_timestamp: Time.zone.yesterday)
       end
     end
 
@@ -122,8 +122,8 @@ FactoryBot.define do
       transient { event_new_balance { 100 } }
 
       after(:create) do |quota_definition, evaluator|
-        create(:quota_balance_event, quota_definition:, new_balance: evaluator.event_new_balance, occurrence_timestamp: Time.zone.today)
-        create(:quota_critical_event, :inactive, quota_definition:, occurrence_timestamp: Time.zone.yesterday)
+        create(:quota_balance_event, quota_definition: quota_definition, new_balance: evaluator.event_new_balance, occurrence_timestamp: Time.zone.today)
+        create(:quota_critical_event, :inactive, quota_definition: quota_definition, occurrence_timestamp: Time.zone.yesterday)
       end
     end
 
@@ -131,37 +131,37 @@ FactoryBot.define do
       transient { event_new_balance { 100 } }
 
       after(:create) do |quota_definition, evaluator|
-        create(:quota_balance_event, quota_definition:, new_balance: evaluator.event_new_balance)
+        create(:quota_balance_event, quota_definition: quota_definition, new_balance: evaluator.event_new_balance)
       end
     end
 
     trait :with_quota_critical_events do
       after(:create) do |quota_definition, _evaluator|
-        create(:quota_critical_event, quota_definition:)
+        create(:quota_critical_event, quota_definition: quota_definition)
       end
     end
 
     trait :with_quota_exhaustion_events do
       after(:create) do |quota_definition, _evaluator|
-        create(:quota_exhaustion_event, quota_definition:)
+        create(:quota_exhaustion_event, quota_definition: quota_definition)
       end
     end
 
     trait :with_quota_unsuspension_events do
       after(:create) do |quota_definition, _evaluator|
-        create(:quota_unsuspension_event, quota_definition:)
+        create(:quota_unsuspension_event, quota_definition: quota_definition)
       end
     end
 
     trait :with_quota_reopening_events do
       after(:create) do |quota_definition, _evaluator|
-        create(:quota_reopening_event, quota_definition:)
+        create(:quota_reopening_event, quota_definition: quota_definition)
       end
     end
 
     trait :with_quota_unblocking_events do
       after(:create) do |quota_definition, _evaluator|
-        create(:quota_unblocking_event, quota_definition:)
+        create(:quota_unblocking_event, quota_definition: quota_definition)
       end
     end
 

--- a/spec/models/measure_action_spec.rb
+++ b/spec/models/measure_action_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe MeasureAction do
   shared_examples_for 'a positive measure action' do |action_code|
-    subject(:measure_action) { build(:measure_action, action_code:) }
+    subject(:measure_action) { build(:measure_action, action_code: action_code) }
 
     it { is_expected.to be_positive_action }
   end
 
   shared_examples_for 'a negative measure action' do |action_code|
-    subject(:measure_action) { build(:measure_action, action_code:) }
+    subject(:measure_action) { build(:measure_action, action_code: action_code) }
 
     it { is_expected.to be_negative_action }
   end

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -941,7 +941,7 @@ RSpec.describe Measure do
           :measure,
           :third_country,
           :with_measure_components,
-          duty_amount:,
+          duty_amount: duty_amount,
         )
       end
 
@@ -957,7 +957,7 @@ RSpec.describe Measure do
             create(
               :measure_component,
               measure_sid: measure.measure_sid,
-              duty_amount:,
+              duty_amount: duty_amount,
               duty_expression_id: '01',
             )
           end

--- a/spec/models/measure_type_spec.rb
+++ b/spec/models/measure_type_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe MeasureType do
 
   describe '#meursing?' do
     shared_examples_for 'a meursing measure type' do |measure_type_id|
-      subject(:measure_type) { build(:measure_type, measure_type_id:) }
+      subject(:measure_type) { build(:measure_type, measure_type_id: measure_type_id) }
 
       it { is_expected.to be_meursing }
     end

--- a/spec/models/quota_critical_event_spec.rb
+++ b/spec/models/quota_critical_event_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe QuotaCriticalEvent do
   end
 
   describe '#active?' do
-    subject(:event) { build(:quota_critical_event, critical_state:) }
+    subject(:event) { build(:quota_critical_event, critical_state: critical_state) }
 
     context 'when the critical event is active' do
       let(:critical_state) { 'Y' }

--- a/spec/presenters/api/v2/measures/measure_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_presenter_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Api::V2::Measures::MeasurePresenter do
              measure_sid: measure.measure_sid,
              geographical_area_sid: xi.geographical_area_sid,
              excluded_geographical_area: xi.geographical_area_id,
-             measure:,
+             measure: measure,
              geographical_area: xi)
     end
 
@@ -101,14 +101,14 @@ RSpec.describe Api::V2::Measures::MeasurePresenter do
     subject(:scheme_code) { described_class.new(measure, measure.goods_nomenclature).scheme_code }
 
     context 'when a rules of origin measure with a matching scheme code' do
-      let(:measure) { create(:measure, :with_measure_type, :tariff_preference, geographical_area_id:) }
+      let(:measure) { create(:measure, :with_measure_type, :tariff_preference, geographical_area_id: geographical_area_id) }
       let(:geographical_area_id) { '1013' }
 
       it { is_expected.to eq('eu') }
     end
 
     context 'when a rules of origin measure with a non-matching scheme code' do
-      let(:measure) { create(:measure, :with_measure_type, :tariff_preference, geographical_area_id:) }
+      let(:measure) { create(:measure, :with_measure_type, :tariff_preference, geographical_area_id: geographical_area_id) }
       let(:geographical_area_id) { 'FOO' }
 
       it { is_expected.to be_nil }

--- a/spec/serializers/api/v2/shared/measure_serializer_spec.rb
+++ b/spec/serializers/api/v2/shared/measure_serializer_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Api::V2::Shared::MeasureSerializer do
   subject(:serializer) { described_class.new(serializable, {}) }
 
-  let(:serializable) { create(:measure, goods_nomenclature:) }
+  let(:serializable) { create(:measure, goods_nomenclature: goods_nomenclature) }
 
   describe '#serializable_hash' do
     shared_examples_for 'a measure with a polymorphic goods nomenclature' do |polymorphic_type|

--- a/spec/services/meursing_measure_finder_service_spec.rb
+++ b/spec/services/meursing_measure_finder_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe MeursingMeasureFinderService do
       let(:meursing_measure) do
         create(
           :meursing_measure,
-          root_measure:,
+          root_measure: root_measure,
           geographical_area_id: GeographicalArea::ERGA_OMNES_ID, # Implicitly validates extensive measure contained geographical area filtering
         )
       end

--- a/spec/support/shared_examples/a_serialized_goods_nomenclature.rb
+++ b/spec/support/shared_examples/a_serialized_goods_nomenclature.rb
@@ -8,7 +8,7 @@ shared_examples_for 'a serialized goods nomenclature' do |type|
       {
         data: {
           id: serializable.goods_nomenclature_sid.to_s,
-          type:,
+          type: type,
           attributes: {
             goods_nomenclature_item_id: match(/\d{10}/),
             producline_suffix: match(/\d{2}/),

--- a/spec/unit/tariff_synchronizer/cds_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/cds_update_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe TariffSynchronizer::CdsUpdate do
   end
 
   describe '#filename_sequence' do
-    subject(:cds_update) { create(:cds_update, filename:) }
+    subject(:cds_update) { create(:cds_update, filename: filename) }
 
     let(:filename) { 'tariff_dailyExtract_v1_20220118T235959.gzip' }
 


### PR DESCRIPTION
### Jira link

HOTT-???

### What?

I have added/removed/altered:

- [x] Re-enabled brakeman scanning
- [x] Changed rubocop to prevent rather then require Ruby 3.1 short hash literals
- [x] Removed usage of short hash literals from existing code

### Why?

I am doing this because:

- Brakeman is more important than utilising Ruby 3.1 hash syntax
- its trivial to convert back at a future point
- for now it reduces noise in PRs because rubocop isn't insisting on an syntax change to existing code

