### PR TITLE
HOTT-1757: Drop and completely recreate beta search indexes

### DIFF
--- a/app/workers/reindex_models_worker.rb
+++ b/app/workers/reindex_models_worker.rb
@@ -6,7 +6,8 @@ class ReindexModelsWorker
   def perform
     logger.info 'Reindexing models in Elastic Search...'
     TradeTariffBackend.reindex
-    TradeTariffBackend.v2_reindex
+    # Drops and completely recreates the index
+    TradeTariffBackend.v2_search_client.reindex_all
     logger.info 'Reindexing of models completed'
   end
 end

--- a/spec/workers/reindex_models_worker_spec.rb
+++ b/spec/workers/reindex_models_worker_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ReindexModelsWorker, type: :worker do
 
       allow(BuildIndexPageWorker).to receive(:perform_async).and_call_original
       allow(TradeTariffBackend).to receive(:reindex).and_call_original
-      allow(TradeTariffBackend).to receive(:v2_reindex).and_call_original
+      allow(TradeTariffBackend).to receive(:v2_search_client).and_call_original
 
       perform
     end
@@ -18,8 +18,8 @@ RSpec.describe ReindexModelsWorker, type: :worker do
       expect(TradeTariffBackend).to have_received(:reindex)
     end
 
-    it 'calls v2_reindex' do
-      expect(TradeTariffBackend).to have_received(:v2_reindex)
+    it 'calls v2_search_client to reindex' do
+      expect(TradeTariffBackend).to have_received(:v2_search_client)
     end
 
     it 'queues workers to build the index' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1757

### What?

I have added/removed/altered:

- [x] Drop, create and repopulate beta search index nightly

### Why?

I am doing this because:

- This makes working with these indexes easier whilst we're quickly iterating on them
- These indexes are very quick to recreate and are frequently changing at the moment. 
- If the promotion out of beta/rate-of-change reduces moving forward I can always go back to repopulate, only
