### PR TITLE
HOTT-1830: Fix missing descriptions in search

### DIFF
--- a/app/models/beta/search/open_search_result.rb
+++ b/app/models/beta/search/open_search_result.rb
@@ -41,8 +41,8 @@ module Beta
           hit.producline_suffix = hit_result._source.producline_suffix
           hit.description = hit_result._source.description
           hit.description_indexed = hit_result._source.description_indexed
-          hit.chapter_description = hit_result._source.chapter_description
-          hit.heading_description = hit_result._source.heading_description
+          hit.chapter_description = hit_result._source.ancestor_1_description_indexed
+          hit.heading_description = hit_result._source.ancestor_2_description_indexed
           hit.search_references = hit_result._source.search_references
           hit.validity_start_date = hit_result._source.validity_start_date
           hit.validity_end_date = hit_result._source.validity_end_date

--- a/spec/fixtures/beta/search/goods_nomenclatures/serialized_result.json
+++ b/spec/fixtures/beta/search/goods_nomenclatures/serialized_result.json
@@ -120,8 +120,8 @@
         "validity_end_date": null,
         "chapter_id": "04",
         "score": 74.98428,
-        "chapter_description": null,
-        "heading_description": null,
+        "chapter_description": "DAIRY PRODUCE; BIRDS' EGGS; NATURAL HONEY; EDIBLE PRODUCTS OF ANIMAL ORIGIN, NOT ELSEWHERE SPECIFIED OR INCLUDED",
+        "heading_description": "Cheese and curd",
         "heading_id": "0406"
       },
       "relationships": {
@@ -175,9 +175,9 @@
       "id": "0406",
       "type": "heading_statistic",
       "attributes": {
-        "description": null,
+        "description": "Cheese and curd",
         "chapter_id": "04",
-        "chapter_description": null,
+        "chapter_description": "DAIRY PRODUCE; BIRDS' EGGS; NATURAL HONEY; EDIBLE PRODUCTS OF ANIMAL ORIGIN, NOT ELSEWHERE SPECIFIED OR INCLUDED",
         "score": 74.98428,
         "cnt": 1,
         "avg": 74.98428,
@@ -188,7 +188,7 @@
       "id": "04",
       "type": "chapter_statistic",
       "attributes": {
-        "description": null,
+        "description": "DAIRY PRODUCE; BIRDS' EGGS; NATURAL HONEY; EDIBLE PRODUCTS OF ANIMAL ORIGIN, NOT ELSEWHERE SPECIFIED OR INCLUDED",
         "cnt": 1,
         "score": 74.98428,
         "avg": 74.98428

--- a/spec/models/beta/search/open_search_result_spec.rb
+++ b/spec/models/beta/search/open_search_result_spec.rb
@@ -52,21 +52,22 @@ RSpec.describe Beta::Search::OpenSearchResult do
         [
           {
             'id' => '01',
-            'description' => nil,
+            'description' => 'LIVE ANIMALS',
             'score' => 485.68718800000005,
             'cnt' => 7,
             'avg' => 69.38388400000001,
           },
           {
             'id' => '02',
-            'description' => nil,
+            'description' => 'MEAT AND EDIBLE MEAT OFFAL',
             'score' => 126.686088,
             'cnt' => 2,
             'avg' => 63.343044,
           },
           {
             'id' => '03',
-            'description' => nil,
+            'description' =>
+            'FISH AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES',
             'score' => 53.984024,
             'cnt' => 1,
             'avg' => 53.984024,
@@ -92,9 +93,9 @@ RSpec.describe Beta::Search::OpenSearchResult do
         [
           {
             'id' => '0101',
-            'description' => nil,
+            'description' => 'Live horses, asses, mules and hinnies',
             'chapter_id' => '01',
-            'chapter_description' => nil,
+            'chapter_description' => 'LIVE ANIMALS',
             'score' => 485.68718800000005,
             'cnt' => 7,
             'avg' => 69.38388400000001,
@@ -102,9 +103,9 @@ RSpec.describe Beta::Search::OpenSearchResult do
           },
           {
             'id' => '0206',
-            'description' => nil,
+            'description' => 'Edible offal of bovine animals, swine, sheep, goats, horses, asses, mules or hinnies, fresh, chilled or frozen',
             'chapter_id' => '02',
-            'chapter_description' => nil,
+            'chapter_description' => 'MEAT AND EDIBLE MEAT OFFAL',
             'score' => 126.686088,
             'cnt' => 2,
             'avg' => 63.343044,
@@ -112,9 +113,9 @@ RSpec.describe Beta::Search::OpenSearchResult do
           },
           {
             'id' => '0302',
-            'description' => nil,
+            'description' => 'Fish, fresh or chilled',
             'chapter_id' => '03',
-            'chapter_description' => nil,
+            'chapter_description' => 'FISH AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES',
             'score' => 53.984024,
             'cnt' => 1,
             'avg' => 53.984024,

--- a/spec/serializers/api/beta/chapter_statistics_serializer_spec.rb
+++ b/spec/serializers/api/beta/chapter_statistics_serializer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Api::Beta::ChapterStatisticsSerializer do
             id: '04',
             type: :chapter_statistic,
             attributes: {
-              description: nil,
+              description: "DAIRY PRODUCE; BIRDS' EGGS; NATURAL HONEY; EDIBLE PRODUCTS OF ANIMAL ORIGIN, NOT ELSEWHERE SPECIFIED OR INCLUDED",
               cnt: 1,
               score: 74.98428,
               avg: 74.98428,

--- a/spec/serializers/api/beta/heading_statistics_serializer_spec.rb
+++ b/spec/serializers/api/beta/heading_statistics_serializer_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe Api::Beta::HeadingStatisticsSerializer do
             id: '0406',
             type: :heading_statistic,
             attributes: {
-              description: nil,
+              description: 'Cheese and curd',
               chapter_id: '04',
-              chapter_description: nil,
+              chapter_description: "DAIRY PRODUCE; BIRDS' EGGS; NATURAL HONEY; EDIBLE PRODUCTS OF ANIMAL ORIGIN, NOT ELSEWHERE SPECIFIED OR INCLUDED",
               score: 74.98428,
               cnt: 1,
               avg: 74.98428,

--- a/spec/services/api/beta/search_result_statistics_service_spec.rb
+++ b/spec/services/api/beta/search_result_statistics_service_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Api::Beta::SearchResultStatisticsService do
         {
           '0101' => {
             'id' => '0101',
-            'description' => nil,
+            'description' => 'Live horses, asses, mules and hinnies',
             'chapter_id' => '01',
-            'chapter_description' => nil,
+            'chapter_description' => 'LIVE ANIMALS',
             'score' => 485.68718800000005,
             'cnt' => 7,
             'avg' => 69.38388400000001,
@@ -19,9 +19,9 @@ RSpec.describe Api::Beta::SearchResultStatisticsService do
           },
           '0206' => {
             'id' => '0206',
-            'description' => nil,
+            'description' => 'Edible offal of bovine animals, swine, sheep, goats, horses, asses, mules or hinnies, fresh, chilled or frozen',
             'chapter_id' => '02',
-            'chapter_description' => nil,
+            'chapter_description' => 'MEAT AND EDIBLE MEAT OFFAL',
             'score' => 126.686088,
             'cnt' => 2,
             'avg' => 63.343044,
@@ -29,9 +29,9 @@ RSpec.describe Api::Beta::SearchResultStatisticsService do
           },
           '0302' => {
             'id' => '0302',
-            'description' => nil,
+            'description' => 'Fish, fresh or chilled',
             'chapter_id' => '03',
-            'chapter_description' => nil,
+            'chapter_description' => 'FISH AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES',
             'score' => 53.984024,
             'cnt' => 1,
             'avg' => 53.984024,
@@ -44,21 +44,21 @@ RSpec.describe Api::Beta::SearchResultStatisticsService do
         {
           '01' => {
             'id' => '01',
-            'description' => nil,
+            'description' => 'LIVE ANIMALS',
             'score' => 485.68718800000005,
             'cnt' => 7,
             'avg' => 69.38388400000001,
           },
           '02' => {
             'id' => '02',
-            'description' => nil,
+            'description' => 'MEAT AND EDIBLE MEAT OFFAL',
             'score' => 126.686088,
             'cnt' => 2,
             'avg' => 63.343044,
           },
           '03' => {
             'id' => '03',
-            'description' => nil,
+            'description' => 'FISH AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES',
             'score' => 53.984024,
             'cnt' => 1,
             'avg' => 53.984024,


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1830

### What?

I have added/removed/altered:

- [x] Added missing chapter/heading statistic descriptions
- [x] Updated specs to reflect them being reinstated

### Why?

I am doing this because:

- This is required for human understanding of chapter/heading stats
