### PR TITLE
HOTT-1738: Fixes multiple CHIEF VAT measures

### DIFF
--- a/app/presenters/api/overview_measure_presenter.rb
+++ b/app/presenters/api/overview_measure_presenter.rb
@@ -1,0 +1,30 @@
+class OverviewMeasurePresenter
+  def initialize(collection, declarable)
+    @collection = collection
+    @declarable = declarable
+  end
+
+  def validate!
+    @collection = measure_deduplicate
+  end
+
+  private
+
+  def measure_deduplicate
+    delete_duplicate_vat_measures(type: 'VTZ')
+    delete_duplicate_vat_measures(type: 'VTS')
+
+    @collection.compact
+  end
+
+  def delete_duplicate_vat_measures(type:)
+    return unless @collection.select { |m| m.measure_type_id == type }.any?
+
+    @collection.delete_if { |m| m.measure_type_id == type && m.goods_nomenclature_sid != @declarable.goods_nomenclature_sid }
+    latest = @collection.select { |m| m.measure_type_id == type }.sort_by(&:effective_start_date).pop
+    @collection.uniq! { |m| m.duty_expression_with_national_measurement_units_for || m.duty_expression.base }
+    @collection.delete_if { |m| m.measure_type_id == type && measure.goods_nomenclature_item_id == @declarable.goods_nomenclature_item_id }
+    @collection.prepend(latest) unless @collection.include?(latest)
+    @collection.compact!
+  end
+end

--- a/app/services/heading_service/cached_heading_service.rb
+++ b/app/services/heading_service/cached_heading_service.rb
@@ -63,7 +63,7 @@ module HeadingService
 
         if TradeTariffBackend.xi?
           # TODO: Removes CHIEF VAT measures that are no longer relevant and need pulling from to the UK service
-          commodity.overview_measures = OverviewMeasurePresenter.new(commodity.overview_measures, commodity).validate!
+          commodity.overview_measures = ::OverviewMeasurePresenter.new(commodity.overview_measures, commodity).validate!
         end
 
         commodity.overview_measure_ids = commodity.overview_measures.map(&:measure_sid)

--- a/app/services/heading_service/cached_heading_service.rb
+++ b/app/services/heading_service/cached_heading_service.rb
@@ -61,6 +61,11 @@ module HeadingService
           has_valid_dates(measure, :effective_start_date, :effective_end_date)
         end
 
+        if TradeTariffBackend.xi?
+          # TODO: Removes CHIEF VAT measures that are no longer relevant and need pulling from to the UK service
+          commodity.overview_measures = OverviewMeasurePresenter.new(commodity.overview_measures, commodity).validate!
+        end
+
         commodity.overview_measure_ids = commodity.overview_measures.map(&:measure_sid)
 
         commodity.goods_nomenclature_indents.keep_if do |ident|


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1738

### What?

I have added/removed/altered:

- [x] Fixes CHIEF measure presentation on cached headings by reinstating CHIEF VAT measure deduplication

### Why?

I am doing this because:

- These measures shouldn't actually be shown at all, but to get a fix out
we're bringing back this deduplication functionality temporarily to
remove a weird overview measure UI experience on the heading page on XI
- See: https://www.trade-tariff.service.gov.uk/xi/headings/1704
