### PR TITLE
Silence noisy alerts in sentry

### DIFF
--- a/app/models/measurement_unit.rb
+++ b/app/models/measurement_unit.rb
@@ -47,9 +47,9 @@ class MeasurementUnit < Sequel::Model
       qualifier_code = unit_key.length == 4 ? unit_key[3..] : ''
 
       if unit.present?
-        Sentry.capture_message("Missing measurement unit in database for measurement unit key: #{unit_key}")
+        Rails.logger.warn("Missing measurement unit in database for measurement unit key: #{unit_key}")
       else
-        Sentry.capture_message("Missing measurement unit in measurement_units.yml: #{unit_key}")
+        Rails.logger.warn("Missing measurement unit in measurement_units.yml: #{unit_key}")
       end
 
       {

--- a/spec/models/measurement_unit_spec.rb
+++ b/spec/models/measurement_unit_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe MeasurementUnit do
 
       before do
         measurement_unit
-        allow(Sentry).to receive(:capture_message).and_call_original
+        allow(Rails.logger).to receive(:warn).and_call_original
         allow(described_class).to receive(:measurement_units).and_return({})
         result
       end
@@ -66,14 +66,14 @@ RSpec.describe MeasurementUnit do
       end
 
       it { is_expected.to eq(expected_units) }
-      it { expect(Sentry).to have_received(:capture_message) }
+      it { expect(Rails.logger).to have_received(:warn) }
     end
 
     context 'with measurement unit not in the database' do
       subject(:result) { described_class.units('FC1', 'FC1X') }
 
       before do
-        allow(Sentry).to receive(:capture_message).and_call_original
+        allow(Rails.logger).to receive(:warn).and_call_original
         allow(described_class).to receive(:measurement_units).and_return({})
         result
       end
@@ -92,7 +92,7 @@ RSpec.describe MeasurementUnit do
       end
 
       it { is_expected.to eq(expected_units) }
-      it { expect(Sentry).to have_received(:capture_message) }
+      it { expect(Rails.logger).to have_received(:warn) }
     end
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Log missing measurement units to stdout rather than sentry
- [x] Update specs to reflect change

### Why?

I am doing this because:

- This adds very little value and gets alerted alot of old CHIEF units
