### PR TITLE
HOTT-2553: Adds origin reference spelling model loader

### DIFF
--- a/app/lib/spelling_corrector/loaders/origin_reference.rb
+++ b/app/lib/spelling_corrector/loaders/origin_reference.rb
@@ -1,0 +1,47 @@
+module SpellingCorrector
+  module Loaders
+    class OriginReference
+      ORIGIN_REFERENCE_OBJECTS_PREFIX_PATH = 'spelling-corrector/origin-reference/'.freeze
+
+      def load
+        each_term do |term|
+          terms[term] += 1
+        end
+
+        terms
+      end
+
+      def terms
+        @terms ||= Hash.new(0)
+      end
+
+      private
+
+      def each_term
+        each_file do |io|
+          io.each_line do |line|
+            line.scan(/\w+/).map do |term|
+              normalised_term = SpellingCorrector::TermHandlerService.new(term).call
+
+              yield normalised_term if normalised_term.present?
+            end
+          end
+        end
+      end
+
+      def each_file
+        object_summaries.each do |object_summary|
+          yield object_summary.get.body
+        end
+      end
+
+      def object_summaries
+        bucket.objects(prefix: ORIGIN_REFERENCE_OBJECTS_PREFIX_PATH)
+      end
+
+      def bucket
+        Rails.application.config.spelling_corrector_s3_bucket
+      end
+    end
+  end
+end

--- a/app/services/spelling_corrector/file_updater_service.rb
+++ b/app/services/spelling_corrector/file_updater_service.rb
@@ -7,6 +7,7 @@ module SpellingCorrector
       SpellingCorrector::Loaders::References,
       SpellingCorrector::Loaders::Intercepts,
       SpellingCorrector::Loaders::StopWords,
+      SpellingCorrector::Loaders::OriginReference,
     ].freeze
 
     SPELLING_MODEL_PATH = 'spelling-corrector/spelling-model.txt'.freeze

--- a/spec/fixtures/spelling_corrector/origin_reference/bar.txt
+++ b/spec/fixtures/spelling_corrector/origin_reference/bar.txt
@@ -1,0 +1,1 @@
+The Origin Reference Document implementing the Agreement establishing a Strategic Partnership and Cooperation Agreement between the United Kingdom of Great Britain and Northern Ireland and Georgia

--- a/spec/fixtures/spelling_corrector/origin_reference/foo.txt
+++ b/spec/fixtures/spelling_corrector/origin_reference/foo.txt
@@ -1,0 +1,1 @@
+Origin Reference Document implementing the Agreement Establishing an Association between the United Kingdom of Great Britain and Northern Ireland and the Republic of Tunisia

--- a/spec/lib/spelling_corrector/loaders/origin_reference_spec.rb
+++ b/spec/lib/spelling_corrector/loaders/origin_reference_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe SpellingCorrector::Loaders::OriginReference do
+  include_context 'with a stubbed s3 bucket'
+
+  describe '#load' do
+    subject(:load) { described_class.new.load }
+
+    let(:expected_terms) do
+      {
+        'the' => 6,
+        'and' => 5,
+        'agreement' => 3,
+        'ireland' => 2,
+        'northern' => 2,
+        'britain' => 2,
+        'great' => 2,
+        'kingdom' => 2,
+        'united' => 2,
+        'between' => 2,
+        'establishing' => 2,
+        'implementing' => 2,
+        'document' => 2,
+        'reference' => 2,
+        'origin' => 2,
+        'georgia' => 1,
+        'cooperation' => 1,
+        'partnership' => 1,
+        'strategic' => 1,
+        'tunisia' => 1,
+        'republic' => 1,
+        'association' => 1,
+      }
+    end
+
+    it { is_expected.to eq(expected_terms) }
+  end
+end

--- a/spec/services/spelling_corrector/file_updater_service_spec.rb
+++ b/spec/services/spelling_corrector/file_updater_service_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe SpellingCorrector::FileUpdaterService do
         allow(SpellingCorrector::Loaders::References).to receive(:new).and_call_original
         allow(SpellingCorrector::Loaders::Intercepts).to receive(:new).and_call_original
         allow(SpellingCorrector::Loaders::StopWords).to receive(:new).and_call_original
+        allow(SpellingCorrector::Loaders::OriginReference).to receive(:new).and_call_original
 
         upload_file
       end
@@ -34,6 +35,7 @@ RSpec.describe SpellingCorrector::FileUpdaterService do
       it { expect(SpellingCorrector::Loaders::References).to have_received(:new) }
       it { expect(SpellingCorrector::Loaders::Intercepts).to have_received(:new) }
       it { expect(SpellingCorrector::Loaders::StopWords).to have_received(:new) }
+      it { expect(SpellingCorrector::Loaders::OriginReference).to have_received(:new) }
     end
 
     context 'when the bucket is not setup' do

--- a/spec/support/shared_contexts/with_a_stubbed_s3_bucket.rb
+++ b/spec/support/shared_contexts/with_a_stubbed_s3_bucket.rb
@@ -1,9 +1,35 @@
 RSpec.shared_context 'with a stubbed s3 bucket' do
   before do
-    stubbed_initial_model_file = StringIO.new(file_fixture('spelling_corrector/initial-spelling-model.txt').read)
-
-    s3_bucket.client.stub_responses(:get_object, { body: stubbed_initial_model_file })
+    s3_bucket.client.stub_responses(:get_object, get_object_handler)
+    s3_bucket.client.stub_responses(:list_objects_v2, list_objects_v2_handler)
     s3_bucket.client.stub_responses(:put_object)
+  end
+
+  let(:get_object_handler) do
+    lambda do |context|
+      case context.params[:key]
+      when 'spelling-corrector/initial-spelling-model.txt'
+        { body: StringIO.new(file_fixture('spelling_corrector/initial-spelling-model.txt').read) }
+      when 'spelling-corrector/origin-reference/foo.txt'
+        { body: StringIO.new(file_fixture('spelling_corrector/origin_reference/foo.txt').read) }
+      when 'spelling-corrector/origin-reference/bar.txt'
+        { body: StringIO.new(file_fixture('spelling_corrector/origin_reference/bar.txt').read) }
+      end
+    end
+  end
+
+  let(:list_objects_v2_handler) do
+    lambda do |context|
+      case context.params[:prefix]
+      when 'spelling-corrector/origin-reference/'
+        {
+          contents: [
+            { key: 'spelling-corrector/origin-reference/foo.txt' },
+            { key: 'spelling-corrector/origin-reference/bar.txt' },
+          ],
+        }
+      end
+    end
   end
 
   let(:s3_bucket) do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2553

### What?

I have added/removed/altered:

- [x] Adds origin reference loader and specs

### Why?

I am doing this because:

- This is required so that the spelling functionality can understand origin reference terms
