### PR TITLE
HOTT-1628: Fixes ordering of goods nomenclature

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -1,7 +1,7 @@
 class GoodsNomenclature < Sequel::Model
   extend ActiveModel::Naming
 
-  set_dataset order(Sequel.asc(:goods_nomenclatures__goods_nomenclature_item_id))
+  set_dataset order(Sequel.asc(:goods_nomenclatures__goods_nomenclature_item_id), Sequel.asc(:goods_nomenclatures__producline_suffix))
   set_primary_key [:goods_nomenclature_sid]
 
   plugin :time_machine

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -1,4 +1,28 @@
 RSpec.describe GoodsNomenclature do
+  describe 'ordering' do
+    subject(:goods_nomenclatures) { described_class.all.pluck(:goods_nomenclature_item_id, :producline_suffix) }
+
+    before do
+      create(:commodity, producline_suffix: '80', goods_nomenclature_item_id: '0101210000')
+      create(:heading, producline_suffix: '80', goods_nomenclature_item_id: '0102000000')
+      create(:chapter, producline_suffix: '80', goods_nomenclature_item_id: '0100000000')
+      create(:heading, producline_suffix: '80', goods_nomenclature_item_id: '0101000000')
+      create(:commodity, producline_suffix: '10', goods_nomenclature_item_id: '0101210000')
+    end
+
+    let(:expected_goods_nomenclatures) do
+      [
+        %w[0100000000 80],
+        %w[0101000000 80],
+        %w[0101210000 10], # Included producline suffix in composite ordering
+        %w[0101210000 80],
+        %w[0102000000 80],
+      ]
+    end
+
+    it { expect(goods_nomenclatures).to eq(expected_goods_nomenclatures) }
+  end
+
   describe 'associations' do
     describe 'goods nomenclature indent' do
       context 'fetching with absolute date' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1628

### What?

I have added/removed/altered:

- [x] Added compound ordering to the goods nomenclature dataset
- [x] Added coverage for this new ordering behaviour

### Why?

I am doing this because:

- This is the correct ordering
