### PR TITLE
HOTT-2128 Extend news apis

### DIFF
--- a/app/controllers/api/admin/news/items_controller.rb
+++ b/app/controllers/api/admin/news/items_controller.rb
@@ -66,7 +66,9 @@ module Api
         end
 
         def news_items
-          @news_items ||= ::News::Item.descending.paginate(current_page, per_page)
+          @news_items ||= ::News::Item.eager(:collections)
+                                      .descending
+                                      .paginate(current_page, per_page)
         end
 
         def pagination_meta

--- a/app/controllers/api/v2/news_items_controller.rb
+++ b/app/controllers/api/v2/news_items_controller.rb
@@ -2,13 +2,14 @@ module Api
   module V2
     class NewsItemsController < ApiController
       def index
-        news_items = ::News::Item.for_service(params[:service])
-                             .for_target(params[:target])
-                             .for_today
-                             .paginate(current_page, per_page)
-                             .descending
+        news_items = ::News::Item.eager(:collections)
+                                 .for_service(params[:service])
+                                 .for_target(params[:target])
+                                 .for_today
+                                 .descending
+                                 .paginate(current_page, per_page)
 
-        serializer = Api::V2::News::ItemSerializer.new(news_items)
+        serializer = Api::V2::News::ItemSerializer.new(news_items, include: %w[collections])
 
         render json: serializer.serializable_hash
       end

--- a/app/serializers/api/admin/news/item_serializer.rb
+++ b/app/serializers/api/admin/news/item_serializer.rb
@@ -8,9 +8,21 @@ module Api
 
         set_id :id
 
-        attributes :title, :content, :display_style, :show_on_xi, :show_on_uk,
-                   :show_on_updates_page, :show_on_home_page, :show_on_banner,
-                   :start_date, :end_date, :created_at, :updated_at
+        attributes :slug,
+                   :title,
+                   :precis,
+                   :content,
+                   :display_style,
+                   :show_on_xi,
+                   :show_on_uk,
+                   :show_on_updates_page,
+                   :show_on_home_page,
+                   :show_on_banner,
+                   :start_date,
+                   :end_date,
+                   :collection_ids,
+                   :created_at,
+                   :updated_at
       end
     end
   end

--- a/app/serializers/api/v2/news/collection_serializer.rb
+++ b/app/serializers/api/v2/news/collection_serializer.rb
@@ -1,0 +1,15 @@
+module Api
+  module V2
+    module News
+      class CollectionSerializer
+        include JSONAPI::Serializer
+
+        set_type :news_collection
+
+        set_id :id
+
+        attributes :name
+      end
+    end
+  end
+end

--- a/app/serializers/api/v2/news/item_serializer.rb
+++ b/app/serializers/api/v2/news/item_serializer.rb
@@ -6,9 +6,23 @@ module Api
 
         set_type :news_item
 
-        attributes :id, :title, :content, :display_style, :show_on_xi, :show_on_uk,
-                   :show_on_updates_page, :show_on_home_page, :show_on_banner,
-                   :start_date, :end_date, :created_at, :updated_at
+        attributes :id,
+                   :slug,
+                   :title,
+                   :precis,
+                   :content,
+                   :display_style,
+                   :show_on_xi,
+                   :show_on_uk,
+                   :show_on_updates_page,
+                   :show_on_home_page,
+                   :show_on_banner,
+                   :start_date,
+                   :end_date,
+                   :created_at,
+                   :updated_at
+
+        has_many :collections
       end
     end
   end

--- a/db/migrate/20221020121609_add_precis_and_slug_to_news_items.rb
+++ b/db/migrate/20221020121609_add_precis_and_slug_to_news_items.rb
@@ -1,0 +1,10 @@
+Sequel.migration do
+  change do
+    alter_table :news_items do
+      add_column :precis, String
+      add_column :slug, String, size: 255, unique: true
+
+      add_index :slug
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5302,7 +5302,9 @@ CREATE TABLE public.news_items (
     end_date date,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone,
-    show_on_banner boolean DEFAULT false NOT NULL
+    show_on_banner boolean DEFAULT false NOT NULL,
+    precis text,
+    slug character varying(255)
 );
 
 
@@ -8496,6 +8498,14 @@ ALTER TABLE ONLY public.news_items
 
 
 --
+-- Name: news_items news_items_slug_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.news_items
+    ADD CONSTRAINT news_items_slug_key UNIQUE (slug);
+
+
+--
 -- Name: nomenclature_group_memberships_oplog nomenclature_group_memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -10454,6 +10464,13 @@ CREATE INDEX news_items_show_on_uk_show_on_xi_show_on_updates_page_show_on_h ON 
 
 
 --
+-- Name: news_items_slug_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX news_items_slug_index ON public.news_items USING btree (slug);
+
+
+--
 -- Name: ngmo_nomgromemopl_ureoupipslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10996,3 +11013,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20220714165446_create_guid
 INSERT INTO "schema_migrations" ("filename") VALUES ('20220908105343_adds_heading_and_chapter_id_to_goods_nomenclatures_view.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20221017110015_add_news_collections.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20221017160811_associate_news_items_and_news_collections.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20221020121609_add_precis_and_slug_to_news_items.rb');

--- a/spec/factories/news_factory.rb
+++ b/spec/factories/news_factory.rb
@@ -42,5 +42,19 @@ FactoryBot.define do
     trait :banner do
       show_on_banner { true }
     end
+
+    trait :with_collections do
+      transient do
+        collection_count { 1 }
+      end
+
+      after :create do |item, evaluator|
+        evaluator.collection_count.times do
+          item.add_collection create(:news_collection)
+        end
+
+        item.reload
+      end
+    end
   end
 end

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe News::Item do
       it { is_expected.to include(title: ['is not present']) }
       it { is_expected.to include(content: ['is not present']) }
     end
+
+    context 'with duplicate slug' do
+      before { create :news_item, slug: 'testing' }
+
+      let(:instance) { described_class.new slug: 'testing' }
+
+      it { is_expected.to include(slug: ['is already taken']) }
+    end
   end
 
   describe 'associations' do
@@ -216,6 +224,35 @@ RSpec.describe News::Item do
       let!(:published_yesterday) { create :news_item, start_date: Time.zone.yesterday }
 
       it { is_expected.to eql [published_today, published_yesterday] }
+    end
+  end
+
+  describe '#slug' do
+    subject { instance.save.reload.slug }
+
+    context 'when assigned' do
+      let(:instance) { build :news_item, slug: 'testing' }
+
+      it { is_expected.to eq 'testing' }
+    end
+
+    context 'when left blank' do
+      let(:instance) { build :news_item, slug: '', title: 'Hello world' }
+
+      it { is_expected.to eq 'hello-world' }
+    end
+
+    context 'with invalid slug' do
+      let(:instance) { create :news_item, slug: 'Something/problematic' }
+
+      it { is_expected.to eq 'somethingproblematic' }
+    end
+
+    context 'with overlong slug' do
+      let(:title) { 'a' * (described_class::MAX_SLUG_LENGTH + 1) }
+      let(:instance) { build :news_item, title: }
+
+      it { is_expected.to eq 'a' * described_class::MAX_SLUG_LENGTH }
     end
   end
 end

--- a/spec/serializers/api/admin/news/item_serializer_spec.rb
+++ b/spec/serializers/api/admin/news/item_serializer_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Api::Admin::News::ItemSerializer do
     described_class.new(news_item).serializable_hash
   end
 
-  let(:news_item) { create :news_item, title: 'Serialized' }
+  let(:news_item) { create :news_item, :with_collections, title: 'Serialized' }
 
   let :expected do
     {
@@ -11,7 +11,9 @@ RSpec.describe Api::Admin::News::ItemSerializer do
         id: news_item.id.to_s,
         type: :news_item,
         attributes: {
+          slug: news_item.slug,
           title: 'Serialized',
+          precis: news_item.precis,
           content: news_item.content,
           display_style: news_item.display_style,
           show_on_xi: news_item.show_on_xi,
@@ -21,6 +23,7 @@ RSpec.describe Api::Admin::News::ItemSerializer do
           show_on_banner: news_item.show_on_banner,
           start_date: news_item.start_date,
           end_date: news_item.end_date,
+          collection_ids: news_item.collections.map(&:id),
           created_at: news_item.created_at,
           updated_at: news_item.updated_at,
         },

--- a/spec/serializers/api/v2/news/collection_serializer_spec.rb
+++ b/spec/serializers/api/v2/news/collection_serializer_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Api::V2::News::CollectionSerializer do
+  subject { described_class.new(collection).serializable_hash }
+
+  let(:collection) { create :news_collection, name: 'Serialized' }
+
+  describe '#serializable_hash' do
+    let :expected do
+      {
+        data: {
+          id: collection.id.to_s,
+          type: :news_collection,
+          attributes: {
+            name: 'Serialized',
+          },
+        },
+      }
+    end
+
+    it { is_expected.to eq expected }
+  end
+end

--- a/spec/serializers/api/v2/news/item_serializer_spec.rb
+++ b/spec/serializers/api/v2/news/item_serializer_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Api::V2::News::ItemSerializer do
   subject(:serializable) { described_class.new(news_item).serializable_hash }
 
-  let(:news_item) { create :news_item }
+  let(:news_item) { create :news_item, :with_collections, collection_count: 2 }
 
   let :expected do
     {
@@ -10,7 +10,9 @@ RSpec.describe Api::V2::News::ItemSerializer do
         type: :news_item,
         attributes: {
           id: news_item.id,
+          slug: news_item.slug,
           title: news_item.title,
+          precis: news_item.precis,
           content: news_item.content,
           display_style: news_item.display_style,
           show_on_xi: news_item.show_on_xi,
@@ -22,6 +24,20 @@ RSpec.describe Api::V2::News::ItemSerializer do
           end_date: news_item.end_date,
           created_at: news_item.created_at,
           updated_at: news_item.updated_at,
+        },
+        relationships: {
+          collections: {
+            data: [
+              {
+                id: news_item.collection_ids.first.to_s,
+                type: :news_collection,
+              },
+              {
+                id: news_item.collection_ids.second.to_s,
+                type: :news_collection,
+              },
+            ],
+          },
         },
       },
     }


### PR DESCRIPTION
### Jira link

HOTT-2128

### What?

I have added/removed/altered:

- [x] Added migration to add `precis` and `slug` fields to database
- [x] Added precis attribute
- [x] Added slug attribute
- [x] Auto assign slug when not provided
- [x] Expose collections, slug and precis on v2 news item api
- [x] Expose collection_ids, slug and precis on admin news item api

### Why?

I am doing this because:

- We will want to use these attributes on the frontend
- We will want to edit these attributes in the admin area

### Deployment risks (optional)

- Significant: Changes `news_items` database table and news items api which is used on _all_ pages
