### PR TITLE
HOTT-1613: Quota order number missing deletes

### DIFF
--- a/app/lib/cds_importer/entity_mapper/quota_order_number_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/quota_order_number_mapper.rb
@@ -11,6 +11,8 @@ class CdsImporter
         'sid' => :quota_order_number_sid,
         'quotaOrderNumberId' => :quota_order_number_id,
       ).freeze
+
+      delete_missing_entities QuotaOrderNumberOriginMapper
     end
   end
 end

--- a/app/lib/cds_importer/entity_mapper/quota_order_number_origin_exclusion_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/quota_order_number_origin_exclusion_mapper.rb
@@ -18,6 +18,10 @@ class CdsImporter
         'quotaOrderNumberOrigin.sid' => :quota_order_number_origin_sid,
         "#{mapping_path}.geographicalArea.sid" => :excluded_geographical_area_sid,
       ).freeze
+
+      self.primary_filters = {
+        quota_order_number_origin_sid: :quota_order_number_origin_sid,
+      }.freeze
     end
   end
 end

--- a/app/lib/cds_importer/entity_mapper/quota_order_number_origin_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/quota_order_number_origin_mapper.rb
@@ -1,7 +1,3 @@
-#
-# QuotaOrderNumberOrigin is nested in to QuotaOrderNumber.
-#
-
 class CdsImporter
   class EntityMapper
     class QuotaOrderNumberOriginMapper < BaseMapper
@@ -19,6 +15,12 @@ class CdsImporter
         "#{mapping_path}.geographicalArea.geographicalAreaId" => :geographical_area_id,
         "#{mapping_path}.geographicalArea.sid" => :geographical_area_sid,
       ).freeze
+
+      self.primary_filters = {
+        quota_order_number_sid: :quota_order_number_sid,
+      }.freeze
+
+      delete_missing_entities QuotaOrderNumberOriginExclusionMapper
     end
   end
 end

--- a/app/lib/cds_importer/xml_parser.rb
+++ b/app/lib/cds_importer/xml_parser.rb
@@ -31,7 +31,7 @@ class CdsImporter
       end
 
       def characters(val)
-        return if !@in_target || val == EXTRA_CONTENT
+        return if !@in_target || val =~ EXTRA_CONTENT
 
         @node[CONTENT_KEY] = val
       end

--- a/app/models/quota_order_number_origin.rb
+++ b/app/models/quota_order_number_origin.rb
@@ -11,4 +11,6 @@ class QuotaOrderNumberOrigin < Sequel::Model
   end
 
   delegate :description, to: :geographical_area, prefix: true
+
+  one_to_many :quota_order_number_origin_exclusions
 end

--- a/spec/factories/quota_factory.rb
+++ b/spec/factories/quota_factory.rb
@@ -42,6 +42,21 @@ FactoryBot.define do
       quota_definition_validity_end_date { Time.zone.yesterday }
     end
 
+    trait :with_quota_order_number_origin do
+      transient do
+        quota_order_number_origin_sid { generate(:sid) }
+      end
+
+      after(:create) do |quota_order_number, evaluator|
+        create(
+          :quota_order_number_origin,
+          :with_quota_order_number_origin_exclusion,
+          quota_order_number_sid: quota_order_number.quota_order_number_sid,
+          quota_order_number_origin_sid: evaluator.quota_order_number_origin_sid,
+        )
+      end
+    end
+
     trait :with_quota_definition do
       transient do
         quota_balance_events { false }
@@ -90,6 +105,15 @@ FactoryBot.define do
         geographical_area = create(:geographical_area)
         qon.geographical_area_id = geographical_area.geographical_area_id
         qon.geographical_area_sid = geographical_area.geographical_area_sid
+      end
+    end
+
+    trait :with_quota_order_number_origin_exclusion do
+      after(:create) do |qon|
+        create(
+          :quota_order_number_origin_exclusion,
+          quota_order_number_origin_sid: qon.quota_order_number_origin_sid,
+        )
       end
     end
   end

--- a/spec/lib/cds_importer/entity_mapper/quota_order_number_mapper_spec.rb
+++ b/spec/lib/cds_importer/entity_mapper/quota_order_number_mapper_spec.rb
@@ -1,27 +1,120 @@
 RSpec.describe CdsImporter::EntityMapper::QuotaOrderNumberMapper do
-  it_behaves_like 'an entity mapper', 'QuotaOrderNumber', 'QuotaOrderNumber' do
-    let(:xml_node) do
-      {
-        'sid' => '21811',
-        'quotaOrderNumberId' => '090718',
-        'validityStartDate' => '1970-01-01T00:00:00',
-        'validityEndDate' => '1972-01-01T00:00:00',
-        'metainfo' => {
-          'opType' => 'U',
-          'transactionDate' => '2016-07-27T09:20:17',
+  let(:xml_node) do
+    {
+      'hjid' => '11914339',
+      'metainfo' => {
+        'opType' => operation,
+        'origin' => 'T',
+        'status' => 'L',
+        'transactionDate' => '2022-09-16T10:49:00',
+      },
+      'sid' => '21006',
+      'quotaOrderNumberId' => '058027',
+      'validityStartDate' => '2022-07-01T00:00:00',
+      'quotaOrderNumberOrigin' => [
+        {
+          'hjid' => '11914340',
+          'metainfo' => {
+            'opType' => operation,
+            'origin' => 'T',
+            'status' => 'L',
+            'transactionDate' => '2022-09-16T10:49:00',
+          },
+          'sid' => '21120',
+          'validityStartDate' => '2022-07-01T00:00:00',
+          'geographicalArea' => {
+            'hjid' => '10643021',
+            'sid' => '496',
+            'geographicalAreaId' => '5050',
+            'validityStartDate' => '2021-01-01T00:00:00',
+          },
+          'quotaOrderNumberOriginExclusions' => [
+            {
+              'hjid' => '11914399',
+              'metainfo' => {
+                'opType' => operation,
+                'origin' => 'T',
+                'status' => 'L',
+                'transactionDate' => '2022-06-30T19:20:14',
+              },
+              'geographicalArea' => {
+                'hjid' => '23522',
+                'sid' => '92',
+                'geographicalAreaId' => 'SI',
+                'validityStartDate' => '1991-11-15T00:00:00',
+              },
+            },
+          ],
         },
-      }
-    end
+      ],
+      'filename' => 'foo.zip',
+    }
+  end
+
+  it_behaves_like 'an entity mapper', 'QuotaOrderNumber', 'QuotaOrderNumber' do
+    let(:operation) { 'U' }
 
     let(:expected_values) do
       {
-        validity_start_date: Time.zone.parse('1970-01-01T00:00:00.000Z'),
-        validity_end_date: Time.zone.parse('1972-01-01T00:00:00.000Z'),
+        validity_start_date: '2022-07-01T00:00:00.000Z',
+        validity_end_date: nil,
         operation: 'U',
-        operation_date: Date.parse('2016-07-27'),
-        quota_order_number_sid: 21_811,
-        quota_order_number_id: '090718',
+        operation_date: Date.parse('2022-09-16 2022'),
+        quota_order_number_sid: 21_006,
+        quota_order_number_id: '058027',
       }
+    end
+  end
+
+  describe '#import' do
+    subject(:entity_mapper) { CdsImporter::EntityMapper.new('QuotaOrderNumber', xml_node) }
+
+    context 'when the quota_order_number is being updated' do
+      let(:operation) { 'U' }
+
+      it_behaves_like 'an entity mapper update operation', QuotaOrderNumber
+      it_behaves_like 'an entity mapper update operation', QuotaOrderNumberOrigin
+      it_behaves_like 'an entity mapper update operation', QuotaOrderNumberOriginExclusion
+    end
+
+    context 'when the quota_order_number is being created' do
+      let(:operation) { 'C' }
+
+      it_behaves_like 'an entity mapper create operation', QuotaOrderNumber
+      it_behaves_like 'an entity mapper create operation', QuotaOrderNumberOrigin
+      it_behaves_like 'an entity mapper create operation', QuotaOrderNumberOriginExclusion
+    end
+
+    context 'when the quota_order_number is being deleted' do
+      before do
+        create(:quota_order_number, quota_order_number_sid: '21006')
+        create(:quota_order_number_origin, quota_order_number_origin_sid: '21120')
+        create(:quota_order_number_origin_exclusion, quota_order_number_origin_sid: '21120', excluded_geographical_area_sid: '92')
+      end
+
+      let(:operation) { 'D' }
+
+      it_behaves_like 'an entity mapper destroy operation', QuotaOrderNumber
+      it_behaves_like 'an entity mapper destroy operation', QuotaOrderNumberOrigin
+      it_behaves_like 'an entity mapper destroy operation', QuotaOrderNumberOriginExclusion
+    end
+
+    context 'when there are missing secondary entities to be soft deleted' do
+      let(:operation) { 'C' }
+
+      before do
+        # Creates entities that will be missing from the xml node
+        create(
+          :quota_order_number,
+          :with_quota_order_number_origin,
+          quota_order_number_sid: '21006',
+        )
+
+        # Control for non-deleted secondary entities
+        create(:quota_order_number_origin, quota_order_number_sid: '21006', quota_order_number_origin_sid: '21120')
+      end
+
+      it_behaves_like 'an entity mapper missing destroy operation', QuotaOrderNumberOrigin, quota_order_number_sid: '21006'
     end
   end
 end

--- a/spec/lib/cds_importer/entity_mapper/quota_order_number_origin_mapper_spec.rb
+++ b/spec/lib/cds_importer/entity_mapper/quota_order_number_origin_mapper_spec.rb
@@ -1,43 +1,93 @@
 RSpec.describe CdsImporter::EntityMapper::QuotaOrderNumberOriginMapper do
-  it_behaves_like 'an entity mapper', 'QuotaOrderNumberOrigin', 'QuotaOrderNumber' do
-    let(:xml_node) do
-      {
-        'sid' => '12113',
-        'quotaOrderNumberOrigin' => {
-          'sid' => '1485',
-          'geographicalArea' => {
-            'sid' => '11993',
-            'geographicalAreaId' => '1101',
-            'metainfo' => {
-              'opType' => 'U',
-              'transactionDate' => '2017-07-15T22:27:51',
-            },
-          },
-          'validityStartDate' => '1970-01-01T00:00:00',
-          'validityEndDate' => '1971-01-01T00:00:00',
+  let(:xml_node) do
+    {
+      'hjid' => '11914339',
+      'metainfo' => {
+        'opType' => operation,
+        'origin' => 'T',
+        'status' => 'L',
+        'transactionDate' => '2022-09-16T10:49:00',
+      },
+      'sid' => '21006',
+      'quotaOrderNumberId' => '058027',
+      'validityStartDate' => '2022-07-01T00:00:00',
+      'quotaOrderNumberOrigin' => [
+        {
+          'hjid' => '11914340',
           'metainfo' => {
-            'opType' => 'C',
-            'transactionDate' => '2017-04-11T10:05:31',
+            'opType' => operation,
+            'origin' => 'T',
+            'status' => 'L',
+            'transactionDate' => '2022-09-16T10:49:00',
           },
+          'sid' => '21120',
+          'validityStartDate' => '2022-07-01T00:00:00',
+          'geographicalArea' => {
+            'hjid' => '10643021',
+            'sid' => '496',
+            'geographicalAreaId' => '5050',
+            'validityStartDate' => '2021-01-01T00:00:00',
+          },
+          'quotaOrderNumberOriginExclusions' => [
+            {
+              'hjid' => '11914399',
+              'metainfo' => {
+                'opType' => operation,
+                'origin' => 'T',
+                'status' => 'L',
+                'transactionDate' => '2022-06-30T19:20:14',
+              },
+              'geographicalArea' => {
+                'hjid' => '23522',
+                'sid' => '92',
+                'geographicalAreaId' => 'SI',
+                'validityStartDate' => '1991-11-15T00:00:00',
+              },
+            },
+          ],
         },
-        'metainfo' => {
-          'opType' => 'U',
-          'transactionDate' => '2017-06-29T20:04:37',
-        },
-      }
-    end
+      ],
+      'filename' => 'foo.zip',
+    }
+  end
+
+  it_behaves_like 'an entity mapper', 'QuotaOrderNumberOrigin', 'QuotaOrderNumber' do
+    let(:operation) { 'U' }
 
     let(:expected_values) do
       {
-        validity_start_date: Time.zone.parse('1970-01-01T00:00:00.000Z'),
-        validity_end_date: Time.zone.parse('1971-01-01T00:00:00.000Z'),
-        operation: 'C',
-        operation_date: Date.parse('2017-04-11'),
-        quota_order_number_origin_sid: 1485,
-        quota_order_number_sid: 12_113,
-        geographical_area_id: '1101',
-        geographical_area_sid: 11_993,
+        validity_start_date: '2022-07-01T00:00:00.000Z',
+        validity_end_date: nil,
+        operation: 'U',
+        operation_date: Date.parse('2022-09-16'),
+        quota_order_number_origin_sid: 21_120,
+        quota_order_number_sid: 21_006,
+        geographical_area_id: '5050',
+        geographical_area_sid: 496,
       }
+    end
+  end
+
+  describe '#import' do
+    subject(:entity_mapper) { CdsImporter::EntityMapper.new('QuotaOrderNumber', xml_node) }
+
+    context 'when there are missing secondary entities to be soft deleted' do
+      let(:operation) { 'C' }
+
+      before do
+        # Creates entities that will be missing from the xml node
+        create(
+          :quota_order_number,
+          :with_quota_order_number_origin,
+          quota_order_number_sid: '21006',
+          quota_order_number_origin_sid: '21120',
+        )
+
+        # Control for non-deleted secondary entities
+        create(:quota_order_number_origin_exclusion, quota_order_number_origin_sid: '21120', excluded_geographical_area_sid: '92')
+      end
+
+      it_behaves_like 'an entity mapper missing destroy operation', QuotaOrderNumberOriginExclusion, quota_order_number_origin_sid: '21120'
     end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1613

### What?

I have added/removed/altered:

- [x] Clear out excess unused content from CDS parser
- [x] Enable missing deletes of quota order numbers

### Why?

I am doing this because:

- The excess content has no impact - it just looks weird in a console
- This will mean that when CDS/DIT/TAP produce a file which is missing some order number secondaries in it we will clear them out
