### PR TITLE
HOTT-1620 Handle Redis connections go READONLY

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'rubyzip'
 
 # Background jobs
 gem 'connection_pool'
+gem 'redis-elasticache'
 gem 'redis-rails'
 gem 'redlock'
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,6 +324,8 @@ GEM
     redis-activesupport (5.3.0)
       activesupport (>= 3, < 8)
       redis-store (>= 1.3, < 2)
+    redis-elasticache (0.2.0)
+      redis (>= 3.0.0)
     redis-rack (2.1.4)
       rack (>= 2.0.8, < 3)
       redis-store (>= 1.2, < 2)
@@ -484,6 +486,7 @@ DEPENDENCIES
   rabl
   rack-timeout
   rails (~> 7.0)
+  redis-elasticache
   redis-rails
   redlock
   responders

--- a/config/initializers/redis_lock_db.rb
+++ b/config/initializers/redis_lock_db.rb
@@ -1,30 +1,7 @@
 module RedisLockDb
-  DEFAULT_POOL_SIZE = 10
-
   class << self
-    delegate :logger, to: Rails
-    attr_writer :redis
-
     def redis
-      @redis ||= build_connection_pool
-    end
-
-  private
-
-    def pool_size
-      if Sidekiq.server?
-        Sidekiq.options[:concurrency] || DEFAULT_POOL_SIZE
-      else
-        Integer(ENV['RAILS_MAX_THREADS'].presence || ENV['MAX_THREADS'].presence || DEFAULT_POOL_SIZE)
-      end
-    end
-
-    def build_connection_pool
-      logger.info "Initialising Redlock connection pool with #{pool_size} connections"
-
-      ConnectionPool.new(size: pool_size) do
-        Redis.new PaasConfig.redis
-      end
+      Sidekiq.redis_pool
     end
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-1620

### What?

I have added/removed/altered:

- [x] Dropped the dedicated connection pool for Redlock
- [x] Added the Redis-Elasticache gem

### Why?

I am doing this because:

- You can get to the Redis connection pool directly, so we don't need to create our own
- Open connections to Redis turn READONLY when the Redis instance failsover - this in effect leaves open connections broken. Redis ElasticCache makes the READONLY responses look like connection errors, triggering reconnects which will connect to the new master, resolving the problem.

### Notes

This gem uses is marked as deprecated because there is now a config option for the Redis instance.

Due to limits in how we deploy our services we cannot set this config option in a persisted manner - if Redis gets recreated (ie we upgrade to a larger instance) we will loose this option re-introducing the problem.

Hence why I'm relying on a deprecated gem - I don't think its likely to become incompatible with the `redis-rb` it extends though.

The part of `redis-rb` it extends is a one line method

```ruby
module Redis
  module Connection
    class Ruby
      def format_error_reply(line)
        CommandError.new(line.strip)
      end
    end
  end
end
```

it replaces it with

```ruby
module Redis
  module Connection
    class Ruby
      def format_error_reply(line)
        error_message = line.strip
        if error_message_has_prefix?(ELASTICACHE_READONLY_ERROR_PREFIX, error_message)
          raise BaseConnectionError, ELASTICACHE_READONLY_MESSAGE
        elsif error_message_has_prefix?(ELASTICACHE_LOADING_ERROR_PREFIX, error_message)
          raise BaseConnectionError, ELASTICACHE_LOADING_MESSAGE
        else
          CommandError.new(error_message)
        end
      end

      private
      def error_message_has_prefix?(prefix, error_message)
        (error_message.slice(0, prefix.length) === prefix)
      end
    end
  end
end
```

AFAICT this is fairly minimal change and unlikely to become incompatible with the Redis gem