### PR TITLE
Removed references to top in originprocesses.md for each country

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk/articles/albania/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/albania/origin_processes.md
@@ -12,7 +12,7 @@
 
 3. Notwithstanding paragraph 5 of Article 17 and paragraph 3 of Article 22 below, where cumulation involves only the United Kingdom, the European Union, Switzerland (including Liechtenstein), Iceland, Norway, the Faroe Islands, Turkey, Albania, Bosnia and Herzegovina, the Republic of North Macedonia, Montenegro, the Republic of Serbia, or the Republic of Kosovo, the proof of origin may be a movement certificate EUR.1 or an origin declaration.
 
-{{ top }}
+
 
 ## Article 17 - Procedure for the issue of a movement certificate EUR.1 or EUR-MED
 
@@ -52,7 +52,7 @@
 
 3. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 18 - Movement certificates EUR.1 or EUR-MED issued retrospectively
 1. Notwithstanding Article 17(9), a movement certificate EUR.1 or EUR-MED may exceptionally be issued after exportation of the products to which it relates if:
@@ -77,7 +77,7 @@
 
 1. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
 
-{{ top }}
+
 
 ## Article 19 - Issue of a duplicate movement certificate EUR.1 or EUR-MED
 
@@ -95,7 +95,7 @@
 
 When originating products are placed under the control of a customs office in the United Kingdom or Albania, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or Albania. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 21 - Accounting segregation
 
@@ -111,7 +111,7 @@ When originating products are placed under the control of a customs office in th
 
 6. The customs authorities shall monitor the use made of the authorisation and may withdraw it whenever the beneficiary makes improper use of the authorisation in any manner whatsoever or fails to fulfil any of the other conditions laid down in this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 22 - Conditions for making out an origin declaration or an origin declaration EUR-MED
 
@@ -153,7 +153,7 @@ When originating products are placed under the control of a customs office in th
 
 8. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 23 - Approved exporter
 
@@ -167,7 +167,7 @@ When originating products are placed under the control of a customs office in th
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 24 - Validity of proof of origin
 
@@ -177,19 +177,19 @@ When originating products are placed under the control of a customs office in th
 
 3. In other cases of belated presentation, the customs authorities of the importing Party may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 25 - Submission of proof of origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing Party in accordance with the procedures applicable in that country. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the United Kingdom-Albania Agreement.
 
-{{ top }}
+
 
 ## Article 26 - Importation by instalments
 
 Where, at the request of the importer and subject to the conditions laid down by the customs authorities of the importing Party, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2007 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 27 - Exemptions from proof of origin
 
@@ -199,7 +199,7 @@ Where, at the request of the importer and subject to the conditions laid down by
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers’ personal luggage.
 
-{{ top }}
+
 
 ## Article 28 - Supporting documents
 
@@ -215,7 +215,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 - appropriate evidence concerning working or processing undergone outside the United Kingdom, Albania or the other countries referred to in Articles 3 and 4 by application of Article 12, proving that the requirements of that Article have been satisfied.
 
-{{ top }}
+
 
 ## Article 29 - Preservation of proof of origin and supporting documents
 
@@ -227,7 +227,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 4. The customs authorities of the importing Party shall keep for at least three years the movement certificates EUR.1 and EUR-MED and the origin declarations and origin declarations EUR-MED submitted to them.
 
-{{ top }}
+
 
 ## Article 30 - Discrepancies and formal errors
 
@@ -235,7 +235,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 2. Obvious formal errors, such as typing errors, on a proof of origin shall not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 31 - Amounts expressed in euro
 
@@ -249,6 +249,6 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 5. The amounts expressed in euro shall be reviewed by the Partnership, Trade and Cooperation Council at the request of any of the Parties. When carrying out this review, the Partnership, Trade and Cooperation Council shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro. 
 
-{{ top }}
+
 
 {{ Articles 16 to 31 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/andean/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/andean/origin_processes.md
@@ -8,7 +8,7 @@
 
 2. Notwithstanding paragraph 1, originating products within the meaning of this Origin Reference Document shall, in the cases specified in Article 25, benefit from the Agreement without it being necessary to submit any of the documents referred to above.
 
-{{ top }}
+
 
 ## Article 16 - Procedure for the Issuance of a Movement Certificate EUR.1
 
@@ -26,7 +26,7 @@
 
 7. A movement certificate EUR.1 shall be issued by the competent authorities or customs authorities and made available to the exporter as soon as the actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 17 - Movement Certificate EUR.1 Issued Retrospectively
 
@@ -48,7 +48,7 @@
  
 5. The endorsement referred to in paragraph 4 shall be inserted in the 'Remarks' box of the movement certificate EUR.1.
 
-{{ top }}
+
 
 ## Article 18 - Issuance of a Duplicate Movement Certificate EUR.1
 
@@ -64,13 +64,13 @@
 
 4. The duplicate, which must bear the date of issue of the original movement certificate EUR.1 shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 19 - Issuance of Movement Certificates EUR.1 on the Basis of a Proof of Origin Previously Issued or Made Out
 
 When originating products are placed under the control of a customs authority in the UK, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 for the purpose of sending all or some of these products elsewhere within the UK or the signatory Andean Countries. The replacement movement certificate(s) EUR.1 shall be issued by the competent authority or by the customs authority, in this last case, under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 20 - Conditions for Making Out an Invoice Declaration
 
@@ -90,7 +90,7 @@ When originating products are placed under the control of a customs authority in
 
 6. An invoice declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing Party no longer than two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 21 - Approved exporter
 
@@ -104,7 +104,7 @@ When originating products are placed under the control of a customs authority in
 
 5. The competent authorities or customs authorities may withdraw the auth-orisation at any time. Such authorities shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 22 - Validity of Proof of Origin
 
@@ -116,19 +116,19 @@ When originating products are placed under the control of a customs authority in
 
 4. For the purposes of applying paragraphs 2 and 3, if a proof of origin is not presented at the time of importation, the importer must declare to the custom authorities of the importing Party the intention of requesting preferential tariff treatment for the products concerned.
 
-{{ top }}
+
 
 ## Article 23 - Submission of Proof of Origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing Party in accordance with the procedures applicable in that Party. The UK authorities may require a translation of a proof of origin and the import declaration to be accompanied by a statement from the importer that the products meet the conditions required for benefiting from the application of the Agreement.
 
-{{ top }}
+
 
 ## Article 24 - Importation by Instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the UK, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2007 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 25 - Exemptions from Proof of Origin
 
@@ -140,7 +140,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 4. For the purposes of paragraph 3, in cases where the products are invoiced in a currency other than euro or USD, amounts in the national currencies of the UK equivalent to the amounts expressed in euro or US dollars shall be fixed in accordance with the current exchange rate applicable in the UK.
 
-{{ top }}
+
 
 ## Article 26 - Supporting Documents
 
@@ -154,7 +154,7 @@ The documents referred to in Articles 16, paragraph 3 and 20 paragraph 3 used fo
 
 - movement certificates EUR.1 or invoice declarations proving the originating status of materials used, issued or made out in a Party in accordance with this Origin Reference Document. 
 
-{{ top }}
+
 
 ## Article 27 - Preservation of Proof of Origin and Supporting Documents
 
@@ -166,7 +166,7 @@ The documents referred to in Articles 16, paragraph 3 and 20 paragraph 3 used fo
 
 4. The customs authorities of the importing Party or the importer, according to domestic law of the importing Party, shall keep for at least three years the movement certificates EUR.1 and the invoice declarations presented to or by them.
 
-{{ top }}
+
 
 ## Article 28 - Discrepancies and Formal Errors
 
@@ -174,7 +174,7 @@ The documents referred to in Articles 16, paragraph 3 and 20 paragraph 3 used fo
 
 2. Obvious formal errors, such as typing errors, on a proof of origin should not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 29 - Amounts Expressed in Euro
 
@@ -186,6 +186,6 @@ The documents referred to in Articles 16, paragraph 3 and 20 paragraph 3 used fo
 
 4. The UK may round up or down the amount resulting from the conversion into its national currency of an amount expressed in euro. The rounded-off amount may not differ from the amount resulting from the conversion by more than five per cent. The UK may retain unchanged its national currency equivalent of an amount expressed in euro if, at the time of the annual adjustment provided   for in paragraph 3, the conversion of that amount, prior to any rounding off, results in an increase of less than 15 per cent in the national currency equivalent. The national currency equivalent may be retained unchanged if the conversion would result in a decrease in that equivalent value. 
 
-{{ top }}
+
 
 {{ Articles 15 to 29 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/cameroon/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/cameroon/origin_processes.md
@@ -8,7 +8,7 @@
 
 2. Notwithstanding paragraph 1, originating products within the meaning of Part A of this Origin Reference Document shall, in the cases specified in Article 25, benefit from the provisions of the United Kingdom-Cameroon Agreement without it being necessary to submit any of the documents referred to in that paragraph.
 
-{{ top }}
+
 
 ## Article 15 - Procedure for the issue of a movement certificate EUR.1
 
@@ -26,7 +26,7 @@
 
 7. A movement certificate EUR.1 shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 16 - Movement certificates EUR.1 issued retrospectively
 
@@ -46,7 +46,7 @@
 
 5. The endorsement referred to in paragraph 4 shall be inserted in box 7 of the movement certificate EUR.1.
 
-{{ top }}
+
 
 ## Article 17 - Issue of a duplicate movement certificate EUR.1
 
@@ -60,13 +60,13 @@
 
 4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 18 - Issue of movement certificates EUR.1 on the basis of a proof of origin issued or made out previously
 
 When originating products are placed under the control of a customs office in Cameroon or in the United Kingdom, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 for the purpose of sending all or some of those products elsewhere within Cameroon or within the United Kingdom. The replacement movement certificate or certificates EUR.1 shall be issued by the customs office under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 19 - Conditions for making out an invoice declaration
 
@@ -86,7 +86,7 @@ When originating products are placed under the control of a customs office in Ca
 
 6. An invoice declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the United Kingdom no longer than two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 20 - Approved exporter
 
@@ -100,7 +100,7 @@ When originating products are placed under the control of a customs office in Ca
 
 5. The customs authorities of Cameroon may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, does not fulfil the conditions referred to in paragraph 2 or otherwise makes incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 21 - Validity of proof of origin
 
@@ -110,7 +110,7 @@ When originating products are placed under the control of a customs office in Ca
 
 3. In other cases of belated presentation, the customs authorities of the United Kingdom may accept the proofs of origin where the products have been submitted before the final date.
 
-{{ top }}
+
 
 ## Article 22 - Transit procedure
 
@@ -124,19 +124,19 @@ When the products enter an eligible ACP State, a further period of validity of f
 
 - the date of the endorsements.
 
-{{ top }}
+
 
 ## Article 23 - Submission of proof of origin
 
 Proofs of origin shall be submitted to the customs authorities of the United Kingdom in accordance with its procedures. Those authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the United Kingdom-Cameroon Agreement.
 
-{{ top }}
+
 
 ## Article 24 - Importation by instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the United Kingdom, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 1996 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 25 - Exemptions from proof of origin
 
@@ -146,7 +146,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 3. Furthermore, the total value of those products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers' personal luggage.
 
-{{ top }}
+
 
 ## Article 26 - Information procedure for cumulation purposes
 
@@ -166,7 +166,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 6. The suppliers' declarations shall be submitted to the competent customs office in Cameroon.
 
-{{ top }}
+
 
 ## Article 27 - Supporting documents
 
@@ -180,7 +180,7 @@ The documents referred to in Articles 15(3) and 19(3) used for the purpose of pr
 
 - movement certificates EUR.1 or invoice declarations proving the originating status of materials used, issued or made out in Cameroon or in one of the other countries or territories referred to in Article 6 and in accordance with Part A of this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 28 - Preservation of proof of origin and supporting documents
 
@@ -192,7 +192,7 @@ The documents referred to in Articles 15(3) and 19(3) used for the purpose of pr
 
 4. The customs authorities of the United Kingdom shall keep the movement certificates EUR.1 and the invoice declarations submitted to them for at least three years.
 
-{{ top }}
+
 
 ## Article 29 - Discrepancies and formal errors
 
@@ -200,7 +200,7 @@ The documents referred to in Articles 15(3) and 19(3) used for the purpose of pr
 
 2. Obvious formal errors such as typing errors on a proof of origin should not cause that document to be rejected if those errors are not such as to create doubts concerning the correctness of the statements made in that document.
 
-{{ top }}
+
 
 ## Article 30 - Amounts expressed in euro
 
@@ -214,6 +214,6 @@ The documents referred to in Articles 15(3) and 19(3) used for the purpose of pr
 
 5. The amounts expressed in euro shall be reviewed by the EPA Committee. When carrying out that review, the EPA Committee shall consider the desirability of preserving the effects of the limits concerned in real terms. For that purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 14 to 30 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/canada/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/canada/origin_processes.md
@@ -6,7 +6,7 @@
 
 3. The different linguistic versions of the text of the origin declaration are set out in Annex 2.
 
-{{ top }}
+
 
 ## Article 19 - Obligations Regarding Exportations
 
@@ -28,7 +28,7 @@
 
 7. The Parties may allow the establishment of a system that permits an origin declaration to be submitted electronically and directly from the exporter in the territory of a Party to an importer in the territory of the other Party, including the replacement of the exporter's signature on the origin declaration with an electronic signature or identification code.
 
-{{ top }}
+
 
 ## Article 20 - Validity of Origin Declaration
 
@@ -36,7 +36,7 @@
 
 2. The Party of import may accept an origin declaration submitted to its customs authority after the validity period referred to in paragraph 1 for the purpose of preferential tariff treatment in accordance with that Party's laws.
 
-{{ top }}
+
 
 ## Article 21 - Obligations Regarding Importations
 
@@ -54,7 +54,7 @@
 
 4. A Party shall, in conformity with its laws, provide that, if a product would have qualified as an originating product when it was imported into the territory of that Party but the importer did not have an origin declaration at the time of importation, the importer of the product may, within a period of time of no less than three years after the date of importation, apply for a refund of duties paid as a result of the product not having been accorded preferential tariff treatment.
 
-{{ top }}
+
 
 ## Article 22 - Proof Related to Transport Thorugh a Third Country
 
@@ -64,13 +64,13 @@ Each Party, through its customs authority, may require an importer to demonstrat
 
 - when the product is shipped through or transhipped outside the territories of the Parties, a copy of the customs control documents indicating to that customs authority that the product remained under customs control while outside the territories of the Parties.
 
-{{ top }}
+
 
 ## Article 23 - Importation by Instalments
 
 Each Party shall provide that if dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or heading 7308 and 9406 of HS 2012 are imported by instalments at the request of the importer and on the conditions set out by the customs authority of the Party of import, a single origin declaration for these products shall be submitted, as required, to that customs authority upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 24 - Exemptions from Origin Declarations 
 
@@ -80,7 +80,7 @@ Each Party shall provide that if dismantled or non-assembled products within the
 
 3. The Parties may set value limits for products referred to in paragraph 1, and shall exchange information regarding those limits.
 
-{{ top }}
+
 
 ## Article 25 - Supporting Documents
 
@@ -94,7 +94,7 @@ The documents referred to in Article 19.2 may include documents relating to the 
 
 - the shipment of the product.
 
-{{ top }}
+
 
 ## Article 26 - Preservation of Records
 
@@ -112,7 +112,7 @@ The documents referred to in Article 19.2 may include documents relating to the 
 
    2. denies access to those records or documentation.
 
-{{ top }}
+
 
 ## Article 27 - Discrepancies and Formal Errors
 
@@ -120,6 +120,6 @@ The documents referred to in Article 19.2 may include documents relating to the 
 
 2. Obvious formal errors such as typing errors on an origin declaration shall not cause this document to be rejected if these errors do not create doubts concerning the correctness of the statements made in the document.
 
-{{ top }}
+
 
 {{ Articles 18 to 29 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/cariforum/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/cariforum/origin_processes.md
@@ -10,7 +10,7 @@
 
 3. For the purpose of applying the provisions of this Title, the exporters shall endeavour to use a language common to both the CARIFORUM States and the United Kingdom.
 
-{{ top }}
+
 
 ## Article 17 - Procedure for the issue of a movement certificate EUR.1
 
@@ -28,7 +28,7 @@
 
 7. A movement certificate EUR.1 shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been affected or ensured.
 
-{{ top }}
+
 
 ## Article 18 - Movement certificates EUR.1 issued retrospectively
 
@@ -44,7 +44,7 @@
 
 5. The endorsement referred to in paragraph 4 shall be inserted in the ‘Remarks’ box of the movement certificate EUR.1.
 
-{{ top }}
+
 
 ## Article 19 - Issue of a duplicate movement certificate EUR.1
 
@@ -58,13 +58,13 @@
 
 4. The duplicate, which must bear the date of issue of the original movement certificate EUR.1, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 20 - Issue of movement certificates EUR.1 on the basis of a proof of origin issued or made out previously
 
 When originating products are placed under the control of a customs office in a CARIFORUM State or in the United Kingdom, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 for the purpose of sending all or some of these products elsewhere within the CARIFORUM States or within the United Kingdom. The replacement movement certificate(s) EUR.1 shall be issued by the customs office under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 21 - Conditions for making out an invoice declaration
 
@@ -84,7 +84,7 @@ When originating products are placed under the control of a customs office in a 
 
 6. An invoice declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country no longer than two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 22 - Approved exporter
 
@@ -98,7 +98,7 @@ When originating products are placed under the control of a customs office in a 
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, does not fulfil the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 23 - Validity of proof of origin
 
@@ -108,19 +108,19 @@ When originating products are placed under the control of a customs office in a 
 
 3. In other cases of belated presentation, the customs authorities of the importing country may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 24 - Submission of proof of origin
 
 Proof of origin shall be submitted to the customs authorities of the importing country in accordance with the procedures applicable in that country. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the Agreement.
 
-{{ top }}
+
 
 ## Article 25 - Importation by instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the importing country, dismantled or non-assembled products within the meaning of General paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or heading 7308 and 9406 of HS 1996 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 26 - Exemptions from proof of origin
 
@@ -130,7 +130,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers' personal luggage.
 
-{{ top }}
+
 
 ## Article 27 - Information procedure for cumulation purposes
 
@@ -150,7 +150,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 8. Suppliers' declarations made and information certificates issued before the entry into force of the UK-CARIFORUM EPA shall, in accordance with Article 27 of Protocol I to the CARIFORUM-EU EPA and for the duration of their validity, be accepted by the Parties for the purposes of applying preferential treatment under the Agreement.
 
-{{ top }}
+
 
 ## Article 28 - Supporting documents
 
@@ -164,7 +164,7 @@ The documents referred to in Articles 17(3) and 21(3) used for the purpose of pr
 
 - movement certificates EUR.1 or invoice declarations proving the originating status of materials used, issued or made out in the CARIFORUM States, in the United Kingdom or in one of the other countries or territories referred to in Articles 3, 4 and 5 and in accordance with this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 29 - Discrepancies and formal errors
 
@@ -172,6 +172,6 @@ The documents referred to in Articles 17(3) and 21(3) used for the purpose of pr
 
 2. Obvious formal errors such as typing errors on a proof of origin should not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 {{ Articles 16 to 29 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/central-america/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/central-america/origin_processes.md
@@ -8,7 +8,7 @@
 
 2. Notwithstanding paragraph 1, originating products within the meaning of this Origin Reference Document shall, in the cases specified in Article 24, benefit from the Agreement without it being necessary to submit any of the documents referred to above.
 
-{{ top }}
+
 
 ## Article 15 - Procedure for the issue of a movement certificate EUR.1
 
@@ -26,7 +26,7 @@
 
 7. A movement certificate EUR.1 shall be issued by the competent public authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 16 - Movement certificates EUR.1 issued retrospectively
 
@@ -48,7 +48,7 @@
 
 5. The endorsement referred to in paragraph 4 shall be inserted in the "Remarks" box of the movement certificate EUR.1.
 
-{{ top }}
+
 
 ## Article 17 - Issue of a duplicate movement certificate EUR.1
 
@@ -64,13 +64,13 @@
 
 4. The duplicate, which must bear the date of issue of the original movement certificate EUR.1, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 18 - Issue of movement certificates EUR.1 on the basis of a proof of origin issued or made out previously
 
 When originating products are placed under the control of a customs office in a Party, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 for the purpose of sending all or some of these products elsewhere within the United Kingdom or Central America. The replacement movement certificate(s) EUR.1 shall be issued by the customs office under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 19 - Conditions for making out an invoice declaration
 
@@ -90,7 +90,7 @@ When originating products are placed under the control of a customs office in a 
 
 6. An invoice declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing Party no longer than the period established in Appendix 5.
 
-{{ top }}
+
 
 ## Article 20 - Approved exporter
 
@@ -104,7 +104,7 @@ When originating products are placed under the control of a customs office in a 
 
 5. The competent public authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 21 - Validity of proof of origin
 
@@ -116,19 +116,19 @@ When originating products are placed under the control of a customs office in a 
 
 4. According to the domestic legislation of the importing Party, a preferential tariff treatment may be awarded, when it proceeds, through the reimbursement of the tariffs in a period no longer than the period established in Appendix 5 from the date of acceptance of the import declaration, where a proof of origin is presented indicating that the imported goods were at that date eligible for preferential tariff treatment.
 
-{{ top }}
+
 
 ## Article 22 - Submission of proof of origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing Party in accordance with the procedures applicable in that Party. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the Agreement.
 
-{{ top }}
+
 
 ## Article 23 - Importation by instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the importing Party, dismantled or nonassembled products within the meaning of paragraph 2(a) of Part Two, Section 1 of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of the HS 2007 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities of the importing Party upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 24 - Exemptions from proof of origin
 
@@ -138,7 +138,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 3. Furthermore, the total value of these products shall not exceed in the case of small packages or of products forming part of travellers' personal luggage, the amounts in Euros established in Appendix 6 (Amounts referred to in Articles 19, paragraph 1(b) and 24, paragraph 3 of this Origin Reference Document, concerning the Definition of the Concept of "Originating Products" and Methods of Administrative Cooperation).
 
-{{ top }}
+
 
 ## Article 25 - Supporting documents
 
@@ -152,7 +152,7 @@ The documents referred to in Articles 15, paragraph 3 and 19, paragraph 3 used f
 
 - movement certificates EUR.1 or invoice declarations proving the originating status of materials used, issued or made out in a Party in accordance with this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 26 - Preservation of proof of origin and supporting documents
 
@@ -164,7 +164,7 @@ The documents referred to in Articles 15, paragraph 3 and 19, paragraph 3 used f
 
 4. The customs authorities of the importing Party shall keep for at least three years the movement certificates EUR.1 and the invoice declarations submitted to them, which may be kept in electronic format.
 
-{{ top }}
+
 
 ## Article 27 - Discrepancies and formal errors
 
@@ -172,7 +172,7 @@ The documents referred to in Articles 15, paragraph 3 and 19, paragraph 3 used f
 
 2. Obvious formal errors such as typing errors on a proof of origin should not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 28 - Amounts expressed in euro
 
@@ -186,6 +186,6 @@ The documents referred to in Articles 15, paragraph 3 and 19, paragraph 3 used f
 
 5. The amounts expressed in euro shall be reviewed by the Association Committee at the request of a Party. When carrying out this review, the Association Committee shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 14 to 28 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/chile/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/chile/origin_processes.md
@@ -8,7 +8,7 @@
 
 2. Notwithstanding paragraph 1, originating products within the meaning of this Origin Reference Document shall, in the cases specified in Article 25, benefit from the United Kingdom-Chile Agreement without it being necessary to submit any of the documents referred to above.
 
-{{ top }}
+
 
 ## Article 16 - Procedure for the issue of a movement certificate EUR.1
 
@@ -26,7 +26,7 @@
 
 7. A movement certificate EUR.1 shall be issued by the customs authorities or competent governmental authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 17 - Movement certificate EUR.1 issued retrospectively
 
@@ -48,7 +48,7 @@
 
 5. The endorsement referred to in paragraph 4 shall be inserted in the ‘Remarks’ box of the movement certificate EUR.1.
 
-{{ top }}
+
 
 ## Article 18 - Issue of a duplicate movement certificate EUR.1
 
@@ -64,13 +64,13 @@
 
 4. The duplicate, which must bear the date of issue of the original movement certificate EUR.1, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 19 - Issue of movement certificates EUR.1 on the basis of a proof of origin issued or made out previously
 
 When originating products are placed under the control of a customs office in the United Kingdom or in Chile, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 for the purpose of sending all or some of these products elsewhere within the United Kingdom or Chile. The replacement movement certificate(s) EUR.1 shall be issued by the customs office of first entry in the United Kingdom or in Chile under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 20 - Conditions for making out an invoice declaration
 
@@ -90,7 +90,7 @@ When originating products are placed under the control of a customs office in th
 
 6. An invoice declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented to the customs authorities of the importing country no longer than two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 21 - Approved exporter
 
@@ -104,7 +104,7 @@ When originating products are placed under the control of a customs office in th
 
 5. The customs authorities or competent governmental authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 22 - Validity of proof of origin
 
@@ -122,13 +122,13 @@ When originating products are placed under the control of a customs office in th
 
 2. The requirements mentioned in paragraph 1 relating to translation and the statement by the importer shall not be systematic and should only be imposed with a view to clarifying the submitted information or to ensuring that the importer endorses the full responsibility for the declared origin.
 
-{{ top }}
+
 
 ## Article 24 - Importation by instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the importing country, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom classified within Sections XVI and XVII or headings 7308 and 9406 of HS 2002 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 25 - Exemptions from proof of origin
 
@@ -138,7 +138,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 3. Furthermore, the total value of these products shall not exceed EUR 500, in the case of products sent from private persons to private persons or EUR 1 200, in the case of products forming part of travellers' personal luggage.
 
-{{ top }}
+
 
 ## Article 26 - Supporting documents
 
@@ -152,7 +152,7 @@ The documents referred to in Articles 16(3) and 20(3) used for the purpose of pr
 
 - movement certificates EUR.1 or invoice declarations proving the originating status of materials used, issued or made out in the United Kingdom or Chile in accordance with this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 27 - Preservation of proof of origin and supporting documents
 
@@ -164,7 +164,7 @@ The documents referred to in Articles 16(3) and 20(3) used for the purpose of pr
 
 4. The customs authorities in the United Kingdom shall keep for at least three years the movement certificates EUR.1 and the invoice declarations submitted to them on importation. The customs authorities of Chile must have at their disposal for five years the movement certificates EUR.1 and the invoice declarations submitted to them on importation.
 
-{{ top }}
+
 
 ## Article 28 - Discrepancies and formal errors
 
@@ -172,7 +172,7 @@ The documents referred to in Articles 16(3) and 20(3) used for the purpose of pr
 
 2. Obvious formal errors such as typing errors on a proof of origin should not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 29 - Amounts expressed in euro
 
@@ -184,6 +184,6 @@ The documents referred to in Articles 16(3) and 20(3) used for the purpose of pr
 
 4. A country may round up or down the amount resulting from the conversion into its national currency of an amount expressed in euro. The rounded-off amount may not differ from the amount resulting from the conversion by more than 5 per cent. A country may retain unchanged its national currency equivalent of an amount expressed in euro if, at the time of the annual adjustment provided for in paragraph 3, the conversion of that amount, prior to any rounding-off, results in an increase of less than 15 per cent in the national currency equivalent. The national currency equivalent may be retained unchanged if the conversion would result in a decrease in that equivalent value.
 
-{{ top }}
+
 
 {{ Articles 15 to 29 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/cotedivoire/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/cotedivoire/origin_processes.md
@@ -14,7 +14,7 @@
 
 5. For the purposes of applying the provisions of this Title, exporters shall endeavour to use English or French.
 
-{{ top }}
+
 
 ## Article 18 - Procedure for the issue of a movement certificate EUR.1
 
@@ -32,7 +32,7 @@
 
 7. A movement certificate EUR.1 shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 19 - Movement certificates EUR.1 issued retrospectively
 
@@ -52,7 +52,7 @@
 
 5. The endorsement referred to in paragraph 4 of this Article shall be inserted in the 'Remarks' box of the movement certificate EUR.1.
 
-{{ top }}
+
 
 ## Article 20 - Issue of a duplicate movement certificate EUR.1
 
@@ -66,7 +66,7 @@
 
 4. The duplicate, which must bear the date of issue of the original movement certificate EUR.1, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 21 - Conditions for making out an origin declaration
 
@@ -92,7 +92,7 @@
 
 6. An origin declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country no longer than two (2) years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 22 - Approved exporter
 
@@ -106,7 +106,7 @@
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1 of this Article, no longer fulfils the conditions referred to in paragraph 2 of this Article or otherwise makes incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 23 - Validity of proof of origin
 
@@ -116,19 +116,19 @@
 
 3. In other cases of belated presentation, the customs authorities of the importing country may accept the proof of origin where the products have been submitted before the final date.
 
-{{ top }}
+
 
 ## Article 24 - Submission of proof of origin
 
 Proof of origin shall be submitted to the customs authorities of the importing country in accordance with the procedures applicable in that country. Those authorities may require proof of origin to be translated. They may also require that the import declaration be accompanied by a statement from the importer to the effect that the products meet the requisite conditions for implementation of the United Kingdom-Côte d'Ivoire Agreement.
 
-{{ top }}
+
 
 ## Article 25 - Importation by instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the importing country, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2012 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment
 
-{{ top }}
+
 
 ## Article 26 - Exemptions from proof of origin
 
@@ -138,7 +138,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 3. Furthermore, the total value of those products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers' personal luggage.
 
-{{ top }}
+
 
 ## Article 27 - Information procedure for cumulation purposes
 
@@ -162,7 +162,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 10. Suppliers' declarations made and information certificates issued before the date of entry into force of this Origin Reference Document in accordance with any previously applicable agreement or arrangement shall remain valid.
 
-{{ top }}
+
 
 ## Article 28 - Supporting documents
 
@@ -176,7 +176,7 @@ The documents referred to in Articles 18(3) and 21(3) of this Origin Reference D
 
 - movement certificates EUR.1 or origin declarations proving the originating status of materials used, issued or made out in Côte d'Ivoire, in the United Kingdom or in one of the other countries or territories referred to in Articles 6, 7 and 8 of this Origin Reference Document, and in accordance with this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 29 - Preservation of proof of origin and supporting documents
 
@@ -190,7 +190,7 @@ The documents referred to in Articles 18(3) and 21(3) of this Origin Reference D
 
 5. The customs authorities of the importing country shall keep the movement certificates EUR.1 and the origin declarations submitted to them for at least three (3) years.
 
-{{ top }}
+
 
 ## Article 30 - Discrepancies and clerical errors
 
@@ -198,7 +198,7 @@ The documents referred to in Articles 18(3) and 21(3) of this Origin Reference D
 
 2. Obvious clerical errors such as typing errors on a proof of origin should not cause this document to be rejected if these errors are not such as to create doubts concerning the accuracy of the entries made in this document.
 
-{{ top }}
+
 
 ## Article 31 - Amounts expressed in euro
 
@@ -212,6 +212,6 @@ The documents referred to in Articles 18(3) and 21(3) of this Origin Reference D
 
 5. The amounts expressed in euro shall be reviewed by the Committee at the request of the United Kingdom or of Côte d'Ivoire. When carrying out this review, the Committee shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 17 to 31 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/egypt/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/egypt/origin_processes.md
@@ -10,7 +10,7 @@
 
 2. Notwithstanding paragraph 1, originating products within the meaning of this Origin Reference Document shall, in the cases specified in Article 27, benefit from the United Kingdom-Egypt Agreement without it being necessary to submit any of the proofs of origin referred to in paragraph 1 of this Article. 
 
-{{ top }}
+
 
 ## Article 17 - Procedure for the issue of a movement certificate EUR.1 or EUR-MED
 
@@ -50,7 +50,7 @@
 
 3. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 18 - Movement certificates EUR.1 or EUR-MED issued retrospectively
 
@@ -76,7 +76,7 @@
 
 6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
 
-{{ top }}
+
 
 ## Article 19 - Issue of a duplicate movement certificate EUR.1 or EUR-MED
 
@@ -90,13 +90,13 @@
 
 4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 20 - Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously 
 
 When originating products are placed under the control of a customs office in the United Kingdom or Egypt, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or Egypt. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 21 - Accounting segregation
 
@@ -112,7 +112,7 @@ When originating products are placed under the control of a customs office in th
 
 6. The customs authorities shall monitor the use made of the authorisation and may withdraw it whenever the beneficiary makes improper use of the authorisation in any manner whatsoever or fails to fulfil any of the other conditions laid down in this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 22 - Conditions for making out an origin declaration or an origin declaration EUR-MED
 
@@ -154,7 +154,7 @@ When originating products are placed under the control of a customs office in th
 
 4. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 23 - Approved exporter
 
@@ -168,7 +168,7 @@ When originating products are placed under the control of a customs office in th
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 24 - Validity of proof of origin
 
@@ -178,19 +178,19 @@ When originating products are placed under the control of a customs office in th
 
 3. In other cases of belated presentation, the customs authorities of the importing Party may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 25 - Submission of proof of origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing Party in accordance with the procedures applicable in that country. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the United Kingdom-Egypt Agreement.
 
-{{ top }}
+
 
 ## Article 26 - Importation by instalments
 
 Where, at the request of the importer and subject to the conditions laid down by the customs authorities of the importing Party, dismantled or non-assembled products within the meaning of  paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2007 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 27 - Exemptions from proof of origin
 
@@ -200,7 +200,7 @@ Where, at the request of the importer and subject to the conditions laid down by
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers’ personal luggage.
 
-{{ top }}
+
 
 ## Article 28 - Supporting documents
 
@@ -216,7 +216,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 - appropriate evidence concerning working or processing undergone outside the United Kingdom, Egypt or the other countries referred to in Articles 3 and 4 by application of Article 12, proving that the requirements of that Article have been satisfied.
 
-{{ top }}
+
 
 ## Article 29 - Preservation of proof of origin and supporting documents
 
@@ -228,7 +228,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 4. The customs authorities of the importing Party shall keep for at least three years the movement certificates EUR.1 and EUR-MED and the origin declarations and origin declarations EUR-MED submitted to them.
 
-{{ top }}
+
 
 ## Article 30 - Discrepancies and formal errors
 
@@ -236,7 +236,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 2. Obvious formal errors, such as typing errors, on a proof of origin shall not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 31 - Amounts expressed in euro
 
@@ -250,6 +250,6 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 5. The amounts expressed in euro shall be reviewed by the Association Council at the request of any of the Parties. When carrying out this review, the Association Council shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 16 to 31 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/esa/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/esa/origin_processes.md
@@ -10,7 +10,7 @@
 
 3. For the purpose of applying the provisions of this Title, the exporters shall endeavour to use a language common to both the ESA States and the UK.
 
-{{ top }}
+
 
 ## Article 17 - Procedure for the issue of a movement certificate EUR.1
 
@@ -28,7 +28,7 @@
 
 7. A movement certificate EUR.1 shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 18 - Movement certificates EUR.1 issued retrospectively
 
@@ -48,7 +48,7 @@
 
 5. The endorsement referred to in paragraph 4 shall be inserted in the ‘Remarks’ box of the movement certificate EUR.1.
 
-{{ top }}
+
 
 ## Article 19 - Issue of a duplicate movement certificate EUR.1
 
@@ -62,13 +62,13 @@
 
 4. The duplicate, which must bear the date of issue of the original movement certificate EUR.1, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 20 - Issue of movement certificates EUR.1 on the basis of a proof of origin issued or made out previously
 
 When originating products are placed under the control of a customs office in an ESA State or in the UK, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 for the purpose of sending all or some of these products elsewhere within the ESA States or within the UK. The replacement movement certificate(s) EUR.1 shall be issued by the customs office under whose control the products are placed and endorsed by the customs authority under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 21 - Conditions for making out an invoice declaration
 
@@ -88,7 +88,7 @@ When originating products are placed under the control of a customs office in an
 
 6. An invoice declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country no longer than two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 22 - Approved exporter
 
@@ -102,7 +102,7 @@ When originating products are placed under the control of a customs office in an
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, does not fulfil the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 23 - Validity of proof of origin
 
@@ -112,7 +112,7 @@ When originating products are placed under the control of a customs office in an
 
 3. In other cases of belated presentation, the customs authorities of the importing country may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 24 - Transit procedure
 
@@ -126,19 +126,19 @@ When the products enter a State or territory referred to in Articles 3 and 4, ot
 
 - date of the endorsements.
 
-{{ top }}
+
 
 ## Article 25 - Submission of proof of origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing country in accordance with the procedures applicable in that country. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the Agreement.
 
-{{ top }}
+
 
 ## Article 26 - Importation by instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the importing country, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or heading 7308 and 9406 of HS 1996 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 27 - Exemptions from proof of origin
 
@@ -148,7 +148,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers’ personal luggage.
 
-{{ top }}
+
 
 ## Article 28 - Information procedure for cumulation purposes
 
@@ -168,7 +168,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 8. Suppliers’ declarations made and information certificates issued before the date of entry into force of this Origin Reference Document in accordance with Article 26 of Protocol 1 to the Cotonou Agreement shall remain valid.
 
-{{ top }}
+
 
 ## Article 29 - Supporting documents
 
@@ -182,7 +182,7 @@ The documents referred to in Articles 17(3) and 21(3) used for the purpose of pr
 
 - movement certificates EUR.1 or invoice declarations proving the originating status of materials used, issued or made out in an ESA State, in the UK or in one of the other countries or territories referred to in Articles 3, 4 and 5 and in accordance with this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 30 - Preservation of proof or origin and supporting documents
 
@@ -196,7 +196,7 @@ The documents referred to in Articles 17(3) and 21(3) used for the purpose of pr
 
 5. The customs authorities of the importing country shall keep for at least three years the movement certificates EUR.1 and the invoice declarations submitted to them.
 
-{{ top }}
+
 
 ## Article 31 - Discrepancies and formal errors
 
@@ -204,7 +204,7 @@ The documents referred to in Articles 17(3) and 21(3) used for the purpose of pr
 
 2. Obvious formal errors such as typing errors on a proof of origin should not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 32 - Amounts expressed in euro
 
@@ -218,6 +218,6 @@ The documents referred to in Articles 17(3) and 21(3) used for the purpose of pr
 
 5. The amounts expressed in euro shall be reviewed by the Customs Cooperation Committee at the request of the UK or of the ESA States. When carrying out this review, the Customs Cooperation Committee shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 16 to 32 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/eu/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/eu/origin_processes.md
@@ -10,7 +10,7 @@
 
 3. The importer making the claim for preferential tariff treatment based on a statement on origin as referred to in point (a) of paragraph 2 shall keep the statement on origin and, when required by the customs authority of the importing Party, shall provide a copy thereof to that customs authority.
 
-{{ top }}
+
 
 ## Article 18a - Time of the Claim for Preferential Tariff Treatment
 
@@ -26,7 +26,7 @@
 
     The other obligations applicable to the importer under Article 18 remain unchanged.
 
-{{ top }}
+
 
 ## Article 19 - Statement on Origin
 
@@ -44,13 +44,13 @@
 
 5. If, at the request of the importer, unassembled or disassembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom that fall within Sections XV to XXI of HS 2017are imported by instalments, a single statement on origin for such products may be used in accordance with the requirements laid down by the customs authority of the importing Party.
 
-{{ top }}
+
 
 ## Article 20 - Discrepancies
 
 The customs authority of the importing Party shall not reject a claim for preferential tariff treatment due to minor errors or discrepancies in the statement on origin, or for the sole reason that an invoice was issued in a third country.
 
-{{ top }}
+
 
 ## Article 21 - Importer's Knowledge
 
@@ -58,7 +58,7 @@ The customs authority of the importing Party shall not reject a claim for prefer
 
 2. Before claiming the preferential treatment, in the event that an importer is unable to obtain the information referred to in paragraph 1 of this Article as a result of the exporter deeming it to be confidential information or for any other reason, the exporter may provide a statement on origin so that the importer may claim the preferential tariff treatment on the basis of point (a) of Article 18(2).
 
-{{ top }}
+
 
 ## Article 22 - Record-Keeping Requirements
 
@@ -72,7 +72,7 @@ The customs authority of the importing Party shall not reject a claim for prefer
 
 3. The records to be kept in accordance with this Article may be held in electronic format.
 
-{{ top }}
+
 
 ## Article 23 - Small Consignments
 
@@ -98,6 +98,6 @@ The customs authority of the importing Party shall not reject a claim for prefer
 
 3. The importer shall be responsible for the correctness of the declaration and for the compliance with the requirements provided for in this Origin Reference Document. The record-keeping requirements set out in Article 22 shall not apply to the importer under this Article.
 
-{{ top }}
+
 
 {{ Articles 18 to 23 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/faroe-islands/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/faroe-islands/origin_processes.md
@@ -12,7 +12,7 @@
 
 3. Notwithstanding paragraph 5 of Article 17 and paragraph 3 of Article 22 below, where cumulation involves only the United Kingdom, the European Union, Switzerland (including Liechtenstein), Iceland, Norway, the Faroe Islands, Turkey, the Republic of Albania, Bosnia and Herzegovina, the Republic of Macedonia, Montenegro, the Republic of Serbia, the Republic of Kosovo, the Republic of Moldova or Georgia, the proof of origin may be a movement certificate EUR.1 or an origin declaration.
 
-{{ top }}
+
 
 ## Article 17 - Procedure for the issue of a movement certificate EUR.1 or EUR-MED
 
@@ -52,7 +52,7 @@
 
 9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 18 - Movement certificates EUR.1 or EUR-MED issued retrospectively
 
@@ -78,7 +78,7 @@
 
 6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
 
-{{ top }}
+
 
 ## Article 19 - Issue of a duplicate movement certificate EUR.1 or EUR-MED
 
@@ -92,13 +92,13 @@
 
 4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 20 - Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously 
 
 When originating products are placed under the control of a customs office in the United Kingdom or the Faroe Islands, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or the Faroe Islands. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 21 - Accounting segregation
 
@@ -114,7 +114,7 @@ When originating products are placed under the control of a customs office in th
 
 6. The customs authorities shall monitor the use made of the authorisation and may withdraw it whenever the beneficiary makes improper use of the authorisation in any manner whatsoever or fails to fulfil any of the other conditions laid down in this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 22 - Conditions for making out an origin declaration or an origin declaration EUR-MED
 
@@ -156,7 +156,7 @@ When originating products are placed under the control of a customs office in th
 
 8. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 23 - Approved exporter
 
@@ -170,7 +170,7 @@ When originating products are placed under the control of a customs office in th
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 24 - Validity of proof of origin
 
@@ -180,19 +180,19 @@ When originating products are placed under the control of a customs office in th
 
 3. In other cases of belated presentation, the customs authorities of the importing Party may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 25 - Submission of proof of origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing Party in accordance with the procedures applicable in that country. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the United Kingdom-Faroe Islands Agreement.
 
-{{ top }}
+
 
 ## Article 26 - Importation by instalments
 
 Where, at the request of the importer and subject to the conditions laid down by the customs authorities of the importing Party, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2007 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 27 - Exemptions from proof of origin
 
@@ -202,7 +202,7 @@ Where, at the request of the importer and subject to the conditions laid down by
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers’ personal luggage.
 
-{{ top }}
+
 
 ## Article 28 - Supporting documents
 
@@ -218,7 +218,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 - appropriate evidence concerning working or processing undergone outside the United Kingdom, the Faroe Islands or the other countries referred to in Articles 3 and 4 by application of Article 12, proving that the requirements of that Article have been satisfied.
 
-{{ top }}
+
 
 ## Article 29 - Preservation of Proof of Origin and Supporting Documents
 
@@ -230,7 +230,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 4. The customs authorities of the importing Party shall keep for at least three years the movement certificates EUR.1 and EUR-MED and the origin declarations and origin declarations EUR-MED submitted to them
 
-{{ top }}
+
 
 ## Article 30 - Discrepancies and formal errors
 
@@ -238,7 +238,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 2. Obvious formal errors, such as typing errors, on a proof of origin shall not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 31 - Amounts expressed in euro
 
@@ -252,6 +252,6 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 5. The amounts expressed in euro shall be reviewed by the Joint Committee at the request of any of the Parties. When carrying out this review, the Joint Committee shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 16 to 31 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/georgia/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/georgia/origin_processes.md
@@ -12,7 +12,7 @@
 
 3. Notwithstanding paragraph 5 of Article 17 and paragraph 3 of Article 22 below, where cumulation involves only the United Kingdom and the ‘Contracting Parties’  to the Regional Convention on Pan-Euro-Mediterranean preferential rules of origin (other than Ukraine and the participants in the Barcelona Process ,  with the exception of Turkey) the proof of origin may be a movement certificate EUR.1 or an origin declaration.
 
-{{ top }}
+
 
 ## Article 17 - Procedure for the issue of a movement certificate EUR.1 or EUR-MED
 
@@ -52,7 +52,7 @@
 
 9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 18 - Movement certificates EUR.1 or EUR-MED issued retrospectively
 
@@ -78,7 +78,7 @@
 
 6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
 
-{{ top }}
+
 
 ## Article 19 - Issue of a duplicate movement certificate EUR.1 or EUR-MED
 
@@ -92,13 +92,13 @@
 
 4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 20 - Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously
 
 When originating products are placed under the control of a customs office in the United Kingdom or Georgia, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or Georgia. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 21 - Accounting segregation
 
@@ -114,7 +114,7 @@ When originating products are placed under the control of a customs office in th
 
 6. The customs authorities shall monitor the use made of the authorisation and may withdraw it whenever the beneficiary makes improper use of the authorisation in any manner whatsoever or fails to fulfil any of the other conditions laid down in this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 22 - Conditions for making out an origin declaration or an origin declaration EUR-MED
 
@@ -156,7 +156,7 @@ When originating products are placed under the control of a customs office in th
 
 4. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 23 - Approved exporter
 
@@ -170,7 +170,7 @@ When originating products are placed under the control of a customs office in th
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 24 - Validity of proof of origin
 
@@ -180,19 +180,19 @@ When originating products are placed under the control of a customs office in th
 
 3. In other cases of belated presentation, the customs authorities of the importing Party may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 25 - Submission of proof of origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing Party in accordance with the procedures applicable in that country. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the United Kingdom-Georgia Agreement.
 
-{{ top }}
+
 
 ## Article 26 - Importation by instalments
 
 Where, at the request of the importer and subject to the conditions laid down by the customs authorities of the importing Party, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2007 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 27 - Exemptions from proof of origin
 
@@ -202,7 +202,7 @@ Where, at the request of the importer and subject to the conditions laid down by
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers’ personal luggage.
 
-{{ top }}
+
 
 ## Article 28 - Supporting documents
 
@@ -218,7 +218,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 - appropriate evidence concerning working or processing undergone outside the United Kingdom, Georgia or the other countries referred to in Articles 3 and 4 by application of Article 12, proving that the requirements of that Article have been satisfied.
 
-{{ top }}
+
 
 ## Article 29 - Preservation of proof of origin and supporting documents
 
@@ -230,7 +230,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 4. The customs authorities of the importing Party shall keep for at least three years the movement certificates EUR.1 and EUR-MED and the origin declarations and origin declarations EUR-MED submitted to them.
 
-{{ top }}
+
 
 ## Article 30 - Discrepancies and formal errors
 
@@ -238,7 +238,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 2. Obvious formal errors, such as typing errors, on a proof of origin shall not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 31 - Amounts expressed in euro
 
@@ -252,6 +252,6 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 5. The amounts expressed in euro shall be reviewed by the Customs Sub-Committee at the request of any of the Parties. When carrying out this review, the Customs Sub-Committee shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 16 to 31 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/ghana/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/ghana/origin_processes.md
@@ -14,7 +14,7 @@
 
 5. For the purposes of applying the provisions of this title, exporters shall endeavour to use a language shared by Ghana and the UK.
 
-{{ top }}
+
 
 ## Article 18 - Procedure for the issue of a movement certificate EUR.1
 
@@ -32,7 +32,7 @@
 
 7. A movement certificate EUR.1 shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 19 - Movement certificates EUR.1 issued retrospectively
 
@@ -52,7 +52,7 @@
 
 5. The endorsement referred to in paragraph 4 of this Article shall be inserted in the "Remarks" box of the movement certificate EUR.1.
 
-{{ top }}
+
 
 ## Article 20 - Issue of a duplicate movement certificate EUR.1
 
@@ -66,7 +66,7 @@
 
 4. The duplicate, which must bear the date of issue of the original movement certificate EUR.1, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 21 - Conditions for making out an origin declaration
 
@@ -92,7 +92,7 @@
 
 6. An origin declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country no longer than two (2) years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 22 - Approved exporter
 
@@ -106,7 +106,7 @@
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 of this Article or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 23 - Validity of proof of origin
 
@@ -116,19 +116,19 @@
 
 3. In other cases of belated presentation, the customs authorities of the importing country may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 24 - Submission of proof of origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing country in accordance with the procedures applicable in that country. These authorities may require that a proof of origin be translated. They may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the United Kingdom-Ghana Agreement.
 
-{{ top }}
+
 
 ## Article 25 - Importation by instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the importing country, dismantled or non‐assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling under Sections XVI and XVII or headings 73.08 and 94.06 of HS 2012 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 26 - Exemptions from proof of origin
 
@@ -138,7 +138,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages, or EUR 1 200 in the case of products forming part of travellers' personal luggage.
 
-{{ top }}
+
 
 ## Article 27 - Information procedure for cumulation purposes
 
@@ -162,7 +162,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 10. Supplier's declarations and information certificates issued before the date of entry into force of this Origin Reference Document in accordance with any previously applicable agreement or arrangement shall remain valid.
 
-{{ top }}
+
 
 ## Article 28 - Supporting documents
 
@@ -176,7 +176,7 @@ The documents referred to in Articles 18(3) and 21(3) of this Origin Reference D
 
 - movement certificates EUR.1 or origin declarations proving the originating status of materials used, issued or made out in Ghana, in the UK or in one of the other countries or territories referred to in Articles 6, 7 and 8 and in accordance with this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 29 - Preservation of proof of origin and supporting documents
 
@@ -190,7 +190,7 @@ The documents referred to in Articles 18(3) and 21(3) of this Origin Reference D
 
 5. The customs authorities of the importing country shall keep for at least three (3) years the movement certificates EUR.1 and the origin declarations submitted to them.
 
-{{ top }}
+
 
 ## Article 30 - Discrepancies and formal errors
 
@@ -198,7 +198,7 @@ The documents referred to in Articles 18(3) and 21(3) of this Origin Reference D
 
 2. Obvious formal errors such as typing errors on a proof of origin should not cause that document to be rejected if those errors are not such as to create doubts concerning the correctness of the statements made in the document.
 
-{{ top }}
+
 
 ## Article 31 - Amounts expressed in euro
 
@@ -212,6 +212,6 @@ The documents referred to in Articles 18(3) and 21(3) of this Origin Reference D
 
 5. The amounts expressed in euro shall be reviewed by the Committee at the request of the UK or Ghana. When carrying out that review, the Committee shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 17 to 31 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/iceland-norway/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/iceland-norway/origin_processes.md
@@ -22,7 +22,7 @@
 
    5. the certificate may be issued in any of the official languages of the Parties.
 
-{{ top }}
+
 
 ## Article 16 - Procedure for the Issue of a Movement Certificate EUR.1 or EUR-MED
 
@@ -62,7 +62,7 @@
 
 9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 17 - Movement Certificates EUR.1 or EUR-MED issued Retrospectively
 
@@ -88,7 +88,7 @@
 
 6. The endorsement referred to in paragraph 5 shall be inserted in box 7 of the movement certificate EUR.1 or EUR-MED.
 
-{{ top }}
+
 
 ## Article 18 - Issue of a Duplicate Movement Certificate EUR.1 or EUR-MED
 
@@ -103,13 +103,13 @@
 
 4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 19 - Issue of Movement Certificates EUR.1 or EUR-MED on the Basis of a Proof of Origin issued or made out previously
 
 When originating products are placed under the control of a customs office in a Party, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within that Party. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 20 - Accounting Segregation
 
@@ -125,7 +125,7 @@ When originating products are placed under the control of a customs office in a 
 
 6. The customs authorities shall monitor the use made of the authorisation and may withdraw it whenever the beneficiary makes improper use of the authorisation in any manner whatsoever or fails to fulfil any of the other conditions laid down in this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 21 - Conditions for making out an Origin Declaration or an Origin Declaration EUR-MED
 
@@ -167,7 +167,7 @@ When originating products are placed under the control of a customs office in a 
 
 8. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing Party at the latest two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 22 - Approved Exporter
 
@@ -181,7 +181,7 @@ When originating products are placed under the control of a customs office in a 
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 23 - Validity of Proof of Origin
 
@@ -191,19 +191,19 @@ When originating products are placed under the control of a customs office in a 
 
 3. In other cases of belated presentation, the customs authorities of the importing Party may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 24 - Submission of Proof of Origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing Party in accordance with the procedures applicable in that country. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the United Kingdom-Iceland Agreement.
 
-{{ top }}
+
 
 ## Article 25 - Importation by instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the importing Party, dismantled or non-assembled products within the meaning of General Interpretive Rule 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within sections XVI and XVII or headings 7308 and 9406 of HS 2007 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 26 - Exemptions from proof of origin
 
@@ -213,7 +213,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers' personal luggage.
 
-{{ top }}
+
 
 ## Article 27 - Supplier's Declaration
 
@@ -235,7 +235,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 6. The supplier making out a declaration must be prepared to submit at any time, at the request of the customs authorities of the country where the declaration is made out, or of the exporting Party for a supplier’s declaration made out in the European Union, all appropriate documents proving that the information given on this declaration is correct.
 
-{{ top }}
+
 
 ## Article 28 - Supporting Documents
 
@@ -253,7 +253,7 @@ The documents referred to in Articles 16(3), 21(5) and 27(6) used for the purpos
 
 - appropriate evidence concerning working or processing undergone outside the Party by application of Article 11, proving that the requirements of that Article have been satisfied.
 
-{{ top }}
+
 
 ## Article 29 - Preservation of Proof of Origin, Supplier's Declarations and Supporting Documents
 
@@ -269,7 +269,7 @@ The documents referred to in Articles 16(3), 21(5) and 27(6) used for the purpos
 
 5. The customs authorities of the importing Party shall keep for at least three years the movement certificates EUR.1 and EUR-MED and the origin declarations and origin declarations EUR-MED submitted to them.
 
-{{ top }}
+
 
 ## Article 30 - Discrepancies and Formal Errors
 
@@ -277,7 +277,7 @@ The documents referred to in Articles 16(3), 21(5) and 27(6) used for the purpos
 
 2. Obvious formal errors such as typing errors on a proof of origin should not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 31 - Amounts Expressed in Euro
 
@@ -291,6 +291,6 @@ The documents referred to in Articles 16(3), 21(5) and 27(6) used for the purpos
 
 5. The amounts expressed in euro shall be reviewed by the Joint Committee at the request of the Parties. When carrying out this review, the Joint Committee shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 15 to 31 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/israel/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/israel/origin_processes.md
@@ -10,7 +10,7 @@
 
 2. Notwithstanding paragraph 1, originating products within the meaning of this Origin Reference Document shall, in the cases specified in Article 27, benefit from the provisions of the UK-Israel Agreement without it being necessary to submit any of the proofs of origin referred to in paragraph 1.
 
-{{ top }}
+
 
 ## Article 17 - Procedure for the issue of a movement certificate EUR.1 or EUR-MED
 
@@ -50,7 +50,7 @@
 
 9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 18 - Movement certificates EUR.1 or EUR-MED issued retrospectively
 
@@ -76,7 +76,7 @@
 
 6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
 
-{{ top }}
+
 
 ## Article 19 - Issue of a duplicate movement certificate EUR.1 or EUR-MED
 
@@ -90,13 +90,13 @@
 
 4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 20 - Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously
 
 When originating products are placed under the control of a customs office in the UK or in Israel, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the UK or Israel. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 21 - Accounting segregation
 
@@ -112,7 +112,7 @@ When originating products are placed under the control of a customs office in th
 
 6. The customs authorities shall monitor the use made of the authorisation and may withdraw it whenever the beneficiary makes improper use of the authorisation in any manner whatsoever or fails to fulfil any of the other conditions laid down in this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 22 - Conditions for making out an invoice declaration or an invoice declaration EUR-MED
 
@@ -154,7 +154,7 @@ When originating products are placed under the control of a customs office in th
 
 8. An invoice declaration or an invoice declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 23 - Approved exporter
 
@@ -168,7 +168,7 @@ When originating products are placed under the control of a customs office in th
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 24 - Validity of proof of origin
 
@@ -178,19 +178,19 @@ When originating products are placed under the control of a customs office in th
 
 3. In other cases of belated presentation, the customs authorities of the importing country may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 25 - Submission of proof of origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing country in accordance with the procedures applicable in that country. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the UK-Israel Agreement.
 
-{{ top }}
+
 
 ## Article 26 - Importation by instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the importing country, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2002are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 27 - Exemptions from proof of origin
 
@@ -200,7 +200,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers' personal luggage.
 
-{{ top }}
+
 
 ## Article 28 - Supporting documents
 
@@ -216,7 +216,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 - appropriate evidence concerning working or processing undergone outside the UK or Israel by application of Article 12, proving that the requirements of that Article have been satisfied.
 
-{{ top }}
+
 
 ## Article 29 - Preservation of Proof of Origin and Supporting Documents
 
@@ -228,7 +228,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 4. The customs authorities of the importing country shall keep for at least three years the movement certificates EUR.1 and EUR-MED and the invoice declarations and invoice declarations EUR-MED submitted to them.
 
-{{ top }}
+
 
 ## Article 30 - Discrepancies and formal errors
 
@@ -236,7 +236,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 2. Obvious formal errors such as typing errors on a proof of origin should not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 31 - Amounts expressed in euro
 
@@ -250,6 +250,6 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 5. The amounts expressed in euro shall be reviewed by the Joint Committee at the request of the UK or of Israel. When carrying out this review, the Joint Committee shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 16 to 31 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/japan/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/japan/origin_processes.md
@@ -15,7 +15,7 @@
 5. Paragraphs 2 to 4 do not apply in the cases specified in Article 20.
 
 
-{{ top }}
+
 
 ## Article 17 - Statement on origin
 
@@ -40,13 +40,13 @@
 6. If, on request of the importer, unassembled or disassembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XV to XXI of HS 2017 are imported by instalments, a single statement on origin for such products may be used in accordance with the requirements laid down by the customs authority of the importing Party.
 
 
-{{ top }}
+
 
 ## Article 18 - Importer's knowledge
 
 The importer's knowledge that a product is originating in the exporting Party shall be based on information demonstrating that the product is originating and satisfies the requirements provided for in this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 19 - Record keeping requirements
 
@@ -63,7 +63,7 @@ The importer's knowledge that a product is originating in the exporting Party sh
 4. Paragraphs 1 to 3 do not apply in the cases specified in Article 20.
 
 
-{{ top }}
+
 
 ## Article 20 - Small consignments and waivers
 
@@ -73,6 +73,6 @@ The importer's knowledge that a product is originating in the exporting Party sh
 
 3. Each Party may provide that the basis for the claim as referred to in paragraph 2 of Article 16 shall not be required for an importation of a product for which the importing Party has waived the requirements.
 
-{{ top }}
+
 
 {{ Articles 16 to 20 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/jordan/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/jordan/origin_processes.md
@@ -10,7 +10,7 @@
 
 2. Notwithstanding paragraph 1, originating products within the meaning of this Origin Reference Document shall, in the cases specified in Article 27, benefit from the provisions of the United Kingdom-Jordan Agreement without it being necessary to submit any of the proofs of origin referred to in paragraph 1. 
 
-{{ top }}
+
 
 ## Article 17 - Procedure for the issue of a movement certificate EUR.1 or EUR-MED
 
@@ -50,7 +50,7 @@
 
 9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured. 
 
-{{ top }}
+
 
 ## Article 18 - Movement certificates EUR.1 or EUR-MED issued retrospectively
 
@@ -76,7 +76,7 @@
 
 6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED. 
 
-{{ top }}
+
 
 ## Article 19 - Issue of a duplicate movement certificate EUR.1 or EUR-MED
 
@@ -90,13 +90,13 @@
 
 4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date. 
 
-{{ top }}
+
 
 ## Article 20 - Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously
 
 When originating products are placed under the control of a customs office in the United Kingdom or in Jordan, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or Jordan. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed. 
 
-{{ top }}
+
 
 ## Article 21 - Accounting segregation
 
@@ -112,7 +112,7 @@ When originating products are placed under the control of a customs office in th
 
 6. The customs authorities shall monitor the use made of the authorisation and may withdraw it whenever the beneficiary makes improper use of the authorisation in any manner whatsoever or fails to fulfil any of the other conditions laid down in this Origin Reference Document. 
 
-{{ top }}
+
 
 ## Article 22 - Conditions for making out an invoice declaration or an invoice declaration EUR-MED
 
@@ -152,7 +152,7 @@ When originating products are placed under the control of a customs office in th
 
 8. An invoice declaration or an invoice declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates. 
 
-{{ top }}
+
 
 ## Article 23 - Approved exporter
 
@@ -166,7 +166,7 @@ When originating products are placed under the control of a customs office in th
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation. 
 
-{{ top }}
+
 
 ## Article 24 - Validity of proof of origin
 
@@ -176,19 +176,19 @@ When originating products are placed under the control of a customs office in th
 
 3. In other cases of belated presentation, the customs authorities of the importing country may accept the proofs of origin where the products have been submitted before the said final date. 
 
-{{ top }}
+
 
 ## Article 25 - Submission of proof of origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing country in accordance with the procedures applicable in that country. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the United Kingdom-Jordan Agreement.
 
-{{ top }}
+
 
 ## Article 26 - Importation by instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the importing country, dismantled or non- assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2002 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 27 - Exemptions from proof of origin
 
@@ -198,7 +198,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers' personal luggage. 
 
-{{ top }}
+
 
 ## Article 28 - Supporting documents
 
@@ -214,7 +214,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 - appropriate evidence concerning working or processing undergone outside the United Kingdom or Jordan by application of Article 12, proving that the requirements of that Article have been satisfied. 
 
-{{ top }}
+
 
 ## Article 29 - Preservation of proof of origin and supporting documents
 
@@ -226,7 +226,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 4. The customs authorities of the importing country shall keep for at least three years the movement certificates EUR.1 and EUR-MED and the invoice declarations and invoice declarations EUR-MED submitted to them. 
 
-{{ top }}
+
 
 ## Article 30 - Discrepancies and formal errors
 
@@ -234,7 +234,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 2. Obvious formal errors such as typing errors on a proof of origin should not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document. 
 
-{{ top }}
+
 
 ## Article 31 - Amounts expressed in euro
 
@@ -248,6 +248,6 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 5. The amounts expressed in euro shall be reviewed by the Association Committee at the request of the United Kingdom or of Jordan. When carrying out this review, the Association Committee shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro. 
 
-{{ top }}
+
 
 {{ Articles 16 to 31 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/kenya/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/kenya/origin_processes.md
@@ -12,7 +12,7 @@
 
 4. For the purpose of applying the provisions of this Title, the exporters shall endeavour to use a language common to both the EAC Partner States and the UK.
 
-{{ top }}
+
 
 ## Article 18 - Procedure for the issue of a movement certificate EUR 1
 
@@ -30,7 +30,7 @@
 
 7. A movement certificate EUR 1 shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 19 - Movement certificates EUR 1 issued retrospectively
 
@@ -50,7 +50,7 @@
 
 5. The endorsement referred to in paragraph 4 shall be inserted in the "Remarks" box of the movement certificate EUR 1.
 
-{{ top }}
+
 
 ## Article 20 - Issue of a duplicate movement certificate EUR 1
 
@@ -62,13 +62,13 @@
 
 4. The duplicate, which must bear the date of issue of the original movement certificate EUR 1, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 21 - Issue of movement certificates EUR 1 on the basis of a proof of origin issued or made out previously
 
 When originating products are placed under the control of a customs office in an EAC Partner State or in the UK, it shall be possible to replace the original proof of origin by one or more movement certificates EUR 1 for the purpose of sending all or some of these products elsewhere within the EAC Partner States or within the UK. The replacement movement certificate(s) EUR 1 shall be issued by the customs office under whose control the products are placed and endorsed by the customs authority under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 22 - Conditions for making out an origin declaration
 
@@ -88,7 +88,7 @@ When originating products are placed under the control of a customs office in an
 
 6. An origin declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country no longer than two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 23 - Approved exporter
 
@@ -102,7 +102,7 @@ When originating products are placed under the control of a customs office in an
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, does not fulfil the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorization.
 
-{{ top }}
+
 
 ## Article 24 - Validity of proof of origin
 
@@ -112,19 +112,19 @@ When originating products are placed under the control of a customs office in an
 
 3. In other cases of belated presentation, the customs authorities of the importing country may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 25 - Submission of proof of origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing country in accordance with the procedures applicable in that country. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the United Kingdom-EAC Agreement.
 
-{{ top }}
+
 
 ## Article 26 - Importation by instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the importing country, dismantled or non-assembled products within the meaning of General Rule 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or heading 7308 and 9406 of HS 2012 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 27 - Exemptions from proof of origin
 
@@ -134,7 +134,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers' personal luggage.
 
-{{ top }}
+
 
 ## Article 28 - Information procedure for cumulation purposes
 
@@ -160,7 +160,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 11. The supplier or long term supplier making out a declaration must be prepared to submit at any time, at the request of the customs authorities of the country where the declaration is made out, all appropriate documents proving that the information given on this declaration is correct.
 
-{{ top }}
+
 
 ## Article 29 - Supporting documents
 
@@ -174,7 +174,7 @@ The documents referred to in Articles 18(3) and 22(3) used for the purpose of pr
 
 - movement certificates EUR 1 or origin declarations proving the originating status of materials used, issued or made out in an EAC Partner State, in the UK or in one of the other countries or territories referred to in Articles 4, 5 and 6(2) and in accordance with this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 30 - Preservation of proof of origin and supporting documents
 
@@ -188,7 +188,7 @@ The documents referred to in Articles 18(3) and 22(3) used for the purpose of pr
 
 5. The customs authorities of the importing country shall keep the movement certificates EUR 1 and the origin declarations submitted to them for five (5) years in EAC Partner States and at least three (3) years in the UK.
 
-{{ top }}
+
 
 ## Article 31 - Discrepancies and formal errors
 
@@ -196,7 +196,7 @@ The documents referred to in Articles 18(3) and 22(3) used for the purpose of pr
 
 2. Obvious formal errors such as typing errors on a proof of origin should not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 32 - Amounts expressed in euro for goods referred to in articles 22(1)(b) and article 27(3)
 
@@ -210,6 +210,6 @@ The documents referred to in Articles 18(3) and 22(3) used for the purpose of pr
 
 5. The amounts expressed in euro shall be reviewed by the Committee at the request of the UK or of the EAC Partner States. When carrying out this review, the Committee shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 17 to 32 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/kosovo/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/kosovo/origin_processes.md
@@ -12,7 +12,7 @@
 
 3. Notwithstanding paragraph 5 of Article 17 and paragraph 3 of Article 22 below, where cumulation involves only the United Kingdom, the European Union, Switzerland (including Liechtenstein), Iceland, Norway, the Faroe Islands, Turkey, the Republic of Albania, Bosnia and Herzegovina, the Republic of North Macedonia, Montenegro, the Republic of Serbia and the Republic of Kosovo, the proof of origin may be a movement certificate EUR.1 or an origin declaration. 
 
-{{ top }}
+
 
 ## Article 17 - Procedure for the issue of a movement certificate EUR.1 or EUR-MED
 
@@ -51,7 +51,7 @@
 
 9.  A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 18 - Movement certificates EUR.1 or EUR-MED issued retrospectively
 
@@ -77,7 +77,7 @@
 
 6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
 
-{{ top }}
+
 
 ## Article 19 - Issue of a duplicate movement certificate EUR.1 or EUR-MED
 
@@ -91,13 +91,13 @@
 
 4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 20 - Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously
 
 When originating products are placed under the control of a customs office in the United Kingdom or Kosovo, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or Kosovo. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 21 - Accounting segregation
 
@@ -113,7 +113,7 @@ When originating products are placed under the control of a customs office in th
 
 6. The customs authorities shall monitor the use made of the authorisation and may withdraw it whenever the beneficiary makes improper use of the authorisation in any manner whatsoever or fails to fulfil any of the other conditions laid down in this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 22 - Conditions for making out an origin declaration or an origin declaration EUR-MED
 
@@ -154,7 +154,7 @@ When originating products are placed under the control of a customs office in th
 
 8. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 23 - Approved exporter
 
@@ -168,7 +168,7 @@ When originating products are placed under the control of a customs office in th
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 24 - Validity of proof of origin
 
@@ -178,19 +178,19 @@ When originating products are placed under the control of a customs office in th
 
 3. In other cases of belated presentation, the customs authorities of the importing Party may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 25 - Submission of proof of origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing Party in accordance with the procedures applicable in that country. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the United Kingdom-Kosovo Agreement.
 
-{{ top }}
+
 
 ## Article 26 - Importation by instalments
 
 Where, at the request of the importer and subject to the conditions laid down by the customs authorities of the importing Party, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2007 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 27 - Exemptions from proof of origin
 
@@ -200,7 +200,7 @@ Where, at the request of the importer and subject to the conditions laid down by
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1,200 in the case of products forming part of travellers’ personal luggage.
 
-{{ top }}
+
 
 ## Article 28 - Supporting documents
 
@@ -216,7 +216,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 - appropriate evidence concerning working or processing undergone outside the United Kingdom, Kosovo or the other countries referred to in Articles 3 and 4 by application of Article 12, proving that the requirements of that Article have been satisfied.
 
-{{ top }}
+
 
 ## Article 29 - Preservation of proof of origin and supporting documents
 
@@ -228,7 +228,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 4. The customs authorities of the importing Party shall keep for at least three years the movement certificates EUR.1 and EUR-MED and the origin declarations and origin declarations EUR-MED submitted to them.
 
-{{ top }}
+
 
 ## Article 30 - Discrepancies and formal errors
 
@@ -236,7 +236,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 2. Obvious formal errors, such as typing errors, on a proof of origin shall not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 31 - Amounts expressed in euro
 
@@ -250,6 +250,6 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 5. The amounts expressed in euro shall be reviewed by the Partnership, Trade and Cooperation Council at the request of any of the Parties. When carrying out this review, the Partnership, Trade and Cooperation Council shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 16 to 31 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/lebanon/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/lebanon/origin_processes.md
@@ -8,7 +8,7 @@
 
 2. Notwithstanding paragraph 1, originating products within the meaning of this Origin Reference Document shall, in the cases specified in Article 26, benefit from the United Kingdom-Lebanon Agreement without it being necessary to submit any of the documents referred to above.
 
-{{ top }}
+
 
 ## Article 17 - Procedure for the issue of a movement certificate EUR.1
 
@@ -28,7 +28,7 @@
 
 7. A movement certificate EUR.1 shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 18 - Movement certificates EUR.1 issued retrospectively
 
@@ -48,7 +48,7 @@
 
 5. The endorsement referred to in paragraph 4 shall be inserted in the ‘Remarks’ box of the movement certificate EUR.1.
 
-{{ top }}
+
 
 ## Article 19 - Issue of a duplicate movement certificate EUR.1
 
@@ -62,13 +62,13 @@
 
 4. The duplicate, which must bear the date of issue of the original movement certificate EUR.1, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 20 - Issue of movement certificates EUR.1 on the basis of a proof of origin issued or made out previously
 
 When originating products are placed under the control of a customs office in the United Kingdom or Lebanon, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 for the purpose of sending all or some of these products elsewhere within the United Kingdom or Lebanon. The replacement movement certificate(s) EUR.1 shall be issued by the customs office under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 21 - Conditions for making out an invoice declaration
 
@@ -88,7 +88,7 @@ When originating products are placed under the control of a customs office in th
 
 6. An invoice declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country no longer than two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 22 - Approved exporter
 
@@ -102,7 +102,7 @@ When originating products are placed under the control of a customs office in th
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, does not fulfil the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 23 - Validity of proof of origin
 
@@ -112,19 +112,19 @@ When originating products are placed under the control of a customs office in th
 
 3. In other cases of belated presentation, the customs authorities of the importing country may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 24 - Submission of proof of origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing country in accordance with the procedures applicable in that country. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the United Kingdom-Lebanon Agreement.
 
-{{ top }}
+
 
 ## Article 25 - Importation by instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the importing country, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part 2, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or heading Nos 7308 and 9406 of HS 2002 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 26 - Exemptions from proof of origin
 
@@ -134,7 +134,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers’ personal luggage.
 
-{{ top }}
+
 
 ## Article 27 - Supporting documents
 
@@ -148,7 +148,7 @@ The documents referred to in Articles 17(3) and 21(3) used for the purpose of pr
 
 - movement certificates EUR.1 or invoice declarations proving the originating status of materials used, issued or made out in the United Kingdom or Lebanon in accordance with this Origin Reference Document, or in one of the other countries referred to in Article 4, in accordance with rules of origin which are identical to the rules in this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 28 - Preservation of proof of origin and supporting documents
 
@@ -160,7 +160,7 @@ The documents referred to in Articles 17(3) and 21(3) used for the purpose of pr
 
 4. The customs authorities of the importing country shall keep for at least three years the movement certificates EUR.1 and the invoice declarations submitted to them.
 
-{{ top }}
+
 
 ## Article 29 - Discrepancies and formal errors
 
@@ -168,7 +168,7 @@ The documents referred to in Articles 17(3) and 21(3) used for the purpose of pr
 
 2. Obvious formal errors such as typing errors on a proof of origin should not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 30 - Amounts expressed in euro
 
@@ -180,6 +180,6 @@ The documents referred to in Articles 17(3) and 21(3) used for the purpose of pr
 
 4. The amounts expressed in euro and their equivalents in the national currencies of the United Kingdom and Lebanon shall be reviewed by the Association Committee at the request of the United Kingdom or Lebanon. When carrying out this review, the Association Committee shall ensure that there will be no decrease in the amounts to be used in national currency and shall furthermore consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 16 to 30 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/mexico/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/mexico/origin_processes.md
@@ -8,7 +8,7 @@
 
 2. Notwithstanding paragraph 1, originating products within the meaning of this Origin Reference Document shall, in the cases specified in Article 25, benefit from the United Kingdom-Mexico Agreement without it being necessary to submit any of the documents referred to above.
 
-{{ top }}
+
 
 ## Article 16 - Procedure for the issue of an EUR.1 movement certificate
 
@@ -26,7 +26,7 @@
 
 7. An EUR.1 movement certificate shall be issued by the customs authority or the competent governmental authority and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 17 - EUR.1 movement certificates issued retrospectively
 
@@ -48,7 +48,7 @@
 
 5. The endorsement referred to in paragraph 4 shall be inserted in the 'Remarks' box of the EUR.1 movement certificate.
 
-{{ top }}
+
 
 ## Article 18 - Issue of a duplicate EUR.1 movement certificate
 
@@ -64,7 +64,7 @@
 
 4. The duplicate, which must bear the date of issue of the original EUR.1 movement certificate, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 19 - Issue of EUR.1 movement certificates on the basis of proof of origin issued or made out previously
 
@@ -74,7 +74,7 @@
 
 3. The replacement certificate shall be issued on the basis of a written request from the re-exporter, after the authorities concerned have verified the information supplied in the applicant's request.
 
-{{ top }}
+
 
 ## Article 20 - Conditions for making out an invoice declaration
 
@@ -94,7 +94,7 @@
 
 6. An invoice declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented to the customs authority of the importing country no longer than the period established in the domestic law of each Party, as set out under Appendix V.
 
-{{ top }}
+
 
 ## Article 21 - Approved exporter
 
@@ -108,7 +108,7 @@
 
 5. The customs authorities or the competent governmental authority may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, does not fulfil the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 22 - Validity of proof of origin
 
@@ -118,19 +118,19 @@
 
 3. In other cases of belated presentation, the customs authorities of the importing country may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 23 - Submission of proof of origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing country in accordance with the procedures applicable in that country. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 24 - Import by instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the importing country, dismantled or non-assembled products within the meaning of paragraph 2 (a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or heading Nos 7308 and 9406 of HS 2002 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities on importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 25 - Exemptions from proof of origin
 
@@ -140,7 +140,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers' personal luggage.
 
-{{ top }}
+
 
 ## Article 26 - Supporting documents
 
@@ -154,7 +154,7 @@ The documents referred to in Articles 16(3) and 20(3) used for the purpose of pr
 
 - EUR.1 movement certificates or invoice declarations proving the originating status of materials used, issued or made out in Mexico or the United Kingdom in accordance with this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 27 - Preservation of proof of origin and supporting documents
 
@@ -166,7 +166,7 @@ The documents referred to in Articles 16(3) and 20(3) used for the purpose of pr
 
 4. The customs authorities of the importing country shall keep for at least three years the EUR.1 movement certificates and the invoice declarations submitted to them.
 
-{{ top }}
+
 
 ## Article 28 - Discrepancies and formal errors
 
@@ -174,7 +174,7 @@ The documents referred to in Articles 16(3) and 20(3) used for the purpose of pr
 
 2. Obvious formal errors such as typing errors on a proof of origin should not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 29 - Amounts expressed in euro
 
@@ -186,6 +186,6 @@ The documents referred to in Articles 16(3) and 20(3) used for the purpose of pr
 
 4. The amounts expressed in euro in this Origin Reference Document and their equivalents in the national currencies of the United Kingdom and Mexico shall be reviewed by the Joint Committee at the request of Mexico or the United Kingdom. When carrying out this review, the Joint Committee shall ensure that there will be no decrease in the amounts to be used in any national currency and shall furthermore consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro in this Origin Reference Document.
 
-{{ top }}
+
 
 {{ Articles 15 to 29 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/moldova/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/moldova/origin_processes.md
@@ -12,7 +12,7 @@
 
 3. Notwithstanding paragraph 5 of Article 17 and paragraph 3 of Article 22 below, where cumulation involves only the UK, the European Union, EFTA States, the Faroe Islands, Turkey, the Republic of Albania, Bosnia and Herzegovina, the Republic of Macedonia, Montenegro, the Republic of Serbia, the Republic of Kosovo and the Republic of Moldova, the proof of origin may be a movement certificate EUR.1 or an origin declaration.
 
-{{ top }}
+
 
 ## Article 17 - Procedure for the issue of a movement certificate EUR.1 or EUR-MED
 
@@ -51,7 +51,7 @@
 
 9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 18 - Movement certificates EUR.1 or EUR-MED issued retrospectively
 
@@ -77,7 +77,7 @@
 
 6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
 
-{{ top }}
+
 
 ## Article 19 - Issue of a duplicate movement certificate EUR.1 or EUR-MED
 
@@ -91,13 +91,13 @@
 
 4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 20 - Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously
 
 When originating products are placed under the control of a customs office in the UK or the Republic of Moldova, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the UK or the Republic of Moldova. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 21 - Accounting segregation
 
@@ -113,7 +113,7 @@ When originating products are placed under the control of a customs office in th
 
 6. The customs authorities shall monitor the use made of the authorisation and may withdraw it whenever the beneficiary makes improper use of the authorisation in any manner whatsoever or fails to fulfil any of the other conditions laid down in this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 22 - Conditions for making out an origin declaration or an origin declaration EUR-MED
 
@@ -155,7 +155,7 @@ When originating products are placed under the control of a customs office in th
 
 8. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 23 - Approved exporter
 
@@ -169,7 +169,7 @@ When originating products are placed under the control of a customs office in th
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 24 - Validity of proof of origin
 
@@ -179,19 +179,19 @@ When originating products are placed under the control of a customs office in th
 
 3. In other cases of belated presentation, the customs authorities of the importing Party may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 25 - Submission of proof of origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing Party in accordance with the procedures applicable in that country. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the United Kingdom-Moldova Agreement.
 
-{{ top }}
+
 
 ## Article 26 - Importation by instalments
 
 Where, at the request of the importer and subject to the conditions laid down by the customs authorities of the importing Party, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2007 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 27 - Exemptions from proof of origin
 
@@ -201,7 +201,7 @@ Where, at the request of the importer and subject to the conditions laid down by
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers’ personal luggage.
 
-{{ top }}
+
 
 ## Article 28 - Supporting documents
 
@@ -217,7 +217,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 - appropriate evidence concerning working or processing undergone outside the UK, the Republic of Moldova or the other countries referred to in Articles 3 and 4 by application of Article 12, proving that the requirements of that Article have been satisfied.
 
-{{ top }}
+
 
 ## Article 29 - Preservation of proof of origin and supporting documents
 
@@ -229,7 +229,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 4. The customs authorities of the importing Party shall keep for at least three years the movement certificates EUR.1 and EUR-MED and the origin declarations and origin declarations EUR-MED submitted to them.
 
-{{ top }}
+
 
 ## Article 30 - Discrepancies and formal errors
 
@@ -237,7 +237,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 2. Obvious formal errors, such as typing errors, on a proof of origin shall not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 31 - Amounts expressed in euro
 
@@ -251,6 +251,6 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 5. The amounts expressed in euro shall be reviewed by the Customs Sub-Committee at the request of any of the Parties. When carrying out this review, the Customs Sub-Committee shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 16 to 31 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/morocco/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/morocco/origin_processes.md
@@ -10,7 +10,7 @@
 
 2. Notwithstanding paragraph 1, originating products within the meaning of this Origin Reference Document shall, in the cases specified in Article 27, benefit from the provisions of the United Kingdom-Morocco Agreement without it being necessary to submit any of the proofs of origin referred to in paragraph 1.
 
-{{ top }}
+
 
 ## Article 17 - Procedure for the issue of a movement certificate EUR.1 or EUR-MED
 
@@ -53,7 +53,7 @@
 9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
 
-{{ top }}
+
 
 ## Article 18 - Movement certificates EUR.1 or EUR-MED issued retrospectively
 
@@ -79,7 +79,7 @@
 
 6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
 
-{{ top }}
+
 
 ## Article 19 - Issue of a duplicate movement certificate EUR.1 or EUR-MED
 
@@ -93,13 +93,13 @@
 
 4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 20 - Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously
 
 When originating products are placed under the control of a customs office in the United Kingdom or in Morocco, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or Morocco. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 21 - Accounting segregation
 
@@ -115,7 +115,7 @@ When originating products are placed under the control of a customs office in th
 
 6. The customs authorities shall monitor the use made of the authorisation and may withdraw it whenever the beneficiary makes improper use of the authorisation in any manner whatsoever or fails to fulfil any of the other conditions laid down in this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 22 - Conditions for making out an invoice declaration or an invoice declaration EUR-MED
 
@@ -159,7 +159,7 @@ When originating products are placed under the control of a customs office in th
 
 8. An invoice declaration or an invoice declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 23 - Approved exporter
 
@@ -174,7 +174,7 @@ When originating products are placed under the control of a customs office in th
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
 
-{{ top }}
+
 
 ## Article 24 - Validity of proof of origin
 
@@ -185,19 +185,19 @@ When originating products are placed under the control of a customs office in th
 3. In other cases of belated presentation, the customs authorities of the importing country may accept the proofs of origin where the products have been submitted before the said final date.
 
 
-{{ top }}
+
 
 ## Article 25 - Submission of proof of origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing country in accordance with the procedures applicable in that country. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the United Kingdom-Morocco Agreement.
 
-{{ top }}
+
 
 ## Article 26 - Importation by instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the importing country, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2007 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 27 - Exemptions from proof of origin
 
@@ -207,7 +207,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers' personal luggage.
 
-{{ top }}
+
 
 ## Article 27a - Supplier's declaration
 
@@ -229,7 +229,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 6. The supplier making out a declaration must be prepared to submit at any time, at the request of the customs authorities of the country where the declaration is made out, or of the exporting Party for a supplier’s declaration made out in the European Union, Iceland and Norway, all appropriate documents proving that the information given on this declaration is correct.
 
-{{ top }}
+
 
 ## Article 28 - Supporting documents
 
@@ -247,7 +247,7 @@ The documents referred to in Articles 17(3), 22(5) and 27a(6) used for the purpo
 
 - supplier's declaration proving the working or processing undergone in the United Kingdom, the European Union, Iceland, Norway, Tunisia, Morocco or Algeria by materials used, made out in one of these countries.
 
-{{ top }}
+
 
 ## Article 29 - Preservation of proof of origin, supplier’s declarations and supporting documents
 
@@ -263,7 +263,7 @@ The documents referred to in Articles 17(3), 22(5) and 27a(6) used for the purpo
 
 2. The customs authorities of the importing country shall keep for at least three years the movement certificates EUR.1 and EUR-MED and the invoice declarations and invoice declarations EUR-MED submitted to them.
 
-{{ top }}
+
 
 ## Article 30 - Discrepancies and formal errors
 
@@ -271,7 +271,7 @@ The documents referred to in Articles 17(3), 22(5) and 27a(6) used for the purpo
 
 2. Obvious formal errors such as typing errors on a proof of origin should not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 31 - Amounts expressed in euro
 
@@ -285,6 +285,6 @@ The documents referred to in Articles 17(3), 22(5) and 27a(6) used for the purpo
 
 5. The amounts expressed in euro shall be reviewed by the Association Committee at the request of the United Kingdom or of Morocco. When carrying out this review, the Association Committee shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 16 to 31 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/north-macedonia/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/north-macedonia/origin_processes.md
@@ -12,7 +12,7 @@
 
 3. Notwithstanding paragraph 5 of Article 17 and paragraph 3 of Article 22 below, where cumulation involves only the United Kingdom, the European Union, Switzerland (including Liechtenstein), Iceland, Norway, the Faroe Islands, Turkey, the Republic of Albania, Bosnia and Herzegovina, North Macedonia, Montenegro, the Republic of Serbia, or the Republic of Kosovo, the proof of origin may be a movement certificate EUR.1 or an origin declaration.
 
-{{ top }}
+
 
 ## Article 17 - Procedure for the issue of a movement certificate EUR.1 or EUR-MED
 
@@ -52,7 +52,7 @@
 
 9.  A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 18 - Movement certificates EUR.1 or EUR-MED issued retrospectively
 
@@ -78,7 +78,7 @@
 
 6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
 
-{{ top }}
+
 
 ## Article 19 - Issue of a duplicate movement certificate EUR.1 or EUR-MED
 
@@ -92,13 +92,13 @@
 
 4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 20 - Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously 
 
 When originating products are placed under the control of a customs office in the United Kingdom or North Macedonia, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or North Macedonia. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 21 - Accounting segregation
 
@@ -114,7 +114,7 @@ When originating products are placed under the control of a customs office in th
 
 6. The customs authorities shall monitor the use made of the authorisation and may withdraw it whenever the beneficiary makes improper use of the authorisation in any manner whatsoever or fails to fulfil any of the other conditions laid down in this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 22 - Conditions for making out an origin declaration or an origin declaration EUR-MED
 
@@ -156,7 +156,7 @@ When originating products are placed under the control of a customs office in th
 
 8. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 23 - Approved exporter
 
@@ -170,7 +170,7 @@ When originating products are placed under the control of a customs office in th
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 24 - Validity of proof of origin
 
@@ -180,19 +180,19 @@ When originating products are placed under the control of a customs office in th
 
 3. In other cases of belated presentation, the customs authorities of the importing Party may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 25 - Submission of proof of origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing Party in accordance with the procedures applicable in that country. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the United Kingdom-North Macedonia Agreement.
 
-{{ top }}
+
 
 ## Article 26 - Importation by instalments
 
 Where, at the request of the importer and subject to the conditions laid down by the customs authorities of the importing Party, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2007 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 27 - Exemptions from proof of origin
 
@@ -202,7 +202,7 @@ Where, at the request of the importer and subject to the conditions laid down by
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers’ personal luggage.
 
-{{ top }}
+
 
 ## Article 28 - Supporting documents
 
@@ -218,7 +218,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 - appropriate evidence concerning working or processing undergone outside the United Kingdom, North Macedonia or the other countries referred to in Articles 3 and 4 by application of Article 12, proving that the requirements of that Article have been satisfied.
 
-{{ top }}
+
 
 ## Article 29 - Preservation of proof of origin and supporting documents
 
@@ -230,7 +230,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 4. The customs authorities of the importing Party shall keep for at least three years the movement certificates EUR.1 and EUR-MED and the origin declarations and origin declarations EUR-MED submitted to them.
 
-{{ top }}
+
 
 ## Article 30 - Discrepancies and formal errors
 
@@ -238,7 +238,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 2. Obvious formal errors, such as typing errors, on a proof of origin shall not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 31 - Amounts expressed in euro
 
@@ -252,6 +252,6 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 5. The amounts expressed in euro shall be reviewed by the Partnership, Trade and Cooperation Council at the request of any of the Parties. When carrying out this review, the Partnership, Trade and Cooperation Council shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 16 to 31 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/pacific/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/pacific/origin_processes.md
@@ -10,7 +10,7 @@
 
 3. For the purpose of applying the provisions of this Title, the exporters shall endeavour to use a language common to both the Pacific States and the UK.
 
-{{ top }}
+
 
 ## Article 16 - Procedure for the issue of a movement certificate EUR.1
 
@@ -28,7 +28,7 @@
 
 7. A movement certificate EUR.1 shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 17 - Movement certificates EUR.1 issued retrospectively
 
@@ -48,7 +48,7 @@
 
 5. The endorsement referred to in paragraph 4 shall be inserted in the ‘Remarks’ box of the movement certificate EUR.1.
 
-{{ top }}
+
 
 ## Article 18 - Issue of a duplicate movement certificate EUR.1
 
@@ -62,13 +62,13 @@
 
 4. The duplicate, which must bear the date of issue of the original movement certificate EUR.1, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 19 - Issue of movement certificates EUR.1 on the basis of a proof of origin issued or made out previously
 
 When originating products are placed under the control of a customs office in a Pacific State Party or the UK, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 for the purpose of sending all or some of these products elsewhere within the Pacific States or the UK. The replacement movement certificate(s) EUR.1 shall be issued by the customs office in the UK or in a Pacific State Party under whose control the products are placed and endorsed by the customs authority under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 20 - Conditions for making out an invoice declaration
 
@@ -88,7 +88,7 @@ When originating products are placed under the control of a customs office in a 
 
 6. An invoice declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country no longer than two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 21 - Approved exporter
 
@@ -102,7 +102,7 @@ When originating products are placed under the control of a customs office in a 
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, does not fulfil the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 22 - Validity of proof of origin
 
@@ -112,19 +112,19 @@ When originating products are placed under the control of a customs office in a 
 
 3. In other cases of belated presentation, the customs authorities of the importing country may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 23 - Submission of proof of origin
 
 Proof of origin shall be submitted to the customs authorities of the importing country in accordance with the procedures applicable in that country. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the United Kingdom – Pacific States Agreement.
 
-{{ top }}
+
 
 ## Article 24 - Importation by instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the importing country, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or heading 7308 and 9406 of HS 1996 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 25 - Exemptions from proof of origin
 
@@ -134,7 +134,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers’ personal luggage.
 
-{{ top }}
+
 
 ## Article 26 - Information procedure for cumulation purposes
 
@@ -154,7 +154,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 8. Suppliers’ declarations made and information certificates issued before the date of entry into force of this Origin Reference Document in accordance with Article 26 of Protocol 1 to the Cotonou Agreement shall remain valid. 
 
-{{ top }}
+
 
 ## Article 27 - Supporting documents
 
@@ -168,7 +168,7 @@ The documents referred to in Articles 16(3) and 20(3) used for the purpose of pr
 
 - movement certificates EUR.1 or invoice declarations proving the originating status of materials used, issued or made out in a Pacific State, in the UK or in one of the other countries or territories referred to in Articles 3 and 4 and in accordance with this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 28 - Discrepancies and formal errors
 
@@ -176,7 +176,7 @@ The documents referred to in Articles 16(3) and 20(3) used for the purpose of pr
 
 2. Obvious formal errors such as typing errors on a proof of origin should not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 29 - Amounts expressed in euro
 
@@ -188,6 +188,6 @@ The documents referred to in Articles 16(3) and 20(3) used for the purpose of pr
 
 4. A country may round up or down the amount resulting from the conversion into its national currency of an amount expressed in euro. The rounded-off amount may not differ from the amount resulting from the conversion by more than 5 per cent. A country may retain unchanged its national currency equivalent of an amount expressed in euro if, at the time of the annual adjustment provided for in paragraph 3, the conversion of that amount, prior to any rounding-off, results in an increase of less than 15 per cent in the national currency equivalent. The national currency equivalent may be retained unchanged if the conversion would result in a decrease in that equivalent value.
 
-{{ top }}
+
 
 {{ Articles 15 to 29 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/palestinian-authority/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/palestinian-authority/origin_processes.md
@@ -10,7 +10,7 @@
 
 2. Notwithstanding paragraph 1, originating products within the meaning of this Origin Reference Document shall, in the cases specified in Article 27, benefit from the United Kingdom-Palestinian Authority Agreement without it being necessary to submit any of the proofs of origin referred to in paragraph 1 of this Article. 
 
-{{ top }}
+
 
 ## Article 17 - Procedure for the issue of a movement certificate EUR.1 or EUR-MED
 
@@ -50,7 +50,7 @@
 
 9.  A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 18 - Movement certificates EUR.1 or EUR-MED issued retrospectively
 
@@ -76,7 +76,7 @@
 
 6. The endorsement referred to in paragraph 5 shall be inserted in box 7 of the movement certificate EUR.1 or EUR-MED.
 
-{{ top }}
+
 
 ## Article 19 - Issue of a duplicate movement certificate EUR.1 or EUR-MED
 
@@ -90,13 +90,13 @@
 
 4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 20 - Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously
 
 When originating products are placed under the control of a customs office in the United Kingdom or the West Bank and the Gaza Strip, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or the West Bank and the Gaza Strip. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 21 - Accounting segregation
 
@@ -112,7 +112,7 @@ When originating products are placed under the control of a customs office in th
 
 6. The customs authorities shall monitor the use made of the authorisation and may withdraw it whenever the beneficiary makes improper use of the authorisation in any manner whatsoever or fails to fulfil any of the other conditions laid down in this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 22 - Conditions for making out an origin declaration or an origin declaration EUR-MED
 
@@ -154,7 +154,7 @@ When originating products are placed under the control of a customs office in th
 
 8. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country or territory at the latest two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 23 - Approved exporter
 
@@ -168,7 +168,7 @@ When originating products are placed under the control of a customs office in th
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 24 - Validity of proof of origin
 
@@ -178,19 +178,19 @@ When originating products are placed under the control of a customs office in th
 
 3. In other cases of belated presentation, the customs authorities of the importing Party may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 25 - Submission of proof of origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing Party in accordance with the procedures applicable in that country or territory. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the United Kingdom-Palestinian Authority Agreement.
 
-{{ top }}
+
 
 ## Article 26 - Importation by instalments
 
 Where, at the request of the importer and subject to the conditions laid down by the customs authorities of the importing Party, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2007 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 27 - Exemptions from proof of origin
 
@@ -200,7 +200,7 @@ Where, at the request of the importer and subject to the conditions laid down by
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1200 in the case of products forming part of travellers’ personal luggage.
 
-{{ top }}
+
 
 ## Article 28 - Supporting documents
 
@@ -217,7 +217,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 - appropriate evidence concerning working or processing undergone outside the United Kingdom, the West Bank and the Gaza Strip or the other countries or territories referred to in Articles 3 and 4 by application of Article 12, proving that the requirements of that Article have been satisfied.
 
 
-{{ top }}
+
 
 ## Article 29 - Preservation of proof of origin and supporting documents
 
@@ -229,7 +229,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 4. The customs authorities of the importing Party shall keep for at least three years the movement certificates EUR.1 and EUR-MED, the origin declarations and the origin declarations EUR-MED submitted to them.
 
-{{ top }}
+
 
 ## Article 30 - Discrepancies and formal errors
 
@@ -237,7 +237,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 2. Obvious formal errors, such as typing errors, on a proof of origin shall not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 31 - Amounts expressed in euro
 
@@ -251,6 +251,6 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 5. The amounts expressed in euro shall be reviewed by the Joint Committee at the request of any of the Parties. When carrying out this review, the Joint Committee shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 16 to 31 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/sacum/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/sacum/origin_processes.md
@@ -10,7 +10,7 @@
 
 3. For the purpose of applying the provisions of this Title, the exporters shall endeavour to use a language common to both the SACU Member States and Mozambique and the UK.
 
-{{ top }}
+
 
 ## Article 20 - Procedure for the issue of a movement certificate EUR.1
 
@@ -28,7 +28,7 @@
 
 7. A movement certificate EUR.1 shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 21 - Movement certificates EUR.1 issued retrospectively
 
@@ -48,7 +48,7 @@
 
 5. The endorsement referred to in paragraph 4 shall be inserted in Box 7 of the movement certificate EUR.1.
 
-{{ top }}
+
 
 ## Article 22 - Issue of a duplicate movement certificate EUR.1
 
@@ -62,13 +62,13 @@
 
 4. The duplicate, which must bear the date of issue of the original movement certificate EUR.1, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 23 - Issue of movement certificates EUR.1 on the basis of a proof of origin issued or made out previously
 
 When originating products are placed under the control of a customs office in a SACU Member State or Mozambique or in the UK, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 for the purpose of sending all or some of these products elsewhere within the SACU Member States or Mozambique or within the UK. The replacement movement certificate(s) EUR.1 shall be issued by the customs office under whose control the products are placed and endorsed by the customs authority under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 24 - Conditions for making out an origin declaration
 
@@ -88,7 +88,7 @@ When originating products are placed under the control of a customs office in a 
 
 6. An origin declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country no longer than two (2) years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 25 - Approved exporter
 
@@ -102,7 +102,7 @@ When originating products are placed under the control of a customs office in a 
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, does not fulfil the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 26 - Validity of proof of origin
 
@@ -112,19 +112,19 @@ When originating products are placed under the control of a customs office in a 
 
 3. In other cases of belated presentation, the customs authorities of the importing country may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 27 - Submission of proof of origin
 
 Proof of origin shall be submitted to the customs authorities of the importing country in accordance with the procedures applicable in that country. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the Agreement.
 
-{{ top }}
+
 
 ## Article 28 - Importation by instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the importing country, dismantled or non–assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or heading 7308 and 9406 of HS 2012 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 29 - Exemptions from proof of origin
 
@@ -134,7 +134,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers' personal luggage.
 
-{{ top }}
+
 
 ## Article 30 - Information procedure for cumulation purposes
 
@@ -158,7 +158,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 10. Suppliers' declarations made and information certificates issued before the date of entry into force of this Origin Reference Document shall remain valid for a transitional period of twelve (12) months.
 
-{{ top }}
+
 
 ## Article 31 - Supporting documents
 
@@ -172,7 +172,7 @@ The documents referred to in Articles 20(3) and 24(3) of this Origin Reference D
 
 - movement certificates EUR.1 or origin declarations proving the originating status of materials used, issued or made out in a SACU Member State or Mozambique, in the UK or in one of the other countries or territories referred to in Article 4 and 4A of this Origin Reference Document and in accordance with this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 32 - Preservation of proof of origin and supporting documents
 
@@ -186,7 +186,7 @@ The documents referred to in Articles 20(3) and 24(3) of this Origin Reference D
 
 5. The customs authorities of the importing country shall keep for at least three (3) years the movement certificates EUR.1 and the origin declarations submitted to them.
 
-{{ top }}
+
 
 ## Article 33 - Discrepancies and formal errors
 
@@ -194,7 +194,7 @@ The documents referred to in Articles 20(3) and 24(3) of this Origin Reference D
 
 2. Obvious formal errors such as typing errors on a proof of origin should not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 34 - Amounts expressed in Euro
 
@@ -208,6 +208,6 @@ The documents referred to in Articles 20(3) and 24(3) of this Origin Reference D
 
 5. The amounts expressed in Euro shall be reviewed by the Committee at the request of the UK, a SACU Member State or Mozambique. When carrying out this review, the Committee shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in Euro.
 
-{{ top }}
+
 
 {{ Articles 19 to 34 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/serbia/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/serbia/origin_processes.md
@@ -12,7 +12,7 @@
 
 3. Notwithstanding paragraph 5 of Article 17 and paragraph 3 of Article 22 below, where cumulation involves only the United Kingdom, the Republic of Serbia, the European Union, Switzerland (including Liechtenstein), Iceland, Norway, Turkey, or anywhere listed in items 10-15 in Annex A, the proof of origin may be a movement certificate EUR.1 or an origin declaration.
 
-{{ top }}
+
 
 ## Article 17 - Procedure for the issue of a movement certificate EUR.1 or EUR-MED
 
@@ -52,7 +52,7 @@
 
 9.  A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 18 - Movement certificates EUR.1 or EUR-MED issued retrospectively
 
@@ -78,7 +78,7 @@
 
 6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
 
-{{ top }}
+
 
 ## Article 19 - Issue of a duplicate movement certificate EUR.1 or EUR-MED
 
@@ -92,13 +92,13 @@
 
 4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 20 - Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously
 
 When originating products are placed under the control of a customs office in the United Kingdom or Serbia, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or Serbia. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 21 - Accounting segregation
 
@@ -114,7 +114,7 @@ When originating products are placed under the control of a customs office in th
 
 6. The customs authorities shall monitor the use made of the authorisation and may withdraw it whenever the beneficiary makes improper use of the authorisation in any manner whatsoever or fails to fulfil any of the other conditions laid down in this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 22 - Conditions for making out an origin declaration or an origin declaration EUR-MED
 
@@ -155,7 +155,7 @@ When originating products are placed under the control of a customs office in th
 
 8. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country or territory at the latest two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 23 - Approved exporter
 
@@ -169,7 +169,7 @@ When originating products are placed under the control of a customs office in th
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 24 - Validity of proof of origin
 
@@ -179,19 +179,19 @@ When originating products are placed under the control of a customs office in th
 
 3. In other cases of belated presentation, the customs authorities of the importing Party may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 25 - Submission of proof of origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing Party in accordance with the procedures applicable in that country or territory. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the United Kingdom-Serbia Agreement.
 
-{{ top }}
+
 
 ## Article 26 - Importation by instalments
 
 Where, at the request of the importer and subject to the conditions laid down by the customs authorities of the importing Party, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2007 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 27 - Exemptions from proof of origin
 
@@ -201,7 +201,7 @@ Where, at the request of the importer and subject to the conditions laid down by
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers’ personal luggage.
 
-{{ top }}
+
 
 ## Article 28 - Supporting documents
 
@@ -217,7 +217,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 - appropriate evidence concerning working or processing undergone outside the United Kingdom, Serbia or the other countries or territory referred to in Articles 3 and 4 by application of Article 12, proving that the requirements of that Article have been satisfied.
 
-{{ top }}
+
 
 ## Article 29 - Preservation of proof of origin and supporting documents
 
@@ -229,7 +229,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 4. The customs authorities of the importing Party shall keep for at least three years the movement certificates EUR.1 and EUR-MED and the origin declarations and origin declarations EUR-MED submitted to them.
 
-{{ top }}
+
 
 ## Article 30 - Discrepancies and formal errors
 
@@ -237,7 +237,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 2. Obvious formal errors, such as typing errors, on a proof of origin shall not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 31 - Amounts expressed in euro
 
@@ -251,6 +251,6 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 5. The amounts expressed in euro shall be reviewed by the Partnership, Trade and Cooperation Council at the request of either of the Parties. When carrying out this review, the Partnership, Trade and Cooperation Council shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 16 to 31 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/singapore/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/singapore/origin_processes.md
@@ -4,7 +4,7 @@
 
 2. Originating products within the meaning of this Origin Reference Document, in the cases specified in Article 22 (Exemptions from Origin Declaration), shall benefit from preferential tariff treatment of the United Kingdom-Singapore Agreement without it being necessary to submit any of the documents referred to in paragraph 1.
 
-{{ top }}
+
 
 ## Article 17 - Conditions for Making Out an Origin Declaration
 
@@ -32,7 +32,7 @@
 
 6. By derogation from paragraph 1, an origin declaration may exceptionally be made out after exportation ("retrospective statement") on condition that it is presented in the importing Party no later than two years, in the case of the UK, and one year, in the case of Singapore, after the entry of the goods into the territory.
 
-{{ top }}
+
 
 ## Article 18 - Approved Exporter
 
@@ -46,7 +46,7 @@
 
 5. The customs authorities of the UK may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 19 - Validity of Origin Declaration
 
@@ -56,19 +56,19 @@
 
 3. In cases of belated presentation other than those of paragraph 2, the customs authorities of the importing Party may accept the origin declarations where the products have been submitted before such final date.
 
-{{ top }}
+
 
 ## Article 20 - Submission of Origin Declaration
 
 For the purposes of claiming preferential tariff treatment, origin declarations shall be submitted to the customs authorities of the importing Party in accordance with the procedures applicable in that Party.
 
-{{ top }}
+
 
 ## Article 21 - Importation in Instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the importing Party, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2017 are imported in instalments, a single origin declaration for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 22 - Exemptions from Origin Declaration
 
@@ -78,7 +78,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 3. The total value of these products shall not exceed 500 euro in the case of small packages or 1 200 euro in the case of products forming part of travellers' personal luggage.
 
-{{ top }}
+
 
 ## Article 23 - Supporting Documents
 
@@ -90,7 +90,7 @@ The documents referred to in paragraph 3 of Article 17 (Conditions for Making Ou
 
 - documents proving the working or processing of materials in a Party, issued or made out in a Party, where these documents are used in accordance with domestic law.
 
-{{ top }}
+
 
 ## Article 24 - Preservation of Origin Declaration and Supporting Documents
 
@@ -100,7 +100,7 @@ The documents referred to in paragraph 3 of Article 17 (Conditions for Making Ou
 
 3. Each Party shall permit, in accordance with that Party's laws and regulations, exporters in its territory to maintain documentation or records in any medium, provided that the documentation or records can be retrieved and printed.
 
-{{ top }}
+
 
 ## Article 25 - Discrepancies and Formal Errors
 
@@ -108,7 +108,7 @@ The documents referred to in paragraph 3 of Article 17 (Conditions for Making Ou
 
 2. Obvious formal errors such as typing errors on a origin declaration should not cause the document to be rejected if those errors are not such as to create doubts concerning the correctness of the statements made in the document.
 
-{{ top }}
+
 
 ## Article 26 - Amounts Expressed in Euro
 
@@ -120,6 +120,6 @@ The documents referred to in paragraph 3 of Article 17 (Conditions for Making Ou
 
 4. The UK may round up or down the amount resulting from the conversion into its national currency of an amount expressed in euro. The rounded amount may not differ from the amount resulting from the conversion by more than five percent. The UK may retain unchanged its national currency equivalent of an amount expressed in euro if, at the time of the annual adjustment provided for in paragraph 3, the conversion of that amount, prior to any rounding-off, results in an increase of less than fifteen percent in the national currency equivalent. The national currency equivalent may be retained unchanged if the conversion would result in a decrease in that equivalent value.
 
-{{ top }}
+
 
 {{ Articles 16 to 26 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/south-korea/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/south-korea/origin_processes.md
@@ -4,7 +4,7 @@
 
 2. Notwithstanding paragraph 1, originating products within the meaning of this Origin Reference Document shall, in the cases specified in Article 20, benefit from preferential tariff treatment of the UK-Korea Agreement without it being necessary to submit any of the documents referred to in paragraph 1.
 
-{{ top }}
+
 
 ## Article 15 - Conditions for making out an origin declaration
 
@@ -24,7 +24,7 @@
 
 6. An origin declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing Party no longer than two years or the period specified in the legislation of the importing Party after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 16 - Approved exporter
 
@@ -38,7 +38,7 @@
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 17 - Validity of proof of origin
 
@@ -48,19 +48,19 @@
 
 3. In cases of belated presentation other than those of paragraph 2, the customs authorities of the importing Party may accept the proofs of origin in accordance with the procedures of the Parties where the products have been presented before the said final date.
 
-{{ top }}
+
 
 ## Article 18 - Claims for preferential tariff treatment and submission of proof of origin
 
 For the purpose of claiming preferential tariff treatment, proofs of origin shall, if required by the laws and regulations of the importing Party, be submitted to the customs authorities of the importing Party. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the application of the UK-Korea Agreement.
 
-{{ top }}
+
 
 ## Article 19 - Importation by instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the importing Party, dismantled or non-assembled products within the meaning of paragraph 2(a) of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2007 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 20 - Exemptions from proof of origin
 
@@ -76,7 +76,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 4. For the purpose of paragraph 3, in cases where the products are invoiced in a currency other than euro or US dollars, amounts in the national currencies of the Parties equivalent to the amounts expressed in euro or US dollars shall be fixed in accordance with the current exchange rate applicable in the importing Party.
 
-{{ top }}
+
 
 ## Article 21 - Supporting documents
 
@@ -92,7 +92,7 @@ The documents referred to in Article 15.3 used for the purpose of proving that p
 
 - appropriate evidence concerning working or processing undergone outside territories of the Parties by application of Article 12, proving that the requirements of that Article have been satisfied.
 
-{{ top }}
+
 
 ## Article 22 - Preservation of proof of origin and supporting documents
 
@@ -104,7 +104,7 @@ The documents referred to in Article 15.3 used for the purpose of proving that p
 
 4. The records to be kept in accordance with paragraphs 1 through 3 may include electronic records.
 
-{{ top }}
+
 
 ## Article 23 - Discrepancies and formal errors
 
@@ -112,7 +112,7 @@ The documents referred to in Article 15.3 used for the purpose of proving that p
 
 2. Obvious formal errors such as typing errors on a proof of origin should not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 24 - Amounts expressed in euro
 
@@ -126,6 +126,6 @@ The documents referred to in Article 15.3 used for the purpose of proving that p
 
 5. The amounts expressed in euro shall be reviewed by the Customs Committee at the request of a Party. When carrying out this review, the Customs Committee shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 14 to 24 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/switzerland-liechtenstein/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/switzerland-liechtenstein/origin_processes.md
@@ -1,4 +1,4 @@
-{{ top }}
+
 
 ## Article 17 - General requirements
 
@@ -16,7 +16,7 @@
 
 4. For the purpose of Article 7, if Article 8(5) applies, the exporter established in a Party who issues a proof of origin on the basis of another proof of origin which benefits from a waiver from the obligation to include the statement as otherwise required by Article 8(4) shall take all necessary steps to ensure that the conditions for applying cumulation are fulfilled and shall be prepared to submit all relevant documents to the customs authorities.
 
-{{ top }}
+
 
 ## Article 18 - Conditions for making out an origin declaration
 
@@ -38,7 +38,7 @@
 
     Where the splitting of a consignment takes place in accordance with Article 14(3) and provided that the same two-year deadline is respected, the retrospective origin declaration shall be made out by the approved exporter of the exporting Party of the products.
 
-{{ top }}
+
 
 ## Article 19 - Approved exporter
 
@@ -50,7 +50,7 @@
 
 4. The customs authorities shall verify the proper use of an authorisation. They may withdraw the authorisation if the approved exporter makes improper use of it and shall do so if the approved exporter no longer offers the guarantees referred to in paragraph 2.
 
-{{ top }}
+
 
 ## Article 20 - Procedure for issuing of a movement certificate EUR.1
 
@@ -68,7 +68,7 @@
 
 7. A movement certificate EUR.1 shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 20 bis - Electronically issued movement certificates EUR.1
 
@@ -88,7 +88,7 @@
 
    5. it may be issued in any of the official languages of the Parties or in English.
 
-{{ top }}
+
 
 ## Article 21 - Movement certificates EUR.1 issued retrospectively
 
@@ -112,7 +112,7 @@
 
 5. The endorsement referred to in paragraph 4 shall be inserted in Box 7 of the movement certificate EUR.1.
 
-{{ top }}
+
 
 ## Article 22 - Issue of a duplicate movement certificate EUR.1
 
@@ -124,7 +124,7 @@
 
 4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 23 - Validity of proof of origin
 
@@ -134,19 +134,19 @@
 
 3. In other cases of belated presentation, the customs authorities of the importing Party may accept the proofs of origin where the products have been presented to customs before the said final date.
 
-{{ top }}
+
 
 ## Article 25 - Importation requirements
 
 Proofs of origin shall be submitted to the customs authorities of the importing Party in accordance with the procedures applicable in that Party.
 
-{{ top }}
+
 
 ## Article 26 - Importation by instalments
 
 Where, at the request of the importer and subject to the conditions laid down by the customs authorities of the importing Party, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2017 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities on importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 27 - Exemptions from proof of origin
 
@@ -162,7 +162,7 @@ Where, at the request of the importer and subject to the conditions laid down by
 
 3. The total value of those products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers’ personal luggage.
 
-{{ top }}
+
 
 ## Article 28 - Discrepancies and formal errors
 
@@ -170,7 +170,7 @@ Where, at the request of the importer and subject to the conditions laid down by
 
 2. Obvious formal errors such as typing errors on a proof of origin shall not cause the documents referred to in paragraph 1 to be rejected if those errors are not such as to create doubts concerning the correctness of the statements made in those documents.
 
-{{ top }}
+
 
 ## Article 29 - Supplier’s declarations
 
@@ -186,7 +186,7 @@ Where, at the request of the importer and subject to the conditions laid down by
 
 6. The supplier making out a declaration shall be prepared to submit at any time, at the request of the customs authorities of the Party or the relevant country referred to in Annex VIII where the declaration is made out, all appropriate documents proving that the information given on that declaration is correct.
 
-{{ top }}
+
 
 ## Article 30 - Amounts expressed in euro
 
@@ -200,6 +200,6 @@ Where, at the request of the importer and subject to the conditions laid down by
 
 5. The amounts expressed in euro shall be reviewed by the Joint Committee at the request of a Party. When carrying out that review, the Joint Committee shall consider the desirability of preserving the effects of the limits concerned in real terms. For that purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 17 to 30 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/tunisia/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/tunisia/origin_processes.md
@@ -10,7 +10,7 @@
 
 2. Notwithstanding paragraph 1, originating products within the meaning of this Origin Reference Document shall, in the cases specified in Article 27, benefit from the provisions of the Agreement without it being necessary to submit any of the proofs of origin referred to in paragraph 1.
 
-{{ top }}
+
 
 ## Article 17 - Procedure for the Issue of a Movement Certificate EUR.1 or EUR-MED
 
@@ -52,7 +52,7 @@
 
 9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 18 - Movement Certificates EUR.1 or EUR-MED Issued Retrospectively
 
@@ -78,7 +78,7 @@
 
 6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
 
-{{ top }}
+
 
 ## Article 19 - Issue of a Duplicate Movement Certificate EUR.1 or EUR-MED
 
@@ -92,13 +92,13 @@
 
 4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 20 - Issue of Movement Certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously
 
 When originating products are placed under the control of a customs office in the United Kingdom or in Tunisia, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or Tunisia. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 21 - Accounting Segregation
 
@@ -114,7 +114,7 @@ When originating products are placed under the control of a customs office in th
 
 6. The customs authorities shall monitor the use made of the authorisation and may withdraw it whenever the beneficiary makes improper use of the authorisation in any manner whatsoever or fails to fulfil any of the other conditions laid down in this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 22 - Conditions for making out an Invoice Declaration or an Invoice Declaration EUR-MED
 
@@ -158,7 +158,7 @@ When originating products are placed under the control of a customs office in th
 
 8. An invoice declaration or an invoice declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 23 - Approved Exporter
 
@@ -172,7 +172,7 @@ When originating products are placed under the control of a customs office in th
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 24 - Validity of Proof of Origin
 
@@ -182,19 +182,19 @@ When originating products are placed under the control of a customs office in th
 
 3. In other cases of belated presentation, the customs authorities of the importing country may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 25 - Submission of Proof of Origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing country in accordance with the procedures applicable in that country. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the Agreement.
 
-{{ top }}
+
 
 ## Article 26 - Importation by Instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the importing country, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2002 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 27 - Exemptions from Proof of Origin
 
@@ -204,7 +204,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers' personal luggage.
 
-{{ top }}
+
 
 ## Article 27a - Supplier's Declaration
 
@@ -226,7 +226,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
 6. The supplier making out a declaration must be prepared to submit at any time, at the request of the customs authorities of the country where the declaration is made out, or of the exporting Party for a supplier’s declaration made out in the European Union, Iceland and Norway, all appropriate documents proving that the information given on this declaration is correct.
 
-{{ top }}
+
 
 ## Article 28 - Supporting Documents
 
@@ -244,7 +244,7 @@ The documents referred to in Articles 17(3) and 22(5) and 27a(6) used for the pu
 
 - supplier's declaration proving the working or processing undergone in the United Kingdom, the European Union, Iceland, Norway, Tunisia, Morocco or Algeria by materials used, made out in one of these countries.
 
-{{ top }}
+
 
 ## Article 29 - Preservation of Proof of Origin, Suppliers’ Declarations and Supporting Documents
 
@@ -260,7 +260,7 @@ The documents referred to in Articles 17(3) and 22(5) and 27a(6) used for the pu
 
 2. The customs authorities of the importing country shall keep for at least three years the movement certificates EUR.1 and EUR-MED and the invoice declarations and invoice declarations EUR-MED submitted to them.
 
-{{ top }}
+
 
 ## Article 30 - Discrepancies and Formal Errors
 
@@ -268,7 +268,7 @@ The documents referred to in Articles 17(3) and 22(5) and 27a(6) used for the pu
 
 2. Obvious formal errors such as typing errors on a proof of origin should not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 31 - Amounts Expressed in Euro
 
@@ -282,6 +282,6 @@ The documents referred to in Articles 17(3) and 22(5) and 27a(6) used for the pu
 
 5. The amounts expressed in euro shall be reviewed by the Association Committee at the request of the United Kingdom or of Tunisia. When carrying out this review, the Association Committee shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 16 to 31 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/turkey/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/turkey/origin_processes.md
@@ -4,7 +4,7 @@
 
 2. The importing Party may deny that claim for preferential treatment if any importer, exporter or party fails to comply with any requirement of this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 18 - Origin declaration
 
@@ -16,7 +16,7 @@
 
 2. Each Party shall permit an origin declaration to be sent electronically and directly from the exporter in one Party to an importer in the other Party. Such an approach will allow the use of electronic signatures or identification codes. 
 
-{{ top }}
+
 
 ## Article 19 - Validity of the origin declaration
 
@@ -32,7 +32,7 @@
 
 4. If unassembled or disassembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XV to XXI of HS 2017 are imported by instalments, a single origin declaration for such products may be used on request of the importer and in accordance with the requirements laid down by the customs authority of the importing Party. 
 
-{{ top }}
+
 
 ## Article 20 - Exemptions from origin declaration requirements
 
@@ -42,13 +42,13 @@
 
 3. Each Party may set value limits for products referred to in paragraph 1, and shall exchange information with the other Party regarding those limits.
 
-{{ top }}
+
 
 ## Article 21 - Delayed claims for preferential treatment
 
 Each Party shall, in conformity with its laws and regulations, provide that, if a good would have qualified as originating when it was imported into the territory of that Party but the importer did not have an origin declaration at the time of importation, the importer of the good may, within a period of time of no less than two years after the date of importation, apply for a refund of duties paid as a result of the good not having been accorded preferential tariff treatment.
 
-{{ top }}
+
 
 ## Article 22 - Incorrect claims for preferential treatment
 
@@ -58,7 +58,7 @@ Each Party shall, in conformity with its laws and regulations, provide that, if 
 
    2. an importer that becomes aware of or has reason to believe that an origin declaration for a good which it has imported and to which preferential treatment has been granted contains incorrect information shall immediately notify the customs authority of the importing Party in writing of any change affecting the originating status of that good and pay any duties owing. 
 
-{{ top }}
+
 
 ## Article 23 - Discrepancies
 
@@ -70,7 +70,7 @@ Each Party shall, in conformity with its laws and regulations, provide that, if 
 
 4. The customs authority of the importing Party shall not reject a claim for preferential tariff treatment for the sole reason that the invoice or other commercial document was issued in a third country.
 
-{{ top }}
+
 
 ## Article 25 - Record keeping requirements 
 
@@ -92,6 +92,6 @@ Each Party shall, in conformity with its laws and regulations, provide that, if 
 
    2. denies access to those records or that documentation.
 
-{{ top }}
+
 
 {{ Articles 17 to 25 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/ukraine/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/ukraine/origin_processes.md
@@ -12,7 +12,7 @@
 
 3. Notwithstanding paragraph 5 of Article 17 and paragraph 3 of Article 22 below, where cumulation involves only the United Kingdom and the 'Contracting Parties' to the Regional Convention on Pan-Euro Mediterranean preferential rules of origin (other than the participants in the Barcelona Process , with the exception of Turkey) the proof of origin may be a movement certificate EUR.1 or an origin declaration.
 
-{{ top }}
+
 
 ## Article 17 - Procedure for the issue of a movement certificate EUR.1 or EUR-MED
 
@@ -52,7 +52,7 @@
 
 9.  A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
 
-{{ top }}
+
 
 ## Article 18 - Movement certificates EUR.1 or EUR-MED issued retrospectively
 
@@ -78,7 +78,7 @@
 
 6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
 
-{{ top }}
+
 
 ## Article 19 - Issue of a duplicate movement certificate EUR.1 or EUR-MED
 
@@ -92,7 +92,7 @@
 
 4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 20
 
@@ -100,7 +100,7 @@ Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origi
 
 When originating products are placed under the control of a customs office in the United Kingdom or Ukraine, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or Ukraine. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.
 
-{{ top }}
+
 
 ## Article 21 - Accounting segregation
 
@@ -116,7 +116,7 @@ When originating products are placed under the control of a customs office in th
 
 6. The customs authorities shall monitor the use made of the authorisation and may withdraw it whenever the beneficiary makes improper use of the authorisation in any manner whatsoever or fails to fulfil any of the other conditions laid down in this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 22 - Conditions for making out an origin declaration or an origin declaration EUR-MED
 
@@ -158,7 +158,7 @@ When originating products are placed under the control of a customs office in th
 
 8. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
 
-{{ top }}
+
 
 ## Article 23 - Approved exporter
 
@@ -172,7 +172,7 @@ When originating products are placed under the control of a customs office in th
 
 5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
 
-{{ top }}
+
 
 ## Article 24 - Validity of proof of origin
 
@@ -182,19 +182,19 @@ When originating products are placed under the control of a customs office in th
 
 3. In other cases of belated presentation, the customs authorities of the importing Party may accept the proofs of origin where the products have been submitted before the said final date.
 
-{{ top }}
+
 
 ## Article 25 - Submission of proof of origin
 
 Proofs of origin shall be submitted to the customs authorities of the importing Party in accordance with the procedures applicable in that country. The said authorities may require a translation of a proof of origin and may also require the import declaration to be accompanied by a statement from the importer to the effect that the products meet the conditions required for the implementation of the United Kingdom-Ukraine Agreement.
 
-{{ top }}
+
 
 ## Article 26 - Importation by instalments
 
 Where, at the request of the importer and subject to the conditions laid down by the customs authorities of the importing Party, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2007 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 27 - Exemptions from proof of origin
 
@@ -204,7 +204,7 @@ Where, at the request of the importer and subject to the conditions laid down by
 
 3. Furthermore, the total value of these products shall not exceed EUR 500 in the case of small packages or EUR 1 200 in the case of products forming part of travellers' personal luggage.
 
-{{ top }}
+
 
 ## Article 28 - Supporting documents
 
@@ -220,7 +220,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 - appropriate evidence concerning working or processing undergone outside the United Kingdom, Ukraine or the other countries referred to in Articles 3 and 4 by application of Article 12, proving that the requirements of that Article have been satisfied.
 
-{{ top }}
+
 
 ## Article 29 - Preservation of proof of origin and supporting documents
 
@@ -232,7 +232,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 4. The customs authorities of the importing Party shall keep for at least three years the movement certificates EUR.1 and EUR-MED and the origin declarations and origin declarations EUR-MED submitted to them.
 
-{{ top }}
+
 
 ## Article 30 - Discrepancies and formal errors
 
@@ -240,7 +240,7 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 2. Obvious formal errors, such as typing errors, on a proof of origin shall not cause this document to be rejected if these errors are not such as to create doubts concerning the correctness of the statements made in this document.
 
-{{ top }}
+
 
 ## Article 31 - Amounts expressed in euro
 
@@ -254,6 +254,6 @@ The documents referred to in Articles 17(3) and 22(5) used for the purpose of pr
 
 5. The amounts expressed in euro shall be reviewed by the Customs Sub-Committee at the request of any of the Parties. When carrying out this review, the Customs Sub-Committee shall consider the desirability of preserving the effects of the limits concerned in real terms. For this purpose, it may decide to modify the amounts expressed in euro.
 
-{{ top }}
+
 
 {{ Articles 16 to 31 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/vietnam/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/vietnam/origin_processes.md
@@ -22,7 +22,7 @@
 
 3. Originating products within the meaning of this Origin Reference Document shall, in the cases specified in Article 24 (Exemptions from Proof of Origin), benefit from the United Kingdom-Viet Nam Agreement without requiring the submission of any of the documents referred to in this Article.
 
-{{ top }}
+
 
 ## Article 16 - Procedure for the Issuance of a Certificate of Origin
 
@@ -40,7 +40,7 @@
 
 7. The certificate of origin shall be issued as soon as possible to but not later than three working days after the date of exportation (the declared shipment date).
 
-{{ top }}
+
 
 ## Article 17 - Certificates of Origin Issued Retrospectively
 
@@ -59,7 +59,7 @@
 
 5. The endorsement referred to in paragraph 4 shall be inserted in Box 7 of the certificate of origin. 
 
-{{ top }}
+
 
 ## Article 18 - Issuance of a Duplicate Certificate of Origin
 
@@ -73,7 +73,7 @@
 
 4. The duplicate, which must bear the date of issue of the original certificate of origin, shall take effect as from that date.
 
-{{ top }}
+
 
 ## Article 19 - Conditions for Making out an Origin Declaration
 
@@ -89,7 +89,7 @@
 
 6. The conditions for making out an origin declaration referred to in paragraphs 1 to 5 apply mutatis mutandis to statements of origin made out by an exporter registered as provided for in subparagraphs 1(c) and 2(c) of Article 15 (General Requirements). 
 
-{{ top }}
+
 
 ## Article 20 - Approved Exporter
 
@@ -103,7 +103,7 @@
 
 5. The competent authorities may withdraw the authorisation at any time. They shall do so when the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation. 
 
-{{ top }}
+
 
 ## Article 21 - Validity of Proof of Origin
 
@@ -113,19 +113,19 @@
 
 3. In other cases of belated presentation, the customs authorities of the importing Party may accept the proofs of origin when the products have been imported within the period of validity referred to in paragraph 1.
 
-{{ top }}
+
 
 ## Article 22 - Submission of Proof of Origin
 
 For the purpose of claiming preferential tariff treatment, proofs of origin shall be submitted to the customs authorities of the importing Party in accordance with the procedures applicable in that Party. Those authorities may request a translation of the proof of origin if it is not issued in English. 
 
-{{ top }}
+
 
 ## Article 23 - Importation by Instalments
 
 Where, at the request of the importer and on the conditions laid down by the customs authorities of the importing Party, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2012 are imported by instalments, a single proof of origin for such products shall be submitted to the customs authorities upon importation of the first instalment.
 
-{{ top }}
+
 
 ## Article 24 - Exemptions from Proof of Origin
 
@@ -139,7 +139,7 @@ Where, at the request of the importer and on the conditions laid down by the cus
 
    2. when entering Viet Nam, USD 200, both in the case of small packages and in the case of products forming part of travellers' personal luggage.
 
-{{ top }}
+
 
 ## Article 25 - Supporting Documents
 
@@ -153,7 +153,7 @@ The documents referred to in paragraph 3 of Article 16 (Procedure for the Issuan
 
 - proof of origin proving the originating status of materials used, issued or made out in a Party in accordance with this Origin Reference Document.
 
-{{ top }}
+
 
 ## Article 26 - Preservation of Proof of Origin and Supporting Documents
 
@@ -165,7 +165,7 @@ The documents referred to in paragraph 3 of Article 16 (Procedure for the Issuan
 
 4. Each Party shall permit, in accordance with that Party's laws and regulations, exporters in its territory to maintain documentation or records in any form or medium, provided that the documentation or records can be retrieved and printed.
 
-{{ top }}
+
 
 ## Article 27 - Discrepancies and Formal Errors
 
@@ -175,7 +175,7 @@ The documents referred to in paragraph 3 of Article 16 (Procedure for the Issuan
 
 3. For multiple goods declared under the same proof of origin, a problem encountered with one of the goods listed shall not affect or delay the granting of preferential tariff treatment and customs clearance of the remaining goods listed in the proof of origin.
 
-{{ top }}
+
 
 ## Article 28 - Amounts Expressed in Euro
 
@@ -187,6 +187,6 @@ The documents referred to in paragraph 3 of Article 16 (Procedure for the Issuan
 
 4. A Party may round up or down the amount resulting from the conversion into its national currency of an amount expressed in euro. The rounded-off amount may not differ from the amount resulting from the conversion by more than 5 per cent. A Party may retain unchanged its national currency equivalent of an amount expressed in euro if, at the time of the annual adjustment provided for in paragraph 3, the conversion of that amount, prior to any rounding-off, results in an increase of less than 15 per cent in the national currency equivalent. The national currency equivalent may be retained unchanged if the conversion would result in a decrease in that equivalent value.
 
-{{ top }}
+
 
 {{ Articles 15 to 28 }}


### PR DESCRIPTION
### Jira link

[HOTT-1716](https://transformuk.atlassian.net/browse/HOTT-1716)

### What?

I have added/removed/altered:

- [ ] Removed references to top in originprocesses.md for each country

### Why?

I am doing this because:

- We will have more freedom when placing a go to top link on our front end and our API will return a cleaner response meaning API users won't have to deal with references to {{ top }}