### PR TITLE
HOTT-2154: Support simpler single classifications per facet

### DIFF
--- a/app/models/beta/search/facet_classification.rb
+++ b/app/models/beta/search/facet_classification.rb
@@ -23,11 +23,12 @@ module Beta
                   # This means we skip assigning classifications for facets that have
                   # previously been assigned lower down the tree or description.
                   encountered_facet = classifications[facet].except(gn.goods_nomenclature_sid).any?
+                  encountered_classification = classifications[facet][gn.goods_nomenclature_sid].present?
 
                   next if encountered_facet
+                  next if encountered_classification
 
-                  classifications[facet][gn.goods_nomenclature_sid] ||= Set.new
-                  classifications[facet][gn.goods_nomenclature_sid] << classification
+                  classifications[facet][gn.goods_nomenclature_sid] = classification
                 end
               end
             end

--- a/app/serializers/search/goods_nomenclature_serializer.rb
+++ b/app/serializers/search/goods_nomenclature_serializer.rb
@@ -124,10 +124,8 @@ module Search
     end
 
     def serializable_classifications
-      facet_classification.classifications.each_with_object({}) do |(facet, classification_values), acc|
-        classification_values = classification_values.sort.join('|')
-
-        acc["filter_#{facet}".to_sym] = classification_values
+      facet_classification.classifications.each_with_object({}) do |(facet, classification_value), acc|
+        acc["filter_#{facet}".to_sym] = classification_value
       end
     end
 

--- a/app/services/api/beta/goods_nomenclature_filter_generator_service.rb
+++ b/app/services/api/beta/goods_nomenclature_filter_generator_service.rb
@@ -30,32 +30,12 @@ module Api
       end
 
       def dynamic_filter_for(filter, term)
-        terms = all_classification_permutations_for(filter, term)
-
         {
-          terms: {
-            "filter_#{filter}".to_sym => terms,
+          term: {
+            "filter_#{filter}".to_sym => term,
             boost: boost_for(filter),
           },
         }
-      end
-
-      def all_classification_permutations_for(filter, target_classification)
-        classifications = TradeTariffBackend
-          .search_facet_classifier_configuration
-          .facet_classifiers[filter].to_a
-
-        classifications -= [target_classification]
-
-        terms = []
-
-        classifications.length.downto(0) do
-          term = classifications.dup.concat([target_classification]).sort.join('|')
-          terms << term
-          classifications.pop
-        end
-
-        terms
       end
 
       def static_filter?(filter)

--- a/app/services/api/beta/goods_nomenclature_token_generator_service.rb
+++ b/app/services/api/beta/goods_nomenclature_token_generator_service.rb
@@ -3,7 +3,7 @@ module Api
     # Generates tokens which are classified later to indicate facet categories the current
     # goods nomenclature belongs too.
     #
-    # This includes phrase tokens and word tokens that have been lemmatized and the stop words removed
+    # This includes phrase tokens and word tokens that have been lemmatized and the stop words removed.
     class GoodsNomenclatureTokenGeneratorService
       delegate :lemmatizer, :stop_words, to: TradeTariffBackend
 
@@ -21,7 +21,7 @@ module Api
           all_tokens << phrase if candidate_description.include?(phrase)
         end
 
-        candidate_tokens = candidate_description.split(WHITESPACE)
+        candidate_tokens = candidate_description.split(WHITESPACE).reverse
 
         candidate_tokens.each do |candidate_token|
           candidate_token = candidate_token.gsub(/\W+/, '')

--- a/spec/models/beta/search/facet_classification/declarable_spec.rb
+++ b/spec/models/beta/search/facet_classification/declarable_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Beta::Search::FacetClassification::Declarable do
 
     let(:expected_classifications) do
       {
-        'animal_product_state' => Set.new(%w[live]),
-        'animal_type' => Set.new(['equine animals']),
+        'animal_product_state' => 'live',
+        'animal_type' => 'equine animals',
       }
     end
 

--- a/spec/models/beta/search/goods_nomenclature_query_spec.rb
+++ b/spec/models/beta/search/goods_nomenclature_query_spec.rb
@@ -232,13 +232,8 @@ RSpec.describe Beta::Search::GoodsNomenclatureQuery do
                 bool: {
                   must: [
                     {
-                      terms: {
-                        filter_cheese_type: [
-                          'containing veins produced by Penicillium roqueforti|fresh|grated or powdered|processed',
-                          'fresh|grated or powdered|processed',
-                          'fresh|processed',
-                          'fresh',
-                        ],
+                      term: {
+                        filter_cheese_type: 'fresh',
                         boost: 1,
                       },
                     },

--- a/spec/services/api/beta/goods_nomenclature_filter_generator_service_spec.rb
+++ b/spec/services/api/beta/goods_nomenclature_filter_generator_service_spec.rb
@@ -30,16 +30,9 @@ RSpec.describe Api::Beta::GoodsNomenclatureFilterGeneratorService do
       let(:expected_filters) do
         [
           {
-            terms: {
+            term: {
               boost: 1,
-              filter_animal_product_state: [
-                'chilled|dried, salted, smoked or in brine|fresh|frozen|live|prepared or preserved',
-                'chilled|dried, salted, smoked or in brine|fresh|frozen|live',
-                'chilled|fresh|frozen|live',
-                'chilled|fresh|live',
-                'fresh|live',
-                'live',
-              ],
+              filter_animal_product_state: 'live',
             },
           },
         ]
@@ -58,9 +51,9 @@ RSpec.describe Api::Beta::GoodsNomenclatureFilterGeneratorService do
       let(:expected_filters) do
         [
           {
-            terms: {
+            term: {
               boost: 10,
-              filter_entity: Array,
+              filter_entity: 'live animal',
             },
           },
         ]

--- a/spec/services/api/beta/goods_nomenclature_token_generator_service_spec.rb
+++ b/spec/services/api/beta/goods_nomenclature_token_generator_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Api::Beta::GoodsNomenclatureTokenGeneratorService do
       let(:goods_nomenclature) { create(:commodity, :with_description, :stop_words_description) } # Live animals with some stop words
 
       it 'removes the stop words' do
-        expected_tokens = %w[live animal]
+        expected_tokens = %w[animal live]
 
         expect(call).to eq(expected_tokens)
       end
@@ -16,7 +16,7 @@ RSpec.describe Api::Beta::GoodsNomenclatureTokenGeneratorService do
       let(:goods_nomenclature) { create(:commodity, :with_description, :special_chars_description) } # Live#~#? (animals,) $* £' '
 
       it 'removes special characters' do
-        expected_tokens = %w[live animal]
+        expected_tokens = %w[animal live]
 
         expect(call).to eq(expected_tokens)
       end
@@ -26,7 +26,7 @@ RSpec.describe Api::Beta::GoodsNomenclatureTokenGeneratorService do
       let(:goods_nomenclature) { create(:commodity, :with_description, :negated_description) } # Live animals, other than cheese
 
       it 'removes the negated words' do
-        expected_tokens = %w[live animal]
+        expected_tokens = %w[animal live]
 
         expect(call).to eq(expected_tokens)
       end
@@ -36,7 +36,7 @@ RSpec.describe Api::Beta::GoodsNomenclatureTokenGeneratorService do
       let(:goods_nomenclature) { create(:commodity, :with_description, :word_phrase) } # 2 LiTres Or Less
 
       it 'returns the word phrase as a token' do
-        expected_tokens = ['2 litres or less', '2', 'litre']
+        expected_tokens = ['2 litres or less', 'litre', '2']
 
         expect(call).to eq(expected_tokens)
       end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2154

### What?

We used to accumulate multiple classifications for a given goods nomenclature for each level we go up the tree.

This isn't actually helpful as the only thing we're interested in classifying are things we can trade which have single (and therefore specific) classifications.

I have added/removed/altered:

- [x] Added support for simpler/singular classifications
- [x] Updated specs to reflect change

### Why?

I am doing this because:

- We only care about low-down and specific search results for specific declarables
- This actually matches Matt's implementation and is less clever by half.
