### PR TITLE
HOTT-1466: Fixes type on certificate list serializer

### DIFF
--- a/app/controllers/api/v2/certificates_controller.rb
+++ b/app/controllers/api/v2/certificates_controller.rb
@@ -10,11 +10,6 @@ module Api
       end
 
       def index
-        certificates = Certificate.actual
-                                  .eager(:certificate_descriptions, :certificate_description_periods, :certificate_type_description)
-                                  .order(Sequel.asc(%i[certificate_type_code certificate_code]))
-                                  .all
-
         render json: Api::V2::Certificates::CertificateListSerializer.new(certificates).serializable_hash
       end
 
@@ -24,6 +19,13 @@ module Api
         TimeMachine.now do
           @certificates = search_service.perform
         end
+      end
+
+      def certificates
+        Certificate.actual
+          .eager(:certificate_descriptions, :certificate_description_periods, :certificate_type_description)
+          .order(Sequel.asc(%i[certificate_type_code certificate_code]))
+          .all
       end
 
       def search_service

--- a/app/serializers/api/v2/certificates/certificate_list_serializer.rb
+++ b/app/serializers/api/v2/certificates/certificate_list_serializer.rb
@@ -4,14 +4,14 @@ module Api
       class CertificateListSerializer
         include JSONAPI::Serializer
 
-        set_type :certificate_type
+        set_type :certificate
 
         set_id :id
 
         attributes :certificate_type_code, :certificate_code, :description, :formatted_description
 
         attribute :certificate_type_description do |certificate|
-          certificate&.certificate_type_description&.description
+          certificate.certificate_type_description&.description
         end
 
         attribute :validity_start_date do |certificate|

--- a/spec/controllers/api/v2/certificate_types_controller_spec.rb
+++ b/spec/controllers/api/v2/certificate_types_controller_spec.rb
@@ -1,45 +1,32 @@
 RSpec.describe Api::V2::CertificateTypesController, type: :controller do
-  describe '#index' do
-    let!(:certificate_type_1) { create :certificate_type }
-    let!(:certificate_type_description_1) { create :certificate_type_description, certificate_type_code: certificate_type_1.certificate_type_code }
-    let!(:certificate_type_2) { create :certificate_type }
-    let!(:certificate_type_description_2) { create :certificate_type_description, certificate_type_code: certificate_type_2.certificate_type_code }
-    let!(:certificate_type_3) { create :certificate_type }
-    let!(:certificate_type_description_3) { create :certificate_type_description, certificate_type_code: certificate_type_3.certificate_type_code }
+  describe 'GET #index' do
+    subject(:do_response) do
+      get :index, format: :json
+
+      response.body
+    end
+
+    let(:certificate_type) { create(:certificate_type, :with_description) }
 
     let(:pattern) do
       {
-        "data": [{
-          "id": String,
-          "type": 'certificate_type',
-          "attributes": {
-            "certificate_type_code": String,
-            "description": String,
+        "data": [
+          {
+            "id": String,
+            "type": 'certificate_type',
+            "attributes": {
+              "certificate_type_code": String,
+              "description": String,
+            },
           },
-        },
-                 {
-                   "id": String,
-                   "type": 'certificate_type',
-                   "attributes": {
-                     "certificate_type_code": String,
-                     "description": String,
-                   },
-                 },
-                 {
-                   "id": String,
-                   "type": 'certificate_type',
-                   "attributes": {
-                     "certificate_type_code": String,
-                     "description": String,
-                   },
-                 }],
+        ],
       }
     end
 
-    it 'returns all certificate types' do
-      get :index, format: :json
-
-      expect(response.body).to match_json_expression pattern
+    before do
+      certificate_type
     end
+
+    it { is_expected.to match_json_expression(pattern) }
   end
 end

--- a/spec/controllers/api/v2/certificates_controller_index_spec.rb
+++ b/spec/controllers/api/v2/certificates_controller_index_spec.rb
@@ -1,54 +1,41 @@
 RSpec.describe Api::V2::CertificatesController, type: :controller do
   describe 'GET #index' do
-    let(:certificate) { create :certificate }
-
-    let(:certificate_type) do
-      create :certificate_type, :with_description,
-             certificate_type_code: certificate.certificate_type_code
+    subject(:do_response) do
+      get :index, format: :json
+      response.body
     end
 
-    let(:certificate_description) do
-      create :certificate_description,
-             :with_period,
-             certificate_type_code: certificate.certificate_type_code,
-             certificate_code: certificate.certificate_code
-    end
+    let(:certificate) { create(:certificate, :with_description, :with_certificate_type) }
 
-    let(:expected_response) do
+    let(:pattern) do
       {
-        data: [{
-          id: String,
-          type: 'certificate_type',
-          attributes: {
-            certificate_type_code: String,
-            certificate_code: String,
-            description: String,
-            formatted_description: String,
-            certificate_type_description: String,
-            validity_start_date: String,
+        data: [
+          {
+            id: String,
+            type: 'certificate',
+            attributes: {
+              certificate_type_code: String,
+              certificate_code: String,
+              description: String,
+              formatted_description: String,
+              certificate_type_description: String,
+              validity_start_date: String,
+            },
           },
-        }],
+        ],
       }
     end
 
     before do
       certificate
-      certificate_description
-      certificate_type
-
-      allow(TimeMachine).to receive(:at).and_call_original
     end
 
-    it 'returns a list of certificates' do
-      get :index, format: :json
-
-      response_data_type = JSON.parse(response.body)['data'].first['type']
-
-      expect(response_data_type).to eq('certificate_type')
-    end
+    it { is_expected.to match_json_expression(pattern) }
 
     it 'the TimeMachine receives the correct Date' do
-      get :index, format: :json
+      allow(TimeMachine).to receive(:at).and_call_original
+
+      do_response
 
       expect(TimeMachine).to have_received(:at).with(Time.zone.today)
     end

--- a/spec/factories/certificate_factory.rb
+++ b/spec/factories/certificate_factory.rb
@@ -22,6 +22,16 @@ FactoryBot.define do
         )
       end
     end
+
+    trait :with_certificate_type do
+      after(:create) do |certificate, _evaluator|
+        create(
+          :certificate_type,
+          :with_description,
+          certificate_type_code: certificate.certificate_type_code,
+        )
+      end
+    end
   end
 
   factory :certificate_description_period do

--- a/spec/serializers/api/v2/certificate/certificate_list_serializer_spec.rb
+++ b/spec/serializers/api/v2/certificate/certificate_list_serializer_spec.rb
@@ -1,41 +1,25 @@
 RSpec.describe Api::V2::Certificates::CertificateListSerializer do
-  subject(:serializer) { described_class.new(certificates).serializable_hash.as_json }
+  subject(:serializer) { described_class.new([certificate]).serializable_hash.as_json }
 
-  let(:certificate) { create :certificate }
-  let(:certificates) { [certificate] }
-
-  let(:certificate_type) do
-    create :certificate_type, :with_description,
-           certificate_type_code: certificate.certificate_type_code
-  end
-
-  let(:certificate_description) do
-    create :certificate_description, :with_period,
-           certificate_type_code: certificate.certificate_type_code,
-           certificate_code: certificate.certificate_code
-  end
+  let(:certificate) { create(:certificate, :with_description, :with_certificate_type) }
 
   let(:expected_pattern) do
     {
-      data: [{
-        id: String,
-        type: 'certificate_type',
-        attributes: {
-          certificate_type_code: certificate.certificate_type_code,
-          certificate_code: certificate.certificate_code,
-          description: certificate.certificate_description.description,
-          formatted_description: certificate.certificate_description.formatted_description,
-          certificate_type_description: certificate.certificate_type_description.description,
-          validity_start_date: certificate.certificate_description_period.validity_start_date,
+      data: [
+        {
+          id: String,
+          type: 'certificate',
+          attributes: {
+            certificate_type_code: String,
+            certificate_code: String,
+            description: String,
+            formatted_description: String,
+            certificate_type_description: String,
+            validity_start_date: String,
+          },
         },
-      }],
+      ],
     }
-  end
-
-  before do
-    certificate
-    certificate_description
-    certificate_type
   end
 
   describe '#serializable_hash' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1466

### What?

I have added/removed/altered:

- [x] Fixes type in certificate list serializer
- [x] Fixed broken coverage in certificate type controller spec
- [x] Linted and tidied up certificate controller spec

### Why?

I am doing this because:

- This is currently returning certificates and saying they're a certificate_type
