### PR TITLE
HOTT-1379 Return empty result for unknown commodities

### DIFF
--- a/app/services/search_service/exact_search.rb
+++ b/app/services/search_service/exact_search.rb
@@ -39,16 +39,17 @@ class SearchService
     private
 
     def find_heading(query)
+      query = normalise_shortened_code(query)
       query = SearchService::CodesMapping.check(query) || query
 
       Heading.actual
-             .by_code(query)
+             .by_declarable_code(query)
              .non_hidden
              .first
     end
 
     def find_commodity(query)
-      query = query + ('0' * (10 - query.length)) if query.length < 10 # normalise shortened codes
+      query = normalise_shortened_code(query)
       query = SearchService::CodesMapping.check(query) || query
 
       commodity = Commodity.actual
@@ -108,6 +109,12 @@ class SearchService
         query.singularize,
         query.pluralize,
       ].uniq
+    end
+
+    def normalise_shortened_code(code)
+      return code if code.length >= 10
+
+      code + ('0' * (10 - code.length))
     end
   end
 end

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -296,6 +296,51 @@ RSpec.describe SearchService do
           expect(result).to match_json_expression commodity_pattern(commodity2)
         end
       end
+
+      context 'unknown commodity' do
+        let(:pattern) do
+          {
+            type: 'fuzzy_match',
+            goods_nomenclature_match: {
+              chapters: [],
+              commodities: [],
+              headings: [],
+              sections: [],
+            },
+            reference_match: {
+              chapters: [],
+              commodities: [],
+              headings: [],
+              sections: [],
+            },
+          }
+        end
+
+        context 'under unknown heading' do
+          it 'returns empty result' do
+            result = described_class.new(data_serializer,
+                                         q: '8418999999',
+                                         as_of: Time.zone.today).to_json
+
+            expect(result).to match_json_expression pattern
+          end
+        end
+
+        context 'under known heading' do
+          let!(:heading) do
+            create :heading, goods_nomenclature_item_id: '8418000000',
+                             validity_start_date: Date.new(2011, 1, 1)
+          end
+
+          it 'returns empty result' do
+            result = described_class.new(data_serializer,
+                                         q: '8418999999',
+                                         as_of: Time.zone.today).to_json
+
+            expect(result).to match_json_expression pattern
+          end
+        end
+      end
     end
 
     context 'chemicals' do


### PR DESCRIPTION
Previously search would return the heading for the missing commodity,
but this places behavioural logic in the backend and removes our ability
to handle empty searches differently on the frontend.

### Jira link

[HOTT-1379](https://transformuk.atlassian.net/browse/HOTT-1379)

### What?

I have added/removed/altered:

- [x] Return an empty result for a unknown commodity, instead of its parent heading

### Why?

I am doing this because:

- Currently we return an exact match, even though its not. 
- The frontend cannot differentiate between an exact match that it should treat as canonical and redirect the user to, and an exact match that actually wasn't and the user should be given options (ie the 404 history page)
- Returning no result makes it clear we didn't find a match for that commodity

### Deployment risks (optional)

- Includes behavioural changes to the search api - this isn't a documented API but is publicly accesible so may affect anyone integrating with the search we don't know about
