### PR TITLE
HOTT-1585: Adds migration for additional code type description view language

### DIFF
--- a/app/models/additional_code_type_description.rb
+++ b/app/models/additional_code_type_description.rb
@@ -1,8 +1,8 @@
 class AdditionalCodeTypeDescription < Sequel::Model
-  plugin :oplog, primary_key: :additional_code_type_id
+  plugin :oplog, primary_key: %i[additional_code_type_id language_id]
 
-  set_primary_key [:additional_code_type_id]
+  set_primary_key %i[additional_code_type_id language_id]
 
   many_to_one :additional_code_type, key: :additional_code_type_id
-  many_to_one :language
+  many_to_one :language, key: :language_id, primary_key: :language_id
 end

--- a/db/migrate/20220526155444_add_language_to_additional_code_type_description_view.rb
+++ b/db/migrate/20220526155444_add_language_to_additional_code_type_description_view.rb
@@ -2,7 +2,7 @@
 
 Sequel.migration do
   up do
-    run %Q{
+    run %{
       CREATE OR REPLACE VIEW public.additional_code_type_descriptions AS
       SELECT
           additional_code_type_descriptions1.additional_code_type_id,
@@ -28,7 +28,7 @@ Sequel.migration do
   end
 
   down do
-    run %Q{
+    run %{
       CREATE OR REPLACE VIEW public.additional_code_type_descriptions AS
       SELECT
           additional_code_type_descriptions1.additional_code_type_id,

--- a/db/migrate/20220526155444_add_language_to_additional_code_type_description_view.rb
+++ b/db/migrate/20220526155444_add_language_to_additional_code_type_description_view.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    run %Q{
+      CREATE OR REPLACE VIEW public.additional_code_type_descriptions AS
+      SELECT
+          additional_code_type_descriptions1.additional_code_type_id,
+          additional_code_type_descriptions1.language_id,
+          additional_code_type_descriptions1.description,
+          additional_code_type_descriptions1."national",
+          additional_code_type_descriptions1.oid,
+          additional_code_type_descriptions1.operation,
+          additional_code_type_descriptions1.operation_date,
+          additional_code_type_descriptions1.filename
+      FROM
+          additional_code_type_descriptions_oplog additional_code_type_descriptions1
+      WHERE (additional_code_type_descriptions1.oid IN (
+              SELECT
+                  max(additional_code_type_descriptions2.oid) AS max
+              FROM
+                  additional_code_type_descriptions_oplog additional_code_type_descriptions2
+              WHERE
+                  additional_code_type_descriptions1.additional_code_type_id::text = additional_code_type_descriptions2.additional_code_type_id::text
+              AND additional_code_type_descriptions1.language_id::text = additional_code_type_descriptions2.language_id::text))
+      AND additional_code_type_descriptions1.operation::text <> 'D'::text;
+    }
+  end
+
+  down do
+    run %Q{
+      CREATE OR REPLACE VIEW public.additional_code_type_descriptions AS
+      SELECT
+          additional_code_type_descriptions1.additional_code_type_id,
+          additional_code_type_descriptions1.language_id,
+          additional_code_type_descriptions1.description,
+          additional_code_type_descriptions1."national",
+          additional_code_type_descriptions1.oid,
+          additional_code_type_descriptions1.operation,
+          additional_code_type_descriptions1.operation_date,
+          additional_code_type_descriptions1.filename
+      FROM
+          additional_code_type_descriptions_oplog additional_code_type_descriptions1
+      WHERE (additional_code_type_descriptions1.oid IN (
+              SELECT
+                  max(additional_code_type_descriptions2.oid) AS max
+              FROM
+                  additional_code_type_descriptions_oplog additional_code_type_descriptions2
+              WHERE
+                  additional_code_type_descriptions1.additional_code_type_id::text = additional_code_type_descriptions2.additional_code_type_id::text))
+      AND additional_code_type_descriptions1.operation::text <> 'D'::text;
+    }
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -331,7 +331,7 @@ CREATE VIEW public.additional_code_type_descriptions AS
    FROM public.additional_code_type_descriptions_oplog additional_code_type_descriptions1
   WHERE ((additional_code_type_descriptions1.oid IN ( SELECT max(additional_code_type_descriptions2.oid) AS max
            FROM public.additional_code_type_descriptions_oplog additional_code_type_descriptions2
-          WHERE ((additional_code_type_descriptions1.additional_code_type_id)::text = (additional_code_type_descriptions2.additional_code_type_id)::text))) AND ((additional_code_type_descriptions1.operation)::text <> 'D'::text));
+          WHERE (((additional_code_type_descriptions1.additional_code_type_id)::text = (additional_code_type_descriptions2.additional_code_type_id)::text) AND ((additional_code_type_descriptions1.language_id)::text = (additional_code_type_descriptions2.language_id)::text)))) AND ((additional_code_type_descriptions1.operation)::text <> 'D'::text));
 
 
 --
@@ -10939,3 +10939,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20220107134210_add_product
 INSERT INTO "schema_migrations" ("filename") VALUES ('20220223091956_add_oplog_inserts_to_tariff_updates.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20220328091515_add_show_on_banner_to_news_items.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20220509104200_create_goods_nomenclature_export_function.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20220526155444_add_language_to_additional_code_type_description_view.rb');

--- a/spec/controllers/api/v2/additional_code_types_controller_spec.rb
+++ b/spec/controllers/api/v2/additional_code_types_controller_spec.rb
@@ -1,42 +1,23 @@
 RSpec.describe Api::V2::AdditionalCodeTypesController, type: :controller do
   describe '#index' do
-    let!(:additional_code_type_1) { create :additional_code_type }
-    let!(:additional_code_type_description_1) { create :additional_code_type_description, additional_code_type_id: additional_code_type_1.additional_code_type_id }
-    let!(:additional_code_type_2) { create :additional_code_type }
-    let!(:additional_code_type_description_2) { create :additional_code_type_description, additional_code_type_id: additional_code_type_2.additional_code_type_id }
-    let!(:additional_code_type_3) { create :additional_code_type }
-    let!(:additional_code_type_description_3) { create :additional_code_type_description, additional_code_type_id: additional_code_type_3.additional_code_type_id }
-
     let(:pattern) do
       {
-        "data": [{
-          "id": String,
-          "type": 'additional_code_type',
-          "attributes": {
-            "additional_code_type_id": String,
-            "description": String,
+        "data": [
+          {
+            "id": String,
+            "type": 'additional_code_type',
+            "attributes": {
+              "additional_code_type_id": String,
+              "description": String,
+            },
           },
-        },
-                 {
-                   "id": String,
-                   "type": 'additional_code_type',
-                   "attributes": {
-                     "additional_code_type_id": String,
-                     "description": String,
-                   },
-                 },
-                 {
-                   "id": String,
-                   "type": 'additional_code_type',
-                   "attributes": {
-                     "additional_code_type_id": String,
-                     "description": String,
-                   },
-                 }],
+        ],
       }
     end
 
     it 'returns all additional code types' do
+      create(:additional_code_type, :with_description)
+
       get :index, format: :json
 
       expect(response.body).to match_json_expression pattern

--- a/spec/factories/additional_code_factory.rb
+++ b/spec/factories/additional_code_factory.rb
@@ -96,6 +96,22 @@ FactoryBot.define do
       end
     end
 
+    trait :with_measure_type do
+      after(:build) do |additional_code_type, _evaluator|
+        create(:additional_code_type_measure_type, additional_code_type_id: additional_code_type.additional_code_type_id)
+      end
+    end
+
+    trait :with_description do
+      transient do
+        language_id { 'EN' }
+      end
+
+      after(:create) do |additional_code_type, evaluator|
+        create(:additional_code_type_description, additional_code_type_id: additional_code_type.additional_code_type_id, language_id: evaluator.language_id)
+      end
+    end
+
     trait :xml do
       validity_end_date { 1.year.ago.beginning_of_day }
     end
@@ -104,6 +120,7 @@ FactoryBot.define do
   factory :additional_code_type_description do
     additional_code_type_id                { generate(:additional_code_type_id) }
     description                            { Forgery(:lorem_ipsum).sentence }
+    language_id                            { 'IT' }
 
     trait :xml do
       language_id { 'EN' }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1586

### What?

I have added/removed/altered:

- [x] Added migration to support uniquely identifying additional code type descriptions in the view
- [x] Added primary key for language id in oplog and model

### Why?

I am doing this because:

- This is how we uniquely identify the additional code type description when there are more than one languages we might pull out
- This was noticed as I was adding coverage for clearing missing versions of these from an additional code description type primary
