### PR TITLE
HOTT-2361 timeouts from search references reduce counts

### DIFF
--- a/app/controllers/api/admin/headings_controller.rb
+++ b/app/controllers/api/admin/headings_controller.rb
@@ -9,7 +9,7 @@ module Api
         options = { is_collection: false }
         options[:include] = %i[commodities chapter]
 
-        render json: Api::Admin::Headings::HeadingSerializer.new(@heading, options).serializable_hash
+        render json: Api::Admin::Headings::HeadingSerializer.new(presented_heading, options).serializable_hash
       end
 
       private
@@ -30,6 +30,14 @@ module Api
 
       def heading_id
         "#{params[:id]}000000"
+      end
+
+      def presented_heading
+        Api::Admin::Headings::HeadingPresenter.new(@heading, search_reference_counts)
+      end
+
+      def search_reference_counts
+        SearchReference.count_for(@heading.commodities + [@heading])
       end
     end
   end

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -225,4 +225,8 @@ class GoodsNomenclature < Sequel::Model
   def classifiable_goods_nomenclatures
     ancestors.dup.push(self).reverse
   end
+
+  def twelvedigit
+    "#{goods_nomenclature_item_id}-#{producline_suffix}"
+  end
 end

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -226,7 +226,7 @@ class GoodsNomenclature < Sequel::Model
     ancestors.dup.push(self).reverse
   end
 
-  def twelvedigit
+  def twelve_digit
     "#{goods_nomenclature_item_id}-#{producline_suffix}"
   end
 end

--- a/app/models/search_reference.rb
+++ b/app/models/search_reference.rb
@@ -62,25 +62,25 @@ class SearchReference < Sequel::Model
 
   class << self
     def count_for(goods_nomenclatures)
-      id_pairs = goods_nomenclatures.map(&:twelvedigit)
+      id_pairs = goods_nomenclatures.map(&:twelve_digit)
 
-      select_group(twelvedigit_column)
-        .select_more(twelvedigit_count_column)
-        .where(twelvedigit_function => id_pairs)
-        .as_hash(:twelvedigit, :twelvedigit_count)
+      select_group(twelve_digit_column)
+        .select_more(twelve_digit_count_column)
+        .where(twelve_digit_function => id_pairs)
+        .as_hash(:twelve_digit, :twelve_digit_count)
     end
 
   private
 
-    def twelvedigit_column
-      Sequel.as twelvedigit_function, :twelvedigit
+    def twelve_digit_column
+      Sequel.as twelve_digit_function, :twelve_digit
     end
 
-    def twelvedigit_count_column
-      Sequel.as Sequel.function(:count, :referenced_id), :twelvedigit_count
+    def twelve_digit_count_column
+      Sequel.as Sequel.function(:count, :referenced_id), :twelve_digit_count
     end
 
-    def twelvedigit_function
+    def twelve_digit_function
       Sequel.function :concat, padded_reference_id_function, '-', :productline_suffix
     end
 

--- a/app/presenters/api/admin/headings/commodity_presenter.rb
+++ b/app/presenters/api/admin/headings/commodity_presenter.rb
@@ -1,0 +1,25 @@
+module Api
+  module Admin
+    module Headings
+      class CommodityPresenter < SimpleDelegator
+        attr_reader :search_references_count
+
+        class << self
+          def wrap(commodities, counts = {})
+            commodities.map do |commodity|
+              count = counts.key?(commodity.twelvedigit) ? counts[commodity.twelvedigit] : 0
+
+              new(commodity, count)
+            end
+          end
+        end
+
+        def initialize(commodity, search_references_count)
+          @search_references_count = search_references_count
+
+          super(commodity)
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/api/admin/headings/commodity_presenter.rb
+++ b/app/presenters/api/admin/headings/commodity_presenter.rb
@@ -7,7 +7,11 @@ module Api
         class << self
           def wrap(commodities, counts = {})
             commodities.map do |commodity|
-              count = counts.key?(commodity.twelvedigit) ? counts[commodity.twelvedigit] : 0
+              count = if counts.key?(commodity.twelve_digit)
+                        counts[commodity.twelve_digit]
+                      else
+                        0
+                      end
 
               new(commodity, count)
             end

--- a/app/presenters/api/admin/headings/heading_presenter.rb
+++ b/app/presenters/api/admin/headings/heading_presenter.rb
@@ -1,0 +1,29 @@
+module Api
+  module Admin
+    module Headings
+      class HeadingPresenter < SimpleDelegator
+        class << self
+          def wrap(headings, search_reference_counts)
+            headings.map do |heading|
+              new(heading, search_reference_counts)
+            end
+          end
+        end
+
+        def initialize(heading, search_reference_counts)
+          @search_reference_counts = search_reference_counts
+
+          super(heading)
+        end
+
+        def commodities
+          @commodities ||= CommodityPresenter.wrap(super, @search_reference_counts)
+        end
+
+        def search_references_count
+          @search_reference_counts[twelvedigit]
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/api/admin/headings/heading_presenter.rb
+++ b/app/presenters/api/admin/headings/heading_presenter.rb
@@ -21,7 +21,7 @@ module Api
         end
 
         def search_references_count
-          @search_reference_counts[twelvedigit]
+          @search_reference_counts[twelve_digit]
         end
       end
     end

--- a/app/serializers/api/admin/headings/commodity_serializer.rb
+++ b/app/serializers/api/admin/headings/commodity_serializer.rb
@@ -8,13 +8,10 @@ module Api
 
         set_id :admin_id
 
-        attributes :description
+        attributes :description,
+                   :search_references_count
 
         attribute :declarable, &:declarable?
-
-        attribute :search_references_count do |commodity|
-          commodity.cast_according_to_declarable.search_references.count
-        end
       end
     end
   end

--- a/app/serializers/api/admin/headings/heading_serializer.rb
+++ b/app/serializers/api/admin/headings/heading_serializer.rb
@@ -8,11 +8,9 @@ module Api
 
         set_id :goods_nomenclature_sid
 
-        attributes :goods_nomenclature_item_id, :description
-
-        attribute :search_references_count do |heading|
-          heading.search_references.count
-        end
+        attributes :goods_nomenclature_item_id,
+                   :description,
+                   :search_references_count
 
         has_one :chapter, serializer: Api::Admin::Headings::ChapterSerializer, id_method_name: :goods_nomenclature_sid, &:chapter
 

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -592,8 +592,8 @@ RSpec.describe GoodsNomenclature do
     end
   end
 
-  describe '#twelvedigit' do
-    subject { commodity.twelvedigit }
+  describe '#twelve_digit' do
+    subject { commodity.twelve_digit }
 
     let :commodity do
       create :commodity, goods_nomenclature_item_id: '0123456789',

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -591,4 +591,15 @@ RSpec.describe GoodsNomenclature do
       it { is_expected.not_to be_empty }
     end
   end
+
+  describe '#twelvedigit' do
+    subject { commodity.twelvedigit }
+
+    let :commodity do
+      create :commodity, goods_nomenclature_item_id: '0123456789',
+                        producline_suffix: '01'
+    end
+
+    it { is_expected.to eql '0123456789-01' }
+  end
 end

--- a/spec/models/search_reference_spec.rb
+++ b/spec/models/search_reference_spec.rb
@@ -120,4 +120,21 @@ RSpec.describe SearchReference do
       it { is_expected.to eq('/commodities/0101291000') }
     end
   end
+
+  describe '.count_for' do
+    subject { described_class.count_for commodities.slice(0, 2) }
+
+    before { search_references }
+
+    let(:commodities) { create_list :commodity, 3 }
+
+    let :search_references do
+      commodities.map { |c| create :search_reference, referenced: c } +
+        create_list(:search_reference, 1, referenced: commodities.first)
+    end
+
+    it { is_expected.to include commodities.first.twelvedigit => 2 }
+    it { is_expected.to include commodities.second.twelvedigit => 1 }
+    it { is_expected.not_to include commodities.third.twelvedigit => 0 }
+  end
 end

--- a/spec/models/search_reference_spec.rb
+++ b/spec/models/search_reference_spec.rb
@@ -133,8 +133,8 @@ RSpec.describe SearchReference do
         create_list(:search_reference, 1, referenced: commodities.first)
     end
 
-    it { is_expected.to include commodities.first.twelvedigit => 2 }
-    it { is_expected.to include commodities.second.twelvedigit => 1 }
-    it { is_expected.not_to include commodities.third.twelvedigit => 0 }
+    it { is_expected.to include commodities.first.twelve_digit => 2 }
+    it { is_expected.to include commodities.second.twelve_digit => 1 }
+    it { is_expected.not_to include commodities.third.twelve_digit => 0 }
   end
 end

--- a/spec/presenters/api/admin/headings/commodity_presenter_spec.rb
+++ b/spec/presenters/api/admin/headings/commodity_presenter_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe Api::Admin::Headings::CommodityPresenter do
+  let(:commodity) { create :commodity }
+
+  describe '.wrap' do
+    subject { described_class.wrap([commodity], { commodity.twelvedigit => 3 }) }
+
+    it { is_expected.to have_attributes length: 1 }
+    it { is_expected.to all be_instance_of described_class }
+    it { is_expected.to all have_attributes values: commodity.values }
+    it { is_expected.to all have_attributes search_references_count: 3 }
+
+    context 'with nil count' do
+      subject { described_class.wrap([commodity], { commodity.twelvedigit => nil }) }
+
+      it { is_expected.to all have_attributes search_references_count: nil }
+    end
+
+    context 'without count' do
+      subject { described_class.wrap([commodity], {}) }
+
+      it { is_expected.to all have_attributes search_references_count: 0 }
+    end
+  end
+
+  describe '.new' do
+    subject { described_class.new(commodity, 3) }
+
+    it { is_expected.to be_instance_of described_class }
+    it { is_expected.to have_attributes values: commodity.values }
+    it { is_expected.to have_attributes search_references_count: 3 }
+  end
+end

--- a/spec/presenters/api/admin/headings/commodity_presenter_spec.rb
+++ b/spec/presenters/api/admin/headings/commodity_presenter_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Api::Admin::Headings::CommodityPresenter do
   let(:commodity) { create :commodity }
 
   describe '.wrap' do
-    subject { described_class.wrap([commodity], { commodity.twelvedigit => 3 }) }
+    subject { described_class.wrap([commodity], { commodity.twelve_digit => 3 }) }
 
     it { is_expected.to have_attributes length: 1 }
     it { is_expected.to all be_instance_of described_class }
@@ -10,7 +10,7 @@ RSpec.describe Api::Admin::Headings::CommodityPresenter do
     it { is_expected.to all have_attributes search_references_count: 3 }
 
     context 'with nil count' do
-      subject { described_class.wrap([commodity], { commodity.twelvedigit => nil }) }
+      subject { described_class.wrap([commodity], { commodity.twelve_digit => nil }) }
 
       it { is_expected.to all have_attributes search_references_count: nil }
     end

--- a/spec/presenters/api/admin/headings/heading_presenter_spec.rb
+++ b/spec/presenters/api/admin/headings/heading_presenter_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Api::Admin::Headings::HeadingPresenter do
 
   let(:counts) do
     {
-      heading.twelvedigit => 1,
-      commodity.twelvedigit => 3,
+      heading.twelve_digit => 1,
+      commodity.twelve_digit => 3,
     }
   end
 

--- a/spec/presenters/api/admin/headings/heading_presenter_spec.rb
+++ b/spec/presenters/api/admin/headings/heading_presenter_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe Api::Admin::Headings::HeadingPresenter do
+  let(:heading) { create(:heading, :with_chapter, :non_declarable).reload }
+  let(:commodity) { heading.commodities.first }
+
+  let(:counts) do
+    {
+      heading.twelvedigit => 1,
+      commodity.twelvedigit => 3,
+    }
+  end
+
+  describe '.wrap' do
+    subject(:wrapped) { described_class.wrap([heading], counts) }
+
+    it { is_expected.to have_attributes length: 1 }
+    it { is_expected.to all be_instance_of described_class }
+    it { is_expected.to all have_attributes values: heading.values }
+    it { is_expected.to all have_attributes search_references_count: 1 }
+    it { expect(wrapped.first.commodities).to have_attributes length: 1 }
+    it { expect(wrapped.first.commodities).to all have_attributes search_references_count: 3 }
+  end
+
+  describe '.new' do
+    subject(:wrapped) { described_class.new(heading, counts) }
+
+    it { is_expected.to be_instance_of described_class }
+    it { is_expected.to have_attributes values: heading.values }
+    it { is_expected.to have_attributes search_references_count: 1 }
+    it { expect(wrapped.commodities).to have_attributes length: 1 }
+    it { expect(wrapped.commodities.first).to have_attributes values: commodity.values }
+    it { expect(wrapped.commodities.first).to have_attributes search_references_count: 3 }
+  end
+end

--- a/spec/requests/api/admin/headings_controller_spec.rb
+++ b/spec/requests/api/admin/headings_controller_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe Api::Admin::HeadingsController do
+  subject(:page_response) { make_request && response }
+
+  let(:json_response) { JSON.parse(page_response.body) }
+  let(:heading) { create(:heading, :non_declarable, :with_chapter).reload }
+
+  describe 'GET to #show' do
+    let(:make_request) do
+      authenticated_get api_heading_path(heading_id, format: :json)
+    end
+
+    context 'with known heading' do
+      let(:heading_id) { heading.short_code }
+
+      it_behaves_like 'a successful jsonapi response'
+    end
+
+    context 'with unknown heading' do
+      let(:heading_id) { 9999 }
+
+      it { is_expected.to have_http_status :not_found }
+    end
+  end
+end

--- a/spec/serializers/api/admin/headings/commodity_serializer_spec.rb
+++ b/spec/serializers/api/admin/headings/commodity_serializer_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe Api::Admin::Headings::CommoditySerializer do
   subject(:serialized) { described_class.new(serializable).serializable_hash }
 
-  let(:serializable) { create(:commodity, :with_heading) }
+  let(:commodity) { create(:commodity, :with_heading) }
+  let(:serializable) { Api::Admin::Headings::CommodityPresenter.new(commodity, 3) }
 
   let(:expected) do
     {
@@ -10,7 +11,7 @@ RSpec.describe Api::Admin::Headings::CommoditySerializer do
         type: :commodity,
         attributes: {
           description: serializable.description,
-          search_references_count: 0,
+          search_references_count: 3,
           declarable: true,
         },
       },

--- a/spec/serializers/api/admin/headings/heading_serializer_spec.rb
+++ b/spec/serializers/api/admin/headings/heading_serializer_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Api::Admin::Headings::HeadingSerializer do
   subject(:serialized) { described_class.new(serializable).serializable_hash }
 
   let(:heading) { create(:heading, :with_chapter, :non_declarable).reload }
-  let(:counts) { { heading.twelvedigit => 12 } }
+  let(:counts) { { heading.twelve_digit => 12 } }
   let(:serializable) { Api::Admin::Headings::HeadingPresenter.new(heading, counts) }
 
   let(:expected) do
@@ -25,7 +25,7 @@ RSpec.describe Api::Admin::Headings::HeadingSerializer do
           commodities: {
             data: heading.commodities.map do |c|
               {
-                id: c.twelvedigit,
+                id: c.twelve_digit,
                 type: :commodity,
               }
             end,

--- a/spec/serializers/api/admin/headings/heading_serializer_spec.rb
+++ b/spec/serializers/api/admin/headings/heading_serializer_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe Api::Admin::Headings::HeadingSerializer do
+  subject(:serialized) { described_class.new(serializable).serializable_hash }
+
+  let(:heading) { create(:heading, :with_chapter, :non_declarable).reload }
+  let(:counts) { { heading.twelvedigit => 12 } }
+  let(:serializable) { Api::Admin::Headings::HeadingPresenter.new(heading, counts) }
+
+  let(:expected) do
+    {
+      data: {
+        id: heading.goods_nomenclature_sid.to_s,
+        type: :heading,
+        attributes: {
+          goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
+          description: heading.description,
+          search_references_count: 12,
+        },
+        relationships: {
+          chapter: {
+            data: {
+              id: heading.chapter.goods_nomenclature_sid.to_s,
+              type: :chapter,
+            },
+          },
+          commodities: {
+            data: heading.commodities.map do |c|
+              {
+                id: c.twelvedigit,
+                type: :commodity,
+              }
+            end,
+          },
+        },
+      },
+    }
+  end
+
+  describe '#serializable_hash' do
+    it { expect(serialized).to eq(expected) }
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-2361

### What?

I have added/removed/altered:

- [x] Added grouped count for search references
- [x] Added missing request spec for admin heading endpoint

### Why?

I am doing this because:

There are 2 key sources of N+1 on the admin headings API - inclusion of declarable field for child commodities, and inclusion of counts for those commodities. 

- declarable is cached so will hopefully avoid those queries in production
- counting the search refs for the commodities

By using a grouped count 1300 queries are removed from api requests for large headings

### Deployment risks (optional)

- Low, only affects admin API
