### PR TITLE
HOTT-1658: Reduce batch size

### DIFF
--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -131,7 +131,7 @@ module TradeTariffBackend
         Elasticsearch::Client.new,
         namespace: 'cache',
         indexes: cache_indexes,
-        index_page_size: 250,
+        index_page_size: 100,
       )
     end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1658

### What?

I have added/removed/altered:

- [x] Update batch size to 100 for cache indexes

### Why?

I am doing this because:

- Getting documents that are bigger than what is support by ES
