### PR TITLE
Set TimeMachine to today in console

### DIFF
--- a/config/initializers/console_time_machine.rb
+++ b/config/initializers/console_time_machine.rb
@@ -1,0 +1,11 @@
+module ConsoleTimeMachine
+  def start(...)
+    # rubocop:disable Rails/Output
+    puts 'Setting TimeMachine to Today'
+    # rubocop:enable Rails/Output
+
+    TimeMachine.now { super }
+  end
+end
+
+Rails::Console.prepend(ConsoleTimeMachine) if defined?(Rails::Console)


### PR DESCRIPTION
### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [x] Changed rails console to set TimeMachine to today

### Why?

I am doing this because:

- It is far far more likely you'll want it set to today rather then unset
- I often forget to set it in debugging sessions and just causes confusion
- New developers wont know to set the thread variable and will be equally confused

### Deployment risks (optional)

- Patches rails code
