### PR TITLE
HOTT-2322: Redirect single digit searches to chapter

### DIFF
--- a/app/models/beta/search/open_search_result.rb
+++ b/app/models/beta/search/open_search_result.rb
@@ -174,6 +174,9 @@ module Beta
         id = short_code
 
         resource_path = case short_code.length
+                        when 1
+                          id = short_code.rjust(2, '0')
+                          '/chapters/:id'
                         when 2
                           '/chapters/:id'
                         when 4

--- a/spec/models/beta/search/open_search_result_spec.rb
+++ b/spec/models/beta/search/open_search_result_spec.rb
@@ -261,6 +261,7 @@ RSpec.describe Beta::Search::OpenSearchResult do
       it { is_expected.to include(expected_path) }
     end
 
+    it_behaves_like 'a redirecting search query', '1', '/chapters/01'
     it_behaves_like 'a redirecting search query', '01', '/chapters/01'
     it_behaves_like 'a redirecting search query', '0101', '/headings/0101'
     it_behaves_like 'a redirecting search query', '010129', '/subheadings/0101290000-80'


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2322

### What?

I have added/removed/altered:

- [x] Added handling of single digit searches

### Why?

I am doing this because:

- Its simple enough to handle this here even if technically the short code is in the wrong format
- Discovered as part of performance testing here: https://sentry.io/organizations/engine-le/issues/3790300560/?project=5557002&referrer=slack
