### PR TITLE
HOTT-1414: Exclude measures without goods nomenclature code search

### DIFF
--- a/app/serializers/cache/additional_code_serializer.rb
+++ b/app/serializers/cache/additional_code_serializer.rb
@@ -10,12 +10,6 @@ module Cache
     end
 
     def as_json
-      measures = additional_code.measures_dataset
-                                .exclude(goods_nomenclature_item_id: nil)
-                                .to_a
-                                .select do |measure|
-        has_valid_dates(measure)
-      end
       {
         additional_code_sid: additional_code.additional_code_sid,
         code: additional_code.code,
@@ -26,21 +20,35 @@ module Cache
         validity_start_date: additional_code.validity_start_date,
         validity_end_date: additional_code.validity_end_date,
         measure_ids: measures.map(&:measure_sid),
-        measures: measures.map do |measure|
-          {
-            id: measure.measure_sid,
-            measure_sid: measure.measure_sid,
-            validity_start_date: measure.validity_start_date,
-            validity_end_date: measure.validity_end_date,
-            goods_nomenclature_item_id: measure.goods_nomenclature_item_id,
-            goods_nomenclature_sid: measure.goods_nomenclature_sid,
-            goods_nomenclature_id: measure.goods_nomenclature_sid,
-            goods_nomenclature: goods_nomenclature_attributes(measure.goods_nomenclature),
-            geographical_area_id: measure.geographical_area_id,
-            geographical_area: geographical_area_attributes(measure.geographical_area),
-          }
-        end,
+        measures: serialized_measures,
       }
+    end
+
+    private
+
+    def serialized_measures
+      measures.map do |measure|
+        {
+          id: measure.measure_sid,
+          measure_sid: measure.measure_sid,
+          validity_start_date: measure.validity_start_date,
+          validity_end_date: measure.validity_end_date,
+          goods_nomenclature_item_id: measure.goods_nomenclature_item_id,
+          goods_nomenclature_sid: measure.goods_nomenclature_sid,
+          goods_nomenclature_id: measure.goods_nomenclature_sid,
+          goods_nomenclature: goods_nomenclature_attributes(measure.goods_nomenclature),
+          geographical_area_id: measure.geographical_area_id,
+          geographical_area: geographical_area_attributes(measure.geographical_area),
+        }
+      end
+    end
+
+    def measures
+      additional_code
+        .measures_dataset.eager(:goods_nomenclature)
+        .exclude(goods_nomenclature_item_id: nil)
+        .all
+        .select { |measure| has_valid_dates(measure) && measure.goods_nomenclature.present? }
     end
   end
 end

--- a/app/serializers/cache/additional_code_serializer.rb
+++ b/app/serializers/cache/additional_code_serializer.rb
@@ -45,7 +45,8 @@ module Cache
 
     def measures
       additional_code
-        .measures_dataset.eager(:goods_nomenclature)
+        .measures_dataset
+        .eager(:goods_nomenclature)
         .exclude(goods_nomenclature_item_id: nil)
         .all
         .select { |measure| has_valid_dates(measure) && measure.goods_nomenclature.present? }

--- a/spec/controllers/api/v2/additional_codes_controller_spec.rb
+++ b/spec/controllers/api/v2/additional_codes_controller_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe Api::V2::AdditionalCodesController, type: :controller do
     let!(:additional_code) { create :additional_code }
     let!(:additional_code_description) { create :additional_code_description, :with_period, additional_code_sid: additional_code.additional_code_sid }
     let!(:measure) { create :measure, :with_base_regulation, additional_code_sid: additional_code.additional_code_sid, goods_nomenclature: create(:heading) }
+    let!(:excluded_measure) { create :measure, :with_base_regulation, additional_code_sid: additional_code.additional_code_sid, goods_nomenclature: nil }
     let!(:goods_nomenclature) { measure.goods_nomenclature }
     let!(:goods_nomenclature_description) { create :goods_nomenclature_description, goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid }
 

--- a/spec/serializers/cache/additional_code_serializer_spec.rb
+++ b/spec/serializers/cache/additional_code_serializer_spec.rb
@@ -1,0 +1,61 @@
+RSpec.describe Cache::AdditionalCodeSerializer do
+  subject(:serialized) { described_class.new(additional_code.reload).as_json }
+
+  before do
+    included_measure
+    excluded_measure_goods_nomenclature
+    excluded_measure_bad_dates
+  end
+
+  let(:additional_code) do
+    code = create(:additional_code)
+
+    create(:additional_code_description, :with_period, additional_code_sid: code.additional_code_sid)
+
+    code
+  end
+
+  let(:included_measure) do
+    create(
+      :measure,
+      :with_base_regulation,
+      additional_code_sid: additional_code.additional_code_sid,
+      goods_nomenclature: create(:heading, :with_description),
+    )
+  end
+
+  let(:excluded_measure_goods_nomenclature) do
+    create(
+      :measure,
+      :with_base_regulation,
+      additional_code_sid: additional_code.additional_code_sid,
+      goods_nomenclature: nil,
+    )
+  end
+
+  let(:excluded_measure_bad_dates) do
+    create(
+      :measure,
+      :with_base_regulation,
+      additional_code_sid: additional_code.additional_code_sid,
+      validity_end_date: Time.zone.yesterday,
+    )
+  end
+
+  let(:pattern) do
+    {
+      additional_code_sid: additional_code.additional_code_sid,
+      code: additional_code.code,
+      additional_code_type_id: String,
+      additional_code: String,
+      description: String,
+      formatted_description: String,
+      validity_start_date: Time,
+      validity_end_date: nil,
+      measure_ids: [included_measure.measure_sid],
+      measures: Array,
+    }
+  end
+
+  it { is_expected.to match_json_expression(pattern) }
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1414

### What?

I have added/removed/altered:

- [x] Added filter for measures without goods nomenclature to cache serializer
- [x] Added filter for measures without goods nomenclature to search service
- [x] Added test coverage for both of the above

### Why?

I am doing this because:

- This is required so we filter out broken measures from the additional code search
