### PR TITLE
HOTT-2302: Exclude chapter descriptions from search

### DIFF
--- a/app/models/beta/search/goods_nomenclature_query.rb
+++ b/app/models/beta/search/goods_nomenclature_query.rb
@@ -17,7 +17,6 @@ module Beta
 
       MULTI_MATCH_FIELDS = [
         'search_references^12',
-        'ancestor_1_description_indexed^10', # chapter
         'ancestor_2_description_indexed^8', # heading
         'description_indexed^6',
         'ancestor_3_description_indexed^4',

--- a/spec/models/beta/search/goods_nomenclature_query_spec.rb
+++ b/spec/models/beta/search/goods_nomenclature_query_spec.rb
@@ -10,14 +10,13 @@ RSpec.describe Beta::Search::GoodsNomenclatureQuery do
   describe '#id' do
     subject(:id) { build(:goods_nomenclature_query, :full_query).id }
 
-    it { is_expected.to eq('b8dc5a3889acb4eb83be5d588ba3f616') }
+    it { is_expected.to eq('ce2599e07a29f13d42922303630abce0') }
   end
 
   describe '#query' do
     let(:expected_multi_match_fields) do
       [
         'search_references^12',
-        'ancestor_1_description_indexed^10',
         'ancestor_2_description_indexed^8',
         'description_indexed^6',
         'ancestor_3_description_indexed^4',

--- a/spec/serializers/api/beta/goods_nomenclature_query_serializer_spec.rb
+++ b/spec/serializers/api/beta/goods_nomenclature_query_serializer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::Beta::GoodsNomenclatureQuerySerializer do
     let(:expected) do
       {
         data: {
-          id: 'b8dc5a3889acb4eb83be5d588ba3f616',
+          id: 'ce2599e07a29f13d42922303630abce0',
           type: :goods_nomenclature_query,
           attributes: {
             query: {
@@ -25,7 +25,6 @@ RSpec.describe Api::Beta::GoodsNomenclatureQuerySerializer do
                         type: 'best_fields',
                         fields: [
                           'search_references^12',
-                          'ancestor_1_description_indexed^10',
                           'ancestor_2_description_indexed^8',
                           'description_indexed^6',
                           'ancestor_3_description_indexed^4',
@@ -54,7 +53,6 @@ RSpec.describe Api::Beta::GoodsNomenclatureQuerySerializer do
                         type: 'best_fields',
                         fields: [
                           'search_references^12',
-                          'ancestor_1_description_indexed^10',
                           'ancestor_2_description_indexed^8',
                           'description_indexed^6',
                           'ancestor_3_description_indexed^4',
@@ -81,7 +79,6 @@ RSpec.describe Api::Beta::GoodsNomenclatureQuerySerializer do
                         type: 'best_fields',
                         fields: [
                           'search_references^12',
-                          'ancestor_1_description_indexed^10',
                           'ancestor_2_description_indexed^8',
                           'description_indexed^6',
                           'ancestor_3_description_indexed^4',

--- a/spec/services/api/beta/search_service_spec.rb
+++ b/spec/services/api/beta/search_service_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe Api::Beta::SearchService do
                     multi_match: {
                       fields: [
                         'search_references^12',
-                        'ancestor_1_description_indexed^10',
                         'ancestor_2_description_indexed^8',
                         'description_indexed^6',
                         'ancestor_3_description_indexed^4',


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2302

### What?

I have added/removed/altered:

- [x] Removed chapter description globally from multi search query
- [x] Updated specs to reflect change

### Why?

I am doing this because:

- Chapters are too broad and include lots of semantically different adjacent concepts
