### PR TITLE
HOTT-2233: Import quota_closed_and_transferred_events

### DIFF
--- a/app/lib/cds_importer/entity_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper.rb
@@ -21,6 +21,9 @@ class CdsImporter
 
         instances.each do |model_instance|
           mapper.before_oplog_inserts_callbacks.each { |callback| callback.call(xml_node, mapper, model_instance) }
+
+          next if model_instance.skip_import?
+
           record_inserter = CdsImporter::RecordInserter.new(model_instance, mapper, @filename)
 
           if logger_enabled?

--- a/app/lib/cds_importer/entity_mapper/quota_balance_event_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/quota_balance_event_mapper.rb
@@ -1,7 +1,3 @@
-#
-# QuotaBalanceEvent is nested in to QuotaDefinition.
-#
-
 class CdsImporter
   class EntityMapper
     class QuotaBalanceEventMapper < BaseMapper

--- a/app/lib/cds_importer/entity_mapper/quota_closed_and_transferred_event_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/quota_closed_and_transferred_event_mapper.rb
@@ -1,0 +1,28 @@
+class CdsImporter
+  class EntityMapper
+    class QuotaClosedAndTransferredEventMapper < BaseMapper
+      self.entity_class = 'QuotaClosedAndTransferredEvent'.freeze
+
+      self.mapping_root = 'QuotaDefinition'.freeze
+
+      self.mapping_path = 'quotaClosedAndTransferredEvent'.freeze
+
+      self.exclude_mapping = ['metainfo.origin', 'validityStartDate', 'validityEndDate'].freeze
+
+      self.entity_mapping = base_mapping.merge(
+        'sid' => :quota_definition_sid,
+        "#{mapping_path}.occurrenceTimestamp" => :occurrence_timestamp,
+        "#{mapping_path}.closingDate" => :closing_date,
+        "#{mapping_path}.targetQuotaDefinition.sid" => :target_quota_definition_sid,
+        "#{mapping_path}.transferredAmount" => :transferred_amount,
+      ).freeze
+
+      before_oplog_inserts do |xml_node, _mapper, model_instance|
+        current_definition_start_date = xml_node['validityStartDate']
+        target_definition_start_date = xml_node.dig('quotaClosedAndTransferredEvent', 'targetQuotaDefinition', 'validityStartDate')
+
+        model_instance.skip_import! if current_definition_start_date >= target_definition_start_date
+      end
+    end
+  end
+end

--- a/app/lib/sequel/plugins/oplog.rb
+++ b/app/lib/sequel/plugins/oplog.rb
@@ -55,6 +55,18 @@ module Sequel
           self[:operation] = operation.present? ? operation[0].upcase : operation
         end
 
+        # Force the CdsImporter not to import the current oplog instance
+        def skip_import!
+          @skip_import = true
+        end
+
+        # Determines whether the CdsImporter will imports the current oplog instance
+        #
+        # Ignored by Taric
+        def skip_import?
+          @skip_import == true
+        end
+
         def operation
           case self[:operation]
           when CREATE_OPERATION then :create

--- a/app/models/quota_closed_and_transferred_event.rb
+++ b/app/models/quota_closed_and_transferred_event.rb
@@ -1,0 +1,15 @@
+class QuotaClosedAndTransferredEvent < Sequel::Model
+  plugin :oplog, primary_key: %i[quota_definition_sid
+                                 occurrence_timestamp]
+
+  set_primary_key %i[quota_definition_sid occurrence_timestamp]
+
+  many_to_one :quota_definition, key: :quota_definition_sid,
+                                 primary_key: :quota_definition_sid
+
+  def id
+    "#{quota_definition_sid}-#{occurrence_timestamp.iso8601}"
+  end
+
+  def self.status; end
+end

--- a/app/models/quota_definition.rb
+++ b/app/models/quota_definition.rb
@@ -64,6 +64,9 @@ class QuotaDefinition < Sequel::Model
   #       - exhausted
   #       - critical
   #       - open events
+  #
+  #       We've explicitly excluded the QuotaClosedAndTransferredEvent since this event isn't relevant
+  #       to the quota definition that we're transferring a balance from.
   def status
     if last_event.present?
       return QuotaCriticalEvent.status if has_active_critical_event?

--- a/lib/generators/data_migration_generator.rb
+++ b/lib/generators/data_migration_generator.rb
@@ -10,9 +10,8 @@ class DataMigrationGenerator < Rails::Generators::NamedBase
 
     create_file data_migration_file_name, <<~EODATAMIGRATION
       Sequel.migration do
-        # IMPORTANT! Data migrations should be Idempotent, they may get re-run as part
-        # of data rollbacks
-
+        # IMPORTANT! Data migrations up block should be idempotent (reruns of up should produce the same effect)
+        # they may get re-run as part of data rollbacks but the rollback (down) function of the data migration will not get invoked
         up do
 
         end

--- a/spec/integration/cds_importer/entity_mapper_spec.rb
+++ b/spec/integration/cds_importer/entity_mapper_spec.rb
@@ -426,6 +426,7 @@ RSpec.describe CdsImporter::EntityMapper do
         CdsImporter::EntityMapper::QuotaAssociationMapper,
         CdsImporter::EntityMapper::QuotaBalanceEventMapper,
         CdsImporter::EntityMapper::QuotaBlockingPeriodMapper,
+        CdsImporter::EntityMapper::QuotaClosedAndTransferredEventMapper,
         CdsImporter::EntityMapper::QuotaCriticalEventMapper,
         CdsImporter::EntityMapper::QuotaDefinitionMapper,
         CdsImporter::EntityMapper::QuotaExhaustionEventMapper,

--- a/spec/lib/cds_importer/entity_mapper/quota_closed_and_transferred_event_mapper_spec.rb
+++ b/spec/lib/cds_importer/entity_mapper/quota_closed_and_transferred_event_mapper_spec.rb
@@ -1,0 +1,72 @@
+RSpec.describe CdsImporter::EntityMapper::QuotaClosedAndTransferredEventMapper do
+  let(:xml_node) do
+    {
+      'sid' => 20_142,
+      'validityStartDate' => current_definition_validity_start_date,
+      'quotaClosedAndTransferredEvent' => {
+        'hjid' => 12_172_305,
+        'metainfo' => {
+          'opType' => 'C',
+          'origin' => 'T',
+          'status' => 'L',
+          'transactionDate' => '2022-10-28T18:02:02',
+        },
+        'closingDate' => '2022-10-28T00:00:00',
+        'occurrenceTimestamp' => '2022-10-28T13:03:00',
+        'targetQuotaDefinition' => {
+          'hjid' => 11_272_027,
+          'sid' => 21_143,
+          'validityStartDate' => target_definition_validity_start_date,
+          'quotaOrderNumber' => {
+            'hjid' => 10_645_458,
+            'sid' => 20_142,
+            'quotaOrderNumberId' => '58001',
+            'validityStartDate' => '2021-01-01T00:00:00',
+          },
+        },
+        'transferredAmount' => 86_055_072.137,
+      },
+    }
+  end
+  let(:current_definition_validity_start_date) { '2022-07-01T00:00:00' }
+  let(:target_definition_validity_start_date) { '2022-07-01T00:00:00' }
+
+  it_behaves_like 'an entity mapper', 'QuotaClosedAndTransferredEvent', 'QuotaDefinition' do
+    let(:expected_values) do
+      {
+        operation: 'C',
+        operation_date: Date.parse('2022-10-28'),
+        quota_definition_sid: 20_142,
+        occurrence_timestamp: Time.zone.parse('2022-10-28T13:03:00'),
+        target_quota_definition_sid: 21_143,
+        transferred_amount: 86_055_072.137,
+        closing_date: Date.parse('2022-10-28'),
+      }
+    end
+  end
+
+  describe '#import' do
+    subject(:entity_mapper) { CdsImporter::EntityMapper.new('QuotaDefinition', xml_node) }
+
+    context 'when the target quota definition is a newer quota definition' do
+      let(:current_definition_validity_start_date) { '2022-07-01T00:00:00' }
+      let(:target_definition_validity_start_date) { '2022-08-01T00:00:00' }
+
+      it { expect { entity_mapper.import }.to change(QuotaClosedAndTransferredEvent, :count) }
+    end
+
+    context 'when the target quota definition has the same start date' do
+      let(:current_definition_validity_start_date) { '2022-07-01T00:00:00' }
+      let(:target_definition_validity_start_date) { '2022-07-01T00:00:00' }
+
+      it { expect { entity_mapper.import }.not_to change(QuotaClosedAndTransferredEvent, :count) }
+    end
+
+    context 'when the target quota definition is an older quota definition ' do
+      let(:current_definition_validity_start_date) { '2022-07-01T00:00:00' }
+      let(:target_definition_validity_start_date) { '2022-06-01T00:00:00' }
+
+      it { expect { entity_mapper.import }.not_to change(QuotaClosedAndTransferredEvent, :count) }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2233

### What?

I have added/removed/altered:

- [x] Added handling to enable importing of the new quota events
- [x] Added test coverage

### Why?

I am doing this because:

- This is required to make sure that transfer events are getting imported
