### PR TITLE
HOTT-1948 Fixed description of chemical mixtures

### DIFF
--- a/db/data_migrations/20220909113745_fix_chemical_mixtures_description.rb
+++ b/db/data_migrations/20220909113745_fix_chemical_mixtures_description.rb
@@ -1,0 +1,50 @@
+Sequel.migration do
+  # IMPORTANT! Data migrations should be Idempotent, they may get re-run as part
+  # of data rollbacks
+
+  up do
+    if TradeTariffBackend.uk?
+      Sequel::Model.db[:goods_nomenclature_descriptions_oplog]
+        .where(
+          goods_nomenclature_description_period_sid: 157_681,
+          goods_nomenclature_sid: 106_141,
+          language_id: 'EN',
+          goods_nomenclature_item_id: '3911909963',
+          productline_suffix: '80',
+          operation_date: '2022-09-07',
+          filename: 'tariff_dailyExtract_v1_20220907T235959.gzip',
+          description: nil,
+        )
+        .update(
+          description: 'Mixture, containing by weight:
+-	20% or more but not more than 40% of a copolymer of methyl vinyl ether and monobutyl maleate (CAS RN 25119-68-0),
+-	7% or more but not more than 20% of a copolymer of methyl vinyl ether and monoethyl maleate (CAS RN 25087-06-3),
+-	40% or more, but not more than 65% of ethanol (CAS RN 64-17-5),
+-	1% or more but not more than 7% of butan-1-ol (CAS RN 71-36-3)',
+        )
+    end
+  end
+
+  down do
+    if TradeTariffBackend.uk?
+      Sequel::Model.db[:goods_nomenclature_descriptions_oplog]
+        .where(
+          goods_nomenclature_description_period_sid: 157_681,
+          goods_nomenclature_sid: 106_141,
+          language_id: 'EN',
+          goods_nomenclature_item_id: '3911909963',
+          productline_suffix: '80',
+          operation_date: '2022-09-07',
+          filename: 'tariff_dailyExtract_v1_20220907T235959.gzip',
+          description: 'Mixture, containing by weight:
+-	20% or more but not more than 40% of a copolymer of methyl vinyl ether and monobutyl maleate (CAS RN 25119-68-0),
+-	7% or more but not more than 20% of a copolymer of methyl vinyl ether and monoethyl maleate (CAS RN 25087-06-3),
+-	40% or more, but not more than 65% of ethanol (CAS RN 64-17-5),
+-	1% or more but not more than 7% of butan-1-ol (CAS RN 71-36-3)',
+        )
+        .update(
+          description: nil,
+        )
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-1948

### What?

I have added/removed/altered:

- [x] Added a data migration to correct the description of chemical mixtures

### Why?

I am doing this because:

- The description in the upstream data was blank

### Deployment risks (optional)

- Includes migratory actions which will affect commodity data

### Before

![Screenshot from 2022-09-09 12-43-16](https://user-images.githubusercontent.com/10818/189360039-7cc46f93-cfca-4bb1-9b22-185503a7f8e5.png)

### After

![Screenshot from 2022-09-09 14-24-52](https://user-images.githubusercontent.com/10818/189360529-cf5240a9-4d4d-4481-bb48-20967739e4ad.png)

