### PR TITLE
Add more role to abrogation regulations

### DIFF
--- a/app/models/complete_abrogation_regulation.rb
+++ b/app/models/complete_abrogation_regulation.rb
@@ -2,4 +2,8 @@ class CompleteAbrogationRegulation < Sequel::Model
   set_primary_key %i[complete_abrogation_regulation_id complete_abrogation_regulation_role]
 
   plugin :oplog, primary_key: %i[complete_abrogation_regulation_id complete_abrogation_regulation_role]
+
+  def role
+    complete_abrogation_regulation_role
+  end
 end

--- a/app/models/explicit_abrogation_regulation.rb
+++ b/app/models/explicit_abrogation_regulation.rb
@@ -2,4 +2,8 @@ class ExplicitAbrogationRegulation < Sequel::Model
   plugin :oplog, primary_key: %i[oid explicit_abrogation_regulation_id explicit_abrogation_regulation_role]
 
   set_primary_key %i[explicit_abrogation_regulation_id explicit_abrogation_regulation_role]
+
+  def role
+    explicit_abrogation_regulation_role
+  end
 end

--- a/spec/factories/explicit_abrogation_regulation_factory.rb
+++ b/spec/factories/explicit_abrogation_regulation_factory.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :explicit_abrogation_regulation do
+    explicit_abrogation_regulation_role { 8 }
+    explicit_abrogation_regulation_id   { Forgery(:basic).text(exactly: 8) }
+
+    published_date                      { Time.zone.now.ago(2.years) }
+  end
+end

--- a/spec/models/complete_abrogation_regulation_spec.rb
+++ b/spec/models/complete_abrogation_regulation_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe CompleteAbrogationRegulation do
+  let(:regulation) { build :complete_abrogation_regulation }
+
+  describe '#role' do
+    it { expect(regulation.role).to eq regulation.complete_abrogation_regulation_role }
+  end
+end

--- a/spec/models/explicit_abrogation_regulation_spec.rb
+++ b/spec/models/explicit_abrogation_regulation_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe ExplicitAbrogationRegulation do
+  let(:ear) { build :explicit_abrogation_regulation }
+
+  describe '#role' do
+    it { expect(ear.role).to eq ear.explicit_abrogation_regulation_role }
+  end
+end


### PR DESCRIPTION
### What?
Add method role for complete_abrogation_regulation and explicit_abrogation_regulation

### Why?
To fulfil the interface implemented in all kinds of regulation. 