### PR TITLE
HOTT-2390: Add support for multiple transfer events

### DIFF
--- a/app/lib/cds_importer.rb
+++ b/app/lib/cds_importer.rb
@@ -95,8 +95,8 @@ class CdsImporter
         oplog_inserts[:operations][operation][entity_class][:duration] += duration
         oplog_inserts[:operations][operation][entity_class][:mapping_path] = mapping_path
 
-        # We only accumulate missing destroy operations because we can work out from the file which record was inserted for non-missing operation types
-        if [CdsImporter::RecordInserter::DESTROY_MISSING_OPERATION, :skipped].include?(operation)
+        # We only accumulate missing destroy and skipped operations because we can work out from the file which record was inserted for non-missing operation types
+        if [CdsImporter::RecordInserter::DESTROY_MISSING_OPERATION, CdsImporter::RecordInserter::SKIPPED_OPERATION].include?(operation)
           oplog_inserts[:operations][operation][entity_class][:records] ||= []
           oplog_inserts[:operations][operation][entity_class][:records] << record.identification
         end

--- a/app/lib/cds_importer.rb
+++ b/app/lib/cds_importer.rb
@@ -25,6 +25,7 @@ class CdsImporter
         destroy: { count: 0, duration: 0 },
         destroy_cascade: { count: 0, duration: 0 },
         destroy_missing: { count: 0, duration: 0 },
+        skipped: { count: 0, duration: 0 },
       },
       total_count: 0,
       total_duration: 0,
@@ -95,7 +96,7 @@ class CdsImporter
         oplog_inserts[:operations][operation][entity_class][:mapping_path] = mapping_path
 
         # We only accumulate missing destroy operations because we can work out from the file which record was inserted for non-missing operation types
-        if operation == CdsImporter::RecordInserter::DESTROY_MISSING_OPERATION
+        if [CdsImporter::RecordInserter::DESTROY_MISSING_OPERATION, :skipped].include?(operation)
           oplog_inserts[:operations][operation][entity_class][:records] ||= []
           oplog_inserts[:operations][operation][entity_class][:records] << record.identification
         end

--- a/app/lib/cds_importer/entity_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper.rb
@@ -22,9 +22,10 @@ class CdsImporter
         instances.each do |model_instance|
           mapper.before_oplog_inserts_callbacks.each { |callback| callback.call(xml_node, mapper, model_instance) }
 
-          next if model_instance.skip_import?
-
           record_inserter = CdsImporter::RecordInserter.new(model_instance, mapper, @filename)
+
+          record_inserter.skip_record if model_instance.skip_import?
+          next if model_instance.skip_import?
 
           if logger_enabled?
             record_inserter.save_record(@key)

--- a/app/lib/cds_importer/entity_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper.rb
@@ -24,7 +24,7 @@ class CdsImporter
 
           record_inserter = CdsImporter::RecordInserter.new(model_instance, mapper, @filename)
 
-          record_inserter.skip_record if model_instance.skip_import?
+          record_inserter.instrument_skip_record if model_instance.skip_import?
           next if model_instance.skip_import?
 
           if logger_enabled?

--- a/app/lib/cds_importer/entity_mapper/quota_closed_and_transferred_event_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/quota_closed_and_transferred_event_mapper.rb
@@ -18,10 +18,23 @@ class CdsImporter
       ).freeze
 
       before_oplog_inserts do |xml_node, _mapper, model_instance|
+        transfer_node = if xml_node[mapping_path].is_a?(Array)
+                          xml_node[mapping_path].find { |transfer_node| xml_node_equivalent_to_model_instance?(model_instance, transfer_node) }
+                        else
+                          xml_node[mapping_path]
+                        end
+
         current_definition_start_date = xml_node['validityStartDate']
-        target_definition_start_date = xml_node.dig('quotaClosedAndTransferredEvent', 'targetQuotaDefinition', 'validityStartDate')
+        target_definition_start_date = transfer_node.dig('targetQuotaDefinition', 'validityStartDate')
 
         model_instance.skip_import! if current_definition_start_date >= target_definition_start_date
+      end
+
+      def self.xml_node_equivalent_to_model_instance?(model_instance, xml_node)
+        model_instance.transferred_amount.to_s == xml_node['transferredAmount'] &&
+          xml_node['closingDate'].to_s.include?(model_instance.closing_date.iso8601) &&
+          model_instance.occurrence_timestamp.iso8601.include?(xml_node['occurrenceTimestamp']) &&
+          model_instance.target_quota_definition_sid.to_s == xml_node['targetQuotaDefinition']['sid']
       end
     end
   end

--- a/app/lib/cds_importer/record_inserter.rb
+++ b/app/lib/cds_importer/record_inserter.rb
@@ -60,6 +60,10 @@ class CdsImporter
       nil
     end
 
+    def skip_record
+      instrument('cds_importer.import.operations', mapper:, operation: :skipped, count: 1, record:)
+    end
+
     private
 
     attr_reader :record, :mapper, :filename

--- a/app/lib/cds_importer/record_inserter.rb
+++ b/app/lib/cds_importer/record_inserter.rb
@@ -2,6 +2,7 @@ class CdsImporter
   class RecordInserter
     DESTROY_CASCADE_OPERATION = :destroy_cascade
     DESTROY_MISSING_OPERATION = :destroy_missing
+    SKIPPED_OPERATION = :skipped
 
     delegate :instrument, to: ActiveSupport::Notifications
 
@@ -60,8 +61,8 @@ class CdsImporter
       nil
     end
 
-    def skip_record
-      instrument('cds_importer.import.operations', mapper:, operation: :skipped, count: 1, record:)
+    def instrument_skip_record
+      instrument('cds_importer.import.operations', mapper:, operation: SKIPPED_OPERATION, count: 1, record:)
     end
 
     private

--- a/spec/integration/cds_importer/cds_importer_spec.rb
+++ b/spec/integration/cds_importer/cds_importer_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe CdsImporter do
           destroy: { count: 0, duration: 0 },
           destroy_cascade: { count: 0, duration: 0 },
           destroy_missing: { count: 0, duration: 0 },
+          skipped: { count: 0, duration: 0 },
         },
         total_count: 0,
         total_duration: 0,

--- a/spec/integration/tariff_synchronizer/cds_update_spec.rb
+++ b/spec/integration/tariff_synchronizer/cds_update_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe TariffSynchronizer::CdsUpdate do
                 'records' => [{ 'oid' => Integer, 'measure_condition_sid' => 20_115_851 }],
               },
             },
+            'skipped' => { 'count' => 0, 'duration' => 0 },
           },
           'total_count' => 3,
           'total_duration' => be_a(Float),


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2390

### What?

I have added/removed/altered:

- [x] Added support for handling multiple transfer events per definition
- [x] Added ability to review skipped transfer events

### Why?

I am doing this because:

- The daily files can include transfer out and transfer in events. I didn't notice this until this morning since most files only have one event per quota definition primary node.
- I wanted the skipped feedback just for development purposes the ability to review skipped transfer nodes

### AC

- [x] Reviewed 100% of imported/skipped events from today's file and all looks good
