### PR TITLE
HOTT-1698: Filter in only erga omnes third country overview measures

### DIFF
--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -26,9 +26,14 @@ class Commodity < GoodsNomenclature
            .filter('goods_nomenclatures.goods_nomenclature_item_id LIKE ?', chapter_id)
   }
 
-  one_to_many :overview_measures, key: {}, primary_key: {}, dataset: -> {
-    measures_dataset.filter(measures__measure_type_id: MeasureType::OVERVIEW_MEASURE_TYPES)
-  }, class_name: 'Measure'
+  one_to_many :overview_measures, key: {}, primary_key: {}, class_name: 'Measure', dataset: lambda {
+    measures_dataset
+      .filter(measures__measure_type_id: MeasureType::OVERVIEW_MEASURE_TYPES)
+      .or(
+        measures__measure_type_id: MeasureType::THIRD_COUNTRY,
+        measures__geographical_area_id: GeographicalArea::ERGA_OMNES_ID,
+      )
+  }
 
   one_to_many :search_references, key: :referenced_id, primary_key: :code, reciprocal: :referenced, conditions: { referenced_class: 'Commodity' },
                                   adder: proc { |search_reference| search_reference.update(referenced_id: code, productline_suffix: producline_suffix, referenced_class: 'Commodity') },

--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -13,7 +13,7 @@ class MeasureType < Sequel::Model
   DEFAULT_EXCLUDED_TYPES = %w[442 447 SPL].freeze
   XI_EXCLUDED_TYPES = DEFAULT_EXCLUDED_TYPES + NATIONAL_PR_TYPES + QUOTA_TYPES
   UK_EXCLUDED_TYPES = DEFAULT_EXCLUDED_TYPES
-  OVERVIEW_MEASURE_TYPES = MeasureType::VAT_TYPES + MeasureType::SUPPLEMENTARY_TYPES + MeasureType::THIRD_COUNTRY # Used for a frontend overview of the most important applicable measures
+  OVERVIEW_MEASURE_TYPES = MeasureType::VAT_TYPES + MeasureType::SUPPLEMENTARY_TYPES # See Commodity#overview_measures
 
   DEFENSE_MEASURES = [
     '551', # Provisional anti-dumping duty

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -155,6 +155,11 @@ FactoryBot.define do
       measure_type_id { MeasureType::THIRD_COUNTRY.sample }
     end
 
+    trait :third_country_overview do
+      geographical_area_id { GeographicalArea::ERGA_OMNES_ID }
+      third_country
+    end
+
     trait :vat do
       measure_type_id { '305' }
     end

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -180,6 +180,66 @@ RSpec.describe Commodity do
       end
     end
 
+    describe '#overview_measures' do
+      subject(:overview_measures) { commodity.overview_measures }
+
+      let(:commodity) { create(:commodity) }
+
+      before { measure }
+
+      context 'when a third country measure that is not explicitly erga omnes' do
+        let(:measure) do
+          create(
+            :measure,
+            :with_base_regulation,
+            :third_country,
+            goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+          )
+        end
+
+        it { is_expected.not_to include(measure) }
+      end
+
+      context 'when a third country measure that is explicitly erga omnes' do
+        let(:measure) do
+          create(
+            :measure,
+            :with_base_regulation,
+            :third_country_overview,
+            goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+          )
+        end
+
+        it { is_expected.to include(measure) }
+      end
+
+      context 'when a vat measure' do
+        let(:measure) do
+          create(
+            :measure,
+            :with_base_regulation,
+            :vat,
+            goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+          )
+        end
+
+        it { is_expected.to include(measure) }
+      end
+
+      context 'when a supplementary unit measure' do
+        let(:measure) do
+          create(
+            :measure,
+            :with_base_regulation,
+            :supplementary,
+            goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+          )
+        end
+
+        it { is_expected.to include(measure) }
+      end
+    end
+
     describe 'measure duplication' do
       # sometimes measures have the same base regulation id and
       # validity_start date
@@ -188,21 +248,21 @@ RSpec.describe Commodity do
       let(:commodity)    { create :commodity, :with_indent, validity_start_date: 3.years.ago.beginning_of_day }
       let!(:measure1)    do
         create :measure, :with_base_regulation, measure_sid: 1,
-                         measure_type_id: measure_type.measure_type_id,
-                         additional_code_type_id: nil,
-                         goods_nomenclature_sid: commodity.goods_nomenclature_sid,
-                         validity_start_date: 1.year.ago.beginning_of_day
+                                                measure_type_id: measure_type.measure_type_id,
+                                                additional_code_type_id: nil,
+                                                goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+                                                validity_start_date: 1.year.ago.beginning_of_day
       end
       let!(:measure2) do
         create :measure, :with_base_regulation, measure_sid: 2,
-                         measure_generating_regulation_id: measure1.measure_generating_regulation_id,
-                         geographical_area_id: measure1.geographical_area_id,
-                         measure_type_id: measure_type.measure_type_id,
-                         geographical_area_sid: measure1.geographical_area_sid,
-                         goods_nomenclature_sid: commodity.goods_nomenclature_sid,
-                         additional_code_type_id: measure1.additional_code_type_id,
-                         additional_code_id: measure1.additional_code_id,
-                         validity_start_date: 2.years.ago.beginning_of_day
+                                                measure_generating_regulation_id: measure1.measure_generating_regulation_id,
+                                                geographical_area_id: measure1.geographical_area_id,
+                                                measure_type_id: measure_type.measure_type_id,
+                                                geographical_area_sid: measure1.geographical_area_sid,
+                                                goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+                                                additional_code_type_id: measure1.additional_code_type_id,
+                                                additional_code_id: measure1.additional_code_id,
+                                                validity_start_date: 2.years.ago.beginning_of_day
       end
 
       it 'groups measures by measure_generating_regulation_id and picks latest one' do
@@ -219,14 +279,14 @@ RSpec.describe Commodity do
         let(:commodity1)          { create :commodity, :with_indent }
         let(:export_measure)      do
           create :measure, :with_base_regulation, measure_type_id: export_measure_type.measure_type_id,
-                           goods_nomenclature_sid: commodity1.goods_nomenclature_sid
+                                                  goods_nomenclature_sid: commodity1.goods_nomenclature_sid
         end
 
         let(:import_measure_type) { create :measure_type, :import }
         let(:commodity2)          { create :commodity, :with_indent }
         let(:import_measure)      do
           create :measure, :with_base_regulation, measure_type_id: import_measure_type.measure_type_id,
-                           goods_nomenclature_sid: commodity2.goods_nomenclature_sid
+                                                  goods_nomenclature_sid: commodity2.goods_nomenclature_sid
         end
 
         it 'fetches measures that have measure type with proper trade movement code' do
@@ -252,7 +312,7 @@ RSpec.describe Commodity do
         end
         let!(:export_measure) do
           create :measure, :with_base_regulation, export_refund_nomenclature_sid: export_refund_nomenclature.export_refund_nomenclature_sid,
-                           goods_nomenclature_item_id: commodity.goods_nomenclature_item_id
+                                                  goods_nomenclature_item_id: commodity.goods_nomenclature_item_id
         end
 
         it 'includes measures that belongs to related export refund nomenclature' do
@@ -321,30 +381,30 @@ RSpec.describe Commodity do
       let!(:modification_regulation) { create :modification_regulation, effective_end_date: Time.zone.now.ago(1.month) }
       let!(:measure1) do
         create :measure, :with_base_regulation,
-                         measure_generating_regulation_id: modification_regulation.modification_regulation_id,
-                         validity_end_date: Time.zone.now.ago(30.months),
-                         goods_nomenclature_sid: commodity.goods_nomenclature_sid,
-                         validity_start_date: Time.zone.now.ago(10.years),
-                         measure_type_id: measure_type.measure_type_id,
-                         geographical_area_sid: 1
+               measure_generating_regulation_id: modification_regulation.modification_regulation_id,
+               validity_end_date: Time.zone.now.ago(30.months),
+               goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+               validity_start_date: Time.zone.now.ago(10.years),
+               measure_type_id: measure_type.measure_type_id,
+               geographical_area_sid: 1
       end
       let!(:measure2) do
         create :measure, :with_base_regulation,
-                         measure_generating_regulation_id: modification_regulation.modification_regulation_id,
-                         goods_nomenclature_sid: commodity.goods_nomenclature_sid,
-                         measure_type_id: measure_type.measure_type_id,
-                         validity_start_date: Time.zone.now.ago(10.years),
-                         validity_end_date: Time.zone.now.ago(18.months),
-                         geographical_area_sid: 2
+               measure_generating_regulation_id: modification_regulation.modification_regulation_id,
+               goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+               measure_type_id: measure_type.measure_type_id,
+               validity_start_date: Time.zone.now.ago(10.years),
+               validity_end_date: Time.zone.now.ago(18.months),
+               geographical_area_sid: 2
       end
       let!(:measure3) do
         create :measure, :with_base_regulation,
-                         measure_generating_regulation_id: modification_regulation.modification_regulation_id,
-                         goods_nomenclature_sid: commodity.goods_nomenclature_sid,
-                         measure_type_id: measure_type.measure_type_id,
-                         validity_start_date: Time.zone.now.ago(10.years),
-                         validity_end_date: nil,
-                         geographical_area_sid: 3
+               measure_generating_regulation_id: modification_regulation.modification_regulation_id,
+               goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+               measure_type_id: measure_type.measure_type_id,
+               validity_start_date: Time.zone.now.ago(10.years),
+               validity_end_date: nil,
+               geographical_area_sid: 3
       end
 
       it 'measure validity date supercedes regulation validity date' do

--- a/spec/models/measure_type_spec.rb
+++ b/spec/models/measure_type_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe MeasureType do
 
   describe '#rules_of_origin_apply?' do
     shared_examples 'a rules of origin measure' do |measure_type_id|
-      subject(:measure_type) { build :measure_type, measure_type_id: measure_type_id }
+      subject(:measure_type) { build :measure_type, measure_type_id: }
 
       it { is_expected.to be_rules_of_origin_apply }
     end

--- a/spec/serializers/cache/heading_serializer_spec.rb
+++ b/spec/serializers/cache/heading_serializer_spec.rb
@@ -27,8 +27,7 @@ RSpec.describe Cache::HeadingSerializer do
       :measure,
       :with_measure_type,
       :with_base_regulation,
-      :third_country,
-      goods_nomenclature: commodity,
+      :third_country_overview,
       goods_nomenclature_sid: commodity.goods_nomenclature_sid,
     )
   end

--- a/spec/services/heading_service/cached_heading_service_spec.rb
+++ b/spec/services/heading_service/cached_heading_service_spec.rb
@@ -3,7 +3,6 @@ RSpec.describe HeadingService::CachedHeadingService do
     create :heading, :non_grouping,
            :with_description
   end
-  let(:measure_type) { create :measure_type, measure_type_id: '103' }
   let(:actual_date) { Time.zone.today }
 
   describe '#serializable_hash' do
@@ -21,13 +20,7 @@ RSpec.describe HeadingService::CachedHeadingService do
                  :with_indent,
                  goods_nomenclature_item_id: "#{heading.short_code}#{6.times.map { Random.rand(9) }.join}"
         end
-        let!(:measure) do
-          create :measure,
-                :with_base_regulation,
-                 measure_type_id: measure_type.measure_type_id,
-                 goods_nomenclature: commodity,
-                 goods_nomenclature_sid: commodity.goods_nomenclature_sid
-        end
+        let!(:measure) { create(:measure, :with_base_regulation, :third_country_overview, goods_nomenclature_sid: commodity.goods_nomenclature_sid) }
         let(:serializable_hash) { described_class.new(heading.reload, actual_date).serializable_hash }
 
         it 'contains chapter' do
@@ -58,12 +51,7 @@ RSpec.describe HeadingService::CachedHeadingService do
                  :with_indent,
                  goods_nomenclature_item_id: "#{heading.short_code}#{6.times.map { Random.rand(9) }.join}"
         end
-        let!(:measure) do
-          create :measure,
-                 measure_type_id: measure_type.measure_type_id,
-                 goods_nomenclature: commodity,
-                 goods_nomenclature_sid: commodity.goods_nomenclature_sid
-        end
+        let!(:measure) { create(:measure, :with_base_regulation, :third_country_overview, goods_nomenclature_sid: commodity.goods_nomenclature_sid) }
         let(:serializable_hash) { described_class.new(heading.reload, actual_date).serializable_hash }
 
         it 'does not contain footnotes' do
@@ -86,12 +74,7 @@ RSpec.describe HeadingService::CachedHeadingService do
                  :with_indent,
                  goods_nomenclature_item_id: "#{heading.short_code}#{6.times.map { Random.rand(9) }.join}"
         end
-        let!(:measure) do
-          create :measure,
-                 measure_type_id: measure_type.measure_type_id,
-                 goods_nomenclature: commodity,
-                 goods_nomenclature_sid: commodity.goods_nomenclature_sid
-        end
+        let!(:measure) { create(:measure, :with_base_regulation, :third_country_overview, goods_nomenclature_sid: commodity.goods_nomenclature_sid) }
         let(:serializable_hash) { described_class.new(heading.reload, actual_date).serializable_hash }
 
         it 'does not contain chapter' do
@@ -115,12 +98,7 @@ RSpec.describe HeadingService::CachedHeadingService do
                  validity_end_date: Time.zone.yesterday,
                  goods_nomenclature_item_id: "#{heading.short_code}#{6.times.map { Random.rand(9) }.join}"
         end
-        let!(:measure) do
-          create :measure,
-                 measure_type_id: measure_type.measure_type_id,
-                 goods_nomenclature: commodity,
-                 goods_nomenclature_sid: commodity.goods_nomenclature_sid
-        end
+        let!(:measure) { create(:measure, :third_country_overview, goods_nomenclature_sid: commodity.goods_nomenclature_sid) }
         let(:serializable_hash) { described_class.new(heading.reload, actual_date).serializable_hash }
 
         it 'does not contain commodities' do
@@ -143,10 +121,10 @@ RSpec.describe HeadingService::CachedHeadingService do
         end
         let!(:measure) do
           create :measure,
+                 :with_base_regulation,
+                 :third_country_overview,
                  validity_start_date: 1.week.ago.beginning_of_day,
                  validity_end_date: Time.zone.yesterday,
-                 measure_type_id: measure_type.measure_type_id,
-                 goods_nomenclature: commodity,
                  goods_nomenclature_sid: commodity.goods_nomenclature_sid
         end
         let(:serializable_hash) { described_class.new(heading.reload, actual_date).serializable_hash }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1698

### What?

I have added/removed/altered:

- [x] Added an additional filter on the overview measures dataset that excludes non-erga-omnes third country measures
- [x] Added coverage for the overview measure filtering

### Why?

I am doing this because:

- We need to make sure that country-specific measures aren't part of the
overview of a commodity on the subheading and heading pages in the
frontend. It doesn't make sense to show these for all users on an
overview
