### PR TITLE
Removes the normalize measure unit feature flag

### DIFF
--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -202,10 +202,6 @@ module TradeTariffBackend
       @chief_cds_guidance ||= ChiefCdsGuidance.load_default
     end
 
-    def normalised_measure_units?
-      ENV['NORMALISED_MEASURE_UNITS'].to_s == 'true'
-    end
-
     def handle_cascade_soft_deletes?
       ENV['SOFT_DELETES_CASCADE'].to_s == 'true'
     end

--- a/app/models/measurement_unit.rb
+++ b/app/models/measurement_unit.rb
@@ -1,5 +1,5 @@
 class MeasurementUnit < Sequel::Model
-  MEASUREMENT_UNIT_OVERLAY_FILE = TradeTariffBackend.normalised_measure_units? ? 'db/measurement_units_20220428.json' : 'db/measurement_units.json'
+  MEASUREMENT_UNIT_OVERLAY_FILE = 'db/measurement_units_20220428.json'.freeze
 
   plugin :oplog, primary_key: :measurement_unit_code
   plugin :time_machine


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Removed normalised_measure_units? feature flag

### Why?

I am doing this because:

- This feature has been switched on for a long time in production and has gone through rigorous testing by @madviv and by me.