### PR TITLE
HOTT-1518: Support text/csv in ACCEPT header

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ Rails.application.routes.draw do
     end
   end
 
-  namespace :api, defaults: { format: 'json' }, path: '/' do
+  namespace :api, path: '/' do
     # How (or even if) API versioning will be implemented is still an open question. We can defer
     # the choice until we need to expose the API to clients which we don't control.
 

--- a/spec/requests/api/v2/chapters_controller_spec.rb
+++ b/spec/requests/api/v2/chapters_controller_spec.rb
@@ -1,21 +1,9 @@
 RSpec.describe Api::V2::ChaptersController do
   describe 'GET #index' do
-    subject(:do_request) { make_request && response }
-
-    before do
-      create(:chapter)
-    end
-
-    context 'when using the mime suffix to configure the mime type' do
-      let(:make_request) { get '/chapters.csv' }
-
-      it_behaves_like 'a successful csv response'
-    end
-
-    context 'when using Accept header to configure the mime type' do
-      let(:make_request) { get '/chapters', headers: { 'ACCEPT' => 'text/csv' } }
-
-      it_behaves_like 'a successful csv response'
+    it_behaves_like 'a successful csv response', '/sections' do
+      before do
+        create(:chapter)
+      end
     end
   end
 end

--- a/spec/requests/api/v2/chapters_controller_spec.rb
+++ b/spec/requests/api/v2/chapters_controller_spec.rb
@@ -2,12 +2,20 @@ RSpec.describe Api::V2::ChaptersController do
   describe 'GET #index' do
     subject(:do_request) { make_request && response }
 
-    let(:make_request) { get '/chapters.csv' }
-
     before do
       create(:chapter)
     end
 
-    it_behaves_like 'a successful csv response'
+    context 'when using the mime suffix to configure the mime type' do
+      let(:make_request) { get '/chapters.csv' }
+
+      it_behaves_like 'a successful csv response'
+    end
+
+    context 'when using Accept header to configure the mime type' do
+      let(:make_request) { get '/chapters', headers: { 'ACCEPT' => 'text/csv' } }
+
+      it_behaves_like 'a successful csv response'
+    end
   end
 end

--- a/spec/requests/api/v2/sections_controller_spec.rb
+++ b/spec/requests/api/v2/sections_controller_spec.rb
@@ -2,8 +2,6 @@ RSpec.describe Api::V2::SectionsController do
   describe 'GET #index' do
     subject(:do_request) { make_request && response }
 
-    let(:make_request) { get '/sections.csv' }
-
     before do
       create(
         :section,
@@ -14,6 +12,16 @@ RSpec.describe Api::V2::SectionsController do
       )
     end
 
-    it_behaves_like 'a successful csv response'
+    context 'when using the mime suffix to configure the mime type' do
+      let(:make_request) { get '/sections.csv' }
+
+      it_behaves_like 'a successful csv response'
+    end
+
+    context 'when using Accept header to configure the mime type' do
+      let(:make_request) { get '/sections', headers: { 'ACCEPT' => 'text/csv' } }
+
+      it_behaves_like 'a successful csv response'
+    end
   end
 end

--- a/spec/requests/api/v2/sections_controller_spec.rb
+++ b/spec/requests/api/v2/sections_controller_spec.rb
@@ -1,27 +1,15 @@
 RSpec.describe Api::V2::SectionsController do
   describe 'GET #index' do
-    subject(:do_request) { make_request && response }
-
-    before do
-      create(
-        :section,
-        id: 18,
-        position: 18,
-        numeral: 'XVIII',
-        title: 'Optical, photographic, cinematographic, measuring',
-      )
-    end
-
-    context 'when using the mime suffix to configure the mime type' do
-      let(:make_request) { get '/sections.csv' }
-
-      it_behaves_like 'a successful csv response'
-    end
-
-    context 'when using Accept header to configure the mime type' do
-      let(:make_request) { get '/sections', headers: { 'ACCEPT' => 'text/csv' } }
-
-      it_behaves_like 'a successful csv response'
+    it_behaves_like 'a successful csv response', '/sections' do
+      before do
+        create(
+          :section,
+          id: 18,
+          position: 18,
+          numeral: 'XVIII',
+          title: 'Optical, photographic, cinematographic, measuring',
+        )
+      end
     end
   end
 end

--- a/spec/support/shared_examples/api_request_examples.rb
+++ b/spec/support/shared_examples/api_request_examples.rb
@@ -4,8 +4,22 @@ RSpec.shared_examples 'a successful jsonapi response' do
   it { expect(JSON.parse(subject.body)).to include 'data' }
 end
 
-RSpec.shared_examples 'a successful csv response' do
-  it { is_expected.to have_http_status :success }
-  it { is_expected.to have_attributes media_type: /csv/ }
-  it { expect { CSV.parse(subject.body) }.not_to raise_error }
+RSpec.shared_examples 'a successful csv response' do |path|
+  subject(:do_request) { make_request && response }
+
+  context 'when using the mime suffix to configure the mime type' do
+    let(:make_request) { get "#{path}.csv" }
+
+    it { is_expected.to have_http_status :success }
+    it { is_expected.to have_attributes media_type: /csv/ }
+    it { expect { CSV.parse(subject.body) }.not_to raise_error }
+  end
+
+  context 'when using Accept header to configure the mime type' do
+    let(:make_request) { get path, headers: { 'ACCEPT' => 'text/csv' } }
+
+    it { is_expected.to have_http_status :success }
+    it { is_expected.to have_attributes media_type: /csv/ }
+    it { expect { CSV.parse(subject.body) }.not_to raise_error }
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1518

### What?

I have added/removed/altered:

- [x] Removed default configuration for api/v2 mimetype at the routing level
- [x] Added coverage in csv request specs for ACCEPT header

### Why?

I am doing this because:

- This is required so we can support the text/csv mimetype in the ACCEPT header

### Deployment risks (optional)

- We should run a full regression and leave this on staging for a bit
