### PR TITLE
HOTT-2308: Remove space before percentage signs on all commodity code…

### DIFF
--- a/app/formatters/description_formatter.rb
+++ b/app/formatters/description_formatter.rb
@@ -6,6 +6,8 @@ class DescriptionFormatter
     return '' if str.blank?
 
     str.gsub!('|%', '%')
+    str.gsub!(160.chr("UTF-8")," ")
+    str.gsub!(/(\d)\s+%/, '\1%')
     str.gsub!('-|', "\n-")
     str.gsub!('|', '&nbsp;')
     str.gsub!('!1!', '<br />')

--- a/spec/formatters/description_formatter_spec.rb
+++ b/spec/formatters/description_formatter_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe DescriptionFormatter do
       ).to eq ' <br /> '
     end
 
+    it 'removes special space character from 1nbsp%' do
+      expect(
+        described_class.format(description: ' 85 % '),
+      ).to eq ' 85% '
+    end
+
     it 'replaces !X! with times html entity' do
       expect(
         described_class.format(description: ' !X! '),


### PR DESCRIPTION
… formatted descriptions

The String contained a non standard space character which I had to replace with a standard space character because regex replace wasn't working. This can be checked by doing formatted_description.chars[-6].ord

Useful links:
https://stackoverflow.com/questions/48174592/change-all-nbsp-to-normal-blank-space-ruby
https://apidock.com/rails/String/ord

### Jira link

[HOTT-<2308>](https://transformuk.atlassian.net/browse/HOTT-2308)

### What?

I have added/removed/altered:

- [ ] Remove space before percentage signs on all commodity code formatted descriptions

### Why?

I am doing this because:

- We don't want a space before percentage signs


### Deployment risks (optional)

- Changes an api that is used in production
<img width="971" alt="Screenshot 2022-12-06 at 14 25 41" src="https://user-images.githubusercontent.com/12201130/205957631-9bf708c9-4aa8-4cd3-8d76-bd4c9af8a422.png">

<img width="1025" alt="Screenshot 2022-12-06 at 14 27 20" src="https://user-images.githubusercontent.com/12201130/205957593-f777f75b-6ebe-4e91-9dbd-9013a4f613bf.png">
