### PR TITLE
HOTT-2132 updated news items api

### DIFF
--- a/app/controllers/api/v2/news/items_controller.rb
+++ b/app/controllers/api/v2/news/items_controller.rb
@@ -9,6 +9,7 @@ module Api
           news_items = ::News::Item.eager(:collections)
                                    .for_service(params[:service])
                                    .for_target(params[:target])
+                                   .for_year(params[:year])
                                    .for_today
                                    .descending
                                    .paginate(current_page, per_page)

--- a/app/controllers/api/v2/news/items_controller.rb
+++ b/app/controllers/api/v2/news/items_controller.rb
@@ -22,7 +22,11 @@ module Api
         end
 
         def show
-          news_item = ::News::Item.for_today.with_pk!(params[:id])
+          news_item = if params[:id].present? && !/\A\d+\z/.match?(params[:id])
+                        ::News::Item.for_today.where(slug: params[:id]).take
+                      else
+                        ::News::Item.for_today.with_pk!(params[:id])
+                      end
 
           serializer = Api::V2::News::ItemSerializer.new(news_item)
 

--- a/app/controllers/api/v2/news/items_controller.rb
+++ b/app/controllers/api/v2/news/items_controller.rb
@@ -10,7 +10,9 @@ module Api
                                    .descending
                                    .paginate(current_page, per_page)
 
-          serializer = Api::V2::News::ItemSerializer.new(news_items, include: %w[collections])
+          serializer = Api::V2::News::ItemSerializer.new(news_items,
+                                                         include: %w[collections],
+                                                         meta: pagination_meta(news_items))
 
           render json: serializer.serializable_hash
         end
@@ -21,6 +23,22 @@ module Api
           serializer = Api::V2::News::ItemSerializer.new(news_item)
 
           render json: serializer.serializable_hash
+        end
+
+      private
+
+        def per_page
+          10
+        end
+
+        def pagination_meta(data_set)
+          {
+            pagination: {
+              page: current_page,
+              per_page:,
+              total_count: data_set.pagination_record_count,
+            },
+          }
         end
       end
     end

--- a/app/controllers/api/v2/news/items_controller.rb
+++ b/app/controllers/api/v2/news/items_controller.rb
@@ -6,13 +6,13 @@ module Api
         DEFAULT_PAGE_SIZE = 20
 
         def index
-          news_items = ::News::Item.eager(:collections)
-                                   .for_service(params[:service])
-                                   .for_target(params[:target])
-                                   .for_year(params[:year])
-                                   .for_today
-                                   .descending
-                                   .paginate(current_page, per_page)
+          news_items = base_scope.eager(:collections)
+                                 .for_service(params[:service])
+                                 .for_target(params[:target])
+                                 .for_year(params[:year])
+                                 .for_today
+                                 .descending
+                                 .paginate(current_page, per_page)
 
           serializer = Api::V2::News::ItemSerializer.new(news_items,
                                                          include: %w[collections],
@@ -53,6 +53,13 @@ module Api
               total_count: data_set.pagination_record_count,
             },
           }
+        end
+
+        def base_scope
+          collection_id = params[:collection_id].presence&.to_i
+          return ::News::Item unless collection_id
+
+          ::News::Collection.where(id: collection_id).take.items_dataset
         end
       end
     end

--- a/app/controllers/api/v2/news/items_controller.rb
+++ b/app/controllers/api/v2/news/items_controller.rb
@@ -2,6 +2,9 @@ module Api
   module V2
     module News
       class ItemsController < ApiController
+        PAGE_SIZES = [1, 10, 20].freeze
+        DEFAULT_PAGE_SIZE = 20
+
         def index
           news_items = ::News::Item.eager(:collections)
                                    .for_service(params[:service])
@@ -28,7 +31,13 @@ module Api
       private
 
         def per_page
-          10
+          requested_page_size = params[:per_page].presence&.to_i
+
+          if PAGE_SIZES.include? requested_page_size
+            requested_page_size
+          else
+            DEFAULT_PAGE_SIZE
+          end
         end
 
         def pagination_meta(data_set)

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -71,6 +71,14 @@ module News
         end
       end
 
+      def for_year(year)
+        year = year.presence&.to_i
+        return self unless year
+
+        first_of_jan = Time.zone.parse("#{year}-01-01 00:00:00")
+        where(start_date: first_of_jan..first_of_jan.end_of_year)
+      end
+
       def years
         distinct.select { date_part('year', :start_date).cast(:integer).as(:year) }
                 .order(Sequel.desc(:year))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -176,8 +176,10 @@ Rails.application.routes.draw do
       if TradeTariffBackend.uk?
         namespace :news do
           resources :items, only: %i[index show]
-          resources :collections, only: %i[index]
           resources :years, only: %i[index]
+          resources :collections, only: %i[index] do
+            resources :items, only: %i[index], shallow: true
+          end
         end
 
         get '/news_items/:id', to: 'news/items#show', as: nil

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -217,6 +217,29 @@ RSpec.describe News::Item do
       it { is_expected.to include ongoing }
     end
 
+    describe '.for_year' do
+      subject { described_class.for_year(year).all }
+
+      before { twentytwo && twentythree }
+
+      let(:twentytwo) { create :news_item, start_date: '2022-01-01' }
+      let(:twentythree) { create :news_item, start_date: '2023-01-01' }
+
+      context 'with year' do
+        let(:year) { '2022' }
+
+        it { is_expected.to include twentytwo }
+        it { is_expected.not_to include twentythree }
+      end
+
+      context 'without year' do
+        let(:year) { '' }
+
+        it { is_expected.to include twentytwo }
+        it { is_expected.to include twentythree }
+      end
+    end
+
     describe '.descending' do
       subject { described_class.descending.to_a }
 

--- a/spec/requests/api/v2/news/items_controller_spec.rb
+++ b/spec/requests/api/v2/news/items_controller_spec.rb
@@ -80,5 +80,32 @@ RSpec.describe Api::V2::News::ItemsController do
     end
 
     it_behaves_like 'a successful jsonapi response'
+
+    context 'with unknown news item' do
+      let :make_request do
+        get api_news_item_path(9999, format: :json),
+            headers: { 'Accept' => 'application/vnd.uktt.v2' }
+      end
+
+      it { is_expected.to have_http_status :not_found }
+    end
+
+    context 'with slug' do
+      let :make_request do
+        get api_news_item_path(news_item.slug, format: :json),
+            headers: { 'Accept' => 'application/vnd.uktt.v2' }
+      end
+
+      it_behaves_like 'a successful jsonapi response'
+    end
+
+    context 'with an unknown slug' do
+      let :make_request do
+        get api_news_item_path('something-unknown', format: :json),
+            headers: { 'Accept' => 'application/vnd.uktt.v2' }
+      end
+
+      it { is_expected.to have_http_status :not_found }
+    end
   end
 end

--- a/spec/requests/api/v2/news/items_controller_spec.rb
+++ b/spec/requests/api/v2/news/items_controller_spec.rb
@@ -32,6 +32,28 @@ RSpec.describe Api::V2::News::ItemsController do
       it_behaves_like 'a successful jsonapi response'
     end
 
+    context 'when filtering by collection' do
+      let(:item) { create :news_item, :with_collections }
+      let(:collection) { item.collections.first }
+
+      let :make_request do
+        get api_news_collection_items_path(collection_id:, format: :json),
+            headers: { 'Accept' => 'application/vnd.uktt.v2' }
+      end
+
+      context 'with known collection' do
+        let(:collection_id) { collection.id }
+
+        it_behaves_like 'a successful jsonapi response'
+      end
+
+      context 'with unknown collection' do
+        let(:collection_id) { collection.id + 100 }
+
+        it { is_expected.to have_http_status :not_found }
+      end
+    end
+
     context 'for uk pages' do
       let(:request_params) { { service: 'uk' } }
 

--- a/spec/requests/api/v2/news/items_controller_spec.rb
+++ b/spec/requests/api/v2/news/items_controller_spec.rb
@@ -11,6 +11,24 @@ RSpec.describe Api::V2::News::ItemsController do
 
     it_behaves_like 'a successful jsonapi response'
 
+    context 'with subsequent page' do
+      let :make_request do
+        get api_news_items_path(service: 'uk', format: :json, page: '3'),
+            headers: { 'Accept' => 'application/vnd.uktt.v2' }
+      end
+
+      it_behaves_like 'a successful jsonapi response'
+    end
+
+    context 'with different page size' do
+      let :make_request do
+        get api_news_items_path(service: 'uk', format: :json, per_page: '1'),
+            headers: { 'Accept' => 'application/vnd.uktt.v2' }
+      end
+
+      it_behaves_like 'a successful jsonapi response'
+    end
+
     context 'for uk pages' do
       let :make_request do
         get api_news_items_path(service: 'uk', format: :json),

--- a/spec/requests/api/v2/news/items_controller_spec.rb
+++ b/spec/requests/api/v2/news/items_controller_spec.rb
@@ -5,82 +5,60 @@ RSpec.describe Api::V2::News::ItemsController do
     subject(:rendered) { make_request && response }
 
     let :make_request do
-      get api_news_items_path(format: :json),
+      get api_news_items_path(request_params.merge(format: :json)),
           headers: { 'Accept' => 'application/vnd.uktt.v2' }
     end
+
+    let(:request_params) { {} }
 
     it_behaves_like 'a successful jsonapi response'
 
     context 'with subsequent page' do
-      let :make_request do
-        get api_news_items_path(service: 'uk', format: :json, page: '3'),
-            headers: { 'Accept' => 'application/vnd.uktt.v2' }
-      end
+      let(:request_params) { { service: 'uk', page: '3' } }
 
       it_behaves_like 'a successful jsonapi response'
     end
 
     context 'with different page size' do
-      let :make_request do
-        get api_news_items_path(service: 'uk', format: :json, per_page: '1'),
-            headers: { 'Accept' => 'application/vnd.uktt.v2' }
-      end
+      let(:request_params) { { service: 'uk', per_page: '1' } }
 
       it_behaves_like 'a successful jsonapi response'
     end
 
     context 'for uk pages' do
-      let :make_request do
-        get api_news_items_path(service: 'uk', format: :json),
-            headers: { 'Accept' => 'application/vnd.uktt.v2' }
-      end
+      let(:request_params) { { service: 'uk' } }
 
       it_behaves_like 'a successful jsonapi response'
 
       context 'with only items for home page' do
-        let :make_request do
-          get api_news_items_path(service: 'uk', target: 'home', format: :json),
-              headers: { 'Accept' => 'application/vnd.uktt.v2' }
-        end
+        let(:request_params) { { service: 'uk', target: 'home' } }
 
         it_behaves_like 'a successful jsonapi response'
       end
 
       context 'with only items for updates page' do
-        let :make_request do
-          get api_news_items_path(service: 'uk', target: 'updates', format: :json),
-              headers: { 'Accept' => 'application/vnd.uktt.v2' }
-        end
+        let(:request_params) { { service: 'uk', target: 'updates' } }
 
         it_behaves_like 'a successful jsonapi response'
       end
 
       context 'with items for both updates and home page' do
-        let :make_request do
-          get api_news_items_path(service: 'uk', target: '', format: :json),
-              headers: { 'Accept' => 'application/vnd.uktt.v2' }
-        end
+        let(:request_params) { { service: 'uk', target: '' } }
 
         it_behaves_like 'a successful jsonapi response'
       end
     end
 
     context 'for xi pages' do
-      let :make_request do
-        get api_news_items_path(service: 'xi', format: :json),
-            headers: { 'Accept' => 'application/vnd.uktt.v2' }
-      end
+      let(:request_params) { { service: 'xi' } }
 
       it_behaves_like 'a successful jsonapi response'
     end
 
     context 'for unknown service pages' do
-      let :make_request do
-        get api_news_items_path(service: 'uk', format: :json),
-            headers: { 'Accept' => 'application/vnd.uktt.v2' }
+      let(:request_params) { { service: 'fr' } }
 
-        it { is_expected.to have_http_status :not_found }
-      end
+      it_behaves_like 'a successful jsonapi response'
     end
   end
 

--- a/spec/requests/api/v2/news/items_controller_spec.rb
+++ b/spec/requests/api/v2/news/items_controller_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe Api::V2::News::ItemsController do
       it_behaves_like 'a successful jsonapi response'
     end
 
+    context 'with a year' do
+      let(:request_params) { { year: item.start_date.year } }
+      let(:item) { create :news_item }
+
+      it_behaves_like 'a successful jsonapi response'
+    end
+
     context 'for uk pages' do
       let(:request_params) { { service: 'uk' } }
 


### PR DESCRIPTION
### Jira link

HOTT-2132

### What?

I have added/removed/altered:

- [x] Allow filtering news items by collection
- [x] Allow filtering news items by year published
- [x] Allow looking up news items by slug
- [x] Added pagination support to news items api
- [x] Fixed N+1 when serializing news items

### Why?

I am doing this because:

- The replacement news UX needs these features
- The N+1 is caused a stupid implementation detail in the sequel paginate plugin

### Deployment risks (optional)

- Changes in use APIs but they are internal only and should maintain the existing API
