### PR TITLE
Remove unused validity periods attribute

### DIFF
--- a/app/serializers/api/v2/validity_period_serializer.rb
+++ b/app/serializers/api/v2/validity_period_serializer.rb
@@ -9,8 +9,7 @@ module Api
                  :producline_suffix,
                  :validity_start_date,
                  :validity_end_date,
-                 :to_param,
-                 :goods_nomenclature_class
+                 :to_param
     end
   end
 end

--- a/spec/serializers/api/v2/validity_period_serializer_spec.rb
+++ b/spec/serializers/api/v2/validity_period_serializer_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Api::V2::ValidityPeriodSerializer do
           validity_start_date: Date.parse('2021-01-01'),
           validity_end_date: nil,
           to_param: '0101',
-          goods_nomenclature_class: 'Heading',
         },
       },
     }


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Removed goods_nomenclature_class from validity periods serializer

### Why?

I am doing this because:

- This creates a dependency on heading commodities and doesn't work with expired headings
