### PR TITLE
HOTT-2173: Move to redirecting for all matched goods nomenclature

### DIFF
--- a/app/models/beta/search/open_search_result.rb
+++ b/app/models/beta/search/open_search_result.rb
@@ -178,8 +178,19 @@ module Beta
                           '/chapters/:id'
                         when 4
                           '/headings/:id'
+                        when 6
+                          '/subheadings/:id0000-80'
+                        when 8
+                          '/subheadings/:id00-80'
                         when 10
                           '/commodities/:id'
+                        when 13
+                          if short_code.match?(/\d{10}-\d{2}/)
+                            '/subheadings/:id'
+                          else
+                            id = short_code.first(4)
+                            '/headings/:id'
+                          end
                         else
                           id = short_code.first(4)
                           '/headings/:id'

--- a/app/services/api/beta/search_query_parser_service.rb
+++ b/app/services/api/beta/search_query_parser_service.rb
@@ -3,9 +3,10 @@ module Api
     class SearchQueryParserService
       delegate :client, to: :class
 
-      def initialize(original_search_query, spell)
+      def initialize(original_search_query, spell: '1', goods_nomenclature_item_id_match: false)
         @original_search_query = original_search_query
         @spell = spell
+        @goods_nomenclature_item_id_match = goods_nomenclature_item_id_match
       end
 
       def call
@@ -30,7 +31,7 @@ module Api
       attr_reader :original_search_query, :spell
 
       def null_result?
-        original_search_query.blank? || AggregatedSynonym.exists?(@original_search_query)
+        original_search_query.blank? || @goods_nomenclature_item_id_match || AggregatedSynonym.exists?(@original_search_query)
       end
     end
   end

--- a/spec/models/beta/search/open_search_result_spec.rb
+++ b/spec/models/beta/search/open_search_result_spec.rb
@@ -255,35 +255,20 @@ RSpec.describe Beta::Search::OpenSearchResult do
   end
 
   describe '#redirect_to' do
-    context 'when the search result tells us to redirect and the search query is a chapter' do
-      subject(:redirect_to) { build(:search_result, :redirect, :chapter).redirect_to }
+    shared_examples 'a redirecting search query' do |goods_nomenclature_item_id, expected_path|
+      subject(:redirect_to) { build(:search_result, :redirect, goods_nomenclature_item_id:).redirect_to }
 
-      it { is_expected.to eq('http://localhost:3001/chapters/01') }
+      it { is_expected.to include(expected_path) }
     end
 
-    context 'when the search result tells us to redirect and the search query is a heading' do
-      subject(:redirect_to) { build(:search_result, :redirect, :heading).redirect_to }
-
-      it { is_expected.to eq('http://localhost:3001/headings/0101') }
-    end
-
-    context 'when the search result tells us to redirect and the search query is a commodity' do
-      subject(:redirect_to) { build(:search_result, :redirect, :commodity).redirect_to }
-
-      it { is_expected.to eq('http://localhost:3001/commodities/0101210000') }
-    end
-
-    context 'when the search result tells us to redirect and the search query is a partial commodity code' do
-      subject(:redirect_to) { build(:search_result, :redirect, :partial_goods_nomenclature).redirect_to }
-
-      it { is_expected.to eq('http://localhost:3001/headings/0101') }
-    end
-
-    context 'when the search result is not a redirect' do
-      subject(:redirect_to) { build(:search_result).redirect_to }
-
-      it { is_expected.to be_nil }
-    end
+    it_behaves_like 'a redirecting search query', '01', '/chapters/01'
+    it_behaves_like 'a redirecting search query', '0101', '/headings/0101'
+    it_behaves_like 'a redirecting search query', '010129', '/subheadings/0101290000-80'
+    it_behaves_like 'a redirecting search query', '01012960', '/subheadings/0101296000-80'
+    it_behaves_like 'a redirecting search query', '0101210000-10', '/subheadings/0101210000-10'
+    it_behaves_like 'a redirecting search query', '0101210000', '/commodities/0101210000'
+    it_behaves_like 'a redirecting search query', '0101210000380', '/headings/0101'
+    it_behaves_like 'a redirecting search query', '010121000038123', '/headings/0101'
   end
 
   describe '#facet_filter_statistics' do

--- a/spec/services/api/beta/search_query_parser_service_spec.rb
+++ b/spec/services/api/beta/search_query_parser_service_spec.rb
@@ -2,26 +2,19 @@ RSpec.describe Api::Beta::SearchQueryParserService do
   let(:search_query_parser_service_url) { 'http://localhost:5000/api/search' }
 
   describe '#call' do
-    context 'when the search query matches a known synonym' do
-      subject(:result) { described_class.new('yakutian laika', '1').call }
+    shared_examples_for 'a null result search query parser call' do |search_query, goods_nomenclature_item_id_match|
+      subject(:result) { described_class.new(search_query, goods_nomenclature_item_id_match:).call }
 
       it { expect(result.null_result).to eq(true) }
     end
 
-    context 'when the search query is empty' do
-      subject(:result) { described_class.new('', '1').call }
-
-      it { expect(result.null_result).to eq(true) }
-    end
-
-    context 'when the search query is nil' do
-      subject(:result) { described_class.new(nil, '1').call }
-
-      it { expect(result.null_result).to eq(true) }
-    end
+    it_behaves_like 'a null result search query parser call', '', false # Empty search query
+    it_behaves_like 'a null result search query parser call', nil, false # Empty search query
+    it_behaves_like 'a null result search query parser call', 'yakutian laika', false # Synonym search query
+    it_behaves_like 'a null result search query parser call', 'ricotta', true # Specific goods nomenclature item id search query
 
     context 'when the search query parser response is success' do
-      subject(:result) { described_class.new('aaa bbb', '1').call }
+      subject(:result) { described_class.new('aaa bbb', spell: '1').call }
 
       before { stub_request(:get, "#{search_query_parser_service_url}/tokens?q=aaa+bbb&spell=1").to_return(response) }
 
@@ -55,7 +48,7 @@ RSpec.describe Api::Beta::SearchQueryParserService do
     end
 
     context 'when the search query parser response is bad request' do
-      subject(:result) { described_class.new('aaa bbb', '1').call }
+      subject(:result) { described_class.new('aaa bbb').call }
 
       before { stub_request(:get, "#{search_query_parser_service_url}/tokens?q=aaa+bbb&spell=1").to_return(response) }
 

--- a/spec/services/api/beta/search_service_spec.rb
+++ b/spec/services/api/beta/search_service_spec.rb
@@ -83,26 +83,27 @@ RSpec.describe Api::Beta::SearchService do
         call
       end
 
-      it { expect(Api::Beta::SearchQueryParserService).to have_received(:new).with('ricotta', '1') }
+      it { expect(Api::Beta::SearchQueryParserService).to have_received(:new).with('ricotta', spell: '1', goods_nomenclature_item_id_match: false) }
       it { expect(TradeTariffBackend.v2_search_client).to have_received(:search).with(expected_search_args) }
       it { expect(Beta::Search::OpenSearchResult::WithHits).to have_received(:build).with(search_result, search_query_parser_result, goods_nomenclature_query) }
       it { expect(Beta::Search::GoodsNomenclatureQuery).to have_received(:build).with(search_query_parser_result, {}) }
       it { expect(call).to be_a(Beta::Search::OpenSearchResult) }
-
-      context 'when the search result has no hits and the query is numeric' do
-        subject(:call) { described_class.new('0101').call }
-
-        let(:goods_nomenclature_query) { build(:goods_nomenclature_query, :numeric) }
-
-        let(:search_result) do
-          fixture_file = file_fixture('beta/search/goods_nomenclatures/no_hits.json')
-
-          Hashie::TariffMash.new(JSON.parse(fixture_file.read))
-        end
-
-        it { is_expected.to be_redirect }
-      end
     end
+
+    shared_examples_for 'a redirecting search result' do |search_query|
+      subject(:call) { described_class.new(search_query).call }
+
+      it { is_expected.to be_redirect }
+    end
+
+    it_behaves_like 'a redirecting search result', '01' # Chapter
+    it_behaves_like 'a redirecting search result', '0101' # Heading
+    it_behaves_like 'a redirecting search result', '010129' # Subheading
+    it_behaves_like 'a redirecting search result', '01012960' # Subheading
+    it_behaves_like 'a redirecting search result', '0101210000' # Commodity
+    it_behaves_like 'a redirecting search result', '0101210000-80' # Subheading
+    it_behaves_like 'a redirecting search result', '0101210000380' # Heading
+    it_behaves_like 'a redirecting search result', '010121000038123' # Heading
   end
   # rubocop:enable RSpec/MultipleMemoizedHelpers
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2173

### What?

We need to make sure we can redirect to the correct chapter, heading, subheading or commodity depending on what the user searches for.

The rules for this are generally:
- If a chapter/heading short code is searched for, then redirect to the chapter/heading
- If a subheading 6, 8 or 13 code is used then redirect to the subheading
- Redirect to the commodity when 10 digits are passed
- For any other number redirect to the heading 

I have added/removed/altered:

- [x] Added support for global goods nomenclature item id redirects

### Why?

I am doing this because:

- The original requirement https://transformuk.atlassian.net/browse/HOTT-1632 asked that no hit results would redirect to the history page. A more consistent approach is to redirect to the relevant goods nomenclature page regardless of the specific search results.
- This new approach is more consistent with the existing search behaviour
