### PR TITLE
HOTT-2238 Remove rack timeout noise from logs

### DIFF
--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,5 +1,11 @@
 if Rails.env.production?
-  Rails.application.config.middleware.insert_before Rack::Runtime, Rack::Timeout, service_timeout: Integer(ENV.fetch('RACK_TIMEOUT_SERVICE', 6))
+  Rails.application.config.middleware.insert_before(
+    Rack::Runtime,
+    Rack::Timeout,
+    service_timeout: Integer(ENV.fetch('RACK_TIMEOUT_SERVICE', 6)),
+  )
+
+  Rack::Timeout::Logger.level = ::Logger::WARN
 else
   logger.info 'Rack::Runtime is disabled in Dev env.'
 end


### PR DESCRIPTION
### Jira link

HOTT-2238

### What?

I have added/removed/altered:

- [x] Changed the log level for Rack::Timeout 

### Why?

I am doing this because:

- This is spamming the logs in NewRelic generating 4 times as much 'noise' as useful logging data

### Deployment risks (optional)

- Should be low - just changing log levels 
