### PR TITLE
Hott 1657 Un-exclude geographical areas

### DIFF
--- a/app/services/cached_geographical_area_service.rb
+++ b/app/services/cached_geographical_area_service.rb
@@ -13,14 +13,6 @@ class CachedGeographicalAreaService
     QX
     QY
     QZ
-    ZB
-    ZD
-    ZE
-    ZF
-    ZG
-    ZH
-    ZN
-    ZU
   ].freeze
 
   DEFAULT_INCLUDES = [:contained_geographical_areas].freeze


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-1657

### What?
Include (or unexclude) 8 geographical areas from api/v2/geographical_areas

### Why?
Matt wrote:
> ... this is a big deal for Northern Ireland
