### PR TITLE
HOTT-2372: Adds sidekiq job for uploading new spelling model

### DIFF
--- a/app/workers/spelling_file_uploader_worker.rb
+++ b/app/workers/spelling_file_uploader_worker.rb
@@ -1,0 +1,9 @@
+class SpellingFileUploaderWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :default, retry: false
+
+  def perform
+    SpellingCorrector::FileUpdaterService.new.call
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -37,3 +37,8 @@
   HealthcheckWorker:
     every: 30.minutes
     description: Trigger the health check
+  UKSpellingFileUploaderWorker:
+    cron: "0 14 * * *"
+    description: "Uploads a new snapshot of the spelling model based on the latest data."
+    class: SpellingFileUploaderWorker
+    status: <%= TradeTariffBackend.uk? ? 'enabled' : 'disabled' %>

--- a/spec/workers/spelling_file_uploader_worker_spec.rb
+++ b/spec/workers/spelling_file_uploader_worker_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe SpellingFileUploaderWorker, type: :worker do
+  before do
+    allow(SpellingCorrector::FileUpdaterService).to receive(:new).and_return(file_updater_service)
+
+    silence { described_class.new.perform }
+  end
+
+  let(:file_updater_service) { instance_double('SpellingCorrector::FileUpdaterService', call: 'foo') }
+
+  it { expect(file_updater_service).to have_received(:call) }
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2372

### What?

I have added/removed/altered:

- [x] Adds async s3 file uploader worker
- [x] Run s3 uploader worker in with sidekiq scheduler

### Why?

I am doing this because:

- This is required to update the spelling model everyday as data changes
