### PR TITLE
HOTT-1658: Adds materialized measures with effective start/end dates

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -2,45 +2,32 @@ module Declarable
   extend ActiveSupport::Concern
   include Formatter
 
-  COMMON_UNION_MEASURE_ORDER = [
-    Sequel.desc(:measures__measure_generating_regulation_id),
-    Sequel.desc(:measures__measure_generating_regulation_role),
-    Sequel.desc(:measures__measure_type_id),
-    Sequel.desc(:measures__goods_nomenclature_sid),
-    Sequel.desc(:measures__geographical_area_id),
-    Sequel.desc(:measures__geographical_area_sid),
-    Sequel.desc(:measures__additional_code_type_id),
-    Sequel.desc(:measures__additional_code_id),
-    Sequel.desc(:measures__ordernumber),
-    Sequel.desc(:effective_start_date),
-  ].freeze
-
   included do
-    # TODO: Move uptree into materialized view
+    # TODO: Move uptree enumeration into materialized view
     one_to_many :measures, primary_key: {}, key: {} do |_ds|
       Measure.actual
         .where(goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid))
         .exclude(measure_type_id: MeasureType.excluded_measure_types)
     end
 
-    one_to_many :import_measures, key: {}, primary_key: {}, dataset: -> {
+    one_to_many :import_measures, key: {}, primary_key: {}, dataset: lambda {
       measures_dataset.join(:measure_types, measure_types__measure_type_id: :measures__measure_type_id)
                       .filter(measure_types__trade_movement_code: MeasureType::IMPORT_MOVEMENT_CODES)
     }, class_name: 'Measure'
 
-    one_to_many :export_measures, key: {}, primary_key: {}, dataset: -> {
+    one_to_many :export_measures, key: {}, primary_key: {}, dataset: lambda {
       measures_dataset.join(:measure_types, measure_types__measure_type_id: :measures__measure_type_id)
                       .filter(measure_types__trade_movement_code: MeasureType::EXPORT_MOVEMENT_CODES)
     }, class_name: 'Measure'
 
-    one_to_many :basic_duty_rate_components, primary_key: {}, key: {}, class_name: 'MeasureComponent', dataset: -> {
+    one_to_many :basic_duty_rate_components, primary_key: {}, key: {}, class_name: 'MeasureComponent', dataset: lambda {
       MeasureComponent.where(measure: import_measures_dataset.where(measures__measure_type_id: MeasureType::THIRD_COUNTRY).all)
     }
 
     custom_format :description_plain, with: DescriptionTrimFormatter,
-                               using: :description
+                                      using: :description
     custom_format :formatted_description, with: DescriptionFormatter,
-                                   using: :description
+                                          using: :description
   end
 
   def chapter_id

--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -16,31 +16,12 @@ module Declarable
   ].freeze
 
   included do
-    one_to_many :measures, primary_key: {}, key: {}, dataset: -> {
-      Measure.join(
-        Measure.with_base_regulations
-               .with_actual(BaseRegulation)
-               .where(measures__goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid))
-               .exclude(measures__measure_type_id: MeasureType.excluded_measure_types)
-               .order(*COMMON_UNION_MEASURE_ORDER)
-       .union(
-         Measure.with_modification_regulations
-                .with_actual(ModificationRegulation)
-                .where(measures__goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid))
-                .exclude(measures__measure_type_id: MeasureType.excluded_measure_types)
-                .order(*COMMON_UNION_MEASURE_ORDER),
-         alias: :measures,
-       )
-       .with_actual(Measure)
-       .order(Sequel.asc(:measures__geographical_area_id),
-              Sequel.asc(:measures__measure_type_id),
-              Sequel.asc(:measures__additional_code_type_id),
-              Sequel.asc(:measures__additional_code_id),
-              Sequel.asc(:measures__ordernumber),
-              Sequel.desc(:effective_start_date)),
-        t1__measure_sid: :measures__measure_sid,
-      )
-    }
+    # TODO: Move uptree into materialized view
+    one_to_many :measures, primary_key: {}, key: {} do |_ds|
+      Measure.actual
+        .where(goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid))
+        .exclude(measure_type_id: MeasureType.excluded_measure_types)
+    end
 
     one_to_many :import_measures, key: {}, primary_key: {}, dataset: -> {
       measures_dataset.join(:measure_types, measure_types__measure_type_id: :measures__measure_type_id)

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -19,7 +19,7 @@ class Measure < Sequel::Model(:measure_real_end_dates)
 
   set_primary_key [:measure_sid]
 
-  plugin :time_machine, period_start_date_column: :effective_start_date, period_end_date_column: :effective_end_date
+  plugin :time_machine, period_end_date_column: :effective_end_date
   plugin :oplog, primary_key: :measure_sid, oplog_table_name: :measures_oplog, view_table_name: :measures, materialized: true
   plugin :national
 
@@ -391,6 +391,8 @@ class Measure < Sequel::Model(:measure_real_end_dates)
   def meursing_measures
     @meursing_measures ||= MeursingMeasureFinderService.new(self, meursing_additional_code_id).call
   end
+
+  alias_method :effective_start_date, :validity_start_date
 
   private
 

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -19,8 +19,8 @@ class Measure < Sequel::Model(:measure_real_end_dates)
 
   set_primary_key [:measure_sid]
 
-  plugin :time_machine
-  plugin :oplog, primary_key: :measure_sid, oplog_table_name: :measures_oplog, view: :measures, materialized: true
+  plugin :time_machine, period_start_date_column: :effective_start_date, period_end_date_column: :effective_end_date
+  plugin :oplog, primary_key: :measure_sid, oplog_table_name: :measures_oplog, view_table_name: :measures, materialized: true
   plugin :national
 
   many_to_one :goods_nomenclature, key: :goods_nomenclature_sid,

--- a/db/migrate/20220909141340_adds_materialized_measures_real_end_dates.rb
+++ b/db/migrate/20220909141340_adds_materialized_measures_real_end_dates.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    run %{
+      CREATE MATERIALIZED VIEW measures AS
+      SELECT
+          "t1"."measure_sid",
+          "t1"."measure_type_id",
+          "t1"."effective_start_date",
+          "t1"."effective_end_date",
+          "t1"."geographical_area_id",
+          "t1"."goods_nomenclature_item_id",
+          "t1"."validity_start_date",
+          "t1"."validity_end_date",
+          "t1"."measure_generating_regulation_role",
+          "t1"."measure_generating_regulation_id",
+          "t1"."justification_regulation_role",
+          "t1"."justification_regulation_id",
+          "t1"."stopped_flag",
+          "t1"."geographical_area_sid",
+          "t1"."goods_nomenclature_sid",
+          "t1"."ordernumber",
+          "t1"."additional_code_type_id",
+          "t1"."additional_code_id",
+          "t1"."additional_code_sid",
+          "t1"."reduction_indicator",
+          "t1"."export_refund_nomenclature_sid",
+          "t1"."national",
+          "t1"."tariff_measure_number",
+          "t1"."invalidated_by",
+          "t1"."invalidated_at",
+          "t1"."oid",
+          "t1"."operation",
+          "t1"."operation_date",
+          "t1"."filename"
+      FROM
+          "measures"
+          INNER JOIN (
+              SELECT
+                  *
+              FROM (
+                  SELECT
+                      *
+                  FROM (
+                      SELECT
+                          "measures".*,
+                          (
+                              CASE WHEN ("measures"."validity_start_date" IS NULL) THEN
+                                  base_regulations.validity_start_date
+                              ELSE
+                                  measures.validity_start_date
+                              END) AS "effective_start_date",
+                          (
+                              CASE WHEN ("measures"."validity_end_date" IS NULL
+                                      AND "base_regulations"."effective_end_date" IS NOT NULL) THEN
+                                  base_regulations.effective_end_date
+                              WHEN ("measures"."validity_end_date" IS NULL
+                                  AND "base_regulations"."effective_end_date" IS NULL) THEN
+                                  base_regulations.effective_end_date
+                              ELSE
+                                  measures.validity_end_date
+                              END) AS "effective_end_date"
+                      FROM
+                          "measures"
+                      INNER JOIN "base_regulations" ON ("base_regulations"."base_regulation_id" = "measures"."measure_generating_regulation_id")
+                  WHERE (("measure_generating_regulation_role" IN (1, 2, 3)))
+              ORDER BY
+                  "measures"."measure_generating_regulation_id" DESC,
+                  "measures"."measure_generating_regulation_role" DESC,
+                  "measures"."measure_type_id" DESC,
+                  "measures"."goods_nomenclature_sid" DESC,
+                  "measures"."geographical_area_id" DESC,
+                  "measures"."geographical_area_sid" DESC,
+                  "measures"."additional_code_type_id" DESC,
+                  "measures"."additional_code_id" DESC,
+                  "measures"."ordernumber" DESC,
+                  "effective_start_date" DESC) AS "t1"
+          UNION (
+              SELECT
+                  *
+              FROM (
+                  SELECT
+                      "measures".*,
+                      (
+                          CASE WHEN ("measures"."validity_start_date" IS NULL) THEN
+                              modification_regulations.validity_start_date
+                          ELSE
+                              measures.validity_start_date
+                          END) AS "effective_start_date",
+                      (
+                          CASE WHEN ("measures"."validity_end_date" IS NULL) THEN
+                              modification_regulations.effective_end_date
+                          ELSE
+                              measures.validity_end_date
+                          END) AS "effective_end_date"
+                  FROM
+                      "measures"
+                      INNER JOIN "modification_regulations" ON ("modification_regulations"."modification_regulation_id" = "measures"."measure_generating_regulation_id")
+                  WHERE (("measure_generating_regulation_role" = 4))
+              ORDER BY
+                  "measures"."measure_generating_regulation_id" DESC,
+                  "measures"."measure_generating_regulation_role" DESC,
+                  "measures"."measure_type_id" DESC,
+                  "measures"."goods_nomenclature_sid" DESC,
+                  "measures"."geographical_area_id" DESC,
+                  "measures"."geographical_area_sid" DESC,
+                  "measures"."additional_code_type_id" DESC,
+                  "measures"."additional_code_id" DESC,
+                  "measures"."ordernumber" DESC,
+                  "effective_start_date" DESC) AS "t1")) AS "measures"
+      ORDER BY
+          "measures"."geographical_area_id" ASC,
+          "measures"."measure_type_id" ASC,
+          "measures"."additional_code_type_id" ASC,
+          "measures"."additional_code_id" ASC,
+          "measures"."ordernumber" ASC,
+          "effective_start_date" DESC) AS "t1" ON ("t1"."measure_sid" = "measures"."measure_sid"
+      )
+      WITH DATA;
+    }
+  end
+
+  down do
+    run %{
+      DROP MATERIALIZED VIEW measure_real_end_dates;
+    }
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4215,10 +4215,9 @@ CREATE VIEW public.modification_regulations AS
 CREATE MATERIALIZED VIEW public.measure_real_end_dates AS
  SELECT t1.measure_sid,
     t1.measure_type_id,
-    t1.effective_start_date,
-    t1.effective_end_date,
     t1.geographical_area_id,
     t1.goods_nomenclature_item_id,
+    t1.effective_end_date,
     t1.validity_start_date,
     t1.validity_end_date,
     t1.measure_generating_regulation_role,
@@ -4270,7 +4269,6 @@ CREATE MATERIALIZED VIEW public.measure_real_end_dates AS
             measures_1.operation,
             measures_1.operation_date,
             measures_1.filename,
-            measures_1.effective_start_date,
             measures_1.effective_end_date
            FROM ( SELECT t1_1.measure_sid,
                     t1_1.measure_type_id,
@@ -4299,7 +4297,6 @@ CREATE MATERIALIZED VIEW public.measure_real_end_dates AS
                     t1_1.operation,
                     t1_1.operation_date,
                     t1_1.filename,
-                    t1_1.effective_start_date,
                     t1_1.effective_end_date
                    FROM ( SELECT measures_2.measure_sid,
                             measures_2.measure_type_id,
@@ -4329,22 +4326,14 @@ CREATE MATERIALIZED VIEW public.measure_real_end_dates AS
                             measures_2.operation_date,
                             measures_2.filename,
                                 CASE
-                                    WHEN (measures_2.validity_start_date IS NULL) THEN base_regulations.validity_start_date
-                                    ELSE measures_2.validity_start_date
-                                END AS effective_start_date,
-                                CASE
-                                    WHEN ((measures_2.validity_end_date IS NULL) AND (base_regulations.effective_end_date IS NOT NULL)) THEN base_regulations.effective_end_date
-                                    WHEN ((measures_2.validity_end_date IS NULL) AND (base_regulations.effective_end_date IS NULL)) THEN base_regulations.effective_end_date
-                                    ELSE measures_2.validity_end_date
+                                    WHEN (measures_2.validity_end_date IS NOT NULL) THEN measures_2.validity_end_date
+                                    WHEN (base_regulations.effective_end_date IS NOT NULL) THEN base_regulations.effective_end_date
+                                    ELSE base_regulations.validity_end_date
                                 END AS effective_end_date
                            FROM (public.measures measures_2
                              JOIN public.base_regulations ON (((base_regulations.base_regulation_id)::text = (measures_2.measure_generating_regulation_id)::text)))
                           WHERE (measures_2.measure_generating_regulation_role = ANY (ARRAY[1, 2, 3]))
-                          ORDER BY measures_2.measure_generating_regulation_id DESC, measures_2.measure_generating_regulation_role DESC, measures_2.measure_type_id DESC, measures_2.goods_nomenclature_sid DESC, measures_2.geographical_area_id DESC, measures_2.geographical_area_sid DESC, measures_2.additional_code_type_id DESC, measures_2.additional_code_id DESC, measures_2.ordernumber DESC,
-                                CASE
-                                    WHEN (measures_2.validity_start_date IS NULL) THEN base_regulations.validity_start_date
-                                    ELSE measures_2.validity_start_date
-                                END DESC) t1_1
+                          ORDER BY measures_2.measure_generating_regulation_id DESC, measures_2.measure_generating_regulation_role DESC, measures_2.measure_type_id DESC, measures_2.goods_nomenclature_sid DESC, measures_2.geographical_area_id DESC, measures_2.geographical_area_sid DESC, measures_2.additional_code_type_id DESC, measures_2.additional_code_id DESC, measures_2.ordernumber DESC, measures_2.validity_start_date DESC) t1_1
                 UNION
                  SELECT t1_1.measure_sid,
                     t1_1.measure_type_id,
@@ -4373,7 +4362,6 @@ CREATE MATERIALIZED VIEW public.measure_real_end_dates AS
                     t1_1.operation,
                     t1_1.operation_date,
                     t1_1.filename,
-                    t1_1.effective_start_date,
                     t1_1.effective_end_date
                    FROM ( SELECT measures_2.measure_sid,
                             measures_2.measure_type_id,
@@ -4403,22 +4391,15 @@ CREATE MATERIALIZED VIEW public.measure_real_end_dates AS
                             measures_2.operation_date,
                             measures_2.filename,
                                 CASE
-                                    WHEN (measures_2.validity_start_date IS NULL) THEN modification_regulations.validity_start_date
-                                    ELSE measures_2.validity_start_date
-                                END AS effective_start_date,
-                                CASE
-                                    WHEN (measures_2.validity_end_date IS NULL) THEN modification_regulations.effective_end_date
-                                    ELSE measures_2.validity_end_date
+                                    WHEN (measures_2.validity_end_date IS NOT NULL) THEN measures_2.validity_end_date
+                                    WHEN (modification_regulations.effective_end_date IS NOT NULL) THEN modification_regulations.effective_end_date
+                                    ELSE modification_regulations.validity_end_date
                                 END AS effective_end_date
                            FROM (public.measures measures_2
                              JOIN public.modification_regulations ON (((modification_regulations.modification_regulation_id)::text = (measures_2.measure_generating_regulation_id)::text)))
                           WHERE (measures_2.measure_generating_regulation_role = 4)
-                          ORDER BY measures_2.measure_generating_regulation_id DESC, measures_2.measure_generating_regulation_role DESC, measures_2.measure_type_id DESC, measures_2.goods_nomenclature_sid DESC, measures_2.geographical_area_id DESC, measures_2.geographical_area_sid DESC, measures_2.additional_code_type_id DESC, measures_2.additional_code_id DESC, measures_2.ordernumber DESC,
-                                CASE
-                                    WHEN (measures_2.validity_start_date IS NULL) THEN modification_regulations.validity_start_date
-                                    ELSE measures_2.validity_start_date
-                                END DESC) t1_1) measures_1
-          ORDER BY measures_1.geographical_area_id, measures_1.measure_type_id, measures_1.additional_code_type_id, measures_1.additional_code_id, measures_1.ordernumber, measures_1.effective_start_date DESC) t1 ON ((t1.measure_sid = measures.measure_sid)))
+                          ORDER BY measures_2.measure_generating_regulation_id DESC, measures_2.measure_generating_regulation_role DESC, measures_2.measure_type_id DESC, measures_2.goods_nomenclature_sid DESC, measures_2.geographical_area_id DESC, measures_2.geographical_area_sid DESC, measures_2.additional_code_type_id DESC, measures_2.additional_code_id DESC, measures_2.ordernumber DESC, measures_2.validity_start_date DESC) t1_1) measures_1
+          ORDER BY measures_1.geographical_area_id, measures_1.measure_type_id, measures_1.additional_code_type_id, measures_1.additional_code_id, measures_1.ordernumber, measures_1.validity_start_date DESC) t1 ON ((t1.measure_sid = measures.measure_sid)))
   WITH NO DATA;
 
 
@@ -8043,6 +8024,14 @@ ALTER TABLE ONLY public.audits
 
 
 --
+-- Name: base_regulations_oplog base_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.base_regulations_oplog
+    ADD CONSTRAINT base_regulations_pkey PRIMARY KEY (oid);
+
+
+--
 -- Name: certificate_description_periods_oplog certificate_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8627,6 +8616,14 @@ ALTER TABLE ONLY public.measurements_oplog
 
 
 --
+-- Name: measures_oplog measures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.measures_oplog
+    ADD CONSTRAINT measures_pkey PRIMARY KEY (oid);
+
+
+--
 -- Name: meursing_additional_codes_oplog meursing_additional_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8672,6 +8669,14 @@ ALTER TABLE ONLY public.meursing_table_cell_components_oplog
 
 ALTER TABLE ONLY public.meursing_table_plans_oplog
     ADD CONSTRAINT meursing_table_plans_pkey PRIMARY KEY (oid);
+
+
+--
+-- Name: modification_regulations_oplog modification_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.modification_regulations_oplog
+    ADD CONSTRAINT modification_regulations_pkey PRIMARY KEY (oid);
 
 
 --

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
 
   factory :measure do
     after(:create) do
-      Measure.refresh_materialized_view # refresh materialized view
+      Measure.refresh_materialized_view
     end
 
     transient do
@@ -221,7 +221,8 @@ FactoryBot.define do
     end
 
     trait :with_measure_components do
-      after(:build) do |measure, evaluator|
+      after(:create) do |measure, evaluator|
+        Measure.refresh_materialized_view
         create_list(
           :measure_component,
           evaluator.measure_components_count,

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -5,6 +5,10 @@ FactoryBot.define do
   sequence(:measure_type_id, 10_000) { |n| n }
 
   factory :measure do
+    after(:create) do
+      Measure.refresh_materialized_view # refresh materialized view
+    end
+
     transient do
       type_explosion_level { 10 }
       gono_number_indents { 1 }

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe Measure do
 	      (69920, 70329, '1999-01-01 00:00:00', 3, '0805201005', '80', '2013-08-02 20:04:48', NULL, 40421, 'C', NULL);
       })
 
+      Measure.refresh # Needed to update materialized view because we're not using factories above and therefore not tripping the refresh callback
       expect(described_class.with_modification_regulations.all.count).to eq 3
       # Measures on a parent code should also be present (e.g. 0805201000 on 0805201005)
       expect(Commodity.by_code('0805201005').first.measures.count).to eq 3

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -72,12 +72,13 @@ RSpec.describe Measure do
 	      (69920, 70329, '1999-01-01 00:00:00', 3, '0805201005', '80', '2013-08-02 20:04:48', NULL, 40421, 'C', NULL);
       })
 
-      Measure.refresh # Needed to update materialized view because we're not using factories above and therefore not tripping the refresh callback
+      # Needed to update materialized view because we're not using factories above and therefore not tripping the refresh callback
+      Measure.refresh_materialized_view
       expect(described_class.with_modification_regulations.all.count).to eq 3
       # Measures on a parent code should also be present (e.g. 0805201000 on 0805201005)
       expect(Commodity.by_code('0805201005').first.measures.count).to eq 3
       # In TimeMachine we should only see vaild/the correct measure (with start date within the time range)
-      # expect(TimeMachine.at(DateTime.parse("2016-07-21")){ Measure.with_modification_regulations.with_actual(ModificationRegulation).all.count }).to eq 1
+      expect(TimeMachine.at(DateTime.parse("2016-07-21")){ Measure.with_modification_regulations.all.count }).to eq 1
       expect(TimeMachine.at(Time.zone.parse('2016-07-21')) { described_class.with_modification_regulations.with_actual(ModificationRegulation).all.first.measure_sid }).to eq 3_445_396
       expect(TimeMachine.at(Time.zone.parse('2016-07-21')) { Commodity.by_code('0805201005').first.measures.count }).to eq 1
       expect(TimeMachine.at(Time.zone.parse('2016-07-21')) { Commodity.by_code('0805201005').first.measures.first.measure_sid }).to eq 3_445_396

--- a/spec/unit/changes_table_populator/measure_end_dated_spec.rb
+++ b/spec/unit/changes_table_populator/measure_end_dated_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe ChangesTablePopulator::MeasureEndDated do
     context 'when there are measures but haven\'t changed' do
       before do
         create :measure, :with_goods_nomenclature
+        require 'pry'; binding.pry
       end
 
       it 'doesn\'t extract changes' do

--- a/test.sql
+++ b/test.sql
@@ -1,0 +1,87 @@
+CREATE MATERIALIZED VIEW measures_real_end_dates
+AS SELECT * FROM measures WHERE "measures"."effective_end_date" IS NOT NULL
+SELECT
+    *
+FROM
+    "measures"
+    INNER JOIN (
+        SELECT
+            *
+        FROM (
+            SELECT
+                *
+            FROM (
+                SELECT
+                    "measures".*,
+                    (
+                        CASE WHEN ("measures"."validity_start_date" IS NULL) THEN
+                            base_regulations.validity_start_date
+                        ELSE
+                            measures.validity_start_date
+                        END) AS "effective_start_date",
+                    (
+                        CASE WHEN ("measures"."validity_end_date" IS NULL
+                                AND "base_regulations"."effective_end_date" IS NOT NULL) THEN
+                            base_regulations.effective_end_date
+                        WHEN ("measures"."validity_end_date" IS NULL
+                            AND "base_regulations"."effective_end_date" IS NULL) THEN
+                            base_regulations.effective_end_date
+                        ELSE
+                            measures.validity_end_date
+                        END) AS "effective_end_date"
+                FROM
+                    "measures"
+                INNER JOIN "base_regulations" ON ("base_regulations"."base_regulation_id" = "measures"."measure_generating_regulation_id")
+            WHERE (("measure_generating_regulation_role" IN (1, 2, 3)))
+        ORDER BY
+            "measures"."measure_generating_regulation_id" DESC,
+            "measures"."measure_generating_regulation_role" DESC,
+            "measures"."measure_type_id" DESC,
+            "measures"."goods_nomenclature_sid" DESC,
+            "measures"."geographical_area_id" DESC,
+            "measures"."geographical_area_sid" DESC,
+            "measures"."additional_code_type_id" DESC,
+            "measures"."additional_code_id" DESC,
+            "measures"."ordernumber" DESC,
+            "effective_start_date" DESC) AS "t1"
+    UNION (
+        SELECT
+            *
+        FROM (
+            SELECT
+                "measures".*,
+                (
+                    CASE WHEN ("measures"."validity_start_date" IS NULL) THEN
+                        modification_regulations.validity_start_date
+                    ELSE
+                        measures.validity_start_date
+                    END) AS "effective_start_date",
+                (
+                    CASE WHEN ("measures"."validity_end_date" IS NULL) THEN
+                        modification_regulations.effective_end_date
+                    ELSE
+                        measures.validity_end_date
+                    END) AS "effective_end_date"
+            FROM
+                "measures"
+                INNER JOIN "modification_regulations" ON ("modification_regulations"."modification_regulation_id" = "measures"."measure_generating_regulation_id")
+            WHERE (("measure_generating_regulation_role" = 4))
+        ORDER BY
+            "measures"."measure_generating_regulation_id" DESC,
+            "measures"."measure_generating_regulation_role" DESC,
+            "measures"."measure_type_id" DESC,
+            "measures"."goods_nomenclature_sid" DESC,
+            "measures"."geographical_area_id" DESC,
+            "measures"."geographical_area_sid" DESC,
+            "measures"."additional_code_type_id" DESC,
+            "measures"."additional_code_id" DESC,
+            "measures"."ordernumber" DESC,
+            "effective_start_date" DESC) AS "t1")) AS "measures"
+ORDER BY
+    "measures"."geographical_area_id" ASC,
+    "measures"."measure_type_id" ASC,
+    "measures"."additional_code_type_id" ASC,
+    "measures"."additional_code_id" ASC,
+    "measures"."ordernumber" ASC,
+    "effective_start_date" DESC) AS "t1" ON ("t1"."measure_sid" = "measures"."measure_sid")
+WITH DATA


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1658

### What?

I have added/removed/altered:

- [x] Added materialized view to enable precaching of measures with their real end dates
- [x] Updated measure model to point at this view
- [x] Removed now-unused declarable scopes
- [ ] Added support for materialized views to the oplog plugin
- [ ] Updated specs to reflect these changes

### Why?

I am doing this because:

- We're spending a lot of time loading measures even when filtering to a small list of measures
- This is a big blocker in enabling us to move towards eager loading goods nomenclature measures which will massively speed up measure loading as part of various workflows