### PR TITLE
HOTT-2326 Fix CDS Importer for QuotaOrderNumberOriginExclusions

### DIFF
--- a/app/lib/cds_importer/entity_mapper/quota_order_number_origin_exclusion_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/quota_order_number_origin_exclusion_mapper.rb
@@ -10,7 +10,7 @@ class CdsImporter
 
       self.mapping_root = 'QuotaOrderNumber'.freeze
 
-      self.mapping_path = 'quotaOrderNumberOrigin.quotaOrderNumberOriginExclusion'.freeze
+      self.mapping_path = 'quotaOrderNumberOrigin.quotaOrderNumberOriginExclusions'.freeze
 
       self.exclude_mapping = ['metainfo.origin', 'validityStartDate', 'validityEndDate'].freeze
 

--- a/spec/lib/cds_importer/entity_mapper/quota_order_number_origin_exclusion_mapper_spec.rb
+++ b/spec/lib/cds_importer/entity_mapper/quota_order_number_origin_exclusion_mapper_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CdsImporter::EntityMapper::QuotaOrderNumberOriginExclusionMapper 
               'transactionDate' => '2017-07-15T22:27:51',
             },
           },
-          'quotaOrderNumberOriginExclusion' => {
+          'quotaOrderNumberOriginExclusions' => {
             'geographicalArea' => {
               'sid' => '11993',
               'geographicalAreaId' => '1101',


### PR DESCRIPTION
### Jira link

HOTT-2326

### What?

I have added/removed/altered:

- [x] Corrected xml node reference

### Why?

I am doing this because:

- The mapper was failing to import QuotaOrderNumberOriginExclusions

### Deployment risks (optional)

- Low, changes sync - should fix the problem
