### PR TITLE
HOTT-1414: Handle certificate search goods nomenclature

### DIFF
--- a/spec/factories/certificate_factory.rb
+++ b/spec/factories/certificate_factory.rb
@@ -11,6 +11,17 @@ FactoryBot.define do
     certificate_code      { Forgery(:basic).text(exactly: 3) }
     validity_start_date   { 2.years.ago.beginning_of_day }
     validity_end_date     { nil }
+
+    trait :with_description do
+      after(:create) do |certificate, _evaluator|
+        create(
+          :certificate_description,
+          :with_period,
+          certificate_type_code: certificate.certificate_type_code,
+          certificate_code: certificate.certificate_code,
+        )
+      end
+    end
   end
 
   factory :certificate_description_period do

--- a/spec/serializers/cache/certificate_serializer_spec.rb
+++ b/spec/serializers/cache/certificate_serializer_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Cache::CertificateSerializer do
       goods_nomenclature: create(:heading, :with_description),
     )
   end
+
   let(:measure_with_no_goods_nomenclature) do
     create(
       :measure,

--- a/spec/serializers/cache/certificate_serializer_spec.rb
+++ b/spec/serializers/cache/certificate_serializer_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe Cache::CertificateSerializer do
+  subject(:serialized) { described_class.new(certificate).as_json }
+
+  let(:certificate) { create(:certificate, :with_description) }
+
+  let(:measure_with_goods_nomenclature) do
+    create(
+      :measure,
+      :with_base_regulation,
+      :with_measure_conditions,
+      certificate_code: certificate.certificate_code,
+      certificate_type_code: certificate.certificate_type_code,
+      goods_nomenclature: create(:heading, :with_description),
+    )
+  end
+  let(:measure_with_no_goods_nomenclature) do
+    create(
+      :measure,
+      :with_base_regulation,
+      :with_measure_conditions,
+      certificate_code: certificate.certificate_code,
+      certificate_type_code: certificate.certificate_type_code,
+      goods_nomenclature: nil,
+    )
+  end
+
+  let(:pattern) do
+    {
+      id: String,
+      certificate_type_code: String,
+      certificate_code: String,
+      description: String,
+      formatted_description: String,
+      validity_start_date: Time,
+      validity_end_date: nil,
+      measure_ids: [measure_with_goods_nomenclature.measure_sid],
+      measures: Array,
+    }
+  end
+
+  before do
+    measure_with_goods_nomenclature
+    measure_with_no_goods_nomenclature
+  end
+
+  it { is_expected.to match_json_expression(pattern) }
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1414

### What?

I have added/removed/altered:

- [x] Added filter for broken certificate measures on certificate search results
- [x] Added cache certificate serializer spec

### Why?

I am doing this because:

- This is in anticipation of the certificate search api returning broken goods nomenclature
