### PR TITLE
HOTT-2127 Added Solomon Islands to Pacific treaty

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk.json
+++ b/db/rules_of_origin/roo_schemes_uk.json
@@ -3328,6 +3328,7 @@
             "countries": [
                 "FJ",
                 "PG",
+                "SB",
                 "WS"
             ]
         },


### PR DESCRIPTION
### Jira link

HOTT-2127

### What?

I have added/removed/altered:

- [x] Added Solomon Islands (SB) to the Pacific treaty

### Why?

I am doing this because:

- Solomon islands is party to that treaty and rules of origin should reflect that

### Deployment risks (optional)

- Low risk

### Before without wizard

![Screenshot from 2022-10-14 11-25-23](https://user-images.githubusercontent.com/10818/195825849-640aa2c5-72d3-4660-bf41-925c5e75abdc.png)

### After with wizard

![Screenshot from 2022-10-14 11-26-25](https://user-images.githubusercontent.com/10818/195825763-c01113bf-3a72-4407-991d-2f70b12a9113.png)

### After without wizard

![image](https://user-images.githubusercontent.com/10818/195824913-b4ba4739-0714-46cb-8dcc-3bbd4a2f44d3.png)
