### PR TITLE
Surface declarable on heading commodity

### DIFF
--- a/app/serializers/api/v2/headings/commodity_serializer.rb
+++ b/app/serializers/api/v2/headings/commodity_serializer.rb
@@ -8,9 +8,20 @@ module Api
 
         set_id :goods_nomenclature_sid
 
-        attributes :description, :number_indents, :goods_nomenclature_item_id, :leaf,
-                   :goods_nomenclature_sid, :formatted_description, :description_plain,
-                   :producline_suffix, :parent_sid
+        attributes :description,
+                   :number_indents,
+                   :goods_nomenclature_item_id,
+                   :leaf,
+                   :producline_suffix,
+                   :goods_nomenclature_sid,
+                   :formatted_description,
+                   :description_plain,
+                   :parent_sid
+
+        attribute :declarable do |commodity|
+          # TODO: Once we've got the ES cache populated with declarable we can use a simple attribute to pull this out
+          commodity.try(:declarable) || commodity.leaf && commodity.producline_suffix == GoodsNomenclatureIndent::NON_GROUPING_PRODUCTLINE_SUFFIX
+        end
 
         has_many :overview_measures, record_type: :measure,
                                      serializer: Api::V2::Measures::OverviewMeasureSerializer

--- a/app/serializers/api/v2/headings/commodity_serializer.rb
+++ b/app/serializers/api/v2/headings/commodity_serializer.rb
@@ -20,7 +20,7 @@ module Api
 
         attribute :declarable do |commodity|
           # TODO: Once we've got the ES cache populated with declarable we can use a simple attribute to pull this out
-          commodity.try(:declarable) || commodity.leaf && commodity.producline_suffix == GoodsNomenclatureIndent::NON_GROUPING_PRODUCTLINE_SUFFIX
+          commodity.leaf && commodity.producline_suffix == GoodsNomenclatureIndent::NON_GROUPING_PRODUCTLINE_SUFFIX
         end
 
         has_many :overview_measures, record_type: :measure,

--- a/app/serializers/cache/heading_serializer.rb
+++ b/app/serializers/cache/heading_serializer.rb
@@ -88,6 +88,7 @@ module Cache
           goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
           validity_start_date: commodity.validity_start_date&.strftime('%FT%T.%LZ'),
           validity_end_date: commodity.validity_end_date,
+          declarable: heading.declarable?,
         }
 
         commodity_attributes[:goods_nomenclature_indents] = commodity.goods_nomenclature_indents.map do |goods_nomenclature_indent|

--- a/spec/serializers/cache/heading_serializer_spec.rb
+++ b/spec/serializers/cache/heading_serializer_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe Cache::HeadingSerializer do
             goods_nomenclature_item_id: String,
             validity_start_date: String,
             validity_end_date: nil,
+            declarable: false,
             goods_nomenclature_indents: [
               {
                 goods_nomenclature_indent_sid: Integer,


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Added declarable to ES headings serializer
- [x] Added declarable to jsonapi serializer
- [x] Added specs

### Why?

I am doing this because:

- Heading commodities are missing this field which makes determining declarability different for headings (see https://github.com/trade-tariff/trade-tariff-frontend/pull/772)