### PR TITLE
HOTT-2006 Report exceptions to sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,8 @@
 Sentry.init do |config|
-  config.rails.report_rescued_exceptions = false
-
   config.breadcrumbs_logger = [:active_support_logger]
+
+  config.excluded_exceptions += %w[
+    Sequel::Plugins::RailsExtensions::ModelNotFound
+    Sequel::NoMatchingRow
+  ]
 end


### PR DESCRIPTION
### Jira link

HOTT-2006

### What?

I have added/removed/altered:

- [x] Enabled reporting exceptions to sentry

### Why?

I am doing this because:

- Previously we were not reporting any exceptions which resulted in the user seeing the branded 500 page

