### PR TITLE
HOTT-1468: Disable guidance on XI

### DIFF
--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -144,11 +144,15 @@ class MeasureCondition < Sequel::Model
   end
 
   def guidance_cds
-    guidance.try(:[], 'guidance_cds')
+    if TradeTariffBackend.uk?
+      guidance.try(:[], 'guidance_cds')
+    end
   end
 
   def guidance_chief
-    guidance.try(:[], 'guidance_chief')
+    if TradeTariffBackend.uk?
+      guidance.try(:[], 'guidance_chief')
+    end
   end
 
 private

--- a/app/serializers/api/v2/certificates/certificate_list_serializer.rb
+++ b/app/serializers/api/v2/certificates/certificate_list_serializer.rb
@@ -19,15 +19,19 @@ module Api
         end
 
         attribute :guidance_cds do |certificate|
-          guidance = TradeTariffBackend.chief_cds_guidance.guidance_for("#{certificate.certificate_type_code}#{certificate.certificate_code}")
+          if TradeTariffBackend.uk?
+            guidance = TradeTariffBackend.chief_cds_guidance.guidance_for("#{certificate.certificate_type_code}#{certificate.certificate_code}")
 
-          guidance.try(:[], 'guidance_cds')
+            guidance.try(:[], 'guidance_cds')
+          end
         end
 
         attribute :guidance_chief do |certificate|
-          guidance = TradeTariffBackend.chief_cds_guidance.guidance_for("#{certificate.certificate_type_code}#{certificate.certificate_code}")
+          if TradeTariffBackend.uk?
+            guidance = TradeTariffBackend.chief_cds_guidance.guidance_for("#{certificate.certificate_type_code}#{certificate.certificate_code}")
 
-          guidance.try(:[], 'guidance_chief')
+            guidance.try(:[], 'guidance_chief')
+          end
         end
       end
     end

--- a/app/serializers/api/v2/certificates/certificates_serializer.rb
+++ b/app/serializers/api/v2/certificates/certificates_serializer.rb
@@ -12,15 +12,20 @@ module Api
                    :formatted_description
 
         attribute :guidance_cds do |certificate|
-          guidance = TradeTariffBackend.chief_cds_guidance.guidance_for("#{certificate.certificate_type_code}#{certificate.certificate_code}")
+          if TradeTariffBackend.uk?
+            guidance = TradeTariffBackend.chief_cds_guidance.guidance_for("#{certificate.certificate_type_code}#{certificate.certificate_code}")
 
-          guidance.try(:[], 'guidance_cds')
+            guidance.try(:[], 'guidance_cds')
+
+          end
         end
 
         attribute :guidance_chief do |certificate|
-          guidance = TradeTariffBackend.chief_cds_guidance.guidance_for("#{certificate.certificate_type_code}#{certificate.certificate_code}")
+          if TradeTariffBackend.uk?
+            guidance = TradeTariffBackend.chief_cds_guidance.guidance_for("#{certificate.certificate_type_code}#{certificate.certificate_code}")
 
-          guidance.try(:[], 'guidance_chief')
+            guidance.try(:[], 'guidance_chief')
+          end
         end
 
         has_many :measures, serializer: Api::V2::Shared::MeasureSerializer

--- a/spec/models/measure_condition_spec.rb
+++ b/spec/models/measure_condition_spec.rb
@@ -259,7 +259,21 @@ RSpec.describe MeasureCondition do
     context 'when the measure condition has a document code with guidance' do
       subject(:guidance_cds) { build(:measure_condition, :with_guidance).guidance_cds }
 
-      it { is_expected.not_to be_nil }
+      before do
+        allow(TradeTariffBackend).to receive(:service).and_return(service)
+      end
+
+      context 'when on uk service' do
+        let(:service) { 'uk' }
+
+        it { is_expected.not_to be_nil }
+      end
+
+      context 'when on xi service' do
+        let(:service) { 'xi' }
+
+        it { is_expected.to be_nil }
+      end
     end
 
     context 'when the measure condition has a document code without guidance' do
@@ -279,7 +293,21 @@ RSpec.describe MeasureCondition do
     context 'when the measure condition has a document code with guidance' do
       subject(:guidance_chief) { build(:measure_condition, :with_guidance).guidance_chief }
 
-      it { is_expected.not_to be_nil }
+      before do
+        allow(TradeTariffBackend).to receive(:service).and_return(service)
+      end
+
+      context 'when on uk service' do
+        let(:service) { 'uk' }
+
+        it { is_expected.not_to be_nil }
+      end
+
+      context 'when on xi service' do
+        let(:service) { 'xi' }
+
+        it { is_expected.to be_nil }
+      end
     end
 
     context 'when the measure condition has a document code without guidance' do

--- a/spec/serializers/api/v2/certificates/certificate_list_serializer_spec.rb
+++ b/spec/serializers/api/v2/certificates/certificate_list_serializer_spec.rb
@@ -1,30 +1,65 @@
 RSpec.describe Api::V2::Certificates::CertificateListSerializer do
-  subject(:serializer) { described_class.new([certificate]).serializable_hash.as_json }
-
-  let(:certificate) { create(:certificate, :with_description, :with_certificate_type, :with_guidance) }
-
-  let(:expected_pattern) do
-    {
-      data: [
-        {
-          id: String,
-          type: 'certificate',
-          attributes: {
-            certificate_type_code: String,
-            certificate_code: String,
-            description: String,
-            formatted_description: String,
-            certificate_type_description: String,
-            validity_start_date: String,
-            guidance_cds: String,
-            guidance_chief: String,
-          },
-        },
-      ],
-    }
-  end
-
   describe '#serializable_hash' do
-    it { is_expected.to match_json_expression(expected_pattern) }
+    subject(:serializable_hash) { described_class.new([certificate]).serializable_hash.as_json }
+
+    let(:certificate) { create(:certificate, :with_description, :with_certificate_type, :with_guidance) }
+
+    before do
+      allow(TradeTariffBackend).to receive(:service).and_return(service)
+    end
+
+    context 'when on uk service' do
+      let(:expected_pattern) do
+        {
+          data: [
+            {
+              id: String,
+              type: 'certificate',
+              attributes: {
+                certificate_type_code: String,
+                certificate_code: String,
+                description: String,
+                formatted_description: String,
+                certificate_type_description: String,
+                validity_start_date: String,
+                guidance_cds: String,
+                guidance_chief: String,
+              },
+            },
+          ],
+        }
+      end
+
+      let(:service) { 'uk' }
+
+      it { is_expected.to match_json_expression(expected_pattern) }
+    end
+
+    context 'when on xi service' do
+      let(:expected_pattern) do
+        {
+          data: [
+            {
+              id: String,
+              type: 'certificate',
+              attributes: {
+                certificate_type_code: String,
+                certificate_code: String,
+                description: String,
+                formatted_description: String,
+                certificate_type_description: String,
+                validity_start_date: String,
+                guidance_cds: nil,
+                guidance_chief: nil,
+              },
+            },
+          ],
+        }
+      end
+
+      let(:service) { 'xi' }
+
+      it { is_expected.to match_json_expression(expected_pattern) }
+    end
   end
 end

--- a/spec/serializers/api/v2/certificates/certificates_serializer_spec.rb
+++ b/spec/serializers/api/v2/certificates/certificates_serializer_spec.rb
@@ -1,42 +1,76 @@
 RSpec.describe Api::V2::Certificates::CertificatesSerializer do
-  subject(:serializer) { described_class.new(serializable).serializable_hash.as_json }
-
-  let(:serializable) do
-    Hashie::TariffMash.new(
-      Cache::CertificateSerializer.new(certificate).as_json,
-    )
-  end
-
-  let(:certificate) do
-    create(
-      :certificate,
-      :with_description,
-      :with_certificate_type,
-      :with_guidance,
-    )
-  end
-
-  let(:expected_pattern) do
-    {
-      data: {
-        id: String,
-        type: 'certificates',
-        attributes: {
-          certificate_type_code: String,
-          certificate_code: String,
-          description: String,
-          formatted_description: String,
-          guidance_cds: String,
-          guidance_chief: String,
-        },
-        relationships: {
-          measures: Hash,
-        },
-      },
-    }
-  end
-
   describe '#serializable_hash' do
-    it { is_expected.to match_json_expression(expected_pattern) }
+    subject(:serializable_hash) { described_class.new(serializable).serializable_hash.as_json }
+
+    let(:serializable) do
+      Hashie::TariffMash.new(
+        Cache::CertificateSerializer.new(certificate).as_json,
+      )
+    end
+
+    let(:certificate) do
+      create(
+        :certificate,
+        :with_description,
+        :with_certificate_type,
+        :with_guidance,
+      )
+    end
+
+    before do
+      allow(TradeTariffBackend).to receive(:service).and_return(service)
+    end
+
+    context 'when on uk service' do
+      let(:expected_pattern) do
+        {
+          data: {
+            id: String,
+            type: 'certificates',
+            attributes: {
+              certificate_type_code: String,
+              certificate_code: String,
+              description: String,
+              formatted_description: String,
+              guidance_cds: String,
+              guidance_chief: String,
+            },
+            relationships: {
+              measures: Hash,
+            },
+          },
+        }
+      end
+
+      let(:service) { 'uk' }
+
+      it { is_expected.to match_json_expression(expected_pattern) }
+    end
+
+    context 'when on xi service' do
+      let(:expected_pattern) do
+        {
+          data: {
+            id: String,
+            type: 'certificates',
+            attributes: {
+              certificate_type_code: String,
+              certificate_code: String,
+              description: String,
+              formatted_description: String,
+              guidance_cds: nil,
+              guidance_chief: nil,
+            },
+            relationships: {
+              measures: Hash,
+            },
+          },
+        }
+      end
+
+      let(:service) { 'xi' }
+
+      it { is_expected.to match_json_expression(expected_pattern) }
+    end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1468

### What?

I have added/removed/altered:

- [x] Only surface certificate guidance on uk
- [x] Only surface measure condition guidance on uk
- [x] Only surface certificate search guidance on uk

### Why?

I am doing this because:

- CDS and CHIEF guidance is never relevant on European data
