### PR TITLE
HOTT-1687 Create releases from hotfix PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -541,6 +541,7 @@ workflows:
             branches:
               ignore:
                 - main
+                - /^hotfix\/.+/
                 - /^dependabot\/.*/
       - deploy_dev:
           matrix:
@@ -554,6 +555,7 @@ workflows:
               ignore:
                 - main
                 - /^dependabot\/.*/
+                - /^hotfix\/.+/
           requires:
             - test
             - build_dev
@@ -564,6 +566,7 @@ workflows:
             branches:
               ignore:
                 - main
+                - /^hotfix\/.+/
                 - /^dependabot\/.*/
           requires:
             - deploy_dev
@@ -574,6 +577,7 @@ workflows:
             branches:
               only:
                 - main
+                - /^hotfix\/.+/
       - deploy_main_to_staging:
           matrix:
             parameters:
@@ -590,6 +594,7 @@ workflows:
             branches:
               only:
                 - main
+                - /^hotfix\/.+/
           requires:
             - deploy_main_to_staging
       - hold_create_release:
@@ -598,6 +603,7 @@ workflows:
             branches:
               only:
                 - main
+                - /^hotfix\/.+/
           requires:
             - deploy_main_to_staging
       - tariff/create-production-release:
@@ -607,6 +613,7 @@ workflows:
             branches:
               only:
                 - main
+                - /^hotfix\/.+/
           requires:
             - hold_create_release
       - deploy_release_to_staging:


### PR DESCRIPTION
### Jira link

HOTT-1687

### What?

I have added/removed/altered:

- [x] Added the ability to push urgent changes to through from PR through to production

### Why?

I am doing this because:

- It avoids the need to choose between no release, reverting changes that have not yet been QAd, or requiring urgent QA decisions. 

### Deployment risks (optional)

- Changes production deployment path
