### PR TITLE
HOTT-1658: Adds fast_declarable?

### DIFF
--- a/app/elastic_search_indexes/cache/heading_index.rb
+++ b/app/elastic_search_indexes/cache/heading_index.rb
@@ -1,18 +1,23 @@
 module Cache
   class HeadingIndex < ::Cache::CacheIndex
+    def dataset
+      TimeMachine.now do
+        super.actual
+      end
+    end
+
     def eager_load_graph
       [
         {
-          commodities: [
-            :goods_nomenclature_descriptions,
-            :goods_nomenclature_indents,
-            { heading: [:commodities] }, # TODO: We should be able to replace loading the heading and its commodities with the materialized path concept and avoid eager loading for the goods nomenclature mapper
+          commodities: %i[
+            goods_nomenclature_descriptions
+            goods_nomenclature_indents
           ],
         },
         { chapter: [:guides, :goods_nomenclature_descriptions, { section: :section_note }] },
         :goods_nomenclature_indents,
         :goods_nomenclature_descriptions,
-        :footnotes,
+        { footnotes: [:footnote_descriptions] },
       ]
     end
 

--- a/app/lib/sequel/plugins/time_machine.rb
+++ b/app/lib/sequel/plugins/time_machine.rb
@@ -46,18 +46,6 @@ module Sequel
       end
 
       module InstanceMethods
-        # Use for fetching associated records with relevant validity period
-        # to parent record.
-        def actual_or_relevant(klass)
-          if self.class.point_in_time.present?
-            klass.filter { |o| o.<=(self.class.period_start_date_column, self.class.point_in_time) & (o.>=(self.class.period_end_date_column, self.class.point_in_time) | ({ self.class.period_end_date_column => nil })) }
-          elsif self.class.relevant_query?
-            klass.filter { |o| o.<=(klass.period_start_date_column, send(self.class.period_start_date_column.column)) & (o.>=(klass.period_end_date_column, send(self.class.period_end_date_column.column)) | ({ klass.period_end_date_column => nil })) }
-          else
-            klass
-          end
-        end
-
         def current?
           now = Time.zone.now # This method will be called by a backgroung JOB, therefore it does not use Thread.current
           period_end_date = self.class.period_end_date_column.column

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -131,7 +131,7 @@ module TradeTariffBackend
         Elasticsearch::Client.new,
         namespace: 'cache',
         indexes: cache_indexes,
-        index_page_size: 200,
+        index_page_size: 250,
       )
     end
 

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -103,6 +103,10 @@ class Commodity < GoodsNomenclature
     end
   end
 
+  def fast_declarable?
+    non_grouping? && descendants_dataset.count.zero?
+  end
+
   def non_grouping?
     producline_suffix == GoodsNomenclatureIndent::NON_GROUPING_PRODUCTLINE_SUFFIX
   end

--- a/app/serializers/cache/heading_serializer.rb
+++ b/app/serializers/cache/heading_serializer.rb
@@ -88,7 +88,7 @@ module Cache
           goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
           validity_start_date: commodity.validity_start_date&.strftime('%FT%T.%LZ'),
           validity_end_date: commodity.validity_end_date,
-          declarable: commodity.declarable?,
+          declarable: commodity.fast_declarable?,
         }
 
         commodity_attributes[:goods_nomenclature_indents] = commodity.goods_nomenclature_indents.map do |goods_nomenclature_indent|

--- a/spec/factories/commodity_factory.rb
+++ b/spec/factories/commodity_factory.rb
@@ -63,6 +63,9 @@ FactoryBot.define do
     end
 
     trait :with_children do
+      goods_nomenclature_sid { 1 }
+      path { Sequel.pg_array([], :integer) }
+
       after(:create) do |commodity, _evaluator|
         # Prepare some intermediate item ids
         item_id = commodity.goods_nomenclature_item_id.to_i
@@ -71,7 +74,7 @@ FactoryBot.define do
         commodity.producline_suffix = '80'
         commodity.save
         create(:goods_nomenclature_indent,
-               goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+               goods_nomenclature_sid: 1,
                goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
                validity_start_date: commodity.validity_start_date,
                validity_end_date: commodity.validity_end_date,
@@ -82,6 +85,8 @@ FactoryBot.define do
         create(:commodity,
                :with_indent,
                goods_nomenclature_item_id: (item_id + 1).to_s,
+               goods_nomenclature_sid: 2,
+               path: Sequel.pg_array([1], :integer),
                producline_suffix: '10',
                indents: 2)
 
@@ -89,10 +94,14 @@ FactoryBot.define do
         create(:commodity,
                :with_indent,
                goods_nomenclature_item_id: (item_id + 1).to_s,
+               goods_nomenclature_sid: 3,
+               path: Sequel.pg_array([1, 2], :integer),
                indents: 3)
         create(:commodity,
                :with_indent,
                goods_nomenclature_item_id: (item_id + 2).to_s,
+               goods_nomenclature_sid: 4,
+               path: Sequel.pg_array([1, 2], :integer),
                indents: 3)
         commodity.reload
       end

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -816,4 +816,30 @@ RSpec.describe Commodity do
       it { is_expected.to eq('Subheading') }
     end
   end
+
+  describe '#fast_declarable?' do
+    context 'when the goods nomenclature has children and a non grouping suffix' do
+      subject(:commodity) { create(:commodity, :with_children, :non_grouping) }
+
+      it { is_expected.not_to be_fast_declarable }
+    end
+
+    context 'when the goods nomenclature has children and a grouping suffix' do
+      subject(:commodity) { create(:commodity, :with_children, :grouping) }
+
+      it { is_expected.not_to be_fast_declarable }
+    end
+
+    context 'when the goods nomenclature has no children and a non grouping suffix' do
+      subject(:commodity) { create(:commodity, :without_children, :non_grouping) }
+
+      it { is_expected.to be_fast_declarable }
+    end
+
+    context 'when the goods nomenclature has no children and a grouping suffix' do
+      subject(:commodity) { create(:commodity, :without_children, :grouping) }
+
+      it { is_expected.not_to be_fast_declarable }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1658

### What?

I have added/removed/altered:

- [x] Move to using fast declarable to avoid using the goods nomenclature mapper

### Why?

I am doing this because:

- This means we can take advantage of the materialized path to work out whether or not a commodity is declarable
