### PR TITLE
HOTT-1665: Tweak autoscale rule for maximum nodes on staging to 4

### DIFF
--- a/config/autoscaling/staging-policy.json
+++ b/config/autoscaling/staging-policy.json
@@ -1,6 +1,6 @@
 {
   "instance_min_count": 2,
-  "instance_max_count": 8,
+  "instance_max_count": 4,
   "scaling_rules": [
     {
       "metric_type": "memoryutil",


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1665

### What?

I have added/removed/altered:

- [x] Altered the max node count on staging to 4 to avoid hitting the postgres max connections

### Why?

I am doing this because:

- This reflects the fact that we get connection issues at 100 connections
despite the govuk documentation saying this should be at 200.
- 4 processes per worker at 6 connections in each pool at 4 workers is 96 and just under the amount that caused issues on staging
- See initial change here: https://github.com/trade-tariff/trade-tariff-backend/pull/496
