### PR TITLE
HOTT-2573: Remove insane duplicate XML validation

### DIFF
--- a/app/lib/tariff_synchronizer/cds_update.rb
+++ b/app/lib/tariff_synchronizer/cds_update.rb
@@ -45,10 +45,6 @@ module TariffSynchronizer
       Date.new(*sequence_date)
     end
 
-    def self.validate_file!(_gzip_string)
-      true
-    end
-
     def to_param
       filename.sub('.gzip', '')
     end

--- a/app/lib/tariff_synchronizer/taric_update.rb
+++ b/app/lib/tariff_synchronizer/taric_update.rb
@@ -81,12 +81,6 @@ module TariffSynchronizer
       filename.match(REGEX_TARIC_SEQUENCE)
     end
 
-    def self.validate_file!(xml_string)
-      Ox.parse(xml_string)
-    rescue Ox::ParseError => e
-      raise InvalidContents.new(e.message, e)
-    end
-
     def next_update
       self.class.new(
         filename: next_update_sequence_update_filename,

--- a/app/lib/tariff_synchronizer/tariff_downloader.rb
+++ b/app/lib/tariff_synchronizer/tariff_downloader.rb
@@ -64,11 +64,9 @@ module TariffSynchronizer
     end
 
     # We do not create records for missing updates
-    def create_record_for_not_found_response
-    end
+    def create_record_for_not_found_response; end
 
     def create_record_for_successful_response
-      update_klass.validate_file!(response.content) # Validate response
       update_or_create(filename, BaseUpdate::PENDING_STATE, response.content.size)
       write_update_file(response.content)
       @success = true

--- a/spec/unit/tariff_synchronizer/tariff_downloader_spec.rb
+++ b/spec/unit/tariff_synchronizer/tariff_downloader_spec.rb
@@ -1,0 +1,86 @@
+RSpec.describe TariffSynchronizer::TariffDownloader do
+  describe '#perform' do
+    subject(:perform) { described_class.new(filename, url, date, update_klass).perform }
+
+    let(:filename) { 'foo.xml.gzip' }
+    let(:url) { 'https://example.com/download-the-file' }
+    let(:date) { Date.current }
+    let(:update_klass) { TariffSynchronizer::CdsUpdate }
+
+    context 'when the file is already downloaded' do
+      before do
+        allow(TariffSynchronizer::FileService).to receive(:file_exists?).with('tmp/data/cds/foo.xml.gzip').and_return(true)
+        allow(TariffSynchronizer::FileService).to receive(:file_size).with('tmp/data/cds/foo.xml.gzip').and_return(1)
+        allow(TariffSynchronizer::TariffUpdatesRequester).to receive(:perform).with(url)
+      end
+
+      context 'when an update already exists' do
+        before do
+          create(:cds_update, :pending, filename:, issue_date: date, filesize: 1)
+        end
+
+        it { expect { perform }.not_to change(update_klass, :count) }
+
+        it 'does not request to download the file' do
+          perform
+          expect(TariffSynchronizer::TariffUpdatesRequester).not_to have_received(:perform)
+        end
+      end
+
+      context 'when an does not yet exists' do
+        it { expect { perform }.to change(update_klass, :count).by(1) }
+
+        it 'does not request to download the file' do
+          perform
+          expect(TariffSynchronizer::TariffUpdatesRequester).not_to have_received(:perform)
+        end
+      end
+    end
+
+    context 'when the file has not been downloaded yet' do
+      before do
+        allow(TariffSynchronizer::TariffUpdatesRequester).to receive(:perform).with(url).and_return(response)
+      end
+
+      context 'when the download response is empty' do
+        let(:response) { build(:response, :blank) }
+
+        it 'creates a failed update' do
+          expect { perform }
+            .to change { update_klass.where(state: TariffSynchronizer::BaseUpdate::FAILED_STATE).count }
+            .by(1)
+        end
+      end
+
+      context 'when the download response is retry exceeded' do
+        let(:response) { build(:response, :retry_exceeded) }
+
+        it 'creates a failed update' do
+          expect { perform }
+            .to change { update_klass.where(state: TariffSynchronizer::BaseUpdate::FAILED_STATE).count }
+            .by(1)
+        end
+      end
+
+      context 'when the download response is not found' do
+        let(:response) { build(:response, :not_found) }
+
+        it { expect { perform }.not_to change(update_klass, :count) }
+      end
+
+      context 'when the download response is successful' do
+        before do
+          allow(TariffSynchronizer::FileService).to receive(:write_file).with('tmp/data/cds/foo.xml.gzip', be_a(String))
+        end
+
+        let(:response) { build(:response, :success) }
+
+        it 'creates a pending update' do
+          expect { perform }
+            .to change { update_klass.where(state: TariffSynchronizer::BaseUpdate::PENDING_STATE).count }
+            .by(1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2573

### What?

I have added/removed/altered:

- [x] Added specs to cover downloading ETL files
- [x] Removed insane validation of XML by non-SAX parsing

### Why?

I am doing this because:

- This was non-SAX parsing and undermining the whole point of using an
event driven parsing implementation
- We had no coverage of this behaviour and needed it 
