### PR TITLE
HOTT-1599: Handle composite primary keys during missing secondary node deletion

### DIFF
--- a/app/lib/cds_importer/entity_mapper/base_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/base_mapper.rb
@@ -153,7 +153,7 @@ class CdsImporter
           xml_node_entities.map do |xml_entity|
             composite_primary_key = {}
 
-            accumulate_primary_key_parts_for(secondary_mapper.relative_primary_key_paths_for_primary_node, xml_node, composite_primary_key)
+            accumulate_primary_key_parts_for(secondary_mapper.primary_key_paths_for_primary_node, xml_node, composite_primary_key)
 
             accumulate_primary_key_parts_for(secondary_mapper.relative_primary_key_paths_for_secondary_node, xml_entity, composite_primary_key)
 

--- a/app/lib/cds_importer/entity_mapper/base_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/base_mapper.rb
@@ -52,12 +52,7 @@ class CdsImporter
           end
         end
 
-        # Register a callback to soft delete missing entities based on the passed in configuration
-        #
-        # Each secondary entity can have the following configuration:
-        #   filter: The filter used to find the secondary entities for soft deletion
-        #   relation_mapping_path: How we dig through the xml node to determine the secondaries that are being imported
-        #   relation_primary_key: How we understand the mapping between the model's primary key and the xml nodes primary key
+        # Register a callback to soft delete missing entities indicated by the passed in secondary mappers
         def delete_missing_entities(*secondary_mappers)
           before_oplog_inserts do |xml_node, _mapper_instance, model_instance|
             if TradeTariffBackend.handle_soft_deletes?
@@ -173,9 +168,8 @@ class CdsImporter
 
         def database_entities_for(primary_model_instance, secondary_mapper)
           filter = secondary_mapper.filter_for(primary_model_instance)
-          primary_keys = secondary_mapper.entity.primary_key
 
-          secondary_mapper.entity.where(filter).pluck(*primary_keys).map do |composite_primary_key|
+          secondary_mapper.entity.where(filter).pluck(*secondary_mapper.entity.primary_key).map do |composite_primary_key|
             composite_primary_key.map(&:to_s)
           end
         end

--- a/app/lib/cds_importer/entity_mapper/base_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/base_mapper.rb
@@ -153,9 +153,9 @@ class CdsImporter
           xml_node_entities.map do |xml_entity|
             composite_primary_key = {}
 
-            accumulate_primary_key_parts_for( secondary_mapper.relative_primary_key_paths_for_primary_node, xml_node, composite_primary_key,)
+            accumulate_primary_key_parts_for(secondary_mapper.relative_primary_key_paths_for_primary_node, xml_node, composite_primary_key)
 
-            accumulate_primary_key_parts_for( secondary_mapper.relative_primary_key_paths_for_secondary_node, xml_entity, composite_primary_key,)
+            accumulate_primary_key_parts_for(secondary_mapper.relative_primary_key_paths_for_secondary_node, xml_entity, composite_primary_key)
 
             secondary_mapper.entity_composite_primary_key.map do |model_primary_key_part|
               composite_primary_key[model_primary_key_part]

--- a/app/lib/cds_importer/entity_mapper/footnote_description_period_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/footnote_description_period_mapper.rb
@@ -12,6 +12,17 @@ class CdsImporter
         'footnoteType.footnoteTypeId' => :footnote_type_id,
         'footnoteId' => :footnote_id,
       ).freeze
+
+      self.primary_filters = {
+        footnote_type_id: :footnote_type_id,
+        footnote_id: :footnote_id,
+      }.freeze
+
+      self.primary_key_mapping = entity_mapping.slice(
+        "#{mapping_path}.sid",
+        'footnoteType.footnoteTypeId',
+        'footnoteId',
+      )
     end
   end
 end

--- a/app/lib/cds_importer/entity_mapper/footnote_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/footnote_mapper.rb
@@ -24,14 +24,7 @@ class CdsImporter
         end
       end
 
-      delete_missing_entities FootnoteDescriptionPeriod => {
-        filter: { footnote_type_id: :footnote_type_id, footnote_id: :footnote_id },
-        relation_mapping_path: FootnoteDescriptionPeriodMapper.mapping_path,
-        relation_primary_key: {
-          model_primary_key: :footnote_description_period_sid,
-          xml_node_primary_key: 'sid',
-        },
-      }
+      delete_missing_entities FootnoteDescriptionPeriodMapper
     end
   end
 end

--- a/spec/lib/cds_importer/entity_mapper/base_mapper_spec.rb
+++ b/spec/lib/cds_importer/entity_mapper/base_mapper_spec.rb
@@ -7,6 +7,10 @@ class MockedModel
 
     self
   end
+
+  def self.primary_key
+    :bar
+  end
 end
 
 RSpec.describe CdsImporter::EntityMapper::BaseMapper do
@@ -64,6 +68,8 @@ RSpec.describe CdsImporter::EntityMapper::BaseMapper do
   it_behaves_like 'an entity mapper accessor', :mapping_path
   it_behaves_like 'an entity mapper accessor', :mapping_root
   it_behaves_like 'an entity mapper accessor', :exclude_mapping
+  it_behaves_like 'an entity mapper accessor', :primary_key_mapping
+  it_behaves_like 'an entity mapper accessor', :primary_filters
 
   describe '.before_oplog_inserts_callbacks' do
     it { expect(secondary_mocked_mapper.before_oplog_inserts_callbacks).to include(an_instance_of(Proc)) }
@@ -82,6 +88,14 @@ RSpec.describe CdsImporter::EntityMapper::BaseMapper do
         'mockedModel.validityEndDate' => :validity_end_date,
       )
     end
+  end
+
+  describe '.entity' do
+    it { expect(primary_mocked_mapper.entity).to eq(MockedModel) }
+  end
+
+  describe '.entity_composite_primary_key' do
+    it { expect(primary_mocked_mapper.entity_composite_primary_key).to eq([:bar]) }
   end
 
   describe '.mapping_with_key_as_array' do

--- a/spec/lib/cds_importer/entity_mapper/footnote_mapper_spec.rb
+++ b/spec/lib/cds_importer/entity_mapper/footnote_mapper_spec.rb
@@ -102,6 +102,15 @@ RSpec.describe CdsImporter::EntityMapper::FootnoteMapper do
     end
 
     context 'when there are multiple footnote description periods and some are missing' do
+      before do
+        create( # Control for a non-deleted period
+          :footnote_description_period,
+          footnote_description_period_sid: '96004',
+          footnote_type_id: 'TM',
+          footnote_id: '133',
+        )
+      end
+
       let(:xml_node) do
         {
           'metainfo' => { 'opType' => 'U', 'origin' => 'T', 'status' => 'L', 'transactionDate' => '2021-07-22T18:02:08' },
@@ -128,7 +137,7 @@ RSpec.describe CdsImporter::EntityMapper::FootnoteMapper do
         }
       end
 
-      it_behaves_like 'an entity mapper missing destroy operation', FootnoteDescriptionPeriod, :footnote_description_period_sid, footnote_type_id: 'TM', footnote_id: '133'
+      it_behaves_like 'an entity mapper missing destroy operation', FootnoteDescriptionPeriod, %i[footnote_description_period_sid footnote_type_id footnote_id], footnote_type_id: 'TM', footnote_id: '133'
     end
   end
 end

--- a/spec/support/shared_examples/an_entity_mapper_missing_entity_destroy_operation.rb
+++ b/spec/support/shared_examples/an_entity_mapper_missing_entity_destroy_operation.rb
@@ -2,6 +2,7 @@ RSpec.shared_examples_for 'an entity mapper missing destroy operation' do |relat
   let(:change_oplog_deletion_count) do
     change { relation::Operation.where(filter.merge(operation: 'D')).count }
   end
+
   it "hides the missing xml nodes from the #{relation} view" do
     before_import_primary_keys = relation.where(filter).pluck(*model_primary_keys)
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1599

### What?

I have added/removed/altered:

- [x] Added support for pulling out composite primary keys for secondary resources for soft deletion
- [x] Added control description period to validate what happens when we do not delete an existing period

### Why?

I am doing this because:

- This is required to support other more complex/dynamic relationships as part of measure missing secondary node soft deletion
