### PR TITLE
HOTT-1505 Refactor Updates Synchronize Worker

### DIFF
--- a/app/lib/tariff_synchronizer.rb
+++ b/app/lib/tariff_synchronizer.rb
@@ -97,7 +97,7 @@ module TariffSynchronizer
   end
 
   # Taric
-  def apply(reindex_all_indexes: false)
+  def apply
     check_tariff_updates_failures
     check_sequence
 
@@ -124,14 +124,14 @@ module TariffSynchronizer
           import_warnings:,
         )
 
-        Sidekiq::Client.enqueue(ClearCacheWorker) if reindex_all_indexes
+        true
       end
     end
   rescue Redlock::LockError
     instrument('apply_lock_error.tariff_synchronizer')
   end
 
-  def apply_cds(reindex_all_indexes: false)
+  def apply_cds
     check_tariff_updates_failures
     check_sequence
 
@@ -160,7 +160,7 @@ module TariffSynchronizer
         instrument('apply.tariff_synchronizer',
                    update_names: applied_updates.map(&:filename))
 
-        Sidekiq::Client.enqueue(ClearCacheWorker) if reindex_all_indexes
+        true
       end
     end
   rescue Redlock::LockError

--- a/lib/tasks/tariff.rake
+++ b/lib/tasks/tariff.rake
@@ -78,14 +78,22 @@ namespace :tariff do
       UpdatesSynchronizerWorker.perform_async
     end
 
-    desc 'Download pending Taric update files, Update tariff_updates table'
+    desc 'Download pending Taric or CDS update files, Update tariff_updates table'
     task download: %i[environment class_eager_load] do
-      TariffSynchronizer.download
+      if TradeTariffBackend.use_cds?
+        TariffSynchronizer.download_cds
+      else
+        TariffSynchronizer.download
+      end
     end
 
-    desc 'Apply pending updates Taric'
+    desc 'Apply pending updates for Taric or CDS'
     task apply: %i[environment class_eager_load] do
-      TariffSynchronizer.apply
+      if TradeTariffBackend.use_cds?
+        TariffSynchronizer.apply_cds
+      else
+        TariffSynchronizer.apply
+      end
     end
 
     desc 'Rollback to specific date in the past'

--- a/spec/factories/cds_update_factory.rb
+++ b/spec/factories/cds_update_factory.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     issue_date { example_date }
 
     filename { "tariff_dailyExtract_v1_#{example_date.strftime('%Y%m%d')}T235959.gzip" }
+    filesize { 10 } # below threshold for oplog inserts check
 
     update_type { 'TariffSynchronizer::CdsUpdate' }
 

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -1,0 +1,1 @@
+Sidekiq.logger.level = Logger::WARN

--- a/spec/workers/rollback_worker_spec.rb
+++ b/spec/workers/rollback_worker_spec.rb
@@ -1,8 +1,4 @@
 RSpec.describe RollbackWorker, type: :worker do
-  before do
-    allow($stdout).to receive(:write)
-  end
-
   let(:date) { '01-01-2020' }
 
   describe '#perform' do


### PR DESCRIPTION
### Jira link

[HOTT-1505](https://transformuk.atlassian.net/browse/HOTT-1505)

### What?

I have added/removed/altered:

- [x] Moved scheduling of cache invalidation out of TariffSynchronizer and into UpdatesSynchronizerWorker
- [x] Changed TariffSynchronizer specs to not mockout calling `#apply` on `TaricUpdate`/`CdsUpdate`s themselves since this actually changes the flow in the calling class that checks after whether updates marked themselves as applied.
- [x] Makes some older Rake tasks aware of CDS
- [x] Reduce log level from sidekiq to avoid the need for silencing $stdout in some specs

### Why?

I am doing this because:

- I want to add another step to the ETL process before the cache invalidation (subsequent PR)
- This new step doesn't relate to the TariffSynchronizer itself
- The ETL process is more then just the TariffSynchronizer, currently its Synchronizer + Cache Invalidation + Index rebuild + Cache rebuild
- As it stands changes to the broader ETL process order potentially require the model for `TariffSynchronizer` to be changed, even if its unrelated

### Deployment risks (optional)

- Changes the critical TariffSynchronizer process - should run overnight in Dev environment prior to merge, and checks should be made that cache invalidation and reindex were run
