### PR TITLE
HOTT-1628: Tweak goods nomenclature attribute default

### DIFF
--- a/app/lib/taric_importer/record_processor/attribute_mutator_overrides/goods_nomenclature_attribute_mutator.rb
+++ b/app/lib/taric_importer/record_processor/attribute_mutator_overrides/goods_nomenclature_attribute_mutator.rb
@@ -1,0 +1,12 @@
+class TaricImporter
+  class RecordProcessor
+    module AttributeMutatorOverrides
+      class GoodsNomenclatureAttributeMutator < TaricImporter::RecordProcessor::AttributeMutator
+        def self.mutate(attributes)
+          attributes['path'] = Sequel.pg_array([], :integer)
+          attributes
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1628

### What?

I have added/removed/altered:

- [x] Mutate attributes of goods nomenclature to default to an empty path rather than null

### Why?

I am doing this because:

- In taric we set unset columns to null where in cds we just don't set them and take the default

See the result, here:

```sql
INSERT INTO "goods_nomenclatures_oplog" ("goods_nomenclature_sid", "goods_nomenclature_item_id", "producline_suffix", "validity_start_date", "validity_end_date", "statistical_indicator", "filename", "path", "operation", "operation_date", "created_at") VALUES (108110, '1902301030', '80', '2022-07-03 00:00:00.000000+0000', NULL, 0, NULL, NULL, 'C', '2022-04-27', '2022-06-14 05:00:10.568476+0000') RETURNING "oid"
```
