### PR TITLE
HOTT-1565 Fix for flaky spec on Healthcheck model

### DIFF
--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -92,6 +92,12 @@ RSpec.describe Healthcheck do
   describe '.check' do
     subject { described_class.check }
 
-    it { is_expected.to include sidekiq: false }
+    before do
+      TradeTariffBackend.redis.set \
+        described_class::SIDEKIQ_KEY,
+        (described_class::SIDEKIQ_THRESHOLD - 1.minute).ago.utc.iso8601
+    end
+
+    it { is_expected.to include sidekiq: true }
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-1565

### What?

I have added/removed/altered:

- [x] Fixed flaky spec introduced as part of the Sidekiq healthcheck work

### Why?

I am doing this because:

- flaky specs result in false negatives for the whole team
