### PR TITLE
HOTT-2314 assign slugs to existing stories

### DIFF
--- a/lib/tasks/news.rake
+++ b/lib/tasks/news.rake
@@ -3,4 +3,9 @@ namespace :news do
   task import_govuk_stories: :environment do
     News::Importer.import!
   end
+
+  desc 'Assign slugs to existing news items'
+  task assign_missing_slugs: :environment do
+    News::Importer.assign_missing_slugs!
+  end
 end


### PR DESCRIPTION
### Jira link

HOTT-2314

### What?

I have added/removed/altered:

- [x] Added rake task to assign slugs missing from existing news stories

### Why?

I am doing this because:

- We will want nice urls when we switch to the new UX

### Deployment risks (optional)

- None but when running the rake task it will change production data
