### PR TITLE
HOTT-1869: Remove rule_offset

### DIFF
--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -5,7 +5,7 @@ module RulesOfOrigin
     include ActiveModel::Model
 
     attr_accessor :scheme_set, :scheme_code, :title, :introductory_notes_file,
-                  :fta_intro_file, :countries, :rule_offset, :footnote,
+                  :fta_intro_file, :countries, :footnote,
                   :adopted_by_uk, :country_code, :notes, :unilateral
 
     attr_writer :rule_sets

--- a/db/rules_of_origin/roo_schemes_uk.json
+++ b/db/rules_of_origin/roo_schemes_uk.json
@@ -24,7 +24,6 @@
                     "detail": "importers-knowledge.md"
                 }
             ],
-            "rule_offset": 10000000,
             "title": "UK / EU Trade and Co-operation Agreement",
             "introductory_notes_file": "eu_intro.md",
             "fta_intro_file": "eu.md",
@@ -92,7 +91,6 @@
                     "detail": "importers-knowledge.md"
                 }
             ],
-            "rule_offset": 13000000,
             "title": "Comprehensive Economic Partnership Agreement UK Japan",
             "introductory_notes_file": "japan_intro.md",
             "fta_intro_file": "japan.md",
@@ -256,7 +254,6 @@
                     "detail": "origin-declaration.md"
                 }
             ],
-            "rule_offset": 11000000,
             "title": "UK-South Korea trade agreement",
             "introductory_notes_file": "south-korea_intro.md",
             "fta_intro_file": "south-korea.md",
@@ -1104,7 +1101,6 @@
                     "detail": "approved-exporter.md"
                 }
             ],
-            "rule_offset": 14000000,
             "title": "UK-Singapore Trade Agreement",
             "introductory_notes_file": "singapore_intro.md",
             "fta_intro_file": "singapore.md",
@@ -1237,7 +1233,6 @@
                     "detail": "origin-declaration.md"
                 }
             ],
-            "rule_offset": 12000000,
             "title": "UK-Turkey trade agreement",
             "introductory_notes_file": "turkey_intro.md",
             "fta_intro_file": "turkey.md",
@@ -1338,7 +1333,6 @@
                     "detail": "invoice-declaration.md"
                 }
             ],
-            "rule_offset": 15000000,
             "title": "Arrangement for import duty on trade in goods from certain British Overseas Territories",
             "introductory_notes_file": "oct_intro.md",
             "fta_intro_file": "oct.md",
@@ -1379,7 +1373,6 @@
                     "detail": "origin-declaration.md"
                 }
             ],
-            "rule_offset": 16000000,
             "title": "Generalised Scheme of Preferences (GSP)",
             "footnote": "Scheme incorporates:</p><ul class='govuk-list govuk-list--bullet govuk-body-s'><li>the GSP Least Developed Countries Framework</li><li>the GSP General Framework</li><li>the GSP Enhanced Framework</li></ul>",
             "introductory_notes_file": "gsp_intro.md",

--- a/db/rules_of_origin/roo_schemes_xi.json
+++ b/db/rules_of_origin/roo_schemes_xi.json
@@ -212,7 +212,6 @@
         },
         {
             "scheme_code": "south-korea",
-            "rule_offset": 30000000,
             "adopted_by_uk": true,
             "title": "EU-South Korea free trade agreement",
             "introductory_notes_file": "south-korea_intro.md",
@@ -821,7 +820,6 @@
         },
         {
             "scheme_code": "turkey",
-            "rule_offset": 20000000,
             "adopted_by_uk": true,
             "title": "EU-Turkey Customs Union",
             "introductory_notes_file": "turkey_intro.md",

--- a/spec/models/rules_of_origin/scheme_spec.rb
+++ b/spec/models/rules_of_origin/scheme_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe RulesOfOrigin::Scheme do
     it { is_expected.to respond_to :links }
     it { is_expected.to respond_to :explainers }
     it { is_expected.to respond_to :countries }
-    it { is_expected.to respond_to :rule_offset }
     it { is_expected.to respond_to :footnote }
     it { is_expected.to respond_to :adopted_by_uk }
     it { is_expected.to respond_to :unilateral }


### PR DESCRIPTION
### Jira link

[HOTT-1869](https://transformuk.atlassian.net/browse/HOTT-1869)

### What?

I have added/removed/altered:

- [ ] Removed rule_offset

### Why?

I am doing this because:

- it wasn't used anywhere