### PR TITLE
HOTT-2248: Fixed bug on XI caused by monetary unit code not existing …

### DIFF
--- a/app/models/currency.rb
+++ b/app/models/currency.rb
@@ -15,7 +15,7 @@ class Currency
     if TO_SYMBOL.key?(monetary_unit)
       TO_SYMBOL[monetary_unit] + duty_amount
     else
-      duty_amount + ' ' + monetary_unit
+      "#{duty_amount} #{monetary_unit}"
     end
   end
 end

--- a/app/models/currency.rb
+++ b/app/models/currency.rb
@@ -2,6 +2,7 @@ class Currency
   TO_SYMBOL = {
     'EUR' => '€',
     'GBP' => '£',
+    'EUR (EUC)' => '€',
   }.freeze
 
   attr_reader :monetary_unit
@@ -11,6 +12,10 @@ class Currency
   end
 
   def format(duty_amount)
-    TO_SYMBOL[monetary_unit] + duty_amount
+    if TO_SYMBOL.key?(monetary_unit)
+      TO_SYMBOL[monetary_unit] + duty_amount
+    else
+      duty_amount + ' ' + monetary_unit
+    end
   end
 end

--- a/spec/models/currency_spec.rb
+++ b/spec/models/currency_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Currency do
     context 'when monetary unit code is not present in the hash' do
       subject(:instance) { described_class.new 'XEM' }
 
-      it 'returns empty string' do        
+      it 'returns empty string' do
         expect(instance.format(duty_amount)).to eq('123 XEM')
       end
     end

--- a/spec/models/currency_spec.rb
+++ b/spec/models/currency_spec.rb
@@ -5,8 +5,18 @@ RSpec.describe Currency do
   let(:duty_amount) { '123' }
 
   describe '#format' do
-    it 'returns the the duty amount with currency symbol ' do
-      expect(instance.format(duty_amount)).to eq('€123')
+    context 'when monetary unit code is present in the hash' do
+      it 'returns the the duty amount with currency symbol ' do
+        expect(instance.format(duty_amount)).to eq('€123')
+      end
+    end
+
+    context 'when monetary unit code is not present in the hash' do
+      subject(:instance) { described_class.new 'XEM' }
+
+      it 'returns empty string' do        
+        expect(instance.format(duty_amount)).to eq('123 XEM')
+      end
     end
   end
 end


### PR DESCRIPTION
…in currency hash

### Jira link

[HOTT-<2248>](https://transformuk.atlassian.net/browse/HOTT-2248)

### What?

I have added/removed/altered:

- [ ] Added EUC to currency hash and Else case

### Why?

I am doing this because:

- EUC monetary unit code was causing errors because it was not present in the currency hash

<img width="788" alt="Screenshot 2022-11-22 at 13 59 27" src="https://user-images.githubusercontent.com/12201130/203334542-928e5c52-7f90-4b39-90af-fb8e3a08d61f.png">

