### PR TITLE
HOTT-2278 dont 404 for news items for unknown collection

### DIFF
--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -78,6 +78,13 @@ module News
         where(start_date: first_of_jan..first_of_jan.end_of_year)
       end
 
+      def for_collection(collection_id)
+        collection_id = collection_id.presence&.to_i
+        return self unless collection_id
+
+        association_join(:collections).where(collection_id:).select_all(:news_items)
+      end
+
       def years
         distinct.select { date_part('year', :start_date).cast(:integer).as(:year) }
                 .order(Sequel.desc(:year))

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -252,6 +252,41 @@ RSpec.describe News::Item do
       end
     end
 
+    describe '.for_collection' do
+      before do
+        inside_collection
+        outside_collection
+      end
+
+      let(:inside_collection) { create :news_item, :with_collections, title: 'in' }
+      let(:outside_collection) { create :news_item, title: 'out' }
+
+      context 'without collection' do
+        subject { described_class.for_collection(nil).all }
+
+        it { is_expected.to include inside_collection }
+        it { is_expected.to include outside_collection }
+      end
+
+      context 'with known collection' do
+        subject do
+          described_class.for_collection(inside_collection.collections.first.id.to_s).all
+        end
+
+        it { is_expected.to include inside_collection }
+        it { is_expected.not_to include outside_collection }
+      end
+
+      context 'with unknown collection' do
+        subject do
+          described_class.for_collection('0').all
+        end
+
+        it { is_expected.not_to include inside_collection }
+        it { is_expected.not_to include outside_collection }
+      end
+    end
+
     describe '.descending' do
       subject { described_class.descending.to_a }
 

--- a/spec/requests/api/v2/news/items_controller_spec.rb
+++ b/spec/requests/api/v2/news/items_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Api::V2::News::ItemsController do
       context 'with unknown collection' do
         let(:collection_id) { collection.id + 100 }
 
-        it { is_expected.to have_http_status :not_found }
+        it_behaves_like 'a successful jsonapi response'
       end
     end
 


### PR DESCRIPTION
We should return an empty list instead of 404

### Jira link

HOTT-2278

### What?

I have added/removed/altered:

- [x] Filter by collection id instead of looking for the corresponding collection and finding its items

### Why?

I am doing this because:

- Previously an invalid collection id would return a 404 rather then no news items

### Deployment risks (optional)

- Changes behaviour of the key news item api but in a manner which should make its usage safer
