### PR TITLE
HOTT 1765 inconsistent font on wholly obtained definition page

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk/articles/cariforum/wholly-obtained.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/cariforum/wholly-obtained.md
@@ -8,7 +8,7 @@ The following shall be considered as wholly obtained in the territory of the CAR
 
 4. **products from live animals** raised there;
 
-5.
+5. 
     1. products obtained by **hunting or fishing** conducted there;
 
     2. products of **aquaculture**, including mariculture, where the fish are born and raised there;

--- a/db/rules_of_origin/roo_schemes_uk/articles/central-america/wholly-obtained.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/central-america/wholly-obtained.md
@@ -8,7 +8,7 @@ The following shall be considered as wholly obtained in the United Kingdom or in
 
 4. **products from live animals** raised there;
 
-5.
+5. 
    1. products obtained by **hunting** conducted there;
 
    2. products obtained by fishing conducted in their inland waters or within twelve nautical miles measured from the baselines of the United Kingdom or of the Republics of the CA Party;

--- a/db/rules_of_origin/roo_schemes_uk/articles/cotedivoire/wholly-obtained.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/cotedivoire/wholly-obtained.md
@@ -8,7 +8,7 @@ The following shall be considered as wholly obtained in Côte d'Ivoire or in the
 
 4. **products from live animals** raised there;
 
-5.
+5. 
    1. products obtained by **hunting or fishing** conducted there;
 
    2. products of **aquaculture**, including mariculture, where the animals are raised from eggs, spawn, larvae or fry;

--- a/db/rules_of_origin/roo_schemes_uk/articles/esa/wholly-obtained.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/esa/wholly-obtained.md
@@ -8,7 +8,7 @@ The following shall be considered as wholly obtained in an ESA State or in the U
 
 4. **products from live animals** raised there;
 
-5.
+5. 
    1. products obtained by **hunting or fishing** conducted there;
 
    2. products of **aquaculture**, including mariculture, where the fish are born and raised there;

--- a/db/rules_of_origin/roo_schemes_uk/articles/ghana/wholly-obtained.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/ghana/wholly-obtained.md
@@ -8,7 +8,7 @@ The following shall be considered as wholly obtained in Ghana or the UK:
 
 4. **products from live animals** raised there;
 
-5.
+5. 
    1. products obtained by **hunting or fishing** conducted there;
 
    2. products of **aquaculture**, including mariculture, where the animals are raised there from eggs, spawning, larvae or fry;

--- a/db/rules_of_origin/roo_schemes_uk/articles/kenya/wholly-obtained.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/kenya/wholly-obtained.md
@@ -11,7 +11,7 @@ The following shall be considered as wholly obtained in an EAC Partner State or 
 
 5. products from **slaughtered animals** born and raised there;
 
-6.
+6. 
     1. products obtained by **hunting or fishing** conducted there;
 
     2. products of **aquaculture**, including mariculture, where the fish are born and raised there;

--- a/db/rules_of_origin/roo_schemes_uk/articles/pacific/wholly-obtained.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/pacific/wholly-obtained.md
@@ -8,7 +8,7 @@ The following shall be considered as wholly obtained in a Pacific State or in th
 
 4. **products from live animals** raised there;
 
-5.
+5. 
    1. products obtained by **hunting or fishing** conducted there;
 
    2. products of **aquaculture**, including mariculture, where the fish are born and raised there;

--- a/db/rules_of_origin/roo_schemes_uk/articles/sacum/wholly-obtained.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/sacum/wholly-obtained.md
@@ -10,7 +10,7 @@ The following shall be considered as wholly obtained in the territory of a SACU 
 
 5. products from **slaughtered animals** born and raised there;
 
-6.
+6. 
    1. products obtained by **hunting or fishing** conducted there;
 
    2. Products of **aquaculture**, where the fish, crustaceans, molluscs and other aquatic invertebrates are born or raised there from eggs, larvae or fry;

--- a/db/rules_of_origin/roo_schemes_uk/articles/south-korea/wholly-obtained.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/south-korea/wholly-obtained.md
@@ -8,7 +8,7 @@ For the purposes of Article 2(a), the following shall be considered as wholly ob
 
 4. **products from live animals** raised there;
 
-5.
+5. 
    1. products obtained by hunting, trapping within the land territory or fishing, conducted within the land waters or within the territorial sea of a Party;
 
    2. Products of **aquaculture**, where the fish, crustaceans and mollusc are born and raised there;

--- a/spec/features/rules_of_origin_data_spec.rb
+++ b/spec/features/rules_of_origin_data_spec.rb
@@ -19,4 +19,28 @@ RSpec.describe 'Rules of Origin Data', :roo_data do
         end
     end
   end
+
+  describe 'UK articles' do
+    RulesOfOrigin::SchemeSet::DEFAULT_SOURCE_PATH
+      .join('roo_schemes_uk', 'articles')
+      .children
+      .select(&:directory?)
+      .each do |country_folder|
+        country_folder
+        .children
+        .select { |c| c.file? && c.extname == '.md' }
+        .each do |file|
+          context "for #{country_folder.basename}/#{file.basename}" do
+            subject(:markdown) { IO.read(file) }
+
+            it 'has parseable numbered lists' do
+              # Empty list entries are invalid markdown.
+              # To fix, add a space after the period following the number
+              # eg `5._`
+              expect(markdown).not_to match(/^\d+\.$/m)
+            end
+          end
+        end
+      end
+  end
 end


### PR DESCRIPTION
### Jira link

[HOTT-1765](https://transformuk.atlassian.net/browse/HOTT-1765)

### What?

I have added/removed/altered:

- [ ] altered broken markdown files
- [ ] added spec to check .MD files

### Why?

I am doing this because:

- of font inconsistencies in the frontend 