### PR TITLE
HOTT-2408 Remove Vanuatu from Geographical Area 1400

### DIFF
--- a/db/data_migrations/20230103143452_remove_vanuatu_from_geographical_group.rb
+++ b/db/data_migrations/20230103143452_remove_vanuatu_from_geographical_group.rb
@@ -1,0 +1,20 @@
+Sequel.migration do
+  # IMPORTANT! Data migrations up block should be idempotent (reruns of up should produce the same effect)
+  # they may get re-run as part of data rollbacks but the rollback (down) function of the data migration will not get invoked
+
+  up do
+    if TradeTariffBackend.uk?
+      Sequel::Model.db[:geographical_area_memberships_oplog]
+        .where(
+          geographical_area_group_sid: 504,
+          geographical_area_sid: 107,
+          operation_date: '2022-06-22',
+          operation: 'C',
+        ).delete
+    end
+  end
+
+  down do
+    # deletion, cannot be reversed
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-2408

### What?

I have added/removed/altered:

- [x] Added data migration to remove Vanuatu from Geographical area 1400

### Why?

I am doing this because:

- It should never have been in that geographical area group

### Deployment risks (optional)

- Data migration
