### PR TITLE
HOTT-1676 allow multiple indexes per model

### DIFF
--- a/app/elastic_search_indexes/search_index.rb
+++ b/app/elastic_search_indexes/search_index.rb
@@ -32,4 +32,8 @@ class SearchIndex
   def goods_nomenclature?
     false
   end
+
+  def include_in_search?
+    goods_nomenclature?
+  end
 end

--- a/app/elastic_search_indexes/search_index.rb
+++ b/app/elastic_search_indexes/search_index.rb
@@ -33,7 +33,7 @@ class SearchIndex
     false
   end
 
-  def include_in_search?
-    goods_nomenclature?
+  def exclude_from_search_results?
+    !goods_nomenclature?
   end
 end

--- a/app/elastic_search_indexes/search_index.rb
+++ b/app/elastic_search_indexes/search_index.rb
@@ -9,12 +9,16 @@ class SearchIndex
     [@server_namespace, type.pluralize].join('-')
   end
 
+  def name_without_namespace
+    self.class.name.split('::').last
+  end
+
   def type
     model_class.to_s.underscore
   end
 
   def model_class
-    self.class.name.split('::').last.chomp('Index').constantize
+    name_without_namespace.chomp('Index').constantize
   end
 
   def serializer

--- a/app/lib/sequel/plugins/elasticsearch.rb
+++ b/app/lib/sequel/plugins/elasticsearch.rb
@@ -18,6 +18,8 @@ module Sequel
 
           self.class.elasticsearch_indexes.each do |index_class|
             TradeTariffBackend.search_client.index(index_class, self)
+          rescue ::Elasticsearch::Transport::Transport::Errors::NotFound
+            false
           end
         end
 
@@ -26,6 +28,8 @@ module Sequel
 
           self.class.elasticsearch_indexes.each do |index_class|
             TradeTariffBackend.search_client.index(index_class, self)
+          rescue ::Elasticsearch::Transport::Transport::Errors::NotFound
+            false
           end
         end
 
@@ -35,7 +39,7 @@ module Sequel
           self.class.elasticsearch_indexes.each do |index_class|
             TradeTariffBackend.search_client.delete(index_class, self)
           rescue ::Elasticsearch::Transport::Transport::Errors::NotFound
-            true
+            false
           end
         end
       end

--- a/app/lib/sequel/plugins/elasticsearch.rb
+++ b/app/lib/sequel/plugins/elasticsearch.rb
@@ -3,24 +3,40 @@
 module Sequel
   module Plugins
     module Elasticsearch
+      def self.configure(model, options = {})
+        index = options[:index] || Search.const_get("#{model}Index")
+        model.elasticsearch_indexes = Array.wrap(index)
+      end
+
+      module ClassMethods
+        attr_accessor :elasticsearch_indexes
+      end
+
       module InstanceMethods
         def after_create
           super
 
-          TradeTariffBackend.search_client.index(self)
+          self.class.elasticsearch_indexes.each do |index_class|
+            TradeTariffBackend.search_client.index(index_class, self)
+          end
         end
 
         def after_update
           super
 
-          TradeTariffBackend.search_client.index(self)
+          self.class.elasticsearch_indexes.each do |index_class|
+            TradeTariffBackend.search_client.index(index_class, self)
+          end
         end
 
         def after_destroy
           super
 
-          TradeTariffBackend.search_client.delete(self)
-        rescue ::Elasticsearch::Transport::Transport::Errors::NotFound
+          self.class.elasticsearch_indexes.each do |index_class|
+            TradeTariffBackend.search_client.delete(index_class, self)
+          rescue ::Elasticsearch::Transport::Transport::Errors::NotFound
+            true
+          end
         end
       end
     end

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -114,14 +114,6 @@ module TradeTariffBackend
       )
     end
 
-    # Returns search index instance for given model instance or
-    # model class instance
-    def search_index_for(namespace, model)
-      index_name = model.is_a?(Class) ? model : model.class
-
-      "::#{namespace.capitalize}::#{index_name}Index".constantize.new
-    end
-
     def search_indexes
       [
         Search::ChapterIndex,

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -100,7 +100,7 @@ module TradeTariffBackend
     def search_client
       @search_client ||= SearchClient.new(
         Elasticsearch::Client.new,
-        indexed_models:,
+        indexes: search_indexes,
         index_page_size: 500,
       )
     end
@@ -109,7 +109,7 @@ module TradeTariffBackend
       @cache_client ||= SearchClient.new(
         Elasticsearch::Client.new,
         namespace: 'cache',
-        indexed_models: cached_models,
+        indexes: cache_indexes,
         index_page_size: 5,
       )
     end
@@ -122,23 +122,23 @@ module TradeTariffBackend
       "::#{namespace.capitalize}::#{index_name}Index".constantize.new
     end
 
-    def indexed_models
+    def search_indexes
       [
-        Chapter,
-        Commodity,
-        Heading,
-        SearchReference,
-        Section,
-      ]
+        Search::ChapterIndex,
+        Search::CommodityIndex,
+        Search::HeadingIndex,
+        Search::SearchReferenceIndex,
+        Search::SectionIndex,
+      ].map(&:new)
     end
 
-    def cached_models
+    def cache_indexes
       [
-        Heading,
-        Certificate,
-        AdditionalCode,
-        Footnote,
-      ]
+        Cache::HeadingIndex,
+        Cache::CertificateIndex,
+        Cache::AdditionalCodeIndex,
+        Cache::FootnoteIndex,
+      ].map(&:new)
     end
 
     def clearable_models
@@ -192,12 +192,6 @@ module TradeTariffBackend
         QuotaOrderNumberOrigin,
         QuotaSuspensionPeriod,
       ]
-    end
-
-    def search_indexes
-      indexed_models.map do |model|
-        "::Search::#{model}Index".constantize.new
-      end
     end
 
     def api_version(request)

--- a/app/lib/trade_tariff_backend/search_client.rb
+++ b/app/lib/trade_tariff_backend/search_client.rb
@@ -75,7 +75,7 @@ module TradeTariffBackend
     def build_index(index)
       total_pages = (index.dataset.count / index_page_size.to_f).ceil
       (1..total_pages).each do |page_number|
-        BuildIndexPageWorker.perform_async(namespace, index.model_class.to_s, page_number, index_page_size)
+        BuildIndexPageWorker.perform_async(namespace, index.name_without_namespace, page_number, index_page_size)
       end
     end
 

--- a/app/lib/trade_tariff_backend/search_client.rb
+++ b/app/lib/trade_tariff_backend/search_client.rb
@@ -10,7 +10,7 @@ module TradeTariffBackend
     cattr_accessor :server_namespace, default: 'tariff'.freeze
     cattr_accessor :search_operation_options, default: {}
 
-    attr_reader :indexed_models,
+    attr_reader :indexes,
                 :index_page_size,
                 :search_operation_options,
                 :namespace
@@ -30,7 +30,7 @@ module TradeTariffBackend
     end
 
     def initialize(search_client, options = {})
-      @indexed_models = options.fetch(:indexed_models, [])
+      @indexes = options.fetch(:indexes, [])
       @index_page_size = options.fetch(:index_page_size, 1000)
       @search_operation_options = options.fetch(:search_operation_options,
                                                 self.class.search_operation_options)
@@ -48,26 +48,22 @@ module TradeTariffBackend
     end
 
     def reindex_all
-      indexed_models.each(&method(:reindex))
+      indexes.each(&method(:reindex))
     end
 
-    def reindex(model)
-      search_index_for(namespace, model).tap do |index|
-        drop_index(index)
-        create_index(index)
-        build_index(index)
-      end
+    def reindex(index)
+      drop_index(index)
+      create_index(index)
+      build_index(index)
     end
 
     def update_all
-      indexed_models.each(&method(:update))
+      indexes.each(&method(:update))
     end
 
-    def update(model)
-      search_index_for(namespace, model).tap do |index|
-        create_index(index)
-        build_index(index)
-      end
+    def update(index)
+      create_index(index)
+      build_index(index)
     end
 
     def create_index(index)

--- a/app/lib/trade_tariff_backend/search_client.rb
+++ b/app/lib/trade_tariff_backend/search_client.rb
@@ -15,8 +15,6 @@ module TradeTariffBackend
                 :search_operation_options,
                 :namespace
 
-    delegate :search_index_for, to: TradeTariffBackend
-
     class << self
       def update_server_config
         Elasticsearch::Client.new
@@ -81,23 +79,21 @@ module TradeTariffBackend
       end
     end
 
-    def index(model)
-      search_index_for(namespace, model.class).tap do |model_index|
-        super({
-          index: model_index.name,
-          id: model.id,
-          body: model_index.serialize_record(model).as_json,
-        }.merge(search_operation_options))
-      end
+    def index(index_class, model)
+      model_index = index_class.new
+
+      super({
+        index: model_index.name,
+        id: model.id,
+        body: model_index.serialize_record(model).as_json,
+      }.merge(search_operation_options))
     end
 
-    def delete(model)
-      search_index_for(namespace, model.class).tap do |model_index|
-        super({
-          index: model_index.name,
-          id: model.id,
-        }.merge(search_operation_options))
-      end
+    def delete(index_class, model)
+      super({
+        index: index_class.new.name,
+        id: model.id,
+      }.merge(search_operation_options))
     end
   end
 end

--- a/app/services/search_service/fuzzy_search/fuzzy_search_result.rb
+++ b/app/services/search_service/fuzzy_search/fuzzy_search_result.rb
@@ -48,7 +48,7 @@ class SearchService
         return to_enum(:each_query) unless block_given?
 
         TradeTariffBackend.search_indexes
-                          .select(&:include_in_search?)
+                          .reject(&:exclude_from_search_results?)
                           .each do |search_index|
           [
             GoodsNomenclatureQuery.new(@query_string, @date, search_index),

--- a/app/workers/build_index_page_worker.rb
+++ b/app/workers/build_index_page_worker.rb
@@ -3,13 +3,10 @@ class BuildIndexPageWorker
 
   sidekiq_options queue: :default, retry: false
 
-  attr_reader :namespace
-
-  def perform(index_namespace, model_name, page_number, page_size)
-    @index_namespace = index_namespace
+  def perform(index_namespace, index_name, page_number, page_size)
     client = Elasticsearch::Client.new
-    model = model_name.constantize
-    index = TradeTariffBackend.search_index_for(index_namespace, model)
+    index_name = "#{index_name}Index" unless index_name.ends_with?('Index')
+    index = "#{index_namespace.camelize}::#{index_name}".constantize.new
 
     client.bulk(
       body: serialize_for(

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -61,5 +61,8 @@ Rails.application.configure do
     # Elasticsearch has a 1 second interval between index refreshes
     # by default.
     TradeTariffBackend::SearchClient.search_operation_options = { refresh: true }
+
+    # ensure server config matches expected behaviour
+    TradeTariffBackend::SearchClient.update_server_config
   end
 end

--- a/spec/controllers/api/v2/additional_codes_controller_spec.rb
+++ b/spec/controllers/api/v2/additional_codes_controller_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Api::V2::AdditionalCodesController, type: :controller do
 
     before do
       Sidekiq::Testing.inline! do
-        TradeTariffBackend.cache_client.reindex(AdditionalCode)
+        TradeTariffBackend.cache_client.reindex(Cache::AdditionalCodeIndex.new)
         sleep(1)
       end
     end

--- a/spec/controllers/api/v2/certificates_controller_search_spec.rb
+++ b/spec/controllers/api/v2/certificates_controller_search_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Api::V2::CertificatesController, type: :controller do
       )
 
       Sidekiq::Testing.inline! do
-        TradeTariffBackend.cache_client.reindex(Certificate)
+        TradeTariffBackend.cache_client.reindex(Cache::CertificateIndex.new)
         sleep(1)
       end
     end

--- a/spec/controllers/api/v2/footnotes_controller_spec.rb
+++ b/spec/controllers/api/v2/footnotes_controller_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Api::V2::FootnotesController, type: :controller do
     create(:footnote_association_measure, measure: measure_no_goods_nomenclature, footnote:)
 
     Sidekiq::Testing.inline! do
-      TradeTariffBackend.cache_client.reindex(Footnote)
+      TradeTariffBackend.cache_client.reindex(Cache::FootnoteIndex.new)
       sleep(2)
     end
   end

--- a/spec/elastic_search_indexes/cache/additional_code_index_spec.rb
+++ b/spec/elastic_search_indexes/cache/additional_code_index_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Cache::AdditionalCodeIndex do
 
   it { is_expected.to have_attributes type: 'additional_code' }
   it { is_expected.to have_attributes name: 'testnamespace-additional_codes-cache' }
+  it { is_expected.to have_attributes name_without_namespace: 'AdditionalCodeIndex' }
   it { is_expected.to have_attributes model_class: AdditionalCode }
   it { is_expected.to have_attributes serializer: Cache::AdditionalCodeSerializer }
 

--- a/spec/elastic_search_indexes/cache/certificate_index_spec.rb
+++ b/spec/elastic_search_indexes/cache/certificate_index_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Cache::CertificateIndex do
 
   it { is_expected.to have_attributes type: 'certificate' }
   it { is_expected.to have_attributes name: 'testnamespace-certificates-cache' }
+  it { is_expected.to have_attributes name_without_namespace: 'CertificateIndex' }
   it { is_expected.to have_attributes model_class: Certificate }
   it { is_expected.to have_attributes serializer: Cache::CertificateSerializer }
 

--- a/spec/elastic_search_indexes/cache/footnote_index_spec.rb
+++ b/spec/elastic_search_indexes/cache/footnote_index_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Cache::FootnoteIndex do
 
   it { is_expected.to have_attributes type: 'footnote' }
   it { is_expected.to have_attributes name: 'testnamespace-footnotes-cache' }
+  it { is_expected.to have_attributes name_without_namespace: 'FootnoteIndex' }
   it { is_expected.to have_attributes model_class: Footnote }
   it { is_expected.to have_attributes serializer: Cache::FootnoteSerializer }
 

--- a/spec/elastic_search_indexes/cache/heading_index_spec.rb
+++ b/spec/elastic_search_indexes/cache/heading_index_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Cache::HeadingIndex do
 
   it { is_expected.to have_attributes type: 'heading' }
   it { is_expected.to have_attributes name: 'testnamespace-headings-cache' }
+  it { is_expected.to have_attributes name_without_namespace: 'HeadingIndex' }
   it { is_expected.to have_attributes model_class: Heading }
   it { is_expected.to have_attributes serializer: Cache::HeadingSerializer }
 

--- a/spec/elastic_search_indexes/search/chapter_index_spec.rb
+++ b/spec/elastic_search_indexes/search/chapter_index_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Search::ChapterIndex do
 
   it { is_expected.to have_attributes type: 'chapter' }
   it { is_expected.to have_attributes name: 'testnamespace-chapters' }
+  it { is_expected.to have_attributes name_without_namespace: 'ChapterIndex' }
   it { is_expected.to have_attributes model_class: Chapter }
   it { is_expected.to have_attributes serializer: Search::ChapterSerializer }
 

--- a/spec/elastic_search_indexes/search/commodity_index_spec.rb
+++ b/spec/elastic_search_indexes/search/commodity_index_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Search::CommodityIndex do
 
   it { is_expected.to have_attributes type: 'commodity' }
   it { is_expected.to have_attributes name: 'testnamespace-commodities' }
+  it { is_expected.to have_attributes name_without_namespace: 'CommodityIndex' }
   it { is_expected.to have_attributes model_class: Commodity }
   it { is_expected.to have_attributes serializer: Search::CommoditySerializer }
 

--- a/spec/elastic_search_indexes/search/heading_index_spec.rb
+++ b/spec/elastic_search_indexes/search/heading_index_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Search::HeadingIndex do
 
   it { is_expected.to have_attributes type: 'heading' }
   it { is_expected.to have_attributes name: 'testnamespace-headings' }
+  it { is_expected.to have_attributes name_without_namespace: 'HeadingIndex' }
   it { is_expected.to have_attributes model_class: Heading }
   it { is_expected.to have_attributes serializer: Search::HeadingSerializer }
 

--- a/spec/elastic_search_indexes/search/search_reference_index_spec.rb
+++ b/spec/elastic_search_indexes/search/search_reference_index_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Search::SearchReferenceIndex do
 
   it { is_expected.to have_attributes type: 'search_reference' }
   it { is_expected.to have_attributes name: 'testnamespace-search_references' }
+  it { is_expected.to have_attributes name_without_namespace: 'SearchReferenceIndex' }
   it { is_expected.to have_attributes model_class: SearchReference }
   it { is_expected.to have_attributes serializer: Search::SearchReferenceSerializer }
 

--- a/spec/elastic_search_indexes/search/section_index_spec.rb
+++ b/spec/elastic_search_indexes/search/section_index_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Search::SectionIndex do
 
   it { is_expected.to have_attributes type: 'section' }
   it { is_expected.to have_attributes name: 'testnamespace-sections' }
+  it { is_expected.to have_attributes name_without_namespace: 'SectionIndex' }
   it { is_expected.to have_attributes model_class: Section }
   it { is_expected.to have_attributes serializer: Search::SectionSerializer }
 

--- a/spec/lib/trade_tariff_backend/search_client_spec.rb
+++ b/spec/lib/trade_tariff_backend/search_client_spec.rb
@@ -50,12 +50,18 @@ RSpec.describe TradeTariffBackend::SearchClient do
   end
 
   describe '#search' do
+    before { commodity } # trigger creation and indexing prior to test results
+
     let(:commodity) do
       create :commodity, :with_description, description: 'test description'
     end
 
+    let(:index_name) do
+      "#{described_class.server_namespace}-commodities"
+    end
+
     let(:search_result) do
-      TradeTariffBackend.search_client.search q: 'test', index: TradeTariffBackend.search_index_for('search', commodity).name
+      TradeTariffBackend.search_client.search q: 'test', index: index_name
     end
 
     it 'searches in supplied index' do

--- a/spec/lib/trade_tariff_backend/search_client_spec.rb
+++ b/spec/lib/trade_tariff_backend/search_client_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe TradeTariffBackend::SearchClient do
 
   describe '#search' do
     let(:commodity) do
-      create :commodity, :with_description, description: 'test description'
+      create(:commodity, :with_description, description: 'test description')
     end
 
     let(:index) do
@@ -64,17 +64,19 @@ RSpec.describe TradeTariffBackend::SearchClient do
       TradeTariffBackend.search_client.search q: 'test', index: index.name
     end
 
+    let(:search_result_commodity_ids) do
+      search_result.hits.hits.map(&:_source).map(&:goods_nomenclature_item_id)
+    end
+
     context 'with existing index' do
-      before { commodity } # trigger creation and indexing prior to test results
+      before { commodity }
 
       it 'searches in supplied index' do
         expect(search_result.hits.total.value).to be >= 1
       end
 
       it 'returns expected results' do
-        expect(search_result.hits.hits.map do |hit|
-          hit._source.goods_nomenclature_item_id
-        end).to include commodity.goods_nomenclature_item_id
+        expect(search_result_commodity_ids).to include commodity.goods_nomenclature_item_id
       end
 
       it 'returns results wrapped in Hashie::Mash structure' do
@@ -89,7 +91,7 @@ RSpec.describe TradeTariffBackend::SearchClient do
 
       before do
         TradeTariffBackend.search_client.drop_index index
-        commodity # trigger creation and indexing prior to test results
+        create :commodity, :with_description
       end
 
       after { TradeTariffBackend.search_client.create_index index }

--- a/spec/services/additional_code_search_service_spec.rb
+++ b/spec/services/additional_code_search_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe AdditionalCodeSearchService do
 
     before do
       Sidekiq::Testing.inline! do
-        TradeTariffBackend.cache_client.reindex(AdditionalCode)
+        TradeTariffBackend.cache_client.reindex(Cache::AdditionalCodeIndex.new)
         sleep(1)
       end
     end

--- a/spec/services/certificate_search_service_spec.rb
+++ b/spec/services/certificate_search_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe CertificateSearchService do
 
     before do
       Sidekiq::Testing.inline! do
-        TradeTariffBackend.cache_client.reindex(Certificate)
+        TradeTariffBackend.cache_client.reindex(Cache::CertificateIndex.new)
         sleep(1)
       end
     end

--- a/spec/workers/build_index_page_worker_spec.rb
+++ b/spec/workers/build_index_page_worker_spec.rb
@@ -1,5 +1,12 @@
 RSpec.describe BuildIndexPageWorker, type: :worker do
   describe '#methods' do
+    let :search_result_commodity_ids do
+      search_result.hits
+                   .hits
+                   .map(&:_source)
+                   .map(&:goods_nomenclature_item_id)
+    end
+
     describe 'build index page' do
       before do
         # Make sure index is fresh
@@ -20,12 +27,8 @@ RSpec.describe BuildIndexPageWorker, type: :worker do
         TradeTariffBackend.search_client.search q: 'test', index: search_index.name
       end
 
-      it 'bulk indexes all model entries' do
-        expect(search_result.hits.total.value).to be >= 1
-      end
-
       it 'has bulk indexed the expected commodity' do
-        expect(search_result.hits.hits.map(&:_source).map(&:goods_nomenclature_item_id)).to \
+        expect(search_result_commodity_ids).to \
           eq(commodities.map(&:goods_nomenclature_item_id))
       end
     end
@@ -49,12 +52,8 @@ RSpec.describe BuildIndexPageWorker, type: :worker do
         TradeTariffBackend.search_client.search q: 'test', index: search_index.name
       end
 
-      it 'bulk indexes all model entries' do
-        expect(search_result.hits.total.value).to be >= 1
-      end
-
       it 'has bulk indexed the expected commodity' do
-        expect(search_result.hits.hits.first._source.goods_nomenclature_item_id).to eq commodity.goods_nomenclature_item_id
+        expect(search_result_commodity_ids.first).to eq commodity.goods_nomenclature_item_id
       end
     end
   end

--- a/spec/workers/build_index_page_worker_spec.rb
+++ b/spec/workers/build_index_page_worker_spec.rb
@@ -1,28 +1,59 @@
 RSpec.describe BuildIndexPageWorker, type: :worker do
   describe '#methods' do
     describe 'build index page' do
+      before do
+        # Make sure index is fresh
+        TradeTariffBackend.search_client.drop_index(search_index)
+        TradeTariffBackend.search_client.create_index(search_index)
+        commodities # trigger creation of commodity
+
+        described_class.new.perform 'search', search_index.name_without_namespace, 1, 10
+      end
+
+      let(:commodities) do
+        create_pair :commodity, :with_description, description: 'test description'
+      end
+
+      let(:search_index) { Search::CommodityIndex.new }
+
+      let(:search_result) do
+        TradeTariffBackend.search_client.search q: 'test', index: search_index.name
+      end
+
+      it 'bulk indexes all model entries' do
+        expect(search_result.hits.total.value).to be >= 1
+      end
+
+      it 'has bulk indexed the expected commodity' do
+        expect(search_result.hits.hits.map(&:_source).map(&:goods_nomenclature_item_id)).to \
+          eq(commodities.map(&:goods_nomenclature_item_id))
+      end
+    end
+
+    describe 'build index page with old worker params' do
+      before do
+        # Make sure index is fresh
+        TradeTariffBackend.search_client.drop_index(search_index)
+        TradeTariffBackend.search_client.create_index(search_index)
+
+        described_class.new.perform 'search', commodity.class.name, 1, 10
+      end
+
       let(:commodity) do
         create :commodity, :with_description, description: 'test description'
       end
 
-      before do
-        # Make sure index is fresh
-        TradeTariffBackend.search_client.drop_index(TradeTariffBackend.search_index_for('search', commodity))
-        TradeTariffBackend.search_client.create_index(TradeTariffBackend.search_index_for('search', commodity))
+      let(:search_index) { Search::CommodityIndex.new }
+
+      let(:search_result) do
+        TradeTariffBackend.search_client.search q: 'test', index: search_index.name
       end
 
       it 'bulk indexes all model entries' do
-        described_class.new.perform(
-          'search',
-          commodity.class.name,
-          1,
-          10,
-        )
-        sleep 2
-
-        search_result = TradeTariffBackend.search_client.search q: 'test', index: TradeTariffBackend.search_index_for('search', commodity).name
-
         expect(search_result.hits.total.value).to be >= 1
+      end
+
+      it 'has bulk indexed the expected commodity' do
         expect(search_result.hits.hits.first._source.goods_nomenclature_item_id).to eq commodity.goods_nomenclature_item_id
       end
     end


### PR DESCRIPTION
### Jira link

[HOTT-1676](https://transformuk.atlassian.net/browse/HOTT-1676)

### What?

I have added/removed/altered:

- [x] Changed SearchClient to require an explicit index when indexing a single model
- [x] Changed the ElasticSearch Sequel plugin to allow specifying one or more indexes to update from a model
- [x] Changed the BuildIndexPageWorker to operate on a index instead of a model
- [x] Generalised the mechanism for excluding an index from the Search
- [x] Allow the ES Sequel extension to silently ignore when an index does not yet exist 

### Why?

I am doing this because:

- This allows us to have multiple indexes for a given model class within the new search namespace
- Those indexes can exclude themselves from Search lookups
- This will allow us to 'evolve' the index definitions by just adding additional V2/V3/V4 indexes and then dropping the old ones in subsequent PRs - the new ones will get created automatically in the overnight sync

### Have you? (optional)

- [x] Added documentation for new apis
- [x] Added new environment variables with correct values to all apps in all spaces

### Deployment risks (optional)

- Changes the parameters contents (but not count) of the BuildIndexPageWorker, there is still compatibility with the old syntax though so any queued jobs will still complete sucessfully.
