### PR TITLE
HOTT-1702: Adds v2 search index

### DIFF
--- a/app/elastic_search_indexes/search/goods_nomenclature_index.rb
+++ b/app/elastic_search_indexes/search/goods_nomenclature_index.rb
@@ -1,0 +1,148 @@
+module Search
+  class GoodsNomenclatureIndex < ::SearchIndex
+    def dataset
+      TimeMachine.now do
+        GoodsNomenclature.actual
+      end
+    end
+
+    def eager_load_graph
+      %i[
+        goods_nomenclature_indents
+        chapter
+        heading
+        ancestors
+      ]
+    end
+
+    def definition
+      {
+        settings: {
+          index: {
+            analysis: {
+              analyzer: {
+                english_exact: {
+                  tokenizer: 'standard',
+                  filter: %w[lowercase],
+                },
+                english: {
+                  tokenizer: 'standard',
+                  filter: %w[
+                    english_possessive_stemmer
+                    lowercase
+                    english_stop
+                    english_stemmer
+                  ],
+                },
+              },
+              filter: {
+                english_stop: {
+                  type: 'stop',
+                  stopwords: '_english_',
+                },
+                english_stemmer: {
+                  type: 'stemmer',
+                  language: 'english',
+                },
+                english_possessive_stemmer: {
+                  type: 'stemmer',
+                  language: 'possessive_english',
+                },
+              },
+              char_filter: {
+                standardise_quotes: {
+                  type: 'mapping',
+                  mappings: [
+                    '\\u0091=>\\u0027',
+                    '\\u0092=>\\u0027',
+                    '\\u2018=>\\u0027',
+                    '\\u2019=>\\u0027',
+                    '\\u201B=>\\u0027',
+                  ],
+                },
+              },
+            },
+          },
+        },
+        mappings: {
+          properties: {
+            goods_nomenclature_class: {
+              analyzer: 'english',
+              type: 'text',
+              fields: {
+                raw: {
+                  type: 'keyword',
+                },
+              },
+            },
+            goods_nomenclature_item_id: {
+              type: 'text',
+              fields: {
+                raw: {
+                  type: 'keyword',
+                },
+              },
+            },
+            producline_suffix: {
+              type: 'text',
+              fields: {
+                raw: {
+                  type: 'keyword',
+                },
+              },
+            },
+            description: {
+              analyzer: 'english',
+              type: 'text',
+              fields: {
+                exact: {
+                  type: 'text',
+                  analyzer: 'english_exact',
+                },
+              },
+            },
+            description_indexed: {
+              analyzer: 'english',
+              type: 'text',
+            },
+            chapter_description: {
+              analyzer: 'english',
+              type: 'text',
+            },
+            heading_description: {
+              type: 'text',
+              analyzer: 'english',
+            },
+            search_references: {
+              analyzer: 'english',
+              type: 'text',
+            },
+            ancestors: {
+              type: 'nested',
+              properties: {
+                goods_nomenclature_item_id: { type: 'text' },
+                producline_suffix: { type: 'text' },
+                class: { type: 'text' },
+                description: { type: 'text' },
+              },
+            },
+            validity_start_date: {
+              type: 'text',
+            },
+            validity_end_date: {
+              type: 'text',
+            },
+            heading_id: {
+              type: 'text',
+              analyzer: 'english',
+            },
+            chapter_id: {
+              type: 'text',
+              analyzer: 'english',
+            },
+          },
+        },
+      }
+    end
+  end
+end

--- a/app/elastic_search_indexes/search_index.rb
+++ b/app/elastic_search_indexes/search_index.rb
@@ -33,6 +33,10 @@ class SearchIndex
     false
   end
 
+  def eager_load_graph
+    []
+  end
+
   def exclude_from_search_results?
     !goods_nomenclature?
   end

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -82,6 +82,12 @@ module TradeTariffBackend
       end
     end
 
+    def v2_reindex(indexer = v2_search_client)
+      indexer.update_all
+    rescue StandardError => e
+      Mailer.reindex_exception(e).deliver_now
+    end
+
     def recache(indexer = cache_client)
       indexer.update_all
     rescue StandardError => e
@@ -105,6 +111,14 @@ module TradeTariffBackend
       )
     end
 
+    def v2_search_client
+      @v2_search_client ||= SearchClient.new(
+        Elasticsearch::Client.new,
+        indexes: v2_search_indexes,
+        index_page_size: 2000,
+      )
+    end
+
     def cache_client
       @cache_client ||= SearchClient.new(
         Elasticsearch::Client.new,
@@ -121,6 +135,12 @@ module TradeTariffBackend
         Search::HeadingIndex,
         Search::SearchReferenceIndex,
         Search::SectionIndex,
+      ].map(&:new)
+    end
+
+    def v2_search_indexes
+      [
+        Search::GoodsNomenclatureIndex,
       ].map(&:new)
     end
 

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -27,7 +27,11 @@ class GoodsNomenclature < Sequel::Model
   one_to_one :chapter, class_name: name, class: self do |_ds|
     Chapter
       .actual
-      .where(goods_nomenclature_item_id: chapter_id)
+      .where(goods_nomenclature_item_id: chapter_code)
+  end
+
+  one_to_one :heading, class_name: name, class: self do |_ds|
+    Heading.actual.where(goods_nomenclature_item_id: heading_code)
   end
 
   one_to_many :ancestors, class_name: name, class: self do |_ds|
@@ -180,6 +184,22 @@ class GoodsNomenclature < Sequel::Model
 
   def chapter_id
     goods_nomenclature_item_id.first(2) + '0' * 8
+  end
+
+  def heading_code
+    heading_short_code + '0' * 6
+  end
+
+  def chapter_code
+    chapter_short_code + '0' * 8
+  end
+
+  def heading_short_code
+    goods_nomenclature_item_id.first(4)
+  end
+
+  def chapter_short_code
+    goods_nomenclature_item_id.first(2)
   end
 
   def code

--- a/app/serializers/search/goods_nomenclature_serializer.rb
+++ b/app/serializers/search/goods_nomenclature_serializer.rb
@@ -1,0 +1,70 @@
+module Search
+  class GoodsNomenclatureSerializer < ::Serializer
+    def serializable_hash(_opts = {})
+      {
+        goods_nomenclature_item_id:,
+        heading_id: heading_short_code,
+        chapter_id: chapter_short_code,
+        producline_suffix:,
+        goods_nomenclature_class:,
+        description:,
+        description_indexed: description,
+        chapter_description:,
+        heading_description:,
+        search_references:,
+        ancestors:,
+      }
+    end
+
+    private
+
+    def goods_nomenclature_class(goods_nomenclature = self)
+      class_name = GoodsNomenclature
+        .sti_load(goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id)
+        .class
+        .name
+
+      if class_name == 'Commodity'
+        goods_nomenclature.declarable? ? 'Commodity' : 'Subheading'
+      else
+        class_name
+      end
+    end
+
+    def chapter_description
+      chapter&.description unless chapter?
+    end
+
+    def heading_description
+      heading&.description unless heading?
+    end
+
+    def search_references
+      SearchReference.where(referenced_id:, referenced_class:, productline_suffix: producline_suffix).pluck(:title).join(', ')
+    end
+
+    def referenced_id
+      case referenced_class
+      when 'Chapter' then chapter_id
+      when 'Heading' then heading_id
+      else
+        goods_nomenclature_item_id
+      end
+    end
+
+    def referenced_class
+      @referenced_class ||= goods_nomenclature_class
+    end
+
+    def ancestors
+      super.map do |ancestor|
+        {
+          goods_nomenclature_item_id: ancestor.goods_nomenclature_item_id,
+          productline_suffix: ancestor.producline_suffix,
+          goods_nomenclature_class: goods_nomenclature_class(ancestor),
+          description: ancestor.description,
+        }
+      end
+    end
+  end
+end

--- a/app/workers/build_index_page_worker.rb
+++ b/app/workers/build_index_page_worker.rb
@@ -12,7 +12,7 @@ class BuildIndexPageWorker
       body: serialize_for(
         :index,
         index,
-        index.dataset.paginate(page_number, page_size),
+        index.dataset.eager(index.eager_load_graph).paginate(page_number, page_size),
       ),
     )
   end

--- a/app/workers/reindex_models_worker.rb
+++ b/app/workers/reindex_models_worker.rb
@@ -6,6 +6,7 @@ class ReindexModelsWorker
   def perform
     logger.info 'Reindexing models in Elastic Search...'
     TradeTariffBackend.reindex
+    TradeTariffBackend.v2_reindex
     logger.info 'Reindexing of models completed'
   end
 end

--- a/spec/elastic_search_indexes/search/goods_nomenclature_index_spec.rb
+++ b/spec/elastic_search_indexes/search/goods_nomenclature_index_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Search::GoodsNomenclatureIndex do
+  subject(:instance) { described_class.new 'testnamespace' }
+
+  it { is_expected.to have_attributes type: 'goods_nomenclature' }
+  it { is_expected.to have_attributes name: 'testnamespace-goods_nomenclatures' }
+  it { is_expected.to have_attributes model_class: GoodsNomenclature }
+  it { is_expected.to have_attributes serializer: Search::GoodsNomenclatureSerializer }
+
+  describe '#serialize_record' do
+    subject { instance.serialize_record record }
+
+    let(:record) { create :goods_nomenclature }
+
+    it { is_expected.to include 'goods_nomenclature_item_id' => record.goods_nomenclature_item_id }
+  end
+
+  describe '#dataset' do
+    subject(:dataset) { described_class.new('testnamespace').dataset }
+
+    it { is_expected.to be_a(Sequel::Postgres::Dataset) }
+    it { expect(dataset.sql).to match(/(validity_start_date|validity_end_date)/) }
+  end
+end

--- a/spec/factories/commodity_factory.rb
+++ b/spec/factories/commodity_factory.rb
@@ -11,12 +11,36 @@ FactoryBot.define do
     trait :with_indent do
       after(:create) do |commodity, evaluator|
         create(:goods_nomenclature_indent,
-                          goods_nomenclature_sid: commodity.goods_nomenclature_sid,
-                          goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
-                          validity_start_date: commodity.validity_start_date,
-                          validity_end_date: commodity.validity_end_date,
-                          productline_suffix: commodity.producline_suffix,
-                          number_indents: evaluator.indents)
+               goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+               goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+               validity_start_date: commodity.validity_start_date,
+               validity_end_date: commodity.validity_end_date,
+               productline_suffix: commodity.producline_suffix,
+               number_indents: evaluator.indents)
+      end
+    end
+
+    trait :with_ancestors do
+      with_description
+      path { Sequel.pg_array([1, 2], :integer) }
+      description { 'Horses' }
+      goods_nomenclature_sid { 3 }
+
+      after(:create) do |commodity, _evaluator|
+        create(
+          :chapter,
+          :with_description,
+          description: 'Live horses, asses, mules and hinnies',
+          goods_nomenclature_sid: 1,
+          goods_nomenclature_item_id: "#{commodity.goods_nomenclature_item_id.first(2)}00000000",
+        )
+        create(
+          :heading,
+          :with_description,
+          description: 'Live animals',
+          goods_nomenclature_sid: 2,
+          goods_nomenclature_item_id: "#{commodity.goods_nomenclature_item_id.first(4)}000000",
+        )
       end
     end
 
@@ -42,29 +66,29 @@ FactoryBot.define do
         commodity.producline_suffix = '80'
         commodity.save
         create(:goods_nomenclature_indent,
-                          goods_nomenclature_sid: commodity.goods_nomenclature_sid,
-                          goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
-                          validity_start_date: commodity.validity_start_date,
-                          validity_end_date: commodity.validity_end_date,
-                          productline_suffix: commodity.producline_suffix,
-                          number_indents: 1)
+               goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+               goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+               validity_start_date: commodity.validity_start_date,
+               validity_end_date: commodity.validity_end_date,
+               productline_suffix: commodity.producline_suffix,
+               number_indents: 1)
 
         # Add another intermediate level
         create(:commodity,
-                          :with_indent,
-                          goods_nomenclature_item_id: (item_id + 1).to_s,
-                          producline_suffix: '10',
-                          indents: 2)
+               :with_indent,
+               goods_nomenclature_item_id: (item_id + 1).to_s,
+               producline_suffix: '10',
+               indents: 2)
 
         # Add two leaf commodities
         create(:commodity,
-                          :with_indent,
-                          goods_nomenclature_item_id: (item_id + 1).to_s,
-                          indents: 3)
+               :with_indent,
+               goods_nomenclature_item_id: (item_id + 1).to_s,
+               indents: 3)
         create(:commodity,
-                          :with_indent,
-                          goods_nomenclature_item_id: (item_id + 2).to_s,
-                          indents: 3)
+               :with_indent,
+               goods_nomenclature_item_id: (item_id + 2).to_s,
+               indents: 3)
         commodity.reload
       end
     end

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -347,6 +347,30 @@ RSpec.describe GoodsNomenclature do
     end
   end
 
+  describe '#chapter_code' do
+    subject(:chapter_code) { build(:goods_nomenclature, goods_nomenclature_item_id: '0101210000').chapter_code }
+
+    it { is_expected.to eq('0100000000') }
+  end
+
+  describe '#heading_code' do
+    subject(:heading_code) { build(:goods_nomenclature, goods_nomenclature_item_id: '0101210000').heading_code }
+
+    it { is_expected.to eq('0101000000') }
+  end
+
+  describe '#chapter_short_code' do
+    subject(:chapter_short_code) { build(:goods_nomenclature, goods_nomenclature_item_id: '0101210000').chapter_short_code }
+
+    it { is_expected.to eq('01') }
+  end
+
+  describe '#heading_short_code' do
+    subject(:heading_short_code) { build(:goods_nomenclature, goods_nomenclature_item_id: '0101210000').heading_short_code }
+
+    it { is_expected.to eq('0101') }
+  end
+
   describe '#to_s' do
     let(:gono) { create(:commodity, goods_nomenclature_item_id: '8056116321', indents: 4) }
 

--- a/spec/serializers/search/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/search/goods_nomenclature_serializer_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe Search::GoodsNomenclatureSerializer do
+  describe '#serializable_hash' do
+    subject(:serializable_hash) { described_class.new(goods_nomenclature).serializable_hash }
+
+    let(:goods_nomenclature) { GoodsNomenclature.find(goods_nomenclature_item_id: '0101210000') }
+
+    let(:pattern) do
+      {
+        goods_nomenclature_item_id: '0101210000',
+        heading_id: '0101',
+        chapter_id: '01',
+        producline_suffix: '80',
+        goods_nomenclature_class: 'Commodity',
+        chapter_description: 'Live horses, asses, mules and hinnies',
+        heading_description: 'Live animals',
+        description: 'Horses',
+        description_indexed: 'Horses',
+        search_references: 'secret sauce',
+        ancestors: [
+          {
+            goods_nomenclature_item_id: '0100000000',
+            productline_suffix: '80',
+            goods_nomenclature_class: 'Chapter',
+            description: 'Live horses, asses, mules and hinnies',
+          },
+          {
+            goods_nomenclature_item_id: '0101000000',
+            productline_suffix: '80',
+            goods_nomenclature_class: 'Heading',
+            description: 'Live animals',
+          },
+        ],
+      }
+    end
+
+    before do
+      commodity = create(
+        :commodity,
+        :with_ancestors,
+        goods_nomenclature_item_id: '0101210000',
+        producline_suffix: '80',
+      )
+
+      create(:search_reference, referenced: commodity, title: 'secret sauce')
+    end
+
+    it { is_expected.to match_json_expression(pattern) }
+  end
+end

--- a/spec/workers/reindex_models_worker_spec.rb
+++ b/spec/workers/reindex_models_worker_spec.rb
@@ -9,16 +9,21 @@ RSpec.describe ReindexModelsWorker, type: :worker do
 
       allow(BuildIndexPageWorker).to receive(:perform_async).and_call_original
       allow(TradeTariffBackend).to receive(:reindex).and_call_original
+      allow(TradeTariffBackend).to receive(:v2_reindex).and_call_original
 
       perform
     end
 
-    it 'calls recache' do
+    it 'calls reindex' do
       expect(TradeTariffBackend).to have_received(:reindex)
     end
 
+    it 'calls v2_reindex' do
+      expect(TradeTariffBackend).to have_received(:v2_reindex)
+    end
+
     it 'queues workers to build the index' do
-      expect(BuildIndexPageWorker).to have_received(:perform_async)
+      expect(BuildIndexPageWorker).to have_received(:perform_async).twice
     end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1702

### What?

I have added/removed/altered:

- [x] Added v2 search index for goods nomenclatures
- [x] Plumbed together the population of this index

### Why?

I am doing this because:

- This is required so we can do some more intelligent querying of the goods nomenclature and their ancestors and is part of a wider rollout of improvements to search
