### PR TITLE
HOTT-1379 Search improvements

### DIFF
--- a/app/services/search_service/exact_search.rb
+++ b/app/services/search_service/exact_search.rb
@@ -4,9 +4,9 @@ class SearchService
       @results = case query_string
                  when /^[0-9]{1,3}$/
                    find_chapter(query_string)
-                 when /^[0-9]{4,9}$/
+                 when /^[0-9]{4}$/
                    find_heading(query_string)
-                 when /^[0-9]{10}$/
+                 when /^[0-9]{5,10}$/
                    # A commodity or declarable heading may have code of
                    # 10 digits
                    find_commodity(query_string) || find_heading(query_string)
@@ -48,6 +48,7 @@ class SearchService
     end
 
     def find_commodity(query)
+      query = query + ('0' * (10 - query.length)) if query.length < 10 # normalise shortened codes
       query = SearchService::CodesMapping.check(query) || query
 
       commodity = Commodity.actual

--- a/app/services/search_service/exact_search.rb
+++ b/app/services/search_service/exact_search.rb
@@ -58,7 +58,13 @@ class SearchService
 
       # NOTE: at the moment scope .declarable is not enough to
       # determine if it is really declarable or not
-      commodity.present? && commodity.declarable? ? commodity : nil
+      if commodity.blank?
+        nil
+      elsif commodity.declarable?
+        commodity
+      else
+        Subheading.actual.by_code(query).declarable.non_hidden.first
+      end
     end
 
     def find_chapter(query)

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -244,12 +244,12 @@ RSpec.describe SearchService do
                  validity_start_date: Date.new(2011, 1, 1)
         end
 
-        let(:heading_pattern) do
+        let(:subheading_pattern) do
           {
             type: 'exact_match',
             entry: {
-              endpoint: 'headings',
-              id: heading.goods_nomenclature_item_id.first(4),
+              endpoint: 'subheadings',
+              id: "8418213100-80",
             },
           }
         end
@@ -259,7 +259,7 @@ RSpec.describe SearchService do
           result = described_class.new(data_serializer, q: commodity1.goods_nomenclature_item_id,
                                                         as_of: Time.zone.today).to_json
 
-          expect(result).to match_json_expression heading_pattern
+          expect(result).to match_json_expression subheading_pattern
         end
       end
 

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -166,6 +166,28 @@ RSpec.describe SearchService do
           expect(result).to match_json_expression commodity_pattern(commodity)
         end
 
+        it 'returns endpoint and identifier if provided with 6 symbol commoditity code' do
+          commodity = create(:commodity, :declarable, :with_heading, :with_indent,
+                                         goods_nomenclature_item_id: '0101010000')
+
+          result = described_class.new(data_serializer,
+                                       q: '010101',
+                                       as_of: Time.zone.today).to_json
+
+          expect(result).to match_json_expression commodity_pattern(commodity)
+        end
+
+        it 'returns endpoint and identifier if provided with 8 symbol commoditity code' do
+          commodity = create(:commodity, :declarable, :with_heading, :with_indent,
+                                         goods_nomenclature_item_id: '0101010100')
+
+          result = described_class.new(data_serializer,
+                                       q: '01010101',
+                                       as_of: Time.zone.today).to_json
+
+          expect(result).to match_json_expression commodity_pattern(commodity)
+        end
+
         it 'returns endpoint and identifier if provided with 10 symbol commodity code separated by spaces' do
           code = [commodity.goods_nomenclature_item_id[0..1],
                   commodity.goods_nomenclature_item_id[2..3],


### PR DESCRIPTION
### Jira link

[HOTT-1379](https://transformuk.atlassian.net/browse/HOTT-1379)

### What?

I have added/removed/altered:

- [x] Check for subheadings as well as commodities when doing an exact search
- [x] Allow matching 6 and 8 digit comm codes when searching, which will take the user to either the relevant commodity or subheading, or fall back to the heading if the comm code is not available

### Why?

I am doing this because:

- I am trying to ensure the search behaves according to the 'scenarios' document attached to the ticket

### Notes

This supercedes #500 