### PR TITLE
HOTT-1414: Handle missing goods nomenclature in footnote search

### DIFF
--- a/app/serializers/api/v2/footnotes/footnote_serializer.rb
+++ b/app/serializers/api/v2/footnotes/footnote_serializer.rb
@@ -11,7 +11,14 @@ module Api
         attributes :code, :footnote_type_id, :footnote_id, :description, :formatted_description, :extra_large_measures
 
         has_many :measures, serializer: Api::V2::Shared::MeasureSerializer
-        has_many :goods_nomenclatures, serializer: proc { |record, _params| "Api::V2::Shared::#{record.goods_nomenclature_class}Serializer".constantize }
+        has_many :goods_nomenclatures,
+                 serializer: proc { |record, _params|
+                   if record && record.respond_to?(:goods_nomenclature_class)
+                     "Api::V2::Shared::#{record.goods_nomenclature_class}Serializer".constantize
+                   else
+                     Api::V2::Shared::GoodsNomenclatureSerializer
+                   end
+                 }
       end
     end
   end

--- a/app/services/footnote_search_service.rb
+++ b/app/services/footnote_search_service.rb
@@ -1,6 +1,5 @@
 class FootnoteSearchService
-  attr_reader :code, :type, :description, :as_of
-  attr_reader :current_page, :per_page, :pagination_record_count
+  attr_reader :code, :type, :description, :as_of, :current_page, :per_page, :pagination_record_count
 
   def initialize(attributes, current_page, per_page)
     @as_of = Footnote.point_in_time
@@ -12,9 +11,9 @@ class FootnoteSearchService
             bool: {
               must: [
                 { range: { validity_start_date: { lte: as_of } } },
-                { range: { validity_end_date: { gte: as_of } } }
-              ]
-            }
+                { range: { validity_end_date: { gte: as_of } } },
+              ],
+            },
           },
           # or is greater than item's validity_start_date
           # and item has blank validity_end_date (is unbounded)
@@ -22,21 +21,21 @@ class FootnoteSearchService
             bool: {
               must: [
                 { range: { validity_start_date: { lte: as_of } } },
-                { bool: { must_not: { exists: { field: 'validity_end_date' } } } }
-              ]
-            }
+                { bool: { must_not: { exists: { field: 'validity_end_date' } } } },
+              ],
+            },
           },
           # or item has blank validity_start_date and validity_end_date
           {
             bool: {
               must: [
                 { bool: { must_not: { exists: { field: 'validity_start_date' } } } },
-                { bool: { must_not: { exists: { field: 'validity_end_date' } } } }
-              ]
-            }
-          }
-        ]
-      }
+                { bool: { must_not: { exists: { field: 'validity_end_date' } } } },
+              ],
+            },
+          },
+        ],
+      },
     }]
 
     @code = attributes['code']
@@ -60,7 +59,7 @@ class FootnoteSearchService
   def fetch
     search_client = ::TradeTariffBackend.cache_client
     index = ::Cache::FootnoteIndex.new(TradeTariffBackend.search_namespace).name
-    result = search_client.search index: index, body: { query: { constant_score: { filter: { bool: { must: @query } } } }, size: per_page, from: (current_page - 1) * per_page, sort: %w(footnote_type_id footnote_id) }
+    result = search_client.search index: index, body: { query: { constant_score: { filter: { bool: { must: @query } } } }, size: per_page, from: (current_page - 1) * per_page, sort: %w[footnote_type_id footnote_id] }
     @pagination_record_count = result&.hits&.total&.value || 0
     @result = result&.hits&.hits&.map(&:_source)
   end

--- a/spec/controllers/api/v2/footnotes_controller_spec.rb
+++ b/spec/controllers/api/v2/footnotes_controller_spec.rb
@@ -1,108 +1,147 @@
 RSpec.describe Api::V2::FootnotesController, type: :controller do
-  context 'footnotes search' do
-    let!(:footnote) { create :footnote, :national }
-    let!(:footnote_description) { create :footnote_description, :with_period, footnote_type_id: footnote.footnote_type_id, footnote_id: footnote.footnote_id }
-    let!(:measure) { create :measure, :with_base_regulation, goods_nomenclature: goods_nomenclature }
-    let!(:footnote_association_measure) { create :footnote_association_measure, footnote_type_id: footnote.footnote_type_id, footnote_id: footnote.footnote_id, measure_sid: measure.measure_sid }
-    let!(:goods_nomenclature) { create :heading }
-    let!(:goods_nomenclature2) { create :chapter }
-    let!(:footnote_association_goods_nomenclature) { create :footnote_association_goods_nomenclature, footnote_type: footnote.footnote_type_id, footnote_id: footnote.footnote_id, goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid }
-    let!(:footnote_association_goods_nomenclature2) { create :footnote_association_goods_nomenclature, footnote_type: footnote.footnote_type_id, footnote_id: footnote.footnote_id, goods_nomenclature_sid: goods_nomenclature2.goods_nomenclature_sid }
-    let!(:goods_nomenclature_description) { create :goods_nomenclature_description, goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid }
-    let!(:goods_nomenclature_description2) { create :goods_nomenclature_description, goods_nomenclature_sid: goods_nomenclature2.goods_nomenclature_sid }
+  subject(:do_response) { get :search, params: query, format: :json && response }
 
-    let(:pattern) do
-      {
-        data: [
-          {
-            id: String,
-            type: 'footnote',
-            attributes: {
-              code: String,
-              footnote_type_id: String,
-              footnote_id: String,
-              description: String,
-              formatted_description: String,
-              extra_large_measures: boolean,
-            },
-            relationships: {
-              measures: {
-                data: [
-                  {
-                    id: String,
-                    type: 'measure',
-                  },
-                ],
-              },
-              goods_nomenclatures: {
-                data: [
-                  {
-                    id: String,
-                    type: 'heading',
-                  },
-                  {
-                    id: String,
-                    type: 'chapter',
-                  },
-                ],
-              },
-            },
+  let(:footnote) { create(:footnote) }
+  let(:pattern) do
+    {
+      data: [
+        {
+          id: String,
+          type: 'footnote',
+          attributes: {
+            code: String,
+            footnote_type_id: String,
+            footnote_id: String,
+            description: String,
+            formatted_description: String,
+            extra_large_measures: false,
           },
-        ].ignore_extra_values!,
-        included: [
-          {
-            id: goods_nomenclature2.goods_nomenclature_sid.to_s,
-            type: 'chapter',
-            attributes: {
-              goods_nomenclature_item_id: String,
-              description: String,
-              formatted_description: String,
-              producline_suffix: String,
+          relationships: {
+            measures: {
+              data: [
+                {
+                  id: String,
+                  type: 'measure',
+                },
+              ],
             },
-          },
-          {
-            id: goods_nomenclature.goods_nomenclature_sid.to_s,
-            type: 'heading',
-            attributes: {
-              goods_nomenclature_item_id: String,
-              description: String,
-              formatted_description: String,
-              producline_suffix: String,
-            },
-          },
-          {
-            id: String,
-            type: 'measure',
-            attributes: {
-              goods_nomenclature_item_id: String,
-              validity_start_date: String,
-              validity_end_date: String,
-            },
-            relationships: {
-              goods_nomenclature: {
-                data: {
+            goods_nomenclatures: {
+              data: [
+                {
                   id: String,
                   type: 'heading',
                 },
-              },
-              geographical_area: {
-                data: {
+                {
                   id: String,
-                  type: 'geographical_area',
+                  type: 'chapter',
                 },
+              ],
+            },
+          },
+        },
+      ],
+      included: [
+        {
+          id: String,
+          type: 'chapter',
+          attributes: {
+            goods_nomenclature_item_id: String,
+            description: String,
+            formatted_description: String,
+            producline_suffix: String,
+          },
+        },
+        {
+          id: String,
+          type: 'heading',
+          attributes: {
+            goods_nomenclature_item_id: String,
+            description: String,
+            formatted_description: String,
+            producline_suffix: String,
+          },
+        },
+        {
+          id: String,
+          type: 'heading',
+          attributes: {
+            goods_nomenclature_item_id: String,
+            description: String,
+            formatted_description: String,
+            producline_suffix: String,
+          },
+        },
+        {
+          id: String,
+          type: 'measure',
+          attributes: {
+            goods_nomenclature_item_id: String,
+            validity_start_date: String,
+            validity_end_date: String,
+          },
+          relationships: {
+            goods_nomenclature: {
+              data: {
+                id: String,
+                type: 'heading',
+              },
+            },
+            geographical_area: {
+              data: {
+                id: String,
+                type: 'geographical_area',
               },
             },
           },
-        ],
-        meta: {
-          pagination: {
-            page: Integer,
-            per_page: Integer,
-            total_count: Integer,
-          },
         },
-      }
+      ],
+      meta: {
+        pagination: {
+          page: Integer,
+          per_page: Integer,
+          total_count: Integer,
+        },
+      },
+    }
+  end
+
+  before do
+    measure_with_goods_nomenclature = create(:measure, :with_base_regulation, goods_nomenclature: create(:heading, :with_description))
+    measure_no_goods_nomenclature = create(:measure, :with_base_regulation, goods_nomenclature: nil)
+
+    create(:footnote_association_goods_nomenclature, footnote:, goods_nomenclature: create(:heading, :with_description))
+    create(:footnote_association_goods_nomenclature, footnote:, goods_nomenclature: create(:chapter, :with_description))
+    create(:footnote_association_goods_nomenclature, footnote:, goods_nomenclature_sid: '9999') # Broken reference
+
+    create(:footnote_association_measure, measure: measure_with_goods_nomenclature, footnote:)
+    create(:footnote_association_measure, measure: measure_no_goods_nomenclature, footnote:)
+
+    Sidekiq::Testing.inline! do
+      TradeTariffBackend.cache_client.reindex
+      sleep(2)
     end
+  end
+
+  context 'when searching by the code' do
+    let(:query) { { code: footnote.footnote_id } }
+
+    it { expect(do_response.body).to match_json_expression pattern }
+  end
+
+  context 'when searching by type' do
+    let(:query) { { type: footnote.footnote_type_id } }
+
+    it { expect(do_response.body).to match_json_expression pattern }
+  end
+
+  context 'when searching by description' do
+    let(:query) { { description: footnote.description } }
+
+    it { expect(do_response.body).to match_json_expression pattern }
+  end
+
+  context 'when no footnotes are found' do
+    let(:query) { { code: 'F-O-O-B-A-R' } }
 
     let(:pattern_empty) do
       {
@@ -118,35 +157,6 @@ RSpec.describe Api::V2::FootnotesController, type: :controller do
       }
     end
 
-    before do
-      Sidekiq::Testing.inline! do
-        TradeTariffBackend.cache_client.reindex
-        sleep(2) # TODO: need to think about better ES rspec integration
-      end
-    end
-
-    it 'returns footnotes, related measures, and goods nomenclatures when searching by footnote id' do
-      get :search, params: { code: footnote.footnote_id }, format: :json
-
-      expect(response.body).to match_json_expression pattern
-    end
-
-    it 'returns footnotes, related measures, and goods nomenclatures when searching by footnote type' do
-      get :search, params: { type: footnote.footnote_type_id }, format: :json
-
-      expect(response.body).to match_json_expression pattern
-    end
-
-    it 'returns footnotes, related measures, and goods nomenclatures when searching by description' do
-      get :search, params: { description: footnote.description }, format: :json
-
-      expect(response.body).to match_json_expression pattern
-    end
-
-    it 'returns an empty JSON object if no footnotes are found' do
-      get :search, params: { code: 'F-O-O-B-A-R' }, format: :json
-
-      expect(response.body).to match_json_expression pattern_empty
-    end
+    it { expect(do_response.body).to match_json_expression pattern_empty }
   end
 end

--- a/spec/factories/footnote_factory.rb
+++ b/spec/factories/footnote_factory.rb
@@ -86,11 +86,25 @@ FactoryBot.define do
   end
 
   factory :footnote_association_goods_nomenclature do
-    goods_nomenclature_sid          { generate(:goods_nomenclature_sid) }
-    footnote_id                     { Forgery(:basic).text(exactly: 3) }
-    footnote_type                   { Forgery(:basic).text(exactly: 2) }
-    validity_start_date             { 3.years.ago.beginning_of_day }
-    validity_end_date               { nil }
+    transient do
+      footnote {}
+      goods_nomenclature {}
+    end
+
+    goods_nomenclature_sid do
+      goods_nomenclature.try(:goods_nomenclature_sid) || generate(:goods_nomenclature_sid)
+    end
+
+    footnote_id do
+      footnote.try(:footnote_id) || Forgery(:basic).text(exactly: 3)
+    end
+
+    footnote_type do
+      footnote.try(:footnote_type_id) || Forgery(:basic).text(exactly: 2)
+    end
+
+    validity_start_date { 3.years.ago.beginning_of_day }
+    validity_end_date   { nil }
   end
 
   factory :footnote_association_ern do
@@ -102,9 +116,22 @@ FactoryBot.define do
   end
 
   factory :footnote_association_measure do
-    measure_sid                     { generate(:measure_sid) }
-    footnote_id                     { Forgery(:basic).text(exactly: 3) }
-    footnote_type_id                { Forgery(:basic).text(exactly: 2) }
+    transient do
+      footnote {}
+      measure {}
+    end
+
+    measure_sid do
+      measure.try(:measure_sid) || generate(:measure_sid)
+    end
+
+    footnote_id do
+      footnote.try(:footnote_id) || Forgery(:basic).text(exactly: 3)
+    end
+
+    footnote_type_id do
+      footnote.try(:footnote_type_id) || Forgery(:basic).text(exactly: 2)
+    end
   end
 
   factory :footnote_association_additional_code do

--- a/spec/serializers/api/v2/footnotes/footnote_serializer_spec.rb
+++ b/spec/serializers/api/v2/footnotes/footnote_serializer_spec.rb
@@ -1,0 +1,91 @@
+RSpec.describe Api::V2::Footnotes::FootnoteSerializer do
+  subject(:serializer) { described_class.new(serializable).serializable_hash.as_json }
+
+  let(:serializable) do
+    cache_serialized_footnote = Cache::FootnoteSerializer.new(footnote).as_json
+
+    Hashie::TariffMash.new(cache_serialized_footnote)
+  end
+
+  let(:footnote) { create(:footnote) }
+
+  describe '#serializable_hash' do
+    context 'when there are associated goods nomenclature' do
+      before do
+        create(
+          :footnote_association_goods_nomenclature,
+          footnote:,
+          goods_nomenclature: create(:heading),
+        )
+
+        create(
+          :footnote_association_measure,
+          footnote:,
+          measure: create(:measure, goods_nomenclature: create(:chapter)),
+        )
+      end
+
+      let(:expected_pattern) do
+        {
+          data: {
+            id: String,
+            type: 'footnote',
+            attributes: {
+              code: String,
+              footnote_type_id: String,
+              footnote_id: String,
+              description: String,
+              formatted_description: String,
+              extra_large_measures: false,
+            },
+            relationships: {
+              measures: { data: [{ id: String, type: 'measure' }] },
+              goods_nomenclatures: { data: [{ id: String, type: 'heading' }] },
+            },
+          },
+        }
+      end
+
+      it { is_expected.to match_json_expression(expected_pattern) }
+    end
+
+    context 'when goods nomenclature references are broken' do
+      before do
+        create(
+          :footnote_association_goods_nomenclature,
+          footnote:,
+          goods_nomenclature_sid: '9999',
+        )
+
+        create(
+          :footnote_association_measure,
+          footnote:,
+          measure: create(:measure, goods_nomenclature: nil),
+        )
+      end
+
+      let(:expected_pattern) do
+        {
+          data: {
+            id: String,
+            type: 'footnote',
+            attributes: {
+              code: String,
+              footnote_type_id: String,
+              footnote_id: String,
+              description: String,
+              formatted_description: String,
+              extra_large_measures: false,
+            },
+            relationships: {
+              goods_nomenclatures: { data: [] },
+              measures: { data: [] },
+            },
+          },
+        }
+      end
+
+      it { is_expected.to match_json_expression(expected_pattern) }
+    end
+  end
+end

--- a/spec/serializers/cache/footnote_serializer_spec.rb
+++ b/spec/serializers/cache/footnote_serializer_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe Cache::FootnoteSerializer do
+  subject(:serialized) { described_class.new(footnote).as_json }
+
+  let(:footnote) { create(:footnote) }
+  let(:measure_with_goods_nomenclature) { create(:measure, :with_base_regulation, goods_nomenclature: create(:heading, :with_description)) }
+
+  let(:pattern) do
+    {
+      code: footnote.code,
+      footnote_type_id: footnote.footnote_type_id,
+      footnote_id: footnote.footnote_id,
+      description: footnote.description,
+      formatted_description: footnote.formatted_description,
+      validity_start_date: footnote.validity_start_date,
+      validity_end_date: footnote.validity_end_date,
+      goods_nomenclature_ids: [],
+      goods_nomenclatures: Array,
+      measures: Array,
+      measure_ids: [measure_with_goods_nomenclature.measure_sid],
+      extra_large_measures: false,
+    }
+  end
+
+  before do
+    measure_no_goods_nomenclature = create(:measure, :with_base_regulation, goods_nomenclature: nil)
+
+    create(:footnote_association_measure, measure: measure_with_goods_nomenclature, footnote:)
+    create(:footnote_association_measure, measure: measure_no_goods_nomenclature, footnote:)
+  end
+
+  it { is_expected.to match_json_expression(pattern) }
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1414

### What?

I have added/removed/altered:

- [x] Refactored the footnote search controller specs
- [x] Added filtering of missing footnote measure goods nomenclature in footnote search results
- [x] Added filtering of missing footnote goods nomenclature in footnote search results
- [x] Added handling for missing/broken goods nomenclature in footnote polymorphic serializer

### Why?

I am doing this because:

- This is required to avoid sentry failures for people scraping footnotes from the api when goods nomenclature associations are broken (see https://sentry.io/organizations/engine-le/issues/3139630294/?project=5557005&query=is%3Aunresolved)
