### PR TITLE
HOTT-2246 add collections api

### DIFF
--- a/app/controllers/api/v2/news/collections_controller.rb
+++ b/app/controllers/api/v2/news/collections_controller.rb
@@ -1,0 +1,14 @@
+module Api
+  module V2
+    module News
+      class CollectionsController < ApiController
+        def index
+          collections = ::News::Collection.order(:name).all
+          serializer = Api::V2::News::CollectionSerializer.new(collections)
+
+          render json: serializer.serializable_hash
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -176,6 +176,7 @@ Rails.application.routes.draw do
       if TradeTariffBackend.uk?
         namespace :news do
           resources :items, only: %i[index show]
+          resources :collections, only: %i[index]
         end
 
         get '/news_items/:id', to: 'news/items#show', as: nil

--- a/spec/requests/api/v2/news/collections_controller_spec.rb
+++ b/spec/requests/api/v2/news/collections_controller_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Api::V2::News::CollectionsController do
+  describe 'GET #index' do
+    subject(:rendered) { make_request && response }
+
+    let :make_request do
+      get api_news_collections_path(format: :json),
+          headers: { 'Accept' => 'application/vnd.uktt.v2' }
+    end
+
+    it_behaves_like 'a successful jsonapi response'
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-2246

### What?

I have added/removed/altered:

- [x] Added a News::Collection endpoint to expose a list of news collections

### Why?

I am doing this because:

- We will want to list the available collections on the new news UX

### Deployment risks (optional)

- Low, new internal only API
