### PR TITLE
HOTT-1612: Update primary keys of quota definition secondaries

### DIFF
--- a/app/lib/cds_importer/entity_mapper/quota_association_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/quota_association_mapper.rb
@@ -1,8 +1,3 @@
-#
-# QuotaAssociation is nested in to QuotaDefinition.
-# So we will pass @values for QuotaAssociation the same as for QuotaDefinition.
-#
-
 class CdsImporter
   class EntityMapper
     class QuotaAssociationMapper < BaseMapper

--- a/app/lib/cds_importer/entity_mapper/quota_critical_event_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/quota_critical_event_mapper.rb
@@ -1,7 +1,3 @@
-#
-# QuotaCriticalEvent is nested in to QuotaDefinition.
-#
-
 class CdsImporter
   class EntityMapper
     class QuotaCriticalEventMapper < BaseMapper

--- a/app/lib/cds_importer/entity_mapper/quota_exhaustion_event_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/quota_exhaustion_event_mapper.rb
@@ -1,7 +1,3 @@
-#
-# QuotaExhaustionEvent is nested in to QuotaDefinition.
-#
-
 class CdsImporter
   class EntityMapper
     class QuotaExhaustionEventMapper < BaseMapper

--- a/app/lib/cds_importer/entity_mapper/quota_reopening_event_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/quota_reopening_event_mapper.rb
@@ -1,7 +1,3 @@
-#
-# QuotaReopeningEvent is nested in to QuotaDefinition.
-#
-
 class CdsImporter
   class EntityMapper
     class QuotaReopeningEventMapper < BaseMapper

--- a/app/lib/cds_importer/entity_mapper/quota_suspension_period_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/quota_suspension_period_mapper.rb
@@ -1,7 +1,3 @@
-#
-# QuotaSuspensionPeriod is nested in to QuotaDefinition.
-#
-
 class CdsImporter
   class EntityMapper
     class QuotaSuspensionPeriodMapper < BaseMapper

--- a/app/lib/cds_importer/entity_mapper/quota_unsuspension_event_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/quota_unsuspension_event_mapper.rb
@@ -1,7 +1,3 @@
-#
-# QuotaUnsuspensionEvent is nested in to QuotaDefinition.
-#
-
 class CdsImporter
   class EntityMapper
     class QuotaUnsuspensionEventMapper < BaseMapper

--- a/app/models/quota_blocking_period.rb
+++ b/app/models/quota_blocking_period.rb
@@ -1,7 +1,7 @@
 class QuotaBlockingPeriod < Sequel::Model
-  plugin :time_machine, period_start_column: :blocking_start_date,
-                        period_end_column: :blocking_end_date
-  plugin :oplog, primary_key: :quota_definition_sid
+  plugin :oplog, primary_key: :quota_blocking_period_sid
+
+  plugin :time_machine, period_start_column: :blocking_start_date, period_end_column: :blocking_end_date
 
   set_primary_key [:quota_blocking_period_sid]
 end

--- a/app/models/quota_exhaustion_event.rb
+++ b/app/models/quota_exhaustion_event.rb
@@ -1,10 +1,9 @@
 class QuotaExhaustionEvent < Sequel::Model
-  plugin :oplog, primary_key: :quota_definition_sid
+  plugin :oplog, primary_key: %i[quota_definition_sid occurrence_timestamp]
 
-  set_primary_key [:quota_definition_sid]
+  set_primary_key %i[quota_definition_sid occurrence_timestamp]
 
-  many_to_one :quota_definition, key: :quota_definition_sid,
-                                 primary_key: :quota_definition_sid
+  many_to_one :quota_definition, key: :quota_definition_sid, primary_key: :quota_definition_sid
 
   def self.status
     'Exhausted'

--- a/app/models/quota_reopening_event.rb
+++ b/app/models/quota_reopening_event.rb
@@ -1,10 +1,10 @@
 class QuotaReopeningEvent < Sequel::Model
-  plugin :oplog, primary_key: :quota_definition_sid
+  plugin :oplog, primary_key: %i[quota_definition_sid
+                                 occurrence_timestamp]
 
-  set_primary_key [:quota_definition_sid]
+  set_primary_key %i[quota_definition_sid occurrence_timestamp]
 
-  many_to_one :quota_definition, key: :quota_definition_sid,
-                                 primary_key: :quota_definition_sid
+  many_to_one :quota_definition, key: :quota_definition_sid, primary_key: :quota_definition_sid
 
   def self.status
     'Open'

--- a/app/models/quota_unblocking_event.rb
+++ b/app/models/quota_unblocking_event.rb
@@ -1,10 +1,9 @@
 class QuotaUnblockingEvent < Sequel::Model
-  plugin :oplog, primary_key: %i[oid quota_definition_sid]
+  plugin :oplog, primary_key: %i[quota_definition_sid occurrence_timestamp]
 
-  many_to_one :quota_definition, key: :quota_definition_sid,
-                                 primary_key: :quota_definition_sid
+  set_primary_key %i[quota_definition_sid occurrence_timestamp]
 
-  set_primary_key [:quota_definition_sid]
+  many_to_one :quota_definition, key: :quota_definition_sid, primary_key: :quota_definition_sid
 
   def self.status
     'Open'

--- a/app/models/quota_unsuspension_event.rb
+++ b/app/models/quota_unsuspension_event.rb
@@ -1,10 +1,10 @@
 class QuotaUnsuspensionEvent < Sequel::Model
-  plugin :oplog, primary_key: :quota_definition_sid
+  plugin :oplog, primary_key: %i[quota_definition_sid
+                                 occurrence_timestamp]
 
-  set_primary_key [:quota_definition_sid]
+  set_primary_key %i[quota_definition_sid occurrence_timestamp]
 
-  many_to_one :quota_definition, key: :quota_definition_sid,
-                                 primary_key: :quota_definition_sid
+  many_to_one :quota_definition, key: :quota_definition_sid, primary_key: :quota_definition_sid
 
   def self.status
     'Open'


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2590

### What?

I have added/removed/altered:

- [x] Altered the primary keys of various quota events
- [x] Fixed the incorrect primary key of the blocking period model

### Why?

I am doing this because:

- The current status of a quota definition can change multiple times (e.g. become exhausted, then critical and back again). This wouldn't be reflected if the exhausted could only exist once in the history of the quota definition. We may also want to plot these events on the graph in the admin UI at a later date.
- The blocking period model was not using its correct primary key
