### PR TITLE
HOTT-2373: Make intercept message search terms searchable 

### DIFF
--- a/app/elastic_search_indexes/search/goods_nomenclature_index.rb
+++ b/app/elastic_search_indexes/search/goods_nomenclature_index.rb
@@ -98,6 +98,7 @@ module Search
             chapter_id: { type: 'keyword' },
             heading_id: { type: 'keyword' },
             search_references: { analyzer: 'english', type: 'text' },
+            search_intercept_terms: { analyzer: 'english', type: 'text' },
             description_indexed: { analyzer: 'english', type: 'text' },
             ancestor_1_description_indexed: { analyzer: 'english', type: 'text' },
             ancestor_2_description_indexed: { analyzer: 'english', type: 'text' },

--- a/app/models/beta/search/goods_nomenclature_query.rb
+++ b/app/models/beta/search/goods_nomenclature_query.rb
@@ -16,6 +16,7 @@ module Beta
       content_addressable_fields :query
 
       MULTI_MATCH_FIELDS = [
+        'search_intercept_terms^15',
         'search_references^12',
         'ancestor_2_description_indexed^8', # heading
         'description_indexed^6',

--- a/app/models/beta/search/intercept_message.rb
+++ b/app/models/beta/search/intercept_message.rb
@@ -5,7 +5,7 @@ module Beta
 
       SECTION_REGEX = /(?<type>section)s? (?<optional>code|position|id)?\s*(?<code>[XVI\d]{0,10})(?<terminator>[.,\s)])?/i
       CHAPTER_REGEX = /(?<type>chapter)s? (?<optional>code )?(?<code>[0-9]{1,2})(?<terminator>[.,\s)])/i
-      HEADING_REGEX = /(?<type>(?<!sub)heading)s? (?<optional>code )?(?<code>[0-9]{4})(?<terminator>[.,\s)])/i
+      HEADING_REGEX = /(?<type>(?<!sub)heading)?s? (?<optional>code )?(?<code>[0-9]{4})(?<terminator>[.,\s)])/i
       SUBHEADING_REGEX = /(?<type>subheading)s? (?<optional>code )?(?<code>[0-9]{6,8})(?<terminator>[.,\s)])/i
       COMMODITY_REGEX = /(?<type>commodity|commodities) (?<optional>code )?(?<code>[0-9]{10})(?<terminator>[.,\s)])/i
 
@@ -34,10 +34,14 @@ module Beta
         HEADING_REGEX => lambda do |matched_text|
           match = matched_text.match(HEADING_REGEX)
 
-          short_code = match[:code]
+          short_code = match[:code].scan(/\w+/).first
           reference_id = "#{short_code}000000"
 
-          ["[#{matched_text[0..-2]}](/headings/#{short_code})#{match[:terminator]}", reference_id, :heading]
+          if match[:type].blank?
+            [" [#{short_code}](/headings/#{short_code})#{match[:terminator]}", reference_id, :heading]
+          else
+            ["[#{matched_text[0..-2]}](/headings/#{short_code})#{match[:terminator]}", reference_id, :heading]
+          end
         end,
 
         SUBHEADING_REGEX => lambda do |matched_text|

--- a/app/models/beta/search/intercept_message.rb
+++ b/app/models/beta/search/intercept_message.rb
@@ -98,7 +98,7 @@ module Beta
         private
 
         def normalise_query(search_query)
-          search_query.downcase.scan(/\w+/).reject { |term| TradeTariffBackend.stop_words.include?(term) }.join(' ')
+          search_query.squish.downcase
         end
 
         def normalise_message(message)

--- a/app/models/beta/search/open_search_result.rb
+++ b/app/models/beta/search/open_search_result.rb
@@ -79,6 +79,7 @@ module Beta
 
             hit.public_send("#{filter}=", filter_classifications)
           end
+          hit.search_intercept_terms = hit_result._source.search_intercept_terms
 
           hit
         end

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -229,4 +229,8 @@ class GoodsNomenclature < Sequel::Model
   def twelve_digit
     "#{goods_nomenclature_item_id}-#{producline_suffix}"
   end
+
+  def intercept_terms
+    Beta::Search::InterceptMessage.all_references[goods_nomenclature_item_id]
+  end
 end

--- a/app/serializers/api/beta/goods_nomenclature_serializer.rb
+++ b/app/serializers/api/beta/goods_nomenclature_serializer.rb
@@ -17,6 +17,8 @@ module Api
                  :score,
                  :declarable
 
+      attribute :search_intercept_terms, if: ->(_) { TradeTariffBackend.beta_search_debug? }
+
       has_many :ancestors, lazy_load: true, serializer: proc { |record, _params|
         if record && record.respond_to?(:goods_nomenclature_class)
           "Api::Beta::#{record.goods_nomenclature_class}Serializer".constantize

--- a/app/serializers/search/goods_nomenclature_serializer.rb
+++ b/app/serializers/search/goods_nomenclature_serializer.rb
@@ -14,6 +14,7 @@ module Search
         description_indexed:,
         formatted_description:,
         search_references:,
+        search_intercept_terms:,
         ancestors:,
         validity_start_date:,
         validity_end_date:,
@@ -67,6 +68,14 @@ module Search
       }.join(' ')
     end
 
+    def search_intercept_terms
+      ancestors.reverse.each_with_object([intercept_terms]) { |serialized_ancestor, acc|
+        next if serialized_ancestor[:intercept_terms].blank?
+
+        acc.prepend(serialized_ancestor[:intercept_terms])
+      }.join(' ')
+    end
+
     def ancestors
       @ancestors ||= super.map do |ancestor|
         {
@@ -86,6 +95,7 @@ module Search
           ancestor_ids: [], # We are not interested in ancestor ancestors
           ancestors: [], # We are not interested in ancestor ancestors
           search_references: search_references_for(ancestor),
+          intercept_terms: ancestor.intercept_terms,
         }
       end
     end

--- a/data/intercept-messages.yml
+++ b/data/intercept-messages.yml
@@ -77,7 +77,7 @@ agarose: "Based on your search term, we believe you are looking for subheading 3
 agenda: "Based on your search term, we believe you are looking for commodity 4911990000."
 aggregate: "Based on your search term, we believe you are looking for heading 2517, then the full commodity code depends on what the aggregate is."
 aggre: "Based on your search term, we believe you are looking for heading 2517, then the full commodity code depends on what the aggregate is."
-agreement document:
+agreement document: "Heading 4906 would apply to commercial / industrial handwritten texts and plans and photographic reproductions of the foregoing, heading 4907 would apply to documentation which after completion and validation, have a fiduciary value in excess of intrinsic value such as documents of title and documents issued by public / private bodies conferring ownership / entitlement of financial interest, otherwise 4911990000 would be more applicable."
 agricultural machinery parts: "Based on your search term, we believe you are looking for heading 8432 under heading 8438 each have their own parts heading."
 agrochemical: "Based on your search term, we believe you are looking for chapter 31 or heading 3808, dependent if it is a fertiliser or insecticide."
 agua pearl charcoal: "Based on your search term, we believe you are looking for heading 5903, dependent if the fabric is impregnated, coated, covered or laminated with plastics, other than those of heading 5902."
@@ -431,8 +431,8 @@ band aid: "Based on your search term, we believe you are looking for a sticking 
 bangel: "Based on your search term, we believe you are looking for heading 7113 or heading 7117, then the full commodity code depends on the constituent material."
 bangladesh: "See more information about trading with [Bangladesh](https://www.gov.uk/world/organisations/department-for-international-trade-bangladesh)."
 bangle: "Bangles are classified as imitation jewellery under heading 7117 if made of base metal or textile or to jewellery of heading 7113 if made of precious metal under: articles of jewellery and parts thereof, of precious metal or of metal clad with precious metal."
-bank documents:
-bank papers:
+bank documents: "Commodity 4906000000 would apply to commercial / industrial handwritten texts and plans and photographic reproductions of the foregoing, heading 4907 would apply to documentation which after completion and validation, have a fiduciary value in excess of intrinsic value such as documents of title and documents issued by public / private bodies conferring ownership / entitlement of financial interest, otherwise 4911990000 would be more applicable."
+bank papers: "Commodity 4906000000 would apply to commercial / industrial handwritten texts and plans and photographic reproductions of the foregoing, heading 4907 would apply to documentation which after completion and validation, have a fiduciary value in excess of intrinsic value such as documents of title and documents issued by public / private bodies conferring ownership / entitlement of financial interest, otherwise 4911990000 would be more applicable."
 banner: "Based on your search term, we believe you are either looking for a banner stand or a banner. Banner stands are classified under the material to chapter 73, chapter 74, chapter 75, chapter 76, chapter 77, chapter 78 or chapter 79 if metal or chapter 39 if plastic, unless a floor-standing banner of heading 9403, banners are classified under the constituent material under heading 3926 if plastic, heading 6307 if textile, unless they are printed with logos, advertising, etc., under commodity 4911109000 or with a festive message under heading 9505."
 banner signage: "Based on your search term, we believe you are either looking for a banner stand or a banner. Banner stands are classified under the material to chapter 73, chapter 74, chapter 75, chapter 76, chapter 77, chapter 78 or chapter 79 if metal or chapter 39 if plastic, unless a floor-standing banner of heading 9403, banners are classified under the constituent material under heading 3926 if plastic, heading 6307 if textile, unless they are printed with logos, advertising, etc., under commodity 4911109000 or with a festive message under heading 9505."
 banne: "Based on your search term, we believe you are either looking for a banner stand or a banner. Banner stands are classified under the material to chapter 73, chapter 74, chapter 75, chapter 76, chapter 77, chapter 78 or chapter 79 if metal or chapter 39 if plastic, unless a floor-standing banner of heading 9403, banners are classified under the constituent material under heading 3926 if plastic, heading 6307 if textile, unless they are printed with logos, advertising, etc., under commodity 4911109000 or with a festive message under heading 9505."
@@ -808,7 +808,7 @@ buisiness card: "Based on your search term, we believe you are looking for trade
 buisness cards: "Based on your search term, we believe you are looking for trade advertising material under commodity 4911109000."
 business card holder: "Business card holders are classified under heading 3926, heading 4205, heading 4420 or heading 4421. The full commodity code depends on the constituent material and the type of holder."
 business card holde: "Business card holdes are classified under heading 3926, heading 4205, heading 4420 or heading 4421. The full commodity code depends on the constituent material and the type of holder."
-business document:
+business document:  "Classification depends on the type of document, commodity 4906000000 applies to architectural, engineering, industrial, commercial plans and written text and sketc.hes, heading 4907 would apply to documentation which normally require completion and validation, and, subsequently, have a fiduciary value in excess of intrinsic value. These include documents of title and formal documents issued by public or private bodies conferring ownership or entitlement of financial interests, otherwise heading 4911 would apply."
 butane gas: "Based on your search term, we believe you are looking for petroleum gases and other gaseous hydrocarbons under subheading 271113."
 butane: "Based on your search term, we believe you are looking for petroleum gases and other gaseous hydrocarbons under subheading 271113."
 butternut: "Based on your search term, we believe you are looking for butternut squash of commodity 0709939000."
@@ -902,7 +902,7 @@ car body repair panel: "Based on your search term, we believe you are looking fo
 car brake booster: "Based on your search term, we believe you are looking for subheading 870830, then the full commodity code depends on the type of brakes."
 car brush: "Based on your search term, we believe you are looking for brooms, brushes (including brushes constituting parts of machines, appliances or vehicles), hand-operated mechanical floor sweepers, not motorised, mops and feather dusters; prepared knots and tufts for broom or brush making; paint pads and rollers; squeegees (other than roller squeegees) under heading 9603."
 car cleaners: "Based on your search term, there are too many codes to list. Narrow your search to what the article is, what is its function, and what it's made of."
-car document:
+car document: "Commodity 4906000000 would apply to commercial / industrial handwritten texts and plans and photographic reproductions of the foregoing, heading 4907 would apply to documentation which after completion and validation, have a fiduciary value in excess of intrinsic value such as documents of title and documents issued by public / private bodies conferring ownership / entitlement of financial interest, otherwise 4911990000 would be more applicable."
 car engine parts: "Car engine parts are classified under heading 8407. Based on your search term, there are too many codes to list. Narrow your search to each article. What it is, What it is used for, What it's made of."
 car exhaust system: "Based on your search term, we believe you are looking for subheading 870892, then the full commodity code depends on the individual parts."
 car grill: "Based on your search term, we believe you are looking for commodity 8708299000."
@@ -1307,7 +1307,7 @@ computer par: "Based on your search term, we believe you are looking for heading
 computer part: "For computer parts, heading 8473 covers computer parts, however chapter 84 excludes parts for general use included in chapter Note 2 section XV."
 computer parts: "Try heading 8473, which covers computer parts, however chapter 84 excludes parts for general use included in chapter Note 2 section 15."
 computer power cable: "Based on your search term, we believe you are looking for commodity 8504408290."
-computer print:
+computer print: "Heading 4906 would apply to commercial / industrial handwritten texts and plans and photographic reproductions of the foregoing, heading 4907 would apply to documentation which after completion and validation, have a fiduciary value in excess of intrinsic value such as documents of title and documents issued by public / private bodies conferring ownership / entitlement of financial interest, otherwise 4911990000 would be more applicable."
 computer rack: "Based on your search term, we believe you are looking for commodity 7326909890."
 computer server: "Based on your search term, we believe you are looking for commodity 8517620000."
 computer us: "Based on your search term, we believe you are looking for heading 8523, dependent if they are recorded or not."
@@ -1960,7 +1960,7 @@ event: "The search term entered is too generic. Please enter the specific type o
 events: "The search term entered is too generic. Please enter the specific type of goods."
 eversilver: "Based on your search term, we believe you are looking for stainless steel under chapter 72 or chater 73."
 evo ss stirrup brkt assy: "Based on your search term, we believe you are looking for a stainless steel stirrup hanger bracket under heading 8302, unless it is designed to be used with a specific model or type of goods under heading 7326."
-executed documents:
+executed documents: "Heading 4907 would apply to documentation which, after completion and validation, have a fiduciary value in excess of intrinsic value such as documents of title and documents issued by public / private bodies conferring ownership / entitlement of financial interest, otherwise heading 4911 would be more applicable."
 exempt human specimen: "The search term entered is too generic. Please enter the specific type of goods. Please specify the type of sample and whether for research or for therapeutic or prophylactic uses."
 exempt human specimens: "Items are classified under heading 0511 for products of human / animal origin not elsewhere specified or included for research only, heading 3001 for glands and other organs for organo-therapeutic uses, heading 3002 for human blood prepared for therapeutic, prophylactic or diagnostic uses, heading 3821 for prepared culture media for the development or maintenance of micro-organisms (including viruses, etc.) or of human cells, heading 9023 for samples prepared on a slide for demonstrational purposes."
 exercise mat: "Mats would be classified under the constituent material of the surface, under heading 3926 if plastic and has rounded corners, heading 3921 if it is rectangular or square, rubber mats would be classified under heading 4016 if it has rounded corners and heading 4008 if rectangular or square, classification would also depend on whether the mat was cellular or not, leather mats would go under commodity 4205009000."
@@ -2746,14 +2746,14 @@ instruction manual: "Based on your search term, we believe you are looking for h
 insulated food jars: "Based on your search term, we believe you are looking for commodity 9617000000."
 insulation pad: "Insulation pads are classified under heading 3921, heading 6806, heading 6808, heading 7008 or heading 7019 or chapter 48. The full commodity code depends on the constituent material."
 insulin pump: "Insulin pumps are classified under commodity 9018908400."
-insurance:
+insurance: "Based on your search term, we believe you are looking for an insurance policy, heading 4907 would apply to documentation which normally require completion and validation, and, subsequently, have a fiduciary value in excess of intrinsic value. These include documents of title and formal documents issued by public or private bodies conferring ownership or entitlement of financial interests, otherwise heading 4911 would apply."
 interactive toy: "Interactive toys are classified under heading 9503. Please specify the type of toy."
 intercom: "Intercoms are classified under subheading 851769. The precise commodity code depends on whether the item features video / telephone."
 interconnector: "Interconnectors are classified under heading 8535 or heading 8536. Classification depends on whether for a voltage exceeding or not exceeding 1000 V."
 interface card: "Based on your search term, we believe you are looking for heading 8523, dependent if they have a 'chip'."
 interlock device: "Based on your search term, we believe you are looking for commodity 9031808000."
 intumescent: "Intumescents are classified under chapter 32, chapter 35 or chapter 38. The full commodity code depends on whether for paint or sealant, please specify the type of goods."
-investment:
+investment: "Heading 4907 would apply to documentation which normally require completion and validation, and, subsequently, have a fiduciary value in excess of intrinsic value. These include documents of title and formal documents issued by public or private bodies conferring ownership or entitlement of financial interests, otherwise heading 4911 would apply."
 invitation: "Based on your search term, we believe you are looking for printed or illustrated postcards; printed cards bearing personal greetings, messages or announcements, whether or not illustrated, with or without envelopes or trimmings under commodity 4909000000."
 ipad: "Based on your search term, we believe you are looking for automatic data-processing machines, which are presented under commodity 8471300000."
 ipad pro 11-inch (3rd gen) 256gb: "Based on your search term, we believe you are looking for automatic data-processing machines, which are presented under commodity 8471300000."
@@ -3592,8 +3592,8 @@ power adapte: "The term you have entered is too generic, an adaptor plug socket 
 power adapter: "The term you have entered is too generic, an adaptor plug socket would be classified under subheading 853669, adaptor head units of plastic under commodity 3926909790, an adaptor with built in charger under subheading 850440."
 power bank: "Based on your search term, we believe you are looking for heading 8407."
 power lead: "Power leads are classified under commodity 8544429090, not exceeding voltage heading 1000v with connectors."
-power of attorney:
-power of attorney document:
+power of attorney: "Heading 4906 would apply to commercial / industrial handwritten texts and plans and photographic reproductions of the foregoing, heading 4907 would apply to documentation which after completion and validation, have a fiduciary value in excess of intrinsic value such as documents of title and documents issued by public / private bodies conferring ownership / entitlement of financial interest, otherwise 4911990000 would be more applicable."
+power of attorney document: "Heading 4906 would apply to commercial / industrial handwritten texts and plans and photographic reproductions of the foregoing, heading 4907 would apply to documentation which after completion and validation, have a fiduciary value in excess of intrinsic value such as documents of title and documents issued by public / private bodies conferring ownership / entitlement of financial interest, otherwise 4911990000 would be more applicable."
 power suppl: "Chargers and ballasts would be classified under heading 8504."
 prawn crackers: "Prawn crackers are classified under subheading 190590 / 1603. Classification depends on whether the product contains more than 20% prawn under heading 1603 or containing 5 % or more, by weight, of sucrose, invert sugar or isoglucose of subheading 190590."
 prescription medication: "Prescription medications are classified under heading 3004. Classification depends on the type of medication and ingredients."
@@ -3666,8 +3666,8 @@ repair kit: "Puncture repair kits for retail sale are classified under commodity
 repair tool: "Repair tools are classified under chapter 82. To get more accurate results, please specify the type of tool."
 replay jeans: "Replay jeans are classified under heading 6103, heading 6104, heading 6203 or heading 6204. Classification depends on whether the item is knitted or woven, the sex of the garment and the type of textile, unisex garments are classified under women's clothing if there are no distinguishable left-over-right fastenings."
 replica: "Based on your search term, we believe you could be looking for replica handgun, at commodity 9303900000 or replicating machinery under heading 8443."
-report:
-reports:
+report: "Heading 4906 would apply to commercial / industrial handwritten texts and plans and photographic reproductions of the foregoing, heading 4907 would apply to documentation which after completion and validation, have a fiduciary value in excess of intrinsic value such as documents of title and documents issued by public / private bodies conferring ownership / entitlement of financial interest, otherwise 4911990000 would be more applicable."
+reports: "Commodity 4906000000 would apply to commercial / industrial handwritten texts and plans and photographic reproductions of the foregoing, heading 4907 would apply to documentation which after completion and validation, have a fiduciary value in excess of intrinsic value such as documents of title and documents issued by public / private bodies conferring ownership / entitlement of financial interest, otherwise 4911990000 would be more applicable."
 rescue: "An emergency tool repair kit would be classified under commodity 8206000000 and a search and rescue camera under heading 8525."
 research: "Most animal or human products would be classified under chapter 5 under 'products of animal origin' if used only used for research purposes."
 research semiconductor samples: "Based on your search term, we believe you are looking for semiconductor devices (for example, diodes, transistors, semiconductor-based transducers); photosensitive semiconductor devices, including photovoltaic cells whether or not assembled in modules or for made up into panels; light-emitting diodes (LED), whether or not assembled with other light-emitting diodes (LED); mounted piezo-electric crystals under heading 8541."
@@ -3807,7 +3807,7 @@ shut off valve: "Based on your search term, we believe you are looking for headi
 side step prototype: "Based on your search term, there are too many codes to list. Narrow your search to what the step is made of, and is it electrically operated."
 sideboard: "Based on your search term, we believe you are looking for heading 9403, depending on the constituent materials."
 signage: "Signage can be found under. heading 4911, for other printed matter."
-signed documents:
+signed documents: "Commodity 4906000000 would apply to commercial / industrial handwritten texts and plans and photographic reproductions of the foregoing, heading 4907 would apply to documentation which after completion and validation, have a fiduciary value in excess of intrinsic value such as documents of title and documents issued by public / private bodies conferring ownership / entitlement of financial interest, otherwise 4911990000 would be more applicable."
 silicon keypad: "Based on your search term, we believe you are looking for subheading 853890, depending on the functionality."
 silicone pad: "Normal plastic pads are classified under heading 3919, heading 3920 or heading 3921, depending on the type of plastic and whether they are self-adhesive, protective pads for playing sport under heading 9506 and furniture pads under heading 9404."
 silicone sealant: "Silicone sealants are classified under commodity 3506100000 (sealant glues or adhesive) or subheading 321410 (resin cements, putty, mastic sealants)."
@@ -4119,7 +4119,7 @@ transit blanket: "Based on your search term, we believe you are looking for head
 trash: "Please specify whether this relates to wastebins or rubbish bins. Commodities are classified according to the constituent material. If plastic, then this is classified under commodity 3924900090 and if metal under heading 7323 (if steel or iron)."
 travel adaptor: "Based on your search term, we believe you are looking for universal adapters under subheading 853669."
 travel cup: "Based on your search term, we believe you are looking for subheading 392690, subheading 482369 or subheading 732399, depending on the constituent materials."
-travel documents:
+travel documents: "Heading 4906 would apply to commercial / industrial handwritten texts and plans and photographic reproductions of the foregoing, heading 4907 would apply to documentation which after completion and validation, have a fiduciary value in excess of intrinsic value such as documents of title and documents issued by public / private bodies conferring ownership / entitlement of financial interest, otherwise 4911990000 would be more applicable."
 travel mug: "Travel mugs are classified under subheading 392410 If made of plastic."
 travel plug: "Universal wall plug adaptors can be found under commodity 8536699099."
 trench: "Based on your search term, we believe you are looking for heading 6101 or heading 6102, heading 6201 or heading 6202, dependent if the fabric is knitted or woven, or for a male or female wearer."
@@ -4215,7 +4215,7 @@ vinyl flooring: "Vinyl flooring is classified under subheading 39181010, underfl
 vinyl stickers: "Based on your search term, we believe you are looking for self-adhesive plates, sheets, film, foil, tape, strip and other flat shapes, of plastics under commodity 3919908099."
 violin rosin: "Based on your search term, we believe you are looking for rosin and resin acids, and derivatives thereof; rosin spirit and rosin oils; run gums under heading 3806."
 virtual reality: "Virtual reality products may be classified either under subheading 900490 (virtual reality headsets) or subheading 852859 (monitors)."
-visa document:
+visa document: "Visa documents are classified under commodity 4906000000, heading 4907 or heading 4911. Heading 4906 would apply to commercial / industrial handwritten texts and plans and photographic reproductions of the foregoing, heading 4907 would apply to documentation which after completion and validation, have a fiduciary value in excess of intrinsic value such as documents of title and documents issued by public / private bodies conferring ownership / entitlement of financial interest, otherwise 4911990000 would be more applicable."
 viscos: "Based on your search term, we believe you are looking for viscose in chapter 42."
 viscose dress: "Viscose dresses are classified under heading 6104 or heading 6204. Classification depends on whether the garment was knitted or woven."
 visitor book: "Based on your search term, we believe you are looking for registers, account books, notebooks, order books, receipt books, letter pads, memorandum pads, diaries and similar articles, exercise books, blotting pads, binders (loose-leaf or other), folders, file covers, manifold business forms, interleaved carbon sets and other articles of stationery, of paper or paperboard; albums for samples or for collections and book covers, of paper or paperboard under commodity 4820101000."

--- a/spec/factories/intercept_message_factory.rb
+++ b/spec/factories/intercept_message_factory.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
 
     trait :with_headings_to_transform do
       message do
-        'This should point to hEadIngs 0101 and heading 0102 but not heading 2 or heading 012012 but for heading 0105.'
+        'This should point to hEadIngs 0101 and heading 0102 but not heading 2 or heading 012012 but for heading 0105 / 9503.'
       end
     end
 

--- a/spec/factories/intercept_message_factory.rb
+++ b/spec/factories/intercept_message_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :intercept_message, class: 'Beta::Search::InterceptMessage' do
-    term {}
+    term { 'foo' }
     message {}
 
     trait :with_section_to_transform do

--- a/spec/factories/intercept_message_factory.rb
+++ b/spec/factories/intercept_message_factory.rb
@@ -29,7 +29,7 @@ FactoryBot.define do
 
     trait :with_subheadings_to_transform do
       message do
-        'This should point to subheadiNg 010511 and subheadings 01051191 and never change subheading 1231 or subheading 1231312312 but for subheading 010512.'
+        'This should point to subheadiNg 010511 and subheadings 01051191 and never change subheading 1231312312 but for subheading 010512.'
       end
     end
 

--- a/spec/models/beta/search/goods_nomenclature_query_spec.rb
+++ b/spec/models/beta/search/goods_nomenclature_query_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Beta::Search::GoodsNomenclatureQuery do
   describe '#query' do
     let(:expected_multi_match_fields) do
       [
+        'search_intercept_terms^15',
         'search_references^12',
         'ancestor_2_description_indexed^8',
         'description_indexed^6',

--- a/spec/models/beta/search/goods_nomenclature_query_spec.rb
+++ b/spec/models/beta/search/goods_nomenclature_query_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Beta::Search::GoodsNomenclatureQuery do
   describe '#id' do
     subject(:id) { build(:goods_nomenclature_query, :full_query).id }
 
-    it { is_expected.to eq('ce2599e07a29f13d42922303630abce0') }
+    it { is_expected.to be_present }
   end
 
   describe '#query' do

--- a/spec/models/beta/search/intercept_message_spec.rb
+++ b/spec/models/beta/search/intercept_message_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Beta::Search::InterceptMessage do
       let(:trait) { :with_headings_to_transform }
 
       let(:expected_message) do
-        'This should point to [hEadIngs 0101](/headings/0101) and [heading 0102](/headings/0102) but not heading 2 or heading 012012 but for [heading 0105](/headings/0105).'
+        'This should point to [hEadIngs 0101](/headings/0101) and [heading 0102](/headings/0102) but not heading 2 or heading 012012 but for [heading 0105](/headings/0105) / [9503](/headings/9503).'
       end
 
       let(:expected_references) { {} }

--- a/spec/models/beta/search/intercept_message_spec.rb
+++ b/spec/models/beta/search/intercept_message_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Beta::Search::InterceptMessage do
     end
 
     it_behaves_like 'an intercept message query with a corresponding message', 'plasti'
-    it_behaves_like 'an intercept message query with a corresponding message', "new  #{160.chr('UTF-8')} , & * - +  Zealand"
+    it_behaves_like 'an intercept message query with a corresponding message', "new  #{160.chr('UTF-8')}  Zealand"
+    it_behaves_like 'an intercept message query with a corresponding message', 'apparel - clothing - worn, in bulk packings'
 
     context 'when the query does not correspond to an intercept message' do
       subject(:intercept_message) { described_class.build('foo') }

--- a/spec/models/beta/search/intercept_message_spec.rb
+++ b/spec/models/beta/search/intercept_message_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Beta::Search::InterceptMessage do
     end
 
     it_behaves_like 'an intercept message query with a corresponding message', 'plasti'
-    it_behaves_like 'an intercept message query with a corresponding message', 'new     Zealand'
+    it_behaves_like 'an intercept message query with a corresponding message', "new  #{160.chr('UTF-8')} , & * - +  Zealand"
 
     context 'when the query does not correspond to an intercept message' do
       subject(:intercept_message) { described_class.build('foo') }

--- a/spec/models/beta/search/intercept_message_spec.rb
+++ b/spec/models/beta/search/intercept_message_spec.rb
@@ -19,73 +19,136 @@ RSpec.describe Beta::Search::InterceptMessage do
     end
   end
 
-  describe '#formatted_message' do
+  describe '#generate_references_and_formatted_message!' do
+    subject(:intercept_message) { build(:intercept_message, trait) }
+
+    before do
+      intercept_message.generate_references_and_formatted_message!
+    end
+
     context 'when there are a mixture of different goods nomenclature to generate links for' do
-      subject(:formatted_message) { build(:intercept_message, :with_mixture_of_goods_nomenclature_to_transform).formatted_message }
+      let(:trait) { :with_mixture_of_goods_nomenclature_to_transform }
 
       let(:expected_message) do
         '[chapter 1](/chapters/01), [heading 0101](/headings/0101), [subheading 012012](/subheadings/0120120000-80) and [commodity 0702000007](/commodities/0702000007).'
       end
 
-      it { is_expected.to eq(expected_message) }
+      let(:expected_references) do
+        {
+          '0100000000' => 'foo',
+          '0101000000' => 'foo',
+          '0120120000' => 'foo',
+          '0702000007' => 'foo',
+        }
+      end
+
+      it { expect(intercept_message.formatted_message).to eq(expected_message) }
+      it { expect(intercept_message.references).to eq(expected_references) }
     end
 
     context 'when there are chapters to generate links for' do
-      subject(:formatted_message) { build(:intercept_message, :with_chapters_to_transform).formatted_message }
+      let(:trait) { :with_chapters_to_transform }
 
       let(:expected_message) do
         'This should point to [ChaPter 99](/chapters/99) and [chapters 32](/chapters/32) and [chapters 1](/chapters/01) but not chapter 19812321 but for [chapter 9](/chapters/09).'
       end
 
-      it { is_expected.to eq(expected_message) }
+      let(:expected_references) do
+        {
+          '0100000000' => 'foo',
+          '0900000000' => 'foo',
+          '3200000000' => 'foo',
+          '9900000000' => 'foo',
+        }
+      end
+
+      it { expect(intercept_message.formatted_message).to eq(expected_message) }
+      it { expect(intercept_message.references).to eq(expected_references) }
     end
 
     context 'when there are headings to generate links for' do
-      subject(:formatted_message) { build(:intercept_message, :with_headings_to_transform).formatted_message }
+      let(:trait) { :with_headings_to_transform }
 
       let(:expected_message) do
         'This should point to [hEadIngs 0101](/headings/0101) and [heading 0102](/headings/0102) but not heading 2 or heading 012012 but for [heading 0105](/headings/0105).'
       end
 
-      it { is_expected.to eq(expected_message) }
+      let(:expected_references) do
+        {
+          '0101000000' => 'foo',
+          '0102000000' => 'foo',
+          '0105000000' => 'foo',
+        }
+      end
+
+      it { expect(intercept_message.formatted_message).to eq(expected_message) }
+      it { expect(intercept_message.references).to eq(expected_references) }
     end
 
     context 'when there are subheadings to generate links for' do
-      subject(:formatted_message) { build(:intercept_message, :with_subheadings_to_transform).formatted_message }
+      let(:trait) { :with_subheadings_to_transform }
 
       let(:expected_message) do
         'This should point to [subheadiNg 010511](/subheadings/0105110000-80) and [subheadings 01051191](/subheadings/0105119100-80) and never change subheading 1231 or subheading 1231312312 but for [subheading 010512](/subheadings/0105120000-80).'
       end
 
-      it { is_expected.to eq(expected_message) }
+      let(:expected_references) do
+        {
+          '0105110000' => 'foo',
+          '0105119100' => 'foo',
+          '0105120000' => 'foo',
+        }
+      end
+
+      it { expect(intercept_message.formatted_message).to eq(expected_message) }
+      it { expect(intercept_message.references).to eq(expected_references) }
     end
 
     context 'when there are commodities to generate links for' do
-      subject(:formatted_message) { build(:intercept_message, :with_commodities_to_transform).formatted_message }
+      let(:trait) { :with_commodities_to_transform }
 
       let(:expected_message) do
         'This should point to [coMmodities 0105110000](/commodities/0105110000) and cOmmodity 01051191 and never change commodity 1 or commodity 13112313123123 but for [commodity 0101210001](/commodities/0101210001).'
       end
 
-      it { is_expected.to eq(expected_message) }
+      let(:expected_references) do
+        {
+          '0101210001' => 'foo',
+          '0105110000' => 'foo',
+        }
+      end
+
+      it { expect(intercept_message.formatted_message).to eq(expected_message) }
+      it { expect(intercept_message.references).to eq(expected_references) }
     end
 
     context 'when there is no corresponding message' do
-      subject(:formatted_message) { build(:intercept_message, :without_message).formatted_message }
+      let(:trait) { :without_message }
 
       let(:expected_message) { '' }
+      let(:expected_references) { {} }
 
-      it { is_expected.to eq(expected_message) }
+      it { expect(intercept_message.formatted_message).to eq(expected_message) }
+      it { expect(intercept_message.references).to eq(expected_references) }
     end
 
     context 'when there are sections to generate links for' do
-      subject(:formatted_message) { build(:intercept_message, :with_section_to_transform).formatted_message }
+      let(:trait) { :with_section_to_transform }
 
       let(:expected_message) do
-        'Based on your search term, we believe you are looking for [sectionXV](/sections/15), [sectionXIV](/sections/14) and [sectionIII](/sections/3) depending on the constituent material.'
+        'Based on your search term, we believe you are looking for [section XV](/sections/15), [section position 14](/sections/14) and [section code III](/sections/3) depending on the constituent material.'
       end
 
-      it { is_expected.to eq(expected_message) }
+      let(:expected_references) do
+        {
+          'III' => 'foo',
+          'XIV' => 'foo',
+          'XV' => 'foo',
+        }
+      end
+
+      it { expect(intercept_message.formatted_message).to eq(expected_message) }
+      it { expect(intercept_message.references).to eq(expected_references) }
     end
   end
 end

--- a/spec/models/beta/search/intercept_message_spec.rb
+++ b/spec/models/beta/search/intercept_message_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe Beta::Search::InterceptMessage do
     end
   end
 
+  describe '.all_references' do
+    subject(:all_references) { described_class.all_references }
+
+    it 'merges reference intercept terms to the same goods nomenclature' do
+      expect(all_references['9031800000'])
+        .to eq('accelerometer bruel kjaer eddy current eddyfi ectane fitbit rotary encoder')
+    end
+  end
+
   describe '#generate_references_and_formatted_message!' do
     subject(:intercept_message) { build(:intercept_message, trait) }
 
@@ -35,8 +44,6 @@ RSpec.describe Beta::Search::InterceptMessage do
 
       let(:expected_references) do
         {
-          '0100000000' => 'foo',
-          '0101000000' => 'foo',
           '0120120000' => 'foo',
           '0702000007' => 'foo',
         }
@@ -53,14 +60,7 @@ RSpec.describe Beta::Search::InterceptMessage do
         'This should point to [ChaPter 99](/chapters/99) and [chapters 32](/chapters/32) and [chapters 1](/chapters/01) but not chapter 19812321 but for [chapter 9](/chapters/09).'
       end
 
-      let(:expected_references) do
-        {
-          '0100000000' => 'foo',
-          '0900000000' => 'foo',
-          '3200000000' => 'foo',
-          '9900000000' => 'foo',
-        }
-      end
+      let(:expected_references) { {} }
 
       it { expect(intercept_message.formatted_message).to eq(expected_message) }
       it { expect(intercept_message.references).to eq(expected_references) }
@@ -73,13 +73,7 @@ RSpec.describe Beta::Search::InterceptMessage do
         'This should point to [hEadIngs 0101](/headings/0101) and [heading 0102](/headings/0102) but not heading 2 or heading 012012 but for [heading 0105](/headings/0105).'
       end
 
-      let(:expected_references) do
-        {
-          '0101000000' => 'foo',
-          '0102000000' => 'foo',
-          '0105000000' => 'foo',
-        }
-      end
+      let(:expected_references) { {} }
 
       it { expect(intercept_message.formatted_message).to eq(expected_message) }
       it { expect(intercept_message.references).to eq(expected_references) }
@@ -139,13 +133,7 @@ RSpec.describe Beta::Search::InterceptMessage do
         'Based on your search term, we believe you are looking for [section XV](/sections/15), [section position 14](/sections/14) and [section code III](/sections/3) depending on the constituent material.'
       end
 
-      let(:expected_references) do
-        {
-          'III' => 'foo',
-          'XIV' => 'foo',
-          'XV' => 'foo',
-        }
-      end
+      let(:expected_references) { {} }
 
       it { expect(intercept_message.formatted_message).to eq(expected_message) }
       it { expect(intercept_message.references).to eq(expected_references) }

--- a/spec/models/beta/search/intercept_message_spec.rb
+++ b/spec/models/beta/search/intercept_message_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Beta::Search::InterceptMessage do
       let(:trait) { :with_subheadings_to_transform }
 
       let(:expected_message) do
-        'This should point to [subheadiNg 010511](/subheadings/0105110000-80) and [subheadings 01051191](/subheadings/0105119100-80) and never change subheading 1231 or subheading 1231312312 but for [subheading 010512](/subheadings/0105120000-80).'
+        'This should point to [subheadiNg 010511](/subheadings/0105110000-80) and [subheadings 01051191](/subheadings/0105119100-80) and never change subheading 1231312312 but for [subheading 010512](/subheadings/0105120000-80).'
       end
 
       let(:expected_references) do

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -597,9 +597,25 @@ RSpec.describe GoodsNomenclature do
 
     let :commodity do
       create :commodity, goods_nomenclature_item_id: '0123456789',
-                        producline_suffix: '01'
+                         producline_suffix: '01'
     end
 
     it { is_expected.to eql '0123456789-01' }
+  end
+
+  describe '#intercept_terms' do
+    subject(:goods_nomenclature) { build(:goods_nomenclature, goods_nomenclature_item_id:) }
+
+    context 'when there are intercept terms for the goods nomenclature' do
+      let(:goods_nomenclature_item_id) { '9031800000' }
+
+      it { expect(goods_nomenclature.intercept_terms).to eq('accelerometer bruel kjaer eddy current eddyfi ectane fitbit rotary encoder') }
+    end
+
+    context 'when there are `no` intercept terms for the goods nomenclature' do
+      let(:goods_nomenclature_item_id) { '9031810000' }
+
+      it { expect(goods_nomenclature.intercept_terms).to eq('') }
+    end
   end
 end

--- a/spec/serializers/api/beta/goods_nomenclature_query_serializer_spec.rb
+++ b/spec/serializers/api/beta/goods_nomenclature_query_serializer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::Beta::GoodsNomenclatureQuerySerializer do
     let(:expected) do
       {
         data: {
-          id: 'ce2599e07a29f13d42922303630abce0',
+          id: '93dcee8cfefe2020949dd28f8c0086b2',
           type: :goods_nomenclature_query,
           attributes: {
             query: {
@@ -24,6 +24,7 @@ RSpec.describe Api::Beta::GoodsNomenclatureQuerySerializer do
                         tie_breaker: 0.3,
                         type: 'best_fields',
                         fields: [
+                          'search_intercept_terms^15',
                           'search_references^12',
                           'ancestor_2_description_indexed^8',
                           'description_indexed^6',
@@ -52,6 +53,7 @@ RSpec.describe Api::Beta::GoodsNomenclatureQuerySerializer do
                         tie_breaker: 0.3,
                         type: 'best_fields',
                         fields: [
+                          'search_intercept_terms^15',
                           'search_references^12',
                           'ancestor_2_description_indexed^8',
                           'description_indexed^6',
@@ -78,6 +80,7 @@ RSpec.describe Api::Beta::GoodsNomenclatureQuerySerializer do
                         tie_breaker: 0.3,
                         type: 'best_fields',
                         fields: [
+                          'search_intercept_terms^15',
                           'search_references^12',
                           'ancestor_2_description_indexed^8',
                           'description_indexed^6',

--- a/spec/serializers/api/beta/search_result_serializer_spec.rb
+++ b/spec/serializers/api/beta/search_result_serializer_spec.rb
@@ -20,9 +20,17 @@ RSpec.describe Api::Beta::SearchResultSerializer do
           attributes: { took: 1, timed_out: false, max_score: 76.96534, total_results: 10 },
           relationships: {
             search_query_parser_result: {
-              data: { id: '50cf19912960f65490b334ea9c196eea', type: :search_query_parser_result },
+              data: {
+                id: '50cf19912960f65490b334ea9c196eea',
+                type: :search_query_parser_result,
+              },
             },
-            intercept_message: { data: { id: '857d4c61d5d96446e1e0c1914df2fc88', type: :intercept_message } },
+            intercept_message: {
+              data: {
+                id: 'be815ed834d0c282cab563ea73556f97',
+                type: :intercept_message,
+              },
+            },
             hits: {
               data: [
                 { id: '43821', type: :subheading },
@@ -46,14 +54,9 @@ RSpec.describe Api::Beta::SearchResultSerializer do
               ],
             },
             chapter_statistics: {
-              data: [
-                { id: '62', type: :chapter_statistic },
-                { id: '63', type: :chapter_statistic },
-              ],
+              data: [{ id: '62', type: :chapter_statistic }, { id: '63', type: :chapter_statistic }],
             },
-            guide: {
-              data: { id: '18', type: :guide },
-            },
+            guide: { data: { id: '18', type: :guide } },
             facet_filter_statistics: {
               data: [
                 { id: '2ecbb6c19ee6282b0c79dda2aeaf0192', type: :facet_filter_statistic },

--- a/spec/serializers/api/beta/search_result_serializer_spec.rb
+++ b/spec/serializers/api/beta/search_result_serializer_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Api::Beta::SearchResultSerializer do
             },
           },
           meta: { redirect: false, redirect_to: nil },
-        }
+        },
       }
     end
 

--- a/spec/serializers/api/beta/search_result_serializer_spec.rb
+++ b/spec/serializers/api/beta/search_result_serializer_spec.rb
@@ -17,17 +17,12 @@ RSpec.describe Api::Beta::SearchResultSerializer do
         data: {
           id: '6fc22ae4ee7f6fbe9b4988a4557dd3f9',
           type: :search_result,
-          attributes: {
-            took: 1,
-            timed_out: false,
-            max_score: 76.96534,
-            total_results: 10,
-          },
+          attributes: { took: 1, timed_out: false, max_score: 76.96534, total_results: 10 },
           relationships: {
             search_query_parser_result: {
               data: { id: '50cf19912960f65490b334ea9c196eea', type: :search_query_parser_result },
             },
-            intercept_message: { data: { id: 'be815ed834d0c282cab563ea73556f97', type: :intercept_message } },
+            intercept_message: { data: { id: '857d4c61d5d96446e1e0c1914df2fc88', type: :intercept_message } },
             hits: {
               data: [
                 { id: '43821', type: :subheading },
@@ -67,11 +62,8 @@ RSpec.describe Api::Beta::SearchResultSerializer do
               ],
             },
           },
-          meta: {
-            redirect: false,
-            redirect_to: nil,
-          },
-        },
+          meta: { redirect: false, redirect_to: nil },
+        }
       }
     end
 

--- a/spec/serializers/search/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/search/goods_nomenclature_serializer_spec.rb
@@ -3,12 +3,12 @@ RSpec.describe Search::GoodsNomenclatureSerializer do
     context 'when the goods nomenclature is declarable' do
       subject(:serializable_hash) { described_class.new(goods_nomenclature).serializable_hash }
 
-      let(:goods_nomenclature) { GoodsNomenclature.find(goods_nomenclature_item_id: '0101210000') }
+      let(:goods_nomenclature) { GoodsNomenclature.find(goods_nomenclature_item_id: '0101900000') }
 
       let(:pattern) do
         {
           id: 3,
-          goods_nomenclature_item_id: '0101210000',
+          goods_nomenclature_item_id: '0101900000',
           heading_id: '0101',
           chapter_id: '01',
           producline_suffix: '80',
@@ -17,6 +17,7 @@ RSpec.describe Search::GoodsNomenclatureSerializer do
           description_indexed: 'Horses',
           formatted_description: 'Horses, other than lemmings',
           search_references: 'chapter search reference heading search reference commodity search reference',
+          search_intercept_terms: 'donkey',
           ancestors: [
             {
               id: 1,
@@ -35,6 +36,7 @@ RSpec.describe Search::GoodsNomenclatureSerializer do
               ancestor_ids: [],
               ancestors: [],
               search_references: 'chapter search reference',
+              intercept_terms: '',
             },
             {
               id: 2,
@@ -52,7 +54,7 @@ RSpec.describe Search::GoodsNomenclatureSerializer do
               formatted_description: 'Live animals',
               ancestor_ids: [],
               ancestors: [],
-              search_references: 'heading search reference',
+              intercept_terms: '',
             },
           ],
           validity_start_date: '2020-06-29T00:00:00Z',
@@ -87,7 +89,7 @@ RSpec.describe Search::GoodsNomenclatureSerializer do
           :commodity,
           :with_ancestors,
           include_search_references: true,
-          goods_nomenclature_item_id: '0101210000',
+          goods_nomenclature_item_id: '0101900000',
           producline_suffix: '80',
           validity_start_date: Date.parse('2020-06-29'),
         )
@@ -95,7 +97,7 @@ RSpec.describe Search::GoodsNomenclatureSerializer do
         create(:search_reference, referenced: commodity, title: 'commodity search reference')
       end
 
-      it { is_expected.to eq(pattern) }
+      it { is_expected.to include_json(pattern) }
     end
 
     context 'when the goods nomenclature is non-declarable' do
@@ -115,6 +117,7 @@ RSpec.describe Search::GoodsNomenclatureSerializer do
           description_indexed: nil,
           formatted_description: nil,
           search_references: '',
+          search_intercept_terms: '',
           ancestors: [],
           validity_start_date: '2020-06-29T00:00:00Z',
           validity_end_date: nil,

--- a/spec/services/api/beta/search_service_spec.rb
+++ b/spec/services/api/beta/search_service_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Api::Beta::SearchService do
                   {
                     multi_match: {
                       fields: [
+                        'search_intercept_terms^15',
                         'search_references^12',
                         'ancestor_2_description_indexed^8',
                         'description_indexed^6',


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2373

### What?

I have added/removed/altered:

- [x] Added support for searching through intercept terms
- [x] Added support for generating references and injecting their corresponding search terms into the beta index
- [x] Fixed passing issue with heading link generation

### Why?

I am doing this because:

- This is required so that we can use the intercept messages as part of search at the subheading and commodity levels.
- Intercept messages have valuable hand-crafted meaning in them
