### PR TITLE
HOTT-1368: Separate UK and XI ETL runs

### DIFF
--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -5,8 +5,6 @@ module TradeTariffBackend
       'xi' => 'EUR',
     }.freeze
 
-    STOP_WORDS_FILE = Rails.root.join('db/beta/search/stop_words.yml')
-
     def configure
       yield self
     end
@@ -238,7 +236,11 @@ module TradeTariffBackend
     end
 
     def stop_words
-      @stop_words ||= YAML.load_file(STOP_WORDS_FILE)[:stop_words]
+      @stop_words ||= YAML.load_file(stop_words_file)[:stop_words]
+    end
+
+    def stop_words_file
+      Rails.root.join('db/beta/search/stop_words.yml')
     end
 
     def handle_cascade_soft_deletes?

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,3 +1,5 @@
+<% require_relative '../app/lib/trade_tariff_backend' %>
+
 :verbose: false
 :concurrency: 10
 :queues:
@@ -26,12 +28,12 @@
     cron: "0 5 * * *"
     description: "Runs ETL of CDS files and populates indexes"
     class: UpdatesSynchronizerWorker
-    status: <% TradeTariffBackend.uk? ? 'enabled' : 'disabled' %>
+    status: <%= TradeTariffBackend.uk? ? 'enabled' : 'disabled' %>
   XIUpdatesSynchronizerWorker:
     cron: "0 0 * * *"
     description: "Runs ETL of Taric files and populates indexes"
     class: UpdatesSynchronizerWorker
-    status: <% TradeTariffBackend.xi? ? 'enabled' : 'disabled' %>
+    status: <%= TradeTariffBackend.xi? ? 'enabled' : 'disabled' %>
   HealthcheckWorker:
     every: 30.minutes
     description: Trigger the health check

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -22,9 +22,16 @@
   PopulateChangesTableWorker:
     cron: "30 4 * * *"
     description: "Populates the changes table"
-  UpdatesSynchronizerWorker:
+  UKUpdatesSynchronizerWorker:
     cron: "0 5 * * *"
-    description: "UpdatesSynchronizerWorker"
+    description: "Runs ETL of CDS files and populates indexes"
+    class: UpdatesSynchronizerWorker
+    status: <% TradeTariffBackend.uk? ? 'enabled' : 'disabled' %>
+  XIUpdatesSynchronizerWorker:
+    cron: "0 0 * * *"
+    description: "Runs ETL of Taric files and populates indexes"
+    class: UpdatesSynchronizerWorker
+    status: <% TradeTariffBackend.xi? ? 'enabled' : 'disabled' %>
   HealthcheckWorker:
     every: 30.minutes
     description: Trigger the health check


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1368

### What?

I have added/removed/altered:

- [x] Added two new schedules for an XI and a UK run with different cron configurations

### Why?

I am doing this because:

- This has been a long-standing requirement but was made important by the fact that we need to make sure that we can merge the UK/XI clusters which requires the two runs to not exhaust write limits by running at similar times.
