### PR TITLE
HOTT-2491 Return 404 when unknown country code

### DIFF
--- a/app/models/measure_collection.rb
+++ b/app/models/measure_collection.rb
@@ -40,6 +40,6 @@ class MeasureCollection < SimpleDelegator
   private
 
   def filtering_country
-    @filtering_country ||= GeographicalArea.find(geographical_area_id: @filters[:geographical_area_id])
+    @filtering_country ||= GeographicalArea.where(geographical_area_id: @filters[:geographical_area_id]).take
   end
 end

--- a/spec/models/measure_collection_spec.rb
+++ b/spec/models/measure_collection_spec.rb
@@ -50,6 +50,14 @@ RSpec.describe MeasureCollection do
 
       it { expect(collection.filter).to eq([italian_measure]) }
     end
+
+    context 'when filtering by unknown country' do
+      let(:measures) { create_pair :measure }
+      let(:filters) { { geographical_area_id: 'IT' } }
+      let(:service) { 'uk' }
+
+      it { expect { collection.filter }.to raise_exception Sequel::RecordNotFound }
+    end
   end
 
   describe '#filtering_by_country?' do


### PR DESCRIPTION
### Jira link

HOTT-2491

### What?

I have added/removed/altered:

- [x] Return a 404 when requesting commodity information for an unknown country

### Why?

I am doing this because:

- it the data requested does not exist and we should return an appropriate status code instead of erroring out

### Deployment risks (optional)

- Changes behaviour of an in use API
