### PR TITLE
HOTT-1665: Adjust off-peak rules for autoscaling production

### DIFF
--- a/config/autoscaling/production-policy.json
+++ b/config/autoscaling/production-policy.json
@@ -1,5 +1,5 @@
 {
-  "instance_min_count": 8,
+  "instance_min_count": 4,
   "instance_max_count": 12,
   "scaling_rules": [
     {
@@ -34,5 +34,26 @@
       "cool_down_secs": 120,
       "adjustment": "-1"
     }
-  ]
+  ],
+  "schedules": {
+    "timezone": "Europe/London",
+    "recurring_schedule": [
+      {
+        "start_time": "06:00",
+        "end_time": "18:00",
+        "days_of_week": [1, 2, 3, 4, 5],
+        "instance_min_count": 8,
+        "instance_max_count": 12,
+        "initial_min_instance_count": 4
+      },
+      {
+        "start_time": "06:00",
+        "end_time": "18:00",
+        "days_of_week": [6, 7],
+        "instance_min_count": 6,
+        "instance_max_count": 12,
+        "initial_min_instance_count": 4
+      }
+    ]
+  }
 }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1665

### What?

I have added/removed/altered:

- [x] Added more intelligent autoscaling policy to enable offpeak rules that are different to onpeak (06:00 to 18:00)

### Why?

We never really scale above the minimum 8 nodes during the week unless there is an exceptional event (e.g. someone scraping the api/calling an expensive endpoint across a range of different resources - iterate over all subheadings, etc).

Given this, we should be safe to change the off-peak rules such that when the number of active users diminishes we can reduce the minimum number of active nodes by 4.

We've also noticed that at weekends the number of users is about half that during peak hours (06:00 to 18:00) of the week so we should be safe to reduce the minimum number of active nodes by 2. 

Over time this should save money.
