### PR TITLE
HOTT-1928: Handle rollover in patched taric downloader

### DIFF
--- a/app/lib/tariff_synchronizer/taric_update.rb
+++ b/app/lib/tariff_synchronizer/taric_update.rb
@@ -94,13 +94,31 @@ module TariffSynchronizer
       )
     end
 
+    def next_rollover_update
+      self.class.new(
+        filename: next_update_sequence_rollover_update_filename,
+        issue_date: next_update_rollover_issue_date,
+      )
+    end
+
     def next_update_sequence_update_filename
       "#{next_update_issue_date.iso8601}_#{next_update_sequence_url_filename}"
+    end
+
+    def next_update_sequence_rollover_update_filename
+      "#{next_update_rollover_issue_date.iso8601}_#{next_update_sequence_rollover_url_filename}"
     end
 
     def next_update_sequence_url_filename
       padded_sequence = next_update_sequence.to_s.rjust(3, '0')
       year = next_update_issue_date.strftime('%y')
+
+      "TGB#{year}#{padded_sequence}.xml"
+    end
+
+    def next_update_sequence_rollover_url_filename
+      padded_sequence = NEW_YEAR_STARTING_SEQUENCE_NUMBER.to_s.rjust(3, '0')
+      year = next_update_rollover_issue_date.strftime('%y')
 
       "TGB#{year}#{padded_sequence}.xml"
     end
@@ -119,6 +137,10 @@ module TariffSynchronizer
 
     def next_update_issue_date
       issue_date + 1.day
+    end
+
+    def next_update_rollover_issue_date
+      (issue_date + 1.year).beginning_of_year
     end
 
     def next_update_year

--- a/app/lib/tariff_synchronizer/taric_update_downloader_patched.rb
+++ b/app/lib/tariff_synchronizer/taric_update_downloader_patched.rb
@@ -13,13 +13,17 @@ module TariffSynchronizer
     def perform
       return if update_exists?
 
-      downloader = download(@update)
+      response = download(@update)
 
-      while downloader.success?
+      # Download this years updates until we encounter a failure
+      while response.success?
         @update = @update.next_update
 
-        downloader = download(@update)
+        response = download(@update)
       end
+
+      # Once we've exhausted this year's updates, try the next years - in most circumstances there will not be one
+      download(@update.next_rollover_update)
     end
 
     private

--- a/spec/unit/tariff_synchronizer/taric_update_downloader_patched_spec.rb
+++ b/spec/unit/tariff_synchronizer/taric_update_downloader_patched_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe TariffSynchronizer::TaricUpdateDownloaderPatched do
   before do
     tariff_downloader = instance_double('TariffSynchronizer::TariffDownloader', perform: nil)
 
-    allow(tariff_downloader).to receive(:success?).and_return(true, false)
+    allow(tariff_downloader).to receive(:success?).and_return(true, false, true)
 
     allow(TariffSynchronizer::TariffDownloader).to receive(:new).and_return(tariff_downloader)
   end
@@ -24,10 +24,10 @@ RSpec.describe TariffSynchronizer::TaricUpdateDownloaderPatched do
       let(:taric_update) { build(:taric_update, example_date: Date.parse('2022-01-24')) }
 
       # rubocop:disable RSpec/MultipleExpectations
-      it 'calls the TariffDownloader until the next not found increment' do
+      it 'calls the TariffDownloader until the next not found update' do
         update_downloader.perform
 
-        # successful increment
+        # successful update
         expect(TariffSynchronizer::TariffDownloader).to have_received(:new).with(
           '2022-01-24_TGB22024.xml',
           'http://example.com/taric/TGB22024.xml',
@@ -35,11 +35,19 @@ RSpec.describe TariffSynchronizer::TaricUpdateDownloaderPatched do
           TariffSynchronizer::TaricUpdate,
         ).once.ordered
 
-        # unsuccessful increment
+        # unsuccessful update
         expect(TariffSynchronizer::TariffDownloader).to have_received(:new).with(
           '2022-01-25_TGB22025.xml',
           'http://example.com/taric/TGB22025.xml',
           Date.parse('2022-01-25'),
+          TariffSynchronizer::TaricUpdate,
+        ).once.ordered
+
+        # successful rollover update
+        expect(TariffSynchronizer::TariffDownloader).to have_received(:new).with(
+          '2023-01-01_TGB23001.xml',
+          'http://example.com/taric/TGB23001.xml',
+          Date.parse('2023-01-01'),
           TariffSynchronizer::TaricUpdate,
         ).once.ordered
       end

--- a/spec/unit/tariff_synchronizer/taric_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/taric_update_spec.rb
@@ -173,6 +173,20 @@ RSpec.describe TariffSynchronizer::TaricUpdate do
     end
   end
 
+  describe '#next_update' do
+    subject(:next_update) { build(:taric_update, :applied, example_date: Date.parse('2022-08-25')).next_update }
+
+    it { is_expected.to have_attributes(issue_date: Time.zone.today, filename: '2022-08-26_TGB22238.xml') }
+  end
+
+  describe '#next_rollover_update' do
+    subject(:next_update) { build(:taric_update, :applied, example_date: Date.parse('2022-08-25')).next_rollover_update }
+
+    let(:issue_date) { (Time.zone.today + 1.year).beginning_of_year }
+
+    it { is_expected.to have_attributes(issue_date:, filename: '2023-01-01_TGB23001.xml') }
+  end
+
   describe '#url_filename' do
     subject(:url_filename) { create(:taric_update, :pending, example_date: Date.parse('2021-12-03'), sequence_number: '203').url_filename }
 

--- a/spec/unit/tariff_synchronizer/taric_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/taric_update_spec.rb
@@ -176,15 +176,13 @@ RSpec.describe TariffSynchronizer::TaricUpdate do
   describe '#next_update' do
     subject(:next_update) { build(:taric_update, :applied, example_date: Date.parse('2022-08-25')).next_update }
 
-    it { is_expected.to have_attributes(issue_date: Time.zone.today, filename: '2022-08-26_TGB22238.xml') }
+    it { is_expected.to have_attributes(issue_date: Date.parse('2022-08-26'), filename: '2022-08-26_TGB22238.xml') }
   end
 
   describe '#next_rollover_update' do
-    subject(:next_update) { build(:taric_update, :applied, example_date: Date.parse('2022-08-25')).next_rollover_update }
+    subject(:next_rollover_update) { build(:taric_update, :applied, example_date: Date.parse('2022-08-25')).next_rollover_update }
 
-    let(:issue_date) { (Time.zone.today + 1.year).beginning_of_year }
-
-    it { is_expected.to have_attributes(issue_date:, filename: '2023-01-01_TGB23001.xml') }
+    it { is_expected.to have_attributes(issue_date: Date.parse('2023-01-01'), filename: '2023-01-01_TGB23001.xml') }
   end
 
   describe '#url_filename' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1928

### What?

The initial (and correct) version of the taric file downloader would determine what file to download for a given date (we call this the issue date) by calling an api with the current days date string.

Sadly this date → file api started giving false negative responses (404s). Calling the file api with the expected next sequence of filename worked but asking for the filename on a given issue date didn’t meaning the ETL process for taric was just blocked.

We fixed this by just checking the next sequence we can expect against the filename api using a patched version of the downloader module using a simple factory pattern.

The patched downloader is not aware of the standard of resetting the sequence when the year changes and sadly we don’t have a 1->1 connection between the issue date and the filename so are unable to predict based on the issue date what the next file is going to be when the year changes.

I have added/removed/altered:

- [x] Adds next rollover update method
- [x] Consume new taric rollover method

### Why?

I am doing this because:

- This patched downloader appears to be the downloader we're going to use after the new year and it would stop working if we didn't add this
