### PR TITLE
HOTT-1585: Rely on primary method rather than heuristic

### DIFF
--- a/app/lib/cds_importer/entity_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper.rb
@@ -41,7 +41,7 @@ class CdsImporter
         mappers = all_mappers.select { |mapper| mapper&.mapping_root == key }.sort_by(&:sort_key)
         mappers = mappers.map { |mapper| mapper.new(xml_node) }
 
-        primary_mapper = mappers.first
+        primary_mapper = mappers.find(&:primary?)
 
         if primary_mapper&.destroy_operation?
           [primary_mapper]

--- a/app/lib/cds_importer/entity_mapper/base_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/base_mapper.rb
@@ -182,6 +182,17 @@ class CdsImporter
           TradeTariffBackend.handle_soft_deletes?
       end
 
+      # In the CDS file we treat the parent node differently from the
+      # secondary child nodes when it comes to support for the destroy operation.
+      #
+      # Each entity mapper represents either a child or a parent node in the xml file.
+      #
+      # Parent nodes have the same assigned entity class as their derived class. Our internal naming
+      # for this has been to name this parent node the primary.
+      def primary?
+        derived_entity_class == entity_class
+      end
+
       private
 
       def build_instance(values)
@@ -203,17 +214,6 @@ class CdsImporter
         values[:approved_flag] = (values[:approved_flag] == APPROVED_FLAG) if values.key?(:approved_flag)
         values[:stopped_flag] = (values[:stopped_flag] == STOPPED_FLAG) if values.key?(:approved_flag)
         values
-      end
-
-      # In the CDS file we treat the parent node differently from the
-      # secondary child nodes when it comes to support for the destroy operation.
-      #
-      # Each entity mapper represents either a child or a parent node in the xml file.
-      #
-      # Parent nodes have the same assigned entity class as their derived class. Our internal naming
-      # for this has been to name this parent node the primary.
-      def primary?
-        derived_entity_class == entity_class
       end
 
       def derived_entity_class

--- a/spec/lib/cds_importer/entity_mapper/base_mapper_spec.rb
+++ b/spec/lib/cds_importer/entity_mapper/base_mapper_spec.rb
@@ -130,6 +130,20 @@ RSpec.describe CdsImporter::EntityMapper::BaseMapper do
     end
   end
 
+  describe '#primary?' do
+    context 'when the mapper entity class matches the derived entity class' do
+      subject(:mapper) { primary_mocked_mapper.new({}) }
+
+      it { is_expected.to be_primary }
+    end
+
+    context 'when the mapper entity class does not match the derived entity class' do
+      subject(:mapper) { secondary_mocked_mapper.new({}) }
+
+      it { is_expected.not_to be_primary }
+    end
+  end
+
   describe '#parse' do
     subject(:parsed) { secondary_mocked_mapper.new(xml_node).parse.first }
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1585

### What?

I have added/removed/altered:

- [x] Altered the applicable_mappers_for method to detect the first primary? mapper in the applicable mappers
- [x] Adds some specs of the primary method

### Why?

I am doing this because:

- When applicable mappers are sorted by their sort key the primary
comes first. Rather than relying on this heuristic rely on the primary? method to
pull out the first primary that matches in the applicable_mappers_for
method just to avoid any ambiguity/potential for regression.
