### PR TITLE
HOTT-2043: Handle empty search query

### DIFF
--- a/app/models/beta/search/search_query_parser_result.rb
+++ b/app/models/beta/search/search_query_parser_result.rb
@@ -12,7 +12,7 @@ module Beta
                     :noun_chunks,
                     :original_search_query,
                     :corrected_search_query,
-                    :synonym_result
+                    :null_result
 
       class Standard
         def self.build(attributes)
@@ -26,13 +26,13 @@ module Beta
           search_query_parser_result.nouns = attributes.dig('tokens', 'nouns')
           search_query_parser_result.verbs = attributes.dig('tokens', 'verbs')
           search_query_parser_result.noun_chunks = attributes.dig('tokens', 'noun_chunks')
-          search_query_parser_result.synonym_result = false
+          search_query_parser_result.null_result = false
 
           search_query_parser_result
         end
       end
 
-      class Synonym
+      class Null
         def self.build(attributes)
           search_query_parser_result = SearchQueryParserResult.new
 
@@ -42,7 +42,7 @@ module Beta
           search_query_parser_result.nouns = []
           search_query_parser_result.verbs = []
           search_query_parser_result.noun_chunks = [attributes['original_search_query']]
-          search_query_parser_result.synonym_result = true
+          search_query_parser_result.null_result = true
 
           search_query_parser_result
         end

--- a/app/serializers/api/beta/search_query_parser_result_serializer.rb
+++ b/app/serializers/api/beta/search_query_parser_result_serializer.rb
@@ -11,7 +11,7 @@ module Api
                  :adjectives,
                  :nouns,
                  :noun_chunks,
-                 :synonym_result
+                 :null_result
     end
   end
 end

--- a/app/services/api/beta/search_query_parser_service.rb
+++ b/app/services/api/beta/search_query_parser_service.rb
@@ -8,8 +8,8 @@ module Api
       end
 
       def call
-        if AggregatedSynonym.exists?(@original_search_query)
-          ::Beta::Search::SearchQueryParserResult::Synonym.build('original_search_query' => @original_search_query)
+        if null_result?
+          ::Beta::Search::SearchQueryParserResult::Null.build('original_search_query' => @original_search_query)
         else
           result_attributes = client.get('tokens', q: @original_search_query).body
 
@@ -22,6 +22,12 @@ module Api
           conn.response :raise_error
           conn.response :json
         end
+      end
+
+      private
+
+      def null_result?
+        @original_search_query.blank? || AggregatedSynonym.exists?(@original_search_query)
       end
     end
   end

--- a/spec/factories/search_query_parser_result_factory.rb
+++ b/spec/factories/search_query_parser_result_factory.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
     noun_chunks { ['halibut sausage stenolepis cheese binocular parsnip pharmacy paper'] }
     original_search_query { 'halbiut sausadge stenolepsis chese bnoculars parnsip farmacy pape' }
     corrected_search_query { 'halibut sausage stenolepis cheese binocular parsnip pharmacy paper' }
-    synonym_result { false }
+    null_result { false }
 
     trait :no_hits do
       original_search_query { 'flibble' }
@@ -77,7 +77,7 @@ FactoryBot.define do
       noun_chunks { ['yakutian laika'] }
       nouns { %w[] }
       verbs { [] }
-      synonym_result { true }
+      null_result { true }
     end
   end
 end

--- a/spec/factories/search_result_factory.rb
+++ b/spec/factories/search_result_factory.rb
@@ -125,7 +125,7 @@ FactoryBot.define do
       search_result = JSON.parse(File.read(fixture_filename))
       presented_search_result = Hashie::TariffMash.new(search_result)
 
-      search_result = Beta::Search::OpenSearchResult.build(
+      search_result = Beta::Search::OpenSearchResult::WithHits.build(
         presented_search_result,
         search_query_parser_result,
         goods_nomenclature_query || build(:goods_nomenclature_query),

--- a/spec/fixtures/beta/search/goods_nomenclatures/serialized_result.json
+++ b/spec/fixtures/beta/search/goods_nomenclatures/serialized_result.json
@@ -174,7 +174,7 @@
         "noun_chunks": [
           "ricotta"
         ],
-        "synonym_result": false
+        "null_result": false
       }
     },
     {

--- a/spec/models/beta/search/open_search_result/no_hits_spec.rb
+++ b/spec/models/beta/search/open_search_result/no_hits_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Beta::Search::OpenSearchResult::NoHits do
+  describe '.build' do
+    subject(:result) { described_class.build(nil, search_query_parser_result, goods_nomenclature_query) }
+
+    let(:search_query_parser_result) { build(:search_query_parser_result, :multiple_hits) }
+    let(:goods_nomenclature_query) { build(:goods_nomenclature_query, :full_query) }
+
+    it { is_expected.to be_a(Beta::Search::OpenSearchResult) }
+    it { expect(result.took).to eq(0) }
+    it { expect(result.timed_out).to eq(false) }
+    it { expect(result.max_score).to eq(0) }
+    it { expect(result.hits.count).to eq(0) }
+    it { expect(result.search_query_parser_result).to eq(search_query_parser_result) }
+    it { expect(result.goods_nomenclature_query).to eq(goods_nomenclature_query) }
+    it { expect(result.id).to eq('') }
+    it { expect(result.empty_query).to be(false) }
+  end
+end

--- a/spec/models/beta/search/open_search_result/no_hits_spec.rb
+++ b/spec/models/beta/search/open_search_result/no_hits_spec.rb
@@ -13,6 +13,6 @@ RSpec.describe Beta::Search::OpenSearchResult::NoHits do
     it { expect(result.search_query_parser_result).to eq(search_query_parser_result) }
     it { expect(result.goods_nomenclature_query).to eq(goods_nomenclature_query) }
     it { expect(result.id).to eq('7c8d5ef8ab9c93729b100e871ed69f33') }
-    it { expect(result.empty_query).to be(false) }
+    it { expect(result.empty_query).to be(true) }
   end
 end

--- a/spec/models/beta/search/open_search_result/no_hits_spec.rb
+++ b/spec/models/beta/search/open_search_result/no_hits_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Beta::Search::OpenSearchResult::NoHits do
     it { expect(result.hits.count).to eq(0) }
     it { expect(result.search_query_parser_result).to eq(search_query_parser_result) }
     it { expect(result.goods_nomenclature_query).to eq(goods_nomenclature_query) }
-    it { expect(result.id).to eq('') }
+    it { expect(result.id).to eq('7c8d5ef8ab9c93729b100e871ed69f33') }
     it { expect(result.empty_query).to be(false) }
   end
 end

--- a/spec/models/beta/search/open_search_result/with_hits_spec.rb
+++ b/spec/models/beta/search/open_search_result/with_hits_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Beta::Search::OpenSearchResult::WithHits do
+  describe '.build' do
+    subject(:result) { described_class.build(search_result, search_query_parser_result, goods_nomenclature_query) }
+
+    let(:search_result) do
+      fixture = file_fixture('beta/search/goods_nomenclatures/multiple_hits.json')
+
+      Hashie::TariffMash.new(JSON.parse(fixture.read))
+    end
+
+    let(:search_query_parser_result) { build(:search_query_parser_result, :multiple_hits) }
+    let(:goods_nomenclature_query) { build(:goods_nomenclature_query, :full_query) }
+
+    it { is_expected.to be_a(Beta::Search::OpenSearchResult) }
+    it { expect(result).to respond_to(:took) }
+    it { expect(result.timed_out).to eq(false) }
+    it { expect(result).to respond_to(:max_score) }
+    it { expect(result.hits.count).to eq(10) }
+    it { expect(result.search_query_parser_result).to eq(search_query_parser_result) }
+    it { expect(result.goods_nomenclature_query).to eq(goods_nomenclature_query) }
+    it { expect(result.id).to eq('773f19eb133e44c7b88f87902b3e557a') }
+  end
+end

--- a/spec/models/beta/search/open_search_result/with_hits_spec.rb
+++ b/spec/models/beta/search/open_search_result/with_hits_spec.rb
@@ -19,5 +19,6 @@ RSpec.describe Beta::Search::OpenSearchResult::WithHits do
     it { expect(result.search_query_parser_result).to eq(search_query_parser_result) }
     it { expect(result.goods_nomenclature_query).to eq(goods_nomenclature_query) }
     it { expect(result.id).to eq('773f19eb133e44c7b88f87902b3e557a') }
+    it { expect(result.empty_query).to be(false) }
   end
 end

--- a/spec/models/beta/search/open_search_result_spec.rb
+++ b/spec/models/beta/search/open_search_result_spec.rb
@@ -1,31 +1,4 @@
 RSpec.describe Beta::Search::OpenSearchResult do
-  describe '.build' do
-    subject(:result) { described_class.build(search_result, search_query_parser_result, goods_nomenclature_query) }
-
-    let(:search_result) do
-      fixture = file_fixture('beta/search/goods_nomenclatures/multiple_hits.json')
-
-      Hashie::TariffMash.new(JSON.parse(fixture.read))
-    end
-
-    let(:search_query_parser_result) { build(:search_query_parser_result, :multiple_hits) }
-    let(:goods_nomenclature_query) { build(:goods_nomenclature_query, :full_query) }
-
-    it { is_expected.to be_a(described_class) }
-    it { expect(result).to respond_to(:took) }
-    it { expect(result.timed_out).to eq(false) }
-    it { expect(result).to respond_to(:max_score) }
-    it { expect(result.hits.count).to eq(10) }
-    it { expect(result.search_query_parser_result).to eq(search_query_parser_result) }
-    it { expect(result.goods_nomenclature_query).to eq(goods_nomenclature_query) }
-  end
-
-  describe '#id' do
-    subject(:id) { build(:search_result).id }
-
-    it { is_expected.to eq('773f19eb133e44c7b88f87902b3e557a') }
-  end
-
   describe '#search_query_parser_result_id' do
     subject(:search_query_parser_result_id) { build(:search_result).search_query_parser_result_id }
 

--- a/spec/models/beta/search/search_query_parser_result/null_spec.rb
+++ b/spec/models/beta/search/search_query_parser_result/null_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Beta::Search::SearchQueryParserResult::Synonym do
+RSpec.describe Beta::Search::SearchQueryParserResult::Null do
   describe '.build' do
     subject(:result) { described_class.build(attributes) }
 

--- a/spec/serializers/api/beta/search_query_parser_result_serializer_spec.rb
+++ b/spec/serializers/api/beta/search_query_parser_result_serializer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Api::Beta::SearchQueryParserResultSerializer do
             adjectives: [],
             nouns: %w[halibut sausage stenolepis cheese binocular parsnip pharmacy paper],
             noun_chunks: ['halibut sausage stenolepis cheese binocular parsnip pharmacy paper'],
-            synonym_result: false,
+            null_result: false,
           },
         },
       }

--- a/spec/services/api/beta/search_query_parser_service_spec.rb
+++ b/spec/services/api/beta/search_query_parser_service_spec.rb
@@ -7,7 +7,19 @@ RSpec.describe Api::Beta::SearchQueryParserService do
     context 'when the search query matches a known synonym' do
       subject(:result) { described_class.new('yakutian laika').call }
 
-      it { expect(result.synonym_result).to eq(true) }
+      it { expect(result.null_result).to eq(true) }
+    end
+
+    context 'when the search query is empty' do
+      subject(:result) { described_class.new('').call }
+
+      it { expect(result.null_result).to eq(true) }
+    end
+
+    context 'when the search query is nil' do
+      subject(:result) { described_class.new(nil).call }
+
+      it { expect(result.null_result).to eq(true) }
     end
 
     context 'when the search query parser response is success' do
@@ -39,7 +51,7 @@ RSpec.describe Api::Beta::SearchQueryParserService do
       it { expect(result.noun_chunks).to eq(%w[aaa bib]) }
       it { expect(result.nouns).to eq(%w[aaa bib]) }
       it { expect(result.verbs).to eq([]) }
-      it { expect(result.synonym_result).to eq(false) }
+      it { expect(result.null_result).to eq(false) }
     end
 
     context 'when the search query parser response is bad request' do

--- a/spec/services/api/beta/search_service_spec.rb
+++ b/spec/services/api/beta/search_service_spec.rb
@@ -1,94 +1,100 @@
 RSpec.describe Api::Beta::SearchService do
   # rubocop:disable RSpec/MultipleMemoizedHelpers
   describe '#call' do
-    subject(:call) { described_class.new('ricotta').call }
+    subject(:call) { described_class.new(search_query).call }
 
-    before do
-      allow(TradeTariffBackend.v2_search_client).to receive(:search).and_return(search_result)
-      allow(Api::Beta::SearchQueryParserService).to receive(:new).and_return(search_query_parser_service)
-      allow(Api::Beta::GoodsNomenclatureFilterGeneratorService).to receive(:new).and_call_original
-      allow(Beta::Search::GoodsNomenclatureQuery).to receive(:build).and_return(goods_nomenclature_query)
-      allow(Beta::Search::OpenSearchResult).to receive(:build).and_call_original
+    context 'when the search query is an empty string' do
+      let(:search_query) { '' }
 
-      call
+      it { expect(call.empty_query).to eq(true) }
     end
 
-    let(:search_result) do
-      fixture_file = file_fixture('beta/search/goods_nomenclatures/single_hit.json')
-
-      Hashie::TariffMash.new(JSON.parse(fixture_file.read))
-    end
-
-    let(:search_query_parser_service) { instance_double('Api::Beta::SearchQueryParserService', call: search_query_parser_result) }
-    let(:search_query_parser_result) { build(:search_query_parser_result, :single_hit) }
-    let(:goods_nomenclature_query) { build(:goods_nomenclature_query, :single_hit) }
-
-    let(:expected_search_args) do
-      {
-        body: {
-          size: '10',
-          query: {
-            bool: {
-              must: [
-                {
-                  multi_match: {
-                    fields: [
-                      'search_references^12',
-                      'ancestor_1_description_indexed^10',
-                      'ancestor_2_description_indexed^8',
-                      'description_indexed^6',
-                      'ancestor_3_description_indexed^4',
-                      'ancestor_4_description_indexed^4',
-                      'ancestor_5_description_indexed^4',
-                      'ancestor_6_description_indexed^4',
-                      'ancestor_7_description_indexed^4',
-                      'ancestor_8_description_indexed^4',
-                      'ancestor_9_description_indexed^4',
-                      'ancestor_10_description_indexed^4',
-                      'ancestor_11_description_indexed^4',
-                      'ancestor_12_description_indexed^4',
-                      'ancestor_13_description_indexed^4',
-                      'goods_nomenclature_item_id',
-                    ],
-                    fuzziness: 0.1,
-                    prefix_length: 2,
-                    query: 'ricotta',
-                    tie_breaker: 0.3,
-                    type: 'best_fields',
-                  },
-                },
-              ],
-            },
-          },
-        },
-        index: 'tariff-test-goods_nomenclatures-uk',
-      }
-    end
-
-    let(:expected_serialized_result) do
-      fixture_file = file_fixture('beta/search/goods_nomenclatures/serialized_result.json')
-
-      JSON.parse(fixture_file.read)
-    end
-
-    it { expect(Api::Beta::SearchQueryParserService).to have_received(:new).with('ricotta') }
-    it { expect(TradeTariffBackend.v2_search_client).to have_received(:search).with(expected_search_args) }
-    it { expect(Beta::Search::OpenSearchResult).to have_received(:build).with(search_result, search_query_parser_result, goods_nomenclature_query) }
-    it { expect(Beta::Search::GoodsNomenclatureQuery).to have_received(:build).with(search_query_parser_result, {}) }
-    it { expect(call).to be_a(Beta::Search::OpenSearchResult) }
-
-    context 'when the search result has no hits and the query is numeric' do
-      subject(:call) { described_class.new('0101').call }
-
-      let(:goods_nomenclature_query) { build(:goods_nomenclature_query, :numeric) }
-
+    context 'when the search query is `ricotta`' do
+      let(:search_query) { 'ricotta' }
       let(:search_result) do
-        fixture_file = file_fixture('beta/search/goods_nomenclatures/no_hits.json')
+        fixture_file = file_fixture('beta/search/goods_nomenclatures/single_hit.json')
 
         Hashie::TariffMash.new(JSON.parse(fixture_file.read))
       end
+      let(:search_query_parser_service) { instance_double('Api::Beta::SearchQueryParserService', call: search_query_parser_result) }
+      let(:search_query_parser_result) { build(:search_query_parser_result, :single_hit) }
+      let(:goods_nomenclature_query) { build(:goods_nomenclature_query, :single_hit) }
+      let(:expected_search_args) do
+        {
+          body: {
+            size: '10',
+            query: {
+              bool: {
+                must: [
+                  {
+                    multi_match: {
+                      fields: [
+                        'search_references^12',
+                        'ancestor_1_description_indexed^10',
+                        'ancestor_2_description_indexed^8',
+                        'description_indexed^6',
+                        'ancestor_3_description_indexed^4',
+                        'ancestor_4_description_indexed^4',
+                        'ancestor_5_description_indexed^4',
+                        'ancestor_6_description_indexed^4',
+                        'ancestor_7_description_indexed^4',
+                        'ancestor_8_description_indexed^4',
+                        'ancestor_9_description_indexed^4',
+                        'ancestor_10_description_indexed^4',
+                        'ancestor_11_description_indexed^4',
+                        'ancestor_12_description_indexed^4',
+                        'ancestor_13_description_indexed^4',
+                        'goods_nomenclature_item_id',
+                      ],
+                      fuzziness: 0.1,
+                      prefix_length: 2,
+                      query: 'ricotta',
+                      tie_breaker: 0.3,
+                      type: 'best_fields',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+          index: 'tariff-test-goods_nomenclatures-uk',
+        }
+      end
+      let(:expected_serialized_result) do
+        fixture_file = file_fixture('beta/search/goods_nomenclatures/serialized_result.json')
 
-      it { is_expected.to be_redirect }
+        JSON.parse(fixture_file.read)
+      end
+
+      before do
+        allow(TradeTariffBackend.v2_search_client).to receive(:search).and_return(search_result)
+        allow(Api::Beta::SearchQueryParserService).to receive(:new).and_return(search_query_parser_service)
+        allow(Api::Beta::GoodsNomenclatureFilterGeneratorService).to receive(:new).and_call_original
+        allow(Beta::Search::GoodsNomenclatureQuery).to receive(:build).and_return(goods_nomenclature_query)
+        allow(Beta::Search::OpenSearchResult::WithHits).to receive(:build).and_call_original
+
+        call
+      end
+
+      it { expect(Api::Beta::SearchQueryParserService).to have_received(:new).with('ricotta') }
+      it { expect(TradeTariffBackend.v2_search_client).to have_received(:search).with(expected_search_args) }
+      it { expect(Beta::Search::OpenSearchResult::WithHits).to have_received(:build).with(search_result, search_query_parser_result, goods_nomenclature_query) }
+      it { expect(Beta::Search::GoodsNomenclatureQuery).to have_received(:build).with(search_query_parser_result, {}) }
+      it { expect(call).to be_a(Beta::Search::OpenSearchResult) }
+
+      context 'when the search result has no hits and the query is numeric' do
+        subject(:call) { described_class.new('0101').call }
+
+        let(:goods_nomenclature_query) { build(:goods_nomenclature_query, :numeric) }
+
+        let(:search_result) do
+          fixture_file = file_fixture('beta/search/goods_nomenclatures/no_hits.json')
+
+          Hashie::TariffMash.new(JSON.parse(fixture_file.read))
+        end
+
+        it { is_expected.to be_redirect }
+      end
     end
   end
   # rubocop:enable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2043

### What?

I have added/removed/altered:

- [x] Adds support for empty search result which bypasses both the tokenisation and the search and returns a NoHits result
- [x] Adds specs for the above
- [x] Rename Synonym tokenisation result to Null

### Why?

I am doing this because:

- This is required to avoid doing a large uncapped query against the cluster
