### PR TITLE
HOTT-1689 Drop feature flag from Permutations API

### DIFF
--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -231,10 +231,6 @@ module TradeTariffBackend
       @chief_cds_guidance ||= ChiefCdsGuidance.load_default
     end
 
-    def permutations?
-      ENV['PERMUTATIONS'].to_s == 'true'
-    end
-
     def normalised_measure_units?
       ENV['NORMALISED_MEASURE_UNITS'].to_s == 'true'
     end

--- a/app/serializers/api/v2/measures/measure_serializer.rb
+++ b/app/serializers/api/v2/measures/measure_serializer.rb
@@ -28,9 +28,7 @@ module Api
                                         record_type: :suspension_legal_act, serializer: Api::V2::Measures::MeasureSuspensionLegalActSerializer,
                                         if: proc { |measure| !measure.national && measure.suspended? }
         has_many :measure_conditions, serializer: Api::V2::Measures::MeasureConditionSerializer
-        if TradeTariffBackend.permutations?
-          has_many :measure_condition_permutation_groups, serializer: Api::V2::Measures::MeasureConditionPermutationGroupSerializer
-        end
+        has_many :measure_condition_permutation_groups, serializer: Api::V2::Measures::MeasureConditionPermutationGroupSerializer
         has_many :measure_components, serializer: Api::V2::Measures::MeasureComponentSerializer
         has_many :resolved_measure_components, serializer: Api::V2::Measures::MeasureComponentSerializer
 

--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -1,5 +1,5 @@
 class CachedCommodityService
-  CACHE_VERSION = TradeTariffBackend.permutations? ? 2 : 1
+  CACHE_VERSION = 2
 
   DEFAULT_INCLUDES = [
     'section',


### PR DESCRIPTION
### Jira link

[HOTT-1689](url)

### What?

I have added/removed/altered:

- [ ] Dropped the feature flag for the Permutations API extensions

### Why?

I am doing this because:

- This has been on for a while and is a purely additive change

