### PR TITLE
HOTT-1414: Handle nil goods nomenclature in polymorphic serializer

### DIFF
--- a/app/serializers/api/v2/shared/measure_serializer.rb
+++ b/app/serializers/api/v2/shared/measure_serializer.rb
@@ -12,7 +12,14 @@ module Api
                    :validity_end_date,
                    :validity_start_date
 
-        has_one :goods_nomenclature, serializer: proc { |record, _params| "Api::V2::Shared::#{record.goods_nomenclature_class}Serializer".constantize }
+        has_one :goods_nomenclature,
+                serializer: proc { |record, _params|
+                  if record && record.respond_to?(:goods_nomenclature_class)
+                    "Api::V2::Shared::#{record.goods_nomenclature_class}Serializer".constantize
+                  else
+                    Api::V2::Shared::GoodsNomenclatureSerializer
+                  end
+                }
 
         has_one :geographical_area, serializer: Api::V2::GeographicalAreaSerializer
       end

--- a/spec/serializers/api/v2/shared/measure_serializer_spec.rb
+++ b/spec/serializers/api/v2/shared/measure_serializer_spec.rb
@@ -49,5 +49,33 @@ RSpec.describe Api::V2::Shared::MeasureSerializer do
     it_behaves_like 'a measure with a polymorphic goods nomenclature', 'chapter' do
       let(:goods_nomenclature) { create(:chapter) }
     end
+
+    context 'when the goods nomenclature is nil' do
+      let(:goods_nomenclature) { nil }
+      let(:expected_pattern) do
+        {
+          data: {
+            id: serializable.measure_sid.to_s,
+            type: 'measure',
+            attributes: {
+              goods_nomenclature_item_id: match(/\d{10}/),
+            },
+            relationships: {
+              geographical_area: {
+                data: {
+                  id: serializable.geographical_area_id,
+                  type: 'geographical_area',
+                },
+              },
+              goods_nomenclature: {
+                data: nil,
+              },
+            },
+          },
+        }
+      end
+
+      it { expect(serializer.serializable_hash.as_json).to include_json(expected_pattern) }
+    end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1414

### What?

I have added/removed/altered:

- [x] Added more graceful handling for measures without goods nomenclature
- [x] Added coverage for the new handling

### Why?

I am doing this because:

- This is causing failures for users that are scraping certain additional codes in production
