### PR TITLE
HOTT-2593: Remove brittle check of transferred amount

### DIFF
--- a/app/lib/cds_importer/entity_mapper/quota_closed_and_transferred_event_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/quota_closed_and_transferred_event_mapper.rb
@@ -31,10 +31,9 @@ class CdsImporter
       end
 
       def self.xml_node_equivalent_to_model_instance?(model_instance, xml_node)
-        model_instance.transferred_amount.to_s == xml_node['transferredAmount'] &&
-          xml_node['closingDate'].to_s.include?(model_instance.closing_date.iso8601) &&
+        xml_node['closingDate'].to_s.include?(model_instance.closing_date.iso8601) &&
           model_instance.occurrence_timestamp.iso8601.include?(xml_node['occurrenceTimestamp']) &&
-          model_instance.target_quota_definition_sid.to_s == xml_node['targetQuotaDefinition']['sid']
+          model_instance.target_quota_definition_sid.to_s == xml_node.dig('targetQuotaDefinition', 'sid').to_s
       end
     end
   end

--- a/spec/lib/cds_importer/entity_mapper/quota_closed_and_transferred_event_mapper_spec.rb
+++ b/spec/lib/cds_importer/entity_mapper/quota_closed_and_transferred_event_mapper_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CdsImporter::EntityMapper::QuotaClosedAndTransferredEventMapper d
             'sid' => '21322',
             'validityStartDate' => '2022-04-01T00:00:00', # newer date
           },
-          'transferredAmount' => '769858.493',
+          'transferredAmount' => '769858',
         },
         { # Invalid older dated transfer event - not imported
           'metainfo' => { 'opType' => 'C', 'transactionDate' => '2022-01-31T17:38:16' },

--- a/spec/lib/cds_importer/entity_mapper/quota_closed_and_transferred_event_mapper_spec.rb
+++ b/spec/lib/cds_importer/entity_mapper/quota_closed_and_transferred_event_mapper_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe CdsImporter::EntityMapper::QuotaClosedAndTransferredEventMapper d
         quota_definition_sid: 21_321,
         occurrence_timestamp: Time.zone.parse('2022-05-03T13:04:00'),
         target_quota_definition_sid: 21_322,
-        transferred_amount: 769_858.493,
+        transferred_amount: 769_858,
         closing_date: Date.parse('2022-05-03'),
       }
     end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2593

### What?

I have added/removed/altered:

- Adds failing spec to capture transferred_amount issue
- Removes check on transferred amount to find equivalent node (making the test pass)

### Why?

I am doing this because:

- This is required to make sure we can import transfer events that have a different string representation for their transferred amounts than what we would pull out of the model

```ruby
a = event.transferred_amount.to_s => "1444634.0"
b = xml_node_event['transferredAmount'] => "1444634"

a == b => false
```
