### PR TITLE
Build docker image concurrently with running tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -525,8 +525,6 @@ workflows:
               ignore:
                 - main
                 - /^dependabot\/.*/
-          requires:
-            - test
       - deploy_dev:
            matrix:
              parameters:
@@ -540,6 +538,7 @@ workflows:
                  - main
                  - /^dependabot\/.*/
            requires:
+             - test
              - build_dev
       - smoketest_dev:
           name: smoketest_dev


### PR DESCRIPTION
### Jira link

HOTT-???

### What?

I have added/removed/altered:

- [x] Build the docker image for DEV concurrently with running specs and linters

### Why?

I am doing this because:

- It will take 3 minutes out the pipeline