### PR TITLE
HOTT-2297: Adds missing measurement unit

### DIFF
--- a/app/serializers/api/v2/quota_order_numbers/quota_definition_serializer.rb
+++ b/app/serializers/api/v2/quota_order_numbers/quota_definition_serializer.rb
@@ -17,6 +17,8 @@ module Api
                    :maximum_precision,
                    :critical_threshold
 
+        attribute :measurement_unit, &:formatted_measurement_unit
+
         has_many :measures, serializer: Api::V2::QuotaOrderNumbers::MeasureSerializer, lazy_load: true
       end
     end

--- a/spec/serializers/api/v2/quota_order_numbers/quota_definition_serializer_spec.rb
+++ b/spec/serializers/api/v2/quota_order_numbers/quota_definition_serializer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Api::V2::QuotaOrderNumbers::QuotaDefinitionSerializer do
             maximum_precision: nil,
             measurement_unit_code: serializable.measurement_unit_code,
             measurement_unit_qualifier_code: serializable.measurement_unit_qualifier_code,
+            measurement_unit: serializable.formatted_measurement_unit,
             quota_order_number_id: serializable.quota_order_number_id,
             validity_end_date: nil,
             validity_start_date: 4.years.ago.beginning_of_day,


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2297

### What?

I have added/removed/altered:

- [x] Added missing measurement unit to the quota definition serializer

### Why?

I am doing this because:

- This is required for serializing definitions in the frontend
