### PR TITLE
HOTT-1505 Reapply data migrations on ETL sync

### DIFF
--- a/app/lib/tariff_synchronizer.rb
+++ b/app/lib/tariff_synchronizer.rb
@@ -207,7 +207,11 @@ module TariffSynchronizer
             end
           end
 
-          DataMigration.since(date_for_rollback).delete # Requeue data migrations
+          # Requeue data migrations
+          # Rollback leaves 'date_for_rollback's data intact, it removes only
+          # removes data for subsequent days - so look for migrations after
+          # the end of the date_for_rollback day
+          DataMigration.since(date_for_rollback.end_of_day).delete
         end
       end
 
@@ -259,7 +263,11 @@ module TariffSynchronizer
             end
           end
 
-          DataMigration.since(date_for_rollback).delete # Requeue data migrations
+          # Requeue data migrations
+          # Rollback leaves 'date_for_rollback's data intact, it removes only
+          # removes data for subsequent days - so look for migrations after
+          # the end of the date_for_rollback day
+          DataMigration.since(date_for_rollback.end_of_day).delete
         end
       end
 

--- a/lib/tasks/tariff.rake
+++ b/lib/tasks/tariff.rake
@@ -75,7 +75,7 @@ namespace :tariff do
   namespace :sync do
     desc 'Update database by downloading and then applying TARIC updates via worker'
     task update: %i[environment class_eager_load] do
-      UpdatesSynchronizerWorker.perform_async
+      UpdatesSynchronizerWorker.perform_async(true, true)
     end
 
     desc 'Download pending Taric or CDS update files, Update tariff_updates table'

--- a/lib/tasks/tariff.rake
+++ b/lib/tasks/tariff.rake
@@ -69,11 +69,11 @@ namespace :tariff do
     end
   end
 
-  desc 'Download and apply Taric data'
-  task sync: %w[environment sync:apply]
+  desc 'Download and apply Taric or CDS data using Sidekiq'
+  task sync: %w[environment sync:update]
 
   namespace :sync do
-    desc 'Update database by downloading and then applying TARIC updates via worker'
+    desc 'Update database by downloading and then applying TARIC or CDS updates via worker'
     task update: %i[environment class_eager_load] do
       UpdatesSynchronizerWorker.perform_async(true, true)
     end


### PR DESCRIPTION
### Jira link

[HOTT-1505](https://transformuk.atlassian.net/browse/HOTT-1505)

### What?

I have added/removed/altered:

- [x] Added option to run outstanding data migrations as part of ETL process
- [x] Use this when manually running ETL process from the rake task but not as part of the overnight sync
- [x] Change the short hand `rake tariff:sync` task to do an `download and apply` via a worker 
- [x] Fixed an off by one issue in the rollback of data migrations

### Why?

I am doing this because:

- If an ETL rollback has been performed, we will potentially have Data Migrations needing to be reapplied
- These should be reapplied before the cache invalidation and reindex process occurs
- This doesn't need to impact the nightly process but its useful for the 'manual roll forward' scenario
- The rollback's _keep_ the data from the chosen data, _but_ the data migration rollback was removing that days migrations - instead in now only removes data migrations from the following day to keep it inline with where data is being rolled back to
- The `rake tariff:sync` task would reasonably be expected to sync the tariff data - previously only did part of the process (apply) but not download, re-applying data migrations, cache invalidation, reindexing. Changed it to kick off the full process via the worker 

### Deployment risks (optional)

- Changes ETL process so needs to run successfully overnight in Development prior to merge
