### PR TITLE
HOTT-2226: Fix issue with non-current quota definition

### DIFF
--- a/app/controllers/api/admin/quota_order_numbers/quota_definitions_controller.rb
+++ b/app/controllers/api/admin/quota_order_numbers/quota_definitions_controller.rb
@@ -13,13 +13,18 @@ module Api
         private
 
         def serialized_quota_definition
-          Api::Admin::QuotaOrderNumbers::QuotaDefinitionSerializer.new(quota_definition, serializer_options)
+          Api::Admin::QuotaOrderNumbers::QuotaDefinitionSerializer.new(quota_definition_or_not_found, serializer_options)
+        end
+
+        def quota_definition_or_not_found
+          quota_definition.presence || (raise Sequel::RecordNotFound)
         end
 
         def quota_definition
           @quota_definition ||= QuotaOrderNumber
             .by_order_number(params[:id])
             .eager(quota_definition: :quota_balance_events)
+            .actual
             .take
             .quota_definition
         end

--- a/spec/factories/quota_factory.rb
+++ b/spec/factories/quota_factory.rb
@@ -55,7 +55,7 @@ FactoryBot.define do
           validity_end_date: evaluator.quota_definition_validity_end_date,
         }
         if evaluator.quota_balance_events
-          create(:quota_definition, :with_quota_balance_events)
+          create(:quota_definition, :with_quota_balance_events, attributes)
         else
           create(:quota_definition, attributes)
         end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2226

### What?

I have added/removed/altered:

- [x] Fixed issue with admin quota definition search

### Why?

I am doing this because:

- This occurs when the quota definition is non-current but the quota order number is current
