### PR TITLE
HOTT-1568 increase priority of healthcheck queue

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,10 +1,10 @@
 :verbose: false
 :concurrency: 10
 :queues:
-  - [healthcheck, 20]
-  - [rollbacks, 2]
-  - [sync, 2]
-  - [default, 5]
+  - healthcheck
+  - rollbacks
+  - sync
+  - default
 :schedule:
   #
   # Syntax:


### PR DESCRIPTION
### Jira link

[HOTT-1568](https://transformuk.atlassian.net/browse/HOTT-1568)

### What?

I have added/removed/altered:

- [x] Changed prioritisation of Sidekiq Queues to check in an explicit order

### Why?

I am doing this because:

- The Sidekiq Healthcheck worker is currently being starved out on the Sidekiq queues and not firing whilst we are rebuilding the cache

### Deployment risks (optional)

- Changes priority levels of job queues
