### PR TITLE
HOTT-1519 Always use latest v1 Ruby orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@2.0.3
-  ruby: circleci/ruby@1.4.0
+  ruby: circleci/ruby@1
   cloudfoundry: circleci/cloudfoundry@1.0
   slack: circleci/slack@4.3.0
   queue: eddiewebb/queue@1.6.4

--- a/spec/models/rules_of_origin/scheme_set_spec.rb
+++ b/spec/models/rules_of_origin/scheme_set_spec.rb
@@ -75,9 +75,9 @@ RSpec.describe RulesOfOrigin::SchemeSet do
     end
 
     context 'with multiple matching schemes' do
-      let(:country_code) { 'KE' }
+      let(:country_code) { 'VN' }
 
-      it { is_expected.to include have_attributes(scheme_code: 'kenya') }
+      it { is_expected.to include have_attributes(scheme_code: 'vietnam') }
       it { is_expected.to include have_attributes(scheme_code: 'gsp') }
     end
   end


### PR DESCRIPTION
### Jira link

[HOTT-1519](https://transformuk.atlassian.net/browse/HOTT-1519)

### What?

I have added/removed/altered:

- [x] Change the CI config to always use the latest v1 version of the Ruby orb
- [x] Fixed rules of origin specs that were failing by a change to the uk schemes file

### Why?

I am doing this because:

- Orbs follow semantic versioning, so it should be safe to upgrade minor and patch releases automatically since they wont include
breaking changes.
- There are known problems with specs not being run for the old v1.4.0 version of the ruby orb we currently use.