### PR TITLE
Clean up/Refactor spec using TimeMachine

### DIFF
--- a/spec/controllers/api/v2/certificates_controller_index_spec.rb
+++ b/spec/controllers/api/v2/certificates_controller_index_spec.rb
@@ -34,12 +34,10 @@ RSpec.describe Api::V2::CertificatesController, type: :controller do
 
     it { is_expected.to match_json_expression(pattern) }
 
-    it 'the TimeMachine receives the correct Date' do
-      allow(TimeMachine).to receive(:at).and_call_original
+    context 'when the validity_end_date is set to a past date' do
+      let(:certificate) { create(:certificate, validity_end_date: 1.day.ago) }
 
-      do_response
-
-      expect(TimeMachine).to have_received(:at).with(Time.zone.today)
+      it { is_expected.to match_json_expression({ data: [] }) }
     end
   end
 end

--- a/spec/controllers/api/v2/measure_actions_controller_spec.rb
+++ b/spec/controllers/api/v2/measure_actions_controller_spec.rb
@@ -3,9 +3,10 @@ RSpec.describe Api::V2::MeasureActionsController, type: :controller do
     subject(:do_request) { get :index }
 
     let(:json_body) { JSON.parse(do_request.body)['data'] }
+    let(:validity_end_date) { nil }
 
     before do
-      create(:measure_action, :with_description, action_code: '01')
+      create(:measure_action, :with_description, action_code: '01', validity_end_date:)
 
       allow(TimeMachine).to receive(:at).and_call_original
     end
@@ -18,8 +19,8 @@ RSpec.describe Api::V2::MeasureActionsController, type: :controller do
           {
             'attributes' => {
               'description' => 'Import/export not allowed after control',
-              'validity_end_date' => nil,
               'validity_start_date' => 3.years.ago.beginning_of_day.as_json,
+              'validity_end_date' => nil,
             },
             'id' => '01',
             'type' => 'measure_action',
@@ -28,9 +29,10 @@ RSpec.describe Api::V2::MeasureActionsController, type: :controller do
       )
     end
 
-    it 'the TimeMachine receives the correct Date' do
-      do_request
-      expect(TimeMachine).to have_received(:at).with(Time.zone.today)
+    context 'when the validity_end_date is set to a past date' do
+      let(:validity_end_date) { 1.day.ago }
+
+      it { expect(json_body).to eq [] }
     end
   end
 end

--- a/spec/controllers/api/v2/measure_condition_codes_controller_spec.rb
+++ b/spec/controllers/api/v2/measure_condition_codes_controller_spec.rb
@@ -3,9 +3,10 @@ RSpec.describe Api::V2::MeasureConditionCodesController, type: :controller do
     subject(:do_request) { get :index }
 
     let(:json_body) { JSON.parse(do_request.body)['data'] }
+    let(:validity_end_date) { nil }
 
     before do
-      create(:measure_condition_code, :with_description, condition_code: 'C')
+      create(:measure_condition_code, :with_description, condition_code: 'C', validity_end_date:)
 
       allow(TimeMachine).to receive(:at).and_call_original
     end
@@ -28,9 +29,10 @@ RSpec.describe Api::V2::MeasureConditionCodesController, type: :controller do
       )
     end
 
-    it 'the TimeMachine receives the correct Date' do
-      do_request
-      expect(TimeMachine).to have_received(:at).with(Time.zone.today)
+    context 'when the validity_end_date is set to a past date' do
+      let(:validity_end_date) { 1.day.ago }
+
+      it { expect(json_body).to eq [] }
     end
   end
 end

--- a/spec/controllers/api/v2/measure_types_controller_spec.rb
+++ b/spec/controllers/api/v2/measure_types_controller_spec.rb
@@ -1,29 +1,27 @@
 RSpec.describe Api::V2::MeasureTypesController, type: :controller do
   describe '#index' do
+    subject(:do_request) { get :index }
+
     before do
-      create(:measure_type, :with_measure_type_series_description)
+      create(:measure_type, :with_measure_type_series_description, validity_end_date:)
 
       allow(TimeMachine).to receive(:at).and_call_original
     end
 
-    it 'returns success' do
-      get :index, format: :json
+    let(:json_body) { JSON.parse(do_request.body)['data'] }
 
-      expect(response).to be_successful
-    end
+    let(:validity_end_date) { nil }
+
+    it { is_expected.to have_http_status(:success) }
 
     it 'returns all measure types' do
-      get :index, format: :json
-
-      data = JSON.parse(response.body)['data']
-
-      expect(data.length).to eq 1
+      expect(json_body.length).to eq 1
     end
 
-    it 'the TimeMachine receives the correct Date' do
-      get :index, format: :json
+    context 'when the validity_end_date is set to a past date' do
+      let(:validity_end_date) { 1.day.ago }
 
-      expect(TimeMachine).to have_received(:at).with(Time.zone.today)
+      it { expect(json_body).to eq [] }
     end
   end
 

--- a/spec/controllers/api/v2/quota_order_numbers_controller_spec.rb
+++ b/spec/controllers/api/v2/quota_order_numbers_controller_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe Api::V2::QuotaOrderNumbersController, type: :controller do
     subject(:do_request) { get :index }
 
     let(:json_body) { JSON.parse(do_request.body) }
+    let(:validity_end_date) { nil }
 
     before do
       create(
@@ -13,6 +14,7 @@ RSpec.describe Api::V2::QuotaOrderNumbersController, type: :controller do
         quota_definition_sid: 1,
         quota_order_number_sid: 5,
         quota_order_number_id: '000001',
+        validity_end_date:,
       )
 
       allow(TimeMachine).to receive(:at).and_call_original
@@ -40,17 +42,18 @@ RSpec.describe Api::V2::QuotaOrderNumbersController, type: :controller do
       )
     end
 
+    context 'when the validity_end_date is set to a past date' do
+      let(:validity_end_date) { 1.day.ago }
+
+      it { expect(json_body['data']).to eq [] }
+    end
+
     it 'returns all the includes' do
       expect(json_body['included']).to include_json(
         [
           { 'id' => '1', 'type' => 'quota_definition' },
         ],
       )
-    end
-
-    it 'the TimeMachine receives the correct Date' do
-      do_request
-      expect(TimeMachine).to have_received(:at).with(Time.zone.today)
     end
 
     it 'rails cache receives fetch with the correct key' do


### PR DESCRIPTION
### What?
Removed specs related to the TimeMachine in the controlles: they are not effective, even removing `.actual` from the queries in the controller, specs continue to pass.

- Add specs that actually test when the validity_end_date is set to a past date.

### Jira link
No Jira