### PR TITLE
HOTT-1718: Promote search reference refresh to production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -557,11 +557,12 @@ workflows:
     jobs:
       - renew_search_references:
           context: trade-tariff
-          environment_key: staging
+          environment_key: production
           filters:
             branches:
               only:
                 - main
+
       - refresh_staging_db:
           context: trade-tariff
           matrix:
@@ -569,13 +570,12 @@ workflows:
               service:
                 - xi
                 - uk
+          requires:
+            - renew_search_references
           filters:
             branches:
               only:
                 - main
-          # TODO: When we promote renewing search refrences to production uncomment these lines
-          # requires:
-          #   - renew_search_references
   ci:
     jobs:
       - linters:


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1718

### What?

I have added/removed/altered:

- [x] Promote search reference database table refresh to production
- [x] Make sure replication of prod -> staging happens *after* the search references have been refreshed

### Why?

I am doing this because:

- This has been running on a weekly schedule for several weeks now and each job succeeds.
- It is a feature requirement

### AC

- [x] Job ran locally successfully
- [x] Job ran on staging successfully
- [x] Backup taken of both xi and uk production services
