### PR TITLE
HOTT-2234 Treat 07 measure actions codes as positive

### DIFF
--- a/app/models/measure_action.rb
+++ b/app/models/measure_action.rb
@@ -11,6 +11,7 @@ class MeasureAction < Sequel::Model
 
   APPLY_MEASURE_ACTION_CODES = [
     '01', # Apply the amount of the action (see components)
+    '07', # Measure not applicable
     '24', # Entry into free circulation allowed
     '25', # Export allowed
     '26', # Import allowed
@@ -25,7 +26,6 @@ class MeasureAction < Sequel::Model
     '04', # The entry into free circulation is not allowed
     '05', # Export is not allowed
     '06', # Import is not allowed
-    '07', # Measure not applicable
     '08', # Declared subheading not allowed
     '09', # Import/export not allowed after control
     '16', # Export refund not applicable

--- a/spec/models/measure_action_spec.rb
+++ b/spec/models/measure_action_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe MeasureAction do
   end
 
   it_behaves_like 'a positive measure action', '01'
+  it_behaves_like 'a positive measure action', '07'
   it_behaves_like 'a positive measure action', '24'
   it_behaves_like 'a positive measure action', '25'
   it_behaves_like 'a positive measure action', '26'
@@ -24,7 +25,6 @@ RSpec.describe MeasureAction do
   it_behaves_like 'a negative measure action', '04'
   it_behaves_like 'a negative measure action', '05'
   it_behaves_like 'a negative measure action', '06'
-  it_behaves_like 'a negative measure action', '07'
   it_behaves_like 'a negative measure action', '08'
   it_behaves_like 'a negative measure action', '09'
   it_behaves_like 'a negative measure action', '16'


### PR DESCRIPTION
### Jira link

HOTT-2234

### What?

I have added/removed/altered:

- [x] Moved the 07 action code from being treated as a negative measure to being treated as a positive measure

### Why?

I am doing this because:

- DIT have changed how the are utilising this measure action code and we are now out of alignment

### Deployment risks (optional)

- Changes how historical pages utilising that code are rendered
