### PR TITLE
HOTT-1544: Add service to csv endpoint filenames

### DIFF
--- a/app/controllers/api/v2/chapters_controller.rb
+++ b/app/controllers/api/v2/chapters_controller.rb
@@ -12,7 +12,7 @@ module Api
             send_data(
               Api::V2::Csv::ChapterSerializer.new(@chapters).serialized_csv,
               type: 'text/csv; charset=utf-8; header=present',
-              disposition: "attachment; filename=chapters-#{actual_date.iso8601}.csv",
+              disposition: "attachment; filename=#{TradeTariffBackend.service}-chapters-#{actual_date.iso8601}.csv",
             )
           end
 

--- a/app/controllers/api/v2/headings_controller.rb
+++ b/app/controllers/api/v2/headings_controller.rb
@@ -16,7 +16,7 @@ module Api
             send_data(
               Api::V2::Csv::CommoditySerializer.new(cached_commodities).serialized_csv,
               type: 'text/csv; charset=utf-8; header=present',
-              disposition: "attachment; filename=headings-#{params[:id]}-commodities-#{actual_date.iso8601}.csv",
+              disposition: "attachment; filename=#{TradeTariffBackend.service}-headings-#{params[:id]}-commodities-#{actual_date.iso8601}.csv",
             )
           end
 

--- a/app/controllers/api/v2/sections_controller.rb
+++ b/app/controllers/api/v2/sections_controller.rb
@@ -11,7 +11,7 @@ module Api
             send_data(
               Api::V2::Csv::SectionSerializer.new(@sections).serialized_csv,
               type: 'text/csv; charset=utf-8; header=present',
-              disposition: "attachment; filename=sections-#{actual_date.iso8601}.csv",
+              disposition: "attachment; filename=#{TradeTariffBackend.service}-sections-#{actual_date.iso8601}.csv",
             )
           end
 
@@ -39,7 +39,7 @@ module Api
             send_data(
               Api::V2::Csv::ChapterSerializer.new(chapters).serialized_csv,
               type: 'text/csv; charset=utf-8; header=present',
-              disposition: "attachment; filename=sections-#{params[:id]}-chapters-#{actual_date.iso8601}.csv",
+              disposition: "attachment; filename=#{TradeTariffBackend.service}-sections-#{params[:id]}-chapters-#{actual_date.iso8601}.csv",
             )
           end
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -6,7 +6,7 @@ class Section < Sequel::Model
   plugin :nullable
   plugin :elasticsearch
 
-  many_to_many :chapters, dataset: -> {
+  many_to_many :chapters, dataset: lambda {
     Chapter.join_table(:inner, :chapters_sections, chapters_sections__goods_nomenclature_sid: :goods_nomenclatures__goods_nomenclature_sid)
            .join_table(:inner, :sections, chapters_sections__section_id: :sections__id)
            .with_actual(Chapter)
@@ -22,7 +22,9 @@ class Section < Sequel::Model
            .with_actual(Chapter)
            .where(Sequel.~(goods_nomenclatures__goods_nomenclature_item_id: HiddenGoodsNomenclature.codes))
            .where(sections__id: id_map.keys).all do |chapter|
-      if sections = id_map[chapter[:section_id]]
+      sections = id_map[chapter[:section_id]]
+
+      if sections.present?
         sections.each do |section|
           section.associations[:chapters] << chapter
         end

--- a/spec/requests/api/v2/chapters_controller_spec.rb
+++ b/spec/requests/api/v2/chapters_controller_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe Api::V2::ChaptersController do
   describe 'GET #index' do
     it_behaves_like 'a successful csv response' do
       let(:path) { '/chapters' }
+      let(:expected_filename) { "chapters-#{Time.zone.today.iso8601}.csv" }
 
       before do
         create(:chapter)

--- a/spec/requests/api/v2/chapters_controller_spec.rb
+++ b/spec/requests/api/v2/chapters_controller_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Api::V2::ChaptersController do
   describe 'GET #index' do
     it_behaves_like 'a successful csv response' do
       let(:path) { '/chapters' }
-      let(:expected_filename) { "chapters-#{Time.zone.today.iso8601}.csv" }
+      let(:expected_filename) { "uk-chapters-#{Time.zone.today.iso8601}.csv" }
 
       before do
         create(:chapter)

--- a/spec/requests/api/v2/headings_controller_spec.rb
+++ b/spec/requests/api/v2/headings_controller_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Api::V2::HeadingsController do
   describe 'GET #commodities' do
     it_behaves_like 'a successful csv response' do
       let(:path) { "/headings/#{heading.short_code}/commodities" }
-      let(:expected_filename) { "headings-#{heading.short_code}-commodities-#{Time.zone.today.iso8601}.csv" }
+      let(:expected_filename) { "uk-headings-#{heading.short_code}-commodities-#{Time.zone.today.iso8601}.csv" }
       let(:heading) { create(:heading, :non_declarable) }
     end
   end

--- a/spec/requests/api/v2/headings_controller_spec.rb
+++ b/spec/requests/api/v2/headings_controller_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe Api::V2::HeadingsController do
   describe 'GET #commodities' do
     it_behaves_like 'a successful csv response' do
       let(:path) { "/headings/#{heading.short_code}/commodities" }
+      let(:expected_filename) { "headings-#{heading.short_code}-commodities-#{Time.zone.today.iso8601}.csv" }
       let(:heading) { create(:heading, :non_declarable) }
     end
   end

--- a/spec/requests/api/v2/sections_controller_chapters_spec.rb
+++ b/spec/requests/api/v2/sections_controller_chapters_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Api::V2::Sections do
 
     it_behaves_like 'a successful csv response' do
       let(:path) { "/sections/#{section.position}/chapters" }
+      let(:expected_filename) { "sections-#{section.position}-chapters-#{Time.zone.today.iso8601}.csv" }
     end
   end
 end

--- a/spec/requests/api/v2/sections_controller_chapters_spec.rb
+++ b/spec/requests/api/v2/sections_controller_chapters_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Api::V2::Sections do
 
     it_behaves_like 'a successful csv response' do
       let(:path) { "/sections/#{section.position}/chapters" }
-      let(:expected_filename) { "sections-#{section.position}-chapters-#{Time.zone.today.iso8601}.csv" }
+      let(:expected_filename) { "uk-sections-#{section.position}-chapters-#{Time.zone.today.iso8601}.csv" }
     end
   end
 end

--- a/spec/requests/api/v2/sections_controller_spec.rb
+++ b/spec/requests/api/v2/sections_controller_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Api::V2::SectionsController do
   describe 'GET #index' do
     it_behaves_like 'a successful csv response' do
       let(:path) { '/sections' }
-      let(:expected_filename) { "sections-#{Time.zone.today.iso8601}.csv" }
+      let(:expected_filename) { "uk-sections-#{Time.zone.today.iso8601}.csv" }
 
       before do
         create(

--- a/spec/requests/api/v2/sections_controller_spec.rb
+++ b/spec/requests/api/v2/sections_controller_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe Api::V2::SectionsController do
   describe 'GET #index' do
     it_behaves_like 'a successful csv response' do
       let(:path) { '/sections' }
+      let(:expected_filename) { "sections-#{Time.zone.today.iso8601}.csv" }
 
       before do
         create(

--- a/spec/support/shared_examples/api_request_examples.rb
+++ b/spec/support/shared_examples/api_request_examples.rb
@@ -9,6 +9,7 @@ RSpec.shared_examples 'a successful csv response' do
 
   let(:make_request) { get "#{path}.csv" }
 
+  it { expect(do_request.headers['Content-Disposition']).to eq("attachment; filename=#{expected_filename}") }
   it { is_expected.to have_http_status :success }
   it { is_expected.to have_attributes media_type: /csv/ }
   it { expect { CSV.parse(subject.body) }.not_to raise_error }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1544

### What?

I have added/removed/altered:

- [x] Added specs for csv endpoint filenames
- [x] Added service to csv endpoint filenames and updated specs

### Why?

I am doing this because:

- This is required for the user to distinguish between files from the two backends
