### PR TITLE
HOTT-1743: Adds heading and chapter statistics to search results

### DIFF
--- a/app/models/beta/search/open_search_result.rb
+++ b/app/models/beta/search/open_search_result.rb
@@ -1,7 +1,9 @@
 module Beta
   module Search
     class OpenSearchResult
-      delegate :id, to: :search_query_parser_result, prefix: true
+      delegate :id, to: :chapter_statistics, prefix: true, allow_nil: true
+      delegate :id, to: :heading_statistics, prefix: true, allow_nil: true
+      delegate :id, to: :search_query_parser_result, prefix: true, allow_nil: true
 
       attr_accessor :took,
                     :timed_out,
@@ -26,7 +28,7 @@ module Beta
           hit = Hashie::TariffMash.new
 
           hit.score = hit_result._score
-          hit.goods_nomenclature_class = hit_result._source.goods_nomenclature_class
+          hit.goods_nomenclature_class = ActiveSupport::StringInquirer.new(hit_result._source.goods_nomenclature_class)
           hit.id = hit_result._source.id
           hit.goods_nomenclature_item_id = hit_result._source.goods_nomenclature_item_id
           hit.producline_suffix = hit_result._source.producline_suffix
@@ -58,6 +60,26 @@ module Beta
 
       def total_results
         hits.count
+      end
+
+      def chapter_statistics
+        @chapter_statistics&.values || []
+      end
+
+      def chapter_statistic_ids
+        chapter_statistics.pluck(:id)
+      end
+
+      def heading_statistics
+        @heading_statistics&.values || []
+      end
+
+      def heading_statistic_ids
+        heading_statistics.pluck(:id)
+      end
+
+      def generate_statistics
+        @chapter_statistics, @heading_statistics = Api::Beta::SearchResultStatisticsService.new(hits).call
       end
     end
   end

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -195,7 +195,7 @@ class GoodsNomenclature < Sequel::Model
   end
 
   def heading_short_code
-    goods_nomenclature_item_id.first(4)
+    goods_nomenclature_item_id.first(4) unless chapter?
   end
 
   def chapter_short_code

--- a/app/serializers/api/beta/chapter_statistics_serializer.rb
+++ b/app/serializers/api/beta/chapter_statistics_serializer.rb
@@ -1,0 +1,14 @@
+module Api
+  module Beta
+    class ChapterStatisticsSerializer
+      include JSONAPI::Serializer
+
+      set_type :chapter_statistic
+
+      attributes :description,
+                 :cnt,
+                 :score,
+                 :avg
+    end
+  end
+end

--- a/app/serializers/api/beta/heading_statistics_serializer.rb
+++ b/app/serializers/api/beta/heading_statistics_serializer.rb
@@ -1,0 +1,17 @@
+module Api
+  module Beta
+    class HeadingStatisticsSerializer
+      include JSONAPI::Serializer
+
+      set_type :heading_statistic
+
+      attributes :description,
+                 :chapter_id,
+                 :chapter_description,
+                 :score,
+                 :cnt,
+                 :avg,
+                 :chapter_score
+    end
+  end
+end

--- a/app/serializers/api/beta/search_result_serializer.rb
+++ b/app/serializers/api/beta/search_result_serializer.rb
@@ -19,6 +19,9 @@ module Api
           Api::Beta::GoodsNomenclatureSerializer
         end
       }
+
+      has_many :heading_statistics, serializer: HeadingStatisticsSerializer
+      has_many :chapter_statistics, serializer: ChapterStatisticsSerializer
     end
   end
 end

--- a/app/services/api/beta/search_result_statistics_service.rb
+++ b/app/services/api/beta/search_result_statistics_service.rb
@@ -1,0 +1,91 @@
+module Api
+  module Beta
+    class SearchResultStatisticsService
+      def initialize(goods_nomenclature_hits)
+        @goods_nomenclature_hits = goods_nomenclature_hits
+        @chapter_statistics = Hashie::TariffMash.new
+        @heading_statistics = Hashie::TariffMash.new
+      end
+
+      def call
+        search_result_statistics = []
+
+        search_result_statistics << generate_chapter_statistics
+        search_result_statistics << generate_heading_statistics
+
+        search_result_statistics
+      end
+
+      private
+
+      attr_reader :goods_nomenclature_hits
+
+      def generate_chapter_statistics
+        goods_nomenclature_hits.each do |goods_nomenclature_hit|
+          @chapter_statistics[goods_nomenclature_hit.chapter_id] ||= Hashie::TariffMash.new
+          @chapter_statistics[goods_nomenclature_hit.chapter_id]['id'] ||= goods_nomenclature_hit.chapter_id
+          @chapter_statistics[goods_nomenclature_hit.chapter_id]['description'] ||= goods_nomenclature_hit.chapter_description
+          @chapter_statistics[goods_nomenclature_hit.chapter_id]['score'] ||= 0
+          @chapter_statistics[goods_nomenclature_hit.chapter_id]['cnt'] ||= 0
+          @chapter_statistics[goods_nomenclature_hit.chapter_id]['cnt'] += 1
+          @chapter_statistics[goods_nomenclature_hit.chapter_id]['score'] += goods_nomenclature_hit.score
+          @chapter_statistics[goods_nomenclature_hit.chapter_id]['avg'] ||= mean_average_chapter_score_for(goods_nomenclature_hit.chapter_id)
+        end
+
+        @chapter_statistics
+      end
+
+      def generate_heading_statistics
+        accumulations = 0
+        goods_nomenclature_hits_with_headings.each do |goods_nomenclature_hit|
+          accumulations += 1
+          @heading_statistics[goods_nomenclature_hit.heading_id] ||= Hashie::TariffMash.new
+          @heading_statistics[goods_nomenclature_hit.heading_id]['id'] ||= goods_nomenclature_hit.heading_id
+          @heading_statistics[goods_nomenclature_hit.heading_id]['description'] ||= goods_nomenclature_hit.heading_description
+          @heading_statistics[goods_nomenclature_hit.heading_id]['chapter_id'] ||= goods_nomenclature_hit.chapter_id
+          @heading_statistics[goods_nomenclature_hit.heading_id]['chapter_description'] ||= goods_nomenclature_hit.chapter_description
+          @heading_statistics[goods_nomenclature_hit.heading_id]['score'] ||= 0
+          @heading_statistics[goods_nomenclature_hit.heading_id]['score'] += goods_nomenclature_hit.score
+          @heading_statistics[goods_nomenclature_hit.heading_id]['cnt'] ||= 0
+          @heading_statistics[goods_nomenclature_hit.heading_id]['cnt'] += 1
+          @heading_statistics[goods_nomenclature_hit.heading_id]['avg'] ||= mean_average_heading_score_for(goods_nomenclature_hit.heading_id)
+          @heading_statistics[goods_nomenclature_hit.heading_id]['chapter_score'] ||= @chapter_statistics[goods_nomenclature_hit.chapter_id]['score']
+        end
+
+        @heading_statistics
+      end
+
+      def goods_nomenclature_hits_with_headings
+        goods_nomenclature_hits.reject do |goods_nomenclature_hit|
+          goods_nomenclature_hit.goods_nomenclature_class.chapter?
+        end
+      end
+
+      def mean_average_heading_score_for(heading_id)
+        mean_average_scores do |goods_nomenclature_hit|
+          goods_nomenclature_hit.heading_id == heading_id
+        end
+      end
+
+      def mean_average_chapter_score_for(chapter_id)
+        mean_average_scores do |goods_nomenclature_hit|
+          goods_nomenclature_hit.chapter_id == chapter_id
+        end
+      end
+
+      def mean_average_scores
+        scores = []
+        count = 0
+
+        goods_nomenclature_hits_with_headings.each do |goods_nomenclature_hit|
+          if yield goods_nomenclature_hit
+            scores << goods_nomenclature_hit.score
+            count += 1
+          end
+        end
+
+        scores.inject(0, :+) / count
+      end
+    end
+  end
+end

--- a/app/services/api/beta/search_service.rb
+++ b/app/services/api/beta/search_service.rb
@@ -1,7 +1,12 @@
 module Api
   module Beta
     class SearchService
-      DEFAULT_INCLUDES = ['hits.ancestors', :search_query_parser_result].freeze
+      DEFAULT_INCLUDES = [
+        'hits.ancestors',
+        :search_query_parser_result,
+        :heading_statistics,
+        :chapter_statistics,
+      ].freeze
       DEFAULT_SEARCH_INDEX = 'tariff-goods_nomenclatures'.freeze
 
       def initialize(search_query)
@@ -13,6 +18,7 @@ module Api
           .search(index: DEFAULT_SEARCH_INDEX, body: generated_search_query)
 
         search_result = ::Beta::Search::OpenSearchResult.build(result, search_query_parser_result)
+        search_result.generate_statistics
 
         Api::Beta::SearchResultSerializer.new(search_result, include: DEFAULT_INCLUDES).serializable_hash
       end

--- a/spec/factories/search_result_factory.rb
+++ b/spec/factories/search_result_factory.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :search_result, class: 'Beta::Search::OpenSearchResult' do
     multiple_hits
+    no_generate_statistics
 
     trait :no_hits do
       transient do
@@ -23,12 +24,28 @@ FactoryBot.define do
       end
     end
 
+    trait :no_generate_statistics do
+      transient do
+        generate_statistics { false }
+      end
+    end
+
+    trait :generate_statistics do
+      transient do
+        generate_statistics { true }
+      end
+    end
+
     initialize_with do
       fixture_filename = Rails.root.join("spec/fixtures/beta/search/goods_nomenclatures/#{result_fixture}.json")
       search_result = JSON.parse(File.read(fixture_filename))
       presented_search_result = Hashie::TariffMash.new(search_result)
 
-      Beta::Search::OpenSearchResult.build(presented_search_result, search_query_parser_result)
+      search_result = Beta::Search::OpenSearchResult.build(presented_search_result, search_query_parser_result)
+
+      search_result.generate_statistics if generate_statistics
+
+      search_result
     end
   end
 end

--- a/spec/fixtures/beta/search/goods_nomenclatures/serialized_result.json
+++ b/spec/fixtures/beta/search/goods_nomenclatures/serialized_result.json
@@ -22,6 +22,22 @@
             "type": "commodity"
           }
         ]
+      },
+      "heading_statistics": {
+        "data": [
+          {
+            "id": "0406",
+            "type": "heading_statistic"
+          }
+        ]
+      },
+      "chapter_statistics": {
+        "data": [
+          {
+            "id": "04",
+            "type": "chapter_statistic"
+          }
+        ]
       }
     }
   },
@@ -138,6 +154,29 @@
         "noun_chunks": [
           "ricotta"
         ]
+      }
+    },
+    {
+      "id": "0406",
+      "type": "heading_statistic",
+      "attributes": {
+        "description": "Cheese and curd",
+        "chapter_id": "04",
+        "chapter_description": "DAIRY PRODUCE; BIRDS' EGGS; NATURAL HONEY; EDIBLE PRODUCTS OF ANIMAL ORIGIN, NOT ELSEWHERE SPECIFIED OR INCLUDED",
+        "score": 74.98428,
+        "cnt": 1,
+        "avg": 74.98428,
+        "chapter_score": 74.98428
+      }
+    },
+    {
+      "id": "04",
+      "type": "chapter_statistic",
+      "attributes": {
+        "description": "DAIRY PRODUCE; BIRDS' EGGS; NATURAL HONEY; EDIBLE PRODUCTS OF ANIMAL ORIGIN, NOT ELSEWHERE SPECIFIED OR INCLUDED",
+        "cnt": 1,
+        "score": 74.98428,
+        "avg": 74.98428
       }
     }
   ]

--- a/spec/models/beta/search/open_search_result_spec.rb
+++ b/spec/models/beta/search/open_search_result_spec.rb
@@ -43,4 +43,104 @@ RSpec.describe Beta::Search::OpenSearchResult do
 
     it { is_expected.to eq(10) }
   end
+
+  describe '#chapter_statistics' do
+    context 'when statistics have been generated' do
+      subject(:chapter_statistics) { build(:search_result, :generate_statistics).chapter_statistics }
+
+      let(:expected_chapter_statistics) do
+        [
+          {
+            'id' => '01',
+            'description' => 'LIVE ANIMALS',
+            'score' => 1133.32071,
+            'cnt' => 8,
+            'avg' => 141.66508875,
+          },
+          {
+            'id' => '03',
+            'description' => 'FISH AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES',
+            'score' => 138.529,
+            'cnt' => 2,
+            'avg' => 69.2645,
+          },
+        ]
+      end
+
+      it { is_expected.to eq(expected_chapter_statistics) }
+    end
+
+    context 'when statistics have not been generated' do
+      subject(:chapter_statistics) { build(:search_result, :no_generate_statistics).chapter_statistics }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
+  describe '#heading_statistics' do
+    context 'when statistics have been generated' do
+      subject(:heading_statistics) { build(:search_result, :generate_statistics).heading_statistics }
+
+      let(:expected_heading_statistics) do
+        [
+          {
+            'id' => '0101',
+            'description' => 'Live horses, asses, mules and hinnies',
+            'chapter_id' => '01',
+            'chapter_description' => 'LIVE ANIMALS',
+            'score' => 1133.32071,
+            'cnt' => 8,
+            'avg' => 141.66508875,
+            'chapter_score' => 1133.32071,
+          },
+          {
+            'id' => '0302',
+            'description' => 'Fish, fresh or chilled, excluding fish fillets and other fish meat of heading 0304',
+            'chapter_id' => '03',
+            'chapter_description' => 'FISH AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES',
+            'score' => 138.529,
+            'cnt' => 2,
+            'avg' => 69.2645,
+            'chapter_score' => 138.529,
+          },
+        ]
+      end
+
+      it { is_expected.to eq(expected_heading_statistics) }
+    end
+
+    context 'when statistics have not been generated' do
+      subject(:heading_statistics) { build(:search_result, :no_generate_statistics).heading_statistics }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
+  describe '#chapter_statistic_ids' do
+    context 'when there are chapter statistics' do
+      subject(:chapter_statistics) { build(:search_result, :generate_statistics).chapter_statistic_ids }
+
+      it { is_expected.to eq(%w[01 03]) }
+    end
+
+    context 'when there are no chapter statistics' do
+      subject(:chapter_statistics) { build(:search_result, :no_generate_statistics).chapter_statistic_ids }
+
+      it { is_expected.to eq(%w[]) }
+    end
+  end
+
+  describe '#heading_statistic_ids' do
+    context 'when there are heading statistics' do
+      subject(:heading_statistics) { build(:search_result, :generate_statistics).heading_statistic_ids }
+
+      it { is_expected.to eq(%w[0101 0302]) }
+    end
+
+    context 'when there are no heading statistics' do
+      subject(:heading_statistics) { build(:search_result, :no_generate_statistics).heading_statistic_ids }
+
+      it { is_expected.to eq(%w[]) }
+    end
+  end
 end

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -366,9 +366,17 @@ RSpec.describe GoodsNomenclature do
   end
 
   describe '#heading_short_code' do
-    subject(:heading_short_code) { build(:goods_nomenclature, goods_nomenclature_item_id: '0101210000').heading_short_code }
+    context 'when the goods nomenclature is `not` a chapter' do
+      subject(:heading_short_code) { build(:goods_nomenclature, goods_nomenclature_item_id: '0101210000').heading_short_code }
 
-    it { is_expected.to eq('0101') }
+      it { is_expected.to eq('0101') }
+    end
+
+    context 'when the goods nomenclature is a chapter' do
+      subject(:heading_short_code) { build(:goods_nomenclature, goods_nomenclature_item_id: '0100000000').heading_short_code }
+
+      it { is_expected.to be_nil }
+    end
   end
 
   describe '#to_s' do

--- a/spec/serializers/api/beta/chapter_statistics_serializer_spec.rb
+++ b/spec/serializers/api/beta/chapter_statistics_serializer_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe Api::Beta::ChapterStatisticsSerializer do
+  describe '#serializable_hash' do
+    subject(:serializable_hash) { described_class.new(serializable).serializable_hash }
+
+    let(:serializable) { build(:search_result, :single_hit, :generate_statistics).chapter_statistics }
+
+    let(:expected) do
+      {
+        data: [
+          {
+            id: '04',
+            type: :chapter_statistic,
+            attributes: {
+              description: "DAIRY PRODUCE; BIRDS' EGGS; NATURAL HONEY; EDIBLE PRODUCTS OF ANIMAL ORIGIN, NOT ELSEWHERE SPECIFIED OR INCLUDED",
+              cnt: 1,
+              score: 74.98428,
+              avg: 74.98428,
+            },
+          },
+        ],
+      }
+    end
+
+    it { is_expected.to eq(expected) }
+  end
+end

--- a/spec/serializers/api/beta/heading_statistics_serializer_spec.rb
+++ b/spec/serializers/api/beta/heading_statistics_serializer_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe Api::Beta::HeadingStatisticsSerializer do
+  describe '#serializable_hash' do
+    subject(:serializable_hash) { described_class.new(serializable).serializable_hash }
+
+    let(:serializable) { build(:search_result, :single_hit, :generate_statistics).heading_statistics }
+
+    let(:expected) do
+      {
+        data: [
+          {
+            id: '0406',
+            type: :heading_statistic,
+            attributes: {
+              description: 'Cheese and curd',
+              chapter_id: '04',
+              chapter_description: "DAIRY PRODUCE; BIRDS' EGGS; NATURAL HONEY; EDIBLE PRODUCTS OF ANIMAL ORIGIN, NOT ELSEWHERE SPECIFIED OR INCLUDED",
+              score: 74.98428,
+              cnt: 1,
+              avg: 74.98428,
+              chapter_score: 74.98428,
+            },
+          },
+        ],
+      }
+    end
+
+    it { is_expected.to eq(expected) }
+  end
+end

--- a/spec/serializers/api/beta/search_result_serializer_spec.rb
+++ b/spec/serializers/api/beta/search_result_serializer_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Api::Beta::SearchResultSerializer do
   describe '#serializable_hash' do
     subject(:serializable_hash) { described_class.new(serializable).serializable_hash }
 
-    let(:serializable) { build(:search_result, :multiple_hits) }
+    let(:serializable) { build(:search_result, :multiple_hits, :generate_statistics) }
 
     let(:expected) do
       {
@@ -29,6 +29,16 @@ RSpec.describe Api::Beta::SearchResultSerializer do
                 { id: '27624', type: :heading },
                 { id: '93994', type: :commodity },
                 { id: '95674', type: :commodity },
+              ],
+            },
+            heading_statistics: { data: [
+              { id: '0101', type: :heading_statistic },
+              { id: '0302', type: :heading_statistic },
+            ] },
+            chapter_statistics: {
+              data: [
+                { id: '01', type: :chapter_statistic },
+                { id: '03', type: :chapter_statistic },
               ],
             },
           },

--- a/spec/services/api/beta/search_result_statistics_service_spec.rb
+++ b/spec/services/api/beta/search_result_statistics_service_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe Api::Beta::SearchResultStatisticsService do
+  describe '#call' do
+    subject(:statistics) { described_class.new(hits).call }
+
+    context 'when there are multiple hits' do
+      let(:hits) { build(:search_result, :multiple_hits).hits }
+
+      let(:expected_chapter_statistics) do
+        {
+          '01' => {
+            'id' => '01',
+            'description' => 'LIVE ANIMALS',
+            'score' => 1133.32071,
+            'cnt' => 8,
+            'avg' => 141.66508875,
+          },
+          '03' => {
+            'id' => '03',
+            'description' => 'FISH AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES',
+            'score' => 138.529,
+            'cnt' => 2,
+            'avg' => 69.2645,
+          },
+        }
+      end
+
+      let(:expected_heading_statistics) do
+        {
+          '0101' => {
+            'id' => '0101',
+            'description' => 'Live horses, asses, mules and hinnies',
+            'chapter_id' => '01',
+            'chapter_description' => 'LIVE ANIMALS',
+            'score' => 1133.32071,
+            'cnt' => 8,
+            'avg' => 141.66508875,
+            'chapter_score' => 1133.32071,
+          },
+          '0302' => {
+            'id' => '0302',
+            'description' => 'Fish, fresh or chilled, excluding fish fillets and other fish meat of heading 0304',
+            'chapter_id' => '03',
+            'chapter_description' => 'FISH AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES',
+            'score' => 138.529,
+            'cnt' => 2,
+            'avg' => 69.2645,
+            'chapter_score' => 138.529,
+          },
+        }
+      end
+
+      it { expect(statistics[0]).to eq(expected_chapter_statistics) }
+      it { expect(statistics[1]).to eq(expected_heading_statistics) }
+    end
+
+    context 'when there are no hits' do
+      let(:hits) { build(:search_result, :no_hits).hits }
+
+      it { is_expected.to eq([{}, {}]) }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1743

### What?

We need to return statistics for unique headings and chapters that were returned by the beta
search functionality.

This will ultimately enable us to know which headings and chapters got the best results and also
to know which headings we can filter on in the frontend UI.

I have added/removed/altered:

- [x] Adds chapter statistics serializer and specs
- [x] Adds heading statistics serializer and specs
- [x] Updates convenience short code method and specs
- [x] Adds statistics service and specs
- [x] Updates beta search service to generate stats
- [x] Update search result serializer to include stats
- [x] Adds statistics to search result model and specs
- [x] Updates serialized search result fixture to fix specs


### Why?

I am doing this because:

- This is required for some of the beta search functionality in the frontend
