### PR TITLE
HOTT-1777: Replace non-breaking spaces in indexable descriptions

### DIFF
--- a/app/models/goods_nomenclature_description.rb
+++ b/app/models/goods_nomenclature_description.rb
@@ -1,5 +1,6 @@
 class GoodsNomenclatureDescription < Sequel::Model
   DESCRIPTION_NEGATION_REGEX = /(?<keep>\A.*)(?<remove>, (?<excluded-term>neither|other than|excluding|not).*\z)/
+  NO_BREAKING_SPACE = "\u00A0".freeze
 
   include Formatter
 
@@ -21,12 +22,14 @@ class GoodsNomenclatureDescription < Sequel::Model
   custom_format :formatted_description, with: DescriptionFormatter,
                                         using: :description
 
+  custom_format :description_indexed, with: DescriptionFormatter,
+                                      using: :description
   def description
     super.try(:gsub, %r/( ?<br> ?){2,}/, '<br>') || ''
   end
 
   def description_indexed
-    description.match(DESCRIPTION_NEGATION_REGEX).try(:[], :keep).presence || description
+    (super.match(DESCRIPTION_NEGATION_REGEX).try(:[], :keep).presence || description).try(:gsub, NO_BREAKING_SPACE, ' ')
   end
 
   def formatted_description

--- a/spec/models/goods_nomenclature_description_spec.rb
+++ b/spec/models/goods_nomenclature_description_spec.rb
@@ -63,6 +63,12 @@ RSpec.describe GoodsNomenclatureDescription do
 
       it { is_expected.to eq('I do not include a handled negation') }
     end
+
+    context 'when the description value has a non-breaking space character' do
+      subject(:description_indexed) { build(:goods_nomenclature_description, description: "I have a\u00A0non-breaking space").description_indexed }
+
+      it { is_expected.to eq('I have a non-breaking space') }
+    end
   end
 
   describe '#to_s' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1777

### What?

I have added/removed/altered:

- [x] Removed non-breaking space from indexable descriptions
- [x] Added specs to highlight this behaviour

### Why?

I am doing this because:

- This is required so we can safely tokenise/match tokens to classifications in beta search
