### PR TITLE
HOTT-2268: Unhide commodity code 9919000030

### DIFF
--- a/db/data_migrations/20221130144331_remove_commodity9919000030_from_hidden_goods_nomenclature_table.rb
+++ b/db/data_migrations/20221130144331_remove_commodity9919000030_from_hidden_goods_nomenclature_table.rb
@@ -1,0 +1,17 @@
+Sequel.migration do
+  # IMPORTANT! Data migrations should be Idempotent, they may get re-run as part
+  # of data rollbacks
+  up do
+    HiddenGoodsNomenclature.where(goods_nomenclature_item_id: '9919000030').delete if TradeTariffBackend.uk?
+  end
+
+  down do
+    if TradeTariffBackend.uk?
+      HiddenGoodsNomenclature.unrestrict_primary_key
+
+      HiddenGoodsNomenclature.find_or_create(goods_nomenclature_item_id: '9919000030')
+
+      HiddenGoodsNomenclature.restrict_primary_key
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[HOTT-<2268>](https://transformuk.atlassian.net/browse/HOTT-2268)

### What?

I have added/removed/altered:

- [ ] Removed commodity code 9919000030 from HiddenGoodsNomenclature table

### Why?

I am doing this because:

- We want to display this commodity

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical data

<img width="1696" alt="Screenshot 2022-12-01 at 11 48 29" src="https://user-images.githubusercontent.com/12201130/205045284-9f56cb93-28ee-422a-93a6-643f2a7c933d.png">


