### PR TITLE
HOTT-1909: Update unit label for BRX measure unit

### DIFF
--- a/db/measurement_units_20220428.json
+++ b/db/measurement_units_20220428.json
@@ -28,7 +28,7 @@
     "abbreviation": "% sucrose",
     "unit_question": "What is the percentage of sucrose (Brix) in your goods?",
     "unit_hint": "If you do not know the percentage sucrose content (Brix value), check the footnotes for the commodity code to identify how to calculate it.",
-    "unit": "percent"
+    "unit": "% sucrose"
   },
   "CCT": {
     "measurement_unit_code": "CCT",

--- a/spec/models/measurement_unit_spec.rb
+++ b/spec/models/measurement_unit_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe MeasurementUnit do
     context 'with a compound measurement unit where one is only in the file' do
       subject(:result) { described_class.units('DTN', 'DTNZ') }
 
-      it { is_expected.to include_json([{ 'unit' => 'kilograms' }, { 'unit' => 'percent' }]) }
+      it { is_expected.to include_json([{ 'unit' => 'kilograms' }, { 'unit' => '% sucrose' }]) }
     end
 
     context 'with missing measurement unit present in database' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1909

### What?

I have added/removed/altered:

- [x] Tweaks BRX unit label
- [x] Make tests reflect change in BRX unit label

### Why?

I am doing this because:

- This more clearly indicates that BRX is the unit being used on the confirmation page of the duty calculator
