### PR TITLE
HOTT-1676 Moved ES options to SearchClient

### DIFF
--- a/app/elastic_search_indexes/search_index.rb
+++ b/app/elastic_search_indexes/search_index.rb
@@ -1,7 +1,7 @@
 class SearchIndex
   delegate :dataset, to: :model_class
 
-  def initialize(server_namespace)
+  def initialize(server_namespace = TradeTariffBackend::SearchClient.server_namespace)
     @server_namespace = server_namespace
   end
 

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -102,7 +102,6 @@ module TradeTariffBackend
         Elasticsearch::Client.new,
         indexed_models:,
         index_page_size: 500,
-        search_operation_options:,
       )
     end
 
@@ -112,25 +111,15 @@ module TradeTariffBackend
         namespace: 'cache',
         indexed_models: cached_models,
         index_page_size: 5,
-        search_operation_options:,
       )
     end
-
-    def search_namespace
-      @search_namespace ||= 'tariff'
-    end
-    attr_writer :search_namespace, :search_operation_options
 
     # Returns search index instance for given model instance or
     # model class instance
     def search_index_for(namespace, model)
       index_name = model.is_a?(Class) ? model : model.class
 
-      "::#{namespace.capitalize}::#{index_name}Index".constantize.new(search_namespace)
-    end
-
-    def search_operation_options
-      @search_operation_options || {}
+      "::#{namespace.capitalize}::#{index_name}Index".constantize.new
     end
 
     def indexed_models
@@ -207,7 +196,7 @@ module TradeTariffBackend
 
     def search_indexes
       indexed_models.map do |model|
-        "::Search::#{model}Index".constantize.new(search_namespace)
+        "::Search::#{model}Index".constantize.new
       end
     end
 

--- a/app/lib/trade_tariff_backend/search_client.rb
+++ b/app/lib/trade_tariff_backend/search_client.rb
@@ -5,6 +5,9 @@ module TradeTariffBackend
     # Raised if Elasticsearch returns an error from query
     QueryError = Class.new(StandardError)
 
+    cattr_accessor :server_namespace, default: 'tariff'.freeze
+    cattr_accessor :search_operation_options, default: {}
+
     attr_reader :indexed_models,
                 :index_page_size,
                 :search_operation_options,
@@ -15,7 +18,8 @@ module TradeTariffBackend
     def initialize(search_client, options = {})
       @indexed_models = options.fetch(:indexed_models, [])
       @index_page_size = options.fetch(:index_page_size, 1000)
-      @search_operation_options = options.fetch(:search_operation_options, {})
+      @search_operation_options = options.fetch(:search_operation_options,
+                                                self.class.search_operation_options)
       @namespace = options.fetch(:namespace, 'search')
 
       super(search_client)

--- a/app/services/additional_code_search_service.rb
+++ b/app/services/additional_code_search_service.rb
@@ -60,7 +60,7 @@ class AdditionalCodeSearchService
 
   def fetch
     search_client = ::TradeTariffBackend.cache_client
-    index = ::Cache::AdditionalCodeIndex.new(TradeTariffBackend.search_namespace).name
+    index = ::Cache::AdditionalCodeIndex.new.name
     result = search_client.search index: index, body: { query: { constant_score: { filter: { bool: { must: @query } } } }, size: per_page, from: (current_page - 1) * per_page, sort: %w[additional_code_type_id additional_code] }
     @pagination_record_count = result&.hits&.total&.value || 0
     @result = result&.hits&.hits&.map(&:_source)

--- a/app/services/certificate_search_service.rb
+++ b/app/services/certificate_search_service.rb
@@ -60,7 +60,7 @@ class CertificateSearchService
 
   def fetch
     search_client = ::TradeTariffBackend.cache_client
-    index = ::Cache::CertificateIndex.new(TradeTariffBackend.search_namespace).name
+    index = ::Cache::CertificateIndex.new.name
     result = search_client.search index: index, body: { query: { constant_score: { filter: { bool: { must: @query } } } }, size: per_page, from: (current_page - 1) * per_page, sort: %w(certificate_type_code certificate_code) }
     @pagination_record_count = result&.hits&.total&.value || 0
     @result = result&.hits&.hits&.map(&:_source)

--- a/app/services/footnote_search_service.rb
+++ b/app/services/footnote_search_service.rb
@@ -58,7 +58,7 @@ class FootnoteSearchService
 
   def fetch
     search_client = ::TradeTariffBackend.cache_client
-    index = ::Cache::FootnoteIndex.new(TradeTariffBackend.search_namespace).name
+    index = ::Cache::FootnoteIndex.new.name
     result = search_client.search index: index, body: { query: { constant_score: { filter: { bool: { must: @query } } } }, size: per_page, from: (current_page - 1) * per_page, sort: %w[footnote_type_id footnote_id] }
     @pagination_record_count = result&.hits&.total&.value || 0
     @result = result&.hits&.hits&.map(&:_source)

--- a/app/services/heading_service/cached_heading_service.rb
+++ b/app/services/heading_service/cached_heading_service.rb
@@ -27,7 +27,7 @@ module HeadingService
 
     def fetch_result
       search_client = ::TradeTariffBackend.cache_client
-      index = ::Cache::HeadingIndex.new(TradeTariffBackend.search_namespace).name
+      index = ::Cache::HeadingIndex.new.name
       result = search_client.search index: index, body: { query: { match: { _id: heading.goods_nomenclature_sid } } }
       result&.hits&.hits&.first&._source
     end

--- a/app/services/search_service/fuzzy_search/fuzzy_search_result.rb
+++ b/app/services/search_service/fuzzy_search/fuzzy_search_result.rb
@@ -16,7 +16,7 @@ class SearchService
       def query_options
         {
           goods_nomenclature_match: {
-            "#{TradeTariffBackend.search_namespace}-sections" => { fields: ['title'] }
+            "#{TradeTariffBackend::SearchClient.server_namespace}-sections" => { fields: ['title'] }
           }
         }
       end

--- a/app/services/search_service/fuzzy_search/reference_query.rb
+++ b/app/services/search_service/fuzzy_search/reference_query.rb
@@ -3,7 +3,7 @@ class SearchService
     class ReferenceQuery < FuzzyQuery
       def query(*)
         {
-          index: "#{TradeTariffBackend.search_namespace}-search_references",
+          index: "#{TradeTariffBackend::SearchClient.server_namespace}-search_references",
           search: {
             query: {
               bool: {

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,13 +54,12 @@ Rails.application.configure do
   config.after_initialize do
     require_relative '../../app/lib/trade_tariff_backend'
 
-    TradeTariffBackend.configure do |tariff|
-      tariff.search_namespace = 'tariff-test' # default is just tariff
-      # We need search index to be refreshed after each operation
-      # in order to assert record presence in the index (in integration specs)
-      # Elasticsearch has a 1 second interval between index refreshes
-      # by default.
-      tariff.search_operation_options = { refresh: true }
-    end
+    TradeTariffBackend::SearchClient.server_namespace = 'tariff-test' # default is just tariff
+
+    # We need search index to be refreshed after each operation
+    # in order to assert record presence in the index (in integration specs)
+    # Elasticsearch has a 1 second interval between index refreshes
+    # by default.
+    TradeTariffBackend::SearchClient.search_operation_options = { refresh: true }
   end
 end

--- a/spec/lib/trade_tariff_backend/search_client_spec.rb
+++ b/spec/lib/trade_tariff_backend/search_client_spec.rb
@@ -1,4 +1,29 @@
 RSpec.describe TradeTariffBackend::SearchClient do
+  describe '.server_namespace' do
+    subject { described_class.server_namespace }
+
+    it { is_expected.to eql 'tariff-test' }
+
+    context 'when overridden' do
+      before do
+        orig_namespace # trigger caching in method
+        described_class.server_namespace = 'overridden'
+      end
+
+      after { described_class.server_namespace = orig_namespace }
+
+      let(:orig_namespace) { described_class.server_namespace }
+
+      it { is_expected.to eql 'overridden' }
+    end
+  end
+
+  describe '.search_operation_options' do
+    subject { described_class.search_operation_options }
+
+    it { is_expected.to be_instance_of Hash }
+  end
+
   describe '#search' do
     let(:commodity) do
       create :commodity, :with_description, description: 'test description'
@@ -10,6 +35,9 @@ RSpec.describe TradeTariffBackend::SearchClient do
 
     it 'searches in supplied index' do
       expect(search_result.hits.total.value).to be >= 1
+    end
+
+    it 'returns expected results' do
       expect(search_result.hits.hits.map do |hit|
         hit._source.goods_nomenclature_item_id
       end).to include commodity.goods_nomenclature_item_id


### PR DESCRIPTION
### Jira link

HOTT-1676

### What?

I have added/removed/altered:

- [x] Moved the global search options onto the SearchClient
- [x] Default the indexes to the namespace defined on the SearchClient

### Why?

I am doing this because:

- Previously these options lacked context for which class they impacted, -locating them on the class they relate to clarifies that

### Deployment risks (optional)

- Affects search index generation, should be run overnight on Dev first
