### PR TITLE
HOTT-2361 Use fast_declarable to speed up admin api

### DIFF
--- a/app/serializers/api/admin/headings/commodity_serializer.rb
+++ b/app/serializers/api/admin/headings/commodity_serializer.rb
@@ -11,7 +11,7 @@ module Api
         attributes :description,
                    :search_references_count
 
-        attribute :declarable, &:declarable?
+        attribute :declarable, &:fast_declarable?
       end
     end
   end


### PR DESCRIPTION
### Jira link

HOTT-2361

### What?

I have added/removed/altered:

- [x] Changed headings admin api to use fast_declarable

### Why?

I am doing this because:

- Whilst it still has a high query count, the ruby processing over head is much less and this allows the search references pages to complete within the timeout

### Deployment risks (optional)

- Low, only impacts admin API
