### PR TITLE
HOTT-1381 Add Banner news items

### DIFF
--- a/app/controllers/api/admin/news_items_controller.rb
+++ b/app/controllers/api/admin/news_items_controller.rb
@@ -59,6 +59,7 @@ module Api
           show_on_uk
           show_on_updates_page
           show_on_home_page
+          show_on_banner
           display_style
         ])
       end

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -26,6 +26,7 @@ class NewsItem < Sequel::Model
       case target_name.to_s
       when 'home' then where(show_on_home_page: true)
       when 'updates' then where(show_on_updates_page: true)
+      when 'banner' then where(show_on_banner: true)
       else self
       end
     end

--- a/app/serializers/api/admin/news_item_serializer.rb
+++ b/app/serializers/api/admin/news_item_serializer.rb
@@ -8,7 +8,7 @@ module Api
       set_id :id
 
       attributes :title, :content, :display_style, :show_on_xi, :show_on_uk,
-                 :show_on_updates_page, :show_on_home_page,
+                 :show_on_updates_page, :show_on_home_page, :show_on_banner,
                  :start_date, :end_date, :created_at, :updated_at
     end
   end

--- a/app/serializers/api/v2/news_item_serializer.rb
+++ b/app/serializers/api/v2/news_item_serializer.rb
@@ -6,8 +6,8 @@ module Api
       set_type :news_item
 
       attributes :id, :title, :content, :display_style, :show_on_xi, :show_on_uk,
-                 :show_on_updates_page, :show_on_home_page, :start_date,
-                 :end_date, :created_at, :updated_at
+                 :show_on_updates_page, :show_on_home_page, :show_on_banner,
+                 :start_date, :end_date, :created_at, :updated_at
     end
   end
 end

--- a/db/migrate/20220328091515_add_show_on_banner_to_news_items.rb
+++ b/db/migrate/20220328091515_add_show_on_banner_to_news_items.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table :news_items do
+      add_column :show_on_banner, 'boolean', null: false, default: false
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5225,7 +5225,8 @@ CREATE TABLE public.news_items (
     start_date date NOT NULL,
     end_date date,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone
+    updated_at timestamp without time zone,
+    show_on_banner boolean DEFAULT false NOT NULL
 );
 
 
@@ -10834,3 +10835,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20210628165555_add_unique_
 INSERT INTO "schema_migrations" ("filename") VALUES ('20210915112121_add_news_items.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20220107134210_add_productline_suffix_to_search_references.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20220223091956_add_oplog_inserts_to_tariff_updates.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20220328091515_add_show_on_banner_to_news_items.rb');

--- a/spec/factories/news_item_factory.rb
+++ b/spec/factories/news_item_factory.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     show_on_xi { true }
     show_on_uk { true }
     show_on_updates_page { false }
-    show_on_home_page { true }
+    show_on_home_page { false }
 
     content do
       <<~CONTENT
@@ -26,13 +26,12 @@ FactoryBot.define do
       show_on_uk { false }
     end
 
-    trait :homepage do
-      show_on_updates_page { false }
+    trait :home_page do
       show_on_home_page { true }
     end
 
-    trait :updates_and_homepage do
-      show_on_home_page { true }
+    trait :updates_page do
+      show_on_updates_page { true }
     end
   end
 end

--- a/spec/factories/news_item_factory.rb
+++ b/spec/factories/news_item_factory.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     show_on_uk { true }
     show_on_updates_page { false }
     show_on_home_page { false }
+    show_on_banner { false }
 
     content do
       <<~CONTENT
@@ -32,6 +33,10 @@ FactoryBot.define do
 
     trait :updates_page do
       show_on_updates_page { true }
+    end
+
+    trait :banner do
+      show_on_banner { true }
     end
   end
 end

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -79,22 +79,10 @@ RSpec.describe NewsItem do
     describe '.for_target' do
       subject(:results) { described_class.for_target(target) }
 
-      let(:home_page) { create :news_item, show_on_home_page: true, show_on_updates_page: false }
-      let(:updates_page) { create :news_item, show_on_home_page: false, show_on_updates_page: true }
-      let(:both_page) { create :news_item, show_on_home_page: true, show_on_updates_page: true }
-      let(:neither_page) { create :news_item, show_on_home_page: false, show_on_updates_page: false }
-
-      shared_examples_for 'a non-filtering target filter invocation' do |target|
-        subject(:results) { described_class.for_target(target) }
-
-        it { is_expected.to include home_page }
-        it { is_expected.to include updates_page }
-        it { is_expected.to include both_page }
-        it { is_expected.to include neither_page }
-      end
-
-      it_behaves_like 'a non-filtering target filter invocation', ''
-      it_behaves_like 'a non-filtering target filter invocation', nil
+      let(:home_page) { create :news_item, :home_page }
+      let(:updates_page) { create :news_item, :updates_page }
+      let(:both_page) { create :news_item, :home_page, :updates_page }
+      let(:neither_page) { create :news_item }
 
       context 'without target' do
         let(:target) { nil }

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -79,7 +79,6 @@ RSpec.describe NewsItem do
     describe '.for_target' do
       subject(:results) { described_class.for_target(target) }
 
-      let(:home_page) { create :news_item, :home_page }
       let(:updates_page) { create :news_item, :updates_page }
       let(:both_page) { create :news_item, :home_page, :updates_page }
       let(:neither_page) { create :news_item }
@@ -87,7 +86,6 @@ RSpec.describe NewsItem do
       context 'without target' do
         let(:target) { nil }
 
-        it { is_expected.to include home_page }
         it { is_expected.to include updates_page }
         it { is_expected.to include both_page }
         it { is_expected.to include neither_page }
@@ -95,6 +93,7 @@ RSpec.describe NewsItem do
 
       context 'with home' do
         let(:target) { 'home' }
+        let(:home_page) { create :news_item, :home_page }
 
         it { is_expected.to include home_page }
         it { is_expected.not_to include updates_page }
@@ -104,10 +103,21 @@ RSpec.describe NewsItem do
 
       context 'with updates' do
         let(:target) { 'updates' }
+        let(:home_page) { create :news_item, :home_page }
 
         it { is_expected.to include updates_page }
         it { is_expected.not_to include home_page }
         it { is_expected.to include both_page }
+        it { is_expected.not_to include neither_page }
+      end
+
+      context 'with banner' do
+        let(:target) { 'banner' }
+        let(:banner) { create :news_item, :banner }
+
+        it { is_expected.to include banner }
+        it { is_expected.not_to include updates_page }
+        it { is_expected.not_to include both_page }
         it { is_expected.not_to include neither_page }
       end
     end
@@ -127,14 +137,14 @@ RSpec.describe NewsItem do
         create :news_item, start_date: Time.zone.tomorrow, end_date: Time.zone.tomorrow
       end
 
-      let :indefinite do
+      let :ongoing do
         create :news_item, start_date: Time.zone.today, end_date: nil
       end
 
       it { is_expected.not_to include yesterdays }
       it { is_expected.to include todays }
       it { is_expected.not_to include tomorrows }
-      it { is_expected.to include indefinite }
+      it { is_expected.to include ongoing }
     end
 
     describe '.descending' do

--- a/spec/serializers/api/admin/news_item_serializer_spec.rb
+++ b/spec/serializers/api/admin/news_item_serializer_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Api::Admin::NewsItemSerializer do
           show_on_uk: news_item.show_on_uk,
           show_on_updates_page: news_item.show_on_updates_page,
           show_on_home_page: news_item.show_on_home_page,
+          show_on_banner: news_item.show_on_banner,
           start_date: news_item.start_date,
           end_date: news_item.end_date,
           created_at: news_item.created_at,

--- a/spec/serializers/api/v2/news_item_serializer_spec.rb
+++ b/spec/serializers/api/v2/news_item_serializer_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Api::V2::NewsItemSerializer do
           show_on_uk: news_item.show_on_uk,
           show_on_updates_page: news_item.show_on_updates_page,
           show_on_home_page: news_item.show_on_home_page,
+          show_on_banner: news_item.show_on_banner,
           start_date: news_item.start_date,
           end_date: news_item.end_date,
           created_at: news_item.created_at,


### PR DESCRIPTION
### Jira link

[HOTT-1381](https://transformuk.atlassian.net/browse/HOTT-1381)

### What?

I have added/removed/altered:

- [x] Added a 'show_on_banner' flag to news items
- [x] Updated serializers to expose flag
- [x] Updated APIs to include banner news items when requested

### Why?

I am doing this because:

- We want to content manage the banner on the frontend site

### Deployment risks (optional)

- Database change included along side code dependency on database change - this should be a non-issue now with the migration fixes
