### PR TITLE
HOTT-1491: Adds heading commodties csv api endpoint

### DIFF
--- a/app/controllers/api/v2/headings_controller.rb
+++ b/app/controllers/api/v2/headings_controller.rb
@@ -3,19 +3,36 @@ require 'goods_nomenclature_mapper'
 module Api
   module V2
     class HeadingsController < ApiController
-      before_action :find_heading, only: [:show, :changes]
+      before_action :find_heading
 
       def show
         service = ::HeadingService::HeadingSerializationService.new(@heading, actual_date)
         render json: service.serializable_hash
       end
 
+      def commodities
+        respond_to do |format|
+          format.csv do
+            send_data(
+              Api::V2::Csv::CommoditySerializer.new(cached_commodities).serialized_csv,
+              type: 'text/csv; charset=utf-8; header=present',
+              disposition: "attachment; filename=headings-#{params[:id]}-commodities-#{actual_date.iso8601}.csv",
+            )
+          end
+
+          format.all do
+            service = ::HeadingService::HeadingSerializationService.new(@heading, actual_date)
+            render json: service.serializable_hash
+          end
+        end
+      end
+
       def changes
         key = "heading-#{@heading.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}/changes"
         @changes = Rails.cache.fetch(key, expires_at: actual_date.end_of_day) do
-          ChangeLog.new(@heading.changes.where { |o|
+          ChangeLog.new(@heading.changes.where do |o|
             o.operation_date <= actual_date
-          })
+          end)
         end
 
         options = {}
@@ -36,6 +53,14 @@ module Api
 
       def heading_id
         "#{params[:id]}000000"
+      end
+
+      def cached_commodities
+        cached_heading.commodities
+      end
+
+      def cached_heading
+        HeadingService::CachedHeadingService.new(@heading, actual_date).serializable_hash
       end
     end
   end

--- a/app/serializers/api/v2/csv/commodity_serializer.rb
+++ b/app/serializers/api/v2/csv/commodity_serializer.rb
@@ -1,0 +1,20 @@
+module Api
+  module V2
+    module Csv
+      class CommoditySerializer
+        include CsvSerializer
+
+        columns :description,
+                :number_indents,
+                :goods_nomenclature_item_id,
+                :declarable,
+                :leaf,
+                :goods_nomenclature_sid,
+                :formatted_description,
+                :description_plain,
+                :producline_suffix,
+                :parent_sid
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ Rails.application.routes.draw do
       resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
         member do
           get :changes
+          get :commodities
         end
 
         resources :validity_periods, only: [:index]

--- a/spec/requests/api/v2/headings_controller_spec.rb
+++ b/spec/requests/api/v2/headings_controller_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe Api::V2::HeadingsController do
+  describe 'GET #commodities' do
+    it_behaves_like 'a successful csv response' do
+      let(:path) { "/headings/#{heading.short_code}/commodities" }
+      let(:heading) { create(:heading, :non_declarable) }
+    end
+  end
+end

--- a/spec/serializers/api/v2/csv/commodity_serializer_spec.rb
+++ b/spec/serializers/api/v2/csv/commodity_serializer_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe Api::V2::Csv::CommoditySerializer do
+  describe '#serializable_array' do
+    subject(:serializable_array) { described_class.new(serializable).serializable_array }
+
+    let(:serializable) do
+      commodity = Hashie::TariffMash.new(
+        description: 'foo',
+        number_indents: 1,
+        goods_nomenclature_item_id: '0702000007',
+        declarable: true,
+        leaf: true,
+        goods_nomenclature_sid: 123,
+        formatted_description: "<span title='foo'>foo</span>",
+        description_plain: 'foo',
+        producline_suffix: 80,
+        parent_sid: 122,
+      )
+
+      [commodity]
+    end
+
+    it 'serializes correctly' do
+      expect(serializable_array).to eq(
+        [
+          %i[description number_indents goods_nomenclature_item_id declarable leaf goods_nomenclature_sid formatted_description description_plain producline_suffix parent_sid],
+          ['foo', 1, '0702000007', true, true, 123, "<span title='foo'>foo</span>", 'foo', 80, 122],
+        ],
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1491

### What?

I have added/removed/altered:

- [x] Added api for pulling out a headings commodities in csv format
- [x] Added csv serializer for the heading commodities
- [x] Added spec coverage for above

### Why?

I am doing this because:

- This is part of a wider rollout of csv apis that are useful to HMRC and our stakeholders generally
