### PR TITLE
HOTT-2241 Fixed removing stories belonging to a collection

### DIFF
--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -42,6 +42,10 @@ module News
       to_remove.each(&method(:remove_collection))
     end
 
+    def before_destroy
+      collections.pluck(:id).each(&method(:remove_collection))
+    end
+
     def validate
       super
 

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -7,6 +7,7 @@ module News
     MAX_SLUG_LENGTH = 254
 
     many_to_many :collections, join_table: :news_collections_news_items
+    plugin :association_dependencies, collections: :nullify
 
     many_to_many :published_collections, join_table: :news_collections_news_items,
                                          conditions: { published: true },
@@ -40,10 +41,6 @@ module News
 
       to_remove = collections.pluck(:id) - collection_ids
       to_remove.each(&method(:remove_collection))
-    end
-
-    def before_destroy
-      collections.pluck(:id).each(&method(:remove_collection))
     end
 
     def validate

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -72,6 +72,16 @@ RSpec.describe News::Item do
 
         it { is_expected.to eq high_then_low_priority_collection_ids }
       end
+
+      describe 'removing item which belongs to collection' do
+        subject { described_class.all.pluck(:id) }
+
+        before { news_item.destroy }
+
+        let(:news_item) { create :news_item, :with_collections }
+
+        it { is_expected.not_to include news_item.id }
+      end
     end
 
     describe '#collection_ids' do


### PR DESCRIPTION
### Jira link

HOTT-2241

### What?

I have added/removed/altered:

- [x] Fixed removing news stories which belong to 1 or more collections

### Why?

I am doing this because:

- All stories belong to collections, so no stories could be removed

### Deployment risks (optional)

- Low, bugfix
