### PR TITLE
Increase max lifetime of the redis lock to 10 mins

### DIFF
--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -1,4 +1,6 @@
 module TradeTariffBackend
+  MAX_LOCK_LIFETIME = 600_000
+
   class << self
     SERVICE_CURRENCIES = {
       'uk' => 'GBP',
@@ -72,7 +74,7 @@ module TradeTariffBackend
 
     def with_redis_lock(lock_name = db_lock_key, &block)
       lock = Redlock::Client.new([RedisLockDb.redis])
-      lock.lock!(lock_name, 5000, &block)
+      lock.lock!(lock_name, MAX_LOCK_LIFETIME, &block)
     end
 
     def redis


### PR DESCRIPTION

### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [x] Increased the max lifetime for the Redis locks to 10 minutes

### Why?

I am doing this because:

- Previously this was 5 seconds - this meant that we only avoided problems from multiple tariff syncs running concurrently for the first 5 seconds of the sync.
- If the job completes before the 10 minutes then the lock is released upon completion anyway.

### Deployment risks (optional)

- Impacts overnight sync
