### PR TITLE
HOTT-1585: Adjust oplog row filenames to match the current update

### DIFF
--- a/app/lib/cds_importer/entity_mapper/additional_code_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/additional_code_mapper.rb
@@ -14,9 +14,10 @@ class CdsImporter
       before_oplog_inserts do |_xml_node, mapper_instance, model_instance|
         if mapper_instance.destroy_operation?
           additional_code_sid = model_instance.additional_code_sid
+          filename = mapper_instance.filename
 
-          instrument_cascade_destroy { FootnoteAssociationAdditionalCode.where(additional_code_sid:) }
-          instrument_cascade_destroy { AdditionalCodeDescriptionPeriod.where(additional_code_sid:) }
+          instrument_cascade_destroy(filename) { FootnoteAssociationAdditionalCode.where(additional_code_sid:) }
+          instrument_cascade_destroy(filename) { AdditionalCodeDescriptionPeriod.where(additional_code_sid:) }
         end
       end
 

--- a/app/lib/cds_importer/entity_mapper/additional_code_type_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/additional_code_type_mapper.rb
@@ -14,9 +14,10 @@ class CdsImporter
       before_oplog_inserts do |_xml_node, mapper_instance, model_instance|
         if mapper_instance.destroy_operation?
           additional_code_type_id = model_instance.additional_code_type_id
+          filename = mapper_instance.filename
 
-          instrument_cascade_destroy { AdditionalCodeTypeMeasureType.where(additional_code_type_id:) }
-          instrument_cascade_destroy { AdditionalCodeTypeDescription.where(additional_code_type_id:) }
+          instrument_cascade_destroy(filename) { AdditionalCodeTypeMeasureType.where(additional_code_type_id:) }
+          instrument_cascade_destroy(filename) { AdditionalCodeTypeDescription.where(additional_code_type_id:) }
         end
       end
 

--- a/app/lib/cds_importer/entity_mapper/footnote_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/footnote_mapper.rb
@@ -14,14 +14,15 @@ class CdsImporter
         if mapper_instance.destroy_operation?
           footnote_id = model_instance.footnote_id
           footnote_type_id = model_instance.footnote_type_id
+          filename = mapper_instance.filename
 
-          instrument_cascade_destroy { FootnoteAssociationAdditionalCode.where(footnote_type_id:, footnote_id:) }
-          instrument_cascade_destroy { FootnoteAssociationGoodsNomenclature.where(footnote_type: footnote_type_id, footnote_id:) }
+          instrument_cascade_destroy(filename) { FootnoteAssociationAdditionalCode.where(footnote_type_id:, footnote_id:) }
+          instrument_cascade_destroy(filename) { FootnoteAssociationGoodsNomenclature.where(footnote_type: footnote_type_id, footnote_id:) }
 
-          instrument_cascade_destroy { FootnoteAssociationMeasure.where(footnote_type_id:, footnote_id:) }
-          instrument_cascade_destroy { FootnoteAssociationMeursingHeading.where(footnote_type: footnote_type_id, footnote_id:) }
-          instrument_cascade_destroy { FootnoteDescription.where(footnote_type_id:, footnote_id:) }
-          instrument_cascade_destroy { FootnoteDescriptionPeriod.where(footnote_type_id:, footnote_id:) }
+          instrument_cascade_destroy(filename) { FootnoteAssociationMeasure.where(footnote_type_id:, footnote_id:) }
+          instrument_cascade_destroy(filename) { FootnoteAssociationMeursingHeading.where(footnote_type: footnote_type_id, footnote_id:) }
+          instrument_cascade_destroy(filename) { FootnoteDescription.where(footnote_type_id:, footnote_id:) }
+          instrument_cascade_destroy(filename) { FootnoteDescriptionPeriod.where(footnote_type_id:, footnote_id:) }
         end
       end
 

--- a/app/lib/cds_importer/entity_mapper/measure_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/measure_mapper.rb
@@ -40,16 +40,17 @@ class CdsImporter
       before_oplog_inserts do |_xml_node, mapper_instance, model_instance|
         if mapper_instance.destroy_operation?
           measure_sid = model_instance.measure_sid
+          filename = mapper_instance.filename
 
-          instrument_cascade_destroy { FootnoteAssociationMeasure.where(measure_sid:) }
-          instrument_cascade_destroy { MeasureComponent.where(measure_sid:) }
-          instrument_cascade_destroy { MeasureExcludedGeographicalArea.where(measure_sid:) }
-          instrument_cascade_destroy { MeasurePartialTemporaryStop.where(measure_sid:) }
+          instrument_cascade_destroy(filename) { FootnoteAssociationMeasure.where(measure_sid:) }
+          instrument_cascade_destroy(filename) { MeasureComponent.where(measure_sid:) }
+          instrument_cascade_destroy(filename) { MeasureExcludedGeographicalArea.where(measure_sid:) }
+          instrument_cascade_destroy(filename) { MeasurePartialTemporaryStop.where(measure_sid:) }
 
-          instrument_cascade_destroy do
+          instrument_cascade_destroy(filename) do
             measure_conditions = MeasureCondition.where(measure_sid:)
 
-            instrument_cascade_destroy do
+            instrument_cascade_destroy(filename) do
               MeasureConditionComponent.where(measure_condition_sid: measure_conditions.pluck(:measure_condition_sid))
             end
 

--- a/app/lib/cds_importer/record_inserter.rb
+++ b/app/lib/cds_importer/record_inserter.rb
@@ -1,0 +1,56 @@
+class CdsImporter
+  class RecordInserter
+    class << self
+      delegate :instrument, :subscribe, to: ActiveSupport::Notifications
+
+      def destroy_cascade_record(record, mapper, filename)
+        instrument('cds_importer.import.operations', mapper:, operation: :destroy_cascade, count: 1) do
+          operation_klass = record.class.operation_klass
+
+          values = record.values.except(:oid)
+          values[:filename] = filename
+          values[:operation] = Sequel::Plugins::Oplog::DESTROY_OPERATION
+          values[:created_at] = operation_klass.dataset.current_datetime if operation_klass.columns.include?(:created_at)
+
+          operation_klass.insert(values)
+        end
+      end
+
+      def destroy_missing_record(record, mapper, filename)
+        instrument('cds_importer.import.operations', mapper:, operation: :destroy_missing, count: 1) do
+          operation_klass = record.class.operation_klass
+
+          values = record.values.except(:oid)
+          values[:filename] = filename
+          values[:operation] = Sequel::Plugins::Oplog::DESTROY_OPERATION
+          values[:created_at] = operation_klass.dataset.current_datetime if operation_klass.columns.include?(:created_at)
+
+          operation_klass.insert(values)
+        end
+      end
+
+      def save_record!(record, mapper, filename)
+        instrument('cds_importer.import.operations', mapper:, operation: record.operation, count: 1) do
+          values = record.values.except(:oid)
+
+          values.merge!(filename:)
+
+          operation_klass = record.class.operation_klass
+
+          if operation_klass.columns.include?(:created_at)
+            values.merge!(created_at: operation_klass.dataset.current_datetime)
+          end
+
+          operation_klass.insert(values)
+        end
+      end
+
+      def save_record(record, mapper, filename, xml_key)
+        save_record!(record, mapper, filename)
+      rescue StandardError => e
+        instrument('cds_error.cds_importer', record:, xml_key:, xml_node: mapper.xml_node, exception: e)
+        nil
+      end
+    end
+  end
+end

--- a/spec/integration/cds_importer/cds_importer_spec.rb
+++ b/spec/integration/cds_importer/cds_importer_spec.rb
@@ -40,15 +40,12 @@ RSpec.describe CdsImporter do
     let(:processor) { CdsImporter::XmlProcessor.new(cds_update.filename) }
 
     context 'with valid import file' do
-      before do
-        allow(CdsImporter::EntityMapper).to receive(:new).with('AdditionalCode', { 'filename' => cds_update.filename }).and_call_original
-        allow_any_instance_of(CdsImporter::EntityMapper).to receive(:import).and_call_original
-      end
-
       it 'invokes EntityMapper' do
-        expect(processor.process_xml_node('AdditionalCode', {})).to eql({
-          'AdditionalCode::Operation' => 1,
-        })
+        allow(CdsImporter::EntityMapper).to receive(:new).with('AdditionalCode', { 'filename' => cds_update.filename }).and_call_original
+
+        expect_any_instance_of(CdsImporter::EntityMapper).to receive(:import).and_call_original
+
+        processor.process_xml_node('AdditionalCode', {})
       end
     end
 

--- a/spec/integration/cds_importer/entity_mapper_spec.rb
+++ b/spec/integration/cds_importer/entity_mapper_spec.rb
@@ -336,7 +336,6 @@ RSpec.describe CdsImporter::EntityMapper do
     end
 
     it { expect { entity_mapper.import }.to change(AdditionalCode, :count).by(1) }
-    it { expect(entity_mapper.import).to eql('AdditionalCode::Operation' => 1) }
 
     it 'saves all attributes for record' do
       entity_mapper.import


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1585

### What?

I have added/removed/altered:

- [x] Added support for update filenames on missing/cascading xml node deletions

### Why?

I am doing this because:

- This was missed when enumerating missing and cascading records and is essential for rollbacks to work
