### PR TITLE
HOTT-1721: Adds beta search endpoint

### DIFF
--- a/app/controllers/api/beta/search_controller.rb
+++ b/app/controllers/api/beta/search_controller.rb
@@ -1,0 +1,15 @@
+module Api
+  module Beta
+    class SearchController < ApiController
+      def index
+        render json: Beta::SearchService.new(search_query).call
+      end
+
+      private
+
+      def search_query
+        params[:q]
+      end
+    end
+  end
+end

--- a/app/elastic_search_indexes/search/goods_nomenclature_index.rb
+++ b/app/elastic_search_indexes/search/goods_nomenclature_index.rb
@@ -66,6 +66,7 @@ module Search
         },
         mappings: {
           properties: {
+            id: { type: 'text' },
             goods_nomenclature_class: {
               analyzer: 'english',
               type: 'text',
@@ -120,12 +121,18 @@ module Search
             ancestors: {
               type: 'nested',
               properties: {
+                id: { type: 'text' },
                 goods_nomenclature_item_id: { type: 'text' },
                 producline_suffix: { type: 'text' },
-                class: { type: 'text' },
+                goods_nomenclature_class: { type: 'text' },
                 description: { type: 'text' },
+                description_indexed: {
+                  analyzer: 'english',
+                  type: 'text',
+                },
               },
             },
+            ancestor_ids: { type: 'nested' },
             validity_start_date: {
               type: 'text',
             },

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -9,6 +9,15 @@ module TradeTariffBackend
       yield self
     end
 
+    # URL used to specify the location of the search query parser application
+    def search_query_parser_url
+      ENV['TARIFF_QUERY_SEARCH_PARSER_URL']
+    end
+
+    def search_query_parser_connection_pool_count
+      ENV.fetch('TARIFF_QUERY_SEARCH_PARSER_CONNECTION_POOL_COUNT', 3)
+    end
+
     # Lock key used for DB locks to keep just one instance of synchronizer
     # running in cluster environment
     def db_lock_key
@@ -204,6 +213,10 @@ module TradeTariffBackend
         QuotaOrderNumberOrigin,
         QuotaSuspensionPeriod,
       ]
+    end
+
+    def default_api_version
+      ENV.fetch('DEFAULT_API_VERSION', '1')
     end
 
     def api_version(request)

--- a/app/models/beta/search/goods_nomenclature_query.rb
+++ b/app/models/beta/search/goods_nomenclature_query.rb
@@ -1,0 +1,142 @@
+module Beta
+  module Search
+    class GoodsNomenclatureQuery
+      attr_writer :nouns, :verbs, :adjectives, :noun_chunks
+
+      def self.build(search_query_parser_result)
+        query = new
+
+        query.nouns = search_query_parser_result.nouns
+        query.noun_chunks = search_query_parser_result.noun_chunks
+        query.verbs = search_query_parser_result.verbs
+        query.adjectives = search_query_parser_result.adjectives
+
+        query
+      end
+
+      def query
+        candidate_query = { query: { bool: {} } }
+
+        candidate_query[:query][:bool][:must] = must_part if must_part.any?
+        candidate_query[:query][:bool][:should] = should_part if should_part.any?
+
+        candidate_query
+      end
+
+      private
+
+      def must_part
+        part = []
+
+        part.concat(noun_part) if nouns.present? || noun_chunks.present?
+
+        part
+      end
+
+      def should_part
+        part = []
+
+        part.concat(verb_part) if verbs.present?
+        part.concat(adjective_part) if adjectives.present?
+
+        part
+      end
+
+      def noun_part
+        [
+          {
+            multi_match: {
+              query: nouns.presence || noun_chunks,
+              fuzziness: 0.1,
+              prefix_length: 2,
+              tie_breaker: 0.3,
+              type: 'best_fields',
+              fields: [
+                'search_references^12',
+                'chapter_description^10',
+                'heading_description^8',
+                'description.exact^6',
+                'description_indexed^6',
+                'goods_nomenclature_item_id',
+              ],
+            },
+          },
+          # TODO: Search for a match in the nested ancestors if possible
+          # {
+          #   nested: {
+          #     path: 'ancestors',
+          #     query: {
+          #       multi_match: {
+          #         query: nouns,
+          #         fields: [
+          #           'description_indexed^6',
+          #         ],
+          #       },
+          #     },
+          #   },
+          # },
+        ]
+      end
+
+      def verb_part
+        [
+          {
+            multi_match: {
+              query: verbs,
+              fuzziness: 0.1,
+              prefix_length: 2,
+              tie_breaker: 0.3,
+              type: 'best_fields',
+              fields: [
+                'search_references^12',
+                'chapter_description^10',
+                'heading_description^8',
+                'description.exact^6',
+                'description_indexed^6',
+                'goods_nomenclature_item_id',
+              ],
+            },
+          },
+        ]
+      end
+
+      def adjective_part
+        [
+          {
+            multi_match: {
+              query: adjectives,
+              fuzziness: 0.1,
+              prefix_length: 2,
+              tie_breaker: 0.3,
+              type: 'best_fields',
+              fields: [
+                'search_references^12',
+                'chapter_description^10',
+                'heading_description^8',
+                'description.exact^6',
+                'description_indexed^6',
+                'goods_nomenclature_item_id',
+              ],
+            },
+          },
+        ]
+      end
+
+      def nouns
+        @nouns.try(:join, ' ').presence || ''
+      end
+
+      def noun_chunks
+        @noun_chunks.try(:join, ' ').presence || ''
+      end
+
+      def verbs
+        @verbs.try(:join, ' ') || ''
+      end
+
+      def adjectives
+        @adjectives.try(:join, ' ') || ''
+      end
+    end
+  end
+end

--- a/app/models/beta/search/search_query_parser_result.rb
+++ b/app/models/beta/search/search_query_parser_result.rb
@@ -1,0 +1,33 @@
+module Beta
+  module Search
+    class SearchQueryParserResult
+      include ActiveModel::Model
+
+      attr_accessor :adjectives,
+                    :nouns,
+                    :verbs,
+                    :noun_chunks,
+                    :original_search_query,
+                    :corrected_search_query
+
+      def self.build(attributes)
+        search_query_parser_result = new
+
+        attributes = JSON.parse(attributes) if attributes.is_a?(String)
+
+        search_query_parser_result.original_search_query = attributes['original_search_query']
+        search_query_parser_result.corrected_search_query = attributes['corrected_search_query']
+        search_query_parser_result.adjectives = attributes.dig('tokens', 'adjectives')
+        search_query_parser_result.nouns = attributes.dig('tokens', 'nouns')
+        search_query_parser_result.verbs = attributes.dig('tokens', 'verbs')
+        search_query_parser_result.noun_chunks = attributes.dig('tokens', 'noun_chunks')
+
+        search_query_parser_result
+      end
+
+      def id
+        Digest::MD5.hexdigest(original_search_query)
+      end
+    end
+  end
+end

--- a/app/models/beta/search/search_result.rb
+++ b/app/models/beta/search/search_result.rb
@@ -1,0 +1,64 @@
+module Beta
+  module Search
+    class SearchResult
+      delegate :id, to: :search_query_parser_result, prefix: true
+
+      attr_accessor :took,
+                    :timed_out,
+                    :hits,
+                    :max_score,
+                    :search_query_parser_result
+
+      class << self
+        def build(result, search_query_parser_result)
+          search_result = new
+
+          search_result.took = result.took
+          search_result.timed_out = result.timed_out
+          search_result.max_score = result.hits.max_score
+          search_result.hits = result.hits.hits.map(&method(:build_hit))
+          search_result.search_query_parser_result = search_query_parser_result
+
+          search_result
+        end
+
+        def build_hit(hit_result)
+          hit = Hashie::TariffMash.new
+
+          hit.score = hit_result._score
+          hit.goods_nomenclature_class = hit_result._source.goods_nomenclature_class
+          hit.id = hit_result._source.id
+          hit.goods_nomenclature_item_id = hit_result._source.goods_nomenclature_item_id
+          hit.producline_suffix = hit_result._source.producline_suffix
+          hit.description = hit_result._source.description
+          hit.description_indexed = hit_result._source.description_indexed
+          hit.chapter_description = hit_result._source.chapter_description
+          hit.heading_description = hit_result._source.heading_description
+          hit.search_references = hit_result._source.search_references
+          hit.validity_start_date = hit_result._source.validity_start_date
+          hit.validity_end_date = hit_result._source.validity_end_date
+          hit.chapter_id = hit_result._source.chapter_id
+          hit.heading_id = hit_result._source.heading_id
+          hit.ancestors = hit_result._source.ancestors
+          hit.ancestor_ids = hit_result._source.ancestors.map(&:id)
+
+          hit
+        end
+      end
+
+      def id
+        digestable = "#{search_query_parser_result.id}-#{hit_ids}"
+
+        Digest::MD5.hexdigest(digestable)
+      end
+
+      def hit_ids
+        hits.map(&:id)
+      end
+
+      def total_results
+        hits.count
+      end
+    end
+  end
+end

--- a/app/models/goods_nomenclature_description.rb
+++ b/app/models/goods_nomenclature_description.rb
@@ -1,5 +1,5 @@
 class GoodsNomenclatureDescription < Sequel::Model
-  DESCRIPTION_NEGATION_REGEX = /(?<keep>\A.*)(?<remove>, (?<excluded-term>neither|other than|excluding|not including).*\z)/
+  DESCRIPTION_NEGATION_REGEX = /(?<keep>\A.*)(?<remove>, (?<excluded-term>neither|other than|excluding|not).*\z)/
 
   include Formatter
 

--- a/app/serializers/api/beta/ancestor_serializer.rb
+++ b/app/serializers/api/beta/ancestor_serializer.rb
@@ -1,0 +1,14 @@
+module Api
+  module Beta
+    class AncestorSerializer
+      include JSONAPI::Serializer
+
+      set_type :ancestor
+
+      attributes :goods_nomenclature_item_id,
+                 :producline_suffix,
+                 :description,
+                 :description_indexed
+    end
+  end
+end

--- a/app/serializers/api/beta/chapter_serializer.rb
+++ b/app/serializers/api/beta/chapter_serializer.rb
@@ -1,0 +1,7 @@
+module Api
+  module Beta
+    class ChapterSerializer < GoodsNomenclatureSerializer
+      set_type :chapter
+    end
+  end
+end

--- a/app/serializers/api/beta/commodity_serializer.rb
+++ b/app/serializers/api/beta/commodity_serializer.rb
@@ -1,0 +1,12 @@
+module Api
+  module Beta
+    class CommoditySerializer < GoodsNomenclatureSerializer
+      set_type :commodity
+
+      attributes :chapter_description,
+                 :chapter_id,
+                 :heading_description,
+                 :heading_id
+    end
+  end
+end

--- a/app/serializers/api/beta/goods_nomenclature_serializer.rb
+++ b/app/serializers/api/beta/goods_nomenclature_serializer.rb
@@ -1,0 +1,21 @@
+module Api
+  module Beta
+    class GoodsNomenclatureSerializer
+      include JSONAPI::Serializer
+
+      set_type :goods_nomenclature
+
+      attributes :goods_nomenclature_item_id,
+                 :producline_suffix,
+                 :description,
+                 :description_indexed,
+                 :search_references,
+                 :validity_start_date,
+                 :validity_end_date,
+                 :chapter_id,
+                 :score
+
+      has_many :ancestors, serializer: Api::Beta::AncestorSerializer
+    end
+  end
+end

--- a/app/serializers/api/beta/heading_serializer.rb
+++ b/app/serializers/api/beta/heading_serializer.rb
@@ -1,0 +1,10 @@
+module Api
+  module Beta
+    class HeadingSerializer < GoodsNomenclatureSerializer
+      set_type :heading
+
+      attributes :chapter_description,
+                 :chapter_id
+    end
+  end
+end

--- a/app/serializers/api/beta/search_query_parser_result_serializer.rb
+++ b/app/serializers/api/beta/search_query_parser_result_serializer.rb
@@ -1,0 +1,16 @@
+module Api
+  module Beta
+    class SearchQueryParserResultSerializer
+      include JSONAPI::Serializer
+
+      set_type :search_query_parser_result
+
+      attributes :corrected_search_query,
+                 :original_search_query,
+                 :verbs,
+                 :adjectives,
+                 :nouns,
+                 :noun_chunks
+    end
+  end
+end

--- a/app/serializers/api/beta/search_result_serializer.rb
+++ b/app/serializers/api/beta/search_result_serializer.rb
@@ -1,0 +1,24 @@
+module Api
+  module Beta
+    class SearchResultSerializer
+      include JSONAPI::Serializer
+
+      set_type :search_result
+
+      attributes :took,
+                 :timed_out,
+                 :max_score,
+                 :total_results
+
+      has_one :search_query_parser_result, serializer: SearchQueryParserResultSerializer
+
+      has_many :hits, serializer: proc { |record, _params|
+        if record && record.respond_to?(:goods_nomenclature_class)
+          "Api::Beta::#{record.goods_nomenclature_class}Serializer".constantize
+        else
+          Api::Beta::GoodsNomenclatureSerializer
+        end
+      }
+    end
+  end
+end

--- a/app/serializers/api/beta/subheading_serializer.rb
+++ b/app/serializers/api/beta/subheading_serializer.rb
@@ -1,0 +1,12 @@
+module Api
+  module Beta
+    class SubheadingSerializer < GoodsNomenclatureSerializer
+      set_type :subheading
+
+      attributes :chapter_description,
+                 :chapter_id,
+                 :heading_description,
+                 :heading_id
+    end
+  end
+end

--- a/app/serializers/search/goods_nomenclature_serializer.rb
+++ b/app/serializers/search/goods_nomenclature_serializer.rb
@@ -64,7 +64,7 @@ module Search
         {
           id: ancestor.goods_nomenclature_sid,
           goods_nomenclature_item_id: ancestor.goods_nomenclature_item_id,
-          productline_suffix: ancestor.producline_suffix,
+          producline_suffix: ancestor.producline_suffix,
           goods_nomenclature_class: goods_nomenclature_class(ancestor),
           description: ancestor.description,
           description_indexed: ancestor.description_indexed,

--- a/app/serializers/search/goods_nomenclature_serializer.rb
+++ b/app/serializers/search/goods_nomenclature_serializer.rb
@@ -2,6 +2,7 @@ module Search
   class GoodsNomenclatureSerializer < ::Serializer
     def serializable_hash(_opts = {})
       {
+        id:,
         goods_nomenclature_item_id:,
         heading_id: heading_short_code,
         chapter_id: chapter_short_code,
@@ -61,10 +62,12 @@ module Search
     def ancestors
       super.map do |ancestor|
         {
+          id: ancestor.goods_nomenclature_sid,
           goods_nomenclature_item_id: ancestor.goods_nomenclature_item_id,
           productline_suffix: ancestor.producline_suffix,
           goods_nomenclature_class: goods_nomenclature_class(ancestor),
           description: ancestor.description,
+          description_indexed: ancestor.description_indexed,
         }
       end
     end

--- a/app/services/api/beta/search_service.rb
+++ b/app/services/api/beta/search_service.rb
@@ -1,0 +1,33 @@
+module Api
+  module Beta
+    class SearchService
+      DEFAULT_INCLUDES = ['hits.ancestors', :search_query_parser_result].freeze
+      DEFAULT_SEARCH_INDEX = 'tariff-goods_nomenclatures'.freeze
+
+      def initialize(search_query)
+        @search_query = search_query
+      end
+
+      def call
+        result = v2_search_client
+          .search(index: DEFAULT_SEARCH_INDEX, body: generated_search_query)
+
+        result = ::Beta::Search::SearchResult.build(result, search_query_parser_result)
+
+        Api::Beta::SearchResultSerializer.new(result, include: DEFAULT_INCLUDES).serializable_hash
+      end
+
+      private
+
+      delegate :v2_search_client, to: TradeTariffBackend
+
+      def generated_search_query
+        @generated_search_query ||= ::Beta::Search::GoodsNomenclatureQuery.build(search_query_parser_result).query
+      end
+
+      def search_query_parser_result
+        @search_query_parser_result ||= SearchQueryParser.new(@search_query).call
+      end
+    end
+  end
+end

--- a/app/services/search_query_parser.rb
+++ b/app/services/search_query_parser.rb
@@ -1,19 +1,20 @@
-require 'uri'
-
 class SearchQueryParser
-  API_URL = ENV['TARIFF_QUERY_SEARCH_PARSER_URL']
+  delegate :client, to: :class
 
-  def initialize
-    @client = Faraday.new(API_URL) do |conn|
-      conn.request :json
+  def initialize(search_query)
+    @search_query = search_query
+  end
 
+  def call
+    result_attributes = client.get('tokens', q: @search_query).body
+
+    Beta::Search::SearchQueryParserResult.build(result_attributes)
+  end
+
+  def self.client
+    @client ||= Faraday.new(TradeTariffBackend.search_query_parser_url) do |conn|
       conn.response :raise_error
       conn.response :json
     end
-  end
-
-  def get_tokens(search_query_term)
-    @client.get('tokens', q: search_query_term)
-           .body
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,8 +43,25 @@ Rails.application.routes.draw do
   end
 
   namespace :api, defaults: { format: 'json' }, path: '/' do
-    # How (or even if) API versioning will be implemented is still an open question. We can defer
-    # the choice until we need to expose the API to clients which we don't control.
+    # TODO: The api versioning is hierarchical as far as the defined order of the routes below.
+    #
+    # If your default api scope (as defined in env['DEFAULT_API_VERSION']) comes before the scopes that are defined below it, then the default scope will always match.
+    #
+    # For example (broken/incorrect scoping arrangement):
+    #   v2 scope (default)
+    #   v1 scope (unreachable)
+    #   beta scope (unreachable)
+    #
+    # For example (correct scoping arrangement): (correct)
+    #   beta scope (reachable)
+    #   v1 scope (reachable)
+    #   v2 scope (default)
+    #
+    # We should adjust this carefully since it's old behaviour
+
+    scope module: :beta, constraints: ApiConstraints.new(version: 'beta') do
+      get 'search' => 'search#index'
+    end
 
     scope module: :v2, constraints: ApiConstraints.new(version: 2) do
       resources :sections, only: %i[index show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,7 @@ Rails.application.routes.draw do
     # We should adjust this carefully since it's old behaviour
 
     scope module: :beta, constraints: ApiConstraints.new(version: 'beta') do
-      get 'search' => 'search#index', as: :beta_search
+      get 'search' => 'search#index'
     end
 
     scope module: :v2, constraints: ApiConstraints.new(version: 2) do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,7 @@ Rails.application.routes.draw do
     # We should adjust this carefully since it's old behaviour
 
     scope module: :beta, constraints: ApiConstraints.new(version: 'beta') do
-      get 'search' => 'search#index'
+      get 'search' => 'search#index', as: :beta_search
     end
 
     scope module: :v2, constraints: ApiConstraints.new(version: 2) do

--- a/spec/factories/goods_nomenclature_query.rb
+++ b/spec/factories/goods_nomenclature_query.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :goods_nomenclature_query, class: 'Beta::Search::GoodsNomenclatureQuery' do
+    adjectives {}
+    noun_chunks {}
+    nouns {}
+    verbs {}
+
+    trait :full_query do
+      adjectives { %w[tall] }
+      noun_chunks { ['tall running man'] }
+      nouns { %w[man] }
+      verbs { %w[run] }
+    end
+  end
+end

--- a/spec/factories/search_query_parser_result_factory.rb
+++ b/spec/factories/search_query_parser_result_factory.rb
@@ -17,5 +17,35 @@ FactoryBot.define do
     noun_chunks { ['halibut sausage stenolepis cheese binocular parsnip pharmacy paper'] }
     original_search_query { 'halbiut sausadge stenolepsis chese bnoculars parnsip farmacy pape' }
     corrected_search_query { 'halibut sausage stenolepis cheese binocular parsnip pharmacy paper' }
+
+    trait :no_hits do
+      original_search_query { 'flibble' }
+      corrected_search_query { 'ribble' }
+
+      adjectives { [] }
+      noun_chunks { [] }
+      nouns { [] }
+      verbs { %w[ribble] }
+    end
+
+    trait :single_hit do
+      original_search_query { 'ricotta' }
+      corrected_search_query { 'ricotta' }
+
+      adjectives { [] }
+      noun_chunks { %w[ricotta] }
+      nouns { [] }
+      verbs { [] }
+    end
+
+    trait :multiple_hits do
+      original_search_query { 'horses' }
+      corrected_search_query { 'horses' }
+
+      adjectives { [] }
+      noun_chunks { %w[horses] }
+      nouns { %w[horses] }
+      verbs { [] }
+    end
   end
 end

--- a/spec/factories/search_query_parser_result_factory.rb
+++ b/spec/factories/search_query_parser_result_factory.rb
@@ -1,0 +1,21 @@
+FactoryBot.define do
+  factory :search_query_parser_result, class: 'Beta::Search::SearchQueryParserResult' do
+    adjectives { [] }
+    nouns do
+      %w[
+        halibut
+        sausage
+        stenolepis
+        cheese
+        binocular
+        parsnip
+        pharmacy
+        paper
+      ]
+    end
+    verbs { [] }
+    noun_chunks { ['halibut sausage stenolepis cheese binocular parsnip pharmacy paper'] }
+    original_search_query { 'halbiut sausadge stenolepsis chese bnoculars parnsip farmacy pape' }
+    corrected_search_query { 'halibut sausage stenolepis cheese binocular parsnip pharmacy paper' }
+  end
+end

--- a/spec/factories/search_result_factory.rb
+++ b/spec/factories/search_result_factory.rb
@@ -1,0 +1,34 @@
+FactoryBot.define do
+  factory :search_result, class: 'Beta::Search::SearchResult' do
+    multiple_hits
+
+    trait :no_hits do
+      transient do
+        result_fixture { 'no_hits' }
+        search_query_parser_result { build(:search_query_parser_result, :no_hits) }
+      end
+    end
+
+    trait :single_hit do
+      transient do
+        result_fixture { 'single_hit' }
+        search_query_parser_result { build(:search_query_parser_result, :single_hit) }
+      end
+    end
+
+    trait :multiple_hits do
+      transient do
+        result_fixture { 'multiple_hits' }
+        search_query_parser_result { build(:search_query_parser_result, :multiple_hits) }
+      end
+    end
+
+    initialize_with do
+      fixture_filename = Rails.root.join("spec/fixtures/beta/search/goods_nomenclatures/#{result_fixture}.json")
+      search_result = JSON.parse(File.read(fixture_filename))
+      search_result = Hashie::TariffMash.new(search_result)
+
+      Beta::Search::SearchResult.build(search_result, search_query_parser_result)
+    end
+  end
+end

--- a/spec/fixtures/beta/search/goods_nomenclatures/multiple_hits.json
+++ b/spec/fixtures/beta/search/goods_nomenclatures/multiple_hits.json
@@ -1,0 +1,489 @@
+{
+  "took": 3,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 98,
+      "relation": "eq"
+    },
+    "max_score": 161.34302,
+    "hits": [
+      {
+        "_index": "tariff-goods_nomenclatures",
+        "_type": "_doc",
+        "_id": "93797",
+        "_score": 161.34302,
+        "_source": {
+          "id": 93797,
+          "goods_nomenclature_item_id": "0101210000",
+          "heading_id": "0101",
+          "chapter_id": "01",
+          "producline_suffix": "10",
+          "goods_nomenclature_class": "Subheading",
+          "description": "Horses",
+          "description_indexed": "Horses",
+          "chapter_description": "LIVE ANIMALS",
+          "heading_description": "Live horses, asses, mules and hinnies",
+          "search_references": "",
+          "ancestors": [
+            {
+              "id": 27623,
+              "goods_nomenclature_item_id": "0100000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Chapter",
+              "description": "LIVE ANIMALS",
+              "description_indexed": "LIVE ANIMALS"
+            },
+            {
+              "id": 27624,
+              "goods_nomenclature_item_id": "0101000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Heading",
+              "description": "Live horses, asses, mules and hinnies",
+              "description_indexed": "Live horses, asses, mules and hinnies"
+            }
+          ],
+          "validity_start_date": "2012-01-01T00:00:00Z",
+          "validity_end_date": null
+        }
+      },
+      {
+        "_index": "tariff-goods_nomenclatures",
+        "_type": "_doc",
+        "_id": "93796",
+        "_score": 138.9776,
+        "_source": {
+          "id": 93796,
+          "goods_nomenclature_item_id": "0101210000",
+          "heading_id": "0101",
+          "chapter_id": "01",
+          "producline_suffix": "80",
+          "goods_nomenclature_class": "Commodity",
+          "description": "Pure-bred breeding animals",
+          "description_indexed": "Pure-bred breeding animals",
+          "chapter_description": "LIVE ANIMALS",
+          "heading_description": "Live horses, asses, mules and hinnies",
+          "search_references": "",
+          "ancestors": [
+            {
+              "id": 27623,
+              "goods_nomenclature_item_id": "0100000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Chapter",
+              "description": "LIVE ANIMALS",
+              "description_indexed": "LIVE ANIMALS"
+            },
+            {
+              "id": 27624,
+              "goods_nomenclature_item_id": "0101000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Heading",
+              "description": "Live horses, asses, mules and hinnies",
+              "description_indexed": "Live horses, asses, mules and hinnies"
+            },
+            {
+              "id": 93797,
+              "goods_nomenclature_item_id": "0101210000",
+              "productline_suffix": "10",
+              "goods_nomenclature_class": "Subheading",
+              "description": "Horses",
+              "description_indexed": "Horses"
+            }
+          ],
+          "validity_start_date": "2012-01-01T00:00:00Z",
+          "validity_end_date": null
+        }
+      },
+      {
+        "_index": "tariff-goods_nomenclatures",
+        "_type": "_doc",
+        "_id": "93798",
+        "_score": 138.9776,
+        "_source": {
+          "id": 93798,
+          "goods_nomenclature_item_id": "0101290000",
+          "heading_id": "0101",
+          "chapter_id": "01",
+          "producline_suffix": "80",
+          "goods_nomenclature_class": "Subheading",
+          "description": "Other",
+          "description_indexed": "Other",
+          "chapter_description": "LIVE ANIMALS",
+          "heading_description": "Live horses, asses, mules and hinnies",
+          "search_references": "",
+          "ancestors": [
+            {
+              "id": 27623,
+              "goods_nomenclature_item_id": "0100000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Chapter",
+              "description": "LIVE ANIMALS",
+              "description_indexed": "LIVE ANIMALS"
+            },
+            {
+              "id": 27624,
+              "goods_nomenclature_item_id": "0101000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Heading",
+              "description": "Live horses, asses, mules and hinnies",
+              "description_indexed": "Live horses, asses, mules and hinnies"
+            },
+            {
+              "id": 93797,
+              "goods_nomenclature_item_id": "0101210000",
+              "productline_suffix": "10",
+              "goods_nomenclature_class": "Subheading",
+              "description": "Horses",
+              "description_indexed": "Horses"
+            }
+          ],
+          "validity_start_date": "2012-01-01T00:00:00Z",
+          "validity_end_date": null
+        }
+      },
+      {
+        "_index": "tariff-goods_nomenclatures",
+        "_type": "_doc",
+        "_id": "93799",
+        "_score": 138.9776,
+        "_source": {
+          "id": 93799,
+          "goods_nomenclature_item_id": "0101291000",
+          "heading_id": "0101",
+          "chapter_id": "01",
+          "producline_suffix": "80",
+          "goods_nomenclature_class": "Commodity",
+          "description": "For slaughter",
+          "description_indexed": "For slaughter",
+          "chapter_description": "LIVE ANIMALS",
+          "heading_description": "Live horses, asses, mules and hinnies",
+          "search_references": "",
+          "ancestors": [
+            {
+              "id": 27623,
+              "goods_nomenclature_item_id": "0100000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Chapter",
+              "description": "LIVE ANIMALS",
+              "description_indexed": "LIVE ANIMALS"
+            },
+            {
+              "id": 27624,
+              "goods_nomenclature_item_id": "0101000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Heading",
+              "description": "Live horses, asses, mules and hinnies",
+              "description_indexed": "Live horses, asses, mules and hinnies"
+            },
+            {
+              "id": 93797,
+              "goods_nomenclature_item_id": "0101210000",
+              "productline_suffix": "10",
+              "goods_nomenclature_class": "Subheading",
+              "description": "Horses",
+              "description_indexed": "Horses"
+            },
+            {
+              "id": 93798,
+              "goods_nomenclature_item_id": "0101290000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Subheading",
+              "description": "Other",
+              "description_indexed": "Other"
+            }
+          ],
+          "validity_start_date": "2012-01-01T00:00:00Z",
+          "validity_end_date": null
+        }
+      },
+      {
+        "_index": "tariff-goods_nomenclatures",
+        "_type": "_doc",
+        "_id": "93800",
+        "_score": 138.9776,
+        "_source": {
+          "id": 93800,
+          "goods_nomenclature_item_id": "0101299000",
+          "heading_id": "0101",
+          "chapter_id": "01",
+          "producline_suffix": "80",
+          "goods_nomenclature_class": "Commodity",
+          "description": "Other",
+          "description_indexed": "Other",
+          "chapter_description": "LIVE ANIMALS",
+          "heading_description": "Live horses, asses, mules and hinnies",
+          "search_references": "",
+          "ancestors": [
+            {
+              "id": 27623,
+              "goods_nomenclature_item_id": "0100000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Chapter",
+              "description": "LIVE ANIMALS",
+              "description_indexed": "LIVE ANIMALS"
+            },
+            {
+              "id": 27624,
+              "goods_nomenclature_item_id": "0101000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Heading",
+              "description": "Live horses, asses, mules and hinnies",
+              "description_indexed": "Live horses, asses, mules and hinnies"
+            },
+            {
+              "id": 93797,
+              "goods_nomenclature_item_id": "0101210000",
+              "productline_suffix": "10",
+              "goods_nomenclature_class": "Subheading",
+              "description": "Horses",
+              "description_indexed": "Horses"
+            },
+            {
+              "id": 93798,
+              "goods_nomenclature_item_id": "0101290000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Subheading",
+              "description": "Other",
+              "description_indexed": "Other"
+            }
+          ],
+          "validity_start_date": "2012-01-01T00:00:00Z",
+          "validity_end_date": null
+        }
+      },
+      {
+        "_index": "tariff-goods_nomenclatures",
+        "_type": "_doc",
+        "_id": "93801",
+        "_score": 138.9776,
+        "_source": {
+          "id": 93801,
+          "goods_nomenclature_item_id": "0101300000",
+          "heading_id": "0101",
+          "chapter_id": "01",
+          "producline_suffix": "80",
+          "goods_nomenclature_class": "Commodity",
+          "description": "Asses",
+          "description_indexed": "Asses",
+          "chapter_description": "LIVE ANIMALS",
+          "heading_description": "Live horses, asses, mules and hinnies",
+          "search_references": "",
+          "ancestors": [
+            {
+              "id": 27623,
+              "goods_nomenclature_item_id": "0100000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Chapter",
+              "description": "LIVE ANIMALS",
+              "description_indexed": "LIVE ANIMALS"
+            },
+            {
+              "id": 27624,
+              "goods_nomenclature_item_id": "0101000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Heading",
+              "description": "Live horses, asses, mules and hinnies",
+              "description_indexed": "Live horses, asses, mules and hinnies"
+            }
+          ],
+          "validity_start_date": "2012-01-01T00:00:00Z",
+          "validity_end_date": null
+        }
+      },
+      {
+        "_index": "tariff-goods_nomenclatures",
+        "_type": "_doc",
+        "_id": "72763",
+        "_score": 138.9776,
+        "_source": {
+          "id": 72763,
+          "goods_nomenclature_item_id": "0101900000",
+          "heading_id": "0101",
+          "chapter_id": "01",
+          "producline_suffix": "80",
+          "goods_nomenclature_class": "Commodity",
+          "description": "Other",
+          "description_indexed": "Other",
+          "chapter_description": "LIVE ANIMALS",
+          "heading_description": "Live horses, asses, mules and hinnies",
+          "search_references": "",
+          "ancestors": [
+            {
+              "id": 27623,
+              "goods_nomenclature_item_id": "0100000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Chapter",
+              "description": "LIVE ANIMALS",
+              "description_indexed": "LIVE ANIMALS"
+            },
+            {
+              "id": 27624,
+              "goods_nomenclature_item_id": "0101000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Heading",
+              "description": "Live horses, asses, mules and hinnies",
+              "description_indexed": "Live horses, asses, mules and hinnies"
+            }
+          ],
+          "validity_start_date": "2002-01-01T00:00:00Z",
+          "validity_end_date": null
+        }
+      },
+      {
+        "_index": "tariff-goods_nomenclatures",
+        "_type": "_doc",
+        "_id": "27624",
+        "_score": 138.11209,
+        "_source": {
+          "id": 27624,
+          "goods_nomenclature_item_id": "0101000000",
+          "heading_id": "0101",
+          "chapter_id": "01",
+          "producline_suffix": "80",
+          "goods_nomenclature_class": "Heading",
+          "description": "Live horses, asses, mules and hinnies",
+          "description_indexed": "Live horses, asses, mules and hinnies",
+          "chapter_description": "LIVE ANIMALS",
+          "heading_description": null,
+          "search_references": "",
+          "ancestors": [
+            {
+              "id": 27623,
+              "goods_nomenclature_item_id": "0100000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Chapter",
+              "description": "LIVE ANIMALS",
+              "description_indexed": "LIVE ANIMALS"
+            }
+          ],
+          "validity_start_date": "1972-01-01T00:00:00Z",
+          "validity_end_date": null
+        }
+      },
+      {
+        "_index": "tariff-goods_nomenclatures",
+        "_type": "_doc",
+        "_id": "93994",
+        "_score": 69.2645,
+        "_source": {
+          "id": 93994,
+          "goods_nomenclature_item_id": "0302451000",
+          "heading_id": "0302",
+          "chapter_id": "03",
+          "producline_suffix": "80",
+          "goods_nomenclature_class": "Commodity",
+          "description": "Atlantic horse mackerel (Trachurus trachurus)",
+          "description_indexed": "Atlantic horse mackerel (Trachurus trachurus)",
+          "chapter_description": "FISH AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES",
+          "heading_description": "Fish, fresh or chilled, excluding fish fillets and other fish meat of heading 0304",
+          "search_references": "",
+          "ancestors": [
+            {
+              "id": 28373,
+              "goods_nomenclature_item_id": "0300000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Chapter",
+              "description": "FISH AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES",
+              "description_indexed": "FISH AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES"
+            },
+            {
+              "id": 28402,
+              "goods_nomenclature_item_id": "0302000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Heading",
+              "description": "Fish, fresh or chilled, excluding fish fillets and other fish meat of heading 0304",
+              "description_indexed": "Fish, fresh or chilled"
+            },
+            {
+              "id": 93985,
+              "goods_nomenclature_item_id": "0302410000",
+              "productline_suffix": "10",
+              "goods_nomenclature_class": "Subheading",
+              "description": "Herrings (Clupea harengus, Clupea pallasii), anchovies (Engraulis spp.), sardines (Sardina pilchardus, Sardinops spp.), sardinella (Sardinella spp.), brisling or sprats (Sprattus sprattus), mackerel (Scomber scombrus, Scomber australasicus, Scomber japonicus), Indian mackerels (Rastrelliger spp.), seerfishes (Scomberomorus spp.), jack and horse mackerel (Trachurus spp.), jacks, crevalles (Caranx spp.), cobia (Rachycentron canadum), silver pomfrets (Pampus spp.), Pacific saury (Cololabis saira), scads (Decapterus spp.), capelin (Mallotus villosus), swordfish (Xiphias gladius), Kawakawa (Euthynnus affinis), bonitos (Sarda spp.), marlins, sailfishes, spearfish (Istiophoridae), excluding edible fish offal of subheadings 0302 91 to 0302 99",
+              "description_indexed": "Herrings (Clupea harengus, Clupea pallasii), anchovies (Engraulis spp.), sardines (Sardina pilchardus, Sardinops spp.), sardinella (Sardinella spp.), brisling or sprats (Sprattus sprattus), mackerel (Scomber scombrus, Scomber australasicus, Scomber japonicus), Indian mackerels (Rastrelliger spp.), seerfishes (Scomberomorus spp.), jack and horse mackerel (Trachurus spp.), jacks, crevalles (Caranx spp.), cobia (Rachycentron canadum), silver pomfrets (Pampus spp.), Pacific saury (Cololabis saira), scads (Decapterus spp.), capelin (Mallotus villosus), swordfish (Xiphias gladius), Kawakawa (Euthynnus affinis), bonitos (Sarda spp.), marlins, sailfishes, spearfish (Istiophoridae)"
+            },
+            {
+              "id": 93993,
+              "goods_nomenclature_item_id": "0302450000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Subheading",
+              "description": "Jack and horse mackerel (Trachurus spp.)",
+              "description_indexed": "Jack and horse mackerel (Trachurus spp.)"
+            }
+          ],
+          "validity_start_date": "2012-01-01T00:00:00Z",
+          "validity_end_date": null
+        }
+      },
+      {
+        "_index": "tariff-goods_nomenclatures",
+        "_type": "_doc",
+        "_id": "95674",
+        "_score": 69.2645,
+        "_source": {
+          "id": 95674,
+          "goods_nomenclature_item_id": "0302459010",
+          "heading_id": "0302",
+          "chapter_id": "03",
+          "producline_suffix": "80",
+          "goods_nomenclature_class": "Commodity",
+          "description": "Horse mackerel (scad) (Caranx trachurus)",
+          "description_indexed": "Horse mackerel (scad) (Caranx trachurus)",
+          "chapter_description": "FISH AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES",
+          "heading_description": "Fish, fresh or chilled, excluding fish fillets and other fish meat of heading 0304",
+          "search_references": "",
+          "ancestors": [
+            {
+              "id": 28373,
+              "goods_nomenclature_item_id": "0300000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Chapter",
+              "description": "FISH AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES",
+              "description_indexed": "FISH AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES"
+            },
+            {
+              "id": 28402,
+              "goods_nomenclature_item_id": "0302000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Heading",
+              "description": "Fish, fresh or chilled, excluding fish fillets and other fish meat of heading 0304",
+              "description_indexed": "Fish, fresh or chilled"
+            },
+            {
+              "id": 93985,
+              "goods_nomenclature_item_id": "0302410000",
+              "productline_suffix": "10",
+              "goods_nomenclature_class": "Subheading",
+              "description": "Herrings (Clupea harengus, Clupea pallasii), anchovies (Engraulis spp.), sardines (Sardina pilchardus, Sardinops spp.), sardinella (Sardinella spp.), brisling or sprats (Sprattus sprattus), mackerel (Scomber scombrus, Scomber australasicus, Scomber japonicus), Indian mackerels (Rastrelliger spp.), seerfishes (Scomberomorus spp.), jack and horse mackerel (Trachurus spp.), jacks, crevalles (Caranx spp.), cobia (Rachycentron canadum), silver pomfrets (Pampus spp.), Pacific saury (Cololabis saira), scads (Decapterus spp.), capelin (Mallotus villosus), swordfish (Xiphias gladius), Kawakawa (Euthynnus affinis), bonitos (Sarda spp.), marlins, sailfishes, spearfish (Istiophoridae), excluding edible fish offal of subheadings 0302 91 to 0302 99",
+              "description_indexed": "Herrings (Clupea harengus, Clupea pallasii), anchovies (Engraulis spp.), sardines (Sardina pilchardus, Sardinops spp.), sardinella (Sardinella spp.), brisling or sprats (Sprattus sprattus), mackerel (Scomber scombrus, Scomber australasicus, Scomber japonicus), Indian mackerels (Rastrelliger spp.), seerfishes (Scomberomorus spp.), jack and horse mackerel (Trachurus spp.), jacks, crevalles (Caranx spp.), cobia (Rachycentron canadum), silver pomfrets (Pampus spp.), Pacific saury (Cololabis saira), scads (Decapterus spp.), capelin (Mallotus villosus), swordfish (Xiphias gladius), Kawakawa (Euthynnus affinis), bonitos (Sarda spp.), marlins, sailfishes, spearfish (Istiophoridae)"
+            },
+            {
+              "id": 93993,
+              "goods_nomenclature_item_id": "0302450000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Subheading",
+              "description": "Jack and horse mackerel (Trachurus spp.)",
+              "description_indexed": "Jack and horse mackerel (Trachurus spp.)"
+            },
+            {
+              "id": 93996,
+              "goods_nomenclature_item_id": "0302459000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Subheading",
+              "description": "Other",
+              "description_indexed": "Other"
+            }
+          ],
+          "validity_start_date": "2012-01-01T00:00:00Z",
+          "validity_end_date": null
+        }
+      }
+    ]
+  }
+}

--- a/spec/fixtures/beta/search/goods_nomenclatures/no_hits.json
+++ b/spec/fixtures/beta/search/goods_nomenclatures/no_hits.json
@@ -1,0 +1,20 @@
+{
+  "took": 1,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 0,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": [
+
+    ]
+  }
+}

--- a/spec/fixtures/beta/search/goods_nomenclatures/serialized_result.json
+++ b/spec/fixtures/beta/search/goods_nomenclatures/serialized_result.json
@@ -1,0 +1,144 @@
+{
+  "data": {
+    "id": "51579623029349bc57538b4773f5a1ed",
+    "type": "search_result",
+    "attributes": {
+      "took": 1,
+      "timed_out": false,
+      "max_score": 74.98428,
+      "total_results": 1
+    },
+    "relationships": {
+      "search_query_parser_result": {
+        "data": {
+          "id": "0e956af30bdc0dcd5679f2249adc6d94",
+          "type": "search_query_parser_result"
+        }
+      },
+      "hits": {
+        "data": [
+          {
+            "id": "98910",
+            "type": "commodity"
+          }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "29417",
+      "type": "ancestor",
+      "attributes": {
+        "goods_nomenclature_item_id": "0400000000",
+        "producline_suffix": null,
+        "description": "DAIRY PRODUCE; BIRDS' EGGS; NATURAL HONEY; EDIBLE PRODUCTS OF ANIMAL ORIGIN, NOT ELSEWHERE SPECIFIED OR INCLUDED",
+        "description_indexed": "DAIRY PRODUCE; BIRDS' EGGS; NATURAL HONEY; EDIBLE PRODUCTS OF ANIMAL ORIGIN, NOT ELSEWHERE SPECIFIED OR INCLUDED"
+      }
+    },
+    {
+      "id": "29719",
+      "type": "ancestor",
+      "attributes": {
+        "goods_nomenclature_item_id": "0406000000",
+        "producline_suffix": null,
+        "description": "Cheese and curd",
+        "description_indexed": "Cheese and curd"
+      }
+    },
+    {
+      "id": "29720",
+      "type": "ancestor",
+      "attributes": {
+        "goods_nomenclature_item_id": "0406100000",
+        "producline_suffix": null,
+        "description": "Fresh (unripened or uncured) cheese, including whey cheese, and curd",
+        "description_indexed": "Fresh (unripened or uncured) cheese, including whey cheese, and curd"
+      }
+    },
+    {
+      "id": "98904",
+      "type": "ancestor",
+      "attributes": {
+        "goods_nomenclature_item_id": "0406103000",
+        "producline_suffix": null,
+        "description": "Of a fat content, by weight, not exceeding 40 %",
+        "description_indexed": "Of a fat content, by weight"
+      }
+    },
+    {
+      "id": "98906",
+      "type": "ancestor",
+      "attributes": {
+        "goods_nomenclature_item_id": "0406105000",
+        "producline_suffix": null,
+        "description": "Other",
+        "description_indexed": "Other"
+      }
+    },
+    {
+      "id": "98910",
+      "type": "commodity",
+      "attributes": {
+        "goods_nomenclature_item_id": "0406105090",
+        "producline_suffix": "80",
+        "description": "Other",
+        "description_indexed": "Other",
+        "search_references": "ricotta, mascarpone",
+        "validity_start_date": "2015-01-01T00:00:00Z",
+        "validity_end_date": null,
+        "chapter_id": "04",
+        "score": 74.98428,
+        "chapter_description": "DAIRY PRODUCE; BIRDS' EGGS; NATURAL HONEY; EDIBLE PRODUCTS OF ANIMAL ORIGIN, NOT ELSEWHERE SPECIFIED OR INCLUDED",
+        "heading_description": "Cheese and curd",
+        "heading_id": "0406"
+      },
+      "relationships": {
+        "ancestors": {
+          "data": [
+            {
+              "id": "29417",
+              "type": "ancestor"
+            },
+            {
+              "id": "29719",
+              "type": "ancestor"
+            },
+            {
+              "id": "29720",
+              "type": "ancestor"
+            },
+            {
+              "id": "98904",
+              "type": "ancestor"
+            },
+            {
+              "id": "98906",
+              "type": "ancestor"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "0e956af30bdc0dcd5679f2249adc6d94",
+      "type": "search_query_parser_result",
+      "attributes": {
+        "corrected_search_query": "ricotta",
+        "original_search_query": "ricotta",
+        "verbs": [
+
+        ],
+        "adjectives": [
+
+        ],
+        "nouns": [
+
+        ],
+        "noun_chunks": [
+          "ricotta"
+        ]
+      }
+    }
+  ]
+}

--- a/spec/fixtures/beta/search/goods_nomenclatures/single_hit.json
+++ b/spec/fixtures/beta/search/goods_nomenclatures/single_hit.json
@@ -1,0 +1,82 @@
+{
+  "took": 1,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 1,
+      "relation": "eq"
+    },
+    "max_score": 74.98428,
+    "hits": [
+      {
+        "_index": "tariff-goods_nomenclatures",
+        "_type": "_doc",
+        "_id": "98910",
+        "_score": 74.98428,
+        "_source": {
+          "id": 98910,
+          "goods_nomenclature_item_id": "0406105090",
+          "heading_id": "0406",
+          "chapter_id": "04",
+          "producline_suffix": "80",
+          "goods_nomenclature_class": "Commodity",
+          "description": "Other",
+          "description_indexed": "Other",
+          "chapter_description": "DAIRY PRODUCE; BIRDS' EGGS; NATURAL HONEY; EDIBLE PRODUCTS OF ANIMAL ORIGIN, NOT ELSEWHERE SPECIFIED OR INCLUDED",
+          "heading_description": "Cheese and curd",
+          "search_references": "ricotta, mascarpone",
+          "ancestors": [
+            {
+              "id": 29417,
+              "goods_nomenclature_item_id": "0400000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Chapter",
+              "description": "DAIRY PRODUCE; BIRDS' EGGS; NATURAL HONEY; EDIBLE PRODUCTS OF ANIMAL ORIGIN, NOT ELSEWHERE SPECIFIED OR INCLUDED",
+              "description_indexed": "DAIRY PRODUCE; BIRDS' EGGS; NATURAL HONEY; EDIBLE PRODUCTS OF ANIMAL ORIGIN, NOT ELSEWHERE SPECIFIED OR INCLUDED"
+            },
+            {
+              "id": 29719,
+              "goods_nomenclature_item_id": "0406000000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Heading",
+              "description": "Cheese and curd",
+              "description_indexed": "Cheese and curd"
+            },
+            {
+              "id": 29720,
+              "goods_nomenclature_item_id": "0406100000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Subheading",
+              "description": "Fresh (unripened or uncured) cheese, including whey cheese, and curd",
+              "description_indexed": "Fresh (unripened or uncured) cheese, including whey cheese, and curd"
+            },
+            {
+              "id": 98904,
+              "goods_nomenclature_item_id": "0406103000",
+              "productline_suffix": "10",
+              "goods_nomenclature_class": "Subheading",
+              "description": "Of a fat content, by weight, not exceeding 40 %",
+              "description_indexed": "Of a fat content, by weight"
+            },
+            {
+              "id": 98906,
+              "goods_nomenclature_item_id": "0406105000",
+              "productline_suffix": "80",
+              "goods_nomenclature_class": "Subheading",
+              "description": "Other",
+              "description_indexed": "Other"
+            }
+          ],
+          "validity_start_date": "2015-01-01T00:00:00Z",
+          "validity_end_date": null
+        }
+      }
+    ]
+  }
+}

--- a/spec/models/beta/search/goods_nomenclature_query_spec.rb
+++ b/spec/models/beta/search/goods_nomenclature_query_spec.rb
@@ -1,0 +1,217 @@
+RSpec.describe Beta::Search::GoodsNomenclatureQuery do
+  describe '.build' do
+    subject(:result) { described_class.build(search_query_parser_result) }
+
+    let(:search_query_parser_result) { build(:search_query_parser_result) }
+
+    it { is_expected.to be_a(described_class) }
+  end
+
+  describe '#query' do
+    context 'when there are nouns, noun_chunks, verbs and adjectives' do
+      subject(:goods_nomenclature_query) { build(:goods_nomenclature_query, :full_query).query }
+
+      let(:expected_query) do
+        {
+          query: {
+            bool: {
+              must: [
+                {
+                  multi_match: {
+                    query: 'man',
+                    fuzziness: 0.1,
+                    prefix_length: 2,
+                    tie_breaker: 0.3,
+                    type: 'best_fields',
+                    fields: [
+                      'search_references^12',
+                      'chapter_description^10',
+                      'heading_description^8',
+                      'description.exact^6',
+                      'description_indexed^6',
+                      'goods_nomenclature_item_id',
+                    ],
+                  },
+                },
+              ],
+              should: [
+                {
+                  multi_match: {
+                    query: 'run',
+                    fuzziness: 0.1,
+                    prefix_length: 2,
+                    tie_breaker: 0.3,
+                    type: 'best_fields',
+                    fields: [
+                      'search_references^12',
+                      'chapter_description^10',
+                      'heading_description^8',
+                      'description.exact^6',
+                      'description_indexed^6',
+                      'goods_nomenclature_item_id',
+                    ],
+                  },
+                },
+                {
+                  multi_match: {
+                    query: 'tall',
+                    fuzziness: 0.1,
+                    prefix_length: 2,
+                    tie_breaker: 0.3,
+                    type: 'best_fields',
+                    fields: [
+                      'search_references^12',
+                      'chapter_description^10',
+                      'heading_description^8',
+                      'description.exact^6',
+                      'description_indexed^6',
+                      'goods_nomenclature_item_id',
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        }
+      end
+
+      it { is_expected.to eq(expected_query) }
+    end
+
+    context 'when there are nouns' do
+      subject(:goods_nomenclature_query) { build(:goods_nomenclature_query, nouns: %w[man]).query }
+
+      let(:expected_query) do
+        {
+          query: {
+            bool: {
+              must: [
+                {
+                  multi_match: {
+                    query: 'man',
+                    fuzziness: 0.1,
+                    prefix_length: 2,
+                    tie_breaker: 0.3,
+                    type: 'best_fields',
+                    fields: [
+                      'search_references^12',
+                      'chapter_description^10',
+                      'heading_description^8',
+                      'description.exact^6',
+                      'description_indexed^6',
+                      'goods_nomenclature_item_id',
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        }
+      end
+
+      it { is_expected.to eq(expected_query) }
+    end
+
+    context 'when there are noun_chunks' do
+      subject(:goods_nomenclature_query) { build(:goods_nomenclature_query, noun_chunks: ['clothing sets']).query }
+
+      let(:expected_query) do
+        {
+          query: {
+            bool: {
+              must: [
+                {
+                  multi_match: {
+                    query: 'clothing sets',
+                    fuzziness: 0.1,
+                    prefix_length: 2,
+                    tie_breaker: 0.3,
+                    type: 'best_fields',
+                    fields: [
+                      'search_references^12',
+                      'chapter_description^10',
+                      'heading_description^8',
+                      'description.exact^6',
+                      'description_indexed^6',
+                      'goods_nomenclature_item_id',
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        }
+      end
+
+      it { is_expected.to eq(expected_query) }
+    end
+
+    context 'when there are verbs' do
+      subject(:goods_nomenclature_query) { build(:goods_nomenclature_query, verbs: %w[running]).query }
+
+      let(:expected_query) do
+        {
+          query: {
+            bool: {
+              should: [
+                {
+                  multi_match: {
+                    query: 'running',
+                    fuzziness: 0.1,
+                    prefix_length: 2,
+                    tie_breaker: 0.3,
+                    type: 'best_fields',
+                    fields: [
+                      'search_references^12',
+                      'chapter_description^10',
+                      'heading_description^8',
+                      'description.exact^6',
+                      'description_indexed^6',
+                      'goods_nomenclature_item_id',
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        }
+      end
+
+      it { is_expected.to eq(expected_query) }
+    end
+
+    context 'when there are adjectives' do
+      subject(:goods_nomenclature_query) { build(:goods_nomenclature_query, verbs: %w[tall]).query }
+
+      let(:expected_query) do
+        {
+          query: {
+            bool: {
+              should: [
+                {
+                  multi_match: {
+                    query: 'tall',
+                    fuzziness: 0.1,
+                    prefix_length: 2,
+                    tie_breaker: 0.3,
+                    type: 'best_fields',
+                    fields: [
+                      'search_references^12',
+                      'chapter_description^10',
+                      'heading_description^8',
+                      'description.exact^6',
+                      'description_indexed^6',
+                      'goods_nomenclature_item_id',
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        }
+      end
+
+      it { is_expected.to eq(expected_query) }
+    end
+  end
+end

--- a/spec/models/beta/search/search_query_parser_result_spec.rb
+++ b/spec/models/beta/search/search_query_parser_result_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Beta::Search::SearchQueryParserResult do
+  describe '.build' do
+    subject(:result) { described_class.build(attributes) }
+
+    let(:attributes) do
+      {
+        'tokens' => {
+          'adjectives' => %w[tall],
+          'nouns' => %w[man],
+          'noun_chunks' => ['tall man'],
+          'verbs' => [],
+        },
+        'original_search_query' => 'tall man',
+        'corrected_search_query' => 'tall man',
+      }
+    end
+
+    it { is_expected.to be_a(described_class) }
+    it { expect(result.adjectives).to eq(%w[tall]) }
+    it { expect(result.nouns).to eq(%w[man]) }
+    it { expect(result.noun_chunks).to eq(['tall man']) }
+    it { expect(result.verbs).to eq([]) }
+    it { expect(result.original_search_query).to eq('tall man') }
+    it { expect(result.corrected_search_query).to eq('tall man') }
+  end
+
+  describe '#id' do
+    subject(:id) { build(:search_query_parser_result).id }
+
+    it { is_expected.to eq('240ad90c8bd0e29cc402ff257d033747') }
+  end
+end

--- a/spec/models/beta/search/search_result_spec.rb
+++ b/spec/models/beta/search/search_result_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe Beta::Search::SearchResult do
+  describe '.build' do
+    subject(:result) { described_class.build(search_result, search_query_parser_result) }
+
+    let(:search_result) do
+      test_filename = Rails.root.join(file_fixture_path, 'beta/search/goods_nomenclatures/multiple_hits.json')
+
+      Hashie::TariffMash.new(JSON.parse(File.read(test_filename)))
+    end
+
+    let(:search_query_parser_result) { build(:search_query_parser_result, :multiple_hits) }
+
+    it { is_expected.to be_a(described_class) }
+    it { expect(result.took).to eq(3) }
+    it { expect(result.time_out).to eq(false) }
+    it { expect(result.max_score).to eq(161.34302) }
+    it { expect(result.hits.count).to eq(10) }
+    it { expect(result.search_query_parser_result).to eq(search_query_parser_result) }
+  end
+
+  describe '#id' do
+    subject(:id) { build(:search_result).id }
+
+    it { is_expected.to eq('40d70a67aafa270656c01738cfec041b') }
+  end
+
+  describe '#search_query_parser_result_id' do
+    subject(:search_query_parser_result_id) { build(:search_result).search_query_parser_result_id }
+
+    it { is_expected.to eq('52b14869c15726dda86b87cb93666a74') }
+  end
+
+  describe '#hit_ids' do
+    subject(:hit_ids) { build(:search_result).hit_ids }
+
+    it { is_expected.to eq([93_797, 93_796, 93_798, 93_799, 93_800, 93_801, 72_763, 27_624, 93_994, 95_674]) }
+  end
+
+  describe '#total_results' do
+    subject(:total_results) { build(:search_result).total_results }
+
+    it { is_expected.to eq(10) }
+  end
+end

--- a/spec/requests/api/beta/search_controller_spec.rb
+++ b/spec/requests/api/beta/search_controller_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe Api::Beta::SearchController, type: :request do
+  describe 'GET #index' do
+    subject(:do_request) do
+      # TODO: We're going to make the version just `beta` in a separate PR
+      headers = { 'Accept' => 'application/vnd.uktt.vbeta' }
+
+      get '/search', params: { q: 'ricotta' }, headers: headers
+
+      response
+    end
+
+    before do
+      allow(TradeTariffBackend.v2_search_client).to receive(:search).and_return(search_result)
+      allow(SearchQueryParser).to receive(:new).and_return(search_query_parser_service)
+    end
+
+    let(:search_result) do
+      test_filename = Rails.root.join(file_fixture_path, 'beta/search/goods_nomenclatures/single_hit.json')
+
+      Hashie::TariffMash.new(JSON.parse(File.read(test_filename)))
+    end
+
+    let(:expected_serialized_result) do
+      test_filename = Rails.root.join(file_fixture_path, 'beta/search/goods_nomenclatures/serialized_result.json')
+
+      JSON.parse(File.read(test_filename))
+    end
+
+    let(:search_query_parser_service) { instance_double('SearchQueryParser', call: search_query_parser_result) }
+    let(:search_query_parser_result) { build(:search_query_parser_result, :single_hit) }
+
+    it { is_expected.to have_http_status(:ok) }
+    it { expect(do_request.body).to match_json_expression(expected_serialized_result) }
+  end
+end

--- a/spec/serializers/api/beta/ancestor_serializer_spec.rb
+++ b/spec/serializers/api/beta/ancestor_serializer_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe Api::Beta::AncestorSerializer do
+  describe '#serializable_hash' do
+    subject(:serializable_hash) { described_class.new(serializable).serializable_hash }
+
+    let(:serializable) do
+      Hashie::TariffMash.new(
+        id: 27_623,
+        goods_nomenclature_item_id: '0100000000',
+        producline_suffix: '80',
+        goods_nomenclature_class: 'Chapter',
+        description: 'LIVE ANIMALS',
+        description_indexed: 'LIVE ANIMALS',
+      )
+    end
+
+    let(:expected) do
+      {
+        data: {
+          id: '27623',
+          type: :ancestor,
+          attributes: {
+            goods_nomenclature_item_id: '0100000000',
+            producline_suffix: '80',
+            description: 'LIVE ANIMALS',
+            description_indexed: 'LIVE ANIMALS',
+          },
+        },
+      }
+    end
+
+    it { is_expected.to eq(expected) }
+  end
+end

--- a/spec/serializers/api/beta/chapter_serializer_spec.rb
+++ b/spec/serializers/api/beta/chapter_serializer_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe Api::Beta::ChapterSerializer do
+  describe '#serializable_hash' do
+    subject(:serializable_hash) { described_class.new(serializable).serializable_hash }
+
+    let(:serializable) do
+      Hashie::TariffMash.new(
+        {
+          score: 10.231,
+          goods_nomenclature_class: 'Chapter',
+          id: 41_064,
+          goods_nomenclature_item_id: '5200000000',
+          producline_suffix: '80',
+          description: 'COTTON',
+          description_indexed: 'COTTON',
+          chapter_description: nil,
+          heading_description: nil,
+          search_references: '',
+          validity_start_date: '1971-12-31T00:00:00Z',
+          validity_end_date: nil,
+          chapter_id: '52',
+          heading_id: '5200',
+          ancestors: [],
+          ancestor_ids: [],
+        },
+      )
+    end
+
+    let(:expected) do
+      {
+        data: {
+          id: '41064',
+          type: :chapter,
+          attributes: {
+            goods_nomenclature_item_id: '5200000000',
+            producline_suffix: '80',
+            description: 'COTTON',
+            description_indexed: 'COTTON',
+            search_references: '',
+            validity_start_date: '1971-12-31T00:00:00Z',
+            validity_end_date: nil,
+            chapter_id: '52',
+            score: 10.231,
+          },
+          relationships: { ancestors: { data: [] } },
+        },
+      }
+    end
+
+    it { is_expected.to eq(expected) }
+  end
+end

--- a/spec/serializers/api/beta/commodity_serializer_spec.rb
+++ b/spec/serializers/api/beta/commodity_serializer_spec.rb
@@ -1,0 +1,108 @@
+RSpec.describe Api::Beta::CommoditySerializer do
+  describe '#serializable_hash' do
+    subject(:serializable_hash) { described_class.new(serializable, include: %w[ancestors]).serializable_hash }
+
+    let(:serializable) do
+      Hashie::TariffMash.new(
+        {
+          score: 10.231,
+          id: 40_956,
+          goods_nomenclature_item_id: '5101190000',
+          heading_id: '5101',
+          chapter_id: '51',
+          producline_suffix: '80',
+          goods_nomenclature_class: 'Commodity',
+          description: 'Other',
+          description_indexed: 'Other',
+          chapter_description: 'WOOL, FINE OR COARSE ANIMAL HAIR; HORSEHAIR YARN AND WOVEN FABRIC',
+          heading_description: 'Wool, not carded or combed',
+          search_references: '',
+          ancestors: [
+            {
+              id: 40_952,
+              goods_nomenclature_item_id: '5100000000',
+              productline_suffix: '80',
+              goods_nomenclature_class: 'Chapter',
+              description: 'WOOL, FINE OR COARSE ANIMAL HAIR; HORSEHAIR YARN AND WOVEN FABRIC',
+              description_indexed: 'WOOL, FINE OR COARSE ANIMAL HAIR; HORSEHAIR YARN AND WOVEN FABRIC',
+            },
+            {
+              id: 40_953,
+              goods_nomenclature_item_id: '5101000000',
+              productline_suffix: '80',
+              goods_nomenclature_class: 'Heading',
+              description: 'Wool, not carded or combed',
+              description_indexed: 'Wool',
+            },
+            {
+              id: 40_954,
+              goods_nomenclature_item_id: '5101110000',
+              productline_suffix: '10',
+              goods_nomenclature_class: 'Subheading',
+              description: 'Greasy, including fleece-washed wool',
+              description_indexed: 'Greasy, including fleece-washed wool',
+            },
+          ],
+          ancestor_ids: [
+            40_952,
+            40_953,
+            40_954,
+          ],
+          validity_start_date: '1972-01-01T00:00:00Z',
+          validity_end_date: nil,
+        },
+      )
+    end
+
+    let(:expected) do
+      {
+        data: {
+          id: '40956',
+          type: :commodity,
+          attributes: {
+            goods_nomenclature_item_id: '5101190000',
+            producline_suffix: '80',
+            description: 'Other',
+            description_indexed: 'Other',
+            search_references: '',
+            validity_start_date: '1972-01-01T00:00:00Z',
+            validity_end_date: nil,
+            chapter_id: '51',
+            score: 10.231,
+            chapter_description: 'WOOL, FINE OR COARSE ANIMAL HAIR; HORSEHAIR YARN AND WOVEN FABRIC',
+            heading_description: 'Wool, not carded or combed',
+            heading_id: '5101',
+          },
+          relationships: {
+            ancestors: {
+              data: [
+                { id: '40952', type: :ancestor },
+                { id: '40953', type: :ancestor },
+                { id: '40954', type: :ancestor },
+              ],
+            },
+          },
+        },
+        included: [
+          {
+            id: '40952',
+            type: :ancestor,
+            attributes: { goods_nomenclature_item_id: '5100000000', producline_suffix: nil, description: 'WOOL, FINE OR COARSE ANIMAL HAIR; HORSEHAIR YARN AND WOVEN FABRIC', description_indexed: 'WOOL, FINE OR COARSE ANIMAL HAIR; HORSEHAIR YARN AND WOVEN FABRIC' },
+          },
+          {
+            id: '40953',
+            type: :ancestor,
+            attributes: { goods_nomenclature_item_id: '5101000000', producline_suffix: nil, description: 'Wool, not carded or combed', description_indexed: 'Wool' },
+          },
+          {
+            id: '40954',
+            type: :ancestor,
+            attributes: { goods_nomenclature_item_id: '5101110000', producline_suffix: nil, description: 'Greasy, including fleece-washed wool', description_indexed: 'Greasy, including fleece-washed wool' },
+          },
+        ],
+      }
+    end
+
+    it { is_expected.to eq(expected) }
+  end
+end

--- a/spec/serializers/api/beta/heading_serializer_spec.rb
+++ b/spec/serializers/api/beta/heading_serializer_spec.rb
@@ -1,0 +1,71 @@
+RSpec.describe Api::Beta::HeadingSerializer do
+  describe '#serializable_hash' do
+    subject(:serializable_hash) { described_class.new(serializable, include: %w[ancestors]).serializable_hash }
+
+    let(:serializable) do
+      Hashie::TariffMash.new(
+        score: 10.24,
+        id: 40_961,
+        goods_nomenclature_item_id: '5102000000',
+        heading_id: '5102',
+        chapter_id: '51',
+        producline_suffix: '80',
+        goods_nomenclature_class: 'Heading',
+        description: 'Fine or coarse animal hair, not carded or combed',
+        description_indexed: 'Fine or coarse animal hair',
+        chapter_description: 'WOOL, FINE OR COARSE ANIMAL HAIR; HORSEHAIR YARN AND WOVEN FABRIC',
+        heading_description: nil,
+        search_references: '',
+        ancestors: [
+          {
+            id: 40_952,
+            goods_nomenclature_item_id: '5100000000',
+            productline_suffix: '80',
+            goods_nomenclature_class: 'Chapter',
+            description: 'WOOL, FINE OR COARSE ANIMAL HAIR; HORSEHAIR YARN AND WOVEN FABRIC',
+            description_indexed: 'WOOL, FINE OR COARSE ANIMAL HAIR; HORSEHAIR YARN AND WOVEN FABRIC',
+          },
+        ],
+        ancestor_ids: [40_952],
+        validity_start_date: '1972-01-01T00:00:00Z',
+        validity_end_date: nil,
+      )
+    end
+
+    let(:expected) do
+      {
+        data: {
+          id: '40961',
+          type: :heading,
+          attributes: {
+            goods_nomenclature_item_id: '5102000000',
+            producline_suffix: '80',
+            description: 'Fine or coarse animal hair, not carded or combed',
+            description_indexed: 'Fine or coarse animal hair',
+            search_references: '',
+            validity_start_date: '1972-01-01T00:00:00Z',
+            validity_end_date: nil,
+            chapter_id: '51',
+            score: 10.24,
+            chapter_description: 'WOOL, FINE OR COARSE ANIMAL HAIR; HORSEHAIR YARN AND WOVEN FABRIC',
+          },
+          relationships: { ancestors: { data: [{ id: '40952', type: :ancestor }] } },
+        },
+        included: [
+          {
+            id: '40952',
+            type: :ancestor,
+            attributes: {
+              goods_nomenclature_item_id: '5100000000',
+              producline_suffix: nil,
+              description: 'WOOL, FINE OR COARSE ANIMAL HAIR; HORSEHAIR YARN AND WOVEN FABRIC',
+              description_indexed: 'WOOL, FINE OR COARSE ANIMAL HAIR; HORSEHAIR YARN AND WOVEN FABRIC',
+            },
+          },
+        ],
+      }
+    end
+
+    it { is_expected.to eq(expected) }
+  end
+end

--- a/spec/serializers/api/beta/search_query_parser_result_serializer_spec.rb
+++ b/spec/serializers/api/beta/search_query_parser_result_serializer_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe Api::Beta::SearchQueryParserResultSerializer do
+  describe '#serializable_hash' do
+    subject(:serializable_hash) { described_class.new(serializable).serializable_hash }
+
+    let(:serializable) { build(:search_query_parser_result) }
+
+    let(:expected) do
+      {
+        data: {
+          id: '240ad90c8bd0e29cc402ff257d033747',
+          type: :search_query_parser_result,
+          attributes: {
+            corrected_search_query: 'halibut sausage stenolepis cheese binocular parsnip pharmacy paper',
+            original_search_query: 'halbiut sausadge stenolepsis chese bnoculars parnsip farmacy pape',
+            verbs: [],
+            adjectives: [],
+            nouns: %w[halibut sausage stenolepis cheese binocular parsnip pharmacy paper],
+            noun_chunks: ['halibut sausage stenolepis cheese binocular parsnip pharmacy paper'],
+          },
+        },
+      }
+    end
+
+    it { is_expected.to eq(expected) }
+  end
+end

--- a/spec/serializers/api/beta/search_result_serializer_spec.rb
+++ b/spec/serializers/api/beta/search_result_serializer_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe Api::Beta::SearchResultSerializer do
+  describe '#serializable_hash' do
+    subject(:serializable_hash) { described_class.new(serializable).serializable_hash }
+
+    let(:serializable) { build(:search_result, :multiple_hits) }
+
+    let(:expected) do
+      {
+        data: {
+          id: '40d70a67aafa270656c01738cfec041b',
+          type: :search_result,
+          attributes: { took: 3, timed_out: false, max_score: 161.34302, total_results: 10 },
+          relationships: {
+            search_query_parser_result: {
+              data: {
+                id: '52b14869c15726dda86b87cb93666a74',
+                type: :search_query_parser_result,
+              },
+            },
+            hits: {
+              data: [
+                { id: '93797', type: :subheading },
+                { id: '93796', type: :commodity },
+                { id: '93798', type: :subheading },
+                { id: '93799', type: :commodity },
+                { id: '93800', type: :commodity },
+                { id: '93801', type: :commodity },
+                { id: '72763', type: :commodity },
+                { id: '27624', type: :heading },
+                { id: '93994', type: :commodity },
+                { id: '95674', type: :commodity },
+              ],
+            },
+          },
+        },
+      }
+    end
+
+    it { is_expected.to eq(expected) }
+  end
+end

--- a/spec/serializers/api/beta/subheading_serializer_spec.rb
+++ b/spec/serializers/api/beta/subheading_serializer_spec.rb
@@ -1,0 +1,90 @@
+RSpec.describe Api::Beta::SubheadingSerializer do
+  describe '#serializable_hash' do
+    subject(:serializable_hash) { described_class.new(serializable, include: %w[ancestors]).serializable_hash }
+
+    let(:serializable) do
+      Hashie::TariffMash.new(
+        id: 73_852,
+        goods_nomenclature_item_id: '5102110000',
+        heading_id: '5102',
+        chapter_id: '51',
+        producline_suffix: '10',
+        goods_nomenclature_class: 'Subheading',
+        description: 'Fine animal hair',
+        description_indexed: 'Fine animal hair',
+        chapter_description: 'WOOL, FINE OR COARSE ANIMAL HAIR; HORSEHAIR YARN AND WOVEN FABRIC',
+        heading_description: 'Fine or coarse animal hair, not carded or combed',
+        search_references: '',
+        ancestors: [
+          {
+            id: 40_952,
+            goods_nomenclature_item_id: '5100000000',
+            productline_suffix: '80',
+            goods_nomenclature_class: 'Chapter',
+            description: 'WOOL, FINE OR COARSE ANIMAL HAIR; HORSEHAIR YARN AND WOVEN FABRIC',
+            description_indexed: 'WOOL, FINE OR COARSE ANIMAL HAIR; HORSEHAIR YARN AND WOVEN FABRIC',
+          },
+          {
+            id: 40_961,
+            goods_nomenclature_item_id: '5102000000',
+            productline_suffix: '80',
+            goods_nomenclature_class: 'Heading',
+            description: 'Fine or coarse animal hair, not carded or combed',
+            description_indexed: 'Fine or coarse animal hair',
+          },
+        ],
+        ancestor_ids: [
+          40_952,
+          40_961,
+        ],
+        validity_start_date: '2002-01-01T00:00:00Z',
+        validity_end_date: nil,
+      )
+    end
+
+    let(:expected) do
+      {
+        data: {
+          id: '73852',
+          type: :subheading,
+          attributes: {
+            goods_nomenclature_item_id: '5102110000',
+            producline_suffix: '10',
+            description: 'Fine animal hair',
+            description_indexed: 'Fine animal hair',
+            search_references: '',
+            validity_start_date: '2002-01-01T00:00:00Z',
+            validity_end_date: nil,
+            chapter_id: '51',
+            score: nil,
+            chapter_description: 'WOOL, FINE OR COARSE ANIMAL HAIR; HORSEHAIR YARN AND WOVEN FABRIC',
+            heading_id: '5102',
+            heading_description: 'Fine or coarse animal hair, not carded or combed',
+          },
+          relationships: {
+            ancestors: {
+              data: [
+                { id: '40952', type: :ancestor },
+                { id: '40961', type: :ancestor },
+              ],
+            },
+          },
+        },
+        included: [
+          {
+            id: '40952',
+            type: :ancestor,
+            attributes: { goods_nomenclature_item_id: '5100000000', producline_suffix: nil, description: 'WOOL, FINE OR COARSE ANIMAL HAIR; HORSEHAIR YARN AND WOVEN FABRIC', description_indexed: 'WOOL, FINE OR COARSE ANIMAL HAIR; HORSEHAIR YARN AND WOVEN FABRIC' },
+          },
+          {
+            id: '40961',
+            type: :ancestor,
+            attributes: { goods_nomenclature_item_id: '5102000000', producline_suffix: nil, description: 'Fine or coarse animal hair, not carded or combed', description_indexed: 'Fine or coarse animal hair' },
+          },
+        ],
+      }
+    end
+
+    it { is_expected.to eq(expected) }
+  end
+end

--- a/spec/serializers/search/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/search/goods_nomenclature_serializer_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Search::GoodsNomenclatureSerializer do
 
     let(:pattern) do
       {
+        id: Integer,
         goods_nomenclature_item_id: '0101210000',
         heading_id: '0101',
         chapter_id: '01',
@@ -18,16 +19,20 @@ RSpec.describe Search::GoodsNomenclatureSerializer do
         search_references: 'secret sauce',
         ancestors: [
           {
+            id: Integer,
             goods_nomenclature_item_id: '0100000000',
             productline_suffix: '80',
             goods_nomenclature_class: 'Chapter',
             description: 'Live horses, asses, mules and hinnies',
+            description_indexed: 'Live horses, asses, mules and hinnies',
           },
           {
+            id: Integer,
             goods_nomenclature_item_id: '0101000000',
             productline_suffix: '80',
             goods_nomenclature_class: 'Heading',
             description: 'Live animals',
+            description_indexed: 'Live animals',
           },
         ],
         validity_start_date: '2020-06-29T00:00:00Z',

--- a/spec/services/api/beta/search_service_spec.rb
+++ b/spec/services/api/beta/search_service_spec.rb
@@ -1,0 +1,64 @@
+RSpec.describe Api::Beta::SearchService do
+  describe '#call' do
+    subject(:call) { described_class.new('ricotta').call }
+
+    before do
+      allow(TradeTariffBackend.v2_search_client).to receive(:search).and_return(search_result)
+      allow(SearchQueryParser).to receive(:new).and_return(search_query_parser_service)
+      allow(Beta::Search::SearchResult).to receive(:build).and_call_original
+
+      call
+    end
+
+    let(:search_result) do
+      test_filename = Rails.root.join(file_fixture_path, 'beta/search/goods_nomenclatures/single_hit.json')
+
+      Hashie::TariffMash.new(JSON.parse(File.read(test_filename)))
+    end
+
+    let(:search_query_parser_service) { instance_double('SearchQueryParser', call: search_query_parser_result) }
+    let(:search_query_parser_result) { build(:search_query_parser_result, :single_hit) }
+
+    let(:expected_search_args) do
+      {
+        body: {
+          query: {
+            bool: {
+              must: [
+                {
+                  multi_match: {
+                    fields: [
+                      'search_references^12',
+                      'chapter_description^10',
+                      'heading_description^8',
+                      'description.exact^6',
+                      'description_indexed^6',
+                      'goods_nomenclature_item_id',
+                    ],
+                    fuzziness: 0.1,
+                    prefix_length: 2,
+                    query: 'ricotta',
+                    tie_breaker: 0.3,
+                    type: 'best_fields',
+                  },
+                },
+              ],
+            },
+          },
+        },
+        index: 'tariff-goods_nomenclatures',
+      }
+    end
+
+    let(:expected_serialized_result) do
+      test_filename = Rails.root.join(file_fixture_path, 'beta/search/goods_nomenclatures/serialized_result.json')
+
+      JSON.parse(File.read(test_filename))
+    end
+
+    it { expect(SearchQueryParser).to have_received(:new).with('ricotta') }
+    it { expect(TradeTariffBackend.v2_search_client).to have_received(:search).with(expected_search_args) }
+    it { expect(Beta::Search::SearchResult).to have_received(:build).with(search_result, search_query_parser_result) }
+    it { expect(call.to_json).to match_json_expression(expected_serialized_result) }
+  end
+end

--- a/spec/services/search_query_parser_spec.rb
+++ b/spec/services/search_query_parser_spec.rb
@@ -1,56 +1,44 @@
 RSpec.describe SearchQueryParser do
-  subject(:search_query_parser) { described_class.new }
-
   let(:search_query_parser_service_url) { 'http://localhost:5000/api/search' }
 
-  before do
-    stub_request(:get, "#{search_query_parser_service_url}/tokens?q=aaa+bbb")
-      .to_return(body: success_response.to_json, status: 200)
+  describe '#call' do
+    subject(:result) { described_class.new('aaa bbb').call }
 
-    stub_request(:get, "#{search_query_parser_service_url}/tokens?q=")
-        .to_return(status: 400)
-  end
+    before { stub_request(:get, "#{search_query_parser_service_url}/tokens?q=aaa+bbb").to_return(response) }
 
-  describe '#get_tokens' do
-    let(:success_response) do
-      {
-        entities: {
-          noun_chunks: [
-            'aaa bbb',
-          ],
-          tokens: {
-            adjectives: [],
-            all: %w[
-              aaa
-              bbb
-            ],
-            nouns: %w[
-              bbb
-            ],
-            verbs: [],
-          },
-        },
-      }
-    end
-
-    let(:pattern) do
-      success_response
-    end
-
-    context 'when the query term is a valid string' do
-      let(:term) { 'aaa bbb' }
-
-      it 'returns a valid response' do
-        response = search_query_parser.get_tokens(term)
-
-        expect(response).to match_json_expression(pattern)
+    context 'when the search query parser response is success' do
+      let(:response) do
+        {
+          status: 200,
+          body: {
+            corrected_search_query: 'aaa bib',
+            original_search_query: 'aaa bbb',
+            tokens: {
+              adjectives: [],
+              all: %w[aaa bib],
+              noun_chunks: %w[aaa bib],
+              nouns: %w[aaa bib],
+              verbs: [],
+            },
+          }.to_json,
+        }
       end
+
+      it { is_expected.to be_a(Beta::Search::SearchQueryParserResult) }
+
+      it { expect(result.id).to eq('ca476c11a9e6c7dea1e75d14ad4cbb10') }
+      it { expect(result.corrected_search_query).to eq('aaa bib') }
+      it { expect(result.original_search_query).to eq('aaa bbb') }
+      it { expect(result.adjectives).to eq([]) }
+      it { expect(result.noun_chunks).to eq(%w[aaa bib]) }
+      it { expect(result.nouns).to eq(%w[aaa bib]) }
+      it { expect(result.verbs).to eq([]) }
     end
 
-    context 'when the query term is empty' do
-      let(:term) { '' }
+    context 'when the search query parser response is bad request' do
+      let(:response) { { status: 400 } }
 
-      it { expect { search_query_parser.get_tokens('') }.to raise_error(Faraday::BadRequestError) }
+      it { expect { result }.to raise_error(Faraday::BadRequestError) }
     end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1721

### What?

This work includes a new api for search which is not currently plumbed together via the frontend.

I have left out the work to adjust the constraints to work with a beta scope (we are currently prefixed v onto beta)
when working out the scope of the new api.

I have added/removed/altered:

- [x] Adds routes for new beta search
- [x] Adds environment configuration to TradeTariffBackend for search
- [x] Updates regex for excluding negating terms
- [x] Adds id and description_indexed to beta search ancestors
- [x] Adds dynamic querying behaviour for the goods nomenclature idx
- [x] Adds search query parser result model and specs
- [x] Adds search result model
- [x] Adds factory for goods nomenclature query
- [x] Adds orchestrating search service and tests
- [x] Adds jsonapi serializers and specs
- [x] Adds beta search controller and request specs

### Why?

I am doing this because:

- All of this is required for our initial search service offering and lays the foundations for future search api work
