### PR TITLE
HOTT-2362: Added Validity start and end dates to included commodities…

### DIFF
--- a/app/serializers/api/v2/commodities/ancestors_serializer.rb
+++ b/app/serializers/api/v2/commodities/ancestors_serializer.rb
@@ -9,7 +9,8 @@ module Api
         set_id :goods_nomenclature_sid
 
         attributes :producline_suffix, :description, :number_indents, :goods_nomenclature_item_id,
-                   :formatted_description, :description_plain
+                   :formatted_description, :description_plain, :validity_start_date,
+                   :validity_end_date
       end
     end
   end

--- a/spec/serializers/api/v2/commodities/ancestors_serializer_spec.rb
+++ b/spec/serializers/api/v2/commodities/ancestors_serializer_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe Api::V2::Commodities::AncestorsSerializer do
+  subject(:serializable) { described_class.new(commodity).serializable_hash.as_json }
+
+  let(:commodity) { create(:commodity) }
+
+  let(:expected) do
+    {
+      data: {
+        id: commodity.goods_nomenclature_sid.to_s,
+        type: :commodity,
+        attributes: {
+          producline_suffix: commodity.producline_suffix,
+          description: commodity.description,
+          number_indents: commodity.number_indents,
+          goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+          formatted_description: commodity.formatted_description,
+          description_plain: commodity.description_plain,
+          validity_start_date: commodity.validity_start_date,
+          validity_end_date: commodity.validity_end_date,
+        },
+      },
+    }.as_json
+  end
+
+  describe '#serializable_hash' do
+    it 'matches the expected hash' do
+      expect(serializable).to include_json(expected)
+    end
+  end
+end


### PR DESCRIPTION
…/ancestors

### Jira link

[HOTT-<2362>](https://transformuk.atlassian.net/browse/HOTT-2362)

### What?

I have added/removed/altered:

- [ ] Added Validity start and end dates to included commodities/ancestors

### Why?

I am doing this because:

- We need to add these attributes to the API response

### Have you? (optional)

- [ ] Added documentation for new apis

### Deployment risks (optional)

- Changes an api that is used in production

<img width="917" alt="Screenshot 2022-12-14 at 11 05 21" src="https://user-images.githubusercontent.com/12201130/207579186-d25f394d-e19e-416a-9aa6-075a667d78df.png">

