### PR TITLE
HOTT-1898 Adds migration for quota data fix

### DIFF
--- a/db/data_migrations/20220815120205_quota_data_fix.rb
+++ b/db/data_migrations/20220815120205_quota_data_fix.rb
@@ -1,0 +1,54 @@
+Sequel.migration do
+  up do
+    QuotaCriticalEvent.unrestrict_primary_key
+    QuotaDefinition.unrestrict_primary_key
+
+    QuotaCriticalEvent.create(quota_definition_sid: 21_419, occurrence_timestamp: '2022-08-12', critical_state: 'N',
+                              critical_state_change_date: '2022-08-12', operation: 'C', operation_date: '2022-08-12')
+
+    QuotaDefinition.create(quota_definition_sid: 21_419, quota_order_number_id: '058020', validity_start_date: '2022-07-01 00:00:00.000', validity_end_date: '2022-09-30 23:59:59.000',
+                           quota_order_number_sid: 20_946, volume: 3_536_000.00, initial_volume: 22_635_000.00, measurement_unit_code: 'KGM', maximum_precision: 3,
+                           critical_state: 'N', critical_threshold: 90, monetary_unit_code: nil, measurement_unit_qualifier_code: nil,
+                           description: nil, operation: 'U', operation_date: '2022-08-12')
+
+    QuotaCriticalEvent.create(quota_definition_sid: 21_917, occurrence_timestamp: '2022-07-12', critical_state: 'N',
+                              critical_state_change_date: '2022-07-12', operation: 'C', operation_date: '2022-07-12')
+
+    QuotaDefinition.create(quota_definition_sid: 21_917, quota_order_number_id: '052012', validity_start_date: '2022-01-01 00:00:00.000', validity_end_date: '2022-12-31 00:00:00.000',
+                           quota_order_number_sid: 20_805, volume: 17_607_437.52, initial_volume: 13_335_000.00, measurement_unit_code: 'KGM', maximum_precision: 3,
+                           critical_state: 'N', critical_threshold: 90, monetary_unit_code: nil, measurement_unit_qualifier_code: nil,
+                           description: nil, operation: 'U', operation_date: '2022-07-12')
+
+    QuotaCriticalEvent.create(quota_definition_sid: 21_929, occurrence_timestamp: '2022-07-12', critical_state: 'N',
+                              critical_state_change_date: '2022-07-12', operation: 'C', operation_date: '2022-07-12')
+
+    QuotaDefinition.create(quota_definition_sid: 21_929, quota_order_number_id: '052105', validity_start_date: '2022-01-01 00:00:00.000', validity_end_date: '2022-12-31 00:00:00.000',
+                           quota_order_number_sid: 20_817, volume: 18_016_449.90, initial_volume: 13_335_000.00, measurement_unit_code: 'KGM', maximum_precision: 3,
+                           critical_state: 'N', critical_threshold: 90, monetary_unit_code: nil, measurement_unit_qualifier_code: nil,
+                           description: nil, operation: 'U', operation_date: '2022-07-12')
+
+    QuotaCriticalEvent.create(quota_definition_sid: 21_930, occurrence_timestamp: '2022-07-12', critical_state: 'N',
+                              critical_state_change_date: '2022-07-12', operation: 'C', operation_date: '2022-07-12')
+
+    QuotaDefinition.create(quota_definition_sid: 21_930, quota_order_number_id: '052106', validity_start_date: '2022-01-01 00:00:00.000', validity_end_date: '2022-12-31 00:00:00.000',
+                           quota_order_number_sid: 20_818, volume: 17_425_752.49, initial_volume: 13_335_000.00, measurement_unit_code: 'KGM', maximum_precision: 3,
+                           critical_state: 'N', critical_threshold: 90, monetary_unit_code: nil, measurement_unit_qualifier_code: nil,
+                           description: nil, operation: 'U', operation_date: '2022-07-12')
+
+    QuotaCriticalEvent.restrict_primary_key
+    QuotaDefinition.restrict_primary_key
+  end
+
+  down do
+    QuotaDefinition.where(quota_definition_sid: 21_419).last.destroy
+    QuotaDefinition.where(quota_definition_sid: 21_917).last.destroy
+    QuotaDefinition.where(quota_definition_sid: 21_929).last.destroy
+    QuotaDefinition.where(quota_definition_sid: 21_930).last.destroy
+
+    QuotaCriticalEvent.where(quota_definition_sid: 21_419).last.destroy
+    QuotaCriticalEvent.where(quota_definition_sid: 21_917).last.destroy
+    QuotaCriticalEvent.where(quota_definition_sid: 21_929).last.destroy
+    QuotaCriticalEvent.where(quota_definition_sid: 21_930).last.destroy
+
+  end
+end

--- a/db/data_migrations/20220815120205_quota_data_fix.rb
+++ b/db/data_migrations/20220815120205_quota_data_fix.rb
@@ -39,15 +39,5 @@ Sequel.migration do
     QuotaDefinition.restrict_primary_key
   end
 
-  down do
-    QuotaDefinition.where(quota_definition_sid: 21_419).last.destroy
-    QuotaDefinition.where(quota_definition_sid: 21_917).last.destroy
-    QuotaDefinition.where(quota_definition_sid: 21_929).last.destroy
-    QuotaDefinition.where(quota_definition_sid: 21_930).last.destroy
-
-    QuotaCriticalEvent.where(quota_definition_sid: 21_419).last.destroy
-    QuotaCriticalEvent.where(quota_definition_sid: 21_917).last.destroy
-    QuotaCriticalEvent.where(quota_definition_sid: 21_929).last.destroy
-    QuotaCriticalEvent.where(quota_definition_sid: 21_930).last.destroy
-  end
+  down {}
 end

--- a/db/data_migrations/20220815120205_quota_data_fix.rb
+++ b/db/data_migrations/20220815120205_quota_data_fix.rb
@@ -49,6 +49,5 @@ Sequel.migration do
     QuotaCriticalEvent.where(quota_definition_sid: 21_917).last.destroy
     QuotaCriticalEvent.where(quota_definition_sid: 21_929).last.destroy
     QuotaCriticalEvent.where(quota_definition_sid: 21_930).last.destroy
-
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-1898](https://transformuk.atlassian.net/browse/HOTT-1898)

### What?

I have added/removed/altered:

- Fixes quotas for following codes

Quota | Country | Comm code  URL
-- | -- | --
052012 | AU (Australia) | https://www.trade-tariff.service.gov.uk/commodities/0204221010?country=AU
052105 | AU (Australia) | https://www.trade-tariff.service.gov.uk/commodities/0204230091?country=AU
052106 | AU (Australia) | https://www.trade-tariff.service.gov.uk/commodities/0204230099?country=AU
058020 | Countries subject to UK safeguard measures (5050) | https://www.trade-tariff.service.gov.uk/commodities/7214200010#quotas



