### PR TITLE
Support using referenced geographical areas for applicability of a measure geo area

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -424,7 +424,7 @@ class Measure < Sequel::Model
     return true if erga_omnes? && measure_type.meursing?
     return true if geographical_area_id.blank? || geographical_area_id == country_id
 
-    geographical_area.contained_geographical_areas.map(&:geographical_area_id).include?(country_id)
+    (geographical_area.referenced.presence || geographical_area).contained_geographical_areas.pluck(:geographical_area_id).include?(country_id)
   end
 
   def erga_omnes?

--- a/spec/factories/geographical_area_factory.rb
+++ b/spec/factories/geographical_area_factory.rb
@@ -62,6 +62,32 @@ FactoryBot.define do
       end
     end
 
+    trait :with_reference_group_and_members do
+      country
+
+      geographical_area_id { 'EU' }
+
+      after(:create) do |_geographical_area, _evaluator|
+        group = create(
+          :geographical_area,
+          :group,
+          geographical_area_id: '1013',
+        )
+
+        country = create(
+          :geographical_area,
+          :country,
+          geographical_area_id: 'FR',
+        )
+
+        create(
+          :geographical_area_membership,
+          geographical_area_sid: country.geographical_area_sid,
+          geographical_area_group_sid: group.geographical_area_sid,
+        )
+      end
+    end
+
     trait :region do
       geographical_code { '2' }
     end

--- a/spec/factories/measure_excluded_geographical_area_factory.rb
+++ b/spec/factories/measure_excluded_geographical_area_factory.rb
@@ -12,29 +12,11 @@ FactoryBot.define do
       excluded_geographical_area { 'EU' }
 
       after(:create) do |measure_excluded_geographical_area, _evaluator|
-        # referencing area
         create(
           :geographical_area,
-          :country,
+          :with_reference_group_and_members,
           geographical_area_id: measure_excluded_geographical_area.excluded_geographical_area,
           geographical_area_sid: measure_excluded_geographical_area.geographical_area_sid,
-        )
-        # referenced area
-        group = create(
-          :geographical_area,
-          :group,
-          geographical_area_id: '1013',
-        )
-
-        country = create(
-          :geographical_area,
-          :country,
-        )
-
-        create(
-          :geographical_area_membership,
-          geographical_area_sid: country.geographical_area_sid,
-          geographical_area_group_sid: group.geographical_area_sid,
         )
       end
     end

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -910,6 +910,14 @@ RSpec.describe Measure do
 
       it { expect(measure.relevant_for_country?(contained_geographical_area.geographical_area_id)).to eq(true) }
     end
+
+    context 'when the measure has a referenced contained geographical area that is the country' do
+      subject(:measure) { create(:measure, geographical_area_sid: geographical_area.geographical_area_sid, geographical_area_id: 'EU') }
+
+      let(:geographical_area) { create(:geographical_area, :with_reference_group_and_members, geographical_area_id: 'EU') }
+
+      it { expect(measure.relevant_for_country?('FR')).to eq(true) }
+    end
   end
 
   describe '#expresses_unit?' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2189

### What?

I have added/removed/altered:

- [x] Added support for referencing geographical areas (e.g. EU) when they're set as the geographical area of a measure.
- [x] Added spec to cover this scenario

### Why?

I am doing this because:

- The CDS team seem to be making extensive use of this referenced area so we need to support filtering it in the declarable responses