### PR TITLE
HOTT-2447 Apply measure type 464 when filtering by country

### DIFF
--- a/app/models/measure_collection.rb
+++ b/app/models/measure_collection.rb
@@ -22,7 +22,7 @@ class MeasureCollection < SimpleDelegator
   end
 
   def apply_country_filter
-    measures = if @filters[:geographical_area_id].present?
+    measures = if filtering_by_country?
                  @measures.select do |measure|
                    measure.relevant_for_country?(filtering_country.geographical_area_id)
                  end
@@ -31,6 +31,10 @@ class MeasureCollection < SimpleDelegator
                end
 
     new(measures, @filters)
+  end
+
+  def filtering_by_country?
+    @filters[:geographical_area_id].present?
   end
 
   private

--- a/app/presenters/api/v2/commodities/commodity_presenter.rb
+++ b/app/presenters/api/v2/commodities/commodity_presenter.rb
@@ -14,6 +14,7 @@ module Api
           super(commodity)
           @commodity = commodity
           @footnotes = commodity.footnotes + commodity.heading.footnotes
+          @filtering_by_country = measures.filtering_by_country?
           @import_measures = measures.select(&:import).map do |measure|
             Api::V2::Measures::MeasurePresenter.new(measure, self)
           end
@@ -95,7 +96,12 @@ module Api
         end
 
         def authorised_use_provisions_submission?
-          @authorised_use_provisions_submission ||= import_measures.any?(&:authorised_use_provisions_submission?)
+          @authorised_use_provisions_submission ||=
+            filtering_by_country? && import_measures.any?(&:authorised_use_provisions_submission?)
+        end
+
+        def filtering_by_country?
+          @filtering_by_country
         end
       end
     end

--- a/app/presenters/api/v2/headings/declarable_heading_presenter.rb
+++ b/app/presenters/api/v2/headings/declarable_heading_presenter.rb
@@ -13,6 +13,7 @@ module Api
         def initialize(heading, measures)
           super(heading)
           @heading = heading
+          @filtering_by_country = measures.filtering_by_country?
           @import_measures = measures.select(&:import).map do |measure|
             Api::V2::Measures::MeasurePresenter.new(measure, self)
           end
@@ -79,7 +80,12 @@ module Api
         end
 
         def authorised_use_provisions_submission?
-          @authorised_use_provisions_submission ||= import_measures.any?(&:authorised_use_provisions_submission?)
+          @authorised_use_provisions_submission ||=
+            filtering_by_country? && import_measures.any?(&:authorised_use_provisions_submission?)
+        end
+
+        def filtering_by_country?
+          @filtering_by_country
         end
       end
     end

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -241,6 +241,13 @@ FactoryBot.define do
       measure_type { create(:measure_type, measure_type_series_id: 'Q', measure_type_id: '306') }
     end
 
+    trait :mfn do
+      with_measure_components
+      with_measure_type
+      third_country
+      duty_amount { 1 }
+    end
+
     trait :single_unit do
       measurement_unit_code { 'DTN' }
       measurement_unit_qualifier_code { 'R' }

--- a/spec/models/measure_collection_spec.rb
+++ b/spec/models/measure_collection_spec.rb
@@ -51,4 +51,22 @@ RSpec.describe MeasureCollection do
       it { expect(collection.filter).to eq([italian_measure]) }
     end
   end
+
+  describe '#filtering_by_country?' do
+    subject { collection.filtering_by_country? }
+
+    let(:measures) { [] }
+
+    context 'with country filter' do
+      let(:filters) { { geographical_area_id: 'CN' } }
+
+      it { is_expected.to be true }
+    end
+
+    context 'without country filter' do
+      let(:filters) { {} }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/models/preference_code_spec.rb
+++ b/spec/models/preference_code_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe PreferenceCode do
 
       let(:presented_measure) { Api::V2::Measures::MeasurePresenter.new(measure, presented_declarable) }
       let(:measures) { [measure] }
+      let(:measure_collection) { MeasureCollection.new measures }
 
       context 'when measure_type_id does not match any conditions' do
         let(:measure) { create(:measure) }
@@ -27,6 +28,10 @@ RSpec.describe PreferenceCode do
 
       context 'when third country duty measure' do
         let(:measure) { create(:measure, measure_type_id: '103') }
+
+        let :measure_collection do
+          MeasureCollection.new measures, geographical_area_id: 'CN'
+        end
 
         context 'when authorised_use_provisions_submission' do
           let(:measures) do
@@ -274,12 +279,18 @@ RSpec.describe PreferenceCode do
     end
 
     it_behaves_like 'a declarable preference code determine_code operation' do
-      let(:presented_declarable) { Api::V2::Commodities::CommodityPresenter.new(declarable, measures) }
+      let(:presented_declarable) do
+        Api::V2::Commodities::CommodityPresenter.new(declarable, measure_collection)
+      end
+
       let(:declarable) { create(:commodity, :with_heading) }
     end
 
     it_behaves_like 'a declarable preference code determine_code operation' do
-      let(:presented_declarable) { Api::V2::Headings::DeclarableHeadingPresenter.new(declarable, measures) }
+      let(:presented_declarable) do
+        Api::V2::Headings::DeclarableHeadingPresenter.new(declarable, measure_collection)
+      end
+
       let(:declarable) { create(:heading, :declarable) }
     end
   end

--- a/spec/models/preference_code_spec.rb
+++ b/spec/models/preference_code_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe PreferenceCode do
   it { expect(preference_code.code).to eq('100') }
   it { expect(preference_code.description).to eq('Erga Omnes third country duty rates') }
 
-  describe '#determine_code' do
+  describe '.determine_code' do
+    subject { described_class.determine_code(presented_declarable, presented_measure) }
+
     shared_examples 'a declarable preference code determine_code operation' do
       before do
         create(
@@ -20,7 +22,7 @@ RSpec.describe PreferenceCode do
       context 'when measure_type_id does not match any conditions' do
         let(:measure) { create(:measure) }
 
-        it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq(nil) }
+        it { is_expected.to eq(nil) }
       end
 
       context 'when third country duty measure' do
@@ -37,7 +39,7 @@ RSpec.describe PreferenceCode do
             [measure, authorised_use_provisions_submission_measure]
           end
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('140') }
+          it { is_expected.to eq('140') }
         end
 
         context 'when special_nature' do
@@ -52,56 +54,56 @@ RSpec.describe PreferenceCode do
             [measure, special_nature_measure]
           end
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('150') }
+          it { is_expected.to eq('150') }
         end
 
         context 'when none of above' do
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('100') }
+          it { is_expected.to eq('100') }
         end
       end
 
       context 'when non preferential duty under authorised use' do
         let(:measure) { create(:measure, measure_type_id: '105') }
 
-        it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('140') }
+        it { is_expected.to eq('140') }
       end
 
       context 'when Customs Union Duty' do
         let(:measure) { create(:measure, measure_type_id: '106') }
 
-        it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('400') }
+        it { is_expected.to eq('400') }
       end
 
       context 'when autonomous tariff suspension' do
         context 'when authorised_use' do
           let(:measure) { create(:measure, :with_measure_conditions, :with_authorised_use, measure_type_id: '112') }
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('115') }
+          it { is_expected.to eq('115') }
         end
 
         context 'when not authorised_use' do
           let(:measure) { create(:measure, :with_measure_conditions, measure_type_id: '112') }
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('110') }
+          it { is_expected.to eq('110') }
         end
       end
 
       context 'when autonomous suspension under authorised use' do
         let(:measure) { create(:measure, measure_type_id: '115') }
 
-        it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('115') }
+        it { is_expected.to eq('115') }
       end
 
       context 'when suspension - goods for certain categories of ships, boats and other vessels and for drilling or production platforms' do
         let(:measure) { create(:measure, measure_type_id: '117') }
 
-        it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('140') }
+        it { is_expected.to eq('140') }
       end
 
       context 'when airworthiness tariff suspension' do
         let(:measure) { create(:measure, measure_type_id: '119') }
 
-        it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('119') }
+        it { is_expected.to eq('119') }
       end
 
       context 'when non preferential tariff quota' do
@@ -119,37 +121,37 @@ RSpec.describe PreferenceCode do
             [measure, special_nature_measure]
           end
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('125') }
+          it { is_expected.to eq('125') }
         end
 
         context 'when authorised_use' do
           let(:measure) { create(:measure, :with_measure_conditions, :with_authorised_use, measure_type_id: '122') }
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('123') }
+          it { is_expected.to eq('123') }
         end
 
         context 'when none of above' do
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('120') }
+          it { is_expected.to eq('120') }
         end
       end
 
       context 'when non preferential tariff quota under authorised use' do
         let(:measure) { create(:measure, measure_type_id: '123') }
 
-        it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('123') }
+        it { is_expected.to eq('123') }
       end
 
       context 'when preferential suspension' do
         context 'when authorised_use' do
           let(:measure) { create(:measure, :with_measure_conditions, :with_authorised_use, measure_type_id: '141') }
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('315') }
+          it { is_expected.to eq('315') }
         end
 
         context 'when not authorised use' do
           let(:measure) { create(:measure, measure_type_id: '141') }
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('310') }
+          it { is_expected.to eq('310') }
         end
       end
 
@@ -157,25 +159,25 @@ RSpec.describe PreferenceCode do
         context 'when GSP and authorised_use' do
           let(:measure) { create(:measure, :with_gsp, :with_measure_conditions, :with_authorised_use, measure_type_id: '142') }
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('240') }
+          it { is_expected.to eq('240') }
         end
 
         context 'when GSP' do
           let(:measure) { create(:measure, :with_gsp, measure_type_id: '142') }
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('200') }
+          it { is_expected.to eq('200') }
         end
 
         context 'when authorised_use and not GSP' do
           let(:measure) { create(:measure, :with_measure_conditions, :with_authorised_use, measure_type_id: '142') }
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('340') }
+          it { is_expected.to eq('340') }
         end
 
         context 'when not authorised_use or GSP' do
           let(:measure) { create(:measure, measure_type_id: '142') }
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('300') }
+          it { is_expected.to eq('300') }
         end
       end
 
@@ -192,7 +194,7 @@ RSpec.describe PreferenceCode do
             )
           end
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('255') }
+          it { is_expected.to eq('255') }
         end
 
         context 'when GSP and authorised_use' do
@@ -206,13 +208,13 @@ RSpec.describe PreferenceCode do
             )
           end
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('223') }
+          it { is_expected.to eq('223') }
         end
 
         context 'when GSP' do
           let(:measure) { create(:measure, :with_gsp, measure_type_id: '143') }
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('220') }
+          it { is_expected.to eq('220') }
         end
 
         context 'when special_nature' do
@@ -226,19 +228,19 @@ RSpec.describe PreferenceCode do
             )
           end
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('325') }
+          it { is_expected.to eq('325') }
         end
 
         context 'when authorised_use' do
           let(:measure) { create(:measure, :with_measure_conditions, :with_authorised_use, measure_type_id: '143') }
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('323') }
+          it { is_expected.to eq('323') }
         end
 
         context 'when not any of above' do
           let(:measure) { create(:measure, measure_type_id: '143') }
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('320') }
+          it { is_expected.to eq('320') }
         end
       end
 
@@ -246,13 +248,13 @@ RSpec.describe PreferenceCode do
         context 'when GSP' do
           let(:measure) { create(:measure, :with_gsp, measure_type_id: '145') }
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('240') }
+          it { is_expected.to eq('240') }
         end
 
         context 'when not GSP' do
           let(:measure) { create(:measure, measure_type_id: '145') }
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('340') }
+          it { is_expected.to eq('340') }
         end
       end
 
@@ -260,13 +262,13 @@ RSpec.describe PreferenceCode do
         context 'when GSP' do
           let(:measure) { create(:measure, :with_gsp, measure_type_id: '146') }
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('223') }
+          it { is_expected.to eq('223') }
         end
 
         context 'when not GSP' do
           let(:measure) { create(:measure, measure_type_id: '146') }
 
-          it { expect(described_class.determine_code(presented_declarable, presented_measure)).to eq('323') }
+          it { is_expected.to eq('323') }
         end
       end
     end

--- a/spec/serializers/api/v2/commodities/commodity_serializer_spec.rb
+++ b/spec/serializers/api/v2/commodities/commodity_serializer_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Api::V2::Commodities::CommoditySerializer do
 
   let(:serializable) { Api::V2::Commodities::CommodityPresenter.new(commodity, measures) }
   let(:commodity) { create(:commodity, :with_heading, :with_chapter, :with_description).reload }
-  let(:measures) { [] }
+  let(:measures) { MeasureCollection.new [] }
 
   let(:expected_pattern) do
     {

--- a/spec/serializers/api/v2/headings/declarable_heading_serializer_spec.rb
+++ b/spec/serializers/api/v2/headings/declarable_heading_serializer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Api::V2::Headings::DeclarableHeadingSerializer do
   end
 
   let(:heading) { create(:heading, :with_description) }
-  let(:measures) { [] }
+  let(:measures) { MeasureCollection.new [] }
 
   let(:chapter) do
     create(


### PR DESCRIPTION
### Jira link

HOTT-2447

### What?

I have added/removed/altered:

- [x] Changed the logic for application of authorised_use_provisions_submission to only be applied when a country is selected

### Why?

I am doing this because:

- Measure type 464 is specific to a country, without knowing the country we cannot know whether it is an authorised_use_provisions_submission

### Deployment risks (optional)

- Low, does change the api values
