### PR TITLE
HOTT-1596: Adds implicit deletion to goods nomenclature primary

### DIFF
--- a/app/lib/cds_importer/entity_mapper/footnote_association_goods_nomenclature_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/footnote_association_goods_nomenclature_mapper.rb
@@ -1,7 +1,3 @@
-#
-# FootnoteAssociationGoodsNomenclature is nested in to GoodsNomenclature.
-#
-
 class CdsImporter
   class EntityMapper
     class FootnoteAssociationGoodsNomenclatureMapper < BaseMapper
@@ -18,6 +14,10 @@ class CdsImporter
         "#{mapping_path}.footnote.footnoteId" => :footnote_id,
         "#{mapping_path}.footnote.footnoteType.footnoteTypeId" => :footnote_type,
       ).freeze
+
+      self.primary_filters = {
+        goods_nomenclature_sid: :goods_nomenclature_sid,
+      }.freeze
     end
   end
 end

--- a/app/lib/cds_importer/entity_mapper/goods_nomenclature_description_period_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/goods_nomenclature_description_period_mapper.rb
@@ -15,6 +15,10 @@ class CdsImporter
         'goodsNomenclatureItemId' => :goods_nomenclature_item_id,
         'produclineSuffix' => :productline_suffix,
       ).freeze
+
+      self.primary_filters = {
+        goods_nomenclature_sid: :goods_nomenclature_sid,
+      }.freeze
     end
   end
 end

--- a/app/lib/cds_importer/entity_mapper/goods_nomenclature_indent_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/goods_nomenclature_indent_mapper.rb
@@ -16,6 +16,10 @@ class CdsImporter
         'goodsNomenclatureItemId' => :goods_nomenclature_item_id,
         'produclineSuffix' => :productline_suffix,
       ).freeze
+
+      self.primary_filters = {
+        goods_nomenclature_sid: :goods_nomenclature_sid,
+      }.freeze
     end
   end
 end

--- a/app/lib/cds_importer/entity_mapper/goods_nomenclature_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/goods_nomenclature_mapper.rb
@@ -13,6 +13,10 @@ class CdsImporter
         'produclineSuffix' => :producline_suffix,
         'statisticalIndicator' => :statistical_indicator,
       ).freeze
+
+      delete_missing_entities FootnoteAssociationGoodsNomenclatureMapper,
+                              GoodsNomenclatureIndentMapper,
+                              GoodsNomenclatureDescriptionPeriodMapper
     end
   end
 end

--- a/spec/factories/footnote_factory.rb
+++ b/spec/factories/footnote_factory.rb
@@ -37,6 +37,10 @@ FactoryBot.define do
       end
     end
 
+    trait :with_goods_nomenclature_association do
+      with_gono_association
+    end
+
     trait :with_measure_association do
       after(:create) do |footnote, evaluator|
         create(

--- a/spec/factories/goods_nomenclature_factory.rb
+++ b/spec/factories/goods_nomenclature_factory.rb
@@ -31,6 +31,10 @@ FactoryBot.define do
       )
     end
 
+    trait :with_goods_nomenclature_indent do
+      # See implicit behaviour above
+    end
+
     trait :non_current do
       validity_end_date { 1.day.ago }
     end
@@ -355,6 +359,16 @@ FactoryBot.define do
         :search_reference,
         referenced: goods_nomenclature,
         title: evaluator.title,
+      )
+    end
+  end
+
+  trait :with_footnote_association do
+    after(:build) do |goods_nomenclature, _evaluator|
+      create(
+        :footnote,
+        :with_goods_nomenclature_association,
+        goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
       )
     end
   end

--- a/spec/lib/cds_importer/entity_mapper/goods_nomenclature_mapper_spec.rb
+++ b/spec/lib/cds_importer/entity_mapper/goods_nomenclature_mapper_spec.rb
@@ -1,31 +1,167 @@
 RSpec.describe CdsImporter::EntityMapper::GoodsNomenclatureMapper do
-  it_behaves_like 'an entity mapper', 'GoodsNomenclature', 'GoodsNomenclature' do
-    let(:xml_node) do
-      {
-        'sid' => '1234',
-        'goodsNomenclatureItemId' => '9950000000',
-        'produclineSuffix' => '80',
-        'statisticalIndicator' => '2',
-        'validityStartDate' => '2017-10-01T00:00:00',
-        'validityEndDate' => '2020-09-01T00:00:00',
-        'metainfo' => {
-          'opType' => 'C',
-          'transactionDate' => '2017-09-27T07:26:25',
+  let(:xml_node) do
+    {
+      'hjid' => '607643',
+      'metainfo' => {
+        'opType' => 'U',
+        'origin' => 'T',
+        'status' => 'L',
+        'transactionDate' => '2023-01-10T17:09:01',
+      },
+      'sid' => '87045',
+      'goodsNomenclatureItemId' => '8112922100',
+      'produclineSuffix' => '80',
+      'statisticalIndicator' => '0',
+      'validityStartDate' => '2007-01-01T00:00:00',
+      'footnoteAssociationGoodsNomenclature' => [
+        {
+          'hjid' => '10681792',
+          'metainfo' => {
+            'opType' => 'C',
+            'origin' => 'T',
+            'status' => 'L',
+            'transactionDate' => '2020-11-28T14:42:15',
+          },
+          'validityStartDate' => '2021-01-01T00:00:00',
+          'footnote' => {
+            'hjid' => '10654982',
+            'footnoteId' => '204',
+            'footnoteType' => {
+              'hjid' => '300',
+              'footnoteTypeId' => 'TN',
+            },
+          },
         },
-      }
-    end
+      ],
+      'goodsNomenclatureDescriptionPeriod' => [
+        {
+          'hjid' => '768715',
+          'metainfo' => {
+            'opType' => 'U',
+            'origin' => 'T',
+            'status' => 'L',
+            'transactionDate' => '2018-12-18T14:15:03',
+          },
+          'sid' => '127397',
+          'validityStartDate' => '2014-01-01T00:00:00',
+          'goodsNomenclatureDescription' => {
+            'hjid' => '8666878',
+            'metainfo' => {
+              'opType' => 'C',
+              'origin' => 'T',
+              'status' => 'L',
+              'transactionDate' => '2018-12-18T14:15:31',
+            },
+            'description' => 'Waste and scrap',
+            'language' => {
+              'hjid' => '9',
+              'languageId' => 'EN',
+            },
+          },
+        },
+      ],
+      'goodsNomenclatureIndents' => [
+        {
+          'hjid' => '671381',
+          'metainfo' => {
+            'opType' => 'C',
+            'origin' => 'T',
+            'status' => 'L',
+            'transactionDate' => '2018-12-15T07:32:00',
+          },
+          'sid' => '86531',
+          'numberIndents' => '04',
+          'validityStartDate' => '2007-01-01T00:00:00',
+        },
+      ],
+      'goodsNomenclatureOrigin' => [
+        {
+          'hjid' => '846308',
+          'metainfo' => {
+            'opType' => 'C',
+            'origin' => 'T',
+            'status' => 'L',
+            'transactionDate' => '2018-12-15T09:01:48',
+          },
+          'derivedGoodsNomenclatureItemId' => '8112925000',
+          'derivedProductlineSuffix' => '80',
+        },
+        {
+          'hjid' => '846307',
+          'metainfo' => {
+            'opType' => 'C',
+            'origin' => 'T',
+            'status' => 'L',
+            'transactionDate' => '2018-12-15T09:01:49',
+          },
+          'derivedGoodsNomenclatureItemId' => '8112923900',
+          'derivedProductlineSuffix' => '80',
+        },
+        {
+          'hjid' => '846305',
+          'metainfo' => {
+            'opType' => 'C',
+            'origin' => 'T',
+            'status' => 'L',
+            'transactionDate' => '2018-12-15T09:01:54',
+          },
+          'derivedGoodsNomenclatureItemId' => '8112304000',
+          'derivedProductlineSuffix' => '80',
+        },
+        {
+          'hjid' => '846306',
+          'metainfo' => {
+            'opType' => 'C',
+            'origin' => 'T',
+            'status' => 'L',
+            'transactionDate' => '2018-12-15T09:01:55',
+          },
+          'derivedGoodsNomenclatureItemId' => '8112401000',
+          'derivedProductlineSuffix' => '80',
+        },
+      ],
+      'filename' => 'tariff_dailyExtract_v1_20230110T235959.gzip',
+    }
+  end
 
+  it_behaves_like 'an entity mapper', 'GoodsNomenclature', 'GoodsNomenclature' do
     let(:expected_values) do
       {
-        validity_start_date: Time.zone.parse('2017-10-01T00:00:00.000Z'),
-        validity_end_date: Time.zone.parse('2020-09-01T00:00:00.000Z'),
-        operation: 'C',
-        operation_date: Date.parse('2017-09-27'),
-        goods_nomenclature_sid: 1234,
-        goods_nomenclature_item_id: '9950000000',
+        validity_start_date: Time.zone.parse('2007-01-01'),
+        validity_end_date: nil,
+        operation: 'U',
+        operation_date: Date.parse('2023-01-10'),
+        goods_nomenclature_sid: 87_045,
+        goods_nomenclature_item_id: '8112922100',
         producline_suffix: '80',
-        statistical_indicator: 2,
+        statistical_indicator: 0,
       }
+    end
+  end
+
+  describe '#import' do
+    subject(:entity_mapper) { CdsImporter::EntityMapper.new('GoodsNomenclature', xml_node) }
+
+    context 'when there are missing secondary entities to be soft deleted' do
+      before do
+        # Creates entities that will be missing from the xml node
+        create(
+          :goods_nomenclature,
+          :with_footnote_association,
+          :with_goods_nomenclature_indent,
+          :with_description,
+          goods_nomenclature_sid: '87045',
+        )
+
+        # Control for non-deleted secondary entities
+        create(:footnote_association_goods_nomenclature, goods_nomenclature_sid: '87045', footnote_type: 'TN', footnote_id: '204')
+        create(:goods_nomenclature_indent, goods_nomenclature_sid: '87045', goods_nomenclature_indent_sid: '86531')
+        create(:goods_nomenclature_description_period, goods_nomenclature_sid: '87045', goods_nomenclature_description_period_sid: '127397')
+      end
+
+      it_behaves_like 'an entity mapper missing destroy operation', FootnoteAssociationGoodsNomenclature, goods_nomenclature_sid: '87045'
+      it_behaves_like 'an entity mapper missing destroy operation', GoodsNomenclatureIndent, goods_nomenclature_sid: '87045'
+      it_behaves_like 'an entity mapper missing destroy operation', GoodsNomenclatureDescriptionPeriod, goods_nomenclature_sid: '87045'
     end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1596

### What?

I have added/removed/altered:

- [x] Added implicit delete behaviour to goods nomenclature mapper
- [x] Added test coverage for the new behaviour

### Why?

I am doing this because:

- This is required to make sure we're clearing out indents that are no longer supplied at the end of the indent sequence (e.g. ironing boards being fixed by removal)
