### PR TITLE
HOTT-2275: Fixes copy/paste error in the admin commodities controller

### DIFF
--- a/app/controllers/api/admin/commodities_controller.rb
+++ b/app/controllers/api/admin/commodities_controller.rb
@@ -5,7 +5,7 @@ module Api
       before_action :authenticate_user!
 
       def show
-        render json: Api::Admin::GoodsNomenclatureSerializer.new(@commodity, { is_collection: false }).serializable_hash
+        render json: Api::Admin::Commodities::CommoditySerializer.new(@commodity).serializable_hash
       end
 
       def index

--- a/spec/requests/api/admin/commodities_controller_spec.rb
+++ b/spec/requests/api/admin/commodities_controller_spec.rb
@@ -1,4 +1,15 @@
 RSpec.describe Api::Admin::CommoditiesController, type: :request do
+  describe 'GET #show' do
+    subject(:do_request) do
+      authenticated_get api_commodity_path(id: commodity.goods_nomenclature_item_id)
+      response
+    end
+
+    let(:commodity) { create(:commodity) }
+
+    it_behaves_like 'a successful jsonapi response'
+  end
+
   describe 'GET #index' do
     subject(:do_request) do
       authenticated_get api_commodities_path(format: :csv)


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2275

### What?

I have added/removed/altered:

- [x] Altered incorrect reference to serializer in admin commodities controller
- [x] Added some missing specs that would have caught this

### Why?

I am doing this because:

- This is required so we can properly manage search references
