### PR TITLE
Kill slack notifier noise

### DIFF
--- a/app/services/slack_notifier_service.rb
+++ b/app/services/slack_notifier_service.rb
@@ -1,10 +1,11 @@
 class SlackNotifierService
   class << self
     def call(message)
-      notifier.ping(message)
+      notifier.ping(message) if notifier.present?
     end
 
-  private
+    private
+
     def notifier
       Rails.application.config.slack_notifier
     end

--- a/config/initializers/slack_notifier.rb
+++ b/config/initializers/slack_notifier.rb
@@ -1,19 +1,9 @@
-require 'slack-notifier'
+slack_env_defined = ENV['SLACK_WEB_HOOK_URL'] && ENV['SLACK_CHANNEL'] && ENV['SLACK_USERNAME']
 
-class FakeSlackNotifier
-  def ping(_message); end
-end
-
-slack_notifier = if Rails.env.production?
-                   if ENV['SLACK_WEB_HOOK_URL'] && ENV['SLACK_CHANNEL'] && ENV['SLACK_USERNAME']
-                     Slack::Notifier.new(ENV['SLACK_WEB_HOOK_URL'],
-                                         channel: ENV['SLACK_CHANNEL'],
-                                         username: ENV['SLACK_USERNAME'])
-                   else
-                     logger.warn('The ENV SLACK_WEB_HOOK_URL, SLACK_CHANNEL or SLACK_USERNAME are not declared. ' \
-                                 'Slack notifications are disabled.')
-                     nil
-                   end
-                 end
-
-Rails.application.config.slack_notifier = slack_notifier || FakeSlackNotifier.new
+Rails.application.config.slack_notifier = if Rails.env.production? && slack_env_defined
+                                            Slack::Notifier.new(
+                                              ENV['SLACK_WEB_HOOK_URL'],
+                                              channel: ENV['SLACK_CHANNEL'],
+                                              username: ENV['SLACK_USERNAME'],
+                                            )
+                                          end

--- a/spec/services/slack_notifier_service_spec.rb
+++ b/spec/services/slack_notifier_service_spec.rb
@@ -1,11 +1,9 @@
 RSpec.describe SlackNotifierService do
+  let(:slack_notifier) { instance_double('Slack::Notiifer', ping: 'pong') }
+
   before do
-    allow(Rails.application.config.slack_notifier).to receive(:ping)
+    allow(Rails.application.config).to receive(:slack_notifier).and_return(slack_notifier)
   end
 
-  it 'sends a Slack message' do
-    SlackNotifierService.call('Hello Slack')
-
-    expect(Rails.application.config.slack_notifier).to have_received(:ping).with("Hello Slack")
-  end
+  it { expect(described_class.call('Hello Slack')).to eq('pong') }
 end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Remove console noise from slack notifier

### Why?

I am doing this because:

- This is not important information and is something a developer that is configuring the service should just be able to fix

### AC

- [ ] Verify notifier still being loaded in the environments where its defined (requires a merge to staging)
