### PR TITLE
HOTT-1380 Allow time for old app to drain during deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ commands:
               cf delete -f "tariff-<< parameters.service >>-backend-<< parameters.environment_key >>-dark"
               exit 1
             fi
+
       - run:
           name: "Switch dark app to live"
           command: |
@@ -91,8 +92,18 @@ commands:
             cf unmap-route "tariff-<< parameters.service >>-backend-<< parameters.environment_key >>" apps.internal -n "tariff-<< parameters.service >>-backend-<< parameters.environment_key >>"
             cf unmap-route "tariff-<< parameters.service >>-backend-<< parameters.environment_key >>" "<< parameters.domain_prefix >>.trade-tariff.service.gov.uk" --path "/<< parameters.service >>/api/beta/"
 
+      - run:
+          name: Drain old app
+          command: sleep 30
+
+      - run:
+          name: Stop and remove old app
+          command: |
             # stop previous version
             cf stop "tariff-<< parameters.service >>-backend-<< parameters.environment_key >>"
+
+            # allow the old app to shutdown prior to deletion of the app
+            sleep 10
 
             # delete previous version
             cf delete "tariff-<< parameters.service >>-backend-<< parameters.environment_key >>" -f


### PR DESCRIPTION
### Jira link

HOTT-1380

### What?

I have added/removed/altered:

- [x] Separated switch to new app from removal of old app in deployment scripts
- [x] Added 10 sec delay between stopping app and deleting it
- [x] Added 30 sec delay between switching to live app and removing old app 

### Why?

I am doing this because:

- It will help with debugging, conceptually they are separate steps anyway
- The 10 sec delay gives chance for the app to shutdown properly before its deleted
- The 30 sec delay between switching apps and removing old apps should give chance for any requests already in progress on the old app time to complete

### Deployment risks (optional)

- Changes deploy pipeline, slows down deploy pipeline by 60 seconds
