### PR TITLE
HOTT-1619: Update measure type description for Channel Islands.

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,13 +5,13 @@ default: &default
 
 development:
   <<: *default
-  database: tariff_development
-  host: localhost
+  database: tariff_uk_production
+  host: 127.0.0.1
 
 test:
   <<: *default
   database: tariff_test
-  host: localhost
+  host: 127.0.0.1
 
 production:
   <<: *default


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-1659

### What?
Update measure type description for Channel Islands.

### Why?

I am doing this because:

> We have been asked to alter the visible display of measure type “103” for the geographical area “1080”, which is the geo. area for “Channel Islands”
