### PR TITLE
HOTT-1483 Include the ancestors tree in the Subheadings API

### DIFF
--- a/app/serializers/api/v2/subheadings/subheading_serializer.rb
+++ b/app/serializers/api/v2/subheadings/subheading_serializer.rb
@@ -22,6 +22,7 @@ module Api
         has_one :section, serializer: Api::V2::Subheadings::SectionSerializer
         has_one :chapter, serializer: Api::V2::Subheadings::ChapterSerializer
         has_one :heading, serializer: Api::V2::Subheadings::HeadingSerializer
+        has_many :ancestors, serializer: Api::V2::Commodities::CommoditySerializer
         has_many :commodities, serializer: Api::V2::Subheadings::CommoditySerializer
         has_many :footnotes, serializer: Api::V2::Subheadings::FootnoteSerializer
       end

--- a/app/services/cached_subheading_service.rb
+++ b/app/services/cached_subheading_service.rb
@@ -37,6 +37,8 @@ class CachedSubheadingService
       presented.heading_id = presented.heading.id
       presented.commodity_ids = presented.commodities.map(&:id)
       presented.footnote_ids = presented.footnotes.map(&:id)
+      presented.ancestors = @subheading.ancestors
+      presented.ancestor_ids = presented.ancestors.map(&:id)
 
       presented.chapter.guide_ids = presented.chapter.guides.map(&:id)
       presented.commodities.each do |commodity|

--- a/spec/services/cached_subheading_service_spec.rb
+++ b/spec/services/cached_subheading_service_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe CachedSubheadingService do
             heading: Hash,
             commodities: Hash,
             chapter: Hash,
+            ancestors: Hash,
           }.ignore_extra_keys!,
         }.ignore_extra_keys!,
       }.ignore_extra_keys!


### PR DESCRIPTION
### Jira link

[HOTT-1483](https://transformuk.atlassian.net/browse/HOTT-1483)

### What?

I have added/removed/altered:

- [x] Include ancestors in the subheadings api

### Why?

I am doing this because:

- The frontend wants to show the list of ancestors for a subheading so we duplicate the commodity references in the API to avoid the frontend computing the ancestors