### PR TITLE
Avoid staging refresh collisions with xi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -549,7 +549,7 @@ workflows:
     triggers:
       - schedule:
           # Every Saturday at midnight.
-          cron: "00 00 * * 6"
+          cron: "00 23 * * 6" # Needs to not collide with xi ETL
           filters:
             branches:
               only:


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Altered the schedule for running a staging database refresh

### Why?

I am doing this because:

- To avoid collisions in the now-moved XI ETL job refresh. The refresh normally takes about 12 minutes so is well within the hour of the ETL job
