### PR TITLE
HOTT-2337: Added validity start and end dates to included chapters in…

### DIFF
--- a/app/serializers/api/v2/commodities/chapter_serializer.rb
+++ b/app/serializers/api/v2/commodities/chapter_serializer.rb
@@ -8,7 +8,8 @@ module Api
 
         set_id :goods_nomenclature_sid
 
-        attributes :goods_nomenclature_item_id, :description, :formatted_description
+        attributes :goods_nomenclature_item_id, :description, :formatted_description,
+                   :validity_start_date, :validity_end_date
 
         attribute :chapter_note, if: Proc.new { |chapter| chapter.chapter_note.present? } do |chapter|
           chapter.chapter_note.content


### PR DESCRIPTION
… commodities API

### Jira link

[HOTT-<2337>](https://transformuk.atlassian.net/browse/HOTT-2337)

### What?

I have added/removed/altered:

- [ ] Added validity start and end dates to included chapters in commodities API

### Why?

I am doing this because:

- We want to expose these attributes on the commodities API

### Have you? (optional)

- [ ] Added documentation for new apis

### Deployment risks (optional)

- Changes an api that is used in production
