### PR TITLE
HOTT-1549 Expose productline_suffix on the api /search_references

### DIFF
--- a/app/serializers/api/v2/search_reference_serializer.rb
+++ b/app/serializers/api/v2/search_reference_serializer.rb
@@ -7,7 +7,7 @@ module Api
 
       set_id :id
 
-      attributes :title, :referenced_id, :referenced_class
+      attributes :title, :referenced_id, :referenced_class, :productline_suffix
     end
   end
 end

--- a/spec/controllers/api/v2/search_references_controller_spec.rb
+++ b/spec/controllers/api/v2/search_references_controller_spec.rb
@@ -9,8 +9,26 @@ RSpec.describe Api::V2::SearchReferencesController do
     let(:pattern) do
       {
         data: [
-          { id: String, type: String, attributes: { title: String, referenced_class: 'Section', referenced_id: String } },
-          { id: String, type: String, attributes: { title: String, referenced_class: 'Chapter', referenced_id: String } },
+          {
+            id: String,
+            type: String,
+            attributes: {
+              title: String,
+              referenced_class: 'Section',
+              referenced_id: String,
+              productline_suffix: String,
+            },
+          },
+          {
+            id: String,
+            type: String,
+            attributes: {
+              title: String,
+              referenced_class: 'Chapter',
+              referenced_id: String,
+              productline_suffix: String,
+            },
+          },
         ],
       }
     end
@@ -26,13 +44,23 @@ RSpec.describe Api::V2::SearchReferencesController do
     let(:pattern) do
       {
         data: [
-          { id: String, type: String, attributes: { title: String, referenced_class: 'Heading', referenced_id: String } },
+          {
+            id: String,
+            type: String,
+            attributes: {
+              title: String,
+              referenced_class: 'Heading',
+              referenced_id: String,
+              productline_suffix: String,
+            },
+          },
         ],
       }
     end
 
     it 'peforms lookup with letter A by default' do
-      get :index, format: :json
+      get :index,
+          format: :json
 
       expect(response.body).to match_json_expression pattern
     end

--- a/spec/serializers/api/v2/search_reference_serializer_spec.rb
+++ b/spec/serializers/api/v2/search_reference_serializer_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe Api::V2::SearchReferenceSerializer do
+  describe '#serializable_hash' do
+    subject(:serializable_hash) { described_class.new(serializable).serializable_hash }
+
+    let(:serializable) { create(:search_reference) }
+
+    let(:expected_pattern) do
+      {
+        data: {
+          id: serializable.id.to_s,
+          type: :search_reference,
+          attributes: {
+            title: serializable.title,
+            referenced_id: serializable.referenced_id,
+            referenced_class: 'Heading',
+            productline_suffix: '80',
+          },
+        },
+      }
+    end
+
+    it { is_expected.to eq(expected_pattern) }
+  end
+end


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-1549

### What?
This PR exposes productline_suffix on the api /search_references

### Why?
To provide a way for the FE to understand if the entries are subheadings.

