### PR TITLE
HOTT-1790 Disable the data specs because they are slow

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --require rails_helper
+--tag ~roo_data


### PR DESCRIPTION
### Jira link

HOTT-1790

### What?

I have added/removed/altered:

- [x] Added an exclusion to the `.rspec` file to exclude the rules of origin data specs

### Why?

I am doing this because:

- They are taking too long to run

