### PR TITLE
Hott 2227 generic schemes api

### DIFF
--- a/app/controllers/api/v2/rules_of_origin_controller.rb
+++ b/app/controllers/api/v2/rules_of_origin_controller.rb
@@ -14,12 +14,32 @@ module Api
           query.scheme_rule_sets,
         )
 
-        @serializer = Api::V2::RulesOfOrigin::SchemeSerializer.new(
-          presented_schemes,
-          include: %i[links proofs rules articles rule_sets rule_sets.rules origin_reference_document],
-        )
+        if query.querying_for_rules?
+          render json: full_serializer(presented_schemes).serializable_hash
+        else
+          render json: minimal_serializer(presented_schemes).serializable_hash
+        end
+      end
 
-        render json: @serializer.serializable_hash
+    private
+
+      def full_serializer(schemes)
+        Api::V2::RulesOfOrigin::FullSchemeSerializer.new schemes, include: %i[
+          links
+          proofs
+          rules
+          articles
+          rule_sets
+          rule_sets.rules
+          origin_reference_document
+        ]
+      end
+
+      def minimal_serializer(schemes)
+        Api::V2::RulesOfOrigin::SchemeSerializer.new schemes, include: %i[
+          links
+          origin_reference_document
+        ]
       end
     end
   end

--- a/app/controllers/api/v2/rules_of_origin_controller.rb
+++ b/app/controllers/api/v2/rules_of_origin_controller.rb
@@ -6,6 +6,8 @@ module Api
           TradeTariffBackend.rules_of_origin,
           params[:heading_code],
           params[:country_code],
+          params[:filter]&.permit(*::RulesOfOrigin::Query::SUPPORTED_FILTERS)
+                         &.to_hash,
         )
 
         presented_schemes = Api::V2::RulesOfOrigin::SchemePresenter.for_many(

--- a/app/models/rules_of_origin/query.rb
+++ b/app/models/rules_of_origin/query.rb
@@ -2,16 +2,19 @@ module RulesOfOrigin
   class Query
     HEADING_CHECKER = /\A\d{6}\z/
     COUNTRY_CHECKER = /\A[A-Z]{2}\z/
+    SUPPORTED_FILTERS = %w[has_article].freeze
 
-    attr_reader :heading_code, :country_code
+    attr_reader :heading_code, :country_code, :filter
 
     delegate :scheme_set, :rule_set, :heading_mappings, to: :@data_set
 
-    def initialize(data_set, heading_code, country_code)
+    def initialize(data_set, heading_code, country_code, filter)
       @data_set = data_set
       @heading_code = heading_code.to_s.slice(0, 6)
       @country_code = country_code.to_s.upcase
       validate!
+
+      self.filter = filter if filter
     end
 
     def rules
@@ -27,6 +30,8 @@ module RulesOfOrigin
     def schemes
       @schemes ||= if querying_for_rules?
                      scheme_set.schemes_for_country(country_code)
+                   elsif filtering_schemes?
+                     scheme_set.schemes_for_filter(**filter.symbolize_keys)
                    else
                      scheme_set.all_schemes
                    end
@@ -51,9 +56,21 @@ module RulesOfOrigin
       heading_code.present? && country_code.present?
     end
 
+    def filtering_schemes?
+      !filter.nil?
+    end
+
     class InvalidParams < ArgumentError; end
+    class InvalidFilter < ArgumentError; end
 
     private
+
+    def filter=(filter)
+      raise InvalidFilter unless filter.is_a?(Hash)
+      raise InvalidFilter unless filter.keys.all?(&SUPPORTED_FILTERS.method(:include?))
+
+      @filter = filter
+    end
 
     def schemes_and_their_id_rules
       @schemes_and_their_id_rules ||=

--- a/app/models/rules_of_origin/query.rb
+++ b/app/models/rules_of_origin/query.rb
@@ -47,6 +47,10 @@ module RulesOfOrigin
              .transform_values { |sc| sc.rule_sets_for_subheading(@heading_code) }
     end
 
+    def querying_for_rules?
+      heading_code.present? && country_code.present?
+    end
+
     class InvalidParams < ArgumentError; end
 
     private
@@ -61,10 +65,6 @@ module RulesOfOrigin
         raise InvalidParams unless HEADING_CHECKER.match?(heading_code)
         raise InvalidParams unless COUNTRY_CHECKER.match?(country_code)
       end
-    end
-
-    def querying_for_rules?
-      heading_code.present? && country_code.present?
     end
   end
 end

--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -89,6 +89,11 @@ module RulesOfOrigin
       rule_sets.select { |rs| rs.for_subheading? subheading_code }
     end
 
+    def has_article?(article_name)
+      articles.find { |article| article.article == article_name }
+              &.content.present?
+    end
+
     private
 
     def new_proof(proof_attrs)

--- a/app/models/rules_of_origin/scheme_set.rb
+++ b/app/models/rules_of_origin/scheme_set.rb
@@ -47,6 +47,10 @@ module RulesOfOrigin
       @_schemes.values_at(*(@_countries[country_code] || []))
     end
 
+    def all_schemes
+      @_schemes.values
+    end
+
     def read_referenced_file(*path_components)
       unless path_components.many? &&
           path_components.all?(&method(:valid_referenced_file?))

--- a/app/models/rules_of_origin/scheme_set.rb
+++ b/app/models/rules_of_origin/scheme_set.rb
@@ -51,6 +51,16 @@ module RulesOfOrigin
       @_schemes.values
     end
 
+    def schemes_for_filter(has_article: nil)
+      filtered_schemes = all_schemes.dup
+
+      if has_article
+        filtered_schemes.select! { |scheme| scheme.has_article?(has_article) }
+      end
+
+      filtered_schemes
+    end
+
     def read_referenced_file(*path_components)
       unless path_components.many? &&
           path_components.all?(&method(:valid_referenced_file?))

--- a/app/presenters/api/v2/rules_of_origin/scheme_presenter.rb
+++ b/app/presenters/api/v2/rules_of_origin/scheme_presenter.rb
@@ -21,7 +21,7 @@ module Api
           @scheme = scheme
           @rules = rules || []
           @links = Array.wrap(scheme_set&.links) + @scheme.links
-          @rule_sets = rule_sets
+          @rule_sets = rule_sets || []
         end
 
         def rule_ids

--- a/app/serializers/api/v2/rules_of_origin/full_scheme_serializer.rb
+++ b/app/serializers/api/v2/rules_of_origin/full_scheme_serializer.rb
@@ -1,0 +1,23 @@
+module Api
+  module V2
+    module RulesOfOrigin
+      class FullSchemeSerializer
+        include JSONAPI::Serializer
+
+        set_type :rules_of_origin_scheme
+
+        set_id :scheme_code
+
+        attributes :scheme_code, :title, :countries, :footnote, :unilateral,
+                   :fta_intro, :introductory_notes, :cumulation_methods
+
+        has_many :rules, serializer: Api::V2::RulesOfOrigin::RuleSerializer
+        has_many :links, serializer: Api::V2::RulesOfOrigin::LinkSerializer
+        has_many :proofs, serializer: Api::V2::RulesOfOrigin::ProofSerializer
+        has_many :articles, serializer: Api::V2::RulesOfOrigin::ArticleSerializer
+        has_many :rule_sets, serializer: Api::V2::RulesOfOrigin::V2::RuleSetSerializer
+        has_one :origin_reference_document, serializer: Api::V2::RulesOfOrigin::OriginReferenceDocumentSerializer
+      end
+    end
+  end
+end

--- a/app/serializers/api/v2/rules_of_origin/scheme_serializer.rb
+++ b/app/serializers/api/v2/rules_of_origin/scheme_serializer.rb
@@ -8,14 +8,9 @@ module Api
 
         set_id :scheme_code
 
-        attributes :scheme_code, :title, :countries, :footnote, :unilateral,
-                   :fta_intro, :introductory_notes, :cumulation_methods
+        attributes :scheme_code, :title, :countries, :unilateral
 
-        has_many :rules, serializer: Api::V2::RulesOfOrigin::RuleSerializer
         has_many :links, serializer: Api::V2::RulesOfOrigin::LinkSerializer
-        has_many :proofs, serializer: Api::V2::RulesOfOrigin::ProofSerializer
-        has_many :articles, serializer: Api::V2::RulesOfOrigin::ArticleSerializer
-        has_many :rule_sets, serializer: Api::V2::RulesOfOrigin::V2::RuleSetSerializer
         has_one :origin_reference_document, serializer: Api::V2::RulesOfOrigin::OriginReferenceDocumentSerializer
       end
     end

--- a/spec/models/rules_of_origin/query_spec.rb
+++ b/spec/models/rules_of_origin/query_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe RulesOfOrigin::Query do
   end
 
   context 'with heading and country codes' do
+    it { is_expected.to have_attributes querying_for_rules?: true }
+
     describe '#rules' do
       subject { query.rules[roo_scheme_code] }
 
@@ -138,5 +140,6 @@ RSpec.describe RulesOfOrigin::Query do
     it { is_expected.to have_attributes schemes: roo_data_set.scheme_set.all_schemes }
     it { is_expected.to have_attributes rules: {} }
     it { is_expected.to have_attributes scheme_rule_sets: {} }
+    it { is_expected.to have_attributes querying_for_rules?: false }
   end
 end

--- a/spec/models/rules_of_origin/scheme_set_spec.rb
+++ b/spec/models/rules_of_origin/scheme_set_spec.rb
@@ -128,4 +128,20 @@ RSpec.describe RulesOfOrigin::SchemeSet do
 
     it { is_expected.to eql scheme_set.schemes.map(&scheme_set.method(:scheme)) }
   end
+
+  describe '#schemes_for_filter' do
+    subject { scheme_set.schemes_for_filter(has_article: article) }
+
+    let :scheme_set do
+      build :rules_of_origin_scheme_set, schemes: [
+        attributes_for(:rules_of_origin_scheme, :with_articles),
+        attributes_for(:rules_of_origin_scheme),
+      ]
+    end
+
+    let(:article) { scheme_set.all_schemes.first.articles.first.article }
+
+    it { is_expected.to include scheme_set.all_schemes.first }
+    it { is_expected.not_to include scheme_set.all_schemes.second }
+  end
 end

--- a/spec/models/rules_of_origin/scheme_set_spec.rb
+++ b/spec/models/rules_of_origin/scheme_set_spec.rb
@@ -122,4 +122,10 @@ RSpec.describe RulesOfOrigin::SchemeSet do
       it { expect { read_file }.to raise_exception Errno::ENOENT }
     end
   end
+
+  describe '#all_schemes' do
+    subject { scheme_set.all_schemes }
+
+    it { is_expected.to eql scheme_set.schemes.map(&scheme_set.method(:scheme)) }
+  end
 end

--- a/spec/models/rules_of_origin/scheme_spec.rb
+++ b/spec/models/rules_of_origin/scheme_spec.rb
@@ -280,4 +280,27 @@ RSpec.describe RulesOfOrigin::Scheme do
       it { is_expected.to be_empty }
     end
   end
+
+  describe '#has_article?' do
+    subject { scheme.has_article? article.article }
+
+    let(:scheme) { build :rules_of_origin_scheme, :with_articles }
+    let(:article) { scheme.articles.first }
+
+    context 'with matching article' do
+      it { is_expected.to be true }
+    end
+
+    context 'with matching but blank article' do
+      before { allow(article).to receive(:content).and_return '' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'without matching article' do
+      subject { scheme.has_article? 'something-unknown' }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/presenters/api/v2/rules_of_origin/scheme_presenter_spec.rb
+++ b/spec/presenters/api/v2/rules_of_origin/scheme_presenter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemePresenter do
     end
 
     let(:query) do
-      RulesOfOrigin::Query.new(roo_data_set, roo_heading_code, roo_country_code)
+      RulesOfOrigin::Query.new(roo_data_set, roo_heading_code, roo_country_code, nil)
     end
 
     it { is_expected.to have_attributes length: 1 }
@@ -33,7 +33,7 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemePresenter do
     it { expect(presenters[0].rule_sets).to be_instance_of Array }
 
     context 'when presenting all schemes' do
-      let(:query) { RulesOfOrigin::Query.new(roo_data_set, nil, nil) }
+      let(:query) { RulesOfOrigin::Query.new(roo_data_set, nil, nil, nil) }
 
       it { is_expected.to have_attributes length: 1 }
       it { is_expected.to all be_instance_of described_class }

--- a/spec/presenters/api/v2/rules_of_origin/scheme_presenter_spec.rb
+++ b/spec/presenters/api/v2/rules_of_origin/scheme_presenter_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemePresenter do
     it { is_expected.to have_attributes length: 1 }
     it { is_expected.to all be_instance_of described_class }
     it { expect(presenters[0].rules).to have_attributes length: 1 }
+    it { expect(presenters[0].rule_sets).to be_instance_of Array }
+
+    context 'when presenting all schemes' do
+      let(:query) { RulesOfOrigin::Query.new(roo_data_set, nil, nil) }
+
+      it { is_expected.to have_attributes length: 1 }
+      it { is_expected.to all be_instance_of described_class }
+      it { expect(presenters[0].rules).to be_empty }
+      it { expect(presenters[0].rule_sets).to be_instance_of Array }
+    end
   end
 
   describe '.links' do

--- a/spec/requests/api/v2/rules_of_origin_controller_spec.rb
+++ b/spec/requests/api/v2/rules_of_origin_controller_spec.rb
@@ -51,5 +51,15 @@ RSpec.describe Api::V2::RulesOfOriginController do
       it { expect(first_scheme).to include 'scheme_code' }
       it { expect(first_scheme).not_to include 'introductory_notes' }
     end
+
+    context 'with filtered list of schemes' do
+      let :make_request do
+        get api_rules_of_origin_schemes_path(filter: { has_article: 'duty-drawback' },
+                                             format: :json),
+            headers: { 'Accept' => 'application/vnd.uktt.v2' }
+      end
+
+      it_behaves_like 'a successful jsonapi response'
+    end
   end
 end

--- a/spec/requests/api/v2/rules_of_origin_controller_spec.rb
+++ b/spec/requests/api/v2/rules_of_origin_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Api::V2::RulesOfOriginController do
 
     let(:heading_code) { roo_heading_code }
     let(:country_code) { roo_country_code }
+    let(:first_scheme) { JSON.parse(rendered.body)['data'].first['attributes'] }
 
     let :make_request do
       get api_rules_of_origin_schemes_path(format: :json),
@@ -14,6 +15,8 @@ RSpec.describe Api::V2::RulesOfOriginController do
     end
 
     it_behaves_like 'a successful jsonapi response'
+    it { expect(first_scheme).to include 'scheme_code' }
+    it { expect(first_scheme).to include 'introductory_notes' }
 
     context 'without match heading' do
       let(:heading_code) { '010101' }
@@ -36,6 +39,17 @@ RSpec.describe Api::V2::RulesOfOriginController do
       end
 
       it_behaves_like 'a successful jsonapi response'
+    end
+
+    context 'when listing all schemes' do
+      let :make_request do
+        get api_rules_of_origin_schemes_path(format: :json),
+            headers: { 'Accept' => 'application/vnd.uktt.v2' }
+      end
+
+      it_behaves_like 'a successful jsonapi response'
+      it { expect(first_scheme).to include 'scheme_code' }
+      it { expect(first_scheme).not_to include 'introductory_notes' }
     end
   end
 end

--- a/spec/serializers/api/v2/rules_of_origin/full_scheme_serializer_spec.rb
+++ b/spec/serializers/api/v2/rules_of_origin/full_scheme_serializer_spec.rb
@@ -1,0 +1,180 @@
+RSpec.describe Api::V2::RulesOfOrigin::FullSchemeSerializer do
+  subject { serializer.serializable_hash }
+
+  let(:scheme_set) { build :rules_of_origin_scheme_set, links: [], schemes: [] }
+
+  let :scheme do
+    build :rules_of_origin_scheme,
+          :with_links,
+          :with_proofs,
+          :with_origin_reference_document,
+          scheme_set:,
+          unilateral: true
+  end
+
+  let :rules do
+    build_list :rules_of_origin_rule, 3, scheme_code: scheme.scheme_code
+  end
+
+  let :serializer do
+    described_class.new \
+      Api::V2::RulesOfOrigin::SchemePresenter.new(scheme, rules, []),
+      include: %i[links proofs rules articles rule_sets rule_sets.rules origin_reference_document]
+  end
+
+  let :expected do
+    {
+      data: {
+        id: scheme.scheme_code,
+        type: :rules_of_origin_scheme,
+        attributes: {
+          scheme_code: scheme.scheme_code,
+          title: scheme.title,
+          countries: scheme.countries,
+          cumulation_methods: scheme.cumulation_methods,
+          footnote: scheme.footnote,
+          unilateral: true,
+          fta_intro: scheme.fta_intro,
+          introductory_notes: scheme.introductory_notes,
+        },
+        relationships: {
+          links: {
+            data: [
+              {
+                id: scheme.links[0].id,
+                type: :rules_of_origin_link,
+              },
+              {
+                id: scheme.links[1].id,
+                type: :rules_of_origin_link,
+              },
+            ],
+          },
+          origin_reference_document: {
+            data: {
+              id: scheme.origin_reference_document.id,
+              type: :rules_of_origin_origin_reference_document,
+            },
+          },
+          proofs: {
+            data: [
+              {
+                id: scheme.proofs[0].id,
+                type: :rules_of_origin_proof,
+              },
+              {
+                id: scheme.proofs[1].id,
+                type: :rules_of_origin_proof,
+              },
+            ],
+          },
+          rules: {
+            data: [
+              {
+                id: rules[0].id_rule.to_s,
+                type: :rules_of_origin_rule,
+              },
+              {
+                id: rules[1].id_rule.to_s,
+                type: :rules_of_origin_rule,
+              },
+              {
+                id: rules[2].id_rule.to_s,
+                type: :rules_of_origin_rule,
+              },
+            ],
+          },
+          articles: {
+            data: [],
+          },
+          rule_sets: {
+            data: [],
+          },
+        },
+      },
+      included: [
+        {
+          id: scheme.links[0].id,
+          type: :rules_of_origin_link,
+          attributes: {
+            text: scheme.links[0].text,
+            url: scheme.links[0].url,
+          },
+        },
+        {
+          id: scheme.links[1].id,
+          type: :rules_of_origin_link,
+          attributes: {
+            text: scheme.links[1].text,
+            url: scheme.links[1].url,
+          },
+        },
+        {
+          id: scheme.proofs[0].id,
+          type: :rules_of_origin_proof,
+          attributes: {
+            summary: scheme.proofs[0].summary,
+            url: scheme.proofs[0].url,
+            subtext: scheme.proofs[0].subtext,
+          },
+        },
+        {
+          id: scheme.proofs[1].id,
+          type: :rules_of_origin_proof,
+          attributes: {
+            summary: scheme.proofs[1].summary,
+            url: scheme.proofs[0].url,
+            subtext: scheme.proofs[0].subtext,
+          },
+        },
+        {
+          id: rules[0].id_rule.to_s,
+          type: :rules_of_origin_rule,
+          attributes: {
+            id_rule: rules[0].id_rule,
+            heading: rules[0].heading,
+            description: rules[0].description,
+            rule: rules[0].rule,
+            alternate_rule: nil,
+          },
+        },
+        {
+          id: rules[1].id_rule.to_s,
+          type: :rules_of_origin_rule,
+          attributes: {
+            id_rule: rules[1].id_rule,
+            heading: rules[1].heading,
+            description: rules[1].description,
+            rule: rules[1].rule,
+            alternate_rule: nil,
+          },
+        },
+        {
+          id: rules[2].id_rule.to_s,
+          type: :rules_of_origin_rule,
+          attributes: {
+            id_rule: rules[2].id_rule,
+            heading: rules[2].heading,
+            description: rules[2].description,
+            rule: rules[2].rule,
+            alternate_rule: nil,
+          },
+        },
+        {
+          id: scheme.origin_reference_document.id,
+          type: :rules_of_origin_origin_reference_document,
+          attributes: {
+            ord_date: scheme.origin_reference_document.ord_date,
+            ord_original: scheme.origin_reference_document.ord_original,
+            ord_title: scheme.origin_reference_document.ord_title,
+            ord_version: scheme.origin_reference_document.ord_version,
+          },
+        },
+      ],
+    }
+  end
+
+  describe '#serializable_hash' do
+    it { is_expected.to eql expected }
+  end
+end

--- a/spec/serializers/api/v2/rules_of_origin/scheme_serializer_spec.rb
+++ b/spec/serializers/api/v2/rules_of_origin/scheme_serializer_spec.rb
@@ -6,20 +6,15 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemeSerializer do
   let :scheme do
     build :rules_of_origin_scheme,
           :with_links,
-          :with_proofs,
           :with_origin_reference_document,
           scheme_set:,
           unilateral: true
   end
 
-  let :rules do
-    build_list :rules_of_origin_rule, 3, scheme_code: scheme.scheme_code
-  end
-
   let :serializer do
     described_class.new \
-      Api::V2::RulesOfOrigin::SchemePresenter.new(scheme, rules, []),
-      include: %i[links proofs rules articles rule_sets rule_sets.rules origin_reference_document]
+      Api::V2::RulesOfOrigin::SchemePresenter.new(scheme, [], []),
+      include: %i[links origin_reference_document]
   end
 
   let :expected do
@@ -31,11 +26,7 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemeSerializer do
           scheme_code: scheme.scheme_code,
           title: scheme.title,
           countries: scheme.countries,
-          cumulation_methods: scheme.cumulation_methods,
-          footnote: scheme.footnote,
           unilateral: true,
-          fta_intro: scheme.fta_intro,
-          introductory_notes: scheme.introductory_notes,
         },
         relationships: {
           links: {
@@ -56,40 +47,6 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemeSerializer do
               type: :rules_of_origin_origin_reference_document,
             },
           },
-          proofs: {
-            data: [
-              {
-                id: scheme.proofs[0].id,
-                type: :rules_of_origin_proof,
-              },
-              {
-                id: scheme.proofs[1].id,
-                type: :rules_of_origin_proof,
-              },
-            ],
-          },
-          rules: {
-            data: [
-              {
-                id: rules[0].id_rule.to_s,
-                type: :rules_of_origin_rule,
-              },
-              {
-                id: rules[1].id_rule.to_s,
-                type: :rules_of_origin_rule,
-              },
-              {
-                id: rules[2].id_rule.to_s,
-                type: :rules_of_origin_rule,
-              },
-            ],
-          },
-          articles: {
-            data: [],
-          },
-          rule_sets: {
-            data: [],
-          },
         },
       },
       included: [
@@ -107,57 +64,6 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemeSerializer do
           attributes: {
             text: scheme.links[1].text,
             url: scheme.links[1].url,
-          },
-        },
-        {
-          id: scheme.proofs[0].id,
-          type: :rules_of_origin_proof,
-          attributes: {
-            summary: scheme.proofs[0].summary,
-            url: scheme.proofs[0].url,
-            subtext: scheme.proofs[0].subtext,
-          },
-        },
-        {
-          id: scheme.proofs[1].id,
-          type: :rules_of_origin_proof,
-          attributes: {
-            summary: scheme.proofs[1].summary,
-            url: scheme.proofs[0].url,
-            subtext: scheme.proofs[0].subtext,
-          },
-        },
-        {
-          id: rules[0].id_rule.to_s,
-          type: :rules_of_origin_rule,
-          attributes: {
-            id_rule: rules[0].id_rule,
-            heading: rules[0].heading,
-            description: rules[0].description,
-            rule: rules[0].rule,
-            alternate_rule: nil,
-          },
-        },
-        {
-          id: rules[1].id_rule.to_s,
-          type: :rules_of_origin_rule,
-          attributes: {
-            id_rule: rules[1].id_rule,
-            heading: rules[1].heading,
-            description: rules[1].description,
-            rule: rules[1].rule,
-            alternate_rule: nil,
-          },
-        },
-        {
-          id: rules[2].id_rule.to_s,
-          type: :rules_of_origin_rule,
-          attributes: {
-            id_rule: rules[2].id_rule,
-            heading: rules[2].heading,
-            description: rules[2].description,
-            rule: rules[2].rule,
-            alternate_rule: nil,
           },
         },
         {


### PR DESCRIPTION
### Jira link

HOTT-2227

### What?

I have added/removed/altered:

- [x] Moved the existing SchemeSerializer to FullSchemeSerializer
- [x] Reduced the fields and relationships in the existing SchemeSerializer
- [x] Changed the Rules of Origin api to switch the serializer depending on whether it is returning all schemes, or just the schemes for a particular country and commodity
- [x] Added filtering the list of schemes depending upon the presence of a particular article (using the default jsonapi `?filter` param format

### Why?

I am doing this because:

- We require a way to list all the schemes with a `duty-drawback` article
- The existing api representation of a scheme is very bulky including a lot of markdown content and a serialization of all schemes is over 3meg
- We need to maintain the existing representation for the existing use case

### Have you? (optional)

- [ ] Added documentation for new apis

### Deployment risks (optional)

- Changes the rules of origin end point but should be in a purely additive manner - primary difference is previously accessing the endpoint without appropriate params triggered a 500 response, now we return all the schemes instead.

### New api

![image](https://user-images.githubusercontent.com/10818/201393119-1d05f2e2-98f9-4723-a3e5-9507c5ee1562.png)

