### PR TITLE
HOTT-2087: Surface hjid for all geographical areas

### DIFF
--- a/app/controllers/api/v2/geographical_areas_controller.rb
+++ b/app/controllers/api/v2/geographical_areas_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V2
     class GeographicalAreasController < ApiController
       def index
-        render json: CachedGeographicalAreaService.new(actual_date).call
+        render json: CachedGeographicalAreaService.new(actual_date, exclude_none:, countries: false).call
       end
 
       def show
@@ -10,7 +10,7 @@ module Api
       end
 
       def countries
-        render json: CachedGeographicalAreaService.new(actual_date, countries: true).call
+        render json: CachedGeographicalAreaService.new(actual_date, exclude_none:, countries: true).call
       end
 
       private
@@ -24,6 +24,10 @@ module Api
 
       def geographical_area
         GeographicalArea.actual.by_id(params[:id]).eager(:geographical_area_descriptions, :contained_geographical_areas).take
+      end
+
+      def exclude_none
+        params.fetch(:filter, {}).permit(:exclude_none).fetch(:exclude_none, false) == 'true'
       end
     end
   end

--- a/app/serializers/api/v2/geographical_area_tree_serializer.rb
+++ b/app/serializers/api/v2/geographical_area_tree_serializer.rb
@@ -7,9 +7,12 @@ module Api
 
       set_type :geographical_area
 
-      attributes :id, :description, :geographical_area_id
+      attributes :id,
+                 :description,
+                 :geographical_area_id,
+                 :hjid
 
-      has_many :contained_geographical_areas, key: :children_geographical_areas, record_type: :geographical_area, serializer: Api::V2::GeographicalAreaTreeSerializer
+      has_many :contained_geographical_areas, key: :children_geographical_areas, serializer: Api::V2::GeographicalAreaTreeSerializer
     end
   end
 end

--- a/spec/controllers/api/v2/geographical_areas_controller_spec.rb
+++ b/spec/controllers/api/v2/geographical_areas_controller_spec.rb
@@ -2,61 +2,65 @@ RSpec.describe Api::V2::GeographicalAreasController do
   before do
     Rails.cache.clear
     allow(Rails.cache).to receive(:fetch).and_call_original
+
+    country_geographical_area
+    group_geographical_area
+    region_geographical_area
+    globally_excluded_area
   end
 
-  let!(:country_geographical_area) { create(:geographical_area, :with_description, :country) }
-  let!(:group_geographical_area) { create(:geographical_area, :with_description, :group) }
-  let!(:region_geographical_area) { create(:geographical_area, :with_description, :region) }
+  let(:country_geographical_area) { create(:geographical_area, :with_description, :country) }
+  let(:group_geographical_area) { create(:geographical_area, :with_description, :group) }
+  let(:region_geographical_area) { create(:geographical_area, :with_description, :region) }
+  let(:globally_excluded_area) { create(:geographical_area, :with_description, :globally_excluded) }
 
   let(:actual_date) { Time.zone.today }
 
   describe 'GET countries' do
     subject(:do_response) { get :countries }
 
-    let(:pattern) do
-      {
-        data: [
-          { id: String, type: String, attributes: { id: String, description: String, geographical_area_id: String }, relationships: { children_geographical_areas: { data: [] } } },
-          { id: String, type: String, attributes: { id: String, description: String, geographical_area_id: String }, relationships: { children_geographical_areas: { data: [] } } },
-        ],
-        included: Array,
-      }
-    end
-
-    it { expect(do_response.body).to match_json_expression(pattern) }
-
     it { expect(do_response.body).to include(region_geographical_area.geographical_area_id) }
+    it { expect(do_response.body).to include(country_geographical_area.geographical_area_id) }
+    it { expect(do_response.body).not_to include(group_geographical_area.geographical_area_id) }
+    it { expect(do_response.body).not_to include(globally_excluded_area.geographical_area_id) }
 
     it 'caches the serialized countries' do
       do_response
 
-      expect(Rails.cache).to have_received(:fetch).with("_geographical-areas-countries-#{actual_date}", expires_in: 24.hours)
+      expect(Rails.cache).to have_received(:fetch).with("_geographical-areas-#{actual_date}-true-false", expires_in: 24.hours)
+    end
+
+    context 'when the exclude none filter is passed' do
+      subject(:do_response) { get :countries, params: { filter: { exclude_none: 'true' } } }
+
+      it { expect(do_response.body).to include(region_geographical_area.geographical_area_id) }
+      it { expect(do_response.body).to include(country_geographical_area.geographical_area_id) }
+      it { expect(do_response.body).to include(globally_excluded_area.geographical_area_id) }
+      it { expect(do_response.body).not_to include(group_geographical_area.geographical_area_id) }
+
+      it 'caches the serialized geographical_areas' do
+        do_response
+
+        expect(Rails.cache).to have_received(:fetch).with("_geographical-areas-#{actual_date}-true-true", expires_in: 24.hours)
+      end
     end
   end
 
   describe 'GET index' do
     subject(:do_response) { get :index }
 
-    let(:pattern) do
-      {
-        data: [
-          { id: String, type: String, attributes: { id: String, description: String, geographical_area_id: String }, relationships: { children_geographical_areas: { data: [] } } },
-          { id: String, type: String, attributes: { id: String, description: String, geographical_area_id: String }, relationships: { children_geographical_areas: { data: [] } } },
-          { id: String, type: String, attributes: { id: String, description: String, geographical_area_id: String }, relationships: { children_geographical_areas: { data: [] } } },
-        ],
-        included: Array,
-      }
-    end
-
-    it { expect(do_response.body).to match_json_expression(pattern) }
+    it { expect(do_response.body).to include(region_geographical_area.geographical_area_id) }
+    it { expect(do_response.body).to include(country_geographical_area.geographical_area_id) }
+    it { expect(do_response.body).to include(group_geographical_area.geographical_area_id) }
+    it { expect(do_response.body).not_to include(globally_excluded_area.geographical_area_id) }
 
     it 'caches the serialized geographical_areas' do
       do_response
 
-      expect(Rails.cache).to have_received(:fetch).with("_geographical-areas-index-#{actual_date}", expires_in: 24.hours)
+      expect(Rails.cache).to have_received(:fetch).with("_geographical-areas-#{actual_date}-false-false", expires_in: 24.hours)
     end
 
-    describe 'with children geographical areas' do
+    context 'when there are children geographical areas' do
       before do
         create(
           :geographical_area_membership,
@@ -70,105 +74,42 @@ RSpec.describe Api::V2::GeographicalAreasController do
         )
       end
 
-      let(:pattern) do
-        {
-          data: [
-            {
-              id: country_geographical_area.geographical_area_id,
-              type: 'geographical_area',
-              attributes: {
-                id: country_geographical_area.geographical_area_id,
-                description: String,
-                geographical_area_id: String,
-              },
-              relationships: {
-                children_geographical_areas: {
-                  data: [],
-                },
-              },
-            },
-            {
-              id: region_geographical_area.geographical_area_id,
-              type: 'geographical_area',
-              attributes: {
-                id: region_geographical_area.geographical_area_id,
-                description: String,
-                geographical_area_id: String,
-              },
-              relationships: {
-                children_geographical_areas: {
-                  data: [],
-                },
-              },
-            },
-            {
-              id: group_geographical_area.geographical_area_id,
-              type: 'geographical_area',
-              attributes: {
-                id: group_geographical_area.geographical_area_id,
-                description: String,
-                geographical_area_id: String,
-              },
-              relationships: {
-                children_geographical_areas: {
-                  data: [
-                    {
-                      id: country_geographical_area.geographical_area_id,
-                      type: 'geographical_area',
-                    },
-                    {
-                      id: region_geographical_area.geographical_area_id,
-                      type: 'geographical_area',
-                    },
-                  ],
-                },
-              },
-            },
-          ],
-          included: [
-            {
-              id: country_geographical_area.geographical_area_id,
-              type: 'geographical_area',
-              attributes: {
-                id: country_geographical_area.geographical_area_id,
-                description: String,
-                geographical_area_id: String,
-              },
-              relationships: Hash,
-            },
-            {
-              id: region_geographical_area.geographical_area_id,
-              type: 'geographical_area',
-              attributes: {
-                id: region_geographical_area.geographical_area_id,
-                description: String,
-                geographical_area_id: String,
-              },
-              relationships: Hash,
-            },
-          ],
-        }
-      end
+      it 'returns the correct contained areas' do
+        geographical_area_group = JSON.parse(do_response.body)['data'].find { |area| area['id'] == '1011' }
 
-      it { expect(do_response.body).to match_json_expression(pattern) }
+        actual_children_geographical_areas = geographical_area_group
+          .dig('relationships', 'children_geographical_areas', 'data')
+          .pluck('id')
+          .sort
+
+        expected_children_geographical_areas = [
+          country_geographical_area.geographical_area_id,
+          region_geographical_area.geographical_area_id,
+        ].sort
+
+        expect(actual_children_geographical_areas).to eq(expected_children_geographical_areas)
+      end
+    end
+
+    context 'when the exclude none filter is passed' do
+      subject(:do_response) { get :index, params: { filter: { exclude_none: 'true' } } }
+
+      it { expect(do_response.body).to include(region_geographical_area.geographical_area_id) }
+      it { expect(do_response.body).to include(country_geographical_area.geographical_area_id) }
+      it { expect(do_response.body).to include(globally_excluded_area.geographical_area_id) }
+      it { expect(do_response.body).to include(group_geographical_area.geographical_area_id) }
+
+      it 'caches the serialized geographical_areas' do
+        do_response
+
+        expect(Rails.cache).to have_received(:fetch).with("_geographical-areas-#{actual_date}-false-true", expires_in: 24.hours)
+      end
     end
   end
 
   describe 'GET show' do
     subject(:do_response) { get :show, params: { id: country_geographical_area.geographical_area_id } }
 
-    let(:pattern) do
-      {
-        data: {
-          id: String,
-          type: String,
-          attributes: { id: String, description: String, geographical_area_id: String },
-          relationships: { children_geographical_areas: { data: [] } },
-        },
-        included: Array,
-      }
-    end
-
-    it { expect(do_response.body).to match_json_expression(pattern) }
+    it { expect(do_response.body).to include(country_geographical_area.geographical_area_id) }
   end
 end

--- a/spec/factories/geographical_area_factory.rb
+++ b/spec/factories/geographical_area_factory.rb
@@ -18,6 +18,12 @@ FactoryBot.define do
 
     trait :group do
       geographical_code { '1' }
+      geographical_area_id { '1011' }
+    end
+
+    trait :globally_excluded do
+      country
+      geographical_area_id { 'EU' }
     end
 
     trait :with_members do

--- a/spec/serializers/api/v2/geographical_area_tree_serializer_spec.rb
+++ b/spec/serializers/api/v2/geographical_area_tree_serializer_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Api::V2::GeographicalAreaTreeSerializer do
+  describe '#serializable_hash' do
+    subject(:serializable_hash) { described_class.new(serializable).serializable_hash }
+
+    let(:serializable) { create(:geographical_area, geographical_area_id: 'IT', hjid: '12312') }
+
+    let(:expected) do
+      {
+        data: {
+          id: 'IT',
+          type: eq(:geographical_area),
+          attributes: {
+            description: be_present,
+            hjid: 12_312,
+            geographical_area_id: 'IT',
+          },
+        },
+      }
+    end
+
+    it { is_expected.to include_json(expected) }
+  end
+end

--- a/spec/services/cached_geographical_area_service_spec.rb
+++ b/spec/services/cached_geographical_area_service_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe CachedGeographicalAreaService do
       end
 
       it 'uses the correct cache key' do
-        expected_key = "_geographical-areas-countries-#{actual_date}"
+        expected_key = "_geographical-areas-#{actual_date}-true-false"
         service.call
         expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 24.hours)
       end
@@ -68,7 +68,7 @@ RSpec.describe CachedGeographicalAreaService do
       end
 
       it 'uses the correct cache key' do
-        expected_key = "_geographical-areas-index-#{actual_date}"
+        expected_key = "_geographical-areas-#{actual_date}-false-false"
         service.call
         expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 24.hours)
       end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2087

### What?

I have added/removed/altered:

- [x] Adds globally-excluded geographical area factory trait
- [x] Enable no exclusions in cached_geographical_area_service
- [x] Pass exclude_none filter to service
- [x] Adds hjid to geo area serializer
- [x] Adds missing spec for serializer
- [x] Adds exclude_none behaviour checks

### Why?

I am doing this because:

We need this to automate the pipeline for providing XLSX files for HMRC (amongst other people).

- When the file includes a membership in the UK CDS file we need to be able to look up the description by the hjid.
- When the file includes memberships for excluded geographical areas we still want to show these in the file
