### PR TITLE
HOTT-1703: Adds negation term removal to description indexed

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -111,7 +111,7 @@ class GoodsNomenclature < Sequel::Model
     end
   end
 
-  delegate :description, :formatted_description, to: :goods_nomenclature_description, allow_nil: true
+  delegate :description, :description_indexed, :formatted_description, to: :goods_nomenclature_description, allow_nil: true
 
   one_to_one :goods_nomenclature_origin, key: %i[goods_nomenclature_item_id
                                                  productline_suffix],

--- a/app/models/goods_nomenclature_description.rb
+++ b/app/models/goods_nomenclature_description.rb
@@ -1,4 +1,6 @@
 class GoodsNomenclatureDescription < Sequel::Model
+  DESCRIPTION_NEGATION_REGEX = /(?<keep>\A.*)(?<remove>, (?<excluded-term>neither|other than|excluding|not including).*\z)/
+
   include Formatter
 
   plugin :time_machine
@@ -21,6 +23,10 @@ class GoodsNomenclatureDescription < Sequel::Model
 
   def description
     super.try(:gsub, %r/( ?<br> ?){2,}/, '<br>') || ''
+  end
+
+  def description_indexed
+    description.match(DESCRIPTION_NEGATION_REGEX).try(:[], :keep).presence || description
   end
 
   def formatted_description

--- a/app/serializers/search/goods_nomenclature_serializer.rb
+++ b/app/serializers/search/goods_nomenclature_serializer.rb
@@ -8,11 +8,13 @@ module Search
         producline_suffix:,
         goods_nomenclature_class:,
         description:,
-        description_indexed: description,
+        description_indexed:,
         chapter_description:,
         heading_description:,
         search_references:,
         ancestors:,
+        validity_start_date:,
+        validity_end_date:,
       }
     end
 
@@ -65,6 +67,14 @@ module Search
           description: ancestor.description,
         }
       end
+    end
+
+    def validity_start_date
+      super&.iso8601
+    end
+
+    def validity_end_date
+      super&.iso8601
     end
   end
 end

--- a/spec/factories/commodity_factory.rb
+++ b/spec/factories/commodity_factory.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
     trait :with_ancestors do
       with_description
       path { Sequel.pg_array([1, 2], :integer) }
-      description { 'Horses' }
+      description { 'Horses, other than lemmings' }
       goods_nomenclature_sid { 3 }
 
       after(:create) do |commodity, _evaluator|

--- a/spec/models/goods_nomenclature_description_spec.rb
+++ b/spec/models/goods_nomenclature_description_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe GoodsNomenclatureDescription do
   describe '#description' do
-    subject(:goods_nomenclature_description) { build :goods_nomenclature_description, description: description }
+    subject(:goods_nomenclature_description) { build :goods_nomenclature_description, description: }
 
     context 'when the description value is nil' do
       let(:description) { nil }
@@ -37,6 +37,31 @@ RSpec.describe GoodsNomenclatureDescription do
       it 'does not change the description' do
         expect(goods_nomenclature_description.description).to eq(description)
       end
+    end
+  end
+
+  describe '#description_indexed' do
+    shared_examples_for 'a description that includes a negation' do |description, expected_description|
+      subject(:description_indexed) { build(:goods_nomenclature_description, description:).description_indexed }
+
+      it { is_expected.to eq(expected_description) }
+    end
+
+    it_behaves_like 'a description that includes a negation', 'Hop cones, neither ground nor powdered nor in the form of pellets', 'Hop cones'
+    it_behaves_like 'a description that includes a negation', 'Other fish, excluding livers and roes', 'Other fish'
+    it_behaves_like 'a description that includes a negation', 'Bulls of the Schwyz, Fribourg and spotted Simmental breeds, other than for slaughter', 'Bulls of the Schwyz, Fribourg and spotted Simmental breeds'
+    it_behaves_like 'a description that includes a negation', 'Tulles and other net fabrics, not including woven, knitted or crocheted fabrics', 'Tulles and other net fabrics'
+
+    context 'when the description value is nil' do
+      subject(:description_indexed) { build(:goods_nomenclature_description, description: nil).description_indexed }
+
+      it { is_expected.to eq('') }
+    end
+
+    context 'when the description value does not include a negation' do
+      subject(:description_indexed) { build(:goods_nomenclature_description, description: 'I do not include a handled negation').description_indexed }
+
+      it { is_expected.to eq('I do not include a handled negation') }
     end
   end
 

--- a/spec/serializers/search/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/search/goods_nomenclature_serializer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Search::GoodsNomenclatureSerializer do
         goods_nomenclature_class: 'Commodity',
         chapter_description: 'Live horses, asses, mules and hinnies',
         heading_description: 'Live animals',
-        description: 'Horses',
+        description: 'Horses, other than lemmings',
         description_indexed: 'Horses',
         search_references: 'secret sauce',
         ancestors: [
@@ -30,6 +30,8 @@ RSpec.describe Search::GoodsNomenclatureSerializer do
             description: 'Live animals',
           },
         ],
+        validity_start_date: '2020-06-29T00:00:00Z',
+        validity_end_date: nil,
       }
     end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1703

### What?

I have added/removed/altered:

- [x] Added negation removal to the indexed description in the new goods nomenclature search index
- [x] Added spec coverage

### Why?

I am doing this because:

- This is required since when we search for a specific term we do not want
it to be included in the results if the term is technically negated.

### Have you? (optional)

- [ ] Added documentation for new apis
- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical data
- Changes an api that is used in production
