### PR TITLE
HOTT-1557 Expose declarable for Subheading.

### DIFF
--- a/app/serializers/api/v2/subheadings/commodity_serializer.rb
+++ b/app/serializers/api/v2/subheadings/commodity_serializer.rb
@@ -15,7 +15,8 @@ module Api
                    :producline_suffix,
                    :goods_nomenclature_sid,
                    :parent_sid,
-                   :leaf
+                   :leaf,
+                   :declarable
 
         attribute :productline_suffix, &:producline_suffix
 

--- a/spec/serializers/api/v2/subheadings/commodity_serializer_spec.rb
+++ b/spec/serializers/api/v2/subheadings/commodity_serializer_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Api::V2::Subheadings::CommoditySerializer do
       ],
       'parent_sid' => 1,
       'leaf' => true,
+      'declarable' => true,
       'number_indents' => 2,
       'producline_suffix' => '80',
       'description' => 'voMrkLOGSd0R1',
@@ -70,6 +71,7 @@ RSpec.describe Api::V2::Subheadings::CommoditySerializer do
           'goods_nomenclature_sid' => 5,
           'parent_sid' => 1,
           'leaf' => true,
+          'declarable' => true,
           'productline_suffix' => '80',
         },
         'relationships' => {


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-1557

### What?
Add declarable to Subheading.

### Why?
To fix the subheading formatting.
The issue with the FE, is not having a `declarable` attribute for the subheading provided by the API.
I am doing this because:
