### PR TITLE
HOTT-2167: Adds admin quotas endpoint

### DIFF
--- a/app/controllers/api/admin/quota_order_numbers/quota_definitions_controller.rb
+++ b/app/controllers/api/admin/quota_order_numbers/quota_definitions_controller.rb
@@ -1,0 +1,32 @@
+module Api
+  module Admin
+    module QuotaOrderNumbers
+      class QuotaDefinitionsController < ApiController
+        DEFAULT_INCLUDES = %w[quota_definition.quota_balance_events].freeze
+
+        def current
+          render json: serialized_quota_order_number
+        end
+
+        private
+
+        def serialized_quota_order_number
+          Api::Admin::QuotaOrderNumbers::QuotaOrderNumberSerializer.new(quota_order_number, serializer_options)
+        end
+
+        def quota_order_number
+          @quota_order_number ||= QuotaOrderNumber
+            .by_order_number(params[:id])
+            .eager(quota_definition: :quota_balance_events)
+            .take
+        end
+
+        def serializer_options
+          {
+            include: DEFAULT_INCLUDES,
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/quota_order_numbers/quota_definitions_controller.rb
+++ b/app/controllers/api/admin/quota_order_numbers/quota_definitions_controller.rb
@@ -2,6 +2,8 @@ module Api
   module Admin
     module QuotaOrderNumbers
       class QuotaDefinitionsController < ApiController
+        before_action :authenticate_user!
+
         DEFAULT_INCLUDES = %w[quota_definition.quota_balance_events].freeze
 
         def current

--- a/app/models/quota_order_number.rb
+++ b/app/models/quota_order_number.rb
@@ -9,6 +9,11 @@ class QuotaOrderNumber < Sequel::Model
   end
 
   dataset_module do
+    def by_order_number(order_number)
+      where(quota_order_number_id: order_number)
+        .actual
+    end
+
     def with_quota_definitions
       inner_join(:quota_definitions, quota_order_numbers__quota_order_number_sid: :quota_definitions__quota_order_number_sid)
         .actual

--- a/app/serializers/api/admin/quota_order_numbers/quota_balance_event_serializer.rb
+++ b/app/serializers/api/admin/quota_order_numbers/quota_balance_event_serializer.rb
@@ -1,0 +1,15 @@
+module Api
+  module Admin
+    module QuotaOrderNumbers
+      class QuotaBalanceEventSerializer
+        include JSONAPI::Serializer
+
+        set_type :quota_balance_event
+
+        attributes :occurrence_timestamp,
+                   :new_balance,
+                   :imported_amount
+      end
+    end
+  end
+end

--- a/app/serializers/api/admin/quota_order_numbers/quota_definition_serializer.rb
+++ b/app/serializers/api/admin/quota_order_numbers/quota_definition_serializer.rb
@@ -1,0 +1,19 @@
+module Api
+  module Admin
+    module QuotaOrderNumbers
+      class QuotaDefinitionSerializer
+        include JSONAPI::Serializer
+
+        set_type :quota_definition
+
+        set_id :quota_definition_sid
+
+        attributes :validity_start_date,
+                   :validity_end_date,
+                   :initial_volume
+
+        has_many :quota_balance_events, serializer: Api::Admin::QuotaOrderNumbers::QuotaBalanceEventSerializer
+      end
+    end
+  end
+end

--- a/app/serializers/api/admin/quota_order_numbers/quota_order_number_serializer.rb
+++ b/app/serializers/api/admin/quota_order_numbers/quota_order_number_serializer.rb
@@ -1,0 +1,19 @@
+module Api
+  module Admin
+    module QuotaOrderNumbers
+      class QuotaOrderNumberSerializer
+        include JSONAPI::Serializer
+
+        set_type :quota_order_number
+
+        set_id :quota_order_number_id
+
+        attributes :quota_order_number_sid,
+                   :validity_start_date,
+                   :validity_end_date
+
+        has_one :quota_definition, serializer: Api::Admin::QuotaOrderNumbers::QuotaDefinitionSerializer
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,13 @@ Rails.application.routes.draw do
           resources :search_references, only: %i[show index destroy create update]
         end
       end
+
+      resources :quota_order_numbers, module: 'quota_order_numbers', only: %i[] do
+        # resources :quota_definitions, only: %i[index]
+        member do
+          get 'quota_definitions/current'
+        end
+      end
     end
 
     # avoid admin named routes clashing with public api named routes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,7 +44,6 @@ Rails.application.routes.draw do
       end
 
       resources :quota_order_numbers, module: 'quota_order_numbers', only: %i[] do
-        # resources :quota_definitions, only: %i[index]
         member do
           get 'quota_definitions/current'
         end

--- a/spec/factories/commodity_factory.rb
+++ b/spec/factories/commodity_factory.rb
@@ -34,6 +34,7 @@ FactoryBot.define do
           description: 'Live horses, asses, mules and hinnies',
           goods_nomenclature_sid: 1,
           goods_nomenclature_item_id: "#{commodity.goods_nomenclature_item_id.first(2)}00000000",
+          validity_start_date: '2020-10-21',
         )
 
         heading = create(
@@ -42,6 +43,7 @@ FactoryBot.define do
           description: 'Live animals',
           goods_nomenclature_sid: 2,
           goods_nomenclature_item_id: "#{commodity.goods_nomenclature_item_id.first(4)}000000",
+          validity_start_date: '2020-10-21',
         )
 
         guide = create(:guide, :aircraft_parts)

--- a/spec/factories/quota_factory.rb
+++ b/spec/factories/quota_factory.rb
@@ -43,15 +43,22 @@ FactoryBot.define do
     end
 
     trait :with_quota_definition do
+      transient do
+        quota_balance_events { false }
+      end
+
       after(:create) do |quota_order_number, evaluator|
-        result = create(
-          :quota_definition,
+        attributes = {
           quota_order_number_id: quota_order_number.quota_order_number_id,
           quota_order_number_sid: quota_order_number.quota_order_number_sid,
           quota_definition_sid: evaluator.quota_definition_sid,
           validity_end_date: evaluator.quota_definition_validity_end_date,
-        )
-        result
+        }
+        if evaluator.quota_balance_events
+          create(:quota_definition, :with_quota_balance_events)
+        else
+          create(:quota_definition, attributes)
+        end
       end
     end
   end

--- a/spec/models/quota_order_number_spec.rb
+++ b/spec/models/quota_order_number_spec.rb
@@ -76,4 +76,12 @@ RSpec.describe QuotaOrderNumber do
 
     it { expect(quota_order_number.method(:quota_definition_id)).to eq(quota_order_number.method(:definition_id)) }
   end
+
+  describe '.by_order_number' do
+    subject(:by_order_number) { described_class.by_order_number(quota_order_number.quota_order_number_id) }
+
+    let(:quota_order_number) { create(:quota_order_number) }
+
+    it { is_expected.to include(quota_order_number) }
+  end
 end

--- a/spec/requests/api/admin/quota_order_numbers/quota_definitions_controller_spec.rb
+++ b/spec/requests/api/admin/quota_order_numbers/quota_definitions_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Api::Admin::QuotaOrderNumbers::QuotaDefinitionsController, type: 
       quota_order_number_id = create(
         :quota_order_number,
         :with_quota_definition,
-        quota_balance_events: true
+        quota_balance_events: true,
       ).quota_order_number_id
 
       authenticated_get quota_definitions_current_api_quota_order_number_path(id: quota_order_number_id)

--- a/spec/requests/api/admin/quota_order_numbers/quota_definitions_controller_spec.rb
+++ b/spec/requests/api/admin/quota_order_numbers/quota_definitions_controller_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Api::Admin::QuotaOrderNumbers::QuotaDefinitionsController, type: :request do
+  describe 'GET #index' do
+    subject(:do_request) do
+      quota_order_number_id = create(
+        :quota_order_number,
+        :with_quota_definition,
+        quota_balance_events: true
+      ).quota_order_number_id
+
+      authenticated_get quota_definitions_current_api_quota_order_number_path(id: quota_order_number_id)
+
+      response
+    end
+
+    it_behaves_like 'a successful jsonapi response'
+  end
+end

--- a/spec/serializers/api/admin/quota_order_numbers/quota_balance_event_serializer_spec.rb
+++ b/spec/serializers/api/admin/quota_order_numbers/quota_balance_event_serializer_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Api::Admin::QuotaOrderNumbers::QuotaBalanceEventSerializer do
+  describe '#serializable_hash' do
+    subject(:serialized) { described_class.new(serializable).serializable_hash }
+
+    let(:serializable) { build(:quota_balance_event) }
+
+    let(:expected) do
+      {
+        data: {
+          id: "#{serializable.quota_definition_sid}-#{serializable.occurrence_timestamp.iso8601}",
+          type: :quota_balance_event,
+          attributes: {
+            occurrence_timestamp: serializable.occurrence_timestamp,
+            new_balance: serializable.new_balance,
+            imported_amount: serializable.imported_amount,
+          },
+        },
+      }
+    end
+
+    it { is_expected.to eq(expected) }
+  end
+end

--- a/spec/serializers/api/admin/quota_order_numbers/quota_definition_serializer_spec.rb
+++ b/spec/serializers/api/admin/quota_order_numbers/quota_definition_serializer_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe Api::Admin::QuotaOrderNumbers::QuotaDefinitionSerializer do
+  describe '#serializable_hash' do
+    subject(:serialized) { described_class.new(serializable).serializable_hash }
+
+    let(:serializable) { build(:quota_definition) }
+
+    let(:expected) do
+      {
+        data: {
+          id: serializable.quota_definition_sid.to_s,
+          type: :quota_definition,
+          attributes: {
+            validity_start_date: serializable.validity_start_date.iso8601,
+            validity_end_date: nil,
+            initial_volume: nil,
+          },
+          relationships: { quota_balance_events: { data: [] } },
+        },
+      }
+    end
+
+    it { is_expected.to eq(expected) }
+  end
+end

--- a/spec/serializers/api/admin/quota_order_numbers/quota_order_number_serializer_spec.rb
+++ b/spec/serializers/api/admin/quota_order_numbers/quota_order_number_serializer_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe Api::Admin::QuotaOrderNumbers::QuotaOrderNumberSerializer do
+  describe '#serializable_hash' do
+    subject(:serialized) { described_class.new(serializable).serializable_hash }
+
+    let(:serializable) { build(:quota_order_number) }
+
+    let(:expected) do
+      {
+        data: {
+          id: serializable.quota_order_number_id,
+          type: :quota_order_number,
+          attributes: {
+            quota_order_number_sid: serializable.quota_order_number_sid,
+            validity_start_date: serializable.validity_start_date.iso8601,
+            validity_end_date: nil,
+          },
+          relationships: { quota_definition: { data: nil } },
+        },
+      }
+    end
+
+    it { is_expected.to eq(expected) }
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2167

![image](https://user-images.githubusercontent.com/8156884/197516849-54d6e1d9-e37a-446f-a84f-419f9fd9e2c8.png)


### What?

I have added/removed/altered:

- [x] Adds route for quota order number
- [x] Adds controller for admin quota order numbers
- [x] Adds serializers for quota order numbers
- [x] Adds convenience scope for quota order number

### Why?

I am doing this because:

- This is required so we can find a specific quota and render its balance events in a graph in the admin UI
