### PR TITLE
HOTT-2130 Model error serialization

### DIFF
--- a/app/controllers/api/admin/chapters/chapter_notes_controller.rb
+++ b/app/controllers/api/admin/chapters/chapter_notes_controller.rb
@@ -20,7 +20,7 @@ module Api
             response.headers['Location'] = api_chapter_chapter_note_url(chapter)
             render json: Api::Admin::Chapters::ChapterNoteSerializer.new(chapter_note, { is_collection: false }).serializable_hash, status: :created
           else
-            render json: Api::Admin::Chapters::ChapterNoteSerializer.new(chapter_note).serialized_errors, status: :unprocessable_entity
+            render json: Api::Admin::ErrorSerializationService.new(chapter_note).call, status: :unprocessable_entity
           end
         end
 
@@ -31,7 +31,7 @@ module Api
           if chapter_note.save(raise_on_failure: false)
             render json: Api::Admin::Chapters::ChapterNoteSerializer.new(chapter_note, { is_collection: false }).serializable_hash, status: :ok
           else
-            render json: Api::Admin::Chapters::ChapterNoteSerializer.new(chapter_note).serialized_errors, status: :unprocessable_entity
+            render json: Api::Admin::ErrorSerializationService.new(chapter_note).call, status: :unprocessable_entity
           end
         end
 

--- a/app/controllers/api/admin/footnotes_controller.rb
+++ b/app/controllers/api/admin/footnotes_controller.rb
@@ -17,12 +17,15 @@ module Api
 
       def update
         @footnote = Footnote.national.with_pk!(footnote_pk)
-        @footnote.footnote_description.tap do |footnote_description|
-          footnote_description.set(footnote_params[:attributes])
-          footnote_description.save
-        end
 
-        render json: Api::Admin::FootnoteSerializer.new(@footnote, { is_collection: false }).serializable_hash
+        @description = @footnote.footnote_description
+        @description.set(footnote_params[:attributes])
+
+        if @description.save
+          render json: Api::Admin::FootnoteSerializer.new(@footnote, { is_collection: false }).serializable_hash
+        else
+          render json: Api::Admin::ErrorSerializationService.new(@description).call, status: :unprocessable_entity
+        end
       end
 
       private

--- a/app/controllers/api/admin/news/items_controller.rb
+++ b/app/controllers/api/admin/news/items_controller.rb
@@ -22,7 +22,7 @@ module Api
                    location: api_admin_news_item_url(news_item.id),
                    status: :created
           else
-            render json: serialize_errors(news_item.errors),
+            render json: serialize_errors(news_item),
                    status: :unprocessable_entity
           end
         end
@@ -36,7 +36,7 @@ module Api
                    location: api_admin_news_item_url(news_item.id),
                    status: :ok
           else
-            render json: serialize_errors(news_item.errors),
+            render json: serialize_errors(news_item),
                    status: :unprocessable_entity
           end
         end
@@ -87,8 +87,8 @@ module Api
           Api::Admin::News::ItemSerializer.new(*args).serializable_hash
         end
 
-        def serialize_errors(errors)
-          Api::V2::ErrorSerializationService.new.serialized_errors(errors)
+        def serialize_errors(news_item)
+          Api::Admin::ErrorSerializationService.new(news_item).call
         end
       end
     end

--- a/app/controllers/api/admin/rollbacks_controller.rb
+++ b/app/controllers/api/admin/rollbacks_controller.rb
@@ -15,14 +15,14 @@ module Api
           rollback.save
           render json: Api::Admin::RollbackSerializer.new(rollback, { is_collection: false }).serializable_hash, status: :created, location: api_rollbacks_url
         else
-          render json: Api::V2::ErrorSerializationService.new.serialized_errors(rollback.errors), status: :unprocessable_entity
+          render json: Api::Admin::ErrorSerializationService.new(rollback).call, status: :unprocessable_entity
         end
       end
 
       private
 
       def rollback_params
-        params.require(:data).permit(:type, attributes: [:date, :keep, :reason, :user_id])
+        params.require(:data).permit(:type, attributes: %i[date keep reason user_id])
       end
 
       def collection
@@ -35,9 +35,9 @@ module Api
             pagination: {
               page: current_page,
               per_page:,
-              total_count: @collection.pagination_record_count
-            }
-          }
+              total_count: @collection.pagination_record_count,
+            },
+          },
         }
       end
     end

--- a/app/controllers/api/admin/sections/section_notes_controller.rb
+++ b/app/controllers/api/admin/sections/section_notes_controller.rb
@@ -21,7 +21,7 @@ module Api
             response.headers['Location'] = api_section_section_note_url(section.id)
             render json: Api::Admin::Sections::SectionNoteSerializer.new(section_note, { is_collection: false }).serializable_hash, status: :created
           else
-            render json: Api::Admin::Sections::SectionNoteSerializer.new(section_note).serialized_errors, status: :unprocessable_entity
+            render json: Api::Admin::ErrorSerializationService.new(section_note).call, status: :unprocessable_entity
           end
         end
 
@@ -32,7 +32,7 @@ module Api
           if section_note.save(raise_on_failure: false)
             render json: Api::Admin::Sections::SectionNoteSerializer.new(section_note, { is_collection: false }).serializable_hash, status: :ok
           else
-            render json: Api::Admin::Sections::SectionNoteSerializer.new(section_note).serialized_errors, status: :unprocessable_entity
+            render json: Api::Admin::ErrorSerializationService.new(section_note).call, status: :unprocessable_entity
           end
         end
 

--- a/app/serializers/api/admin/chapters/chapter_note_serializer.rb
+++ b/app/serializers/api/admin/chapters/chapter_note_serializer.rb
@@ -9,14 +9,6 @@ module Api
         set_id :id
 
         attributes :section_id, :chapter_id, :content
-
-        def serialized_errors
-          errors = @resource.errors.flat_map do |attribute, error|
-            { title: attribute, detail: error }
-          end
-
-          { errors: }
-        end
       end
     end
   end

--- a/app/serializers/api/admin/sections/section_note_serializer.rb
+++ b/app/serializers/api/admin/sections/section_note_serializer.rb
@@ -9,14 +9,6 @@ module Api
         set_id :id
 
         attributes :section_id, :content
-
-        def serialized_errors
-          errors = @resource.errors.flat_map do |attribute, error|
-            { title: attribute, detail: error }
-          end
-
-          { errors: }
-        end
       end
     end
   end

--- a/app/services/api/admin/error_serialization_service.rb
+++ b/app/services/api/admin/error_serialization_service.rb
@@ -1,0 +1,47 @@
+module Api
+  module Admin
+    class ErrorSerializationService
+      DEFAULT_ERROR_STATUS_CODE = 422 # Unprocessable_entity
+      STATUS_CODES_FOR_ERRORS = {
+        'is already taken' => 409, # Conflict
+      }.freeze
+
+      def initialize(model)
+        @model = model
+      end
+
+      def call
+        { errors: }
+      end
+
+    private
+
+      def errors
+        @model.errors.flat_map do |attribute, errors|
+          attribute_errors(attribute, errors)
+        end
+      end
+
+      def attribute_errors(attribute, messages)
+        messages.map do |message|
+          attribute_error attribute, message
+        end
+      end
+
+      def attribute_error(attribute, message)
+        {
+          status: status_code(message),
+          title: message,
+          detail: "#{attribute.to_s.humanize} #{message}",
+          source: {
+            pointer: "/data/attributes/#{attribute}",
+          },
+        }
+      end
+
+      def status_code(message)
+        STATUS_CODES_FOR_ERRORS[message] || DEFAULT_ERROR_STATUS_CODE
+      end
+    end
+  end
+end

--- a/spec/services/api/admin/error_serialization_service_spec.rb
+++ b/spec/services/api/admin/error_serialization_service_spec.rb
@@ -1,0 +1,119 @@
+RSpec.describe Api::Admin::ErrorSerializationService do
+  describe '#call' do
+    subject { described_class.new(instance).call }
+
+    let(:instance) { News::Collection.new }
+
+    context 'with errors' do
+      before { instance.valid? }
+
+      let :error_response do
+        {
+          errors: [
+            {
+              status: 422,
+              title: 'is not present',
+              detail: 'Name is not present',
+              source: {
+                pointer: '/data/attributes/name',
+              },
+            },
+          ],
+        }
+      end
+
+      it { is_expected.to eql error_response }
+    end
+
+    context 'with multiple errors' do
+      before { instance.validate }
+
+      let :error_response do
+        {
+          errors: [
+            {
+              status: 422,
+              title: 'is not present',
+              detail: 'Name is not present',
+              source: {
+                pointer: '/data/attributes/name',
+              },
+            },
+            {
+              status: 422,
+              title: 'is not present',
+              detail: 'Created at is not present',
+              source: {
+                pointer: '/data/attributes/created_at',
+              },
+            },
+          ],
+        }
+      end
+
+      it { is_expected.to eql error_response }
+    end
+
+    context 'with multiple errors per attribute' do
+      before do
+        instance.valid?
+        instance.validate
+      end
+
+      let :error_response do
+        {
+          errors: [
+            {
+              status: 422,
+              title: 'is not present',
+              detail: 'Name is not present',
+              source: {
+                pointer: '/data/attributes/name',
+              },
+            },
+            {
+              status: 422,
+              title: 'is not present',
+              detail: 'Name is not present',
+              source: {
+                pointer: '/data/attributes/name',
+              },
+            },
+          ],
+        }
+      end
+
+      it { is_expected.to eql error_response }
+    end
+
+    context 'with conflict error' do
+      before do
+        News::Collection.create name: instance.name
+        instance.valid?
+      end
+
+      let(:instance) { build :news_collection }
+
+      let :error_response do
+        {
+          errors: [
+            {
+              status: 409,
+              title: 'is already taken',
+              detail: 'Name is already taken',
+              source: {
+                pointer: '/data/attributes/name',
+              },
+            },
+          ],
+        }
+      end
+
+      it { is_expected.to eql error_response }
+    end
+
+    context 'without errors' do
+      it { is_expected.to eql(errors: []) }
+    end
+  end
+end

--- a/spec/support/shared_examples/v2_search_reference_controller_examples.rb
+++ b/spec/support/shared_examples/v2_search_reference_controller_examples.rb
@@ -1,8 +1,8 @@
 RSpec.shared_examples_for 'v2 search references controller' do
-  before { login_as_api_user }
-
-
-  before { search_reference }
+  before do
+    login_as_api_user
+    search_reference
+  end
 
   describe 'GET #index' do
     let(:pattern) do
@@ -54,7 +54,6 @@ RSpec.shared_examples_for 'v2 search references controller' do
     it 'includes pagination meta data in HTTP meta header' do
       get(:index, params: { format: :json }.merge(collection_query))
 
-      expect(response.headers).to have_key 'X-Meta'
       expect(JSON.parse(response.headers['X-Meta'])).to have_key 'pagination'
     end
   end
@@ -99,7 +98,7 @@ RSpec.shared_examples_for 'v2 search references controller' do
   describe 'POST to #create' do
     let(:search_reference) { build :search_reference }
 
-    context 'valid params provided' do
+    context 'with valid params provided' do
       let(:pattern) do
         {
           data:
@@ -139,7 +138,7 @@ RSpec.shared_examples_for 'v2 search references controller' do
       end
     end
 
-    context 'invalid params provided' do
+    context 'with invalid params provided' do
       let(:pattern) do
         { errors: Array }
       end
@@ -162,7 +161,7 @@ RSpec.shared_examples_for 'v2 search references controller' do
   end
 
   describe 'DELETE #destroy' do
-    context 'search reference exists' do
+    context 'with valid search reference' do
       before { search_reference }
 
       it 'destroys SearchReference entry' do
@@ -174,7 +173,7 @@ RSpec.shared_examples_for 'v2 search references controller' do
       end
     end
 
-    context 'search reference does not exist' do
+    context 'with non-existant search reference' do
       let(:bogus_search_ref_id) { 666 }
 
       it 'does not destroy SearchReference entry' do
@@ -200,7 +199,7 @@ RSpec.shared_examples_for 'v2 search references controller' do
   describe 'PUT #update' do
     let(:new_title) { 'new title' }
 
-    context 'valid params provided' do
+    context 'with valid params provided' do
       before do
         put :update, params: {
           data: { type: search_reference, attributes: { title: new_title } },
@@ -221,9 +220,9 @@ RSpec.shared_examples_for 'v2 search references controller' do
       end
     end
 
-    context 'invalid params provided' do
+    context 'with invalid params provided' do
       let(:pattern) do
-        { errors: Hash }
+        { errors: Array }
       end
 
       before do


### PR DESCRIPTION
### Jira link

HOTT-2130

### What?

I have added/removed/altered:

- [x] Added JSON-API compliant error serializer
- [x] Converted Section Notes admin api to use new serializer
- [x] Converted Chapter Notes admin api to use new serializer
- [x] Converted Rollbacks admin api to use new serializer
- [x] Converted Footnotes admin api to use new serializer
- [x] Converted Search References admin api to use new serializer

### Why?

I am doing this because:

- We can now show backend validation errors in the admin area so we should expose the errors in the appropriate format

### Deployment risks (optional)

- Changes admin api error responses but these should be internal only
