### PR TITLE
HOTT-2262 Updated validity start date on certificate description

### DIFF
--- a/db/data_migrations/20221124145340_correct_validity_start_date_certificate_9035.rb
+++ b/db/data_migrations/20221124145340_correct_validity_start_date_certificate_9035.rb
@@ -1,0 +1,20 @@
+Sequel.migration do
+  # IMPORTANT! Data migrations should be Idempotent, they may get re-run as part
+  # of data rollbacks
+
+  up do
+    if TradeTariffBackend.uk?
+      Sequel::Model.db[:certificate_description_periods_oplog]
+        .where(certificate_description_period_sid: 5167, validity_start_date: '2023-11-23 00:00:00')
+        .update(validity_start_date: '2022-11-23 00:00:00')
+    end
+  end
+
+  down do
+    if TradeTariffBackend.uk?
+      Sequel::Model.db[:certificate_description_periods_oplog]
+        .where(certificate_description_period_sid: 5167, validity_start_date: '2022-11-23 00:00:00')
+        .update(validity_start_date: '2023-11-23 00:00:00')
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-2262

### What?

I have added/removed/altered:

- [x] Added data migration to correct validity start date on description for certificate 035

### Why?

I am doing this because:

- The data from CDS sync was a year out

### Deployment risks (optional)

- Changes production data
