### PR TITLE
HOTT-2263: Hide all commodities in chapter 98

### DIFF
--- a/db/data_migrations/20221130132800_add_all_of_chapter98_to_hidden_goods_nomenclature_table.rb
+++ b/db/data_migrations/20221130132800_add_all_of_chapter98_to_hidden_goods_nomenclature_table.rb
@@ -1,0 +1,23 @@
+Sequel.migration do
+  # IMPORTANT! Data migrations should be Idempotent, they may get re-run as part
+  # of data rollbacks
+
+  up do
+    if TradeTariffBackend.uk?
+      HiddenGoodsNomenclature.unrestrict_primary_key
+
+      GoodsNomenclature.where(Sequel.like(:goods_nomenclature_item_id, '98%')).where(validity_end_date: nil).all.each do |goods_nomenclature|
+        HiddenGoodsNomenclature.find_or_create(goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id)
+      end
+
+      HiddenGoodsNomenclature.restrict_primary_key
+    end
+  end
+
+  down do
+    if TradeTariffBackend.uk?
+      item_ids = GoodsNomenclature.where(Sequel.like(:goods_nomenclature_item_id, '98%')).where(validity_end_date: nil).all.pluck(:goods_nomenclature_item_id)
+      HiddenGoodsNomenclature.where(goods_nomenclature_item_id: item_ids).delete
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[HOTT-<2263>](https://transformuk.atlassian.net/browse/HOTT-2263)

### What?

I have added/removed/altered:

- [ ] Added all commodities in chapter 98 to HiddenGoodsNomenclature table

### Why?

I am doing this because:

- We need to hide these pages

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical data

<img width="1186" alt="Screenshot 2022-12-01 at 11 43 22" src="https://user-images.githubusercontent.com/12201130/205044380-a85cc46b-0704-4441-837d-26a41070095d.png">

