### PR TITLE
HOTT-1492: Fix bug in last_allocation_date

### DIFF
--- a/app/serializers/api/v2/quotas/quota_definition_serializer.rb
+++ b/app/serializers/api/v2/quotas/quota_definition_serializer.rb
@@ -10,12 +10,12 @@ module Api
 
         attributes :quota_definition_sid, :quota_order_number_id, :initial_volume, :validity_start_date, :validity_end_date, :status, :description, :balance
 
-        attribute(:measurement_unit, &:formatted_measurement_unit)
-        attribute(:monetary_unit, &:monetary_unit_code)
-        attribute(:measurement_unit_qualifier, &:measurement_unit_qualifier_code)
+        attribute :measurement_unit, &:formatted_measurement_unit
+        attribute :monetary_unit, &:monetary_unit_code
+        attribute :measurement_unit_qualifier, &:measurement_unit_qualifier_code
 
         attribute :last_allocation_date do |definition|
-          definition.last_balance_event.try(:occurrence_timestamp)
+          definition.last_balance_event&.last_import_date_in_allocation
         end
 
         attribute :suspension_period_start_date do |definition|

--- a/spec/serializers/api/v2/quotas/quota_definition_serializer_spec.rb
+++ b/spec/serializers/api/v2/quotas/quota_definition_serializer_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Api::V2::Quotas::QuotaDefinitionSerializer do
           measurement_unit: nil,
           monetary_unit: be_a(String),
           measurement_unit_qualifier: be_a(String),
-          last_allocation_date: serializable.last_balance_event.occurrence_timestamp.xmlschema(3),
+          last_allocation_date: serializable.last_balance_event.last_import_date_in_allocation.iso8601,
           suspension_period_start_date: nil,
           suspension_period_end_date: nil,
           blocking_period_start_date: nil,


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1492

### What?

I have added/removed/altered:

- [x] Alter quota definition serializer to pull the last allocation date out correctly
- [x] Alter specs to show change

### Why?

I am doing this because:

- This has been broken for quite a while and has only recently been noticed
