### PR TITLE
HOTT-1628: Fixes ordering of headings and chapters

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -3,7 +3,10 @@ class Chapter < GoodsNomenclature
   plugin :elasticsearch
 
   set_dataset filter('goods_nomenclatures.goods_nomenclature_item_id LIKE ?', '__00000000')
-              .order(Sequel.asc(:goods_nomenclature_item_id))
+              .order(
+                Sequel.asc(:goods_nomenclature_item_id),
+                Sequel.asc(:goods_nomenclatures__producline_suffix),
+              )
 
   set_primary_key [:goods_nomenclature_sid]
 

--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -6,7 +6,10 @@ class Heading < GoodsNomenclature
 
   set_dataset filter('goods_nomenclatures.goods_nomenclature_item_id LIKE ?', '____000000')
               .filter('goods_nomenclatures.goods_nomenclature_item_id NOT LIKE ?', '__00______')
-              .order(Sequel.asc(:goods_nomenclature_item_id))
+              .order(
+                Sequel.asc(:goods_nomenclature_item_id),
+                Sequel.asc(:goods_nomenclatures__producline_suffix),
+              )
 
   set_primary_key [:goods_nomenclature_sid]
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1719

### What?

I have added/removed/altered:

- [x] Added explicit ordering of headings and chapters

### Why?

I am doing this because:

- This is required to make sure the goods nomenclature mapper returns the correct root headings of a chapter and is the only correct implementation
