### PR TITLE
HOTT-1832 Fix quota search pagination

### DIFF
--- a/app/services/quota_search_service.rb
+++ b/app/services/quota_search_service.rb
@@ -31,6 +31,7 @@ class QuotaSearchService
   def call
     @scope = Measure
       .actual
+      .with_actual(QuotaDefinition)
       .join(:quota_definitions, [%i[measures__ordernumber quota_definitions__quota_order_number_id]])
       .eager(eager_load_graph)
       .distinct(:measures__ordernumber)
@@ -45,7 +46,7 @@ class QuotaSearchService
 
     @scope = @scope.paginate(current_page, per_page)
 
-    @scope.map(&:quota_definition).compact
+    @scope.map(&:quota_definition)
   end
 
   private

--- a/spec/services/quota_search_service_spec.rb
+++ b/spec/services/quota_search_service_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe QuotaSearchService do
     context 'when a quota definition is end dated' do
       before do
         # Modifying records directly because oplog plugin doesn't support dataset CRUD operations
-        QuotaDefinition.dataset.each do |qd|
+        QuotaDefinition.each do |qd|
           qd.validity_end_date = Date.yesterday
           qd.save
         end
@@ -195,7 +195,7 @@ RSpec.describe QuotaSearchService do
     context 'with end dated quota definitions' do
       before do
         # Modifying records directly because oplog plugin doesn't support dataset CRUD operations
-        QuotaDefinition.dataset.each do |qd|
+        QuotaDefinition.each do |qd|
           qd.validity_end_date = Date.yesterday
           qd.save
         end

--- a/spec/services/quota_search_service_spec.rb
+++ b/spec/services/quota_search_service_spec.rb
@@ -167,6 +167,42 @@ RSpec.describe QuotaSearchService do
         expect(service.call).to eq([quota_definition2])
       end
     end
+
+    context 'when a quota definition is end dated' do
+      before do
+        # Modifying records directly because oplog plugin doesn't support dataset CRUD operations
+        QuotaDefinition.dataset.each do |qd|
+          qd.validity_end_date = Date.yesterday
+          qd.save
+        end
+      end
+
+      let(:filter) { {} }
+
+      it { expect(service.call).to be_empty }
+    end
+  end
+
+  describe '#pagination_record_count' do
+    subject { service.tap(&:call).pagination_record_count }
+
+    let(:filter) { {} }
+
+    context 'with records' do
+      it { is_expected.to eq 2 }
+    end
+
+    context 'with end dated quota definitions' do
+      before do
+        # Modifying records directly because oplog plugin doesn't support dataset CRUD operations
+        QuotaDefinition.dataset.each do |qd|
+          qd.validity_end_date = Date.yesterday
+          qd.save
+        end
+      end
+
+      it { is_expected.to eq 0 }
+    end
   end
 end
 # rubocop:enable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
### Jira link

HOTT-1832

### What?

I have added/removed/altered:

- [x] Added specs to check behaviour when measures which are not end dated reference quota definitions which are end dated
- [x] Changed how quota definitions are retrieved to exclude them from the query, rather then removing blanks post factom with `.compact`

### Why?

I am doing this because:

- If a Measure references a QuotaDefinition, and the Measure is not end dated but the quota definition is - then the scope will still include those quota definitions. Subsequent retrieval via association will return `nil` results for these quota definitions which were previously then being excluded via `.compact`
- This works but leaves a `COUNT(*)` on the original scope returning a different value to the number of records the service will actually return - leading to incorrect pagination
- By excluding these end-dated quota definitions from the original query and removing the use of `.compact` the `COUNT(*)` on the scope is correct, and so is the pagination. There shouldn't be any actual change to the quota definitions returned by the service.

### Deployment risks (optional)

- Changes behaviour of quota definitions search.
