### PR TITLE
Hott 2296 Add slug and published fields to collections

### DIFF
--- a/app/controllers/api/v2/news/collections_controller.rb
+++ b/app/controllers/api/v2/news/collections_controller.rb
@@ -3,7 +3,7 @@ module Api
     module News
       class CollectionsController < ApiController
         def index
-          collections = ::News::Collection.all
+          collections = ::News::Collection.published.all
           serializer = Api::V2::News::CollectionSerializer.new(collections)
 
           render json: serializer.serializable_hash

--- a/app/controllers/api/v2/news/items_controller.rb
+++ b/app/controllers/api/v2/news/items_controller.rb
@@ -22,7 +22,9 @@ module Api
                                                     .descending
                                                     .all
 
-          serializer = Api::V2::News::ItemSerializer.new(news_items_with_collections,
+          presented_news_items = Api::V2::News::ItemPresenter.wrap(news_items_with_collections)
+
+          serializer = Api::V2::News::ItemSerializer.new(presented_news_items,
                                                          include: %i[collections],
                                                          meta: pagination_meta(news_items_page))
 
@@ -40,7 +42,9 @@ module Api
                         scope.with_pk!(slug_or_id)
                       end
 
-          serializer = Api::V2::News::ItemSerializer.new(news_item, include: %i[collections])
+          presented_news_item = Api::V2::News::ItemPresenter.new(news_item)
+
+          serializer = Api::V2::News::ItemSerializer.new(presented_news_item, include: %i[collections])
 
           render json: serializer.serializable_hash
         end

--- a/app/controllers/api/v2/news/items_controller.rb
+++ b/app/controllers/api/v2/news/items_controller.rb
@@ -12,6 +12,7 @@ module Api
                                    .for_collection(params[:collection_id])
                                    .for_today
                                    .descending
+                                   .distinct
                                    .select { news_items[:id] }
                                    .paginate(current_page, per_page)
 

--- a/app/controllers/api/v2/news/items_controller.rb
+++ b/app/controllers/api/v2/news/items_controller.rb
@@ -13,11 +13,11 @@ module Api
                                    .for_today
                                    .descending
                                    .distinct
-                                   .select { news_items[:id] }
+                                   .select { [news_items[:id], news_items[:start_date]] }
                                    .paginate(current_page, per_page)
 
           # Why? you may ask - because #paginate ignores #eager
-          news_items_with_collections = ::News::Item.eager(:collections)
+          news_items_with_collections = ::News::Item.eager(:published_collections)
                                                     .where(id: news_items_page.pluck(:id))
                                                     .descending
                                                     .all

--- a/app/controllers/api/v2/news/items_controller.rb
+++ b/app/controllers/api/v2/news/items_controller.rb
@@ -30,10 +30,14 @@ module Api
         end
 
         def show
-          news_item = if params[:id].present? && !/\A\d+\z/.match?(params[:id])
-                        ::News::Item.for_today.where(slug: params[:id]).take
+          scope = ::News::Item.for_today.for_collection(nil)
+
+          slug_or_id = params[:id]
+
+          news_item = if slug_or_id.present? && !/\A\d+\z/.match?(slug_or_id)
+                        scope.where { news_items[:slug] =~ slug_or_id }.take
                       else
-                        ::News::Item.for_today.with_pk!(params[:id])
+                        scope.with_pk!(slug_or_id)
                       end
 
           serializer = Api::V2::News::ItemSerializer.new(news_item, include: %i[collections])

--- a/app/models/news/collection.rb
+++ b/app/models/news/collection.rb
@@ -7,5 +7,12 @@ module News
                          order: Sequel.desc(:start_date)
 
     set_dataset order(Sequel.desc(:priority), :name)
+
+    def validate
+      super
+
+      validates_presence :slug
+      validates_format %r{\A[a-z0-9\-_]+\z}, :slug if slug.present?
+    end
   end
 end

--- a/app/models/news/collection.rb
+++ b/app/models/news/collection.rb
@@ -8,6 +8,12 @@ module News
 
     set_dataset order(Sequel.desc(:priority), :name)
 
+    dataset_module do
+      def published
+        where(published: true)
+      end
+    end
+
     def validate
       super
 

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -79,10 +79,18 @@ module News
       end
 
       def for_collection(collection_id)
-        collection_id = collection_id.presence&.to_i
+        collection_id = collection_id.presence
         return self unless collection_id
 
-        association_join(:collections).where(collection_id:).select_all(:news_items)
+        if collection_id.to_s.match? %r{\A\d+\z}
+          association_join(:collections)
+            .where(collection_id: collection_id.to_i)
+            .select_all(:news_items)
+        else
+          association_join(:collections)
+            .where { collections[:slug] =~ collection_id }
+            .select_all(:news_items)
+        end
       end
 
       def years

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -80,16 +80,17 @@ module News
 
       def for_collection(collection_id)
         collection_id = collection_id.presence
-        return self unless collection_id
+
+        scope = association_join(:collections)
+                  .select_all(:news_items)
+                  .where { collections[:published] =~ true }
 
         if collection_id.to_s.match? %r{\A\d+\z}
-          association_join(:collections)
-            .where(collection_id: collection_id.to_i)
-            .select_all(:news_items)
+          scope.where(collection_id: collection_id.to_i)
+        elsif collection_id
+          scope.where { collections[:slug] =~ collection_id }
         else
-          association_join(:collections)
-            .where { collections[:slug] =~ collection_id }
-            .select_all(:news_items)
+          scope
         end
       end
 

--- a/app/presenters/api/v2/news/item_presenter.rb
+++ b/app/presenters/api/v2/news/item_presenter.rb
@@ -1,0 +1,21 @@
+module Api
+  module V2
+    module News
+      class ItemPresenter < SimpleDelegator
+        class << self
+          def wrap(items)
+            items.map(&method(:new))
+          end
+        end
+
+        def collections
+          published_collections
+        end
+
+        def collection_ids
+          published_collections.map(&:id)
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/admin/news/collection_serializer.rb
+++ b/app/serializers/api/admin/news/collection_serializer.rb
@@ -8,7 +8,7 @@ module Api
 
         set_id :id
 
-        attributes :name, :created_at, :updated_at
+        attributes :name, :slug, :created_at, :updated_at
       end
     end
   end

--- a/app/serializers/api/v2/news/collection_serializer.rb
+++ b/app/serializers/api/v2/news/collection_serializer.rb
@@ -8,7 +8,7 @@ module Api
 
         set_id :id
 
-        attributes :name, :description, :priority
+        attributes :name, :slug, :description, :priority
       end
     end
   end

--- a/db/data_migrations/20221202133634_assign_existing_news_to_trade_news.rb
+++ b/db/data_migrations/20221202133634_assign_existing_news_to_trade_news.rb
@@ -1,0 +1,19 @@
+Sequel.migration do
+  # IMPORTANT! Data migrations should be Idempotent, they may get re-run as part
+  # of data rollbacks
+
+  up do
+    trade_news = News::Collection.find_or_create(name: 'Trade news') do |collection|
+      collection.slug = 'trade_news'
+    end
+
+    News::Item.eager_graph(:collections)
+              .where { { collections[:id] => nil } }
+              .all
+              .each { |item| item.add_collection trade_news }
+  end
+
+  down do
+    # not reversable
+  end
+end

--- a/db/migrate/20221202094157_add_slug_to_collections.rb
+++ b/db/migrate/20221202094157_add_slug_to_collections.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :news_collections do
+      add_column :slug, String, size: 255, unique: true
+    end
+  end
+end

--- a/db/migrate/20221202094157_add_slug_to_collections.rb
+++ b/db/migrate/20221202094157_add_slug_to_collections.rb
@@ -2,6 +2,7 @@ Sequel.migration do
   change do
     alter_table :news_collections do
       add_column :slug, String, size: 255, unique: true
+      add_column :published, :boolean, default: true
     end
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5260,7 +5260,8 @@ CREATE TABLE public.news_collections (
     updated_at timestamp without time zone,
     priority integer DEFAULT 0 NOT NULL,
     description text,
-    slug character varying(255)
+    slug character varying(255),
+    published boolean DEFAULT true
 );
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5259,7 +5259,8 @@ CREATE TABLE public.news_collections (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone,
     priority integer DEFAULT 0 NOT NULL,
-    description text
+    description text,
+    slug character varying(255)
 );
 
 
@@ -8492,6 +8493,14 @@ ALTER TABLE ONLY public.news_collections
 
 
 --
+-- Name: news_collections news_collections_slug_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.news_collections
+    ADD CONSTRAINT news_collections_slug_key UNIQUE (slug);
+
+
+--
 -- Name: news_items news_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11017,3 +11026,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20221017110015_add_news_co
 INSERT INTO "schema_migrations" ("filename") VALUES ('20221017160811_associate_news_items_and_news_collections.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20221020121609_add_precis_and_slug_to_news_items.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20221127173137_add_description_and_priority_to_news_collections.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20221202094157_add_slug_to_collections.rb');

--- a/spec/factories/news_factory.rb
+++ b/spec/factories/news_factory.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :news_collection, class: 'News::Collection' do
     sequence(:name) { |n| "News Collection #{n}" }
+    sequence(:slug) { |n| "news_collection_#{n}" }
 
     trait :with_description do
       sequence(:description) { |n| "Description of News collection #{n}" }

--- a/spec/factories/news_factory.rb
+++ b/spec/factories/news_factory.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :news_collection, class: 'News::Collection' do
     sequence(:name) { |n| "News Collection #{n}" }
     sequence(:slug) { |n| "news_collection_#{n}" }
+    published { true }
 
     trait :with_description do
       sequence(:description) { |n| "Description of News collection #{n}" }

--- a/spec/factories/news_factory.rb
+++ b/spec/factories/news_factory.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
     trait :with_description do
       sequence(:description) { |n| "Description of News collection #{n}" }
     end
+
+    trait :unpublished do
+      published { false }
+    end
   end
 
   factory :news_item, class: 'News::Item' do

--- a/spec/models/news/collection_spec.rb
+++ b/spec/models/news/collection_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe News::Collection do
         unpublished
       end
 
-      let(:published) { create :news_collection, published: true }
-      let(:unpublished) { create :news_collection, published: false }
+      let(:published) { create :news_collection }
+      let(:unpublished) { create :news_collection, :unpublished }
 
       it { is_expected.to include published }
       it { is_expected.not_to include unpublished }

--- a/spec/models/news/collection_spec.rb
+++ b/spec/models/news/collection_spec.rb
@@ -3,8 +3,10 @@ require 'rails_helper'
 RSpec.describe News::Collection do
   describe 'attributes' do
     it { is_expected.to respond_to :name }
+    it { is_expected.to respond_to :slug }
     it { is_expected.to respond_to :priority }
     it { is_expected.to respond_to :description }
+    it { is_expected.to respond_to :published }
     it { is_expected.to respond_to :created_at }
     it { is_expected.to respond_to :updated_at }
   end
@@ -56,6 +58,23 @@ RSpec.describe News::Collection do
       end
 
       it { is_expected.to eq items.map(&:id).reverse }
+    end
+  end
+
+  describe 'scopes' do
+    describe '#published' do
+      subject { described_class.published.all }
+
+      before do
+        published
+        unpublished
+      end
+
+      let(:published) { create :news_collection, published: true }
+      let(:unpublished) { create :news_collection, published: false }
+
+      it { is_expected.to include published }
+      it { is_expected.not_to include unpublished }
     end
   end
 end

--- a/spec/models/news/collection_spec.rb
+++ b/spec/models/news/collection_spec.rb
@@ -15,19 +15,28 @@ RSpec.describe News::Collection do
     let(:instance) { described_class.new }
 
     it { is_expected.to include(name: ['is not present']) }
+    it { is_expected.to include(slug: ['is not present']) }
 
-    context 'with blank name' do
-      let(:instance) { described_class.new name: '' }
+    context 'with blank attributes' do
+      let(:instance) { described_class.new name: '', slug: '' }
 
       it { is_expected.to include(name: ['is not present']) }
+      it { is_expected.to include(slug: ['is not present']) }
     end
 
-    context 'with duplicate collection name' do
-      before { create :news_collection, name: 'testing' }
+    context 'with duplicated attributes' do
+      before { create :news_collection, name: 'testing', slug: 'testing' }
 
-      let(:instance) { described_class.new name: 'testing' }
+      let(:instance) { described_class.new name: 'testing', slug: 'testing' }
 
       it { is_expected.to include(name: ['is already taken']) }
+      it { is_expected.to include(slug: ['is already taken']) }
+    end
+
+    context 'with invalid format slug' do
+      let(:instance) { described_class.new name: 'testing', slug: 'with space' }
+
+      it { is_expected.to include(slug: ['is invalid']) }
     end
   end
 

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -285,6 +285,26 @@ RSpec.describe News::Item do
         it { is_expected.not_to include inside_collection }
         it { is_expected.not_to include outside_collection }
       end
+
+      context 'with slugs' do
+        context 'with known collection' do
+          subject do
+            described_class.for_collection(inside_collection.collections.first.slug).all
+          end
+
+          it { is_expected.to include inside_collection }
+          it { is_expected.not_to include outside_collection }
+        end
+
+        context 'with unknown slug' do
+          subject do
+            described_class.for_collection('random').all
+          end
+
+          it { is_expected.not_to include inside_collection }
+          it { is_expected.not_to include outside_collection }
+        end
+      end
     end
 
     describe '.descending' do

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -116,6 +116,23 @@ RSpec.describe News::Item do
         it { is_expected.to match_array [collections.first.id, another.id] }
       end
     end
+
+    describe '#published_collections' do
+      subject { described_class.first(id: item.id).published_collections.pluck(:name) }
+
+      before { collections.each(&item.method(:add_collection)) }
+
+      let(:item) { create :news_item }
+
+      let :collections do
+        [
+          create(:news_collection, name: 'AAA'),
+          create(:news_collection, :unpublished, name: 'BBB'),
+        ]
+      end
+
+      it { is_expected.to eq %w[AAA] }
+    end
   end
 
   describe 'scopes' do

--- a/spec/presenters/api/v2/news/item_presenter_spec.rb
+++ b/spec/presenters/api/v2/news/item_presenter_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe Api::V2::News::ItemPresenter do
+  subject(:presented) { described_class.new news_item }
+
+  let :news_item do
+    item = create :news_item
+    item.add_collection unpublished
+    item.add_collection published
+    item.reload
+  end
+
+  let(:unpublished) { create(:news_collection, :unpublished) }
+  let(:published) { create(:news_collection) }
+
+  describe '#collection_ids' do
+    subject { presented.collection_ids }
+
+    it { is_expected.to include published.id }
+    it { is_expected.not_to include unpublished.id }
+  end
+
+  describe '#collections' do
+    subject { presented.collections }
+
+    it { is_expected.to include published }
+    it { is_expected.not_to include unpublished }
+  end
+
+  describe '.wrap' do
+    subject { described_class.wrap items }
+
+    let(:items) { create_list :news_item, 3, :with_collections }
+
+    it { is_expected.to all be_instance_of described_class }
+  end
+end

--- a/spec/requests/api/v2/news/items_controller_spec.rb
+++ b/spec/requests/api/v2/news/items_controller_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Api::V2::News::ItemsController do
   describe 'GET #show' do
     subject(:rendered) { make_request && response }
 
-    let(:news_item) { create :news_item }
+    let(:news_item) { create :news_item, :with_collections }
 
     let :make_request do
       get api_news_item_path(news_item.id, format: :json),
@@ -126,6 +126,18 @@ RSpec.describe Api::V2::News::ItemsController do
         get api_news_item_path('something-unknown', format: :json),
             headers: { 'Accept' => 'application/vnd.uktt.v2' }
       end
+
+      it { is_expected.to have_http_status :not_found }
+    end
+
+    context 'with unpublished collection' do
+      before { news_item.collections.first.update(published: false) }
+
+      it { is_expected.to have_http_status :not_found }
+    end
+
+    context 'without collection' do
+      let(:news_item) { create :news_item }
 
       it { is_expected.to have_http_status :not_found }
     end

--- a/spec/serializers/api/admin/news/collection_serializer_spec.rb
+++ b/spec/serializers/api/admin/news/collection_serializer_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Api::Admin::News::CollectionSerializer do
   subject { described_class.new(collection).serializable_hash }
 
-  let(:collection) { create :news_collection, name: 'Serialized' }
+  let(:collection) { create :news_collection, name: 'Serialized', slug: 'serialized' }
 
   describe '#serializable_hash' do
     let :expected do
@@ -11,6 +11,7 @@ RSpec.describe Api::Admin::News::CollectionSerializer do
           type: :news_collection,
           attributes: {
             name: 'Serialized',
+            slug: 'serialized',
             created_at: collection.created_at,
             updated_at: collection.updated_at,
           },

--- a/spec/serializers/api/v2/news/collection_serializer_spec.rb
+++ b/spec/serializers/api/v2/news/collection_serializer_spec.rb
@@ -1,7 +1,10 @@
 RSpec.describe Api::V2::News::CollectionSerializer do
   subject { described_class.new(collection).serializable_hash }
 
-  let(:collection) { create :news_collection, :with_description, name: 'Serialized' }
+  let :collection do
+    create :news_collection, :with_description, name: 'Serialized',
+                                                slug: 'serialized'
+  end
 
   describe '#serializable_hash' do
     let :expected do
@@ -11,6 +14,7 @@ RSpec.describe Api::V2::News::CollectionSerializer do
           type: :news_collection,
           attributes: {
             name: 'Serialized',
+            slug: 'serialized',
             description: collection.description,
             priority: 0,
           },

--- a/spec/services/api/admin/error_serialization_service_spec.rb
+++ b/spec/services/api/admin/error_serialization_service_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Api::Admin::ErrorSerializationService do
   describe '#call' do
     subject { described_class.new(instance).call }
 
-    let(:instance) { News::Collection.new }
+    let(:instance) { News::Collection.new slug: 'test' }
 
     context 'with errors' do
       before { instance.valid? }
@@ -88,7 +88,7 @@ RSpec.describe Api::Admin::ErrorSerializationService do
 
     context 'with conflict error' do
       before do
-        News::Collection.create name: instance.name
+        News::Collection.create name: instance.name, slug: 'test2'
         instance.valid?
       end
 


### PR DESCRIPTION
### Jira link

HOTT-2296

### What?

I have added/removed/altered:

- [x] Added a slug field to news collections
- [x] Allow filtering collection slug as well as collection id
- [x] Added a published boolean field to news collections
- [x] Added a `published_collections` relationship which is a filtered list of collections
- [x] Changed the frontend news collections api to only expose published collections
- [x] Changed the frontend news items api to only include published collections
- [x] Changed the frontend news item filtering to only allow filtering on published collections

### Why?

I am doing this because:

- We need to hide all `tariff_notices` stories
- We want to use slugs for the urls when filtering stories

### Deployment risks (optional)

- Includes data migrations which change the news stories data in use in production
