### PR TITLE
HOTT-2210 Avoid serialization warnings from Sidekiq

### DIFF
--- a/app/models/rollback.rb
+++ b/app/models/rollback.rb
@@ -24,7 +24,7 @@ class Rollback < Sequel::Model
   end
 
   def after_create
-    RollbackWorker.perform_async(date, keep)
+    RollbackWorker.perform_async(date.to_formatted_s(:db), keep)
   end
 
   def before_create

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,6 +2,8 @@ require 'sidekiq'
 
 redis_config = PaasConfig.redis
 
+Sidekiq.strict_args!
+
 Sidekiq.configure_server do |config|
   config.redis = redis_config
 end


### PR DESCRIPTION
### Jira link

HOTT-2210

### What?

I have added/removed/altered:

- [x] Changed the Rollback worker date serialization
- [x] Enable strict arg checking in Sidekiq

### Why?

I am doing this because:

- The current value (a Date object) is raising errors, so instead I'm using a 'db formatted' date - this simple, easily readable in the logs, unambiguous and avoids including potentially incorrect time and zone information since this is subsequently ignored by the Rollback model.
- This is a preliminary fix for the other sidekiq 7 related changes

### Deployment risks (optional)

- Low - new jobs get serialized in a different format but the Rollback model understands both old and new formats anyway
