### PR TITLE
Fixed double notification of backend release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,6 +519,11 @@ jobs:
           environment_key: "production"
           service: << parameters.service >>
       - sentry-release
+
+  notify_production_deployment:
+    docker:
+      - image: cimg/ruby:3.1.2
+    steps:
       - tariff/notify-production-release:
           app-name: Backend
           slack-channel: trade_tariff
@@ -677,3 +682,12 @@ workflows:
               ignore: /.*/
           requires:
             - hold_deploy_production
+      - notify_production_deployment:
+          context: trade-tariff
+          filters:
+            tags:
+              only: /^release-202[\d-]+/
+            branches:
+              ignore: /.*/
+          requires:
+            - deploy_production


### PR DESCRIPTION
### Jira link

HOTT-???

### What?

I have added/removed/altered:

- [x] Fixed the double notification error upon backend release

### Why?

I am doing this because:

- it creates unnecessary noise

### Deployment risks (optional)

- Changes an production deployment pipeline
