### PR TITLE
HOTT-1759 - Permit intercept messages to be used on search terms

### DIFF
--- a/app/controllers/api/beta/search_controller.rb
+++ b/app/controllers/api/beta/search_controller.rb
@@ -7,6 +7,7 @@ module Api
         :heading_statistics,
         :chapter_statistics,
         :guide,
+        :intercept_message,
         'facet_filter_statistics.facet_classification_statistics',
       ].freeze
 

--- a/app/models/beta/search/intercept_message.rb
+++ b/app/models/beta/search/intercept_message.rb
@@ -12,8 +12,8 @@ module Beta
 
         result = new
 
-        result.term = (I18n.t "#{search_query}.title")
-        result.message = (I18n.t "#{search_query}.message")
+        result.term = I18n.t "#{search_query}.title"
+        result.message = I18n.t "#{search_query}.message"
 
         result
       end

--- a/app/models/beta/search/intercept_message.rb
+++ b/app/models/beta/search/intercept_message.rb
@@ -8,12 +8,14 @@ module Beta
       attr_accessor :intercept_message, :term, :message
 
       def self.build(search_query)
-        return unless search_query.eql?((I18n.t "#{search_query}.title"))
+        query = search_query.downcase
+
+        return unless query.eql?((I18n.t "#{query}.title"))
 
         result = new
 
-        result.term = I18n.t "#{search_query}.title"
-        result.message = I18n.t "#{search_query}.message"
+        result.term = I18n.t "#{query}.title"
+        result.message = I18n.t "#{query}.message"
 
         result
       end

--- a/app/models/beta/search/intercept_message.rb
+++ b/app/models/beta/search/intercept_message.rb
@@ -1,0 +1,22 @@
+module Beta
+  module Search
+    class InterceptMessage
+      include ContentAddressableId
+
+      content_addressable_fields :intercept_message
+
+      attr_accessor :intercept_message, :term, :message
+
+      def self.build(search_query)
+        return unless search_query.eql?((I18n.t "#{search_query}.title"))
+
+        result = new
+
+        result.term = (I18n.t "#{search_query}.title")
+        result.message = (I18n.t "#{search_query}.message")
+
+        result
+      end
+    end
+  end
+end

--- a/app/models/beta/search/intercept_message.rb
+++ b/app/models/beta/search/intercept_message.rb
@@ -3,19 +3,19 @@ module Beta
     class InterceptMessage
       include ContentAddressableId
 
-      content_addressable_fields :intercept_message
+      content_addressable_fields :term, :message
 
-      attr_accessor :intercept_message, :term, :message
+      attr_accessor :term, :message
 
       def self.build(search_query)
         query = search_query.downcase
 
-        return unless query.eql?((I18n.t "#{query}.title"))
+        return unless query.eql?(I18n.t("#{query}.title"))
 
         result = new
 
-        result.term = I18n.t "#{query}.title"
-        result.message = I18n.t "#{query}.message"
+        result.term = I18n.t("#{query}.title")
+        result.message = I18n.t("#{query}.message")
 
         result
       end

--- a/app/models/beta/search/open_search_result.rb
+++ b/app/models/beta/search/open_search_result.rb
@@ -141,6 +141,8 @@ module Beta
       def intercept_message
         searched_term = search_query_parser_result.corrected_search_query
 
+        return unless searched_term.eql?((I18n.t "#{searched_term}.title"))
+
         {
           term: (I18n.t "#{searched_term}.title"),
           message: (I18n.t "#{searched_term}.message"),

--- a/app/models/beta/search/open_search_result.rb
+++ b/app/models/beta/search/open_search_result.rb
@@ -137,6 +137,15 @@ module Beta
       def redirect?
         @redirect
       end
+
+      def intercept_message
+        searched_term = search_query_parser_result.corrected_search_query
+
+        {
+          term: (I18n.t "#{searched_term}.title"),
+          message: (I18n.t "#{searched_term}.message"),
+        }
+      end
     end
   end
 end

--- a/app/models/beta/search/open_search_result.rb
+++ b/app/models/beta/search/open_search_result.rb
@@ -5,6 +5,7 @@ module Beta
       delegate :id, to: :heading_statistics, prefix: true, allow_nil: true
       delegate :id, to: :search_query_parser_result, prefix: true, allow_nil: true
       delegate :id, to: :guide, prefix: true, allow_nil: true
+      delegate :id, to: :intercept_message, prefix: true, allow_nil: true
 
       delegate :goods_nomenclature_item_id, :numeric?, :short_code, to: :goods_nomenclature_query, allow_nil: true
 
@@ -139,14 +140,7 @@ module Beta
       end
 
       def intercept_message
-        searched_term = search_query_parser_result.corrected_search_query
-
-        return unless searched_term.eql?((I18n.t "#{searched_term}.title"))
-
-        {
-          term: (I18n.t "#{searched_term}.title"),
-          message: (I18n.t "#{searched_term}.message"),
-        }
+        @intercept_message ||= ::Beta::Search::InterceptMessage.build(search_query_parser_result.original_search_query)
       end
     end
   end

--- a/app/serializers/api/beta/intercept_message_serializer.rb
+++ b/app/serializers/api/beta/intercept_message_serializer.rb
@@ -1,0 +1,12 @@
+module Api
+  module Beta
+    class InterceptMessageSerializer
+      include JSONAPI::Serializer
+
+      set_type :intercept_message
+
+      attributes :term,
+                 :message
+    end
+  end
+end

--- a/app/serializers/api/beta/search_result_serializer.rb
+++ b/app/serializers/api/beta/search_result_serializer.rb
@@ -8,7 +8,8 @@ module Api
       attributes :took,
                  :timed_out,
                  :max_score,
-                 :total_results
+                 :total_results,
+                 :intercept_message
 
       has_one :search_query_parser_result, serializer: Api::Beta::SearchQueryParserResultSerializer
 

--- a/app/serializers/api/beta/search_result_serializer.rb
+++ b/app/serializers/api/beta/search_result_serializer.rb
@@ -8,10 +8,10 @@ module Api
       attributes :took,
                  :timed_out,
                  :max_score,
-                 :total_results,
-                 :intercept_message
+                 :total_results
 
       has_one :search_query_parser_result, serializer: Api::Beta::SearchQueryParserResultSerializer
+      has_one :intercept_message, serializer: Api::Beta::InterceptMessageSerializer
 
       has_many :hits, serializer: proc { |record, _params|
         if record && record.respond_to?(:goods_nomenclature_class)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,3 +47,7 @@ en:
   clothing:
     title: "clothing"
     message: "Based on your search term we have provided the subheading for clothing"
+
+  ricotta:
+    title: "ricotta"
+    message: "Based on your search term we have provided the subheading for ricotta"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,19 @@
 
 en:
   hello: "Hello world"
+  gifts:
+    title: "gifts"
+    message: "There isn't a single commodity code for gifts. Classification is specific to the type of good being imported so, to find the right code, you need to know the details about your product.
+              This may include the: type of product; purpose of the product; materials used to make it; production methods used to make it; way it's packaged.
+              You may also be interested in the following guidance on the duty implications of importing gifts at: [https://www.gov.uk/goods-sent-from-abroad/tax-and-duty](https://www.gov.uk/goods-sent-from-abroad/tax-and-duty)"
+  lantern:
+    title: "lantern"
+    message: "Based on your search term we have provided the subheading for non-electrical lighting. If your product is electrical, you should consider lamps or lightsources of [chapter 85](/chapters/85)"
+
+  horses:
+    title: "horses"
+    message: "Based on your search term we have provided the subheading for horses."
+
+  clothing:
+    title: "clothing"
+    message: "Based on your search term we have provided the subheading for clothing"

--- a/spec/fixtures/beta/search/goods_nomenclatures/serialized_result.json
+++ b/spec/fixtures/beta/search/goods_nomenclatures/serialized_result.json
@@ -6,7 +6,11 @@
       "took": 1,
       "timed_out": false,
       "max_score": 74.98428,
-      "total_results": 1
+      "total_results": 1,
+      "intercept_message": {
+        "term": "ricotta",
+        "message": "Based on your search term we have provided the subheading for ricotta"
+      }
     },
     "relationships": {
       "search_query_parser_result": {

--- a/spec/fixtures/beta/search/goods_nomenclatures/serialized_result.json
+++ b/spec/fixtures/beta/search/goods_nomenclatures/serialized_result.json
@@ -6,17 +6,19 @@
       "took": 1,
       "timed_out": false,
       "max_score": 74.98428,
-      "total_results": 1,
-      "intercept_message": {
-        "term": "ricotta",
-        "message": "Based on your search term we have provided the subheading for ricotta"
-      }
+      "total_results": 1
     },
     "relationships": {
       "search_query_parser_result": {
         "data": {
           "id": "0e956af30bdc0dcd5679f2249adc6d94",
           "type": "search_query_parser_result"
+        }
+      },
+      "intercept_message": {
+        "data": {
+          "id": "d41d8cd98f00b204e9800998ecf8427e",
+          "type": "intercept_message"
         }
       },
       "hits": {
@@ -196,6 +198,14 @@
         "cnt": 1,
         "score": 74.98428,
         "avg": 74.98428
+      }
+    },
+    {
+      "id": "d41d8cd98f00b204e9800998ecf8427e",
+      "type": "intercept_message",
+      "attributes": {
+        "term": "ricotta",
+        "message": "Based on your search term we have provided the subheading for ricotta"
       }
     },
     {

--- a/spec/fixtures/beta/search/goods_nomenclatures/serialized_result.json
+++ b/spec/fixtures/beta/search/goods_nomenclatures/serialized_result.json
@@ -17,7 +17,7 @@
       },
       "intercept_message": {
         "data": {
-          "id": "d41d8cd98f00b204e9800998ecf8427e",
+          "id": "bdf0d878278f881cb5f14d7fd0703d6d",
           "type": "intercept_message"
         }
       },
@@ -201,7 +201,7 @@
       }
     },
     {
-      "id": "d41d8cd98f00b204e9800998ecf8427e",
+      "id": "bdf0d878278f881cb5f14d7fd0703d6d",
       "type": "intercept_message",
       "attributes": {
         "term": "ricotta",

--- a/spec/models/beta/search/intercept_message_spec.rb
+++ b/spec/models/beta/search/intercept_message_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe Beta::Search::InterceptMessage do
+  describe '.build' do
+    subject(:result) { described_class.build(search_query_parser_result.original_search_query) }
+
+    let(:search_query_parser_result) { build(:search_query_parser_result, :multiple_hits) }
+
+    it { is_expected.to be_a(described_class) }
+    it { expect(result).to respond_to(:term) }
+    it { expect(result).to respond_to(:message) }
+  end
+end

--- a/spec/models/beta/search/intercept_message_spec.rb
+++ b/spec/models/beta/search/intercept_message_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Beta::Search::InterceptMessage do
     let(:search_query_parser_result) { build(:search_query_parser_result, :multiple_hits) }
 
     it { is_expected.to be_a(described_class) }
+    it { expect(result.id).to eq('f12f2d963bd9edfcbc56138adff3698a') }
     it { expect(result).to respond_to(:term) }
     it { expect(result).to respond_to(:message) }
   end

--- a/spec/models/beta/search/open_search_result_spec.rb
+++ b/spec/models/beta/search/open_search_result_spec.rb
@@ -266,6 +266,15 @@ RSpec.describe Beta::Search::OpenSearchResult do
     it { expect { result.redirect! }.to change(result, :redirect?).from(nil).to(true) }
   end
 
+  describe '#intercept_message' do
+    subject(:result) { build(:search_result) }
+
+    it 'will match the object in the yaml file' do
+      searched_term = result.search_query_parser_result.corrected_search_query
+      expect(searched_term).to eq((I18n.t "#{searched_term}.title"))
+    end
+  end
+
   describe '#facet_filter_statistics' do
     context 'when filter statistics have been generated' do
       subject(:search_result) { build(:search_result, :generate_facet_statistics).facet_filter_statistics.map(&:id) }

--- a/spec/models/beta/search/open_search_result_spec.rb
+++ b/spec/models/beta/search/open_search_result_spec.rb
@@ -273,6 +273,11 @@ RSpec.describe Beta::Search::OpenSearchResult do
       searched_term = result.search_query_parser_result.corrected_search_query
       expect(searched_term).to eq((I18n.t "#{searched_term}.title"))
     end
+
+    it 'will not match the object in the yaml file' do
+      searched_term = 'random_string'
+      expect(searched_term).not_to eq((I18n.t "#{searched_term}.title"))
+    end
   end
 
   describe '#facet_filter_statistics' do

--- a/spec/models/beta/search/open_search_result_spec.rb
+++ b/spec/models/beta/search/open_search_result_spec.rb
@@ -271,12 +271,12 @@ RSpec.describe Beta::Search::OpenSearchResult do
 
     it 'will match the object in the yaml file' do
       searched_term = result.search_query_parser_result.corrected_search_query
-      expect(searched_term).to eq((I18n.t "#{searched_term}.title"))
+      expect(searched_term).to eq(I18n.t("#{searched_term}.title"))
     end
 
     it 'will not match the object in the yaml file' do
       searched_term = 'random_string'
-      expect(searched_term).not_to eq((I18n.t "#{searched_term}.title"))
+      expect(searched_term).not_to eq(I18n.t("#{searched_term}.title"))
     end
   end
 

--- a/spec/serializers/api/beta/search_result_serializer_spec.rb
+++ b/spec/serializers/api/beta/search_result_serializer_spec.rb
@@ -17,7 +17,16 @@ RSpec.describe Api::Beta::SearchResultSerializer do
         data: {
           id: '6fc22ae4ee7f6fbe9b4988a4557dd3f9',
           type: :search_result,
-          attributes: { took: 1, timed_out: false, max_score: 76.96534, total_results: 10 },
+          attributes: {
+            took: 1,
+            timed_out: false,
+            max_score: 76.96534,
+            total_results: 10,
+            intercept_message: {
+              term: 'clothing',
+              message: 'Based on your search term we have provided the subheading for clothing',
+            },
+          },
           relationships: {
             search_query_parser_result: {
               data: { id: '50cf19912960f65490b334ea9c196eea', type: :search_query_parser_result },

--- a/spec/serializers/api/beta/search_result_serializer_spec.rb
+++ b/spec/serializers/api/beta/search_result_serializer_spec.rb
@@ -22,14 +22,13 @@ RSpec.describe Api::Beta::SearchResultSerializer do
             timed_out: false,
             max_score: 76.96534,
             total_results: 10,
-            intercept_message: {
-              term: 'clothing',
-              message: 'Based on your search term we have provided the subheading for clothing',
-            },
           },
           relationships: {
             search_query_parser_result: {
               data: { id: '50cf19912960f65490b334ea9c196eea', type: :search_query_parser_result },
+            },
+            intercept_message: {
+              data: { id: 'd41d8cd98f00b204e9800998ecf8427e', type: :intercept_message },
             },
             hits: {
               data: [

--- a/spec/serializers/api/beta/search_result_serializer_spec.rb
+++ b/spec/serializers/api/beta/search_result_serializer_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Api::Beta::SearchResultSerializer do
               data: { id: '50cf19912960f65490b334ea9c196eea', type: :search_query_parser_result },
             },
             intercept_message: {
-              data: { id: 'd41d8cd98f00b204e9800998ecf8427e', type: :intercept_message },
+              data: { id: '70201b59ccf1f7afde3975fa2c2da023', type: :intercept_message },
             },
             hits: {
               data: [


### PR DESCRIPTION
### Jira link

[HOTT-1759](https://transformuk.atlassian.net/browse/HOTT-1759)

### What?

I have added/removed/altered:
 - [x] A Model named `intercept_messages`
 - [x]  A serializer named `intercept_messages_serializer.rb`
 - [x] Added test cases for this scenario
 - [x] Populated en.yml with valid keys to test the messages
### Why?

I am doing this because:

- To cater ticket requirements

### Have you? (optional)

- [ ] Added documentation for new apis
- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical data
- Changes an api that is used in production
