### PR TITLE
HOTT-1628: Generate materialized paths for all goods nomenclature

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,9 @@ Rails/ActiveRecordAliases:
 Rails/CreateTableWithTimestamps:
   Enabled: false # doesn't recognise
 
+Rails/FindBy:
+  Enabled: false # We use sequel not active record
+
 Rails/SaveBang:
   Enabled: false
 

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -16,6 +16,13 @@ class Chapter < GoodsNomenclature
            .where(Sequel.~(goods_nomenclatures__goods_nomenclature_item_id: HiddenGoodsNomenclature.codes))
   }
 
+  one_to_many :goods_nomenclatures do |_ds|
+    GoodsNomenclature
+      .actual
+      .filter('goods_nomenclature_item_id LIKE ?', relevant_goods_nomenclature)
+      .exclude(goods_nomenclature_item_id:)
+  end
+
   one_to_one :chapter_note, primary_key: :to_param
 
   one_to_many :search_references, key: :referenced_id, primary_key: :short_code, reciprocal: :referenced, conditions: { referenced_class: 'Chapter' },
@@ -91,8 +98,7 @@ class Chapter < GoodsNomenclature
       Sequel.as(depth, :depth),
     ).where(pk_hash)
      .union(Heading.changes_for(depth + 1, ['goods_nomenclature_item_id LIKE ? AND goods_nomenclature_item_id NOT LIKE ?', relevant_headings, '__00______']))
-     .union(Commodity.changes_for(depth + 1, ['goods_nomenclature_item_id LIKE ? AND goods_nomenclature_item_id NOT LIKE ?', relevant_commodities, '____000000']))
-     .union(Measure.changes_for(depth + 1, ['goods_nomenclature_item_id LIKE ?', relevant_commodities]))
+     .union(Commodity.changes_for(depth + 1, ['goods_nomenclature_item_id LIKE ? AND goods_nomenclature_item_id NOT LIKE ?', relevant_goods_nomenclature, '____000000'])) .union(Measure.changes_for(depth + 1, ['goods_nomenclature_item_id LIKE ?', relevant_goods_nomenclature]))
      .from_self
      .where(Sequel.~(operation_date: nil))
      .tap! { |criteria|
@@ -114,7 +120,7 @@ class Chapter < GoodsNomenclature
     "#{short_code}__000000"
   end
 
-  def relevant_commodities
+  def relevant_goods_nomenclature
     "#{short_code}________"
   end
 end

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -41,12 +41,12 @@ class GoodsNomenclature < Sequel::Model
   end
 
   one_to_one :parent, class_name: name, class: self do |_ds|
-    parent_sid = not_heading? ? path.last : chapter.goods_nomenclature_sid
+    parent_sid = !heading? ? path.last : chapter.goods_nomenclature_sid
 
     if parent_sid.present?
       GoodsNomenclature.actual.where(goods_nomenclature_sid: parent_sid)
     else
-      GoodsNomenclature.nullify
+      GoodsNomenclature.dataset.nullify
     end
   end
 
@@ -150,11 +150,7 @@ class GoodsNomenclature < Sequel::Model
 
       return class_name unless class_name == 'Commodity'
 
-      goods_nomenclature = where(goods_nomenclature_sid:).take
-
-      'Commodity' if goods_nomenclature.declarable?
-
-      'Subheading'
+      Commodity.find(goods_nomenclature_sid:).goods_nomenclature_class
     end
   end
 
@@ -198,16 +194,8 @@ class GoodsNomenclature < Sequel::Model
     !!goods_nomenclature_item_id.match(/\A\d{4}000000\z/)
   end
 
-  def not_heading?
-    !heading?
-  end
-
   def chapter?
     !!goods_nomenclature_item_id.match(/\A\d{2}00000000\z/)
-  end
-
-  def not_chapter?
-    !chapter?
   end
 
   def declarable?

--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -16,6 +16,14 @@ class Heading < GoodsNomenclature
              .where(Sequel.~(goods_nomenclatures__goods_nomenclature_item_id: HiddenGoodsNomenclature.codes))
   }
 
+  one_to_many :goods_nomenclatures do |_ds|
+    GoodsNomenclature
+      .actual
+      .filter('goods_nomenclature_item_id LIKE ?', relevant_goods_nomenclature)
+      .exclude(goods_nomenclature_item_id:)
+      .exclude(goods_nomenclature_item_id: HiddenGoodsNomenclature.codes)
+  end
+
   one_to_one :chapter, dataset: lambda {
     actual_or_relevant(Chapter).filter('goods_nomenclatures.goods_nomenclature_item_id LIKE ?', chapter_id)
   }
@@ -87,8 +95,8 @@ class Heading < GoodsNomenclature
       :operation,
       Sequel.as(depth, :depth),
     ).where(pk_hash)
-     .union(Commodity.changes_for(depth + 1, ['goods_nomenclature_item_id LIKE ? AND goods_nomenclature_item_id NOT LIKE ?', relevant_commodities, '____000000']))
-     .union(Measure.changes_for(depth + 1, ['goods_nomenclature_item_id LIKE ?', relevant_commodities]))
+     .union(Commodity.changes_for(depth + 1, ['goods_nomenclature_item_id LIKE ? AND goods_nomenclature_item_id NOT LIKE ?', relevant_goods_nomenclature, '____000000']))
+     .union(Measure.changes_for(depth + 1, ['goods_nomenclature_item_id LIKE ?', relevant_goods_nomenclature]))
      .from_self
      .where(Sequel.~(operation_date: nil))
      .tap! { |criteria|
@@ -114,7 +122,7 @@ class Heading < GoodsNomenclature
 
   private
 
-  def relevant_commodities
+  def relevant_goods_nomenclature
     "#{short_code}______"
   end
 end

--- a/app/services/materialized_path_updater_service.rb
+++ b/app/services/materialized_path_updater_service.rb
@@ -1,6 +1,7 @@
 # Generates a materialized path for all of the goods nomenclatures under a given chapter
 #
-# We accumulate updates inside of updated_goods_nomenclatures so we can execute one SQL statement for each goods nomenclature that has their path updated without slowing ourselves down with lots of queries.
+# We accumulate updates inside of updated_goods_nomenclatures so we can execute one SQL statement
+# for each goods nomenclature that has their path updated without slowing ourselves down with lots of queries.
 class MaterializedPathUpdaterService
   def initialize(chapter)
     @chapter = chapter
@@ -17,14 +18,11 @@ class MaterializedPathUpdaterService
       accumulate_update_for(previous_goods_nomenclature, current_path)
 
       goods_nomenclatures.each do |current_goods_nomenclature|
-        # When the heading changes, we restart the accumulation of the current path to be under the chapter
-        if current_goods_nomenclature.heading? && previous_goods_nomenclature.not_chapter?
+        if reset_path?(current_goods_nomenclature, previous_goods_nomenclature)
           current_path = [chapter.goods_nomenclature_sid]
-        # Chapters and headings have the same indentation and chapters need to live under headings
-        elsif current_goods_nomenclature.number_indents > previous_goods_nomenclature.number_indents || previous_goods_nomenclature.chapter? && current_goods_nomenclature.heading?
+        elsif add_to_path?(current_goods_nomenclature, previous_goods_nomenclature)
           current_path.push(previous_goods_nomenclature.goods_nomenclature_sid)
-        # We reflect the change in indentation in the path by popping off the path parts that are no longer relevant when the indents drop
-        elsif current_goods_nomenclature.number_indents < previous_goods_nomenclature.number_indents
+        elsif remove_from_path?(current_goods_nomenclature, previous_goods_nomenclature)
           pop_count = previous_goods_nomenclature.number_indents - current_goods_nomenclature.number_indents
 
           current_path.pop(pop_count)
@@ -56,5 +54,29 @@ class MaterializedPathUpdaterService
 
   def goods_nomenclatures
     @goods_nomenclatures ||= chapter.goods_nomenclatures_dataset.eager(:goods_nomenclature_indents)
+  end
+
+  # When the heading changes (e.g. we were previously looking at another heading branch's last commodity and now
+  # our cursor is on a new heading branch) we should reset the path to contain just the chapter.
+  def reset_path?(current_goods_nomenclature, previous_goods_nomenclature)
+    current_goods_nomenclature.heading? && !previous_goods_nomenclature.chapter?
+  end
+
+  # The most common case for adding to a previous_goods_nomenclature to the current_goods_nomenclatures path
+  # is when the current_goods_nomenclatures indents are larger than the previous_goods_nomenclatures
+  #
+  # The only exception to this rule is when a heading comes after the chapter. Headings and chapters have the
+  # same number of indents but headings are technically underneath chapters so we want to push the chapter into the
+  # headings path.
+  def add_to_path?(current_goods_nomenclature, previous_goods_nomenclature)
+    current_goods_nomenclature.number_indents > previous_goods_nomenclature.number_indents ||
+      previous_goods_nomenclature.chapter? && current_goods_nomenclature.heading?
+  end
+
+  # When the current_goods_nomenclature's indents drop this indicates we need to remove one
+  # or more members from the current goods nomenclature's path (corresponding to how many indents dropped
+  # between the previous_goods_nomenclature and the current goods nomenclature.
+  def remove_from_path?(current_goods_nomenclature, previous_goods_nomenclature)
+    current_goods_nomenclature.number_indents < previous_goods_nomenclature.number_indents
   end
 end

--- a/app/services/materialized_path_updater_service.rb
+++ b/app/services/materialized_path_updater_service.rb
@@ -1,0 +1,60 @@
+# Generates a materialized path for all of the goods nomenclatures under a given chapter
+#
+# We accumulate updates inside of updated_goods_nomenclatures so we can execute one SQL statement for each goods nomenclature that has their path updated without slowing ourselves down with lots of queries.
+class MaterializedPathUpdaterService
+  def initialize(chapter)
+    @chapter = chapter
+    @updated_goods_nomenclatures = []
+  end
+
+  def call
+    # We want to use the TimeMachine so we don't have a bunch of non-current goods nomenclatures or
+    # duplicate versions of the goods nomenclature that we are targeting.
+    TimeMachine.now do
+      previous_goods_nomenclature = chapter
+      current_path = []
+
+      accumulate_update_for(previous_goods_nomenclature, current_path)
+
+      goods_nomenclatures.each do |current_goods_nomenclature|
+        # When the heading changes, we restart the accumulation of the current path to be under the chapter
+        if current_goods_nomenclature.heading? && previous_goods_nomenclature.not_chapter?
+          current_path = [chapter.goods_nomenclature_sid]
+        # Chapters and headings have the same indentation and chapters need to live under headings
+        elsif current_goods_nomenclature.number_indents > previous_goods_nomenclature.number_indents || previous_goods_nomenclature.chapter? && current_goods_nomenclature.heading?
+          current_path.push(previous_goods_nomenclature.goods_nomenclature_sid)
+        # We reflect the change in indentation in the path by popping off the path parts that are no longer relevant when the indents drop
+        elsif current_goods_nomenclature.number_indents < previous_goods_nomenclature.number_indents
+          pop_count = previous_goods_nomenclature.number_indents - current_goods_nomenclature.number_indents
+
+          current_path.pop(pop_count)
+        end
+
+        accumulate_update_for(current_goods_nomenclature, current_path)
+
+        previous_goods_nomenclature = current_goods_nomenclature
+      end
+
+      GoodsNomenclature.db.transaction do
+        sql = updated_goods_nomenclatures.join(";\n")
+
+        GoodsNomenclature.db.run(sql)
+      end
+    end
+  end
+
+  private
+
+  attr_reader :updated_goods_nomenclatures, :chapter
+
+  def accumulate_update_for(goods_nomenclature, path)
+    updated_goods_nomenclatures << GoodsNomenclature::Operation.where(
+      oid: goods_nomenclature.oid,
+      goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
+    ).update_sql(path: Sequel.pg_array(path, :integer))
+  end
+
+  def goods_nomenclatures
+    @goods_nomenclatures ||= chapter.goods_nomenclatures_dataset.eager(:goods_nomenclature_indents)
+  end
+end

--- a/app/workers/generate_materialized_paths_worker.rb
+++ b/app/workers/generate_materialized_paths_worker.rb
@@ -1,0 +1,13 @@
+class GenerateMaterializedPathsWorker
+  include Sidekiq::Worker
+
+  sidekiq_options retry: false
+
+  def perform
+    TimeMachine.now do
+      Chapter.dataset.actual.each do |chapter|
+        MaterializedPathUpdaterService.new(chapter).call
+      end
+    end
+  end
+end

--- a/app/workers/updates_synchronizer_worker.rb
+++ b/app/workers/updates_synchronizer_worker.rb
@@ -34,6 +34,7 @@ class UpdatesSynchronizerWorker
 
     Sidekiq::Client.enqueue(ClearCacheWorker)
     Sidekiq::Client.enqueue(ClearInvalidSearchReferences)
+    Sidekiq::Client.enqueue(GenerateMaterializedPathsWorker)
   end
 
 private

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,7 @@ module TradeTariffBackend
       Sequel::Model.db.extension :pagination
       Sequel::Model.db.extension :server_block
       Sequel::Model.db.extension :auto_literal_strings
+      Sequel::Model.db.extension :pg_array
     end
 
     config.sequel.allow_missing_migration_files = \

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,7 @@ module TradeTariffBackend
       Sequel::Model.db.extension :server_block
       Sequel::Model.db.extension :auto_literal_strings
       Sequel::Model.db.extension :pg_array
+      Sequel::Model.db.extension :null_dataset
     end
 
     config.sequel.allow_missing_migration_files = \

--- a/db/migrate/20220609140555_add_path_to_goods_nomenclatures_oplog.rb
+++ b/db/migrate/20220609140555_add_path_to_goods_nomenclatures_oplog.rb
@@ -38,12 +38,10 @@ Sequel.migration do
   end
 
   down do
-    alter_table :goods_nomenclatures_oplog do
-      drop_column :path
-    end
-
+    # We need to DROP the view and recreated because we're removing columns from it
     run %{
-      CREATE OR REPLACE VIEW public.goods_nomenclatures AS
+      DROP VIEW public.goods_nomenclatures;
+      CREATE VIEW public.goods_nomenclatures AS
       SELECT
           goods_nomenclatures1.goods_nomenclature_sid,
           goods_nomenclatures1.goods_nomenclature_item_id,
@@ -66,5 +64,9 @@ Sequel.migration do
                   goods_nomenclatures1.goods_nomenclature_sid = goods_nomenclatures2.goods_nomenclature_sid))
       AND goods_nomenclatures1.operation::text <> 'D'::text;
     }
+
+    alter_table :goods_nomenclatures_oplog do
+      drop_column :path
+    end
   end
 end

--- a/db/migrate/20220609140555_add_path_to_goods_nomenclatures_oplog.rb
+++ b/db/migrate/20220609140555_add_path_to_goods_nomenclatures_oplog.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table :goods_nomenclatures_oplog do
+      add_column :path, 'int[]', default: [], null: false
+    end
+
+    add_index :goods_nomenclatures_oplog, :path, type: :gin
+
+    run %{
+      CREATE OR REPLACE VIEW public.goods_nomenclatures AS
+      SELECT
+          goods_nomenclatures1.goods_nomenclature_sid,
+          goods_nomenclatures1.goods_nomenclature_item_id,
+          goods_nomenclatures1.producline_suffix,
+          goods_nomenclatures1.validity_start_date,
+          goods_nomenclatures1.validity_end_date,
+          goods_nomenclatures1.statistical_indicator,
+          goods_nomenclatures1.oid,
+          goods_nomenclatures1.operation,
+          goods_nomenclatures1.operation_date,
+          goods_nomenclatures1.filename,
+          goods_nomenclatures1.path
+      FROM
+          goods_nomenclatures_oplog goods_nomenclatures1
+      WHERE (goods_nomenclatures1.oid IN (
+              SELECT
+                  max(goods_nomenclatures2.oid) AS max
+              FROM
+                  goods_nomenclatures_oplog goods_nomenclatures2
+              WHERE
+                  goods_nomenclatures1.goods_nomenclature_sid = goods_nomenclatures2.goods_nomenclature_sid))
+      AND goods_nomenclatures1.operation::text <> 'D'::text;
+
+    }
+
+  end
+
+  down do
+    alter_table :goods_nomenclatures_oplog do
+      drop_column :path
+    end
+
+    run %{
+      CREATE OR REPLACE VIEW public.goods_nomenclatures AS
+      SELECT
+          goods_nomenclatures1.goods_nomenclature_sid,
+          goods_nomenclatures1.goods_nomenclature_item_id,
+          goods_nomenclatures1.producline_suffix,
+          goods_nomenclatures1.validity_start_date,
+          goods_nomenclatures1.validity_end_date,
+          goods_nomenclatures1.statistical_indicator,
+          goods_nomenclatures1.oid,
+          goods_nomenclatures1.operation,
+          goods_nomenclatures1.operation_date,
+          goods_nomenclatures1.filename
+      FROM
+          goods_nomenclatures_oplog goods_nomenclatures1
+      WHERE (goods_nomenclatures1.oid IN (
+              SELECT
+                  max(goods_nomenclatures2.oid) AS max
+              FROM
+                  goods_nomenclatures_oplog goods_nomenclatures2
+              WHERE
+                  goods_nomenclatures1.goods_nomenclature_sid = goods_nomenclatures2.goods_nomenclature_sid))
+      AND goods_nomenclatures1.operation::text <> 'D'::text;
+    }
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3354,7 +3354,8 @@ CREATE VIEW public.goods_nomenclatures AS
     goods_nomenclatures1.oid,
     goods_nomenclatures1.operation,
     goods_nomenclatures1.operation_date,
-    goods_nomenclatures1.filename
+    goods_nomenclatures1.filename,
+    goods_nomenclatures1.path
    FROM public.goods_nomenclatures_oplog goods_nomenclatures1
   WHERE ((goods_nomenclatures1.oid IN ( SELECT max(goods_nomenclatures2.oid) AS max
            FROM public.goods_nomenclatures_oplog goods_nomenclatures2
@@ -3432,7 +3433,8 @@ CREATE TABLE public.language_descriptions_oplog (
     oid integer NOT NULL,
     operation character varying(1) DEFAULT 'C'::character varying,
     operation_date date,
-    filename text
+    filename text,
+    path integer[] DEFAULT ARRAY[]::integer[] NOT NULL
 );
 
 
@@ -9566,6 +9568,13 @@ CREATE INDEX goods_nomenclature_validity_dates ON public.goods_nomenclature_inde
 
 
 --
+-- Name: goods_nomenclatures_oplog_path_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX goods_nomenclatures_oplog_path_index ON public.goods_nomenclatures_oplog USING gin (path);
+
+
+--
 -- Name: index_additional_code_type_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10940,3 +10949,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20220223091956_add_oplog_i
 INSERT INTO "schema_migrations" ("filename") VALUES ('20220328091515_add_show_on_banner_to_news_items.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20220509104200_create_goods_nomenclature_export_function.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20220526155444_add_language_to_additional_code_type_description_view.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20220609140555_add_path_to_goods_nomenclatures_oplog.rb');

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3336,7 +3336,8 @@ CREATE TABLE public.goods_nomenclatures_oplog (
     oid integer NOT NULL,
     operation character varying(1) DEFAULT 'C'::character varying,
     operation_date date,
-    filename text
+    filename text,
+    path integer[] DEFAULT ARRAY[]::integer[] NOT NULL
 );
 
 
@@ -3433,8 +3434,7 @@ CREATE TABLE public.language_descriptions_oplog (
     oid integer NOT NULL,
     operation character varying(1) DEFAULT 'C'::character varying,
     operation_date date,
-    filename text,
-    path integer[] DEFAULT ARRAY[]::integer[] NOT NULL
+    filename text
 );
 
 

--- a/spec/factories/goods_nomenclature_factory.rb
+++ b/spec/factories/goods_nomenclature_factory.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     producline_suffix   { '80' }
     validity_start_date { 2.years.ago.beginning_of_day }
     validity_end_date   { nil }
-    path   { Sequel.pg_array([], :integer) }
+    path { Sequel.pg_array([], :integer) }
 
     # TODO: Put this in a trait. This forces indents on all nomenclature regardless of
     #       what is passed to the individual factory and adds non-fun surprises for developers.
@@ -29,6 +29,82 @@ FactoryBot.define do
         number_indents: evaluator.indents,
         productline_suffix: gono.producline_suffix,
       )
+    end
+
+    trait :with_ancestors do
+      path { Sequel.pg_array([1, 2], :integer) }
+
+      after(:create) do
+        create(:goods_nomenclature, goods_nomenclature_sid: 1)
+        create(:goods_nomenclature, goods_nomenclature_sid: 2)
+      end
+    end
+
+    trait :without_ancestors do
+      path { Sequel.pg_array([], :integer) }
+    end
+
+    trait :with_parent do
+      path { Sequel.pg_array([1], :integer) }
+
+      after(:create) { create(:goods_nomenclature, goods_nomenclature_sid: 1) }
+    end
+
+    trait :without_parent do
+      path { Sequel.pg_array([1], :integer) }
+    end
+
+    trait :with_siblings do
+      path { Sequel.pg_array([1, 2], :integer) }
+
+      after(:create) { create(:goods_nomenclature, path: Sequel.pg_array([1, 2], :integer)) }
+    end
+
+    trait :without_siblings do
+      path { Sequel.pg_array([1, 2], :integer) }
+    end
+
+    trait :with_children do
+      goods_nomenclature_sid { 1 }
+      path { Sequel.pg_array([], :integer) }
+
+      after(:create) do
+        create(
+          :goods_nomenclature,
+          goods_nomenclature_sid: 2,
+          path: Sequel.pg_array([1], :integer),
+        )
+        create(
+          :goods_nomenclature,
+          goods_nomenclature_sid: 3,
+          path: Sequel.pg_array([1, 2], :integer),
+        )
+      end
+    end
+
+    trait :without_children do
+      goods_nomenclature_sid { 1 }
+      path { Sequel.pg_array([], :integer) }
+    end
+
+    trait :with_descendants do
+      with_children
+    end
+
+    trait :without_descendants do
+      without_children
+    end
+
+    trait :chapter do
+      goods_nomenclature_item_id { '0100000000' }
+    end
+
+    trait :heading do
+      goods_nomenclature_item_id { '0101000000' }
+    end
+
+    trait :commodity do
+      goods_nomenclature_item_id { '0102901019' }
     end
 
     trait :grouping do

--- a/spec/factories/goods_nomenclature_factory.rb
+++ b/spec/factories/goods_nomenclature_factory.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
     producline_suffix   { '80' }
     validity_start_date { 2.years.ago.beginning_of_day }
     validity_end_date   { nil }
+    path   { Sequel.pg_array([], :integer) }
 
     # TODO: Put this in a trait. This forces indents on all nomenclature regardless of
     #       what is passed to the individual factory and adds non-fun surprises for developers.

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -220,19 +220,19 @@ RSpec.describe Chapter do
     end
   end
 
-  describe '#relevant_commodities' do
+  describe '#relevant_goods_nomenclature' do
     let!(:chapter) { create :chapter, goods_nomenclature_item_id: '1200000000' }
 
     it 'includes short_code' do
-      expect(chapter.send(:relevant_commodities)).to include(chapter.short_code)
+      expect(chapter.send(:relevant_goods_nomenclature)).to include(chapter.short_code)
     end
 
     it 'includes suffix __000000' do
-      expect(chapter.send(:relevant_commodities)).to include('________')
+      expect(chapter.send(:relevant_goods_nomenclature)).to include('________')
     end
 
     it 'has valid format' do
-      expect(chapter.send(:relevant_commodities)).to eq("#{chapter.short_code}________")
+      expect(chapter.send(:relevant_goods_nomenclature)).to eq("#{chapter.short_code}________")
     end
   end
 end

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -384,4 +384,180 @@ RSpec.describe GoodsNomenclature do
       it { is_expected.to eq('Chapter') }
     end
   end
+
+  describe '#chapter' do
+    before do
+      create(:chapter, goods_nomenclature_item_id: '0100000000')
+    end
+
+    context 'when the goods nomenclature is a chapter' do
+      subject(:chapter) { create(:chapter, goods_nomenclature_item_id: '0100000000') }
+
+      it { is_expected.to be_a(Chapter) }
+    end
+
+    context 'when the goods nomenclature is a heading' do
+      subject(:chapter) { create(:heading, goods_nomenclature_item_id: '0101000000').chapter }
+
+      it { is_expected.to be_a(Chapter) }
+    end
+
+    context 'when the goods nomenclature is a commodity' do
+      subject(:chapter) { create(:commodity, goods_nomenclature_item_id: '0111110000').chapter }
+
+      it { is_expected.to be_a(Chapter) }
+    end
+  end
+
+  describe '#ancestors' do
+    context 'when the goods nomenclature has ancestors' do
+      subject(:ancestors) { create(:goods_nomenclature, :with_ancestors).ancestors }
+
+      it { expect(ancestors).to include(an_instance_of(described_class)) }
+    end
+
+    context 'when the goods nomenclature has no ancestors' do
+      subject(:ancestors) { create(:goods_nomenclature, :without_ancestors).ancestors }
+
+      it { expect(ancestors).to be_empty }
+    end
+  end
+
+  describe '#parent' do
+    context 'when the goods nomenclature has an immediate parent' do
+      subject(:parent) { create(:goods_nomenclature, :with_parent).parent }
+
+      it { expect(parent).to be_a(described_class) }
+    end
+
+    context 'when the goods nomenclature has no parent' do
+      subject(:parent) { create(:goods_nomenclature, :without_parent).parent }
+
+      it { expect(parent).to be_nil }
+    end
+  end
+
+  describe '#siblings' do
+    context 'when the goods nomenclature has siblings' do
+      subject(:siblings) { create(:goods_nomenclature, :with_siblings).siblings }
+
+      it { expect(siblings).to include(an_instance_of(described_class)) }
+    end
+
+    context 'when the goods nomenclature has no siblings' do
+      subject(:siblings) { create(:goods_nomenclature, :without_siblings).siblings }
+
+      it { expect(siblings).to be_empty }
+    end
+  end
+
+  describe '#children' do
+    context 'when the goods nomenclature has children' do
+      subject(:child_sids) { create(:goods_nomenclature, :with_children).children.map(&:goods_nomenclature_sid) }
+
+      it { is_expected.to eq([2]) }
+    end
+
+    context 'when the goods nomenclature has no children' do
+      subject(:child_sids) { create(:goods_nomenclature, :without_children).children.map(&:goods_nomenclature_sid) }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
+  describe '#descendants' do
+    context 'when the goods nomenclature has descendants' do
+      subject(:descendant_sids) { create(:goods_nomenclature, :with_descendants).descendants.map(&:goods_nomenclature_sid) }
+
+      it { is_expected.to match_array([2, 3]) }
+    end
+
+    context 'when the goods nomenclature has no descendants' do
+      subject(:descendant_sids) { create(:goods_nomenclature, :without_descendants).descendants.map(&:goods_nomenclature_sid) }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
+  describe '#heading?' do
+    context 'when the goods nomenclature has a heading goods nomenclature item id' do
+      subject(:goods_nomenclature) { create(:goods_nomenclature, :heading) }
+
+      it { is_expected.to be_heading }
+    end
+
+    context 'when the goods nomenclature has a non-heading goods nomenclature item id' do
+      subject(:goods_nomenclature) { create(:goods_nomenclature, :commodity) }
+
+      it { is_expected.not_to be_heading }
+    end
+  end
+
+  describe '#not_heading?' do
+    context 'when the goods nomenclature has a heading goods nomenclature item id' do
+      subject(:goods_nomenclature) { create(:goods_nomenclature, :heading) }
+
+      it { is_expected.not_to be_not_heading }
+    end
+
+    context 'when the goods nomenclature has a non-heading goods nomenclature item id' do
+      subject(:goods_nomenclature) { create(:goods_nomenclature, :commodity) }
+
+      it { is_expected.to be_not_heading }
+    end
+  end
+
+  describe '#chapter?' do
+    context 'when the goods nomenclature has a chapter goods nomenclature item id' do
+      subject(:goods_nomenclature) { create(:goods_nomenclature, :chapter) }
+
+      it { is_expected.to be_chapter }
+    end
+
+    context 'when the goods nomenclature has a non-chapter goods nomenclature item id' do
+      subject(:goods_nomenclature) { create(:goods_nomenclature, :commodity) }
+
+      it { is_expected.not_to be_chapter }
+    end
+  end
+
+  describe '#not_chapter?' do
+    context 'when the goods nomenclature has a chapter goods nomenclature item id' do
+      subject(:goods_nomenclature) { create(:goods_nomenclature, :chapter) }
+
+      it { is_expected.not_to be_not_chapter }
+    end
+
+    context 'when the goods nomenclature has a non-chapter goods nomenclature item id' do
+      subject(:goods_nomenclature) { create(:goods_nomenclature, :commodity) }
+
+      it { is_expected.to be_not_chapter }
+    end
+  end
+
+  describe '#declarable?' do
+    context 'when the goods nomenclature has children and a non grouping suffix' do
+      subject(:goods_nomenclature) { create(:goods_nomenclature, :with_children, :non_grouping) }
+
+      it { is_expected.not_to be_declarable }
+    end
+
+    context 'when the goods nomenclature has children and a grouping suffix' do
+      subject(:goods_nomenclature) { create(:goods_nomenclature, :with_children, :grouping) }
+
+      it { is_expected.not_to be_declarable }
+    end
+
+    context 'when the goods nomenclature has no children and a non grouping suffix' do
+      subject(:goods_nomenclature) { create(:goods_nomenclature, :without_children, :non_grouping) }
+
+      it { is_expected.to be_declarable }
+    end
+
+    context 'when the goods nomenclature has no children and a grouping suffix' do
+      subject(:goods_nomenclature) { create(:goods_nomenclature, :without_children, :grouping) }
+
+      it { is_expected.not_to be_declarable }
+    end
+  end
 end

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -493,20 +493,6 @@ RSpec.describe GoodsNomenclature do
     end
   end
 
-  describe '#not_heading?' do
-    context 'when the goods nomenclature has a heading goods nomenclature item id' do
-      subject(:goods_nomenclature) { create(:goods_nomenclature, :heading) }
-
-      it { is_expected.not_to be_not_heading }
-    end
-
-    context 'when the goods nomenclature has a non-heading goods nomenclature item id' do
-      subject(:goods_nomenclature) { create(:goods_nomenclature, :commodity) }
-
-      it { is_expected.to be_not_heading }
-    end
-  end
-
   describe '#chapter?' do
     context 'when the goods nomenclature has a chapter goods nomenclature item id' do
       subject(:goods_nomenclature) { create(:goods_nomenclature, :chapter) }
@@ -518,20 +504,6 @@ RSpec.describe GoodsNomenclature do
       subject(:goods_nomenclature) { create(:goods_nomenclature, :commodity) }
 
       it { is_expected.not_to be_chapter }
-    end
-  end
-
-  describe '#not_chapter?' do
-    context 'when the goods nomenclature has a chapter goods nomenclature item id' do
-      subject(:goods_nomenclature) { create(:goods_nomenclature, :chapter) }
-
-      it { is_expected.not_to be_not_chapter }
-    end
-
-    context 'when the goods nomenclature has a non-chapter goods nomenclature item id' do
-      subject(:goods_nomenclature) { create(:goods_nomenclature, :commodity) }
-
-      it { is_expected.to be_not_chapter }
     end
   end
 

--- a/spec/services/materialized_path_updater_service_spec.rb
+++ b/spec/services/materialized_path_updater_service_spec.rb
@@ -2,36 +2,36 @@ RSpec.describe MaterializedPathUpdaterService do
   subject(:service) { described_class.new(chapter) }
 
   context 'when passed a chapter with nested goods nomenclatures' do
-    let(:chapter) { Chapter.by_code('01').take }
+    let(:chapter) { Chapter.by_code('02').take }
 
     before do
       # Full tree
-      create(:chapter,   :with_indent, goods_nomenclature_sid: 1, indents: 0, producline_suffix: '80', goods_nomenclature_item_id: '0100000000') # Live animals
-      create(:heading,   :with_indent, goods_nomenclature_sid: 2, indents: 0, producline_suffix: '80', goods_nomenclature_item_id: '0101000000') # Live horses, asses, mules and hinnies
-      create(:commodity, :with_indent, goods_nomenclature_sid: 3, indents: 1, producline_suffix: '10', goods_nomenclature_item_id: '0101210000') # Horses < target subheading
-      create(:commodity, :with_indent, goods_nomenclature_sid: 4, indents: 2, producline_suffix: '80', goods_nomenclature_item_id: '0101210000') # -- Pure-bred breeding animals
-      create(:commodity, :with_indent, goods_nomenclature_sid: 5, indents: 2, producline_suffix: '80', goods_nomenclature_item_id: '0101290000') # -- Other
-      create(:commodity, :with_indent, goods_nomenclature_sid: 6, indents: 3, producline_suffix: '80', goods_nomenclature_item_id: '0101291000') # ---- For slaughter
-      create(:commodity, :with_indent, goods_nomenclature_sid: 7, indents: 3, producline_suffix: '80', goods_nomenclature_item_id: '0101299000') # ---- Other
-      create(:commodity, :with_indent, goods_nomenclature_sid: 8, indents: 1, producline_suffix: '80', goods_nomenclature_item_id: '0101300000') # Asses
-      create(:commodity, :with_indent, goods_nomenclature_sid: 9, indents: 1, producline_suffix: '80', goods_nomenclature_item_id: '0101900000') # Other
+      create(:chapter,   :with_indent, goods_nomenclature_sid: 10_000, indents: 0, producline_suffix: '80', goods_nomenclature_item_id: '0200000000') # Live animals
+      create(:heading,   :with_indent, goods_nomenclature_sid: 20_000, indents: 0, producline_suffix: '80', goods_nomenclature_item_id: '0201000000') # Live horses, asses, mules and hinnies
+      create(:commodity, :with_indent, goods_nomenclature_sid: 30_000, indents: 1, producline_suffix: '10', goods_nomenclature_item_id: '0201210000') # Horses < target subheading
+      create(:commodity, :with_indent, goods_nomenclature_sid: 40_000, indents: 2, producline_suffix: '80', goods_nomenclature_item_id: '0201210000') # -- Pure-bred breeding animals
+      create(:commodity, :with_indent, goods_nomenclature_sid: 50_000, indents: 2, producline_suffix: '80', goods_nomenclature_item_id: '0201290000') # -- Other
+      create(:commodity, :with_indent, goods_nomenclature_sid: 60_000, indents: 3, producline_suffix: '80', goods_nomenclature_item_id: '0201291000') # ---- For slaughter
+      create(:commodity, :with_indent, goods_nomenclature_sid: 70_000, indents: 3, producline_suffix: '80', goods_nomenclature_item_id: '0201299000') # ---- Other
+      create(:commodity, :with_indent, goods_nomenclature_sid: 80_000, indents: 1, producline_suffix: '80', goods_nomenclature_item_id: '0201300000') # Asses
+      create(:commodity, :with_indent, goods_nomenclature_sid: 90_000, indents: 1, producline_suffix: '80', goods_nomenclature_item_id: '0201900000') # Other
     end
 
     it 'generates the paths correctly' do
       service.call
 
-      actual_paths = GoodsNomenclature.pluck(:path).map(&:to_a)
+      actual_paths = [chapter.path.to_a] + chapter.goods_nomenclatures.pluck(:path).map(&:to_a)
 
       expected_paths = [
         [],
-        [1],
-        [1, 2],
-        [1, 2, 3],
-        [1, 2, 3],
-        [1, 2, 3, 5],
-        [1, 2, 3, 5],
-        [1, 2],
-        [1, 2],
+        [10_000],
+        [10_000, 20_000],
+        [10_000, 20_000, 30_000],
+        [10_000, 20_000, 30_000],
+        [10_000, 20_000, 30_000, 50_000],
+        [10_000, 20_000, 30_000, 50_000],
+        [10_000, 20_000],
+        [10_000, 20_000],
       ]
 
       expect(actual_paths).to eq(expected_paths)

--- a/spec/services/materialized_path_updater_service_spec.rb
+++ b/spec/services/materialized_path_updater_service_spec.rb
@@ -1,0 +1,52 @@
+RSpec.describe MaterializedPathUpdaterService do
+  subject(:service) { described_class.new(chapter) }
+
+  context 'when passed a chapter with nested goods nomenclatures' do
+    let(:chapter) { Chapter.by_code('01').take }
+
+    before do
+      # Full tree
+      create(:chapter,   :with_indent, goods_nomenclature_sid: 1, indents: 0, producline_suffix: '80', goods_nomenclature_item_id: '0100000000') # Live animals
+      create(:heading,   :with_indent, goods_nomenclature_sid: 2, indents: 0, producline_suffix: '80', goods_nomenclature_item_id: '0101000000') # Live horses, asses, mules and hinnies
+      create(:commodity, :with_indent, goods_nomenclature_sid: 3, indents: 1, producline_suffix: '10', goods_nomenclature_item_id: '0101210000') # Horses < target subheading
+      create(:commodity, :with_indent, goods_nomenclature_sid: 4, indents: 2, producline_suffix: '80', goods_nomenclature_item_id: '0101210000') # -- Pure-bred breeding animals
+      create(:commodity, :with_indent, goods_nomenclature_sid: 5, indents: 2, producline_suffix: '80', goods_nomenclature_item_id: '0101290000') # -- Other
+      create(:commodity, :with_indent, goods_nomenclature_sid: 6, indents: 3, producline_suffix: '80', goods_nomenclature_item_id: '0101291000') # ---- For slaughter
+      create(:commodity, :with_indent, goods_nomenclature_sid: 7, indents: 3, producline_suffix: '80', goods_nomenclature_item_id: '0101299000') # ---- Other
+      create(:commodity, :with_indent, goods_nomenclature_sid: 8, indents: 1, producline_suffix: '80', goods_nomenclature_item_id: '0101300000') # Asses
+      create(:commodity, :with_indent, goods_nomenclature_sid: 9, indents: 1, producline_suffix: '80', goods_nomenclature_item_id: '0101900000') # Other
+    end
+
+    it 'generates the paths correctly' do
+      service.call
+
+      actual_paths = GoodsNomenclature.pluck(:path).map(&:to_a)
+
+      expected_paths = [
+        [],
+        [1],
+        [1, 2],
+        [1, 2, 3],
+        [1, 2, 3],
+        [1, 2, 3, 5],
+        [1, 2, 3, 5],
+        [1, 2],
+        [1, 2],
+      ]
+
+      expect(actual_paths).to eq(expected_paths)
+    end
+  end
+
+  context 'when passed a chapter with no goods nomenclatures' do
+    let(:chapter) { create(:chapter) }
+
+    let(:change_goods_nomenclatures_with_paths) do
+      change { GoodsNomenclature.exclude(path: Sequel.pg_array([], :integer)).count }
+    end
+
+    before { chapter }
+
+    it { expect { service.call }.not_to change_goods_nomenclatures_with_paths }
+  end
+end

--- a/spec/workers/generate_materialized_paths_worker_spec.rb
+++ b/spec/workers/generate_materialized_paths_worker_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe GenerateMaterializedPathsWorker, type: :worker do
+  subject(:do_perform) { silence { described_class.new.perform } }
+
+  before do
+    allow(MaterializedPathUpdaterService).to receive(:new).and_call_original
+
+    # Full tree
+    create(:chapter,   :with_indent, goods_nomenclature_sid: 1, indents: 0, producline_suffix: '80', goods_nomenclature_item_id: '0100000000') # Live animals
+    create(:heading,   :with_indent, goods_nomenclature_sid: 2, indents: 0, producline_suffix: '80', goods_nomenclature_item_id: '0101000000') # Live horses, asses, mules and hinnies
+    create(:commodity, :with_indent, goods_nomenclature_sid: 3, indents: 1, producline_suffix: '10', goods_nomenclature_item_id: '0101210000') # Horses < target subheading
+    create(:commodity, :with_indent, goods_nomenclature_sid: 4, indents: 2, producline_suffix: '80', goods_nomenclature_item_id: '0101210000') # -- Pure-bred breeding animals
+    create(:commodity, :with_indent, goods_nomenclature_sid: 5, indents: 2, producline_suffix: '80', goods_nomenclature_item_id: '0101290000') # -- Other
+    create(:commodity, :with_indent, goods_nomenclature_sid: 6, indents: 3, producline_suffix: '80', goods_nomenclature_item_id: '0101291000') # ---- For slaughter
+    create(:commodity, :with_indent, goods_nomenclature_sid: 7, indents: 3, producline_suffix: '80', goods_nomenclature_item_id: '0101299000') # ---- Other
+    create(:commodity, :with_indent, goods_nomenclature_sid: 8, indents: 1, producline_suffix: '80', goods_nomenclature_item_id: '0101300000') # Asses
+    create(:commodity, :with_indent, goods_nomenclature_sid: 9, indents: 1, producline_suffix: '80', goods_nomenclature_item_id: '0101900000') # Other
+  end
+
+  it 'generates materialized paths against all goods nomenclature' do
+    do_perform
+
+    actual_paths = GoodsNomenclature.pluck(:path).map(&:to_a)
+
+    expected_paths = [
+      [],
+      [1],
+      [1, 2],
+      [1, 2, 3],
+      [1, 2, 3],
+      [1, 2, 3, 5],
+      [1, 2, 3, 5],
+      [1, 2],
+      [1, 2],
+    ]
+
+    expect(actual_paths).to eq(expected_paths)
+  end
+
+  it 'calls the MaterializedPathUpdaterService' do
+    do_perform
+
+    expect(MaterializedPathUpdaterService).to have_received(:new).with(an_instance_of(Chapter))
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1628

### What?

I have added/removed/altered:

- [x] Adds materialized path migration to goods nomenclatures oplog table and view
- [x] Adds materialised path generation worker
- [x] Adds materialised path generation service
- [x] Adds convenience methods for pulling on chapter goods nomenclatures
- [x] Adds api for retrieving parent, ancestors, siblings, children and descendants
- [x] Adds specs for the new api

### Why?

I am doing this because:

- This is required to make for a speedier hierarchy generation and was driven by upcoming changes to search indexes
