### PR TITLE
Hott 1449 include 08 negative conditions

### DIFF
--- a/spec/models/measure_condition_permutations/calculator_spec.rb
+++ b/spec/models/measure_condition_permutations/calculator_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe MeasureConditionPermutations::Calculator do
 
   describe 'filtering measure_conditions' do
     subject :measure_conditions do
-      calculator.permutation_groups.first.permutations.flat_map(&:measure_conditions)
+      calculator.permutation_groups
+                .flat_map(&:permutations)
+                .flat_map(&:measure_conditions)
     end
 
     let(:regular_condition) { measure.measure_conditions.first }

--- a/spec/models/measure_condition_permutations/calculator_spec.rb
+++ b/spec/models/measure_condition_permutations/calculator_spec.rb
@@ -37,8 +37,17 @@ RSpec.describe MeasureConditionPermutations::Calculator do
       expect(measure_conditions).not_to include(waiver_condition)
     end
 
-    it 'exlcudes negative action conditions' do
+    it 'excludes negative action conditions' do
       expect(measure_conditions).not_to include(negative_condition)
+    end
+
+    context 'with action_code=08 negative condition' do
+      let :negative_condition do
+        create :measure_condition, :negative, measure_sid: measure.measure_sid,
+                                              action_code: '08'
+      end
+
+      it { is_expected.to include negative_condition }
     end
   end
 


### PR DESCRIPTION
### Jira link

[HOTT-1449](https://transformuk.atlassian.net/browse/HOTT-1449)

### What?

I have added/removed/altered:

- [x] Added an exception to include negative measure conditions which have a measure action with an action code of 08
- [x] Fixed some flaky specs - they incorrectly assumed there would only be one permutation group, this assumption was sometimes wrong

### Why?

I am doing this because:

- We want to still show negative measure conditions with an action code of 08 in the new permutations modal

