### PR TITLE
HOTT-2392: Fixes bug with redirecting search references

### DIFF
--- a/app/services/api/beta/search_query_parser_service.rb
+++ b/app/services/api/beta/search_query_parser_service.rb
@@ -3,10 +3,10 @@ module Api
     class SearchQueryParserService
       delegate :client, to: :class
 
-      def initialize(original_search_query, spell: '1', goods_nomenclature_item_id_match: false)
+      def initialize(original_search_query, spell: '1', should_search: true)
         @original_search_query = original_search_query
         @spell = spell
-        @goods_nomenclature_item_id_match = goods_nomenclature_item_id_match
+        @should_search = should_search
       end
 
       def call
@@ -31,7 +31,7 @@ module Api
       attr_reader :original_search_query, :spell
 
       def null_result?
-        original_search_query.blank? || @goods_nomenclature_item_id_match || AggregatedSynonym.exists?(@original_search_query)
+        original_search_query.blank? || !@should_search || AggregatedSynonym.exists?(@original_search_query)
       end
     end
   end

--- a/app/services/api/beta/search_service.rb
+++ b/app/services/api/beta/search_service.rb
@@ -38,7 +38,7 @@ module Api
                                nil,
                                search_query_parser_result,
                                generated_search_query,
-                               exact_search_reference_match,
+                               exact_search_reference_match.first,
                              )
                            end
       end
@@ -52,7 +52,7 @@ module Api
       end
 
       def search_query_parser_result
-        @search_query_parser_result ||= Api::Beta::SearchQueryParserService.new(@search_query, spell: @search_params[:spell], goods_nomenclature_item_id_match: goods_nomenclature_item_id_match?).call
+        @search_query_parser_result ||= Api::Beta::SearchQueryParserService.new(@search_query, spell: @search_params[:spell], should_search: should_search?).call
       end
 
       def should_search?

--- a/spec/requests/api/beta/search_controller_spec.rb
+++ b/spec/requests/api/beta/search_controller_spec.rb
@@ -1,37 +1,53 @@
 RSpec.describe Api::Beta::SearchController, type: :request do
   describe 'GET #index' do
-    before do
-      allow(TradeTariffBackend.v2_search_client).to receive(:search).and_return(search_result)
-      allow(Api::Beta::SearchQueryParserService).to receive(:new).and_return(search_query_parser_service)
+    context 'when doing a full search' do
+      before do
+        allow(TradeTariffBackend.v2_search_client).to receive(:search).and_return(search_result)
+        allow(Api::Beta::SearchQueryParserService).to receive(:new).and_return(search_query_parser_service)
+      end
+
+      let(:search_result) do
+        fixture_file = file_fixture('beta/search/goods_nomenclatures/single_hit.json')
+
+        Hashie::TariffMash.new(JSON.parse(fixture_file.read))
+      end
+
+      let(:expected_serialized_result) do
+        fixture_file = file_fixture('beta/search/goods_nomenclatures/serialized_result.json')
+        JSON.parse(fixture_file.read)
+      end
+
+      let(:search_query_parser_service) { instance_double('Api::Beta::SearchQueryParserService', call: search_query_parser_result) }
+      let(:search_query_parser_result) { build(:search_query_parser_result, :single_hit) }
+
+      shared_examples_for 'a working search request' do |prefix|
+        subject(:do_request) do
+          get "#{prefix}/api/beta/search?q=ricotta&filter[cheese_type]=fresh"
+
+          response
+        end
+
+        it { is_expected.to have_http_status(:ok) }
+        it { expect(do_request.body).to match_json_expression(expected_serialized_result) }
+      end
+
+      it_behaves_like 'a working search request', '/xi'
+      it_behaves_like 'a working search request', '/uk'
+      it_behaves_like 'a working search request', ''
     end
 
-    let(:search_result) do
-      fixture_file = file_fixture('beta/search/goods_nomenclatures/single_hit.json')
-
-      Hashie::TariffMash.new(JSON.parse(fixture_file.read))
-    end
-
-    let(:expected_serialized_result) do
-      fixture_file = file_fixture('beta/search/goods_nomenclatures/serialized_result.json')
-      JSON.parse(fixture_file.read)
-    end
-
-    let(:search_query_parser_service) { instance_double('Api::Beta::SearchQueryParserService', call: search_query_parser_result) }
-    let(:search_query_parser_result) { build(:search_query_parser_result, :single_hit) }
-
-    shared_examples_for 'a working search request' do |prefix|
+    context 'when redirecting because of a search reference' do
       subject(:do_request) do
-        get "#{prefix}/api/beta/search?q=ricotta&filter[cheese_type]=fresh"
+        get '/api/beta/search?q=raw'
 
         response
       end
 
-      it { is_expected.to have_http_status(:ok) }
-      it { expect(do_request.body).to match_json_expression(expected_serialized_result) }
-    end
+      let(:actual_redirect_to) { JSON.parse(do_request.body).dig('data', 'meta', 'redirect_to') }
 
-    it_behaves_like 'a working search request', '/xi'
-    it_behaves_like 'a working search request', '/uk'
-    it_behaves_like 'a working search request', ''
+      before { create(:search_reference, :with_heading, title: 'raw') }
+
+      it { expect(actual_redirect_to).to include('/headings/0101') }
+    end
   end
 end

--- a/spec/services/api/beta/search_query_parser_service_spec.rb
+++ b/spec/services/api/beta/search_query_parser_service_spec.rb
@@ -2,16 +2,16 @@ RSpec.describe Api::Beta::SearchQueryParserService do
   let(:search_query_parser_service_url) { 'http://localhost:5000/api/search' }
 
   describe '#call' do
-    shared_examples_for 'a null result search query parser call' do |search_query, goods_nomenclature_item_id_match|
-      subject(:result) { described_class.new(search_query, goods_nomenclature_item_id_match:).call }
+    shared_examples_for 'a null result search query parser call' do |search_query, should_search|
+      subject(:result) { described_class.new(search_query, should_search:).call }
 
       it { expect(result.null_result).to eq(true) }
     end
 
-    it_behaves_like 'a null result search query parser call', '', false # Empty search query
-    it_behaves_like 'a null result search query parser call', nil, false # Empty search query
-    it_behaves_like 'a null result search query parser call', 'yakutian laika', false # Synonym search query
-    it_behaves_like 'a null result search query parser call', 'ricotta', true # Specific goods nomenclature item id search query
+    it_behaves_like 'a null result search query parser call', '', true # Empty search query
+    it_behaves_like 'a null result search query parser call', nil, true # Empty search query
+    it_behaves_like 'a null result search query parser call', 'yakutian laika', true # Synonym search query
+    it_behaves_like 'a null result search query parser call', 'ricotta', false # No search due to instruction
 
     context 'when the search query parser response is success' do
       subject(:result) { described_class.new('aaa bbb', spell: '1').call }

--- a/spec/services/api/beta/search_service_spec.rb
+++ b/spec/services/api/beta/search_service_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Api::Beta::SearchService do
         search_result
       end
 
-      it { expect(Api::Beta::SearchQueryParserService).to have_received(:new).with('ricotta', spell: '1', goods_nomenclature_item_id_match: false) }
+      it { expect(Api::Beta::SearchQueryParserService).to have_received(:new).with('ricotta', spell: '1', should_search: true) }
       it { expect(TradeTariffBackend.v2_search_client).to have_received(:search).with(expected_search_args) }
       it { expect(Beta::Search::OpenSearchResult::WithHits).to have_received(:build).with(opensearch_result, search_query_parser_result, goods_nomenclature_query, nil) }
       it { expect(Beta::Search::GoodsNomenclatureQuery).to have_received(:build).with(search_query_parser_result, {}) }
@@ -91,6 +91,10 @@ RSpec.describe Api::Beta::SearchService do
 
     shared_examples_for 'a redirecting search result' do |search_query|
       subject(:search_result) { described_class.new(search_query).call }
+
+      before do
+        create(:search_reference, title: 'raw')
+      end
 
       it { is_expected.to be_redirect }
     end
@@ -103,6 +107,7 @@ RSpec.describe Api::Beta::SearchService do
     it_behaves_like 'a redirecting search result', '0101210000-80' # Subheading
     it_behaves_like 'a redirecting search result', '0101210000380' # Heading
     it_behaves_like 'a redirecting search result', '010121000038123' # Heading
+    it_behaves_like 'a redirecting search result', 'raw'
 
     context 'when the search query has multiple corresponding search references' do
       let(:search_query) { 'same' }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2392

### What?

I have added/removed/altered:

- [x] Added integration test to validate redirecting for search references
- [x] Fixed broken search reference redirect

### Why?

I am doing this because:

- This is required as part of the beta search functionality
