### PR TITLE
HOTT-1738: Remove CHIEF VAT measures from the heading commodity overview

### DIFF
--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -28,7 +28,7 @@ class Commodity < GoodsNomenclature
 
   one_to_many :overview_measures, key: {}, primary_key: {}, class_name: 'Measure', dataset: lambda {
     measures_dataset
-      .filter(measures__measure_type_id: MeasureType::OVERVIEW_MEASURE_TYPES)
+      .filter(measures__measure_type_id: MeasureType.overview_measure_types)
       .or(
         measures__measure_type_id: MeasureType::THIRD_COUNTRY,
         measures__geographical_area_id: GeographicalArea::ERGA_OMNES_ID,

--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -13,7 +13,6 @@ class MeasureType < Sequel::Model
   DEFAULT_EXCLUDED_TYPES = %w[442 447 SPL].freeze
   XI_EXCLUDED_TYPES = DEFAULT_EXCLUDED_TYPES + NATIONAL_PR_TYPES + QUOTA_TYPES
   UK_EXCLUDED_TYPES = DEFAULT_EXCLUDED_TYPES
-  OVERVIEW_MEASURE_TYPES = MeasureType::VAT_TYPES + MeasureType::SUPPLEMENTARY_TYPES # See Commodity#overview_measures
 
   DEFENSE_MEASURES = [
     '551', # Provisional anti-dumping duty
@@ -104,6 +103,15 @@ class MeasureType < Sequel::Model
 
   def rules_of_origin_apply?
     measure_type_id.in?(RULES_OF_ORIGIN_MEASURES)
+  end
+
+  # See Commodity#overview_measures
+  def self.overview_measure_types
+    if TradeTariffBackend.xi?
+      MeasureType::SUPPLEMENTARY_TYPES
+    else
+      MeasureType::VAT_TYPES + MeasureType::SUPPLEMENTARY_TYPES
+    end
   end
 
   def self.excluded_measure_types

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -376,6 +376,10 @@ FactoryBot.define do
       trade_movement_code { 0 }
     end
 
+    trait :vat do
+      measure_type_id { 'VTZ' } # CHIEF VAT type
+    end
+
     trait :import_and_export do
       trade_movement_code { 2 }
     end

--- a/spec/models/measure_type_spec.rb
+++ b/spec/models/measure_type_spec.rb
@@ -194,4 +194,24 @@ RSpec.describe MeasureType do
       it { is_expected.not_to be_rules_of_origin_apply }
     end
   end
+
+  describe '.overview_measures_types' do
+    subject(:measure_type) { described_class.overview_measure_types }
+
+    before do
+      allow(TradeTariffBackend).to receive(:service).and_return(service)
+    end
+
+    context 'when on the xi service' do
+      let(:service) { 'xi' }
+
+      it { is_expected.to eq(%w[109 110 111]) }
+    end
+
+    context 'when on the uk service' do
+      let(:service) { 'uk' }
+
+      it { is_expected.to eq(%w[VTA VTE VTS VTZ 305 109 110 111]) }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1738

### What?

I have added/removed/altered:

- [x] Filter out VAT measures on XI

### Why?

I am doing this because:

- This is required because CHIEF VAT measures are dead and VAT measures should be coming from the UK (coming later)
