### PR TITLE
HOTT-2164 Add validations to news attributes

### DIFF
--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -47,6 +47,7 @@ module News
       super
 
       validates_presence :slug
+      validates_presence :precis if show_on_updates_page
       validates_presence :collection_ids, message: 'must include at least one collection'
     end
 

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -47,6 +47,7 @@ module News
       super
 
       validates_presence :slug
+      validates_presence :collection_ids, message: 'must include at least one collection'
     end
 
     dataset_module do

--- a/spec/factories/news_factory.rb
+++ b/spec/factories/news_factory.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
 
     start_date { 1.day.ago }
     sequence(:title) { |n| "News item #{n}" }
+    precis { 'This is the precis' }
     display_style { News::Item::DISPLAY_REGULAR }
     show_on_xi { true }
     show_on_uk { true }

--- a/spec/factories/news_factory.rb
+++ b/spec/factories/news_factory.rb
@@ -14,6 +14,11 @@ FactoryBot.define do
   end
 
   factory :news_item, class: 'News::Item' do
+    transient do
+      collection_count { 1 }
+      collection_traits { nil }
+    end
+
     start_date { 1.day.ago }
     sequence(:title) { |n| "News item #{n}" }
     display_style { News::Item::DISPLAY_REGULAR }
@@ -22,6 +27,10 @@ FactoryBot.define do
     show_on_updates_page { false }
     show_on_home_page { false }
     show_on_banner { false }
+
+    collection_ids do
+      create_list(:news_collection, collection_count, *Array.wrap(collection_traits)).map(&:id)
+    end
 
     content do
       <<~CONTENT
@@ -51,20 +60,6 @@ FactoryBot.define do
 
     trait :banner do
       show_on_banner { true }
-    end
-
-    trait :with_collections do
-      transient do
-        collection_count { 1 }
-      end
-
-      after :create do |item, evaluator|
-        evaluator.collection_count.times do
-          item.add_collection create(:news_collection)
-        end
-
-        item.reload
-      end
     end
   end
 end

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe News::Item do
     it { is_expected.to respond_to :start_date }
     it { is_expected.to respond_to :end_date }
     it { is_expected.to respond_to :title }
+    it { is_expected.to respond_to :slug }
+    it { is_expected.to respond_to :precis }
     it { is_expected.to respond_to :content }
     it { is_expected.to respond_to :display_style }
     it { is_expected.to respond_to :show_on_xi }
@@ -20,6 +22,7 @@ RSpec.describe News::Item do
 
     it { is_expected.to include(title: ['is not present']) }
     it { is_expected.to include(content: ['is not present']) }
+    it { is_expected.not_to include(precis: ['is not present']) }
     it { is_expected.to include(display_style: ['is not present']) }
     it { is_expected.to include(show_on_uk: ['is not present']) }
     it { is_expected.to include(show_on_xi: ['is not present']) }
@@ -41,6 +44,12 @@ RSpec.describe News::Item do
       let(:instance) { described_class.new slug: 'testing' }
 
       it { is_expected.to include(slug: ['is already taken']) }
+    end
+
+    context 'when showing on updates page' do
+      let(:instance) { described_class.new(show_on_updates_page: true) }
+
+      it { is_expected.to include(precis: ['is not present']) }
     end
   end
 

--- a/spec/presenters/api/v2/news/item_presenter_spec.rb
+++ b/spec/presenters/api/v2/news/item_presenter_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Api::V2::News::ItemPresenter do
   describe '.wrap' do
     subject { described_class.wrap items }
 
-    let(:items) { create_list :news_item, 3, :with_collections }
+    let(:items) { create_list :news_item, 3 }
 
     it { is_expected.to all be_instance_of described_class }
   end

--- a/spec/requests/api/v2/news/items_controller_spec.rb
+++ b/spec/requests/api/v2/news/items_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Api::V2::News::ItemsController do
     end
 
     context 'when filtering by collection' do
-      let(:item) { create :news_item, :with_collections }
+      let(:item) { create :news_item }
       let(:collection) { item.collections.first }
 
       let :make_request do
@@ -94,7 +94,7 @@ RSpec.describe Api::V2::News::ItemsController do
   describe 'GET #show' do
     subject(:rendered) { make_request && response }
 
-    let(:news_item) { create :news_item, :with_collections }
+    let(:news_item) { create :news_item }
 
     let :make_request do
       get api_news_item_path(news_item.id, format: :json),
@@ -137,6 +137,8 @@ RSpec.describe Api::V2::News::ItemsController do
     end
 
     context 'without collection' do
+      before { news_item.remove_collection news_item.collections.first.id }
+
       let(:news_item) { create :news_item }
 
       it { is_expected.to have_http_status :not_found }

--- a/spec/serializers/api/admin/news/item_serializer_spec.rb
+++ b/spec/serializers/api/admin/news/item_serializer_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Api::Admin::News::ItemSerializer do
     described_class.new(news_item).serializable_hash
   end
 
-  let(:news_item) { create :news_item, :with_collections, title: 'Serialized' }
+  let(:news_item) { create :news_item, title: 'Serialized' }
 
   let :expected do
     {

--- a/spec/serializers/api/v2/news/item_serializer_spec.rb
+++ b/spec/serializers/api/v2/news/item_serializer_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Api::V2::News::ItemSerializer do
   subject(:serializable) { described_class.new(news_item).serializable_hash }
 
-  let(:news_item) { create :news_item, :with_collections, collection_count: 2 }
+  let(:news_item) { create :news_item, collection_count: 2 }
 
   let :expected do
     {


### PR DESCRIPTION
### Jira link

HOTT-2164

### What?

I have added/removed/altered:

- [x] Validate all news stories belong to a collection
- [x] Validate all news stories on updates page have a precis
- [x] Added data migration to assign collection to all existing news items

### Why?

I am doing this because:

- We will ultimately want to show all news items in the news area of the frontend within collections

### Deployment risks (optional)

- Changes logic for creation of news items
- Modifies data of existing news items
