### PR TITLE
HOTT-2555: Hide past transfer events

### DIFF
--- a/app/models/quota_definition.rb
+++ b/app/models/quota_definition.rb
@@ -1,4 +1,5 @@
 class QuotaDefinition < Sequel::Model
+  DATE_HMRC_STARTED_MANAGING_PENDING_BALANCES = Date.parse('2022-07-01').freeze
   DEFINITION_CRITICAL_STATE = 'Y'.freeze
 
   plugin :time_machine
@@ -116,7 +117,11 @@ class QuotaDefinition < Sequel::Model
     @last_blocking_period ||= quota_blocking_periods.last
   end
 
-private
+  def shows_balance_transfers?
+    validity_start_date.to_date >= DATE_HMRC_STARTED_MANAGING_PENDING_BALANCES
+  end
+
+  private
 
   # We only care about Open, Exhausted and Critical statuses from a UI perspective
   def has_active_critical_event?

--- a/app/serializers/api/v2/quotas/order_number/quota_definition_serializer.rb
+++ b/app/serializers/api/v2/quotas/order_number/quota_definition_serializer.rb
@@ -37,7 +37,7 @@ module Api
             definition.last_blocking_period.try(:blocking_end_date)
           end
 
-          has_one :incoming_quota_closed_and_transferred_event, serializer: Api::V2::Quotas::QuotaClosedAndTransferredEventSerializer
+          has_one :incoming_quota_closed_and_transferred_event, serializer: Api::V2::Quotas::QuotaClosedAndTransferredEventSerializer, if: ->(definition) { definition.shows_balance_transfers? }
         end
       end
     end

--- a/app/serializers/api/v2/quotas/quota_definition_serializer.rb
+++ b/app/serializers/api/v2/quotas/quota_definition_serializer.rb
@@ -41,7 +41,7 @@ module Api
           definition.last_blocking_period.try(:blocking_end_date)
         end
 
-        has_one :incoming_quota_closed_and_transferred_event, serializer: Api::V2::Quotas::QuotaClosedAndTransferredEventSerializer
+        has_one :incoming_quota_closed_and_transferred_event, serializer: Api::V2::Quotas::QuotaClosedAndTransferredEventSerializer, if: ->(definition) { definition.shows_balance_transfers? }
         has_one :quota_order_number, key: :order_number, record_type: :order_number, serializer: Api::V2::Quotas::QuotaOrderNumberSerializer, lazy_load_data: true
         has_many :measures, serializer: Api::V2::Shared::MeasureSerializer, lazy_load_data: true
         has_many :quota_balance_events, serializer: Api::V2::Quotas::QuotaBalanceEventSerializer, lazy_load_data: true

--- a/spec/models/quota_definition_spec.rb
+++ b/spec/models/quota_definition_spec.rb
@@ -154,4 +154,26 @@ RSpec.describe QuotaDefinition do
       it { is_expected.not_to be_present }
     end
   end
+
+  describe '#shows_balance_transfers?' do
+    subject(:quota_definition) { build(:quota_definition, validity_start_date:) }
+
+    context 'when the validity start date is before the hmrc date' do
+      let(:validity_start_date) { Date.parse('2022-06-30').iso8601 }
+
+      it { is_expected.not_to be_shows_balance_transfers }
+    end
+
+    context 'when the validity start date is on the hmrc date' do
+      let(:validity_start_date) { Date.parse('2022-07-01').iso8601 }
+
+      it { is_expected.to be_shows_balance_transfers }
+    end
+
+    context 'when the validity start date is after the hmrc date' do
+      let(:validity_start_date) { Date.parse('2022-07-02').iso8601 }
+
+      it { is_expected.to be_shows_balance_transfers }
+    end
+  end
 end

--- a/spec/serializers/api/v2/quotas/order_number/quota_definition_serializer_spec.rb
+++ b/spec/serializers/api/v2/quotas/order_number/quota_definition_serializer_spec.rb
@@ -3,8 +3,6 @@ RSpec.describe Api::V2::Quotas::OrderNumber::QuotaDefinitionSerializer do
     subject(:serializable_hash) { described_class.new(serializable, options).serializable_hash.as_json }
 
     let(:serializable) { create(:quota_definition, :with_quota_balance_events) }
-    let(:options) { {} }
-
     let(:expected_pattern) do
       {
         data: {
@@ -32,7 +30,18 @@ RSpec.describe Api::V2::Quotas::OrderNumber::QuotaDefinitionSerializer do
         },
       }
     end
+    let(:options) { {} }
+
+    before do
+      allow(serializable).to receive(:shows_balance_transfers?).and_return(true)
+    end
 
     it { is_expected.to include_json(expected_pattern) }
+
+    it 'asks the quota definition is balance transfers should be shown' do
+      serializable_hash
+
+      expect(serializable).to have_received(:shows_balance_transfers?)
+    end
   end
 end

--- a/spec/serializers/api/v2/quotas/quota_definition_serializer_spec.rb
+++ b/spec/serializers/api/v2/quotas/quota_definition_serializer_spec.rb
@@ -2,8 +2,6 @@ RSpec.describe Api::V2::Quotas::QuotaDefinitionSerializer do
   subject(:serializer) { described_class.new(serializable, options) }
 
   let(:serializable) { create(:quota_definition, :with_quota_balance_events) }
-  let(:options) { {} }
-
   let(:expected_pattern) do
     {
       data: {
@@ -36,9 +34,20 @@ RSpec.describe Api::V2::Quotas::QuotaDefinitionSerializer do
       },
     }
   end
+  let(:options) { {} }
+
+  before do
+    allow(serializable).to receive(:shows_balance_transfers?).and_return(true)
+  end
 
   describe '#serializable_hash' do
     it { expect(serializer.serializable_hash.as_json).to include_json(expected_pattern) }
+
+    it 'asks the quota definition is balance transfers should be shown' do
+      serializer.serializable_hash
+
+      expect(serializable).to have_received(:shows_balance_transfers?)
+    end
 
     context 'when passing include options' do
       before do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2555

### What?

I have added/removed/altered:

- [x] Hide transfer events before a certain start date

### Why?

I am doing this because:

- This is required to reflect when HMRC started managing balance transfers
