### PR TITLE
HOTT-1970: Fixes the heading cache key

### DIFF
--- a/spec/controllers/api/v2/headings_controller_spec.rb
+++ b/spec/controllers/api/v2/headings_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Api::V2::HeadingsController, type: :controller do
       expected_hash = Digest::MD5.hexdigest('{}')
 
       expect(Rails.cache).to have_received(:fetch).with(
-        "_heading-uk-1-2022-09-14-false-#{expected_hash}",
+        "_heading-uk-#{heading.goods_nomenclature_sid}-#{Time.zone.today.iso8601}-false-#{expected_hash}",
         { expires_in: 24.hours },
       )
     end
@@ -38,7 +38,7 @@ RSpec.describe Api::V2::HeadingsController, type: :controller do
         expected_hash = Digest::MD5.hexdigest(filter.to_json)
 
         expect(Rails.cache).to have_received(:fetch).with(
-          "_heading-uk-1-2022-09-14-false-#{expected_hash}",
+          "_heading-uk-#{heading.goods_nomenclature_sid}-#{Time.zone.today.iso8601}-false-#{expected_hash}",
           { expires_in: 24.hours },
         )
       end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1970

### What?

I have added/removed/altered:

- [x] Added filter md5 sum hash to the fragment cache for declarable headings

### Why?

I am doing this because:

- This change includes the md5 sum of the geographical area id filter
so we distinguish responses between different declarable headings and
their expected measures. Without this we do not recognise changes in the are that's being filtered.
