### PR TITLE
HOTT-2414: Fix bug in last allocation date

### DIFF
--- a/app/serializers/api/v2/quotas/order_number/quota_definition_serializer.rb
+++ b/app/serializers/api/v2/quotas/order_number/quota_definition_serializer.rb
@@ -18,7 +18,7 @@ module Api
           attribute :measurement_unit_qualifier, &:measurement_unit_qualifier_code
 
           attribute :last_allocation_date do |definition|
-            definition.last_balance_event.try(:occurrence_timestamp)
+            definition.last_balance_event&.last_import_date_in_allocation
           end
 
           attribute :suspension_period_start_date do |definition|

--- a/spec/serializers/api/v2/quotas/order_number/quota_definition_serializer_spec.rb
+++ b/spec/serializers/api/v2/quotas/order_number/quota_definition_serializer_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe Api::V2::Quotas::OrderNumber::QuotaDefinitionSerializer do
+  describe '#serializable_hash' do
+    subject(:serializable_hash) { described_class.new(serializable, options).serializable_hash.as_json }
+
+    let(:serializable) { create(:quota_definition, :with_quota_balance_events) }
+    let(:options) { {} }
+
+    let(:expected_pattern) do
+      {
+        data: {
+          id: be_a(String),
+          type: 'definition',
+          attributes: {
+            initial_volume: nil,
+            validity_start_date: 4.years.ago.beginning_of_day.as_json,
+            validity_end_date: nil,
+            status: 'Open',
+            description: nil,
+            balance: serializable.balance.to_s,
+            measurement_unit: nil,
+            monetary_unit: be_a(String),
+            measurement_unit_qualifier: be_a(String),
+            last_allocation_date: serializable.last_balance_event.last_import_date_in_allocation.iso8601,
+            suspension_period_start_date: nil,
+            suspension_period_end_date: nil,
+            blocking_period_start_date: nil,
+            blocking_period_end_date: nil,
+          },
+          relationships: {
+            incoming_quota_closed_and_transferred_event: {},
+          },
+        },
+      }
+    end
+
+    it { is_expected.to include_json(expected_pattern) }
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2414

![image](https://user-images.githubusercontent.com/8156884/210542116-65940302-f0fb-4f65-9dd1-911c2ad038b0.png)

### What?

The commodity api response with the quota definition in it for the quota measures needs to actually return the correct allocation date and not just return the occurrence timestamp.

I have added/removed/altered:

- [x] Use the correct field for the allocation date from the balance event
- [x] Adds missing coverage of the commodity quota serializer

### Why?

I am doing this because:

- These values are just wrong and were discovered by our users
- This has been wrong since this feature was implemented https://github.com/trade-tariff/trade-tariff-backend/commit/9bbad5984e459405b9697f573fea73049fc8949f
