### PR TITLE
HOTT-2310: Used regex to change text on UK version

### DIFF
--- a/app/formatters/description_formatter.rb
+++ b/app/formatters/description_formatter.rb
@@ -20,7 +20,12 @@ class DescriptionFormatter
     str.gsub!('!<=!', '&le;')
     str.gsub!(/\n\s*\n/, '<br/>')
     str.gsub!("\n", '<br/>')
-    str.gsub!(/(\d),(\d)/, '\1.\2') if TradeTariffBackend.uk?
+    if TradeTariffBackend.uk?
+      str.gsub!(/izing/i, 'ising')
+      str.gsub!(/ization/i, 'isation')
+      str.gsub!(/ized/i, 'ised')
+      str.gsub!(/(\d),(\d)/, '\1.\2')
+    end
     str.gsub! /@(.)/ do
       "<sub>#{$1}</sub>"
     end

--- a/spec/formatters/description_formatter_spec.rb
+++ b/spec/formatters/description_formatter_spec.rb
@@ -124,6 +124,24 @@ RSpec.describe DescriptionFormatter do
       ).to eq ' 11.11% '
     end
 
+    it 'replaces izing with ising' do
+      expect(
+        described_class.format(description: ' vaporizing '),
+      ).to eq ' vaporising '
+    end
+
+    it 'replaces ization with isation' do
+      expect(
+        described_class.format(description: ' utilization '),
+      ).to eq ' utilisation '
+    end
+
+    it 'replaces ized  with ised' do
+      expect(
+        described_class.format(description: ' unpasteurized '),
+      ).to eq ' unpasteurised '
+    end
+
     context 'when xi' do
       before do
         allow(TradeTariffBackend).to receive(:uk?).and_return(false)
@@ -133,6 +151,24 @@ RSpec.describe DescriptionFormatter do
         expect(
           described_class.format(description: ' 11,11% '),
         ).to eq ' 11,11% '
+      end
+
+      it 'does not replace izing with ising' do
+        expect(
+          described_class.format(description: ' vaporizing '),
+        ).to eq ' vaporizing '
+      end
+
+      it 'does not replace ization with isation' do
+        expect(
+          described_class.format(description: ' utilization '),
+        ).to eq ' utilization '
+      end
+
+      it 'does not replace ized  with ised' do
+        expect(
+          described_class.format(description: ' unpasteurized '),
+        ).to eq ' unpasteurized '
       end
     end
   end


### PR DESCRIPTION
### Jira link

[HOTT-<2310>](https://transformuk.atlassian.net/browse/HOTT-2310)

### What?

I have added/removed/altered:

- [ ] Used regex to change text on UK version

### Why?

I am doing this because:

- XI and UK need to display different text

### Deployment risks (optional)

- Changes an api that is used in production

<img width="751" alt="Screenshot 2022-12-13 at 17 10 47" src="https://user-images.githubusercontent.com/12201130/207398961-cce638e7-5750-40a0-bf9d-616fc221dfa9.png">
