### PR TITLE
HOTT-2408: Remove vanuatu from VAT group

### DIFF
--- a/db/data_migrations/20230103143020_vanuatu_fixes.rb
+++ b/db/data_migrations/20230103143020_vanuatu_fixes.rb
@@ -1,0 +1,39 @@
+Sequel.migration do
+  # IMPORTANT! Data migrations up block should be idempotent (reruns of up should produce the same effect)
+  # they may get re-run as part of data rollbacks but the rollback (down) function of the data migration will not get invoked
+  up do
+    area = GeographicalAreaMembership.where(
+      geographical_area_sid: 107,
+      geographical_area_group_sid: 504,
+      validity_start_date: '2021-01-01T00:00:00.000Z',
+      validity_end_date: nil,
+      national: false,
+      operation: 'C',
+      operation_date: '2022-06-22',
+      filename: 'tariff_dailyExtract_v1_20220622T235959.gzip',
+      hjid: 11_901_227,
+      geographical_area_hjid: nil,
+      geographical_area_group_hjid: nil,
+    ).first
+
+    area && area.destroy
+  end
+
+  down do
+    GeographicalAreaMembership.unrestrict_primary_key
+
+    GeographicalAreaMembership.new(
+      geographical_area_sid: 107,
+      geographical_area_group_sid: 504,
+      validity_start_date: '2021-01-01T00:00:00.000Z',
+      validity_end_date: nil,
+      national: false,
+      operation: 'C',
+      operation_date: '2022-06-22',
+      filename: 'tariff_dailyExtract_v1_20220622T235959.gzip',
+      hjid: 11_901_227,
+      geographical_area_hjid: nil,
+      geographical_area_group_hjid: nil,
+    ).save
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2408

### What?

I have added/removed/altered:

- [x] Added data migration to remove Vanuatu from the VAT geographical area group

### Why?

I am doing this because:

- This is an urgent data fix until CDS produce a file with this adjustment
