### PR TITLE
HOTT-2270: Fixed missing percent symbol in verbose duty

### DIFF
--- a/app/formatters/duty_expression_formatter.rb
+++ b/app/formatters/duty_expression_formatter.rb
@@ -63,7 +63,7 @@ class DutyExpressionFormatter
         output << if monetary_unit.present? && !verbose
                     monetary_unit
                   else
-                    '%' unless verbose
+                    '%' unless monetary_unit
                   end
         if measurement_unit_abbreviation.present?
           output << if formatted

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -403,7 +403,7 @@ class Measure < Sequel::Model
   end
 
   def prettify_generated_duty_expression!(duty_expression)
-    duty_expression.sub(/\s\s/, ' ').gsub(/(\d)\s+%/, '\1%').sub(/\/\s[a-zA-Z]/, &:downcase)
+    duty_expression.gsub(/\s\s/, ' ').gsub(/(\d)\s+%/, '\1%').sub(/\/\s[a-zA-Z]/, &:downcase)
   end
 
   def national_measurement_units_for(declarable)

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -403,10 +403,7 @@ class Measure < Sequel::Model
   end
 
   def prettify_generated_duty_expression!(duty_expression)
-    duty_expression.sub!(/\s\s/, ' ')
-    duty_expression.sub!(/\s%/, '%') if duty_expression.scan(/\d\s%/).present?
-    duty_expression.sub!(/\/\s[a-zA-Z]/, &:downcase)
-    duty_expression
+    duty_expression.sub(/\s\s/, ' ').gsub(/(\d)\s+%/, '\1%').sub(/\/\s[a-zA-Z]/, &:downcase)
   end
 
   def national_measurement_units_for(declarable)

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -1428,6 +1428,10 @@ RSpec.describe Measure do
       expect(measure.prettify_generated_duty_expression!(generated_string)).to eq '100% / percentage ABV (% vol) per 100 litre (hl)'
     end
 
+    it 'removes spaces if there are multiple % symbols' do
+      expect(measure.prettify_generated_duty_expression!('2.70 % + EAR MAX 6.20 % +ADSZR 11 %')).to eq '2.70% + EAR MAX 6.20% +ADSZR 11%'
+    end
+
     it 'does not remove space if unit is not present' do
       expect(measure.prettify_generated_duty_expression!(generated_string_without_percent_amount)).to eq generated_string_without_percent_amount
     end


### PR DESCRIPTION
### Jira link

[HOTT-<2270>](https://transformuk.atlassian.net/browse/HOTT-2270)

### What?

I have added/removed/altered:

- [ ] Fixed missing percent symbol in verbose duty

### Why?

I am doing this because:

- verbose_duty output was incorrect


