### PR TITLE
HOTT-2355: Removed sub tag from emails

### DIFF
--- a/app/formatters/description_formatter.rb
+++ b/app/formatters/description_formatter.rb
@@ -32,6 +32,7 @@ class DescriptionFormatter
     str.gsub! /\$(.)/ do
       "<sup>#{$1}</sup>"
     end
+    str.gsub!(/<sub>([a-z])<\/sub>/i, '@\1')
     str.strip
     str.html_safe
   end

--- a/spec/formatters/description_formatter_spec.rb
+++ b/spec/formatters/description_formatter_spec.rb
@@ -136,10 +136,16 @@ RSpec.describe DescriptionFormatter do
       ).to eq ' utilisation '
     end
 
-    it 'replaces ized  with ised' do
+    it 'replaces ized with ised' do
       expect(
         described_class.format(description: ' unpasteurized '),
       ).to eq ' unpasteurised '
+    end
+
+    it 'removes sub tag from emails' do
+      expect(
+        described_class.format(description: ' email<sub>h</sub>se.gov.uk '),
+      ).to eq ' email@hse.gov.uk '
     end
 
     context 'when xi' do


### PR DESCRIPTION
### Jira link

[HOTT-<TODO>
](https://transformuk.atlassian.net/browse/HOTT-2355)

### What?

I have added/removed/altered:

- [ ] Removed sub tag from emails

### Why?

I am doing this because:

- Emails were displaying incorrectly

### Deployment risks (optional)

- Changes an api that is used in production

<img width="981" alt="Screenshot 2023-01-04 at 11 32 01" src="https://user-images.githubusercontent.com/12201130/210547718-27a0c1a9-9c18-4488-8910-15f1b349935a.png">

