### PR TITLE
HOTT-1701 tweaks to roo api additions

### DIFF
--- a/app/models/rules_of_origin/v2/rule_set.rb
+++ b/app/models/rules_of_origin/v2/rule_set.rb
@@ -12,13 +12,12 @@ module RulesOfOrigin
 
       attr_accessor :scheme,
                     :heading,
-                    :subdivision,
                     :prefix,
                     :min,
                     :max,
                     :valid
 
-      attr_reader :rules
+      attr_reader :rules, :subdivision
 
       class << self
         def build_for_scheme(scheme, rule_sets_data)
@@ -32,6 +31,10 @@ module RulesOfOrigin
         attributes.each do |attribute_name, attribute_value|
           public_send "#{attribute_name}=", attribute_value
         end
+      end
+
+      def subdivision=(value)
+        @subdivision = value.presence
       end
 
       def headings_range

--- a/app/serializers/api/v2/rules_of_origin/v2/rule_serializer.rb
+++ b/app/serializers/api/v2/rules_of_origin/v2/rule_serializer.rb
@@ -7,7 +7,7 @@ module Api
 
           set_type :rules_of_origin_v2_rule
 
-          attributes :rule, :original, :rule_class, :operator
+          attributes :rule, :rule_class, :operator
         end
       end
     end

--- a/spec/models/rules_of_origin/v2/rule_set_spec.rb
+++ b/spec/models/rules_of_origin/v2/rule_set_spec.rb
@@ -131,4 +131,10 @@ RSpec.describe RulesOfOrigin::V2::RuleSet do
       it { is_expected.to be false }
     end
   end
+
+  describe '#subdivision' do
+    subject { described_class.new(subdivision: '').subdivision }
+
+    it { is_expected.to be_nil }
+  end
 end

--- a/spec/serializers/api/v2/rules_of_origin/v2/rule_serializer_spec.rb
+++ b/spec/serializers/api/v2/rules_of_origin/v2/rule_serializer_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Api::V2::RulesOfOrigin::V2::RuleSerializer do
         type: :rules_of_origin_v2_rule,
         attributes: {
           rule: rule.rule,
-          original: rule.original,
           rule_class: rule.rule_class,
           operator: rule.operator,
         },


### PR DESCRIPTION
### Jira link

HOTT-1701

### What?

I have added/removed/altered:

- [x] Treat blank subdivision as an absence of subdivision
- [x] Don't expose the original field

### Why?

I am doing this because:

- A blank string is different from an absence of value and I believe this is an error in the source JSON file
- The original field is not currently required so minimising the API surface we need to support

### Deployment risks (optional)

- Changes an api that is used in production, but undocumented sections of that API which have only recently been deployed so there should be no impact
