### PR TITLE
HOTT-2048: Exposed API endpoints needed for measure_type page

### DIFF
--- a/app/controllers/api/v2/measure_types_controller.rb
+++ b/app/controllers/api/v2/measure_types_controller.rb
@@ -6,6 +6,14 @@ module Api
 
         render json: Api::V2::Measures::MeasureTypeSerializer.new(@measure_types).serializable_hash
       end
+
+      def show
+        measure_type = MeasureType.where(measure_type_id: params[:id]).take
+
+        serializer = Api::V2::Measures::MeasureTypeSerializer.new(measure_type)
+
+        render json: serializer.serializable_hash
+      end
     end
   end
 end

--- a/app/controllers/api/v2/preference_codes_controller.rb
+++ b/app/controllers/api/v2/preference_codes_controller.rb
@@ -10,6 +10,14 @@ module Api
           end
         end
       end
+
+      def show
+        preference_code = PreferenceCode[params[:id]]
+
+        serializer = Api::V2::PreferenceCodeSerializer.new(preference_code)
+
+        render json: serializer.serializable_hash
+      end
     end
   end
 end

--- a/app/controllers/api/v2/preference_codes_controller.rb
+++ b/app/controllers/api/v2/preference_codes_controller.rb
@@ -14,6 +14,8 @@ module Api
       def show
         preference_code = PreferenceCode[params[:id]]
 
+        raise Sequel::RecordNotFound unless preference_code
+
         serializer = Api::V2::PreferenceCodeSerializer.new(preference_code)
 
         render json: serializer.serializable_hash

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,7 +112,7 @@ Rails.application.routes.draw do
         collection { get :countries }
       end
 
-      resources :preference_codes, only: [:index]
+      resources :preference_codes, only: %i[index show]
 
       resources :monetary_exchange_rates, only: [:index]
 
@@ -135,7 +135,7 @@ Rails.application.routes.draw do
       resources :measure_actions, only: %i[index]
       resources :measure_condition_codes, only: %i[index]
       resources :quota_order_numbers, only: %i[index]
-      resources :measure_types, only: %i[index]
+      resources :measure_types, only: %i[index show]
 
       resources :additional_codes, only: [] do
         collection { get :search }

--- a/spec/controllers/api/v2/measure_types_controller_spec.rb
+++ b/spec/controllers/api/v2/measure_types_controller_spec.rb
@@ -48,6 +48,8 @@ RSpec.describe Api::V2::MeasureTypesController, type: :controller do
       let(:measure_type) { create(:measure_type, :with_measure_type_series_description) }
 
       it { expect(do_request.body).to match_json_expression pattern }
+
+      it { is_expected.to have_http_status :success }
     end
 
     context 'when records are not present' do
@@ -61,6 +63,8 @@ RSpec.describe Api::V2::MeasureTypesController, type: :controller do
       end
 
       it { expect(do_request.body).to match_json_expression pattern }
+
+      it { is_expected.to have_http_status :not_found }
     end
   end
 end

--- a/spec/controllers/api/v2/measure_types_controller_spec.rb
+++ b/spec/controllers/api/v2/measure_types_controller_spec.rb
@@ -26,4 +26,41 @@ RSpec.describe Api::V2::MeasureTypesController, type: :controller do
       expect(TimeMachine).to have_received(:at).with(Time.zone.today)
     end
   end
+
+  describe 'GET #show' do
+    context 'when records are present' do
+      subject(:do_request) { get :show, params: { id: measure_type.id, format: :json } }
+
+      let(:pattern) do
+        {
+          data: {
+            id: String,
+            type: 'measure_type',
+            attributes: {
+              description: String,
+              measure_type_series_id: String,
+              id: String,
+            }.ignore_extra_keys!,
+          }.ignore_extra_keys!,
+        }
+      end
+
+      let(:measure_type) { create(:measure_type, :with_measure_type_series_description) }
+
+      it { expect(do_request.body).to match_json_expression pattern }
+    end
+
+    context 'when records are not present' do
+      subject(:do_request) { get :show, params: { id: 'foo', format: :json } }
+
+      let(:pattern) do
+        {
+          error: 'not found',
+          url: 'http://test.host/measure_types/foo',
+        }
+      end
+
+      it { expect(do_request.body).to match_json_expression pattern }
+    end
+  end
 end

--- a/spec/requests/api/v2/preference_codes_controller_spec.rb
+++ b/spec/requests/api/v2/preference_codes_controller_spec.rb
@@ -10,4 +10,18 @@ RSpec.describe Api::V2::PreferenceCodesController do
 
     it_behaves_like 'a successful jsonapi response'
   end
+
+  describe 'GET #show' do
+    subject(:rendered) { make_request && response }
+
+    let(:preference_code) { PreferenceCode[code] }
+
+    let(:code) { '100' }
+
+    let :make_request do
+      get api_preference_code_path(preference_code.code, format: :json)
+    end
+
+    it_behaves_like 'a successful jsonapi response'
+  end
 end

--- a/spec/requests/api/v2/preference_codes_controller_spec.rb
+++ b/spec/requests/api/v2/preference_codes_controller_spec.rb
@@ -12,16 +12,30 @@ RSpec.describe Api::V2::PreferenceCodesController do
   end
 
   describe 'GET #show' do
-    subject(:rendered) { make_request && response }
+    context 'when it finds a preference_code' do
+      subject(:rendered) { make_request && response }
 
-    let(:preference_code) { PreferenceCode[code] }
+      let(:preference_code) { PreferenceCode[code] }
 
-    let(:code) { '100' }
+      let(:code) { '100' }
 
-    let :make_request do
-      get api_preference_code_path(preference_code.code, format: :json)
+      let :make_request do
+        get api_preference_code_path(preference_code.code, format: :json)
+      end
+
+      it_behaves_like 'a successful jsonapi response'
+
+      it { is_expected.to have_http_status :success }
     end
 
-    it_behaves_like 'a successful jsonapi response'
+    context 'when preference code is not found' do
+      subject(:rendered) { make_request && response }
+
+      let :make_request do
+        get api_preference_code_path('foo', format: :json)
+      end
+
+      it { is_expected.to have_http_status :not_found }
+    end
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-<2048>](https://transformuk.atlassian.net/browse/HOTT-2048)

### What?

I have added/removed/altered:

- [ ] Exposed API endpoints needed for measure_type page

### Why?

I am doing this because:

- We need access to measure_type and preference_code on the frontend

### Have you? (optional)

- [ ] Added documentation for new apis

### Deployment risks (optional)

- Changes an api that is used in production

<img width="1283" alt="Screenshot 2022-10-18 at 14 57 16" src="https://user-images.githubusercontent.com/12201130/196450575-3db63a61-f1cb-4d03-bae2-ed879cf6ef1e.png">
