### PR TITLE
HOTT-1658: Optimise heading cache performance

### DIFF
--- a/app/elastic_search_indexes/cache/heading_index.rb
+++ b/app/elastic_search_indexes/cache/heading_index.rb
@@ -1,11 +1,27 @@
 module Cache
   class HeadingIndex < ::Cache::CacheIndex
+    def eager_load_graph
+      [
+        {
+          commodities: [
+            :goods_nomenclature_descriptions,
+            :goods_nomenclature_indents,
+            { heading: [:commodities] }, # TODO: We should be able to replace loading the heading and its commodities with the materialized path concept and avoid eager loading for the goods nomenclature mapper
+          ],
+        },
+        { chapter: [:guides, :goods_nomenclature_descriptions, { section: :section_note }] },
+        :goods_nomenclature_indents,
+        :goods_nomenclature_descriptions,
+        :footnotes,
+      ]
+    end
+
     def definition
       {
         mappings: {
           dynamic: false,
-          properties: {}
-        }
+          properties: {},
+        },
       }
     end
   end

--- a/app/lib/cds_importer/record_inserter.rb
+++ b/app/lib/cds_importer/record_inserter.rb
@@ -15,7 +15,7 @@ class CdsImporter
       instrument('cds_importer.import.operations', mapper:, operation: DESTROY_CASCADE_OPERATION, count: 1, record:) do
         operation_klass = record.class.operation_klass
 
-        values = record.values.except(:oid)
+        values = record.values.slice(*operation_klass.columns).except(:oid)
         values[:filename] = filename
         values[:operation] = Sequel::Plugins::Oplog::DESTROY_OPERATION
         values[:created_at] = operation_klass.dataset.current_datetime if operation_klass.columns.include?(:created_at)
@@ -28,7 +28,7 @@ class CdsImporter
       instrument('cds_importer.import.operations', mapper:, operation: DESTROY_MISSING_OPERATION, count: 1, record:) do
         operation_klass = record.class.operation_klass
 
-        values = record.values.except(:oid)
+        values = record.values.slice(*operation_klass.columns).except(:oid)
         values[:filename] = filename
         values[:operation] = Sequel::Plugins::Oplog::DESTROY_OPERATION
         values[:created_at] = operation_klass.dataset.current_datetime if operation_klass.columns.include?(:created_at)
@@ -39,11 +39,11 @@ class CdsImporter
 
     def save_record!
       instrument('cds_importer.import.operations', mapper:, operation: record.operation, count: 1, record:) do
-        values = record.values.except(:oid)
+        operation_klass = record.class.operation_klass
+
+        values = record.values.slice(*operation_klass.columns).except(:oid)
 
         values.merge!(filename:)
-
-        operation_klass = record.class.operation_klass
 
         if operation_klass.columns.include?(:created_at)
           values.merge!(created_at: operation_klass.dataset.current_datetime)

--- a/app/lib/sequel/plugins/oplog.rb
+++ b/app/lib/sequel/plugins/oplog.rb
@@ -77,7 +77,7 @@ module Sequel
         def _insert_raw(_dataset)
           self.operation = :create
 
-          values = self.values.except(:oid)
+          values = self.values.slice(*operation_klass.columns).except(:oid)
           if operation_klass.columns.include?(:created_at)
             values.merge!(created_at: operation_klass.dataset.current_datetime)
           end
@@ -88,7 +88,7 @@ module Sequel
         def _destroy_delete
           self.operation = :destroy
 
-          values = self.values.except(:oid)
+          values = self.values.slice(*operation_klass.columns).except(:oid)
           if operation_klass.columns.include?(:created_at)
             values.merge!(created_at: operation_klass.dataset.current_datetime)
           end
@@ -99,7 +99,7 @@ module Sequel
         def _update_columns(_columns)
           self.operation = :update
 
-          values = self.values.except(:oid)
+          values = self.values.slice(*operation_klass.columns).except(:oid)
           if operation_klass.columns.include?(:created_at)
             values.merge!(created_at: operation_klass.dataset.current_datetime)
           end

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -131,7 +131,7 @@ module TradeTariffBackend
         Elasticsearch::Client.new,
         namespace: 'cache',
         indexes: cache_indexes,
-        index_page_size: 5,
+        index_page_size: 200,
       )
     end
 

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -13,11 +13,9 @@ class Chapter < GoodsNomenclature
   many_to_many :sections, left_key: :goods_nomenclature_sid,
                           join_table: :chapters_sections
 
-  one_to_many :headings, dataset: lambda {
-    Heading.actual
-           .filter("goods_nomenclature_item_id LIKE ? AND goods_nomenclature_item_id NOT LIKE '__00______'", relevant_headings)
-           .where(Sequel.~(goods_nomenclatures__goods_nomenclature_item_id: HiddenGoodsNomenclature.codes))
-  }
+  one_to_many :headings, primary_key: :chapter_short_code, key: :chapter_short_code, foreign_key: :chapter_short_code do |ds|
+    ds.with_actual(Heading).exclude(goods_nomenclature_item_id: HiddenGoodsNomenclature.codes)
+  end
 
   one_to_many :goods_nomenclatures do |_ds|
     GoodsNomenclature

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -15,16 +15,14 @@ class Commodity < GoodsNomenclature
     "#{goods_nomenclature_item_id}-#{producline_suffix}"
   end
 
-  one_to_one :heading, dataset: -> {
-    actual_or_relevant(Heading)
-           .filter('goods_nomenclatures.goods_nomenclature_item_id LIKE ?', heading_id)
-           .filter(producline_suffix: GoodsNomenclatureIndent::NON_GROUPING_PRODUCTLINE_SUFFIX)
-  }
+  one_to_one :heading, primary_key: :heading_short_code, key: :heading_short_code, foreign_key: :heading_short_code do |ds|
+    ds.with_actual(Heading)
+      .filter(producline_suffix: GoodsNomenclatureIndent::NON_GROUPING_PRODUCTLINE_SUFFIX)
+  end
 
-  one_to_one :chapter, dataset: -> {
-    actual_or_relevant(Chapter)
-           .filter('goods_nomenclatures.goods_nomenclature_item_id LIKE ?', chapter_id)
-  }
+  one_to_one :chapter, primary_key: :chapter_short_code, key: :chapter_short_code, foreign_key: :chapter_short_code do |ds|
+    ds.with_actual(Chapter)
+  end
 
   one_to_many :overview_measures, key: {}, primary_key: {}, class_name: 'Measure', dataset: lambda {
     measures_dataset
@@ -127,10 +125,6 @@ class Commodity < GoodsNomenclature
 
       mapped.try(:children) || []
     end
-  end
-
-  def heading_short_code
-    goods_nomenclature_item_id.first(4)
   end
 
   def to_param

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -190,19 +190,15 @@ class GoodsNomenclature < Sequel::Model
   end
 
   def heading_code
-    heading_short_code + '0' * 6 unless chapter?
+    if heading_short_code
+      heading_short_code + '0' * 6
+    end
   end
 
   def chapter_code
-    chapter_short_code + '0' * 8
-  end
-
-  def heading_short_code
-    goods_nomenclature_item_id.first(4) unless chapter?
-  end
-
-  def chapter_short_code
-    goods_nomenclature_item_id.first(2)
+    if chapter_short_code
+      chapter_short_code + '0' * 8
+    end
   end
 
   def code

--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -13,11 +13,10 @@ class Heading < GoodsNomenclature
 
   set_primary_key [:goods_nomenclature_sid]
 
-  one_to_many :commodities, dataset: lambda {
-    actual_or_relevant(Commodity)
-             .filter('goods_nomenclatures.goods_nomenclature_item_id LIKE ?', heading_id)
-             .where(Sequel.~(goods_nomenclatures__goods_nomenclature_item_id: HiddenGoodsNomenclature.codes))
-  }
+  one_to_many :commodities, primary_key: :heading_short_code, key: :heading_short_code, foreign_key: :heading_short_code do |ds|
+    ds.with_actual(Commodity)
+      .exclude(goods_nomenclature_item_id: HiddenGoodsNomenclature.codes)
+  end
 
   one_to_many :goods_nomenclatures do |_ds|
     GoodsNomenclature

--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -26,9 +26,9 @@ class Heading < GoodsNomenclature
       .exclude(goods_nomenclature_item_id: HiddenGoodsNomenclature.codes)
   end
 
-  one_to_one :chapter, dataset: lambda {
-    actual_or_relevant(Chapter).filter('goods_nomenclatures.goods_nomenclature_item_id LIKE ?', chapter_id)
-  }
+  one_to_one :chapter, primary_key: :chapter_short_code, key: :chapter_short_code, foreign_key: :chapter_short_code do |ds|
+    ds.with_actual(Chapter)
+  end
 
   one_to_many :search_references, key: :referenced_id, primary_key: :short_code, reciprocal: :referenced, conditions: { referenced_class: 'Heading' },
                                   adder: proc { |search_reference| search_reference.update(referenced_id: short_code, referenced_class: 'Heading') },

--- a/app/serializers/cache/heading_serializer.rb
+++ b/app/serializers/cache/heading_serializer.rb
@@ -112,6 +112,16 @@ module Cache
           }
         end
 
+        overview_measures = if commodity.respond_to?(:overview_measures_dataset)
+                              commodity.overview_measures_dataset.eager(
+                                [
+                                  { measure_type: [:measure_type_description] },
+                                  { duty_expression: [:duty_expression_description] },
+                                ],
+                              )
+                            else
+                              commodity.overview_measures
+                            end
         commodity_attributes[:overview_measures] = commodity.overview_measures.map do |measure|
           {
             measure_sid: measure.measure_sid,

--- a/app/serializers/cache/heading_serializer.rb
+++ b/app/serializers/cache/heading_serializer.rb
@@ -116,13 +116,13 @@ module Cache
                               commodity.overview_measures_dataset.eager(
                                 [
                                   { measure_type: [:measure_type_description] },
-                                  { duty_expression: [:duty_expression_description] },
+                                  { measure_components: [{ duty_expression_description: :duty_expression_description }, :measurement_unit_qualifier] },
                                 ],
                               )
                             else
                               commodity.overview_measures
                             end
-        commodity_attributes[:overview_measures] = commodity.overview_measures.map do |measure|
+        commodity_attributes[:overview_measures] = overview_measures.map do |measure|
           {
             measure_sid: measure.measure_sid,
             effective_start_date: measure.effective_start_date&.strftime('%FT%T.%LZ'),

--- a/db/migrate/20220908105343_adds_heading_and_chapter_id_to_goods_nomenclatures_view.rb
+++ b/db/migrate/20220908105343_adds_heading_and_chapter_id_to_goods_nomenclatures_view.rb
@@ -1,0 +1,68 @@
+Sequel.migration do
+  up do
+    run %{
+      CREATE OR REPLACE VIEW public.goods_nomenclatures
+      AS SELECT goods_nomenclatures1.goods_nomenclature_sid,
+          goods_nomenclatures1.goods_nomenclature_item_id,
+          goods_nomenclatures1.producline_suffix,
+          goods_nomenclatures1.validity_start_date,
+          goods_nomenclatures1.validity_end_date,
+          goods_nomenclatures1.statistical_indicator,
+          goods_nomenclatures1.oid,
+          goods_nomenclatures1.operation,
+          goods_nomenclatures1.operation_date,
+          goods_nomenclatures1.filename,
+          goods_nomenclatures1.path,
+          (
+              CASE WHEN "goods_nomenclatures1"."goods_nomenclature_item_id" LIKE '__00000000' THEN
+                  NULL
+              ELSE
+              LEFT ("goods_nomenclatures1"."goods_nomenclature_item_id",
+                  4)
+              END) AS "heading_short_code",
+          (
+              LEFT ("goods_nomenclatures1"."goods_nomenclature_item_id",
+                  2)
+          ) AS "chapter_short_code"
+      FROM
+          goods_nomenclatures_oplog goods_nomenclatures1
+      WHERE (goods_nomenclatures1.oid IN (
+              SELECT
+                  max(goods_nomenclatures2.oid) AS max
+              FROM
+                  goods_nomenclatures_oplog goods_nomenclatures2
+              WHERE
+                  goods_nomenclatures1.goods_nomenclature_sid = goods_nomenclatures2.goods_nomenclature_sid))
+          AND goods_nomenclatures1.operation::text <> 'D'::text;
+    }
+  end
+
+  down do
+    run %{
+      DROP VIEW public.goods_nomenclatures;
+      CREATE OR REPLACE VIEW public.goods_nomenclatures AS
+      SELECT
+          goods_nomenclatures1.goods_nomenclature_sid,
+          goods_nomenclatures1.goods_nomenclature_item_id,
+          goods_nomenclatures1.producline_suffix,
+          goods_nomenclatures1.validity_start_date,
+          goods_nomenclatures1.validity_end_date,
+          goods_nomenclatures1.statistical_indicator,
+          goods_nomenclatures1.oid,
+          goods_nomenclatures1.operation,
+          goods_nomenclatures1.operation_date,
+          goods_nomenclatures1.filename,
+          goods_nomenclatures1.path
+      FROM
+          goods_nomenclatures_oplog goods_nomenclatures1
+      WHERE (goods_nomenclatures1.oid IN (
+              SELECT
+                  max(goods_nomenclatures2.oid) AS max
+              FROM
+                  goods_nomenclatures_oplog goods_nomenclatures2
+              WHERE
+                  goods_nomenclatures1.goods_nomenclature_sid = goods_nomenclatures2.goods_nomenclature_sid))
+      AND goods_nomenclatures1.operation::text <> 'D'::text;
+    }
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 10.10
--- Dumped by pg_dump version 10.10
+-- Dumped from database version 10.21 (Debian 10.21-1.pgdg90+1)
+-- Dumped by pg_dump version 14.3
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -3260,7 +3260,12 @@ CREATE VIEW public.goods_nomenclatures AS
     goods_nomenclatures1.operation,
     goods_nomenclatures1.operation_date,
     goods_nomenclatures1.filename,
-    goods_nomenclatures1.path
+    goods_nomenclatures1.path,
+        CASE
+            WHEN ((goods_nomenclatures1.goods_nomenclature_item_id)::text ~~ '__00000000'::text) THEN NULL::text
+            ELSE "left"((goods_nomenclatures1.goods_nomenclature_item_id)::text, 4)
+        END AS heading_short_code,
+    "left"((goods_nomenclatures1.goods_nomenclature_item_id)::text, 2) AS chapter_short_code
    FROM public.goods_nomenclatures_oplog goods_nomenclatures1
   WHERE ((goods_nomenclatures1.oid IN ( SELECT max(goods_nomenclatures2.oid) AS max
            FROM public.goods_nomenclatures_oplog goods_nomenclatures2
@@ -10906,3 +10911,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20220609140555_add_path_to
 INSERT INTO "schema_migrations" ("filename") VALUES ('20220614130523_drop_function_fetch_chapter_commodities_for_date.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20220713145800_add_strapline_to_guides.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20220714165446_create_guides_goods_nomenclatures.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20220908105343_adds_heading_and_chapter_id_to_goods_nomenclatures_view.rb');

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -38,14 +38,6 @@ RSpec.describe Commodity do
         end
       end
 
-      context 'fetching relevant' do
-        it 'fetches correct chapter' do
-          TimeMachine.with_relevant_validity_periods do
-            expect(gono2.reload.heading.pk).to eq heading2.pk
-          end
-        end
-      end
-
       context 'heading with sub-headings' do
         # Example from real world scenario
         # https://www.pivotaltracker.com/story/show/55703384
@@ -106,14 +98,6 @@ RSpec.describe Commodity do
           end
           TimeMachine.at('2010-1-1') do
             expect(gono1.reload.chapter.pk).to eq chapter2.pk
-          end
-        end
-      end
-
-      context 'fetching relevant' do
-        it 'fetches correct chapter' do
-          TimeMachine.with_relevant_validity_periods do
-            expect(gono2.reload.chapter.pk).to eq chapter2.pk
           end
         end
       end

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -819,12 +819,6 @@ RSpec.describe Commodity do
     it { expect(result).to eq([non_declarable_commodity]) }
   end
 
-  describe '.heading_short_code' do
-    subject(:heading_short_code) { build(:commodity, goods_nomenclature_item_id: '0101000000').heading_short_code }
-
-    it { is_expected.to eq('0101') }
-  end
-
   describe '#goods_nomenclature_class' do
     context 'when the Commodity is declarable' do
       subject(:goods_nomenclature_class) { create(:commodity, :declarable, :with_heading).goods_nomenclature_class }

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -354,29 +354,9 @@ RSpec.describe GoodsNomenclature do
   end
 
   describe '#heading_code' do
-    subject(:heading_code) { build(:goods_nomenclature, goods_nomenclature_item_id: '0101210000').heading_code }
+    subject(:heading_code) { create(:goods_nomenclature, goods_nomenclature_item_id: '0101210000').heading_code }
 
     it { is_expected.to eq('0101000000') }
-  end
-
-  describe '#chapter_short_code' do
-    subject(:chapter_short_code) { build(:goods_nomenclature, goods_nomenclature_item_id: '0101210000').chapter_short_code }
-
-    it { is_expected.to eq('01') }
-  end
-
-  describe '#heading_short_code' do
-    context 'when the goods nomenclature is `not` a chapter' do
-      subject(:heading_short_code) { build(:goods_nomenclature, goods_nomenclature_item_id: '0101210000').heading_short_code }
-
-      it { is_expected.to eq('0101') }
-    end
-
-    context 'when the goods nomenclature is a chapter' do
-      subject(:heading_short_code) { build(:goods_nomenclature, goods_nomenclature_item_id: '0100000000').heading_short_code }
-
-      it { is_expected.to be_nil }
-    end
   end
 
   describe '#to_s' do

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -348,7 +348,7 @@ RSpec.describe GoodsNomenclature do
   end
 
   describe '#chapter_code' do
-    subject(:chapter_code) { build(:goods_nomenclature, goods_nomenclature_item_id: '0101210000').chapter_code }
+    subject(:chapter_code) { create(:goods_nomenclature, goods_nomenclature_item_id: '0101210000').chapter_code }
 
     it { is_expected.to eq('0100000000') }
   end

--- a/spec/models/heading_spec.rb
+++ b/spec/models/heading_spec.rb
@@ -45,16 +45,6 @@ RSpec.describe Heading do
           end
         end
       end
-
-      context 'fetching relevant' do
-        it 'fetches correct chapter' do
-          TimeMachine.with_relevant_validity_periods do
-            expect(
-              heading2.reload.chapter.pk,
-            ).to eq chapter2.pk
-          end
-        end
-      end
     end
 
     describe '#measures' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1658

### What?

I have added/removed/altered:

- [x] Adds migration for heading and chapter short code to view
- [x] Increase heading batch size to 400
- [x] Make Chapter#headings eager loadable
- [x] Make Commodity#chapter and Commodity#heading eager loadable
- [x] Make Heading#commodities eager loadable
- [x] Make Heading#chapter eager loadable
- [x] Adds an eager load graph for cached heading index
- [x] Eager load overview measure associations
- [x] Make use of short code columns
- [x] Exclude non-persisted values from inserts
- [x] Removes dead methods

### Why?

I am doing this because:

- Building the heading indexes currently takes days (totally unnacceptable from a team responsiveness perspective).
- Devs validating changes to endpoints that use the heading cache are also massively affected by the slowness
- Faster ETL finish would mean we could push the ETL process later without affecting live users
