### PR TITLE
HOTT-1567 Update Rails cache to use the redis cache store.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem 'rubyzip'
 # Background jobs
 gem 'connection_pool'
 gem 'redis-elasticache'
-gem 'redis-rails'
 gem 'redlock'
 gem 'sidekiq'
 gem 'sidekiq-scheduler'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,24 +316,8 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     redis (4.6.0)
-    redis-actionpack (5.3.0)
-      actionpack (>= 5, < 8)
-      redis-rack (>= 2.1.0, < 3)
-      redis-store (>= 1.1.0, < 2)
-    redis-activesupport (5.3.0)
-      activesupport (>= 3, < 8)
-      redis-store (>= 1.3, < 2)
     redis-elasticache (0.2.0)
       redis (>= 3.0.0)
-    redis-rack (2.1.4)
-      rack (>= 2.0.8, < 3)
-      redis-store (>= 1.2, < 2)
-    redis-rails (5.0.2)
-      redis-actionpack (>= 5.0, < 6)
-      redis-activesupport (>= 5.0, < 6)
-      redis-store (>= 1.2, < 2)
-    redis-store (1.9.1)
-      redis (>= 4, < 5)
     redlock (1.2.2)
       redis (>= 3.0.0, < 5.0)
     regexp_parser (2.3.1)
@@ -482,7 +466,6 @@ DEPENDENCIES
   rack-timeout
   rails (~> 7.0)
   redis-elasticache
-  redis-rails
   redlock
   responders
   rspec-json_expectations

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,12 +65,13 @@ Rails.application.configure do
 
   # Rails cache store
   # PaasConfig returns url and db
-  config.cache_store = :redis_store,
+  config.cache_store = :redis_cache_store,
                        PaasConfig.redis.merge({
                          expires_in: 1.day,
                          namespace: ENV['GOVUK_APP_DOMAIN'],
-                         pool_size: Integer(ENV['MAX_THREADS'] || 5)
+                         pool_size: Integer(ENV['MAX_THREADS'] || 5),
                        })
+
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
 


### PR DESCRIPTION
### What?
Update Rails cache to use the Redis cache store.

### Why?
The reason of this PR is because Rails 5.2.0 (and following versions) includes a Redis cache store out of the box, so you don't need this gem anymore if you just need to store the cache in Redis.

### Jira link
https://transformuk.atlassian.net/browse/HOTT-1567
