### PR TITLE
HOTT-1503: Add time machine support to measure#goods_nomenclature

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -24,7 +24,9 @@ class Measure < Sequel::Model
   plugin :national
 
   many_to_one :goods_nomenclature, key: :goods_nomenclature_sid,
-                                   foreign_key: :goods_nomenclature_sid
+                                   foreign_key: :goods_nomenclature_sid do |ds|
+                                     ds.with_actual(GoodsNomenclature)
+                                   end
 
   many_to_one :export_refund_nomenclature, key: :export_refund_nomenclature_sid,
                                            foreign_key: :export_refund_nomenclature_sid


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1503

### What?

I have added/removed/altered:

- [x] Added time machine support to measure goods nomenclature relationship

### Why?

I am doing this because:

- This is required to make sure that non-active goods nomenclature aren't serialized accidentally for quota search
