### PR TITLE
 Disable RSpec dsl in main

### DIFF
--- a/spec/factories_spec.rb
+++ b/spec/factories_spec.rb
@@ -1,5 +1,5 @@
 FactoryBot.factories.map(&:name).each do |factory_name|
-  describe "#{factory_name} factory" do
+  RSpec.describe "#{factory_name} factory" do
     it 'is valid' do
       factory = build factory_name
       expect(factory).to be_valid if factory.respond_to?(:valid)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ RSpec.configure do |config|
 
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
+  config.expose_dsl_globally = false
 
   config.order = :random
 

--- a/spec/support/shared_examples/a_component.rb
+++ b/spec/support/shared_examples/a_component.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'a component' do |type|
+RSpec.shared_examples_for 'a component' do |type|
   it_is_associated 'one to one to', :duty_expression do
     let(:duty_expression_id) { Forgery(:basic).text(exactly: 3) }
   end

--- a/spec/support/shared_examples/a_serialized_goods_nomenclature.rb
+++ b/spec/support/shared_examples/a_serialized_goods_nomenclature.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'a serialized goods nomenclature' do |type|
+RSpec.shared_examples_for 'a serialized goods nomenclature' do |type|
   subject(:serializer) { described_class.new(serializable, {}) }
 
   let(:serializable) { build(:goods_nomenclature, :with_description) }

--- a/spec/support/shared_examples/association_shared_examples.rb
+++ b/spec/support/shared_examples/association_shared_examples.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'one to one to' do |associated_object, eager_load_association = associated_object|
+RSpec.shared_examples_for 'one to one to' do |associated_object, eager_load_association = associated_object|
   @source_record =  :"#{described_class.to_s.underscore}"
   let!(:primary_key)               { associated_object.to_s.classify.constantize.primary_key }
   let!(:left_primary_key)          { primary_key }

--- a/spec/support/shared_examples/base_update_shared_examples.rb
+++ b/spec/support/shared_examples/base_update_shared_examples.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Base Update' do
+RSpec.shared_examples_for 'Base Update' do
   describe '.sync' do
     include BankHolidaysHelper
 

--- a/spec/support/shared_examples/v2_search_reference_controller_examples.rb
+++ b/spec/support/shared_examples/v2_search_reference_controller_examples.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'v2 search references controller' do
+RSpec.shared_examples_for 'v2 search references controller' do
   before { login_as_api_user }
 
 


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Avoid monkey patched rspec dsl

### Why?

I am doing this because:

- This is consistent with the rails generators and it is generally more desirable to do things in one way, only: https://github.com/rspec/rspec-rails/commit/ca0d249858903949052e06884e8e7f9d596cdc79
