### PR TITLE
HOTT-2200 Fixed incorrect chapter links in RoO data

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/albania.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/albania.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) shall be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "ORIGINATING",
@@ -111,7 +111,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -128,7 +128,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -145,7 +145,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -162,7 +162,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -179,7 +179,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -196,7 +196,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -213,7 +213,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -231,7 +231,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -265,7 +265,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "MAXNOM"
@@ -283,7 +283,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -352,7 +352,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -369,7 +369,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -386,7 +386,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -403,7 +403,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -420,7 +420,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -437,7 +437,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -454,7 +454,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -488,7 +488,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -692,7 +692,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -743,7 +743,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -811,7 +811,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -879,7 +879,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -897,7 +897,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -983,7 +983,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/1), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/01), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "PRODUCTION FROM"
@@ -1208,7 +1208,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1840,7 +1840,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2027,7 +2027,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "ORIGINATING"

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/andean.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/andean.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) shall be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO"
                               ],
@@ -109,7 +109,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -126,7 +126,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -143,7 +143,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -160,7 +160,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -177,7 +177,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -194,7 +194,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -211,7 +211,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -229,7 +229,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -263,7 +263,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "All the products of [chapter&nbsp;6](/chapters/6) shall be wholly obtained.",
+                              "rule": "All the products of [chapter&nbsp;6](/chapters/06) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -280,7 +280,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -297,7 +297,7 @@
                   "max": "0899999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;8](/chapters/8) used are wholly obtained *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;8](/chapters/08) used are wholly obtained *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO"
                               ],
@@ -314,7 +314,7 @@
                   "max": "0901999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -535,7 +535,7 @@
                   "max": "1102999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all edible vegetables, roots and tubers of [chapter&nbsp;7](/chapters/7), fruits of [chapter&nbsp;8](/chapters/8) and cereals of [chapter&nbsp;10](/chapters/10) used are wholly obtained.",
+                              "rule": "Manufacture in which all edible vegetables, roots and tubers of [chapter&nbsp;7](/chapters/07), fruits of [chapter&nbsp;8](/chapters/08) and cereals of [chapter&nbsp;10](/chapters/10) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -552,7 +552,7 @@
                   "max": "1103999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all edible vegetables, roots and tubers of [chapter&nbsp;7](/chapters/7), fruits of [chapter&nbsp;8](/chapters/8) and cereals of [chapter&nbsp;10](/chapters/10) used are wholly obtained.",
+                              "rule": "Manufacture in which all edible vegetables, roots and tubers of [chapter&nbsp;7](/chapters/07), fruits of [chapter&nbsp;8](/chapters/08) and cereals of [chapter&nbsp;10](/chapters/10) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -569,7 +569,7 @@
                   "max": "1104999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all edible vegetables, roots and tubers of [chapter&nbsp;7](/chapters/7), fruits of [chapter&nbsp;8](/chapters/8) and cereals of [chapter&nbsp;10](/chapters/10) used are wholly obtained.",
+                              "rule": "Manufacture in which all edible vegetables, roots and tubers of [chapter&nbsp;7](/chapters/07), fruits of [chapter&nbsp;8](/chapters/08) and cereals of [chapter&nbsp;10](/chapters/10) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -586,7 +586,7 @@
                   "max": "1105999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all edible vegetables, roots and tubers of [chapter&nbsp;7](/chapters/7), fruits of [chapter&nbsp;8](/chapters/8) and cereals of [chapter&nbsp;10](/chapters/10) used are wholly obtained.",
+                              "rule": "Manufacture in which all edible vegetables, roots and tubers of [chapter&nbsp;7](/chapters/07), fruits of [chapter&nbsp;8](/chapters/08) and cereals of [chapter&nbsp;10](/chapters/10) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -620,7 +620,7 @@
                   "max": "1106999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all edible vegetables, roots and tubers of [chapter&nbsp;7](/chapters/7), fruits of [chapter&nbsp;8](/chapters/8) and cereals of [chapter&nbsp;10](/chapters/10) used are wholly obtained.",
+                              "rule": "Manufacture in which all edible vegetables, roots and tubers of [chapter&nbsp;7](/chapters/07), fruits of [chapter&nbsp;8](/chapters/08) and cereals of [chapter&nbsp;10](/chapters/10) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -637,7 +637,7 @@
                   "max": "1107999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all edible vegetables, roots and tubers of [chapter&nbsp;7](/chapters/7), fruits of [chapter&nbsp;8](/chapters/8) and cereals of [chapter&nbsp;10](/chapters/10) used are wholly obtained.",
+                              "rule": "Manufacture in which all edible vegetables, roots and tubers of [chapter&nbsp;7](/chapters/07), fruits of [chapter&nbsp;8](/chapters/08) and cereals of [chapter&nbsp;10](/chapters/10) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -671,7 +671,7 @@
                   "max": "1108999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all edible vegetables, roots and tubers of [chapter&nbsp;7](/chapters/7), fruits of [chapter&nbsp;8](/chapters/8) and cereals of [chapter&nbsp;10](/chapters/10) used are wholly obtained.",
+                              "rule": "Manufacture in which all edible vegetables, roots and tubers of [chapter&nbsp;7](/chapters/07), fruits of [chapter&nbsp;8](/chapters/08) and cereals of [chapter&nbsp;10](/chapters/10) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -688,7 +688,7 @@
                   "max": "1109999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all edible vegetables, roots and tubers of [chapter&nbsp;7](/chapters/7), fruits of [chapter&nbsp;8](/chapters/8) and cereals of [chapter&nbsp;10](/chapters/10) used are wholly obtained.",
+                              "rule": "Manufacture in which all edible vegetables, roots and tubers of [chapter&nbsp;7](/chapters/07), fruits of [chapter&nbsp;8](/chapters/08) and cereals of [chapter&nbsp;10](/chapters/10) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -984,7 +984,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- at least **40%** by weight of all the materials of [chapter&nbsp;4](/chapters/4) used are originating, *and*\n\n- the value of all the materials used does not exceed **20%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- at least **40%** by weight of all the materials of [chapter&nbsp;4](/chapters/04) used are originating, *and*\n\n- the value of all the materials used does not exceed **20%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -1069,7 +1069,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/1), *and*\n\n- in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/01), *and*\n\n- in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1240,7 +1240,7 @@
                   "max": "1901999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the weight of all the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **50%** of the total weight of the product.",
+                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the weight of all the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **50%** of the total weight of the product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1309,7 +1309,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;11](/chapters/11) used are originating. However, durum wheat and its derivatives of [chapter&nbsp;11](/chapters/11) may be used, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;11](/chapters/11) used are originating. However, durum wheat and its derivatives of [chapter&nbsp;11](/chapters/11) may be used, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1394,7 +1394,7 @@
                   "max": "2001999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the vegetables, fruits and nuts of [chapter&nbsp;7](/chapters/7) and [chapter&nbsp;8](/chapters/8) used are wholly obtained.",
+                              "rule": "Manufacture in which all the vegetables, fruits and nuts of [chapter&nbsp;7](/chapters/07) and [chapter&nbsp;8](/chapters/08) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1411,7 +1411,7 @@
                   "max": "2002999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the vegetables, fruits and nuts of [chapter&nbsp;7](/chapters/7) and [chapter&nbsp;8](/chapters/8) used are wholly obtained.",
+                              "rule": "Manufacture in which all the vegetables, fruits and nuts of [chapter&nbsp;7](/chapters/07) and [chapter&nbsp;8](/chapters/08) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1428,7 +1428,7 @@
                   "max": "2003999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the vegetables, fruits and nuts of [chapter&nbsp;7](/chapters/7) and [chapter&nbsp;8](/chapters/8) used are wholly obtained.",
+                              "rule": "Manufacture in which all the vegetables, fruits and nuts of [chapter&nbsp;7](/chapters/07) and [chapter&nbsp;8](/chapters/08) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1445,7 +1445,7 @@
                   "max": "2004999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the vegetables, fruits and nuts of [chapter&nbsp;7](/chapters/7) and [chapter&nbsp;8](/chapters/8) used are wholly obtained.",
+                              "rule": "Manufacture in which all the vegetables, fruits and nuts of [chapter&nbsp;7](/chapters/07) and [chapter&nbsp;8](/chapters/08) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1462,7 +1462,7 @@
                   "max": "2005999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the vegetables, fruits and nuts of [chapter&nbsp;7](/chapters/7) and [chapter&nbsp;8](/chapters/8) used are wholly obtained.",
+                              "rule": "Manufacture in which all the vegetables, fruits and nuts of [chapter&nbsp;7](/chapters/07) and [chapter&nbsp;8](/chapters/08) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1479,7 +1479,7 @@
                   "max": "2006999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- the weight of all the materials of [chapter&nbsp;7](/chapters/7) and [chapter&nbsp;8](/chapters/8) used does not exceed **50%** of the total weight of the product, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- the weight of all the materials of [chapter&nbsp;7](/chapters/07) and [chapter&nbsp;8](/chapters/08) used does not exceed **50%** of the total weight of the product, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -1496,7 +1496,7 @@
                   "max": "2007999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- the weight of all the materials of [chapter&nbsp;7](/chapters/7) and [chapter&nbsp;8](/chapters/8) used does not exceed **50%** of the total weight of the product, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- the weight of all the materials of [chapter&nbsp;7](/chapters/07) and [chapter&nbsp;8](/chapters/08) used does not exceed **50%** of the total weight of the product, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -1513,7 +1513,7 @@
                   "max": "2008999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- the weight of all the materials of [chapter&nbsp;7](/chapters/7) and [chapter&nbsp;8](/chapters/8) used does not exceed **50%** of the total weight of the product, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- the weight of all the materials of [chapter&nbsp;7](/chapters/07) and [chapter&nbsp;8](/chapters/08) used does not exceed **50%** of the total weight of the product, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -1581,7 +1581,7 @@
                   "max": "2008999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the vegetables, fruits and nuts of [chapter&nbsp;7](/chapters/7) and [chapter&nbsp;8](/chapters/8) used are wholly obtained.",
+                              "rule": "Manufacture in which all the vegetables, fruits and nuts of [chapter&nbsp;7](/chapters/07) and [chapter&nbsp;8](/chapters/08) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1598,7 +1598,7 @@
                   "max": "2009999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product\n\n- the weight of all the materials of [chapter&nbsp;7](/chapters/7) and [chapter&nbsp;8](/chapters/8) used does not exceed **50%** of the total weight of the product, *and*\n\n- in which the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product\n\n- the weight of all the materials of [chapter&nbsp;7](/chapters/07) and [chapter&nbsp;8](/chapters/08) used does not exceed **50%** of the total weight of the product, *and*\n\n- in which the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -1717,7 +1717,7 @@
                   "max": "2105999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the weight of all the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **50%** of the total weight of the product.",
+                              "rule": "Manufacture in which the weight of all the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **50%** of the total weight of the product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1928,7 +1928,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2047,7 +2047,7 @@
                   "max": "2306999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the olives of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the olives of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2115,7 +2115,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- the weight of all the materials from [heading&nbsp;1006](/headings/1006), [chapter&nbsp;11](/chapters/11) and [heading&nbsp;2302](/headings/2302) and [heading&nbsp;2303](/headings/2303) used does not exceed **20%** of the total weight of the product,\n\n- all the sugar, molasses or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- the weight of all the materials from [heading&nbsp;1006](/headings/1006), [chapter&nbsp;11](/chapters/11) and [heading&nbsp;2302](/headings/2302) and [heading&nbsp;2303](/headings/2303) used does not exceed **20%** of the total weight of the product,\n\n- all the sugar, molasses or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/cameroon.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/cameroon.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) used must be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -59,7 +59,7 @@
                   "max": "0302999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -76,7 +76,7 @@
                   "max": "0303999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0304999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -110,7 +110,7 @@
                   "max": "0305999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -127,7 +127,7 @@
                   "max": "0306999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -144,7 +144,7 @@
                   "max": "0306999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -161,7 +161,7 @@
                   "max": "0307999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -178,7 +178,7 @@
                   "max": "0307999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -195,7 +195,7 @@
                   "max": "0308999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -212,7 +212,7 @@
                   "max": "0309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -228,7 +228,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -245,7 +245,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -263,7 +263,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained\n\n- any fruit juice (except those of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used must already be originating\n\n- the value of any materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained\n\n- any fruit juice (except those of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used must already be originating\n\n- the value of any materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO"
                               ],
@@ -279,7 +279,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -296,7 +296,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -313,7 +313,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -330,7 +330,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -347,7 +347,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -364,7 +364,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -381,7 +381,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -399,7 +399,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -433,7 +433,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used must be wholly obtained\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used must be wholly obtained\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO"
                               ],
@@ -450,7 +450,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -518,7 +518,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -535,7 +535,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -552,7 +552,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -569,7 +569,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -586,7 +586,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -603,7 +603,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -620,7 +620,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -654,7 +654,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -858,7 +858,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -909,7 +909,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -977,7 +977,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1045,7 +1045,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used must be wholly obtained\n\n- all the vegetable materials used must be wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used must be wholly obtained\n\n- all the vegetable materials used must be wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO"
                               ],
@@ -1062,7 +1062,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used must be wholly obtained\n\n- all the vegetable materials used must be wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used must be wholly obtained\n\n- all the vegetable materials used must be wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO"
                               ],
@@ -1146,7 +1146,7 @@
                   "max": "1601999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/1).",
+                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/01).",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1163,7 +1163,7 @@
                   "max": "1602999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/1).",
+                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/01).",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1180,7 +1180,7 @@
                   "max": "1603999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/1).",
+                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/01).",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1198,7 +1198,7 @@
                   "max": "1605999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -1419,7 +1419,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all cereals and derivatives (except durum wheat and its derivatives) used must be wholly obtained\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all cereals and derivatives (except durum wheat and its derivatives) used must be wholly obtained\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2034,7 +2034,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2221,7 +2221,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used must already be originating\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used must already be originating\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/canada.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/canada.json
@@ -7,7 +7,7 @@
                   "max": "0106999999",
                   "rules": [
                         {
-                              "rule": "All animals of [chapter&nbsp;1](/chapters/1) are wholly obtained.",
+                              "rule": "All animals of [chapter&nbsp;1](/chapters/01) are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -23,7 +23,7 @@
                   "max": "0210999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the material of [chapter&nbsp;1](/chapters/1) or [chapter&nbsp;2](/chapters/2) used is wholly obtained.",
+                              "rule": "Production in which all the material of [chapter&nbsp;1](/chapters/01) or [chapter&nbsp;2](/chapters/02) used is wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -39,7 +39,7 @@
                   "max": "0309999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the material of [chapter&nbsp;3](/chapters/3) used is wholly obtained.",
+                              "rule": "Production in which all the material of [chapter&nbsp;3](/chapters/03) used is wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -55,7 +55,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, except from dairy preparations of [subheading&nbsp;190190](/subheading/1901900000-80) containing more than **10%** by dry weight of milk solids, provided that all the material of [chapter&nbsp;4](/chapters/4) used is wholly obtained.",
+                              "rule": "A change from any other chapter, except from dairy preparations of [subheading&nbsp;190190](/subheading/1901900000-80) containing more than **10%** by dry weight of milk solids, provided that all the material of [chapter&nbsp;4](/chapters/04) used is wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -71,7 +71,7 @@
                   "max": "0402199999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, except from dairy preparations of [subheading&nbsp;190190](/subheading/1901900000-80) containing more than **10%** by dry weight of milk solids, provided that:\n\n\n- a) all the material of [chapter&nbsp;4](/chapters/4) used is wholly obtained, *and*\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product.",
+                              "rule": "A change from any other chapter, except from dairy preparations of [subheading&nbsp;190190](/subheading/1901900000-80) containing more than **10%** by dry weight of milk solids, provided that:\n\n\n- a) all the material of [chapter&nbsp;4](/chapters/04) used is wholly obtained, *and*\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product.",
                               "class": [
                                     "WO"
                               ],
@@ -87,7 +87,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, except from dairy preparations of [subheading&nbsp;190190](/subheading/1901900000-80) containing more than **10%** by dry weight of milk solids, provided that:\n\n\n- a) all the material of [chapter&nbsp;4](/chapters/4) used is wholly obtained, *and*\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other chapter, except from dairy preparations of [subheading&nbsp;190190](/subheading/1901900000-80) containing more than **10%** by dry weight of milk solids, provided that:\n\n\n- a) all the material of [chapter&nbsp;4](/chapters/04) used is wholly obtained, *and*\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
                                     "WO"
                               ],
@@ -103,7 +103,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, except from dairy preparations of [subheading&nbsp;190190](/subheading/1901900000-80) containing more than **10%** by dry weight of milk solids, provided that:\n\n- a) all the material of [chapter&nbsp;4](/chapters/4) used is wholly obtained, *and*\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other chapter, except from dairy preparations of [subheading&nbsp;190190](/subheading/1901900000-80) containing more than **10%** by dry weight of milk solids, provided that:\n\n- a) all the material of [chapter&nbsp;4](/chapters/04) used is wholly obtained, *and*\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
                                     "WO"
                               ],
@@ -119,7 +119,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Production in which:\n\n- a) all the material of [chapter&nbsp;4](/chapters/4) used is wholly obtained, *and*\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "Production in which:\n\n- a) all the material of [chapter&nbsp;4](/chapters/04) used is wholly obtained, *and*\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
                                     "WO"
                               ],
@@ -151,7 +151,7 @@
                   "max": "0604999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the material of [chapter&nbsp;6](/chapters/6) used is wholly obtained.",
+                              "rule": "Production in which all the material of [chapter&nbsp;6](/chapters/06) used is wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -167,7 +167,7 @@
                   "max": "0709999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the material of [chapter&nbsp;7](/chapters/7) used is wholly obtained.",
+                              "rule": "Production in which all the material of [chapter&nbsp;7](/chapters/07) used is wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -183,7 +183,7 @@
                   "max": "0710899999",
                   "rules": [
                         {
-                              "rule": "Production in which all the material of [chapter&nbsp;7](/chapters/7) used is wholly obtained.",
+                              "rule": "Production in which all the material of [chapter&nbsp;7](/chapters/07) used is wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -199,7 +199,7 @@
                   "max": "0710999999",
                   "rules": [
                         {
-                              "rule": "A change from any other subheading, provided that:\n\n- a) the net weight of non-originating asparagus, beans, broccoli, cabbage, carrots, cauliflower, courgettes, cucumbers, gherkins, globe artichokes, mushrooms, onions, peas, potatoes, sweet corn, sweet peppers and tomatoes of [chapter&nbsp;7](/chapters/7) used in production does not exceed **20%** of the net weight of the product, *and*\n\n- b) the net weight of non-originating vegetables of [chapter&nbsp;7](/chapters/7) used in production does not exceed **50%** of the net weight of the product.",
+                              "rule": "A change from any other subheading, provided that:\n\n- a) the net weight of non-originating asparagus, beans, broccoli, cabbage, carrots, cauliflower, courgettes, cucumbers, gherkins, globe artichokes, mushrooms, onions, peas, potatoes, sweet corn, sweet peppers and tomatoes of [chapter&nbsp;7](/chapters/07) used in production does not exceed **20%** of the net weight of the product, *and*\n\n- b) the net weight of non-originating vegetables of [chapter&nbsp;7](/chapters/07) used in production does not exceed **50%** of the net weight of the product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -215,7 +215,7 @@
                   "max": "0711999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the material of [chapter&nbsp;7](/chapters/7) used is wholly obtained.",
+                              "rule": "Production in which all the material of [chapter&nbsp;7](/chapters/07) used is wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -231,7 +231,7 @@
                   "max": "0712399999",
                   "rules": [
                         {
-                              "rule": "Production in which all the material of [chapter&nbsp;7](/chapters/7) used is wholly obtained.",
+                              "rule": "Production in which all the material of [chapter&nbsp;7](/chapters/07) used is wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -247,14 +247,14 @@
                   "max": "0712999999",
                   "rules": [
                         {
-                              "rule": "A change to mixtures of dried vegetables from single dried vegetables from within this subheading or any other subheading, provided that:\n\n- a) the net weight of non-originating cabbage, carrots, courgettes, cucumbers, gherkins, globe artichokes, mushrooms, potatoes, sweet corn, sweet peppers, tomatoes and turnips of [chapter&nbsp;7](/chapters/7) used in production does not exceed **20%** of the net weight of the product, *and*\n\n- b) the net weight of non-originating vegetables of [chapter&nbsp;7](/chapters/7) used in production does not exceed **50%** of the net weight of the product.",
+                              "rule": "A change to mixtures of dried vegetables from single dried vegetables from within this subheading or any other subheading, provided that:\n\n- a) the net weight of non-originating cabbage, carrots, courgettes, cucumbers, gherkins, globe artichokes, mushrooms, potatoes, sweet corn, sweet peppers, tomatoes and turnips of [chapter&nbsp;7](/chapters/07) used in production does not exceed **20%** of the net weight of the product, *and*\n\n- b) the net weight of non-originating vegetables of [chapter&nbsp;7](/chapters/07) used in production does not exceed **50%** of the net weight of the product.",
                               "class": [
                                     "Unspecified"
                               ],
                               "operator": null
                         },
                         {
-                              "rule": "For any other product of [subheading&nbsp;071290](/subheading/0712900000-80), production in which all the material of [chapter&nbsp;7](/chapters/7) used is wholly obtained.",
+                              "rule": "For any other product of [subheading&nbsp;071290](/subheading/0712900000-80), production in which all the material of [chapter&nbsp;7](/chapters/07) used is wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -270,7 +270,7 @@
                   "max": "0714999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the material of [chapter&nbsp;7](/chapters/7) used is wholly obtained.",
+                              "rule": "Production in which all the material of [chapter&nbsp;7](/chapters/07) used is wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -286,7 +286,7 @@
                   "max": "0810999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the material of [chapter&nbsp;8](/chapters/8) used is wholly obtained.",
+                              "rule": "Production in which all the material of [chapter&nbsp;8](/chapters/08) used is wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -302,7 +302,7 @@
                   "max": "0811999999",
                   "rules": [
                         {
-                              "rule": "Production in which:\n\n- a) all the material of [chapter&nbsp;8](/chapters/8) used is wholly obtained, *and*\n\n- b) the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product.",
+                              "rule": "Production in which:\n\n- a) all the material of [chapter&nbsp;8](/chapters/08) used is wholly obtained, *and*\n\n- b) the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product.",
                               "class": [
                                     "WO"
                               ],
@@ -318,7 +318,7 @@
                   "max": "0812999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the material of [chapter&nbsp;8](/chapters/8) used is wholly obtained.",
+                              "rule": "Production in which all the material of [chapter&nbsp;8](/chapters/08) used is wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -334,7 +334,7 @@
                   "max": "0813499999",
                   "rules": [
                         {
-                              "rule": "Production in which all the material of [chapter&nbsp;8](/chapters/8) used is wholly obtained.",
+                              "rule": "Production in which all the material of [chapter&nbsp;8](/chapters/08) used is wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -350,7 +350,7 @@
                   "max": "0813599999",
                   "rules": [
                         {
-                              "rule": "A change from any other subheading, provided that:\n\n- a) the net weight of non-originating almonds, apples, apricots, bananas, cherries, chestnuts, citrus fruit, figs, grapes, hazelnuts, nectarines, peaches, pears, plums and walnuts of [chapter&nbsp;8](/chapters/8) used in production does not exceed **20%** of the net weight of the product,\n\n- b) the net weight of non-originating fruits and nuts other than almonds, apples, apricots, bananas, brazil nuts, carambola, cashew apples, cashew nuts, cherries, chestnuts, citrus fruit, coconuts, figs, grapes, guava, hazelnuts, jackfruit, lychees, macadamia nuts, mangoes, mangosteens, nectarines, papaws (papaya), passion fruit, peaches, pears, pistachios, pitahaya, plums, tamarinds or walnuts of [chapter&nbsp;8](/chapters/8) used in production does not exceed **50%** of the net weight of the product, *and*\n\n- c) the net weight of non-originating fruits and nuts of [chapter&nbsp;8](/chapters/8) used in production does not exceed **80%** of the net weight of the product.",
+                              "rule": "A change from any other subheading, provided that:\n\n- a) the net weight of non-originating almonds, apples, apricots, bananas, cherries, chestnuts, citrus fruit, figs, grapes, hazelnuts, nectarines, peaches, pears, plums and walnuts of [chapter&nbsp;8](/chapters/08) used in production does not exceed **20%** of the net weight of the product,\n\n- b) the net weight of non-originating fruits and nuts other than almonds, apples, apricots, bananas, brazil nuts, carambola, cashew apples, cashew nuts, cherries, chestnuts, citrus fruit, coconuts, figs, grapes, guava, hazelnuts, jackfruit, lychees, macadamia nuts, mangoes, mangosteens, nectarines, papaws (papaya), passion fruit, peaches, pears, pistachios, pitahaya, plums, tamarinds or walnuts of [chapter&nbsp;8](/chapters/08) used in production does not exceed **50%** of the net weight of the product, *and*\n\n- c) the net weight of non-originating fruits and nuts of [chapter&nbsp;8](/chapters/08) used in production does not exceed **80%** of the net weight of the product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -366,7 +366,7 @@
                   "max": "0814999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the material of [chapter&nbsp;8](/chapters/8) used is wholly obtained.",
+                              "rule": "Production in which all the material of [chapter&nbsp;8](/chapters/08) used is wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -749,7 +749,7 @@
                   "max": "1602999999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, except from [chapter&nbsp;2](/chapters/2).",
+                              "rule": "A change from any other chapter, except from [chapter&nbsp;2](/chapters/02).",
                               "class": [
                                     "CC EXCEPT"
                               ],
@@ -765,7 +765,7 @@
                   "max": "1603999999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, except from [chapter&nbsp;2](/chapters/2) or [chapter&nbsp;3](/chapters/3).",
+                              "rule": "A change from any other chapter, except from [chapter&nbsp;2](/chapters/02) or [chapter&nbsp;3](/chapters/03).",
                               "class": [
                                     "CC EXCEPT"
                               ],
@@ -781,7 +781,7 @@
                   "max": "1605999999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, except from [chapter&nbsp;3](/chapters/3).",
+                              "rule": "A change from any other chapter, except from [chapter&nbsp;3](/chapters/03).",
                               "class": [
                                     "CC EXCEPT"
                               ],
@@ -846,7 +846,7 @@
                   "max": "1704999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n- a) \n\n- i) the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product or (ii) the value of non-originating sugar used in production does not exceed **30%** of the transaction value or ex-works price of the product *and*\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/4) used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that:\n\n- a) \n\n- i) the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product or (ii) the value of non-originating sugar used in production does not exceed **30%** of the transaction value or ex-works price of the product *and*\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -911,7 +911,7 @@
                   "max": "1806999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n- a) \n\n- i) the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product or (ii) the value of non-originating sugar used in production does not exceed **30%** of the transaction value or ex-works price of the product, *and*\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/4) used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that:\n\n- a) \n\n- i) the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product or (ii) the value of non-originating sugar used in production does not exceed **30%** of the transaction value or ex-works price of the product, *and*\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -928,7 +928,7 @@
                   "max": "1901999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n- a) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n- b) the net weight of non-originating sugar used in production does not exceed **30%** of the net weight of the product,\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/4) used in production does not exceed **20%** of the net weight of the product, *and*\n\n- d) the net weight of non-originating sugar and non-originating material of [chapter&nbsp;4](/chapters/4) used in production does not exceed **40%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that:\n\n- a) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n- b) the net weight of non-originating sugar used in production does not exceed **30%** of the net weight of the product,\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product, *and*\n\n- d) the net weight of non-originating sugar and non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **40%** of the net weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -945,7 +945,7 @@
                   "max": "1902199999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/4) used in production does not exceed **20%** of the weight of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the weight of the net weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -962,7 +962,7 @@
                   "max": "1902299999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating material of [chapter&nbsp;2](/chapters/2), [chapter&nbsp;3](/chapters/3) or [chapter&nbsp;16](/chapters/16) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n\n- c) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- d) the net weight of non-originating material of [chapter&nbsp;4](/chapters/4) used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating material of [chapter&nbsp;2](/chapters/02), [chapter&nbsp;3](/chapters/03) or [chapter&nbsp;16](/chapters/16) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n\n- c) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- d) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -979,7 +979,7 @@
                   "max": "1902499999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/4) used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -1013,7 +1013,7 @@
                   "max": "1904299999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **30%** of the net weight of the product,\n\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/4) used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- d) the net weight of non-originating sugar and non-originating material of [chapter&nbsp;4](/chapters/4) used in production does not exceed **40%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **30%** of the net weight of the product,\n\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- d) the net weight of non-originating sugar and non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **40%** of the net weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -1047,7 +1047,7 @@
                   "max": "1904999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **30%** of the net weight of the product,\n\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/4) used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- d) the net weight of non-originating sugar and non-originating material of [chapter&nbsp;4](/chapters/4) used in production does not exceed **40%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **30%** of the net weight of the product,\n\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- d) the net weight of non-originating sugar and non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **40%** of the net weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -1064,7 +1064,7 @@
                   "max": "1905999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product,\n\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/4) used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- d) the net weight of non-originating sugar and non-originating material of [chapter&nbsp;4](/chapters/4) used in production does not exceed **50%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product,\n\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- d) the net weight of non-originating sugar and non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **50%** of the net weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -1097,7 +1097,7 @@
                   "max": "2003999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, in which all the material of [chapter&nbsp;7](/chapters/7) used is wholly obtained.",
+                              "rule": "A change from any other heading, in which all the material of [chapter&nbsp;7](/chapters/07) used is wholly obtained.",
                               "class": [
                                     "CTH",
                                     "MAXNOM",
@@ -1434,7 +1434,7 @@
                   "max": "2101399999",
                   "rules": [
                         {
-                              "rule": "A change from any other subheading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/4) used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other subheading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1544,7 +1544,7 @@
                   "max": "2105999999",
                   "rules": [
                         {
-                              "rule": "A change from any other subheading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/4) used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other subheading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1560,7 +1560,7 @@
                   "max": "2106999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/4) used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -1593,7 +1593,7 @@
                   "max": "2202199999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/4) used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -1617,7 +1617,7 @@
                               "operator": null
                         },
                         {
-                              "rule": "A change to any other product of [subheading&nbsp;220290](/subheading/2202900000-80) from any other heading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/4) used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change to any other product of [subheading&nbsp;220290](/subheading/2202900000-80) from any other heading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1781,7 +1781,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, except from [chapter&nbsp;2](/chapters/2) or [chapter&nbsp;3](/chapters/3), provided that:\n\n\n- a) the net weight of non-originating material of [chapter&nbsp;10](/chapters/10) or [chapter&nbsp;11](/chapters/11) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/4) used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other heading, except from [chapter&nbsp;2](/chapters/02) or [chapter&nbsp;3](/chapters/03), provided that:\n\n\n- a) the net weight of non-originating material of [chapter&nbsp;10](/chapters/10) or [chapter&nbsp;11](/chapters/11) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -2699,7 +2699,7 @@
                   "max": "3502999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, except from [chapter&nbsp;2](/chapters/2) to [chapter&nbsp;4](/chapters/4).",
+                              "rule": "A change from any other heading, except from [chapter&nbsp;2](/chapters/02) to [chapter&nbsp;4](/chapters/04).",
                               "class": [
                                     "CTH",
                                     "CTH EXCEPT"
@@ -2707,7 +2707,7 @@
                               "operator": null
                         },
                         {
-                              "rule": "A change from [chapter&nbsp;2](/chapters/2) to [chapter&nbsp;4](/chapters/4), whether or not there is also a change from any other heading, provided that the value of non-originating materials of [chapter&nbsp;2](/chapters/2) to [chapter&nbsp;4](/chapters/4) does not exceed **40%** of the transaction value or ex-works price of the product.",
+                              "rule": "A change from [chapter&nbsp;2](/chapters/02) to [chapter&nbsp;4](/chapters/04), whether or not there is also a change from any other heading, provided that the value of non-originating materials of [chapter&nbsp;2](/chapters/02) to [chapter&nbsp;4](/chapters/04) does not exceed **40%** of the transaction value or ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -2723,7 +2723,7 @@
                   "max": "3503999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, except from [chapter&nbsp;2](/chapters/2) other than swine skin or [chapter&nbsp;3](/chapters/3) other than fish skin.",
+                              "rule": "A change from any other heading, except from [chapter&nbsp;2](/chapters/02) other than swine skin or [chapter&nbsp;3](/chapters/03) other than fish skin.",
                               "class": [
                                     "CTH",
                                     "CTH EXCEPT"
@@ -2731,7 +2731,7 @@
                               "operator": null
                         },
                         {
-                              "rule": "A change from [chapter&nbsp;2](/chapters/2) other than swine skin or [chapter&nbsp;3](/chapters/3) other than fish skin, whether or not there is also a change from any other heading, swine skin of [chapter&nbsp;2](/chapters/2) or fish skin of [chapter&nbsp;3](/chapters/3), provided that the value of non-originating materials of [chapter&nbsp;2](/chapters/2) other than swine skin or [chapter&nbsp;3](/chapters/3) other than fish skin does not exceed **40%** of the transaction value or ex-works price of the product.",
+                              "rule": "A change from [chapter&nbsp;2](/chapters/02) other than swine skin or [chapter&nbsp;3](/chapters/03) other than fish skin, whether or not there is also a change from any other heading, swine skin of [chapter&nbsp;2](/chapters/02) or fish skin of [chapter&nbsp;3](/chapters/03), provided that the value of non-originating materials of [chapter&nbsp;2](/chapters/02) other than swine skin or [chapter&nbsp;3](/chapters/03) other than fish skin does not exceed **40%** of the transaction value or ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -2747,21 +2747,21 @@
                   "max": "3504999999",
                   "rules": [
                         {
-                              "rule": "A change to milk protein substances from any other heading, except from [chapter&nbsp;4](/chapters/4) or dairy preparations of [subheading&nbsp;190190](/subheading/1901900000-80) containing more than **10%** by dry weight of milk solids.",
+                              "rule": "A change to milk protein substances from any other heading, except from [chapter&nbsp;4](/chapters/04) or dairy preparations of [subheading&nbsp;190190](/subheading/1901900000-80) containing more than **10%** by dry weight of milk solids.",
                               "class": [
                                     "Unspecified"
                               ],
                               "operator": null
                         },
                         {
-                              "rule": "A change to any other product of [heading&nbsp;3504](/headings/3504) from any other heading, except from non-originating material of [chapter&nbsp;2](/chapters/2) to [chapter&nbsp;4](/chapters/4) or [heading&nbsp;1108](/headings/1108).",
+                              "rule": "A change to any other product of [heading&nbsp;3504](/headings/3504) from any other heading, except from non-originating material of [chapter&nbsp;2](/chapters/02) to [chapter&nbsp;4](/chapters/04) or [heading&nbsp;1108](/headings/1108).",
                               "class": [
                                     "Unspecified"
                               ],
                               "operator": "or"
                         },
                         {
-                              "rule": "A change to any other product of [heading&nbsp;3504](/headings/3504) from [chapter&nbsp;2](/chapters/2) to [chapter&nbsp;4](/chapters/4) or [heading&nbsp;1108](/headings/1108), whether or not there is also a change from any other heading, provided that the value of non-originating materials of [chapter&nbsp;2](/chapters/2) to [chapter&nbsp;4](/chapters/4) or [heading&nbsp;1108](/headings/1108) does not exceed **40%** of the transaction value or ex-works price of the product.",
+                              "rule": "A change to any other product of [heading&nbsp;3504](/headings/3504) from [chapter&nbsp;2](/chapters/02) to [chapter&nbsp;4](/chapters/04) or [heading&nbsp;1108](/headings/1108), whether or not there is also a change from any other heading, provided that the value of non-originating materials of [chapter&nbsp;2](/chapters/02) to [chapter&nbsp;4](/chapters/04) or [heading&nbsp;1108](/headings/1108) does not exceed **40%** of the transaction value or ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/cariforum.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/cariforum.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) used must be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0301999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -59,7 +59,7 @@
                   "max": "0302999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -76,7 +76,7 @@
                   "max": "0303999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0304999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -110,7 +110,7 @@
                   "max": "0305999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -127,7 +127,7 @@
                   "max": "0306999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -144,7 +144,7 @@
                   "max": "0306999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -161,7 +161,7 @@
                   "max": "0307999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -178,7 +178,7 @@
                   "max": "0307999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -195,7 +195,7 @@
                   "max": "0308999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -212,7 +212,7 @@
                   "max": "0309999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -228,7 +228,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -245,7 +245,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -263,7 +263,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained\n\n- any fruit juice (except those of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used must already be originating\n\n- the value of any materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained\n\n- any fruit juice (except those of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used must already be originating\n\n- the value of any materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO"
                               ],
@@ -279,7 +279,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -296,7 +296,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -313,7 +313,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -330,7 +330,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -347,7 +347,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -364,7 +364,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -381,7 +381,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -399,7 +399,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -433,7 +433,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used must be wholly obtained\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used must be wholly obtained\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO"
                               ],
@@ -450,7 +450,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -519,7 +519,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -536,7 +536,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -553,7 +553,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -570,7 +570,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -587,7 +587,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -604,7 +604,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -621,7 +621,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -655,7 +655,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -995,7 +995,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1046,7 +1046,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1114,7 +1114,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1182,7 +1182,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used must be wholly obtained\n\n- all the vegetable materials used must be wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used must be wholly obtained\n\n- all the vegetable materials used must be wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO"
                               ],
@@ -1199,7 +1199,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used must be wholly obtained\n\n- all the vegetable materials used must be wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used must be wholly obtained\n\n- all the vegetable materials used must be wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO"
                               ],
@@ -1283,7 +1283,7 @@
                   "max": "1601999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/1).",
+                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/01).",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1300,7 +1300,7 @@
                   "max": "1602999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/1).",
+                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/01).",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1317,7 +1317,7 @@
                   "max": "1603999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/1).",
+                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/01).",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1335,7 +1335,7 @@
                   "max": "1605999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -1580,7 +1580,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all cereals and derivatives (except durum wheat and its derivatives) used must be wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all cereals and derivatives (except durum wheat and its derivatives) used must be wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2268,7 +2268,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2455,7 +2455,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used must already be originating\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used must already be originating\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/chile.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/chile.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) shall be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "ORIGINATING",
@@ -111,7 +111,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -128,7 +128,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -145,7 +145,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -162,7 +162,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -179,7 +179,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -196,7 +196,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -213,7 +213,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -231,7 +231,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -265,7 +265,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "MAXNOM"
@@ -283,7 +283,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -352,7 +352,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -369,7 +369,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -386,7 +386,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -403,7 +403,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -420,7 +420,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -437,7 +437,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -454,7 +454,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -488,7 +488,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -692,7 +692,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -743,7 +743,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -811,7 +811,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -879,7 +879,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -897,7 +897,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -983,7 +983,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/1), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/01), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "PRODUCTION FROM"
@@ -1208,7 +1208,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1855,7 +1855,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2042,7 +2042,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "ORIGINATING"

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/egypt.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/egypt.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) shall be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "ORIGINATING",
@@ -111,7 +111,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -128,7 +128,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -145,7 +145,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -162,7 +162,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -179,7 +179,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -196,7 +196,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -213,7 +213,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -231,7 +231,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -265,7 +265,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "MAXNOM"
@@ -283,7 +283,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -352,7 +352,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -369,7 +369,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -386,7 +386,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -403,7 +403,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -420,7 +420,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -437,7 +437,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -454,7 +454,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -488,7 +488,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -692,7 +692,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -743,7 +743,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -811,7 +811,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -879,7 +879,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -897,7 +897,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -983,7 +983,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/1), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/01), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "PRODUCTION FROM"
@@ -1208,7 +1208,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1840,7 +1840,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2027,7 +2027,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "ORIGINATING"

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/esa.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/esa.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) used must be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0301999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -59,7 +59,7 @@
                   "max": "0302999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -76,7 +76,7 @@
                   "max": "0303999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0304999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -110,7 +110,7 @@
                   "max": "0305999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -127,7 +127,7 @@
                   "max": "0306999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -144,7 +144,7 @@
                   "max": "0306999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -161,7 +161,7 @@
                   "max": "0307999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -178,7 +178,7 @@
                   "max": "0307999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -195,7 +195,7 @@
                   "max": "0308999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -212,7 +212,7 @@
                   "max": "0309999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -228,7 +228,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -245,7 +245,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -263,7 +263,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained\n\n- any fruit juice (except those of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used must already be originating\n\n- the value of any materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained\n\n- any fruit juice (except those of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used must already be originating\n\n- the value of any materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO"
                               ],
@@ -279,7 +279,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -296,7 +296,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -313,7 +313,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -330,7 +330,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -347,7 +347,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -364,7 +364,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -381,7 +381,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -399,7 +399,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -433,7 +433,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used must be wholly obtained\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used must be wholly obtained\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO"
                               ],
@@ -450,7 +450,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -518,7 +518,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -535,7 +535,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -552,7 +552,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -569,7 +569,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -586,7 +586,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -603,7 +603,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -620,7 +620,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -654,7 +654,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -858,7 +858,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -909,7 +909,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -977,7 +977,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1045,7 +1045,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used must be wholly obtained\n\n- all the vegetable materials used must be wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used must be wholly obtained\n\n- all the vegetable materials used must be wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO"
                               ],
@@ -1062,7 +1062,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used must be wholly obtained\n\n- all the vegetable materials used must be wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used must be wholly obtained\n\n- all the vegetable materials used must be wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO"
                               ],
@@ -1146,7 +1146,7 @@
                   "max": "1601999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/1).",
+                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/01).",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1163,7 +1163,7 @@
                   "max": "1602999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/1).",
+                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/01).",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1180,7 +1180,7 @@
                   "max": "1603999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/1).",
+                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/01).",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1198,7 +1198,7 @@
                   "max": "1605999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -1419,7 +1419,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all cereals and derivatives (except durum wheat and its derivatives) used must be wholly obtained\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all cereals and derivatives (except durum wheat and its derivatives) used must be wholly obtained\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2033,7 +2033,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2220,7 +2220,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used must already be originating\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used must already be originating\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/eu.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/eu.json
@@ -7,7 +7,7 @@
                   "max": "0106999999",
                   "rules": [
                         {
-                              "rule": "All animals of [chapter&nbsp;1](/chapters/1) are wholly obtained.",
+                              "rule": "All animals of [chapter&nbsp;1](/chapters/01) are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -23,7 +23,7 @@
                   "max": "0210999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -39,7 +39,7 @@
                   "max": "0309999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -55,7 +55,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Production in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) does not exceed **20%** of the weight of the product.",
+                              "rule": "Production in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) does not exceed **20%** of the weight of the product.",
                               "class": [
                                     "WO",
                                     "MAXWEIGHT"
@@ -88,7 +88,7 @@
                   "max": "0604999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -104,7 +104,7 @@
                   "max": "0714999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -120,7 +120,7 @@
                   "max": "0814999999",
                   "rules": [
                         {
-                              "rule": "Production in which:\n\n- all the materials of [chapter&nbsp;8](/chapters/8) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) does not exceed **20%** of the weight of the product.",
+                              "rule": "Production in which:\n\n- all the materials of [chapter&nbsp;8](/chapters/08) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) does not exceed **20%** of the weight of the product.",
                               "class": [
                                     "WO",
                                     "MAXWEIGHT"
@@ -378,7 +378,7 @@
                   "max": "1604189999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapters 1](/chapters/1), 2, 3 and 16 used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapters 1](/chapters/01), 2, 3 and 16 used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -426,7 +426,7 @@
                   "max": "1604299999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapter&nbsp;3](/chapters/3) and [chapter&nbsp;16](/chapters/16) used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;3](/chapters/03) and [chapter&nbsp;16](/chapters/16) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -442,7 +442,7 @@
                   "max": "1605699999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapter&nbsp;3](/chapters/3) and [chapter&nbsp;16](/chapters/16) used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;3](/chapters/03) and [chapter&nbsp;16](/chapters/16) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -507,7 +507,7 @@
                   "max": "1704999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n\n- a) all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n\n- b) \n\n- i) the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n\n- a) all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n\n- b) \n\n- i) the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -531,7 +531,7 @@
                   "max": "1704999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -564,7 +564,7 @@
                   "max": "1806199999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -581,7 +581,7 @@
                   "max": "1806999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n\n- a) all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n\n- b) the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product, or the value of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n\n- a) all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n\n- b) the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product, or the value of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -598,7 +598,7 @@
                   "max": "1905999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [chapters 2](/chapters/2), 3 and 16 used does not exceed **20%** of the weight of the product, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1006](/headings/1006) and [heading&nbsp;1108](/headings/1108) used does not exceed **20%** of the weight of the product, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [chapters 2](/chapters/02), 3 and 16 used does not exceed **20%** of the weight of the product, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1006](/headings/1006) and [heading&nbsp;1108](/headings/1108) used does not exceed **20%** of the weight of the product, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -631,7 +631,7 @@
                   "max": "2003999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -664,7 +664,7 @@
                   "max": "2102999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **20%** of the weight of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **20%** of the weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -766,7 +766,7 @@
                   "max": "2106999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **20%** of the weight of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **20%** of the weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -783,7 +783,7 @@
                   "max": "2206999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading) except from non-originating materials of [heading&nbsp;2207](/headings/2207) and [heading&nbsp;2208](/headings/2208), provided that:\n\n- all the materials of [subheading&nbsp;080610](/subheading/0806100000-80), [subheading&nbsp;200961](/subheading/2009610000-80), [subheading&nbsp;200969](/subheading/2009690000-80) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **20%** of the weight of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading) except from non-originating materials of [heading&nbsp;2207](/headings/2207) and [heading&nbsp;2208](/headings/2208), provided that:\n\n- all the materials of [subheading&nbsp;080610](/subheading/0806100000-80), [subheading&nbsp;200961](/subheading/2009610000-80), [subheading&nbsp;200969](/subheading/2009690000-80) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **20%** of the weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -883,7 +883,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1001](/headings/1001) to [heading&nbsp;1004](/headings/1004), [heading&nbsp;1007](/headings/1007) to [heading&nbsp;1008](/headings/1008), [chapter&nbsp;11](/chapters/11), and [heading&nbsp;2302](/headings/2302) and [heading&nbsp;2303](/headings/2303) used does not exceed **20%** of the weight of the product, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **20%** of the weight of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1001](/headings/1001) to [heading&nbsp;1004](/headings/1004), [heading&nbsp;1007](/headings/1007) to [heading&nbsp;1008](/headings/1008), [chapter&nbsp;11](/chapters/11), and [heading&nbsp;2302](/headings/2302) and [heading&nbsp;2303](/headings/2303) used does not exceed **20%** of the weight of the product, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **20%** of the weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -1516,7 +1516,7 @@
                   "max": "3504999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading) except from non-originating materials of [chapter&nbsp;4](/chapters/4).",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading) except from non-originating materials of [chapter&nbsp;4](/chapters/04).",
                               "class": [
                                     "CTH"
                               ],

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/faroe-islands.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/faroe-islands.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) shall be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "ORIGINATING",
@@ -111,7 +111,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -128,7 +128,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -145,7 +145,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -162,7 +162,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -179,7 +179,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -196,7 +196,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -213,7 +213,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -231,7 +231,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -265,7 +265,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "MAXNOM"
@@ -283,7 +283,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -352,7 +352,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -369,7 +369,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -386,7 +386,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -403,7 +403,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -420,7 +420,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -437,7 +437,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -454,7 +454,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -488,7 +488,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -692,7 +692,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -743,7 +743,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -811,7 +811,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -879,7 +879,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -897,7 +897,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -983,7 +983,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/1), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/01), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "PRODUCTION FROM"
@@ -1208,7 +1208,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1840,7 +1840,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2027,7 +2027,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "ORIGINATING"

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/georgia.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/georgia.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) shall be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "ORIGINATING",
@@ -111,7 +111,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -128,7 +128,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -145,7 +145,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -162,7 +162,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -179,7 +179,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -196,7 +196,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -213,7 +213,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -231,7 +231,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -265,7 +265,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "MAXNOM"
@@ -283,7 +283,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -352,7 +352,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -369,7 +369,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -386,7 +386,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -403,7 +403,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -420,7 +420,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -437,7 +437,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -454,7 +454,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -488,7 +488,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -692,7 +692,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -743,7 +743,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -811,7 +811,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -879,7 +879,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -897,7 +897,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -983,7 +983,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/1), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/01), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "PRODUCTION FROM"
@@ -1208,7 +1208,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1840,7 +1840,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2027,7 +2027,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "ORIGINATING"

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/ghana.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/ghana.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) used are wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -41,7 +41,7 @@
                   "max": "0301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0302999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0303999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0304999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of all the materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex\u2010works price of the product.",
+                              "rule": "Manufacture in which the value of all the materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex\u2010works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -110,7 +110,7 @@
                   "max": "0305999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of all the materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex\u2010works price of the product.",
+                              "rule": "Manufacture in which the value of all the materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex\u2010works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -127,7 +127,7 @@
                   "max": "0306999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of all the materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex\u2010works price of the product.",
+                              "rule": "Manufacture in which the value of all the materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex\u2010works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -144,7 +144,7 @@
                   "max": "0307999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of all the materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex\u2010works price of the product.",
+                              "rule": "Manufacture in which the value of all the materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex\u2010works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -161,7 +161,7 @@
                   "max": "0308999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of all the materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex\u2010works price of the product.",
+                              "rule": "Manufacture in which the value of all the materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex\u2010works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -177,7 +177,7 @@
                   "max": "0309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -194,7 +194,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -211,7 +211,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -229,7 +229,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained\n\n- fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating *and*\n\n- the value of any materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex\u2010works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained\n\n- fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating *and*\n\n- the value of any materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex\u2010works price of the product.",
                               "class": [
                                     "WO",
                                     "ORIGINATING",
@@ -247,7 +247,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -264,7 +264,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -281,7 +281,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -298,7 +298,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -315,7 +315,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -332,7 +332,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -349,7 +349,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -367,7 +367,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -401,7 +401,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained\n\n- the value of all the materials used does not exceed **50%** of the ex\u2010works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained\n\n- the value of all the materials used does not exceed **50%** of the ex\u2010works price of the product.",
                               "class": [
                                     "WO",
                                     "MAXNOM"
@@ -419,7 +419,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -488,7 +488,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -505,7 +505,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -522,7 +522,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -539,7 +539,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -556,7 +556,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -573,7 +573,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -590,7 +590,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -624,7 +624,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -828,7 +828,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -879,7 +879,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -947,7 +947,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1015,7 +1015,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -1033,7 +1033,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -1118,7 +1118,7 @@
                   "max": "1601999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/1).",
+                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/01).",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1135,7 +1135,7 @@
                   "max": "1602999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/1).",
+                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/01).",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1152,7 +1152,7 @@
                   "max": "1603999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/1).",
+                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/01).",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1170,7 +1170,7 @@
                   "max": "1605999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of all the materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex\u2010works price of the product.",
+                              "rule": "Manufacture in which the value of all the materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex\u2010works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -1391,7 +1391,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- the cereals and derivatives (except durum wheat and its derivatives) used are wholly obtained *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- the cereals and derivatives (except durum wheat and its derivatives) used are wholly obtained *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2019,7 +2019,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2206,7 +2206,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are already originating *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are already originating *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "ORIGINATING"

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/iceland-norway.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/iceland-norway.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) shall be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "ORIGINATING",
@@ -111,7 +111,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -128,7 +128,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -145,7 +145,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -162,7 +162,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -179,7 +179,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -196,7 +196,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -213,7 +213,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -231,7 +231,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -265,7 +265,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "MAXNOM"
@@ -283,7 +283,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -352,7 +352,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -369,7 +369,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -386,7 +386,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -403,7 +403,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -420,7 +420,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -437,7 +437,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -454,7 +454,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -488,7 +488,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -692,7 +692,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -743,7 +743,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -811,7 +811,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -879,7 +879,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -897,7 +897,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -983,7 +983,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/1), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/01), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "PRODUCTION FROM"
@@ -1208,7 +1208,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1840,7 +1840,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2027,7 +2027,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "ORIGINATING"

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/israel.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/israel.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) shall be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "ORIGINATING",
@@ -111,7 +111,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -128,7 +128,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -145,7 +145,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -162,7 +162,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -179,7 +179,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -196,7 +196,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -213,7 +213,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -231,7 +231,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -265,7 +265,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "MAXNOM"
@@ -283,7 +283,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -352,7 +352,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -369,7 +369,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -386,7 +386,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -403,7 +403,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -420,7 +420,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -437,7 +437,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -454,7 +454,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -488,7 +488,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -692,7 +692,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -743,7 +743,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -811,7 +811,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -879,7 +879,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -897,7 +897,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -983,7 +983,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/1), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/01), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "PRODUCTION FROM"
@@ -1208,7 +1208,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1840,7 +1840,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2027,7 +2027,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "ORIGINATING"

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/japan.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/japan.json
@@ -7,7 +7,7 @@
                   "max": "0106999999",
                   "rules": [
                         {
-                              "rule": "All animals of [chapter&nbsp;1](/chapters/1) are wholly obtained.",
+                              "rule": "All animals of [chapter&nbsp;1](/chapters/01) are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -23,7 +23,7 @@
                   "max": "0210999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -78,7 +78,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -110,7 +110,7 @@
                   "max": "0604999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -126,7 +126,7 @@
                   "max": "0714999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -142,7 +142,7 @@
                   "max": "0814999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapter&nbsp;8](/chapters/8) used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;8](/chapters/08) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -673,7 +673,7 @@
                   "max": "1601999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapters 2](/chapters/2), 3 and 16 and heading\n\n10.06 used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapters 2](/chapters/02), 3 and 16 and heading\n\n10.06 used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -705,7 +705,7 @@
                   "max": "1602329999",
                   "rules": [
                         {
-                              "rule": "CC except from [chapter&nbsp;2](/chapters/2).",
+                              "rule": "CC except from [chapter&nbsp;2](/chapters/02).",
                               "class": [
                                     "Unspecified"
                               ],
@@ -751,7 +751,7 @@
                   "max": "1602599999",
                   "rules": [
                         {
-                              "rule": "CC except from [chapter&nbsp;2](/chapters/2).",
+                              "rule": "CC except from [chapter&nbsp;2](/chapters/02).",
                               "class": [
                                     "Unspecified"
                               ],
@@ -797,7 +797,7 @@
                   "max": "1603999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapters 2](/chapters/2), 3 and 16 used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapters 2](/chapters/02), 3 and 16 used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -813,7 +813,7 @@
                   "max": "1605999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapters 2](/chapters/2), 3 and 16 and heading\n\n10.06 used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapters 2](/chapters/02), 3 and 16 and heading\n\n10.06 used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -901,7 +901,7 @@
                   "max": "1806999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- the total weight of non-originating materials of [chapter&nbsp;4](/chapters/4) and heading\n\n19.01 used does not exceed **10%** of the weight of the product, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **30%** of the weight of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- the total weight of non-originating materials of [chapter&nbsp;4](/chapters/04) and heading\n\n19.01 used does not exceed **10%** of the weight of the product, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **30%** of the weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -1158,7 +1158,7 @@
                   "max": "2003999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1343,7 +1343,7 @@
                   "max": "2105999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- the total weight of non-originating materials of [chapter&nbsp;4](/chapters/4) and [heading&nbsp;1901](/headings/1901) used does not exceed **10%** of the weight of the product, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **20%** of the weight of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- the total weight of non-originating materials of [chapter&nbsp;4](/chapters/04) and [heading&nbsp;1901](/headings/1901) used does not exceed **10%** of the weight of the product, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **20%** of the weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -1360,7 +1360,7 @@
                   "max": "2106999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- the materials of Konnyaku of [subheading&nbsp;121299](/subheading/1212990000-80) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [chapter&nbsp;4](/chapters/4) and [heading&nbsp;1901](/headings/1901) used does not exceed **10%** of the weight of the product, *and*\n\n- the weight of non-originating materials of [heading&nbsp;1001](/headings/1001) used does not exceed **30%** of the weight of the product, *and*\n\n- the weight of non-originating materials of [heading&nbsp;1003](/headings/1003) used does not exceed **10%** of the weight of the product, *and*\n\n- the weight of non-originating materials of [heading&nbsp;1006](/headings/1006) used does not exceed **10%** of the weight of the product, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **30%** of the weight of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- the materials of Konnyaku of [subheading&nbsp;121299](/subheading/1212990000-80) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [chapter&nbsp;4](/chapters/04) and [heading&nbsp;1901](/headings/1901) used does not exceed **10%** of the weight of the product, *and*\n\n- the weight of non-originating materials of [heading&nbsp;1001](/headings/1001) used does not exceed **30%** of the weight of the product, *and*\n\n- the weight of non-originating materials of [heading&nbsp;1003](/headings/1003) used does not exceed **10%** of the weight of the product, *and*\n\n- the weight of non-originating materials of [heading&nbsp;1006](/headings/1006) used does not exceed **10%** of the weight of the product, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **30%** of the weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -1393,7 +1393,7 @@
                   "max": "2202999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- the total weight of non-originating materials of [chapter&nbsp;4](/chapters/4) and [heading&nbsp;1901](/headings/1901) used does not exceed **10%** of the weight of the product, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- the total weight of non-originating materials of [chapter&nbsp;4](/chapters/04) and [heading&nbsp;1901](/headings/1901) used does not exceed **10%** of the weight of the product, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -1410,7 +1410,7 @@
                   "max": "2208999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading) except from [heading&nbsp;2207](/headings/2207) and [heading&nbsp;2208](/headings/2208), provided that:\n\n- all the materials of [subheading&nbsp;080610](/subheading/0806100000-80), [subheading&nbsp;200961](/subheading/2009610000-80) and [subheading&nbsp;200969](/subheading/2009690000-80) used are wholly obtained, *and*\n\n- the weight of non-originating materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of the product, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading) except from [heading&nbsp;2207](/headings/2207) and [heading&nbsp;2208](/headings/2208), provided that:\n\n- all the materials of [subheading&nbsp;080610](/subheading/0806100000-80), [subheading&nbsp;200961](/subheading/2009610000-80) and [subheading&nbsp;200969](/subheading/2009690000-80) used are wholly obtained, *and*\n\n- the weight of non-originating materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of the product, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/jordan.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/jordan.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) shall be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "ORIGINATING",
@@ -111,7 +111,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -128,7 +128,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -145,7 +145,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -162,7 +162,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -179,7 +179,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -196,7 +196,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -213,7 +213,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -231,7 +231,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -265,7 +265,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "MAXNOM"
@@ -283,7 +283,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -352,7 +352,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -369,7 +369,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -386,7 +386,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -403,7 +403,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -420,7 +420,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -437,7 +437,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -454,7 +454,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -488,7 +488,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -692,7 +692,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -743,7 +743,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -811,7 +811,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -879,7 +879,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -897,7 +897,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -983,7 +983,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/1),\n\n- and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/01),\n\n- and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "PRODUCTION FROM"
@@ -1208,7 +1208,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1840,7 +1840,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2027,7 +2027,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "ORIGINATING"

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/kosovo.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/kosovo.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) shall be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "ORIGINATING",
@@ -111,7 +111,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -128,7 +128,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -145,7 +145,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -162,7 +162,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -179,7 +179,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -196,7 +196,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -213,7 +213,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -231,7 +231,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -265,7 +265,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "MAXNOM"
@@ -283,7 +283,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -352,7 +352,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -369,7 +369,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -386,7 +386,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -403,7 +403,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -420,7 +420,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -437,7 +437,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -454,7 +454,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -488,7 +488,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -692,7 +692,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -743,7 +743,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -811,7 +811,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -879,7 +879,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -897,7 +897,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -983,7 +983,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/1), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/01), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "PRODUCTION FROM"
@@ -1208,7 +1208,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1840,7 +1840,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2027,7 +2027,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "ORIGINATING"

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/lebanon.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/lebanon.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) shall be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "ORIGINATING",
@@ -111,7 +111,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -128,7 +128,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -145,7 +145,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -162,7 +162,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -179,7 +179,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -196,7 +196,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -213,7 +213,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -231,7 +231,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -265,7 +265,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "MAXNOM"
@@ -283,7 +283,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -352,7 +352,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -369,7 +369,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -386,7 +386,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -403,7 +403,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -420,7 +420,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -437,7 +437,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -454,7 +454,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -488,7 +488,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -692,7 +692,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -743,7 +743,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -811,7 +811,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -879,7 +879,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -897,7 +897,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -983,7 +983,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/1), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/01), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "PRODUCTION FROM"
@@ -1208,7 +1208,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1840,7 +1840,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2027,7 +2027,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "ORIGINATING"

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/mexico.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/mexico.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) used must be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained,\n\n- any fruit juice (expect those of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used must already be originating,\n\n- the value of any materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained,\n\n- any fruit juice (expect those of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used must already be originating,\n\n- the value of any materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO"
                               ],
@@ -109,7 +109,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -126,7 +126,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -143,7 +143,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -160,7 +160,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -177,7 +177,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -194,7 +194,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -211,7 +211,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -229,7 +229,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -263,7 +263,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used must be wholly obtained,\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used must be wholly obtained,\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO"
                               ],
@@ -280,7 +280,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -348,7 +348,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -365,7 +365,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -382,7 +382,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -399,7 +399,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -416,7 +416,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -433,7 +433,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -450,7 +450,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -484,7 +484,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -688,7 +688,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -739,7 +739,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -807,7 +807,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -875,7 +875,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used must be wholly obtained,\n\n- all the vegetable materials used must be wholly obtained.\n\n- However, materials of heading Nos 1507, 150, 1511 and 1513 may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used must be wholly obtained,\n\n- all the vegetable materials used must be wholly obtained.\n\n- However, materials of heading Nos 1507, 150, 1511 and 1513 may be used.",
                               "class": [
                                     "WO"
                               ],
@@ -892,7 +892,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used must be wholly obtained, all the vegetable materials used must be wholly obtained.\n\nHowever, materials of heading Nos 1507, 1508, 1511 and 1513 may be used.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used must be wholly obtained, all the vegetable materials used must be wholly obtained.\n\nHowever, materials of heading Nos 1507, 1508, 1511 and 1513 may be used.",
                               "class": [
                                     "WO"
                               ],
@@ -977,7 +977,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/1). All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/01). All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1198,7 +1198,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals and derivatives (except durum wheat and its derivatives) used must be wholly obtained,\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals and derivatives (except durum wheat and its derivatives) used must be wholly obtained,\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1827,7 +1827,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2014,7 +2014,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used must already be originating,\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used must already be originating,\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/moldova.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/moldova.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) shall be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "ORIGINATING",
@@ -111,7 +111,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -128,7 +128,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -145,7 +145,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -162,7 +162,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -179,7 +179,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -196,7 +196,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -213,7 +213,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -231,7 +231,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -265,7 +265,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "MAXNOM"
@@ -283,7 +283,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -352,7 +352,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -369,7 +369,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -386,7 +386,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -403,7 +403,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -420,7 +420,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -437,7 +437,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -454,7 +454,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -488,7 +488,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -692,7 +692,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -743,7 +743,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -811,7 +811,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -879,7 +879,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -897,7 +897,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -983,7 +983,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/1), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/01), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "PRODUCTION FROM"
@@ -1208,7 +1208,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1840,7 +1840,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2027,7 +2027,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "ORIGINATING"

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/morocco.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/morocco.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) shall be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "ORIGINATING",
@@ -111,7 +111,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -128,7 +128,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -145,7 +145,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -162,7 +162,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -179,7 +179,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -196,7 +196,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -213,7 +213,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -231,7 +231,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -265,7 +265,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "MAXNOM"
@@ -283,7 +283,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -352,7 +352,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -369,7 +369,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -386,7 +386,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -403,7 +403,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -420,7 +420,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -437,7 +437,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -454,7 +454,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -488,7 +488,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -692,7 +692,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -743,7 +743,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -811,7 +811,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -879,7 +879,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -897,7 +897,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -983,7 +983,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/1), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/01), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "PRODUCTION FROM"
@@ -1208,7 +1208,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1840,7 +1840,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2027,7 +2027,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "ORIGINATING"

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/north-macedonia.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/north-macedonia.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) shall be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "ORIGINATING",
@@ -111,7 +111,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -128,7 +128,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -145,7 +145,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -162,7 +162,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -179,7 +179,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -196,7 +196,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -213,7 +213,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -231,7 +231,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -265,7 +265,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "MAXNOM"
@@ -283,7 +283,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -352,7 +352,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -369,7 +369,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -386,7 +386,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -403,7 +403,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -420,7 +420,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -437,7 +437,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -454,7 +454,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -488,7 +488,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -692,7 +692,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -743,7 +743,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -811,7 +811,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -879,7 +879,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -897,7 +897,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -983,7 +983,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/1), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/01), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "PRODUCTION FROM"
@@ -1208,7 +1208,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1840,7 +1840,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2027,7 +2027,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "ORIGINATING"

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/pacific.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/pacific.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) used must be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0301999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -59,7 +59,7 @@
                   "max": "0302999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -76,7 +76,7 @@
                   "max": "0303999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0304999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -110,7 +110,7 @@
                   "max": "0305999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -127,7 +127,7 @@
                   "max": "0306999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -144,7 +144,7 @@
                   "max": "0306999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -161,7 +161,7 @@
                   "max": "0307999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -178,7 +178,7 @@
                   "max": "0307999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -195,7 +195,7 @@
                   "max": "0308999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -212,7 +212,7 @@
                   "max": "0309999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -228,7 +228,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -245,7 +245,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -263,7 +263,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained\n\n- any fruit juice (except those of pineapple, lime or grape fruit) of [heading&nbsp;2009](/headings/2009) used must already be originating\n\n- the value of any materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the\n\n- ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained\n\n- any fruit juice (except those of pineapple, lime or grape fruit) of [heading&nbsp;2009](/headings/2009) used must already be originating\n\n- the value of any materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the\n\n- ex-works price of the product.",
                               "class": [
                                     "WO"
                               ],
@@ -279,7 +279,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -296,7 +296,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -313,7 +313,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -330,7 +330,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -347,7 +347,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -364,7 +364,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -381,7 +381,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -399,7 +399,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -433,7 +433,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used must be wholly obtained\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used must be wholly obtained\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO"
                               ],
@@ -450,7 +450,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -518,7 +518,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -535,7 +535,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -552,7 +552,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -569,7 +569,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -586,7 +586,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -603,7 +603,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -620,7 +620,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -654,7 +654,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -858,7 +858,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -909,7 +909,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -977,7 +977,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1045,7 +1045,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used must be wholly obtained\n\n- all the vegetable materials used must be wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used must be wholly obtained\n\n- all the vegetable materials used must be wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -1063,7 +1063,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used must be wholly obtained\n\n- all the vegetable materials used must be wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used must be wholly obtained\n\n- all the vegetable materials used must be wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -1148,7 +1148,7 @@
                   "max": "1601999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/1).",
+                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/01).",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1165,7 +1165,7 @@
                   "max": "1602999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/1).",
+                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/01).",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1182,7 +1182,7 @@
                   "max": "1603999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/1).",
+                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/01).",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1200,7 +1200,7 @@
                   "max": "1605999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -1421,7 +1421,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all cereals and derivatives (except durum wheat and its derivatives) used must be wholly obtained\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all cereals and derivatives (except durum wheat and its derivatives) used must be wholly obtained\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2035,7 +2035,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2222,7 +2222,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used must already be originating\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used must already be originating\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/palestinian-authority.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/palestinian-authority.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) shall be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "ORIGINATING",
@@ -111,7 +111,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -128,7 +128,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -145,7 +145,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -162,7 +162,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -179,7 +179,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -196,7 +196,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -213,7 +213,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -231,7 +231,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -265,7 +265,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "MAXNOM"
@@ -283,7 +283,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -352,7 +352,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -369,7 +369,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -386,7 +386,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -403,7 +403,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -420,7 +420,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -437,7 +437,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -454,7 +454,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -488,7 +488,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -692,7 +692,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -743,7 +743,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -811,7 +811,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -879,7 +879,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -897,7 +897,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -983,7 +983,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/1), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/01), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "PRODUCTION FROM"
@@ -1208,7 +1208,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1840,7 +1840,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2027,7 +2027,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "ORIGINATING"

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/sacum.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/sacum.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) used must be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0301999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -59,7 +59,7 @@
                   "max": "0302999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -76,7 +76,7 @@
                   "max": "0303999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0304999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -110,7 +110,7 @@
                   "max": "0305999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -127,7 +127,7 @@
                   "max": "0306999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -144,7 +144,7 @@
                   "max": "0306999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -161,7 +161,7 @@
                   "max": "0307999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -178,7 +178,7 @@
                   "max": "0307999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -195,7 +195,7 @@
                   "max": "0308999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -212,7 +212,7 @@
                   "max": "0308999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -229,7 +229,7 @@
                   "max": "0309999999",
                   "rules": [
                         {
-                              "rule": "All the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "All the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -245,7 +245,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -262,7 +262,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -280,7 +280,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained\n\n- any fruit juice (except those of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used must already be originating\n\n- the value of any materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained\n\n- any fruit juice (except those of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used must already be originating\n\n- the value of any materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO"
                               ],
@@ -296,7 +296,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -313,7 +313,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -330,7 +330,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -347,7 +347,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -364,7 +364,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -381,7 +381,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -398,7 +398,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -416,7 +416,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -450,7 +450,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used must be wholly obtained\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used must be wholly obtained\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO"
                               ],
@@ -467,7 +467,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -535,7 +535,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -552,7 +552,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -569,7 +569,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -586,7 +586,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -603,7 +603,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -620,7 +620,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -637,7 +637,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -671,7 +671,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -875,7 +875,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -926,7 +926,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -994,7 +994,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1062,7 +1062,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used must be wholly obtained\n\n- all the vegetable materials used must be wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and 1513\n\n- may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used must be wholly obtained\n\n- all the vegetable materials used must be wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and 1513\n\n- may be used.",
                               "class": [
                                     "WO"
                               ],
@@ -1079,7 +1079,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used must be wholly obtained\n\n- all the vegetable materials used must be wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and 1513\n\n- may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used must be wholly obtained\n\n- all the vegetable materials used must be wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and 1513\n\n- may be used.",
                               "class": [
                                     "WO"
                               ],
@@ -1163,7 +1163,7 @@
                   "max": "1601999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/1).",
+                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/01).",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1180,7 +1180,7 @@
                   "max": "1602999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/1).",
+                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/01).",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1197,7 +1197,7 @@
                   "max": "1603999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/1).",
+                              "rule": "Manufacture from animals of [chapter&nbsp;1](/chapters/01).",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1215,7 +1215,7 @@
                   "max": "1605999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/3) used does not exceed **15%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which the value of any materials of [chapter&nbsp;3](/chapters/03) used does not exceed **15%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -1436,7 +1436,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all cereals and derivatives (except durum wheat and its derivatives) used must be wholly obtained\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all cereals and derivatives (except durum wheat and its derivatives) used must be wholly obtained\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2050,7 +2050,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2237,7 +2237,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used must already be originating\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used must be wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used must already be originating\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used must be wholly obtained.",
                               "class": [
                                     "WO"
                               ],

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/serbia.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/serbia.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) shall be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "ORIGINATING",
@@ -111,7 +111,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -128,7 +128,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -145,7 +145,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -162,7 +162,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -179,7 +179,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -196,7 +196,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -213,7 +213,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -231,7 +231,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -265,7 +265,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "MAXNOM"
@@ -283,7 +283,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -352,7 +352,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -369,7 +369,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -386,7 +386,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -403,7 +403,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -420,7 +420,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -437,7 +437,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -454,7 +454,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -488,7 +488,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -692,7 +692,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -743,7 +743,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -811,7 +811,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -879,7 +879,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -897,7 +897,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -983,7 +983,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/1), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/01), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "PRODUCTION FROM"
@@ -1208,7 +1208,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1840,7 +1840,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2027,7 +2027,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "ORIGINATING"

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/singapore.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/singapore.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) are wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -229,7 +229,7 @@
                   "max": "0304999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -263,7 +263,7 @@
                   "max": "0305999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -297,7 +297,7 @@
                   "max": "0306999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -331,7 +331,7 @@
                   "max": "0307999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -382,7 +382,7 @@
                   "max": "0499999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "WO",
                                     "(PRODUCTION FROM",
@@ -435,7 +435,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -452,7 +452,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -469,7 +469,7 @@
                   "max": "0899999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the fruit, nuts and peels of citrus fruits or melons of [chapter&nbsp;8](/chapters/8) used are wholly obtained, *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
+                              "rule": "Manufacture in which:\n\n- all the fruit, nuts and peels of citrus fruits or melons of [chapter&nbsp;8](/chapters/08) used are wholly obtained, *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "WO",
                                     "(WO",
@@ -846,7 +846,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapters 2](/chapters/2), 3 and 16 used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapters 2](/chapters/02), 3 and 16 used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -914,7 +914,7 @@
                   "max": "1704999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **20%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **20%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of final product.",
                               "class": [
                                     "(CTH RESTRICTION (MAXWEIGHT",
                                     "MAXWEIGHT))"
@@ -932,7 +932,7 @@
                   "max": "1899999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **20%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **20%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of final product.",
                               "class": [
                                     "(CTH RESTRICTION (MAXWEIGHT",
                                     "MAXWEIGHT))"
@@ -950,7 +950,7 @@
                   "max": "1999999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe weight of the materials of [chapters 2](/chapters/2), 3 and 16 used does not exceed **20%** of the weight of the final product, *and*\n\nthe weight of the materials of [heading&nbsp;1006](/headings/1006) and [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used does not exceed **20%** of the weight of the final product, *and*\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **20%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe weight of the materials of [chapters 2](/chapters/02), 3 and 16 used does not exceed **20%** of the weight of the final product, *and*\n\nthe weight of the materials of [heading&nbsp;1006](/headings/1006) and [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used does not exceed **20%** of the weight of the final product, *and*\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **20%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of final product.",
                               "class": [
                                     "(CTH RESTRICTION (MAXWEIGHT",
                                     "MAXWEIGHT",
@@ -969,7 +969,7 @@
                   "max": "1901209999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe weight of the materials of [chapters 2](/chapters/2), 3 and 16 used does not exceed **20%** of the weight of the final product, *and*\n\nthe weight of the materials of [heading&nbsp;1006](/headings/1006) and [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used does not exceed **40%** of the weight of the final product, *and*\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **70%** of the weight of final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe weight of the materials of [chapters 2](/chapters/02), 3 and 16 used does not exceed **20%** of the weight of the final product, *and*\n\nthe weight of the materials of [heading&nbsp;1006](/headings/1006) and [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used does not exceed **40%** of the weight of the final product, *and*\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **70%** of the weight of final product.",
                               "class": [
                                     "(CTH RESTRICTION (MAXWEIGHT",
                                     "MAXWEIGHT",
@@ -988,7 +988,7 @@
                   "max": "1901909999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe weight of the materials of [chapters 2](/chapters/2), 3 and 16 used does not exceed **20%** of the weight of the final product, *and*\n\nthe weight of the materials of [heading&nbsp;1006](/headings/1006) and [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used does not exceed **40%** of the weight of the final product, *and*\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **70%** of the weight of final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe weight of the materials of [chapters 2](/chapters/02), 3 and 16 used does not exceed **20%** of the weight of the final product, *and*\n\nthe weight of the materials of [heading&nbsp;1006](/headings/1006) and [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used does not exceed **40%** of the weight of the final product, *and*\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **70%** of the weight of final product.",
                               "class": [
                                     "(CTH RESTRICTION (MAXWEIGHT",
                                     "MAXWEIGHT",
@@ -1007,7 +1007,7 @@
                   "max": "1902199999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe weight of the materials of [chapters 2](/chapters/2), 3 and 16 used does not exceed **20%** of the weight of the final product, *and*\n\nthe weight of the materials of [heading&nbsp;1006](/headings/1006) and [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used does not exceed **40%** of the weight of the final product, *and*\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **70%** of the weight of final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe weight of the materials of [chapters 2](/chapters/02), 3 and 16 used does not exceed **20%** of the weight of the final product, *and*\n\nthe weight of the materials of [heading&nbsp;1006](/headings/1006) and [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used does not exceed **40%** of the weight of the final product, *and*\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **70%** of the weight of final product.",
                               "class": [
                                     "(CTH RESTRICTION (MAXWEIGHT",
                                     "MAXWEIGHT",
@@ -1026,7 +1026,7 @@
                   "max": "1902209999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe weight of the materials of [chapters 2](/chapters/2), 3 and 16 used does not exceed **20%** of the weight of the final product, *and*\n\nthe weight of the materials of [heading&nbsp;1006](/headings/1006) and [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used does not exceed **40%** of the weight of the final product, *and*\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **70%** of the weight of final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe weight of the materials of [chapters 2](/chapters/02), 3 and 16 used does not exceed **20%** of the weight of the final product, *and*\n\nthe weight of the materials of [heading&nbsp;1006](/headings/1006) and [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used does not exceed **40%** of the weight of the final product, *and*\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **70%** of the weight of final product.",
                               "class": [
                                     "(CTH RESTRICTION (MAXWEIGHT",
                                     "MAXWEIGHT",
@@ -1045,7 +1045,7 @@
                   "max": "1902309999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe weight of the materials of [chapters 2](/chapters/2), 3 and 16 used does not exceed **20%** of the weight of the final product, *and*\n\nthe weight of the materials of [heading&nbsp;1006](/headings/1006) and [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used does not exceed **40%** of the weight of the final product, *and*\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **70%** of the weight of final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe weight of the materials of [chapters 2](/chapters/02), 3 and 16 used does not exceed **20%** of the weight of the final product, *and*\n\nthe weight of the materials of [heading&nbsp;1006](/headings/1006) and [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used does not exceed **40%** of the weight of the final product, *and*\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **70%** of the weight of final product.",
                               "class": [
                                     "(CTH RESTRICTION (MAXWEIGHT",
                                     "MAXWEIGHT",
@@ -1064,7 +1064,7 @@
                   "max": "1905909999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe weight of the materials of [chapters 2](/chapters/2), 3 and 16 used does not exceed **20%** of the weight of the final product, *and*\n\nthe weight of the materials of [heading&nbsp;1006](/headings/1006) and [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used does not exceed **40%** of the weight of the final product, *and*\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **70%** of the weight of final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe weight of the materials of [chapters 2](/chapters/02), 3 and 16 used does not exceed **20%** of the weight of the final product, *and*\n\nthe weight of the materials of [heading&nbsp;1006](/headings/1006) and [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used does not exceed **40%** of the weight of the final product, *and*\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **70%** of the weight of final product.",
                               "class": [
                                     "(CTH RESTRICTION (MAXWEIGHT",
                                     "MAXWEIGHT",
@@ -1101,7 +1101,7 @@
                   "max": "2003999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) and [chapter&nbsp;8](/chapters/8) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) and [chapter&nbsp;8](/chapters/08) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1226,7 +1226,7 @@
                   "max": "2199999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **20%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **20%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of final product.",
                               "class": [
                                     "(CTH RESTRICTION (MAXWEIGHT",
                                     "MAXWEIGHT))"
@@ -1244,7 +1244,7 @@
                   "max": "2101119999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **60%** of the weight of final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **60%** of the weight of final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1261,7 +1261,7 @@
                   "max": "2101129999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **60%** of the weight of final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **60%** of the weight of final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1278,7 +1278,7 @@
                   "max": "2101209999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **60%** of the weight of final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **60%** of the weight of final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1295,7 +1295,7 @@
                   "max": "2103109999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **60%** of the weight of final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **60%** of the weight of final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1312,7 +1312,7 @@
                   "max": "2103909999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **60%** of the weight of final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **60%** of the weight of final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1329,7 +1329,7 @@
                   "max": "2104109999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **60%** of the weight of final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **60%** of the weight of final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1346,7 +1346,7 @@
                   "max": "2106909999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **60%** of the weight of final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **60%** of the weight of final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1363,7 +1363,7 @@
                   "max": "2299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product and [heading&nbsp;2207](/headings/2207) and [heading&nbsp;2208](/headings/2208), in which:\n\n- all the materials of [subheading&nbsp;080610](/subheading/0806100000-80), [subheading&nbsp;200961](/subheading/2009610000-80), [subheading&nbsp;200969](/subheading/2009690000-80) used are wholly obtained, *and*\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **20%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product and [heading&nbsp;2207](/headings/2207) and [heading&nbsp;2208](/headings/2208), in which:\n\n- all the materials of [subheading&nbsp;080610](/subheading/0806100000-80), [subheading&nbsp;200961](/subheading/2009610000-80), [subheading&nbsp;200969](/subheading/2009690000-80) used are wholly obtained, *and*\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **20%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of final product.",
                               "class": [
                                     "WO"
                               ],
@@ -1533,7 +1533,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nall the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained, *and*\n\nthe materials of [chapter&nbsp;10](/chapters/10) and [chapter&nbsp;11](/chapters/11) and [heading&nbsp;2302](/headings/2302) and [heading&nbsp;2303](/headings/2303) used does not exceed **20%** of the weight of the final product, *and*\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **20%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nall the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained, *and*\n\nthe materials of [chapter&nbsp;10](/chapters/10) and [chapter&nbsp;11](/chapters/11) and [heading&nbsp;2302](/headings/2302) and [heading&nbsp;2303](/headings/2303) used does not exceed **20%** of the weight of the final product, *and*\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **20%** of the weight of the final product, *and*\n\nthe total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of final product.",
                               "class": [
                                     "WO"
                               ],

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/south-korea.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/south-korea.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) shall be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "ORIGINATING",
@@ -111,7 +111,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -128,7 +128,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -145,7 +145,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -162,7 +162,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -179,7 +179,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -196,7 +196,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -213,7 +213,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -231,7 +231,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -248,7 +248,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "MAXNOM"
@@ -266,7 +266,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -283,7 +283,7 @@
                   "max": "0899999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the fruit and nuts of [chapter&nbsp;8](/chapters/8) used are wholly obtained, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the value of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the fruit and nuts of [chapter&nbsp;8](/chapters/08) used are wholly obtained, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the value of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "(WO",
@@ -302,7 +302,7 @@
                   "max": "0901999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -336,7 +336,7 @@
                   "max": "0902199999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -370,7 +370,7 @@
                   "max": "0902199999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -387,7 +387,7 @@
                   "max": "0902299999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -421,7 +421,7 @@
                   "max": "0902399999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -455,7 +455,7 @@
                   "max": "0902499999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -489,7 +489,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -506,7 +506,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -523,7 +523,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -540,7 +540,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -557,7 +557,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -574,7 +574,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -591,7 +591,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -608,7 +608,7 @@
                   "max": "0910119999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -625,7 +625,7 @@
                   "max": "0910129999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -642,7 +642,7 @@
                   "max": "0910299999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -659,7 +659,7 @@
                   "max": "0910399999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -676,7 +676,7 @@
                   "max": "0910919999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -710,7 +710,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -743,7 +743,7 @@
                   "max": "1101999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7), [chapter&nbsp;8](/chapters/8), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;11](/chapters/11) and [chapter&nbsp;23](/chapters/23) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07), [chapter&nbsp;8](/chapters/08), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;11](/chapters/11) and [chapter&nbsp;23](/chapters/23) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -760,7 +760,7 @@
                   "max": "1102999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7), [chapter&nbsp;8](/chapters/8), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;11](/chapters/11) and [chapter&nbsp;23](/chapters/23) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07), [chapter&nbsp;8](/chapters/08), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;11](/chapters/11) and [chapter&nbsp;23](/chapters/23) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -777,7 +777,7 @@
                   "max": "1103999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7), [chapter&nbsp;8](/chapters/8), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;11](/chapters/11) and [chapter&nbsp;23](/chapters/23) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07), [chapter&nbsp;8](/chapters/08), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;11](/chapters/11) and [chapter&nbsp;23](/chapters/23) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -794,7 +794,7 @@
                   "max": "1104999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7), [chapter&nbsp;8](/chapters/8), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;11](/chapters/11) and [chapter&nbsp;23](/chapters/23) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07), [chapter&nbsp;8](/chapters/08), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;11](/chapters/11) and [chapter&nbsp;23](/chapters/23) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -811,7 +811,7 @@
                   "max": "1105999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7), [chapter&nbsp;8](/chapters/8), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;11](/chapters/11) and [chapter&nbsp;23](/chapters/23) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07), [chapter&nbsp;8](/chapters/08), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;11](/chapters/11) and [chapter&nbsp;23](/chapters/23) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -828,7 +828,7 @@
                   "max": "1106999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7), [chapter&nbsp;8](/chapters/8), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;11](/chapters/11) and [chapter&nbsp;23](/chapters/23) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07), [chapter&nbsp;8](/chapters/08), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;11](/chapters/11) and [chapter&nbsp;23](/chapters/23) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -862,7 +862,7 @@
                   "max": "1107999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7), [chapter&nbsp;8](/chapters/8), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;11](/chapters/11) and [chapter&nbsp;23](/chapters/23) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07), [chapter&nbsp;8](/chapters/08), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;11](/chapters/11) and [chapter&nbsp;23](/chapters/23) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -879,7 +879,7 @@
                   "max": "1108999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7), [chapter&nbsp;8](/chapters/8), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;11](/chapters/11) and [chapter&nbsp;23](/chapters/23) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07), [chapter&nbsp;8](/chapters/08), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;11](/chapters/11) and [chapter&nbsp;23](/chapters/23) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -896,7 +896,7 @@
                   "max": "1109999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7), [chapter&nbsp;8](/chapters/8), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;11](/chapters/11) and [chapter&nbsp;23](/chapters/23) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07), [chapter&nbsp;8](/chapters/08), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;11](/chapters/11) and [chapter&nbsp;23](/chapters/23) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1101,7 +1101,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and bones of [heading&nbsp;0506](/headings/0506) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and bones of [heading&nbsp;0506](/headings/0506) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1815,7 +1815,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained, *and*\n\n- all the vegetable materials of [chapter&nbsp;7](/chapters/7), [chapter&nbsp;8](/chapters/8), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;15](/chapters/15) and [chapter&nbsp;23](/chapters/23) used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained, *and*\n\n- all the vegetable materials of [chapter&nbsp;7](/chapters/07), [chapter&nbsp;8](/chapters/08), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;15](/chapters/15) and [chapter&nbsp;23](/chapters/23) used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO",
@@ -1851,7 +1851,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- all the vegetable materials of [chapter&nbsp;7](/chapters/7), [chapter&nbsp;8](/chapters/8), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;15](/chapters/15) and [chapter&nbsp;23](/chapters/23) used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- all the vegetable materials of [chapter&nbsp;7](/chapters/07), [chapter&nbsp;8](/chapters/08), [chapter&nbsp;10](/chapters/10), [chapter&nbsp;15](/chapters/15) and [chapter&nbsp;23](/chapters/23) used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO",
@@ -1938,7 +1938,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/1), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/01), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "PRODUCTION FROM"
@@ -2213,7 +2213,7 @@
                   "max": "1901999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product,\n\n- in which all the materials of [chapter&nbsp;4](/chapters/4), [heading&nbsp;1006](/headings/1006) and [chapter&nbsp;11](/chapters/11) used are wholly obtained, *and*\n\n- in which the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product,\n\n- in which all the materials of [chapter&nbsp;4](/chapters/04), [heading&nbsp;1006](/headings/1006) and [chapter&nbsp;11](/chapters/11) used are wholly obtained, *and*\n\n- in which the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "(CTH",
@@ -2232,7 +2232,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) of [chapter&nbsp;10](/chapters/10) and [chapter&nbsp;11](/chapters/11) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained if they represent more than **20%** by weight of the product.",
+                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) of [chapter&nbsp;10](/chapters/10) and [chapter&nbsp;11](/chapters/11) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained if they represent more than **20%** by weight of the product.",
                               "class": [
                                     "WO",
                                     "(WO",
@@ -2354,7 +2354,7 @@
                   "max": "2001999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the fruit, nuts or vegetables of [chapter&nbsp;7](/chapters/7), [chapter&nbsp;8](/chapters/8) and [chapter&nbsp;12](/chapters/12) used are wholly obtained, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the fruit, nuts or vegetables of [chapter&nbsp;7](/chapters/07), [chapter&nbsp;8](/chapters/08) and [chapter&nbsp;12](/chapters/12) used are wholly obtained, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "(WO",
@@ -2373,7 +2373,7 @@
                   "max": "2002999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the fruit, nuts or vegetables of [chapter&nbsp;7](/chapters/7), [chapter&nbsp;8](/chapters/8) and [chapter&nbsp;12](/chapters/12) used are wholly obtained, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the fruit, nuts or vegetables of [chapter&nbsp;7](/chapters/07), [chapter&nbsp;8](/chapters/08) and [chapter&nbsp;12](/chapters/12) used are wholly obtained, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "(WO",
@@ -2392,7 +2392,7 @@
                   "max": "2003999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the fruit, nuts or vegetables of [chapter&nbsp;7](/chapters/7), [chapter&nbsp;8](/chapters/8) and [chapter&nbsp;12](/chapters/12) used are wholly obtained, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the fruit, nuts or vegetables of [chapter&nbsp;7](/chapters/07), [chapter&nbsp;8](/chapters/08) and [chapter&nbsp;12](/chapters/12) used are wholly obtained, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "(WO",
@@ -2411,7 +2411,7 @@
                   "max": "2004999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the fruit, nuts or vegetables of [chapter&nbsp;7](/chapters/7), [chapter&nbsp;8](/chapters/8) and [chapter&nbsp;12](/chapters/12) used are wholly obtained, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the fruit, nuts or vegetables of [chapter&nbsp;7](/chapters/07), [chapter&nbsp;8](/chapters/08) and [chapter&nbsp;12](/chapters/12) used are wholly obtained, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "(WO",
@@ -2430,7 +2430,7 @@
                   "max": "2005999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the fruit, nuts or vegetables of [chapter&nbsp;7](/chapters/7), [chapter&nbsp;8](/chapters/8) and [chapter&nbsp;12](/chapters/12) used are wholly obtained, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the fruit, nuts or vegetables of [chapter&nbsp;7](/chapters/07), [chapter&nbsp;8](/chapters/08) and [chapter&nbsp;12](/chapters/12) used are wholly obtained, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "(WO",
@@ -2484,7 +2484,7 @@
                   "max": "2008999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the fruit, nuts or vegetables of [chapter&nbsp;7](/chapters/7), [chapter&nbsp;8](/chapters/8) and [chapter&nbsp;12](/chapters/12) used are wholly obtained, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the fruit, nuts or vegetables of [chapter&nbsp;7](/chapters/07), [chapter&nbsp;8](/chapters/08) and [chapter&nbsp;12](/chapters/12) used are wholly obtained, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "(WO",
@@ -2937,7 +2937,7 @@
                   "max": "2105999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- the value of all the materials of [chapters 4](/chapters/4) used does not exceed **30%** of the ex-works price of the product\n\n- the value of all the materials of [chapters 17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- the value of all the materials of [chapters 4](/chapters/04) used does not exceed **30%** of the ex-works price of the product\n\n- the value of all the materials of [chapters 17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM",
                                     "(MAXNOM",
@@ -2973,7 +2973,7 @@
                   "max": "2106999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product,\n\n- in which all the materials of [subheading&nbsp;121120](/subheading/1211200000-80) and [subheading&nbsp;130219](/subheading/1302190000-80) used are wholly obtained, *and*\n\n- in which the value of all the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **30%** of the ex-works price of the product, *and*\n\n- the value of all the materials of [chapters 17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product,\n\n- in which all the materials of [subheading&nbsp;121120](/subheading/1211200000-80) and [subheading&nbsp;130219](/subheading/1302190000-80) used are wholly obtained, *and*\n\n- in which the value of all the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **30%** of the ex-works price of the product, *and*\n\n- the value of all the materials of [chapters 17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "(CTH",
@@ -3175,7 +3175,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -3447,7 +3447,7 @@
                   "max": "2306999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the olives of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the olives of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -3515,7 +3515,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\nall the materials of [chapters 2](/chapters/2), 3, 4,\n\n10, 11 and 17, used are originating.",
+                              "rule": "Manufacture in which:\n\nall the materials of [chapters 2](/chapters/02), 3, 4,\n\n10, 11 and 17, used are originating.",
                               "class": [
                                     "ORIGINATING"
                               ],

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/switzerland-liechtenstein.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/switzerland-liechtenstein.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) shall be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -59,7 +59,7 @@
                   "max": "0499999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -110,7 +110,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -127,7 +127,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -144,7 +144,7 @@
                   "max": "0899999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the fruit, nuts and peels of citrus fruits or melons of [chapter&nbsp;8](/chapters/8) used are wholly obtained.",
+                              "rule": "Manufacture in which all the fruit, nuts and peels of citrus fruits or melons of [chapter&nbsp;8](/chapters/08) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -195,7 +195,7 @@
                   "max": "1199999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapters 8](/chapters/8), 10 and 11, [heading&nbsp;0701](/headings/0701), [heading&nbsp;0714](/headings/0714), [heading&nbsp;2302](/headings/2302) and [heading&nbsp;2303](/headings/2303), and [subheading&nbsp;071010](/subheading/0710100000-80) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapters 8](/chapters/08), 10 and 11, [heading&nbsp;0701](/headings/0701), [heading&nbsp;0714](/headings/0714), [heading&nbsp;2302](/headings/2302) and [heading&nbsp;2303](/headings/2303), and [subheading&nbsp;071010](/subheading/0710100000-80) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -637,7 +637,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2), [chapter&nbsp;3](/chapters/3) and [chapter&nbsp;16](/chapters/16) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02), [chapter&nbsp;3](/chapters/03) and [chapter&nbsp;16](/chapters/16) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1028,7 +1028,7 @@
                   "max": "1901999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which the individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of the final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which the individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1045,7 +1045,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\n- the weight of the materials of [heading&nbsp;1006](/headings/1006) and [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used does not exceed **20%** of the weight of the final product, *and*\n\n- the weight of the materials of [chapters 2](/chapters/2), 3 and 16 used does not exceed **20%** of the weight of the final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\n- the weight of the materials of [heading&nbsp;1006](/headings/1006) and [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used does not exceed **20%** of the weight of the final product, *and*\n\n- the weight of the materials of [chapters 2](/chapters/02), 3 and 16 used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1130,7 +1130,7 @@
                   "max": "2003999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1351,7 +1351,7 @@
                   "max": "2105999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\n- the individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of the final product\n\nand\n\n- the total combined weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **60%** of the weight of the final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\n- the individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of the final product\n\nand\n\n- the total combined weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **60%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1657,7 +1657,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained,\n\n- the weight of materials of [chapter&nbsp;10](/chapters/10) and [chapter&nbsp;11](/chapters/11) and [heading&nbsp;2302](/headings/2302) and [heading&nbsp;2303](/headings/2303) used does not exceed **20%** of the weight of the final product,\n\n- the individual weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of the final product, *and*\n\n- the total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **50%** of the weight of the final product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained,\n\n- the weight of materials of [chapter&nbsp;10](/chapters/10) and [chapter&nbsp;11](/chapters/11) and [heading&nbsp;2302](/headings/2302) and [heading&nbsp;2303](/headings/2303) used does not exceed **20%** of the weight of the final product,\n\n- the individual weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of the final product, *and*\n\n- the total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **50%** of the weight of the final product.",
                               "class": [
                                     "WO"
                               ],

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/tunisia.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/tunisia.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) shall be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "ORIGINATING",
@@ -111,7 +111,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -128,7 +128,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -145,7 +145,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -162,7 +162,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -179,7 +179,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -196,7 +196,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -213,7 +213,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -231,7 +231,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -265,7 +265,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "MAXNOM"
@@ -283,7 +283,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -352,7 +352,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -369,7 +369,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -386,7 +386,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -403,7 +403,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -420,7 +420,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -437,7 +437,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -454,7 +454,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -488,7 +488,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -692,7 +692,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -743,7 +743,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -811,7 +811,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -879,7 +879,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -897,7 +897,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -983,7 +983,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/1), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/01), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "PRODUCTION FROM"
@@ -1208,7 +1208,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1840,7 +1840,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2027,7 +2027,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "ORIGINATING"

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/turkey.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/turkey.json
@@ -7,7 +7,7 @@
                   "max": "0106999999",
                   "rules": [
                         {
-                              "rule": "All animals of [chapter&nbsp;1](/chapters/1) are wholly obtained.",
+                              "rule": "All animals of [chapter&nbsp;1](/chapters/01) are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -23,7 +23,7 @@
                   "max": "0210999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -39,7 +39,7 @@
                   "max": "0309999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -55,7 +55,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Production in which: \n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained, and \n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) does not exceed **20%** of the weight of the product.",
+                              "rule": "Production in which: \n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained, and \n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) does not exceed **20%** of the weight of the product.",
                               "class": [
                                     "WO",
                                     "MAXWEIGHT"
@@ -88,7 +88,7 @@
                   "max": "0604999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -104,7 +104,7 @@
                   "max": "0714999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -120,7 +120,7 @@
                   "max": "0814999999",
                   "rules": [
                         {
-                              "rule": "Production in which:\n\n- all the materials of [chapter&nbsp;8](/chapters/8) used are wholly obtained, and \n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) does not exceed **20%** of the weight of the product.",
+                              "rule": "Production in which:\n\n- all the materials of [chapter&nbsp;8](/chapters/08) used are wholly obtained, and \n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) does not exceed **20%** of the weight of the product.",
                               "class": [
                                     "WO",
                                     "MAXWEIGHT"
@@ -378,7 +378,7 @@
                   "max": "1604189999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapters 1](/chapters/1), 2, 3 and 16 used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapters 1](/chapters/01), 2, 3 and 16 used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -426,7 +426,7 @@
                   "max": "1604299999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapter&nbsp;3](/chapters/3) and [chapter&nbsp;16](/chapters/16) used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;3](/chapters/03) and [chapter&nbsp;16](/chapters/16) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -442,7 +442,7 @@
                   "max": "1605699999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapter&nbsp;3](/chapters/3) and [chapter&nbsp;16](/chapters/16) used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;3](/chapters/03) and [chapter&nbsp;16](/chapters/16) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -507,7 +507,7 @@
                   "max": "1704999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -531,7 +531,7 @@
                   "max": "1704999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -564,7 +564,7 @@
                   "max": "1806199999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -581,7 +581,7 @@
                   "max": "1806999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product, or\n\n- the value of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **40%** of the weight of the product, or\n\n- the value of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -598,7 +598,7 @@
                   "max": "1905999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -606,7 +606,7 @@
                               "operator": null
                         },
                         {
-                              "rule": "The total weight of non-originating materials of [chapters 2](/chapters/2), 3 and 16 used does not exceed **20%** of the weight of the product.",
+                              "rule": "The total weight of non-originating materials of [chapters 2](/chapters/02), 3 and 16 used does not exceed **20%** of the weight of the product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -645,7 +645,7 @@
                   "max": "2003999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -678,7 +678,7 @@
                   "max": "2102999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained, and \n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **20%** of the weight of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained, and \n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **20%** of the weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -780,7 +780,7 @@
                   "max": "2106999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **20%** of the weight of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **20%** of the weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -805,7 +805,7 @@
                               "operator": null
                         },
                         {
-                              "rule": "All the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **20%** of the weight of the product.",
+                              "rule": "All the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **20%** of the weight of the product.",
                               "class": [
                                     "WO"
                               ],
@@ -904,7 +904,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained\n\n- the total weight of non-originating materials of [heading&nbsp;1001](/headings/1001) to [heading&nbsp;1004](/headings/1004), [heading&nbsp;1007](/headings/1007) to [heading&nbsp;1008](/headings/1008), [chapter&nbsp;11](/chapters/11), and [heading&nbsp;2302](/headings/2302) and [heading&nbsp;2303](/headings/2303) used does not exceed **20%** of the weight of the product, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **20%** of the weight of the product.",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained\n\n- the total weight of non-originating materials of [heading&nbsp;1001](/headings/1001) to [heading&nbsp;1004](/headings/1004), [heading&nbsp;1007](/headings/1007) to [heading&nbsp;1008](/headings/1008), [chapter&nbsp;11](/chapters/11), and [heading&nbsp;2302](/headings/2302) and [heading&nbsp;2303](/headings/2303) used does not exceed **20%** of the weight of the product, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **20%** of the weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -1528,7 +1528,7 @@
                   "max": "3504999999",
                   "rules": [
                         {
-                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading) except from non-originating materials of [chapter&nbsp;4](/chapters/4).",
+                              "rule": "All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading) except from non-originating materials of [chapter&nbsp;4](/chapters/04).",
                               "class": [
                                     "CTH"
                               ],

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/ukraine.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/ukraine.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) shall be wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) shall be wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -25,7 +25,7 @@
                   "max": "0299999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/1) and [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;1](/chapters/01) and [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -42,7 +42,7 @@
                   "max": "0399999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -58,7 +58,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -75,7 +75,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained,\n\n- all the fruit juice (except that of pineapple, lime or grapefruit) of [heading&nbsp;2009](/headings/2009) used is originating, *and*\n\n- the value of all the materials of [chapter&nbsp;17](/chapters/17) used does not exceed **30%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "ORIGINATING",
@@ -111,7 +111,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -128,7 +128,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -145,7 +145,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -162,7 +162,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -179,7 +179,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -196,7 +196,7 @@
                   "max": "0409999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -213,7 +213,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -231,7 +231,7 @@
                   "max": "0599999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/5) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -265,7 +265,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained, *and*\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "WO",
                                     "MAXNOM"
@@ -283,7 +283,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -352,7 +352,7 @@
                   "max": "0903999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -369,7 +369,7 @@
                   "max": "0904999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -386,7 +386,7 @@
                   "max": "0905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -403,7 +403,7 @@
                   "max": "0906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -420,7 +420,7 @@
                   "max": "0907999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -437,7 +437,7 @@
                   "max": "0908999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -454,7 +454,7 @@
                   "max": "0909999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -488,7 +488,7 @@
                   "max": "0910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/9) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -692,7 +692,7 @@
                   "max": "1502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -743,7 +743,7 @@
                   "max": "1504999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -811,7 +811,7 @@
                   "max": "1506999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -879,7 +879,7 @@
                   "max": "1516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -897,7 +897,7 @@
                   "max": "1517999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;4](/chapters/4) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;4](/chapters/04) used are wholly obtained, *and*\n\n- all the vegetable materials used are wholly obtained. However, materials of [heading&nbsp;1507](/headings/1507), [heading&nbsp;1508](/headings/1508), [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) may be used.",
                               "class": [
                                     "WO",
                                     "(WO TOLERANCE MAY BE USED)"
@@ -983,7 +983,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/1), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture:\n\n- from animals of [chapter&nbsp;1](/chapters/01), and&nbsp;/&nbsp;or\n\n- in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "PRODUCTION FROM"
@@ -1208,7 +1208,7 @@
                   "max": "1902999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals and their derivatives (except durum wheat and its derivatives) used are wholly obtained, *and*\n\n- all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1840,7 +1840,7 @@
                   "max": "2301999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -2027,7 +2027,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which:\n\n- all the cereals, sugar or molasses, meat or milk used are originating, *and*\n\n- all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO",
                                     "ORIGINATING"

--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/vietnam.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/vietnam.json
@@ -8,7 +8,7 @@
                   "max": "0199999999",
                   "rules": [
                         {
-                              "rule": "All the animals of [chapter&nbsp;1](/chapters/1) are wholly obtained.",
+                              "rule": "All the animals of [chapter&nbsp;1](/chapters/01) are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -93,7 +93,7 @@
                   "max": "0304999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -110,7 +110,7 @@
                   "max": "0305999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -127,7 +127,7 @@
                   "max": "0306999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -161,7 +161,7 @@
                   "max": "0307999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -195,7 +195,7 @@
                   "max": "0308999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -245,7 +245,7 @@
                   "max": "0401999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "WO",
                                     "(PRODUCTION FROM",
@@ -264,7 +264,7 @@
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "WO",
                                     "(PRODUCTION FROM",
@@ -283,7 +283,7 @@
                   "max": "0403999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "WO",
                                     "(PRODUCTION FROM",
@@ -302,7 +302,7 @@
                   "max": "0404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "WO",
                                     "(PRODUCTION FROM",
@@ -321,7 +321,7 @@
                   "max": "0405999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "WO",
                                     "(PRODUCTION FROM",
@@ -340,7 +340,7 @@
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "WO",
                                     "(PRODUCTION FROM",
@@ -359,7 +359,7 @@
                   "max": "0407999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "WO",
                                     "(PRODUCTION FROM",
@@ -378,7 +378,7 @@
                   "max": "0408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "WO",
                                     "(PRODUCTION FROM",
@@ -414,7 +414,7 @@
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/4) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
+                              "rule": "Manufacture in which:\n\n- all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "WO",
                                     "(PRODUCTION FROM",
@@ -468,7 +468,7 @@
                   "max": "0699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;6](/chapters/6) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;6](/chapters/06) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -485,7 +485,7 @@
                   "max": "0799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -502,7 +502,7 @@
                   "max": "0899999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- all the fruit, nuts and peels of citrus fruits or melons of [chapter&nbsp;8](/chapters/8) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
+                              "rule": "Manufacture in which:\n\n- all the fruit, nuts and peels of citrus fruits or melons of [chapter&nbsp;8](/chapters/08) used are wholly obtained *and*\n\n- the weight of sugar used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "WO",
                                     "(WO",
@@ -964,7 +964,7 @@
                   "max": "1699999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapters 2](/chapters/2), 3 and 16 used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapters 2](/chapters/02), 3 and 16 used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1032,7 +1032,7 @@
                   "max": "1704999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\n- the individual weight of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **20%** of the weight of the final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\n- the individual weight of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1046,7 +1046,7 @@
                               "operator": null
                         },
                         {
-                              "rule": "The total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **50%** of the weight of the final product.",
+                              "rule": "The total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **50%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1063,14 +1063,14 @@
                   "max": "1899999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **40%** of the weight of the final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which\n\nthe individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **40%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
                               "operator": null
                         },
                         {
-                              "rule": "The total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **60%** of the weight of the final product.",
+                              "rule": "The total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **60%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1087,7 +1087,7 @@
                   "max": "1999999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\n- the weight of the materials of [chapters 2](/chapters/2), 3 and 16 used does not exceed **20%** of the weight of the final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\n- the weight of the materials of [chapters 2](/chapters/02), 3 and 16 used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1101,7 +1101,7 @@
                               "operator": null
                         },
                         {
-                              "rule": "The individual weight of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **20%** of the weight of the final product.",
+                              "rule": "The individual weight of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1115,7 +1115,7 @@
                               "operator": null
                         },
                         {
-                              "rule": "The total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **50%** of the weight of the final product.",
+                              "rule": "The total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **50%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1150,7 +1150,7 @@
                   "max": "2003999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/7) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;7](/chapters/07) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1274,7 +1274,7 @@
                   "max": "2101999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **20%** of the weight of the final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1288,7 +1288,7 @@
                               "operator": null
                         },
                         {
-                              "rule": "The total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **50%** of the weight of the final product.",
+                              "rule": "The total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **50%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1305,7 +1305,7 @@
                   "max": "2102999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **20%** of the weight of the final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1319,7 +1319,7 @@
                               "operator": null
                         },
                         {
-                              "rule": "The total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **50%** of the weight of the final product.",
+                              "rule": "The total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **50%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1370,7 +1370,7 @@
                   "max": "2104999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **20%** of the weight of the final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1384,7 +1384,7 @@
                               "operator": null
                         },
                         {
-                              "rule": "The total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **50%** of the weight of the final product.",
+                              "rule": "The total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **50%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1401,7 +1401,7 @@
                   "max": "2105999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **20%** of the weight of the final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1415,7 +1415,7 @@
                               "operator": null
                         },
                         {
-                              "rule": "The total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **50%** of the weight of the final product.",
+                              "rule": "The total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **50%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1432,7 +1432,7 @@
                   "max": "2106999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **20%** of the weight of the final product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nthe individual weight of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1446,7 +1446,7 @@
                               "operator": null
                         },
                         {
-                              "rule": "The total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **50%** of the weight of the final product.",
+                              "rule": "The total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **50%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1471,7 +1471,7 @@
                               "operator": null
                         },
                         {
-                              "rule": "The individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **20%** of the weight of the final product.",
+                              "rule": "The individual weight of sugar and of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1641,7 +1641,7 @@
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nall the materials of [chapter&nbsp;2](/chapters/2) and [chapter&nbsp;3](/chapters/3) used are wholly obtained.",
+                              "rule": "Manufacture from materials of any heading, except that of the product, in which:\n\nall the materials of [chapter&nbsp;2](/chapters/02) and [chapter&nbsp;3](/chapters/03) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1655,7 +1655,7 @@
                               "operator": null
                         },
                         {
-                              "rule": "The individual weight of the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **20%** of the weight of the final product.",
+                              "rule": "The individual weight of the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **20%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],
@@ -1669,7 +1669,7 @@
                               "operator": null
                         },
                         {
-                              "rule": "The total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/4) used does not exceed **50%** of the weight of the final product.",
+                              "rule": "The total combined weight of sugar and the materials of [chapter&nbsp;4](/chapters/04) used does not exceed **50%** of the weight of the final product.",
                               "class": [
                                     "Unspecified"
                               ],


### PR DESCRIPTION
### Jira link

HOTT-2200

### What?

I have added/removed/altered:

- [x] Correct chapter links in rules of origin data

### Why?

I am doing this because:

- There were following an incorrect format and stripping leading 0s from the urls, ie linking to `/chapters/1` instead of `/chapters/01`

### Deployment risks (optional)

- Low, affects pages currently feature flagged off on the frontend
