### PR TITLE
HOTT-1658: Removes export refund nomenclature query

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -42,32 +42,6 @@ module Declarable
       )
     }
 
-    one_to_many :measures, primary_key: {}, key: {}, dataset: -> {
-      Measure.join(
-        Measure.with_base_regulations
-               .with_actual(BaseRegulation)
-               .where(measures__goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid))
-               .exclude(measures__measure_type_id: MeasureType.excluded_measure_types)
-               .order(*COMMON_UNION_MEASURE_ORDER)
-       .union(
-         Measure.with_modification_regulations
-                .with_actual(ModificationRegulation)
-                .where(measures__goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid))
-                .exclude(measures__measure_type_id: MeasureType.excluded_measure_types)
-                .order(*COMMON_UNION_MEASURE_ORDER),
-         alias: :measures,
-       )
-       .with_actual(Measure)
-       .order(Sequel.asc(:measures__geographical_area_id),
-              Sequel.asc(:measures__measure_type_id),
-              Sequel.asc(:measures__additional_code_type_id),
-              Sequel.asc(:measures__additional_code_id),
-              Sequel.asc(:measures__ordernumber),
-              Sequel.desc(:effective_start_date)),
-        t1__measure_sid: :measures__measure_sid,
-      )
-    }
-
     one_to_many :import_measures, key: {}, primary_key: {}, dataset: -> {
       measures_dataset.join(:measure_types, measure_types__measure_type_id: :measures__measure_type_id)
                       .filter(measure_types__trade_movement_code: MeasureType::IMPORT_MOVEMENT_CODES)

--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -20,33 +20,41 @@ module Declarable
       Measure.join(
         Measure.with_base_regulations
                .with_actual(BaseRegulation)
-               .where({ measures__goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid) })
-               .where { Sequel.~(measures__measure_type_id: MeasureType.excluded_measure_types) }
+               .where(measures__goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid))
+               .exclude(measures__measure_type_id: MeasureType.excluded_measure_types)
                .order(*COMMON_UNION_MEASURE_ORDER)
-               .tap! { |query|
-                 query.union(
-                   Measure.with_base_regulations
-                     .with_actual(BaseRegulation)
-                     .where({ measures__export_refund_nomenclature_sid: export_refund_uptree.map(&:export_refund_nomenclature_sid) })
-                     .where { Sequel.~(measures__measure_type_id: MeasureType.excluded_measure_types) }
-                     .order(*COMMON_UNION_MEASURE_ORDER),
-                 ) if export_refund_uptree.present?
-               }
        .union(
          Measure.with_modification_regulations
                 .with_actual(ModificationRegulation)
-                .where({ measures__goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid) })
-                .where { Sequel.~(measures__measure_type_id: MeasureType.excluded_measure_types) }
-                .order(*COMMON_UNION_MEASURE_ORDER)
-                .tap! { |query|
-                  query.union(
-                    Measure.with_modification_regulations
-                           .with_actual(ModificationRegulation)
-                           .where({ measures__export_refund_nomenclature_sid: export_refund_uptree.map(&:export_refund_nomenclature_sid) })
-                           .where { Sequel.~(measures__measure_type_id: MeasureType.excluded_measure_types) }
-                           .order(*COMMON_UNION_MEASURE_ORDER),
-                  ) if export_refund_uptree.present?
-                },
+                .where(measures__goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid))
+                .exclude(measures__measure_type_id: MeasureType.excluded_measure_types)
+                .order(*COMMON_UNION_MEASURE_ORDER),
+         alias: :measures,
+       )
+       .with_actual(Measure)
+       .order(Sequel.asc(:measures__geographical_area_id),
+              Sequel.asc(:measures__measure_type_id),
+              Sequel.asc(:measures__additional_code_type_id),
+              Sequel.asc(:measures__additional_code_id),
+              Sequel.asc(:measures__ordernumber),
+              Sequel.desc(:effective_start_date)),
+        t1__measure_sid: :measures__measure_sid,
+      )
+    }
+
+    one_to_many :measures, primary_key: {}, key: {}, dataset: -> {
+      Measure.join(
+        Measure.with_base_regulations
+               .with_actual(BaseRegulation)
+               .where(measures__goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid))
+               .exclude(measures__measure_type_id: MeasureType.excluded_measure_types)
+               .order(*COMMON_UNION_MEASURE_ORDER)
+       .union(
+         Measure.with_modification_regulations
+                .with_actual(ModificationRegulation)
+                .where(measures__goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid))
+                .exclude(measures__measure_type_id: MeasureType.excluded_measure_types)
+                .order(*COMMON_UNION_MEASURE_ORDER),
          alias: :measures,
        )
        .with_actual(Measure)
@@ -78,10 +86,6 @@ module Declarable
                                using: :description
     custom_format :formatted_description, with: DescriptionFormatter,
                                    using: :description
-  end
-
-  def export_refund_uptree
-    @_export_refund_uptree ||= export_refund_nomenclatures.map(&:uptree).flatten
   end
 
   def chapter_id

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -287,23 +287,6 @@ RSpec.describe Commodity do
           expect(commodity2.import_measures.map(&:measure_sid)).not_to include export_measure.measure_sid
         end
       end
-
-      context 'export refund nomenclature' do
-        let!(:commodity) { create :commodity, :with_indent }
-        let!(:export_refund_nomenclature) do
-          create :export_refund_nomenclature, :with_indent,
-                 goods_nomenclature_sid: commodity.goods_nomenclature_sid
-        end
-        let!(:export_measure) do
-          create :measure, :with_base_regulation, export_refund_nomenclature_sid: export_refund_nomenclature.export_refund_nomenclature_sid,
-                                                  goods_nomenclature_item_id: commodity.goods_nomenclature_item_id
-        end
-
-        it 'includes measures that belongs to related export refund nomenclature' do
-          expect(commodity.measures).not_to be_blank
-          expect(commodity.measures.map(&:measure_sid)).to include export_measure.measure_sid
-        end
-      end
     end
 
     describe 'measures and base_regulations' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1658

### What?

I have added/removed/altered:

- [x] Removed unused export refund nomenclature query from measures association

### Why?

I am doing this because:

- This hasn't been supported functionality since the end of 2016 and complicates the measures association
