### PR TITLE
Converted NewsItemController to be a request spec

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,6 +32,7 @@ RSpec.configure do |config|
   config.alias_it_should_behave_like_to :it_is_associated, 'it is associated'
   config.include RSpec::Rails::RequestExampleGroup, type: :request, file_path: /spec\/api/
   config.include ControllerSpecHelper, type: :controller
+  config.include RequestSpecHelper, type: :request
   config.include SynchronizerHelper
   config.include LoggerHelper
   config.include RescueHelper

--- a/spec/requests/api/admin/news_items_controller_spec.rb
+++ b/spec/requests/api/admin/news_items_controller_spec.rb
@@ -5,11 +5,9 @@ RSpec.describe Api::Admin::NewsItemsController do
   let(:news_item) { create :news_item }
 
   describe 'GET to #index' do
-    render_views
-
-    before { login_as_api_user }
-
-    let(:make_request) { get :index, format: :json }
+    let(:make_request) do
+      authenticated_get api_admin_news_items_path(format: :json)
+    end
 
     context 'with some news items' do
       it { is_expected.to have_http_status :success }
@@ -24,12 +22,8 @@ RSpec.describe Api::Admin::NewsItemsController do
   end
 
   describe 'GET to #show' do
-    render_views
-
-    before { login_as_api_user }
-
     let(:make_request) do
-      get :show, format: :json, params: { id: news_item_id }
+      authenticated_get api_admin_news_item_path(news_item_id, format: :json)
     end
 
     context 'with existent news item' do
@@ -47,11 +41,9 @@ RSpec.describe Api::Admin::NewsItemsController do
   end
 
   describe 'POST to #create' do
-    render_views
-
-    before { login_as_api_user }
-
-    let(:make_request) { post :create, format: :json, params: news_item_data }
+    let(:make_request) do
+      authenticated_post api_admin_news_items_path(format: :json), params: news_item_data
+    end
 
     let :news_item_data do
       {
@@ -84,16 +76,11 @@ RSpec.describe Api::Admin::NewsItemsController do
   end
 
   describe 'PATCH to #update' do
-    render_views
-
-    before { login_as_api_user }
-
     let(:news_item_id) { news_item.id }
     let(:updated_title) { 'Updated title' }
 
     let(:make_request) do
-      patch :update, format: :json, params: {
-        id: news_item_id,
+      authenticated_patch api_admin_news_item_path(news_item_id, format: :json), params: {
         data: {
           type: :news_item,
           attributes: { title: updated_title },
@@ -128,12 +115,8 @@ RSpec.describe Api::Admin::NewsItemsController do
   end
 
   describe 'DELETE to #destroy' do
-    render_views
-
-    before { login_as_api_user }
-
     let :make_request do
-      delete :destroy, format: :json, params: { id: news_item_id }
+      authenticated_delete api_admin_news_item_path(news_item_id, format: :json)
     end
 
     context 'with known news item' do

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -1,0 +1,29 @@
+module RequestSpecHelper
+  def authenticated_head(path, **kwargs)
+    head path, **add_authentication_header(**kwargs)
+  end
+
+  def authenticated_get(path, **kwargs)
+    get path, **add_authentication_header(**kwargs)
+  end
+
+  def authenticated_post(path, **kwargs)
+    post path, **add_authentication_header(**kwargs)
+  end
+
+  def authenticated_patch(path, **kwargs)
+    patch path, **add_authentication_header(**kwargs)
+  end
+
+  def authenticated_delete(path, **kwargs)
+    delete path, **add_authentication_header(**kwargs)
+  end
+
+private
+
+  def add_authentication_header(headers: {}, **kwargs)
+    headers['HTTP_AUTHORIZATION'] ||= 'Bearer tariff-api-test-token'
+
+    kwargs.merge(headers:)
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [x] Converted NewsItemController to be a request spec

### Why?

I am doing this because:

- Controller specs are deprecated and this provides a nice example of using request specs with for admin area apis
