### PR TITLE
HOTT-1619 Update Section title

### DIFF
--- a/app/models/data_migration.rb
+++ b/app/models/data_migration.rb
@@ -1,6 +1,8 @@
 class DataMigration < Sequel::Model
   VERSION_FORMAT = /\A20\d{12}\z/
 
+  set_dataset order(Sequel.asc(:filename))
+
   dataset_module do
     def version(version)
       raise ArgumentError, 'Invalid version number' unless version =~ VERSION_FORMAT
@@ -25,5 +27,9 @@ class DataMigration < Sequel::Model
     def within(since, upto)
       since(since).upto(upto)
     end
+  end
+
+  def version
+    filename.first(14)
   end
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,6 +1,8 @@
 class Section < Sequel::Model
   extend ActiveModel::Naming
 
+  set_dataset order(Sequel.asc(:position))
+
   plugin :timestamps
   plugin :active_model
   plugin :nullable

--- a/db/data_migrations/20220513092532_update_section_title.rb
+++ b/db/data_migrations/20220513092532_update_section_title.rb
@@ -1,0 +1,25 @@
+Sequel.migration do
+  up do
+    Sequel::Model.db[:sections]
+      .where(
+        numeral: 'III',
+        title: %(Animal or vegetable fats and oils and their cleavage products; prepared edible fats; animal or vegetable waxes),
+      )
+      .update(
+        title: %(Animal, vegetable or microbial fats and oils and their cleavage products; prepared edible fats; animal or vegetable waxes),
+        updated_at: Time.zone.now.utc,
+      )
+  end
+
+  down do
+    Sequel::Model.db[:sections]
+      .where(
+        numeral: 'III',
+        title: %(Animal, vegetable or microbial fats and oils and their cleavage products; prepared edible fats; animal or vegetable waxes),
+      )
+      .update(
+        title: %(Animal or vegetable fats and oils and their cleavage products; prepared edible fats; animal or vegetable waxes),
+        updated_at: nil,
+      )
+  end
+end

--- a/spec/models/data_migration_spec.rb
+++ b/spec/models/data_migration_spec.rb
@@ -1,9 +1,22 @@
 RSpec.describe DataMigration do
+  before { described_class.unrestrict_primary_key }
+
+  describe 'default ordering' do
+    subject { described_class.all.map(&:version) }
+
+    before do
+      described_class.create filename: '20220301010101-test-3.rb'
+      described_class.create filename: '20220201010101-test-2.rb'
+      described_class.create filename: '20220101010101-test-1.rb'
+    end
+
+    it { is_expected.to eql %w[20220101010101 20220201010101 20220301010101] }
+  end
+
   describe '.for_version' do
     subject(:count) { described_class.version(version).count }
 
     before do
-      described_class.unrestrict_primary_key
       described_class.create(filename: '20220401000000_test_record.rb')
     end
 
@@ -26,7 +39,6 @@ RSpec.describe DataMigration do
     let(:since) { Time.zone.parse '2022-04-10' }
 
     before do
-      described_class.unrestrict_primary_key
       described_class.create(filename: '20220501000000_second.rb')
       described_class.create(filename: '20220601000000_third.rb')
       described_class.create(filename: '20220401000000_test.rb')
@@ -43,7 +55,6 @@ RSpec.describe DataMigration do
     let(:upto) { Time.zone.parse '2022-05-10' }
 
     before do
-      described_class.unrestrict_primary_key
       described_class.create(filename: '20220501000000_second.rb')
       described_class.create(filename: '20220601000000_third.rb')
       described_class.create(filename: '20220401000000_test.rb')
@@ -61,7 +72,6 @@ RSpec.describe DataMigration do
     let(:upto) { Time.zone.parse '2022-05-10' }
 
     before do
-      described_class.unrestrict_primary_key
       described_class.create(filename: '20220501000000_second.rb')
       described_class.create(filename: '20220601000000_third.rb')
       described_class.create(filename: '20220401000000_test.rb')
@@ -70,5 +80,13 @@ RSpec.describe DataMigration do
     it { is_expected.not_to include '20220401000000_test.rb' }
     it { is_expected.to include '20220501000000_second.rb' }
     it { is_expected.not_to include '20220601000000_third.rb' }
+  end
+
+  describe '#version' do
+    subject { migration.version }
+
+    let(:migration) { described_class.create filename: '20220301010101_test.rb' }
+
+    it { is_expected.to eql '20220301010101' }
   end
 end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -1,4 +1,16 @@
 RSpec.describe Section do
+  describe 'default ordering' do
+    subject { described_class.all.pluck(:position) }
+
+    before do
+      create :section, position: 3, title: 'Section 3'
+      create :section, position: 2, title: 'Section 2'
+      create :section, position: 1, title: 'Section 1'
+    end
+
+    it { is_expected.to eql [1, 2, 3] }
+  end
+
   describe 'associations' do
     describe 'chapters' do
       let!(:chapter) { create(:chapter, :with_section) }


### PR DESCRIPTION
### Jira link

[HOTT-1619](https://transformuk.atlassian.net/browse/HOTT-1619)

### What?

I have added/removed/altered:

- [x] Added a data migration to update the title of Section III
- [x] Fixed default ordering of Section model
- [x] Fixed default ordering of DataMigration model

### Why?

I am doing this because:

- We want to amend the title of Section III
- Previously API returned sections in the order of 'least recently modified' first - which meant the newly modified Section III was at the end, not between Section II and Section IV as it should be
- The DataMigrations also have a natural order, so we should follow that in retrieval to avoid confusing future developers - note this model isn't used by the migration system itself, its just a convenience model I've added for working with records from the Data Migrator
