### PR TITLE
HOTT-1676 move responsibilities to indexes

### DIFF
--- a/app/elastic_search_indexes/search_index.rb
+++ b/app/elastic_search_indexes/search_index.rb
@@ -1,20 +1,28 @@
 class SearchIndex
-  delegate :dataset, to: :model
+  delegate :dataset, to: :model_class
 
-  def initialize(namespace)
-    @namespace = namespace
+  def initialize(server_namespace)
+    @server_namespace = server_namespace
   end
 
   def name
-    [@namespace, type.pluralize].join('-')
+    [@server_namespace, type.pluralize].join('-')
   end
 
   def type
-    model.to_s.underscore
+    model_class.to_s.underscore
   end
 
-  def model
+  def model_class
     self.class.name.split('::').last.chomp('Index').constantize
+  end
+
+  def serializer
+    self.class.name.gsub(/Index\z/, 'Serializer').constantize
+  end
+
+  def serialize_record(record)
+    serializer.new(record).as_json
   end
 
   def goods_nomenclature?

--- a/app/elastic_search_indexes/search_index.rb
+++ b/app/elastic_search_indexes/search_index.rb
@@ -1,4 +1,6 @@
 class SearchIndex
+  delegate :dataset, to: :model
+
   def initialize(namespace)
     @namespace = namespace
   end

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -211,10 +211,6 @@ module TradeTariffBackend
       end
     end
 
-    def model_serializer_for(namespace, model)
-      "::#{namespace.capitalize}::#{model}Serializer".constantize
-    end
-
     def api_version(request)
       request.headers['Accept']&.scan(/application\/vnd.uktt.v(\d+)/)&.flatten&.first || '1'
     end

--- a/app/lib/trade_tariff_backend/search_client.rb
+++ b/app/lib/trade_tariff_backend/search_client.rb
@@ -5,10 +5,10 @@ module TradeTariffBackend
     # Raised if Elasticsearch returns an error from query
     QueryError = Class.new(StandardError)
 
-    attr_reader :indexed_models
-    attr_reader :index_page_size
-    attr_reader :search_operation_options
-    attr_reader :namespace
+    attr_reader :indexed_models,
+                :index_page_size,
+                :search_operation_options,
+                :namespace
 
     delegate :search_index_for, to: TradeTariffBackend
 
@@ -63,7 +63,7 @@ module TradeTariffBackend
     def build_index(index)
       total_pages = (index.dataset.count / index_page_size.to_f).ceil
       (1..total_pages).each do |page_number|
-        BuildIndexPageWorker.perform_async(namespace, index.model.to_s, page_number, index_page_size)
+        BuildIndexPageWorker.perform_async(namespace, index.model_class.to_s, page_number, index_page_size)
       end
     end
 
@@ -72,7 +72,7 @@ module TradeTariffBackend
         super({
           index: model_index.name,
           id: model.id,
-          body: TradeTariffBackend.model_serializer_for(namespace, model_index.model).new(model).as_json
+          body: model_index.serialize_record(model).as_json,
         }.merge(search_operation_options))
       end
     end
@@ -81,7 +81,7 @@ module TradeTariffBackend
       search_index_for(namespace, model.class).tap do |model_index|
         super({
           index: model_index.name,
-          id: model.id
+          id: model.id,
         }.merge(search_operation_options))
       end
     end

--- a/app/lib/trade_tariff_backend/search_client.rb
+++ b/app/lib/trade_tariff_backend/search_client.rb
@@ -37,7 +37,7 @@ module TradeTariffBackend
       search_index_for(namespace, model).tap do |index|
         drop_index(index)
         create_index(index)
-        build_index(model)
+        build_index(index)
       end
     end
 
@@ -48,7 +48,7 @@ module TradeTariffBackend
     def update(model)
       search_index_for(namespace, model).tap do |index|
         create_index(index)
-        build_index(model)
+        build_index(index)
       end
     end
 
@@ -60,10 +60,10 @@ module TradeTariffBackend
       indices.delete(index: index.name) if indices.exists(index: index.name)
     end
 
-    def build_index(model)
-      total_pages = (model.dataset.count / index_page_size.to_f).ceil
+    def build_index(index)
+      total_pages = (index.dataset.count / index_page_size.to_f).ceil
       (1..total_pages).each do |page_number|
-        BuildIndexPageWorker.perform_async(namespace, model.to_s, page_number, index_page_size)
+        BuildIndexPageWorker.perform_async(namespace, index.model.to_s, page_number, index_page_size)
       end
     end
 

--- a/app/serializers/search/search_reference_serializer.rb
+++ b/app/serializers/search/search_reference_serializer.rb
@@ -1,21 +1,27 @@
 module Search
   class SearchReferenceSerializer < ::Serializer
-    def referenced
-      TradeTariffBackend.model_serializer_for('search', __getobj__.referenced.class).new(__getobj__.referenced)
-    end
-
     def serializable_hash(_opts = {})
-      if referenced.blank?
+      if serializer_instance.blank?
         {}
       else
         {
           title:,
           reference_class: referenced_class,
-          reference: referenced.serializable_hash.merge(
-            class: referenced_class
-          )
+          reference: serializer_instance.serializable_hash.merge(
+            class: referenced_class,
+          ),
         }
       end
+    end
+
+  private
+
+    def serializer_for_referenced_class
+      Search.const_get("#{__getobj__.referenced.class}Serializer")
+    end
+
+    def serializer_instance
+      @serializer_instance ||= serializer_for_referenced_class.new(__getobj__.referenced)
     end
   end
 end

--- a/app/workers/build_index_page_worker.rb
+++ b/app/workers/build_index_page_worker.rb
@@ -5,18 +5,18 @@ class BuildIndexPageWorker
 
   attr_reader :namespace
 
-  def perform(namespace, model_name, page_number, page_size)
-    @namespace = namespace
+  def perform(index_namespace, model_name, page_number, page_size)
+    @index_namespace = index_namespace
     client = Elasticsearch::Client.new
     model = model_name.constantize
-    index = TradeTariffBackend.search_index_for(namespace, model)
+    index = TradeTariffBackend.search_index_for(index_namespace, model)
 
     client.bulk(
       body: serialize_for(
         :index,
         index,
-        index.dataset.paginate(page_number, page_size)
-      )
+        index.dataset.paginate(page_number, page_size),
+      ),
     )
   end
 
@@ -28,8 +28,8 @@ class BuildIndexPageWorker
         operation => {
           _index: index.name,
           _id: model.id,
-          data: TradeTariffBackend.model_serializer_for(namespace, index.model).new(model).as_json
-        }
+          data: index.serialize_record(model),
+        },
       )
     end
   end

--- a/app/workers/build_index_page_worker.rb
+++ b/app/workers/build_index_page_worker.rb
@@ -15,7 +15,7 @@ class BuildIndexPageWorker
       body: serialize_for(
         :index,
         index,
-        model.dataset.paginate(page_number, page_size)
+        index.dataset.paginate(page_number, page_size)
       )
     )
   end

--- a/spec/elastic_search_indexes/cache/additional_code_index_spec.rb
+++ b/spec/elastic_search_indexes/cache/additional_code_index_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Cache::AdditionalCodeIndex do
+  subject(:instance) { described_class.new 'testnamespace' }
+
+  it { is_expected.to have_attributes type: 'additional_code' }
+  it { is_expected.to have_attributes name: 'testnamespace-additional_codes-cache' }
+  it { is_expected.to have_attributes model_class: AdditionalCode }
+  it { is_expected.to have_attributes serializer: Cache::AdditionalCodeSerializer }
+
+  describe '#serialize_record' do
+    subject { instance.serialize_record record }
+
+    let(:record) { create :additional_code, :with_description }
+
+    it { is_expected.to include additional_code_sid: record.additional_code_sid }
+  end
+end

--- a/spec/elastic_search_indexes/cache/certificate_index_spec.rb
+++ b/spec/elastic_search_indexes/cache/certificate_index_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Cache::CertificateIndex do
+  subject(:instance) { described_class.new 'testnamespace' }
+
+  it { is_expected.to have_attributes type: 'certificate' }
+  it { is_expected.to have_attributes name: 'testnamespace-certificates-cache' }
+  it { is_expected.to have_attributes model_class: Certificate }
+  it { is_expected.to have_attributes serializer: Cache::CertificateSerializer }
+
+  describe '#serialize_record' do
+    subject { instance.serialize_record record }
+
+    let(:record) { create :certificate, :with_description }
+
+    it { is_expected.to include id: record.id }
+  end
+end

--- a/spec/elastic_search_indexes/cache/footnote_index_spec.rb
+++ b/spec/elastic_search_indexes/cache/footnote_index_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Cache::FootnoteIndex do
+  subject(:instance) { described_class.new 'testnamespace' }
+
+  it { is_expected.to have_attributes type: 'footnote' }
+  it { is_expected.to have_attributes name: 'testnamespace-footnotes-cache' }
+  it { is_expected.to have_attributes model_class: Footnote }
+  it { is_expected.to have_attributes serializer: Cache::FootnoteSerializer }
+
+  describe '#serialize_record' do
+    subject { instance.serialize_record record }
+
+    let(:record) { create :footnote }
+
+    it { is_expected.to include footnote_id: record.footnote_id }
+  end
+end

--- a/spec/elastic_search_indexes/cache/heading_index_spec.rb
+++ b/spec/elastic_search_indexes/cache/heading_index_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Cache::HeadingIndex do
+  subject(:instance) { described_class.new 'testnamespace' }
+
+  it { is_expected.to have_attributes type: 'heading' }
+  it { is_expected.to have_attributes name: 'testnamespace-headings-cache' }
+  it { is_expected.to have_attributes model_class: Heading }
+  it { is_expected.to have_attributes serializer: Cache::HeadingSerializer }
+
+  describe '#serialize_record' do
+    subject { instance.serialize_record record }
+
+    let(:record) { create :heading }
+
+    it { is_expected.to include id: record.id }
+  end
+end

--- a/spec/elastic_search_indexes/search/chapter_index_spec.rb
+++ b/spec/elastic_search_indexes/search/chapter_index_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Search::ChapterIndex do
+  subject(:instance) { described_class.new 'testnamespace' }
+
+  it { is_expected.to have_attributes type: 'chapter' }
+  it { is_expected.to have_attributes name: 'testnamespace-chapters' }
+  it { is_expected.to have_attributes model_class: Chapter }
+  it { is_expected.to have_attributes serializer: Search::ChapterSerializer }
+
+  describe '#serialize_record' do
+    subject { instance.serialize_record record }
+
+    let(:record) { create :chapter }
+
+    it { is_expected.to include 'id' => record.goods_nomenclature_sid }
+    it { is_expected.to include 'description' => record.description.presence }
+  end
+end

--- a/spec/elastic_search_indexes/search/commodity_index_spec.rb
+++ b/spec/elastic_search_indexes/search/commodity_index_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Search::CommodityIndex do
+  subject(:instance) { described_class.new 'testnamespace' }
+
+  it { is_expected.to have_attributes type: 'commodity' }
+  it { is_expected.to have_attributes name: 'testnamespace-commodities' }
+  it { is_expected.to have_attributes model_class: Commodity }
+  it { is_expected.to have_attributes serializer: Search::CommoditySerializer }
+
+  describe '#serialize_record' do
+    subject { instance.serialize_record record }
+
+    let(:record) { create :commodity }
+
+    it { is_expected.to include 'id' => record.goods_nomenclature_sid }
+  end
+end

--- a/spec/elastic_search_indexes/search/heading_index_spec.rb
+++ b/spec/elastic_search_indexes/search/heading_index_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Search::HeadingIndex do
+  subject(:instance) { described_class.new 'testnamespace' }
+
+  it { is_expected.to have_attributes type: 'heading' }
+  it { is_expected.to have_attributes name: 'testnamespace-headings' }
+  it { is_expected.to have_attributes model_class: Heading }
+  it { is_expected.to have_attributes serializer: Search::HeadingSerializer }
+
+  describe '#serialize_record' do
+    subject { instance.serialize_record record }
+
+    let(:record) { create :heading }
+
+    it { is_expected.to include 'id' => record.goods_nomenclature_sid }
+  end
+end

--- a/spec/elastic_search_indexes/search/search_reference_index_spec.rb
+++ b/spec/elastic_search_indexes/search/search_reference_index_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Search::SearchReferenceIndex do
+  subject(:instance) { described_class.new 'testnamespace' }
+
+  it { is_expected.to have_attributes type: 'search_reference' }
+  it { is_expected.to have_attributes name: 'testnamespace-search_references' }
+  it { is_expected.to have_attributes model_class: SearchReference }
+  it { is_expected.to have_attributes serializer: Search::SearchReferenceSerializer }
+
+  describe '#serialize_record' do
+    subject { instance.serialize_record record }
+
+    let(:record) { create :search_reference }
+
+    it { is_expected.to include 'title' => record.title }
+  end
+end

--- a/spec/elastic_search_indexes/search/section_index_spec.rb
+++ b/spec/elastic_search_indexes/search/section_index_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Search::SectionIndex do
+  subject(:instance) { described_class.new 'testnamespace' }
+
+  it { is_expected.to have_attributes type: 'section' }
+  it { is_expected.to have_attributes name: 'testnamespace-sections' }
+  it { is_expected.to have_attributes model_class: Section }
+  it { is_expected.to have_attributes serializer: Search::SectionSerializer }
+
+  describe '#serialize_record' do
+    subject { instance.serialize_record record }
+
+    let(:record) { create :section }
+
+    it { is_expected.to include 'id' => record.id }
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-1676

### What?

I have added/removed/altered:

- [x] Moved retrieval of data to be indexed to the index
- [x] Moved selection of serializer for data to be indexed to the index
- [x] Clarified naming of index versus elasticsearch server namespaces
- [x] Renamed `.model` to `.model_class` to make it clearer what it returns
- [x] Added specs around existing indexes

### Why?

I am doing this because:

- We want to add/extend our search indexes and this is necessary to have different behaviours in new vs old indexes

### Deployment risks (optional)

- Changes the Search Indexing behaviour so needs to run in Dev overnight prior to any merge
