### PR TITLE
HOTT-2329: Search reference handling improvements in beta search

### DIFF
--- a/app/models/search_reference.rb
+++ b/app/models/search_reference.rb
@@ -72,6 +72,21 @@ class SearchReference < Sequel::Model
     self.referenced = Commodity.by_code(commodity_id).declarable.take if commodity_id.present?
   end
 
+  def resource_path
+    path = case referenced_class
+           when 'Chapter'
+             '/chapters/:id'
+           when 'Heading'
+             '/headings/:id'
+           when 'Subheading'
+             '/subheadings/:id'
+           else
+             '/commodities/:id'
+           end
+
+    path.sub(':id', referenced.to_param)
+  end
+
   def validate
     super
 

--- a/spec/factories/commodity_factory.rb
+++ b/spec/factories/commodity_factory.rb
@@ -22,13 +22,16 @@ FactoryBot.define do
 
     trait :with_ancestors do
       with_description
+      transient {
+        include_search_references { false }
+      }
       path { Sequel.pg_array([1, 2], :integer) }
       description { 'Horses, other than lemmings' }
       goods_nomenclature_item_id { '0101210000' }
       goods_nomenclature_sid { 3 }
 
-      after(:create) do |commodity, _evaluator|
-        create(
+      after(:create) do |commodity, evaluator|
+        chapter = create(
           :chapter,
           :with_description,
           description: 'Live horses, asses, mules and hinnies',
@@ -36,6 +39,14 @@ FactoryBot.define do
           goods_nomenclature_item_id: "#{commodity.goods_nomenclature_item_id.first(2)}00000000",
           validity_start_date: '2020-10-21',
         )
+
+        if evaluator.include_search_references
+          create(
+            :search_reference,
+            referenced: chapter,
+            title: 'chapter search reference',
+          )
+        end
 
         heading = create(
           :heading,
@@ -45,6 +56,14 @@ FactoryBot.define do
           goods_nomenclature_item_id: "#{commodity.goods_nomenclature_item_id.first(4)}000000",
           validity_start_date: '2020-10-21',
         )
+
+        if evaluator.include_search_references
+          create(
+            :search_reference,
+            referenced: heading,
+            title: 'heading search reference',
+          )
+        end
 
         guide = create(:guide, :aircraft_parts)
         create(:guides_goods_nomenclature, guide:, goods_nomenclature: heading)

--- a/spec/factories/commodity_factory.rb
+++ b/spec/factories/commodity_factory.rb
@@ -22,9 +22,9 @@ FactoryBot.define do
 
     trait :with_ancestors do
       with_description
-      transient {
+      transient do
         include_search_references { false }
-      }
+      end
       path { Sequel.pg_array([1, 2], :integer) }
       description { 'Horses, other than lemmings' }
       goods_nomenclature_item_id { '0101210000' }

--- a/spec/factories/search_reference_factory.rb
+++ b/spec/factories/search_reference_factory.rb
@@ -3,14 +3,38 @@ FactoryBot.define do
 
   factory :search_reference do
     title { Forgery(:basic).text }
-    referenced { create :heading }
+    referenced { create(:heading) }
+
+    trait :with_chapter do
+      referenced { create(:chapter, goods_nomenclature_item_id: '0100000000') }
+    end
+
+    trait :with_heading do
+      referenced { create(:heading, goods_nomenclature_item_id: '0101000000') }
+    end
+
+    trait :with_subheading do
+      referenced do
+        create(
+          :commodity,
+          producline_suffix: '10',
+          goods_nomenclature_item_id: '0101210000',
+        )
+
+        Subheading.find(goods_nomenclature_item_id: '0101210000')
+      end
+    end
+
+    trait :with_commodity do
+      referenced { create(:commodity, goods_nomenclature_item_id: '0101291000') }
+    end
 
     trait :with_current_commodity do
-      referenced { create :commodity, validity_end_date: Time.zone.tomorrow }
+      referenced { create(:commodity, validity_end_date: Time.zone.tomorrow) }
     end
 
     trait :with_non_current_commodity do
-      referenced { create :commodity, validity_end_date: Time.zone.yesterday }
+      referenced { create(:commodity, validity_end_date: Time.zone.yesterday) }
     end
   end
 end

--- a/spec/factories/search_result_factory.rb
+++ b/spec/factories/search_result_factory.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     no_redirect
 
     goods_nomenclature_query {}
+    search_reference {}
 
     trait :no_hits do
       transient do
@@ -100,8 +101,23 @@ FactoryBot.define do
     end
 
     trait :redirect do
-      goods_nomenclature_query { build(:goods_nomenclature_query, :numeric, original_search_query: goods_nomenclature_item_id || '0101') }
       transient { redirect { true } }
+    end
+
+    trait :with_search_reference do
+      goods_nomenclature_query {}
+      search_reference { create(:search_reference, :with_subheading) }
+    end
+
+    trait :without_search_reference do
+      goods_nomenclature_query do
+        build(
+          :goods_nomenclature_query,
+          :numeric,
+          original_search_query: goods_nomenclature_item_id || '0101',
+        )
+      end
+      search_reference {}
     end
 
     trait :no_redirect do
@@ -129,6 +145,7 @@ FactoryBot.define do
         presented_search_result,
         search_query_parser_result,
         goods_nomenclature_query || build(:goods_nomenclature_query),
+        search_reference,
       )
 
       search_result.generate_heading_and_chapter_statistics if generate_heading_and_chapter_statistics

--- a/spec/models/beta/search/open_search_result/no_hits_spec.rb
+++ b/spec/models/beta/search/open_search_result/no_hits_spec.rb
@@ -1,9 +1,10 @@
 RSpec.describe Beta::Search::OpenSearchResult::NoHits do
   describe '.build' do
-    subject(:result) { described_class.build(nil, search_query_parser_result, goods_nomenclature_query) }
+    subject(:result) { described_class.build(nil, search_query_parser_result, goods_nomenclature_query, search_reference) }
 
     let(:search_query_parser_result) { build(:search_query_parser_result, :multiple_hits) }
     let(:goods_nomenclature_query) { build(:goods_nomenclature_query, :full_query) }
+    let(:search_reference) { build(:search_reference) }
 
     it { is_expected.to be_a(Beta::Search::OpenSearchResult) }
     it { expect(result.took).to eq(0) }
@@ -14,5 +15,6 @@ RSpec.describe Beta::Search::OpenSearchResult::NoHits do
     it { expect(result.goods_nomenclature_query).to eq(goods_nomenclature_query) }
     it { expect(result.id).to eq('7c8d5ef8ab9c93729b100e871ed69f33') }
     it { expect(result.empty_query).to be(true) }
+    it { expect(result.search_reference).to eq(search_reference) }
   end
 end

--- a/spec/models/beta/search/open_search_result/with_hits_spec.rb
+++ b/spec/models/beta/search/open_search_result/with_hits_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Beta::Search::OpenSearchResult::WithHits do
   describe '.build' do
-    subject(:result) { described_class.build(search_result, search_query_parser_result, goods_nomenclature_query) }
+    subject(:result) { described_class.build(search_result, search_query_parser_result, goods_nomenclature_query, search_reference) }
 
     let(:search_result) do
       fixture = file_fixture('beta/search/goods_nomenclatures/multiple_hits.json')
@@ -10,6 +10,7 @@ RSpec.describe Beta::Search::OpenSearchResult::WithHits do
 
     let(:search_query_parser_result) { build(:search_query_parser_result, :multiple_hits) }
     let(:goods_nomenclature_query) { build(:goods_nomenclature_query, :full_query) }
+    let(:search_reference) { 'foo' }
 
     it { is_expected.to be_a(Beta::Search::OpenSearchResult) }
     it { expect(result).to respond_to(:took) }
@@ -20,5 +21,6 @@ RSpec.describe Beta::Search::OpenSearchResult::WithHits do
     it { expect(result.goods_nomenclature_query).to eq(goods_nomenclature_query) }
     it { expect(result.id).to eq('773f19eb133e44c7b88f87902b3e557a') }
     it { expect(result.empty_query).to be(false) }
+    it { expect(result.search_reference).to eq(search_reference) }
   end
 end

--- a/spec/models/beta/search/open_search_result_spec.rb
+++ b/spec/models/beta/search/open_search_result_spec.rb
@@ -255,21 +255,36 @@ RSpec.describe Beta::Search::OpenSearchResult do
   end
 
   describe '#redirect_to' do
-    shared_examples 'a redirecting search query' do |goods_nomenclature_item_id, expected_path|
-      subject(:redirect_to) { build(:search_result, :redirect, goods_nomenclature_item_id:).redirect_to }
+    context 'when the redirect happens because the query is for a goods nomenclature item id' do
+      shared_examples 'a redirecting search query' do |goods_nomenclature_item_id, expected_path|
+        subject(:redirect_to) do
+          build(
+            :search_result,
+            :redirect,
+            :without_search_reference,
+            goods_nomenclature_item_id:,
+          ).redirect_to
+        end
 
-      it { is_expected.to include(expected_path) }
+        it { is_expected.to include(expected_path) }
+      end
+
+      it_behaves_like 'a redirecting search query', '1', '/chapters/01'
+      it_behaves_like 'a redirecting search query', '01', '/chapters/01'
+      it_behaves_like 'a redirecting search query', '0101', '/headings/0101'
+      it_behaves_like 'a redirecting search query', '010129', '/subheadings/0101290000-80'
+      it_behaves_like 'a redirecting search query', '01012960', '/subheadings/0101296000-80'
+      it_behaves_like 'a redirecting search query', '0101210000-10', '/subheadings/0101210000-10'
+      it_behaves_like 'a redirecting search query', '0101210000', '/commodities/0101210000'
+      it_behaves_like 'a redirecting search query', '0101210000380', '/headings/0101'
+      it_behaves_like 'a redirecting search query', '010121000038123', '/headings/0101'
     end
 
-    it_behaves_like 'a redirecting search query', '1', '/chapters/01'
-    it_behaves_like 'a redirecting search query', '01', '/chapters/01'
-    it_behaves_like 'a redirecting search query', '0101', '/headings/0101'
-    it_behaves_like 'a redirecting search query', '010129', '/subheadings/0101290000-80'
-    it_behaves_like 'a redirecting search query', '01012960', '/subheadings/0101296000-80'
-    it_behaves_like 'a redirecting search query', '0101210000-10', '/subheadings/0101210000-10'
-    it_behaves_like 'a redirecting search query', '0101210000', '/commodities/0101210000'
-    it_behaves_like 'a redirecting search query', '0101210000380', '/headings/0101'
-    it_behaves_like 'a redirecting search query', '010121000038123', '/headings/0101'
+    context 'when the redirect happens because of a search reference' do
+      subject(:redirect_to) { build(:search_result, :redirect, :with_search_reference).redirect_to }
+
+      it { is_expected.to eq('http://localhost:3001/subheadings/0101210000-10') }
+    end
   end
 
   describe '#facet_filter_statistics' do

--- a/spec/models/search_reference_spec.rb
+++ b/spec/models/search_reference_spec.rb
@@ -92,4 +92,32 @@ RSpec.describe SearchReference do
       end
     end
   end
+
+  describe '#resource_path' do
+    subject(:resource_path) { create(:search_reference, trait).resource_path }
+
+    context 'when referenced is a chapter' do
+      let(:trait) { :with_chapter }
+
+      it { is_expected.to eq('/chapters/01') }
+    end
+
+    context 'when referenced is a heading' do
+      let(:trait) { :with_heading }
+
+      it { is_expected.to eq('/headings/0101') }
+    end
+
+    context 'when referenced is a subheading' do
+      let(:trait) { :with_subheading }
+
+      it { is_expected.to eq('/subheadings/0101210000-10') }
+    end
+
+    context 'when referenced is a commodity' do
+      let(:trait) { :with_commodity }
+
+      it { is_expected.to eq('/commodities/0101291000') }
+    end
+  end
 end

--- a/spec/serializers/search/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/search/goods_nomenclature_serializer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Search::GoodsNomenclatureSerializer do
           description: 'Horses, other than lemmings',
           description_indexed: 'Horses',
           formatted_description: 'Horses, other than lemmings',
-          search_references: 'secret sauce',
+          search_references: 'chapter search reference heading search reference commodity search reference',
           ancestors: [
             {
               id: 1,
@@ -34,6 +34,7 @@ RSpec.describe Search::GoodsNomenclatureSerializer do
               formatted_description: 'Live horses, asses, mules and hinnies',
               ancestor_ids: [],
               ancestors: [],
+              search_references: 'chapter search reference',
             },
             {
               id: 2,
@@ -51,6 +52,7 @@ RSpec.describe Search::GoodsNomenclatureSerializer do
               formatted_description: 'Live animals',
               ancestor_ids: [],
               ancestors: [],
+              search_references: 'heading search reference',
             },
           ],
           validity_start_date: '2020-06-29T00:00:00Z',
@@ -84,12 +86,13 @@ RSpec.describe Search::GoodsNomenclatureSerializer do
         commodity = create(
           :commodity,
           :with_ancestors,
+          include_search_references: true,
           goods_nomenclature_item_id: '0101210000',
           producline_suffix: '80',
           validity_start_date: Date.parse('2020-06-29'),
         )
 
-        create(:search_reference, referenced: commodity, title: 'secret sauce')
+        create(:search_reference, referenced: commodity, title: 'commodity search reference')
       end
 
       it { is_expected.to eq(pattern) }

--- a/spec/services/api/beta/search_service_spec.rb
+++ b/spec/services/api/beta/search_service_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Api::Beta::SearchService do
 
       it { expect(Api::Beta::SearchQueryParserService).to have_received(:new).with('ricotta', spell: '1', goods_nomenclature_item_id_match: false) }
       it { expect(TradeTariffBackend.v2_search_client).to have_received(:search).with(expected_search_args) }
-      it { expect(Beta::Search::OpenSearchResult::WithHits).to have_received(:build).with(search_result, search_query_parser_result, goods_nomenclature_query) }
+      it { expect(Beta::Search::OpenSearchResult::WithHits).to have_received(:build).with(search_result, search_query_parser_result, goods_nomenclature_query, nil) }
       it { expect(Beta::Search::GoodsNomenclatureQuery).to have_received(:build).with(search_query_parser_result, {}) }
       it { expect(call).to be_a(Beta::Search::OpenSearchResult) }
     end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2329
https://transformuk.atlassian.net/browse/HOTT-2358
https://transformuk.atlassian.net/browse/HOTT-2364

### What?

I have added/removed/altered:

- [x] Support redirecting beta search users when the search term matches an exact search reference title
- [x] Support searching through search reference tokens

### Why?

I am doing this because:

- This is required to advance the beta search to support legacy features around search references
- This is required make sure we can promote search reference tokens for partial search reference matches in the with hit search results
