### PR TITLE
HOTT-2120 Run RoO data specs in CI if data changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,6 +398,19 @@ jobs:
           command: |
             curl "http://localhost:9200/_cat/health"
       - ruby/rspec-test
+      - run:
+          name: Test Rules of Origin data files
+          command: |
+            if [ -z `git diff --name-only $(git merge-base main HEAD)..HEAD -- db/rules_of_origin` ]; then
+              echo "Skipping data checks - Rules of origin data unchanged"
+            else
+              bundle exec rspec --tag=roo_data \
+                                --format RspecJunitFormatter \
+                                --out /tmp/test-results/roo_data/results.xml \
+                                --format progress
+            fi
+      - store_test_results:
+          path: /tmp/test-results/roo_data
       - store_artifacts:
           path: coverage
       - slack/notify:


### PR DESCRIPTION
### Jira link

HOTT-2120

### What?

I have added/removed/altered:

- [x] Added a CI step to run the Roo Data specs if the `db/rules_of_origin` folder changes

### Why?

I am doing this because:

- We have data specs but they are slow to run so are disabled by default.
- The data specs are hidden behind a RSpec tag which makes them quite undiscoverable and a developer just updating the files might not realise they should be run when the data changes
- Automating this solves both problems

### Deployment risks (optional)

- None - only affects CI runs
