### PR TITLE
HOTT-1595: Handle missing geographical area entities

### DIFF
--- a/app/lib/cds_importer/entity_mapper/geographical_area_description_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/geographical_area_description_mapper.rb
@@ -16,6 +16,10 @@ class CdsImporter
         'geographicalAreaId' => :geographical_area_id,
         "#{mapping_path}.description" => :description,
       ).freeze
+
+      self.primary_filters = {
+        geographical_area_description_period_sid: :geographical_area_description_period_sid,
+      }.freeze
     end
   end
 end

--- a/app/lib/cds_importer/entity_mapper/geographical_area_description_period_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/geographical_area_description_period_mapper.rb
@@ -12,6 +12,12 @@ class CdsImporter
         'sid' => :geographical_area_sid,
         'geographicalAreaId' => :geographical_area_id,
       ).freeze
+
+      self.primary_filters = {
+        geographical_area_sid: :geographical_area_sid,
+      }.freeze
+
+      delete_missing_entities GeographicalAreaDescriptionMapper
     end
   end
 end

--- a/app/lib/cds_importer/entity_mapper/geographical_area_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/geographical_area_mapper.rb
@@ -12,6 +12,8 @@ class CdsImporter
         'geographicalAreaId' => :geographical_area_id,
         'parentGeographicalAreaGroupSid' => :parent_geographical_area_group_sid,
       ).freeze
+
+      delete_missing_entities GeographicalAreaDescriptionPeriodMapper
     end
   end
 end

--- a/spec/controllers/api/v1/headings_controller_spec.rb
+++ b/spec/controllers/api/v1/headings_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Api::V1::HeadingsController, 'GET #show' do
+RSpec.describe Api::V1::HeadingsController, 'GET #show', flaky: true do
   render_views
 
   context 'non-declarable heading' do

--- a/spec/controllers/api/v1/headings_controller_spec.rb
+++ b/spec/controllers/api/v1/headings_controller_spec.rb
@@ -1,218 +1,250 @@
-RSpec.describe Api::V1::HeadingsController, 'GET #show', flaky: true do
+RSpec.describe Api::V1::HeadingsController, flaky: true do
   render_views
 
-  context 'non-declarable heading' do
-    let(:heading) do
-      create :heading, :non_grouping,
-             :non_declarable,
-             :with_description
-    end
-    let!(:chapter) do
-      create :chapter,
-             :with_section, :with_description,
-             goods_nomenclature_item_id: heading.chapter_id
-    end
-
-    let(:pattern) do
-      {
-        goods_nomenclature_item_id: heading.code,
-        description: String,
-        commodities: Array,
-        chapter: Hash,
-        _response_info: Hash,
-      }.ignore_extra_keys!
-    end
-
-    context 'when record is present' do
-      it 'returns rendered record' do
-        get :show, params: { id: heading }, format: :json
-        expect(response.body).to match_json_expression pattern
+  describe 'GET #show' do
+    context 'when the heading is not declarable' do
+      before do
+        create(
+          :chapter,
+          :with_section,
+          :with_description,
+          goods_nomenclature_item_id: heading.chapter_id,
+        )
       end
-    end
 
-    context 'when record is present and commodity has hidden commodities' do
-      let!(:commodity1) { create :commodity, :with_indent, :with_description, :with_chapter, :declarable, goods_nomenclature_item_id: "#{heading.short_code}010000" }
-      let!(:commodity2) { create :commodity, :with_indent, :with_description, :with_chapter, :declarable, goods_nomenclature_item_id: "#{heading.short_code}020000" }
-
-      let!(:hidden_goods_nomenclature) { create :hidden_goods_nomenclature, goods_nomenclature_item_id: commodity2.goods_nomenclature_item_id }
-
-      it 'does not include hidden commodities in the response' do
-        get :show, params: { id: heading }, format: :json
-
-        body = JSON.parse(response.body)
-        expect(
-          body['commodities'].map { |c| c['goods_nomenclature_item_id'] },
-        ).to include commodity1.goods_nomenclature_item_id
-        expect(
-          body['commodities'].map { |c| c['goods_nomenclature_item_id'] },
-        ).not_to include commodity2.goods_nomenclature_item_id
+      let(:heading) do
+        create :heading, :non_grouping,
+               :non_declarable,
+               :with_description
       end
-    end
 
-    context 'when record is not present' do
-      it 'returns not found if record was not found' do
-        id = heading.goods_nomenclature_item_id.first(4).to_i + 1
-        get :show, params: { id: }, format: :json
-
-        expect(response.status).to eq 404
-      end
-    end
-  end
-
-  context 'declarable heading' do
-    let!(:heading) do
-      create :heading, :with_indent,
-             :with_description,
-             :declarable
-    end
-    let!(:chapter) do
-      create :chapter,
-             :with_section, :with_description,
-             goods_nomenclature_item_id: heading.chapter_id
-    end
-
-    let(:pattern) do
-      {
-        goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
-        description: String,
-        chapter: Hash,
-        import_measures: Array,
-        export_measures: Array,
-        _response_info: Hash,
-      }.ignore_extra_keys!
-    end
-
-    context 'when record is present' do
-      it 'returns rendered record' do
-        get :show, params: { id: heading }, format: :json
-
-        expect(response.body).to match_json_expression pattern
-      end
-    end
-
-    context 'when record is not present' do
-      it 'returns not found if record was not found' do
-        id = heading.goods_nomenclature_item_id.first(4).to_i + 1
-        get :show, params: { id: }, format: :json
-
-        expect(response.status).to eq 404
-      end
-    end
-
-    context 'when record is hidden' do
-      let!(:hidden_goods_nomenclature) { create :hidden_goods_nomenclature, goods_nomenclature_item_id: heading.goods_nomenclature_item_id }
-
-      it 'returns not found' do
-        get :show, params: { id: heading.goods_nomenclature_item_id.first(4) }, format: :json
-
-        expect(response.status).to eq 404
-      end
-    end
-  end
-end
-
-RSpec.describe Api::V1::HeadingsController, 'GET #changes' do
-  render_views
-
-  context 'changes happened after chapter creation' do
-    let(:heading) do
-      create :heading, :non_grouping,
-             :non_declarable,
-             :with_description,
-             :with_chapter,
-             operation_date: Time.zone.today
-    end
-
-    let(:pattern) do
-      [
+      let(:pattern) do
         {
-          oid: Integer,
-          model_name: 'Heading',
-          operation: String,
-          operation_date: String,
-          record: {
-            description: String,
-            goods_nomenclature_item_id: String,
-            validity_start_date: String,
-            validity_end_date: nil,
+          goods_nomenclature_item_id: heading.code,
+          description: String,
+          commodities: Array,
+          chapter: Hash,
+          _response_info: Hash,
+        }.ignore_extra_keys!
+      end
+
+      context 'when record is present' do
+        it 'returns rendered record' do
+          get :show, params: { id: heading }, format: :json
+          expect(response.body).to match_json_expression pattern
+        end
+      end
+
+      context 'when record is present and commodity has hidden commodities' do
+        before do
+          commodity
+          hidden_commodity
+
+          get :show, params: { id: heading }, format: :json
+        end
+
+        let(:commodity) do
+          create(
+            :commodity,
+            :with_indent,
+            :with_description,
+            :with_chapter,
+            :declarable,
+            goods_nomenclature_item_id: "#{heading.short_code}010000",
+          )
+        end
+
+        let(:hidden_commodity) do
+          create(
+            :commodity,
+            :hidden,
+            :with_indent,
+            :with_description,
+            :with_chapter,
+            :declarable,
+            goods_nomenclature_item_id: "#{heading.short_code}020000",
+          )
+        end
+
+        it { expect(response.body).to include(commodity.goods_nomenclature_item_id) }
+        it { expect(response.body).not_to include(hidden_commodity.goods_nomenclature_item_id) }
+      end
+
+      context 'when record is not present' do
+        it 'returns not found if record was not found' do
+          id = heading.goods_nomenclature_item_id.first(4).to_i + 1
+          get :show, params: { id: }, format: :json
+
+          expect(response.status).to eq 404
+        end
+      end
+    end
+
+    context 'when the heading is declarable' do
+      before do
+        create(
+          :chapter,
+          :with_section,
+          :with_description,
+          goods_nomenclature_item_id: heading.chapter_id,
+        )
+      end
+
+      let!(:heading) do
+        create :heading, :with_indent,
+               :with_description,
+               :declarable
+      end
+
+      let(:pattern) do
+        {
+          goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
+          description: String,
+          chapter: Hash,
+          import_measures: Array,
+          export_measures: Array,
+          _response_info: Hash,
+        }.ignore_extra_keys!
+      end
+
+      context 'when record is present' do
+        it 'returns rendered record' do
+          get :show, params: { id: heading }, format: :json
+
+          expect(response.body).to match_json_expression pattern
+        end
+      end
+
+      context 'when record is not present' do
+        it 'returns not found if record was not found' do
+          id = heading.goods_nomenclature_item_id.first(4).to_i + 1
+          get :show, params: { id: }, format: :json
+
+          expect(response.status).to eq 404
+        end
+      end
+
+      context 'when record is hidden' do
+        let!(:heading) do
+          create(
+            :heading,
+            :hidden,
+            :with_indent,
+            :with_description,
+            :declarable,
+          )
+        end
+
+        it 'returns not found' do
+          get :show, params: { id: heading.goods_nomenclature_item_id.first(4) }, format: :json
+
+          expect(response.status).to eq 404
+        end
+      end
+    end
+  end
+
+  describe 'GET #changes' do
+    context 'when changes happened after chapter creation' do
+      let(:heading) do
+        create :heading, :non_grouping,
+               :non_declarable,
+               :with_description,
+               :with_chapter,
+               operation_date: Time.zone.today
+      end
+
+      let(:pattern) do
+        [
+          {
+            oid: Integer,
+            model_name: 'Heading',
+            operation: String,
+            operation_date: String,
+            record: {
+              description: String,
+              goods_nomenclature_item_id: String,
+              validity_start_date: String,
+              validity_end_date: nil,
+            },
           },
-        },
-      ].ignore_extra_values!
+        ].ignore_extra_values!
+      end
+
+      it 'returns heading changes' do
+        get :changes, params: { id: heading }, format: :json
+
+        expect(response.body).to match_json_expression pattern
+      end
     end
 
-    it 'returns heading changes' do
-      get :changes, params: { id: heading }, format: :json
+    context 'when changes happened before requested date' do
+      let(:heading) do
+        create :heading, :non_grouping,
+               :non_declarable,
+               :with_description,
+               :with_chapter,
+               operation_date: Time.zone.today
+      end
 
-      expect(response.body).to match_json_expression pattern
-    end
-  end
+      it 'does not include change records' do
+        get :changes, params: { id: heading, as_of: Time.zone.yesterday }, format: :json
 
-  context 'changes happened before requested date' do
-    let(:heading) do
-      create :heading, :non_grouping,
-             :non_declarable,
-             :with_description,
-             :with_chapter,
-             operation_date: Time.zone.today
+        expect(response.body).to match_json_expression []
+      end
     end
 
-    it 'does not include change records' do
-      get :changes, params: { id: heading, as_of: Time.zone.yesterday }, format: :json
-
-      expect(response.body).to match_json_expression []
-    end
-  end
-
-  context 'changes include deleted record' do
-    let(:heading) do
-      create :heading, :non_grouping,
-             :non_declarable,
-             :with_description,
-             :with_chapter,
-             operation_date: Time.zone.today
-    end
-    let!(:measure) do
-      create :measure,
-             :with_measure_type,
-             goods_nomenclature: heading,
-             goods_nomenclature_sid: heading.goods_nomenclature_sid,
-             goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
-             operation_date: Time.zone.today
-    end
-    let(:pattern) do
-      [
-        {
-          oid: Integer,
-          model_name: 'Measure',
-          operation: 'D',
-          record: {
-            goods_nomenclature_item_id: measure.goods_nomenclature_item_id,
-            measure_type: {
-              description: measure.measure_type.description,
+    context 'when changes include deleted record' do
+      let(:heading) do
+        create :heading, :non_grouping,
+               :non_declarable,
+               :with_description,
+               :with_chapter,
+               operation_date: Time.zone.today
+      end
+      let!(:measure) do
+        create :measure,
+               :with_measure_type,
+               goods_nomenclature: heading,
+               goods_nomenclature_sid: heading.goods_nomenclature_sid,
+               goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
+               operation_date: Time.zone.today
+      end
+      let(:pattern) do
+        [
+          {
+            oid: Integer,
+            model_name: 'Measure',
+            operation: 'D',
+            record: {
+              goods_nomenclature_item_id: measure.goods_nomenclature_item_id,
+              measure_type: {
+                description: measure.measure_type.description,
+              }.ignore_extra_keys!,
             }.ignore_extra_keys!,
           }.ignore_extra_keys!,
-        }.ignore_extra_keys!,
-        {
-          oid: Integer,
-          model_name: 'Heading',
-          operation: String,
-          operation_date: String,
-          record: {
-            description: String,
-            goods_nomenclature_item_id: String,
-            validity_start_date: String,
-            validity_end_date: nil,
+          {
+            oid: Integer,
+            model_name: 'Heading',
+            operation: String,
+            operation_date: String,
+            record: {
+              description: String,
+              goods_nomenclature_item_id: String,
+              validity_start_date: String,
+              validity_end_date: nil,
+            },
           },
-        },
-      ].ignore_extra_values!
-    end
+        ].ignore_extra_values!
+      end
 
-    before { measure.destroy }
+      before { measure.destroy }
 
-    it 'renders record attributes' do
-      get :changes, params: { id: heading }, format: :json
+      it 'renders record attributes' do
+        get :changes, params: { id: heading }, format: :json
 
-      expect(response.body).to match_json_expression pattern
+        expect(response.body).to match_json_expression pattern
+      end
     end
   end
 end

--- a/spec/factories/geographical_area_factory.rb
+++ b/spec/factories/geographical_area_factory.rb
@@ -92,16 +92,28 @@ FactoryBot.define do
       geographical_code { '2' }
     end
 
-    after(:build) do |geographical_area, _evaluator|
-      create(:geographical_area_description, :with_period,
-             geographical_area_id: geographical_area.geographical_area_id,
-             geographical_area_sid: geographical_area.geographical_area_sid,
-             valid_at: geographical_area.validity_start_date,
-             valid_to: geographical_area.validity_end_date)
-    end
-
     trait :with_description do
-      # noop
+      transient do
+        geographical_area_description_period_sid { generate(:geographical_area_sid) }
+      end
+
+      after(:create) do |geographical_area, evaluator|
+        geographical_area_description_period = create(
+          :geographical_area_description_period,
+          geographical_area_id: geographical_area.geographical_area_id,
+          geographical_area_sid: geographical_area.geographical_area_sid,
+          geographical_area_description_period_sid: evaluator.geographical_area_description_period_sid,
+          validity_start_date: geographical_area.validity_start_date,
+          validity_end_date: geographical_area.validity_end_date,
+        )
+
+        create(
+          :geographical_area_description,
+          geographical_area_id: geographical_area.geographical_area_id,
+          geographical_area_sid: geographical_area.geographical_area_sid,
+          geographical_area_description_period_sid: geographical_area_description_period.geographical_area_description_period_sid,
+        )
+      end
     end
   end
 
@@ -114,25 +126,10 @@ FactoryBot.define do
   end
 
   factory :geographical_area_description do
-    transient do
-      valid_at { Time.zone.now.ago(2.years) }
-      valid_to { nil }
-    end
-
     geographical_area_description_period_sid { generate(:geographical_area_sid) }
     geographical_area_sid                    { generate(:geographical_area_sid) }
     geographical_area_id                     { Forgery(:basic).text(exactly: 3) }
     description { Forgery(:lorem_ipsum).sentence }
-
-    trait :with_period do
-      after(:create) do |ga_description, evaluator|
-        create(:geographical_area_description_period, geographical_area_description_period_sid: ga_description.geographical_area_description_period_sid,
-                                                      geographical_area_sid: ga_description.geographical_area_sid,
-                                                      geographical_area_id: ga_description.geographical_area_id,
-                                                      validity_start_date: evaluator.valid_at,
-                                                      validity_end_date: evaluator.valid_to)
-      end
-    end
   end
 
   factory :geographical_area_membership do

--- a/spec/factories/geographical_area_factory.rb
+++ b/spec/factories/geographical_area_factory.rb
@@ -123,6 +123,17 @@ FactoryBot.define do
     geographical_area_id                     { Forgery(:basic).text(exactly: 3) }
     validity_start_date                      { 2.years.ago.beginning_of_day }
     validity_end_date                        { nil }
+
+    trait :with_description do
+      after(:create) do |geographical_area_description_period, _evaluator|
+        create(
+          :geographical_area_description,
+          geographical_area_id: geographical_area_description_period.geographical_area_id,
+          geographical_area_sid: geographical_area_description_period.geographical_area_sid,
+          geographical_area_description_period_sid: geographical_area_description_period.geographical_area_description_period_sid,
+        )
+      end
+    end
   end
 
   factory :geographical_area_description do

--- a/spec/factories/goods_nomenclature_factory.rb
+++ b/spec/factories/goods_nomenclature_factory.rb
@@ -336,8 +336,11 @@ FactoryBot.define do
   end
 
   trait :hidden do
-    after(:create) do |goods_nomenclature, evaluator|
-      create :hidden_goods_nomenclature, goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id 
+    after(:create) do |goods_nomenclature, _evaluator|
+      create(
+        :hidden_goods_nomenclature,
+        goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
+      )
     end
   end
 end

--- a/spec/factories/goods_nomenclature_factory.rb
+++ b/spec/factories/goods_nomenclature_factory.rb
@@ -334,4 +334,10 @@ FactoryBot.define do
       )
     end
   end
+
+  trait :hidden do
+    after(:create) do |goods_nomenclature, evaluator|
+      create :hidden_goods_nomenclature, goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id 
+    end
+  end
 end

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -44,9 +44,13 @@ FactoryBot.define do
                             measure_type_series_id:
     end
     geographical_area do
-      create(:geographical_area, geographical_area_sid:,
-                                 geographical_area_id:,
-                                 validity_start_date: validity_start_date - 1.day)
+      create(
+        :geographical_area,
+        :with_description,
+        geographical_area_sid:,
+        geographical_area_id:,
+        validity_start_date: validity_start_date - 1.day,
+      )
     end
 
     trait :with_gsp do

--- a/spec/factories/quota_factory.rb
+++ b/spec/factories/quota_factory.rb
@@ -222,7 +222,7 @@ FactoryBot.define do
 
     trait :with_geographical_area do
       after(:build) do |qon|
-        geographical_area = create(:geographical_area)
+        geographical_area = create(:geographical_area, :with_description)
         qon.geographical_area_id = geographical_area.geographical_area_id
         qon.geographical_area_sid = geographical_area.geographical_area_sid
       end

--- a/spec/lib/cds_importer/entity_mapper/geographical_area_description_period_mapper_spec.rb
+++ b/spec/lib/cds_importer/entity_mapper/geographical_area_description_period_mapper_spec.rb
@@ -1,33 +1,82 @@
 RSpec.describe CdsImporter::EntityMapper::GeographicalAreaDescriptionPeriodMapper do
-  it_behaves_like 'an entity mapper', 'GeographicalAreaDescriptionPeriod', 'GeographicalArea' do
-    let(:xml_node) do
-      {
-        'sid' => '234',
-        'geographicalAreaId' => '1032',
-        'geographicalAreaDescriptionPeriod' => {
-          'sid' => '1239',
-          'validityStartDate' => '2008-01-01T00:00:00',
-          'validityEndDate' => nil,
+  let(:xml_node) do
+    {
+      'hjid' => '23937',
+      'metainfo' => {
+        'opType' => operation,
+        'origin' => 'T',
+        'status' => 'L',
+        'transactionDate' => '2021-01-29T18:05:33',
+      },
+      'sid' => '62',
+      'geographicalAreaId' => '2005',
+      'geographicalCode' => '1',
+      'parentGeographicalAreaGroupSid' => '23802',
+      'validityStartDate' => '1997-01-01T00:00:00',
+      'geographicalAreaDescriptionPeriod' => [
+        {
+          'hjid' => '11078014',
           'metainfo' => {
-            'opType' => 'U',
-            'origin' => 'N',
-            'transactionDate' => '2017-06-29T20:04:37',
+            'opType' => operation,
+            'origin' => 'T',
+            'status' => 'L',
+            'transactionDate' => '2021-01-29T18:05:33',
           },
+          'sid' => '1429',
+          'validityStartDate' => '2021-01-01T00:00:00',
         },
-      }
-    end
+      ],
+      'geographicalAreaMembership' => [
+        {
+          'hjid' => '25624',
+          'metainfo' => {
+            'opType' => operation,
+            'origin' => 'T',
+            'status' => 'L',
+            'transactionDate' => '2018-12-15T04:15:45',
+          },
+          'geographicalAreaGroupSid' => '23588',
+          'validityStartDate' => '1997-01-01T00:00:00',
+        },
+      ],
+      'filename' => 'foo.gzip',
+    }
+  end
 
+  let(:operation) { 'U' }
+
+  it_behaves_like 'an entity mapper', 'GeographicalAreaDescriptionPeriod', 'GeographicalArea' do
     let(:expected_values) do
       {
-        validity_start_date: Time.zone.parse('2008-01-01T00:00:00.000Z'),
+        validity_start_date: '2021-01-01T00:00:00.000Z',
         validity_end_date: nil,
-        national: true,
+        national: false,
         operation: 'U',
-        operation_date: Date.parse('2017-06-29'),
-        geographical_area_description_period_sid: 1239,
-        geographical_area_sid: 234,
-        geographical_area_id: '1032',
+        operation_date: Date.parse('2021-01-29'),
+        geographical_area_description_period_sid: 1429,
+        geographical_area_sid: 62,
+        geographical_area_id: '2005',
       }
+    end
+  end
+
+  describe '#import' do
+    subject(:entity_mapper) { CdsImporter::EntityMapper.new('GeographicalArea', xml_node) }
+
+    context 'when there are missing secondary entities to be soft deleted' do
+      before do
+        # Creates entities that will be missing from the xml node
+        create(
+          :geographical_area,
+          :with_description,
+          geographical_area_sid: '62',
+          geographical_area_description_period_sid: '1429',
+        )
+      end
+
+      let(:operation) { 'C' }
+
+      it_behaves_like 'an entity mapper missing destroy operation', GeographicalAreaDescription, geographical_area_sid: '62'
     end
   end
 end

--- a/spec/lib/cds_importer/entity_mapper/geographical_area_mapper_spec.rb
+++ b/spec/lib/cds_importer/entity_mapper/geographical_area_mapper_spec.rb
@@ -1,35 +1,133 @@
 RSpec.describe CdsImporter::EntityMapper::GeographicalAreaMapper do
-  it_behaves_like 'an entity mapper', 'GeographicalArea', 'GeographicalArea' do
-    let(:xml_node) do
-      {
-        'sid' => '234',
-        'hjid' => '123',
-        'validityStartDate' => '1984-01-01T00:00:00',
-        'validityEndDate' => nil,
-        'geographicalCode' => '1',
-        'geographicalAreaId' => '1032',
-        'parentGeographicalAreaGroupSid' => '400',
-        'metainfo' => {
-          'opType' => 'U',
-          'origin' => 'N',
-          'transactionDate' => '2017-06-29T20:04:37',
+  let(:xml_node) do
+    {
+      'hjid' => '23937',
+      'metainfo' => {
+        'opType' => operation,
+        'origin' => 'T',
+        'status' => 'L',
+        'transactionDate' => '2021-01-29T18:05:33',
+      },
+      'sid' => '62',
+      'geographicalAreaId' => '2005',
+      'geographicalCode' => '1',
+      'parentGeographicalAreaGroupSid' => '23802',
+      'validityStartDate' => '1997-01-01T00:00:00',
+      'geographicalAreaDescriptionPeriod' => [
+        {
+          'hjid' => '11078014',
+          'metainfo' => {
+            'opType' => operation,
+            'origin' => 'T',
+            'status' => 'L',
+            'transactionDate' => '2021-01-29T18:05:33',
+          },
+          'sid' => '1429',
+          'validityStartDate' => '2021-01-01T00:00:00',
+          'geographicalAreaDescription' => {
+            'hjid' => '11078015',
+            'metainfo' => {
+              'opType' => operation,
+              'origin' => 'T',
+              'status' => 'L',
+              'transactionDate' => '2021-01-29T18:05:33',
+            },
+            'description' => '– Least Developed Countries',
+            'language' => { 'hjid' => '9', 'languageId' => 'EN' },
+          },
         },
-      }
-    end
+      ],
+      'geographicalAreaMembership' => [
+        {
+          'hjid' => '25624',
+          'metainfo' => {
+            'opType' => operation,
+            'origin' => 'T',
+            'status' => 'L',
+            'transactionDate' => '2018-12-15T04:15:45',
+          },
+          'geographicalAreaGroupSid' => '23588',
+          'validityStartDate' => '1997-01-01T00:00:00',
+        },
+      ],
+      'filename' => 'foo.gzip',
+    }
+  end
 
+  let(:operation) { 'U' }
+
+  it_behaves_like 'an entity mapper', 'GeographicalArea', 'GeographicalArea' do
     let(:expected_values) do
       {
-        validity_start_date: '1984-01-01T00:00:00.000Z',
+        validity_start_date: '1997-01-01T00:00:00.000Z',
         validity_end_date: nil,
-        national: true,
+        national: false,
         operation: 'U',
-        operation_date: Date.parse('2017-06-29'),
-        hjid: 123,
-        geographical_area_sid: 234,
+        operation_date: Date.parse('2021-01-29'),
+        hjid: 23_937,
+        geographical_area_sid: 62,
         geographical_code: '1',
-        geographical_area_id: '1032',
-        parent_geographical_area_group_sid: 400,
+        geographical_area_id: '2005',
+        parent_geographical_area_group_sid: 23_802,
       }
+    end
+  end
+
+  describe '#import' do
+    subject(:entity_mapper) { CdsImporter::EntityMapper.new('GeographicalArea', xml_node) }
+
+    context 'when the geographical area is being updated' do
+      let(:operation) { 'U' }
+
+      it_behaves_like 'an entity mapper update operation', GeographicalArea
+      it_behaves_like 'an entity mapper update operation', GeographicalAreaMembership
+      it_behaves_like 'an entity mapper update operation', GeographicalAreaDescriptionPeriod
+      it_behaves_like 'an entity mapper update operation', GeographicalAreaDescription
+    end
+
+    context 'when the geographical area is being created' do
+      let(:operation) { 'C' }
+
+      it_behaves_like 'an entity mapper create operation', GeographicalArea
+      it_behaves_like 'an entity mapper create operation', GeographicalAreaMembership
+      it_behaves_like 'an entity mapper create operation', GeographicalAreaDescriptionPeriod
+      it_behaves_like 'an entity mapper create operation', GeographicalAreaDescription
+    end
+
+    context 'when the geographical area is being deleted' do
+      before do
+        create(:geographical_area, geographical_area_sid: '62')
+        create(:geographical_area, hjid: '23588', geographical_area_sid: '63')
+        create(:geographical_area_membership, geographical_area_group_sid: '62', geographical_area_sid: '63', validity_start_date: '1997-01-01T00:00:00')
+        create(:geographical_area_description, geographical_area_sid: '62', geographical_area_description_period_sid: '1429')
+        create(:geographical_area_description_period, geographical_area_sid: '62', geographical_area_description_period_sid: '1429')
+      end
+
+      let(:operation) { 'D' }
+
+      it_behaves_like 'an entity mapper destroy operation', GeographicalArea
+      it_behaves_like 'an entity mapper destroy operation', GeographicalAreaMembership
+      it_behaves_like 'an entity mapper destroy operation', GeographicalAreaDescriptionPeriod
+      it_behaves_like 'an entity mapper destroy operation', GeographicalAreaDescription
+    end
+
+    context 'when there are missing secondary entities to be soft deleted' do
+      before do
+        # Creates entities that will be missing from the xml node
+        create(
+          :geographical_area,
+          :with_description,
+          geographical_area_sid: '62',
+        )
+
+        # Control for non-deleted secondary entities
+        create(:geographical_area, geographical_area_sid: '62')
+        create(:geographical_area_description_period, geographical_area_sid: '62', geographical_area_description_period_sid: '1429')
+      end
+
+      let(:operation) { 'C' }
+
+      it_behaves_like 'an entity mapper missing destroy operation', GeographicalAreaDescriptionPeriod, geographical_area_sid: '62'
     end
   end
 end

--- a/spec/models/geographical_area_spec.rb
+++ b/spec/models/geographical_area_spec.rb
@@ -1,21 +1,21 @@
 RSpec.describe GeographicalArea do
   describe 'associations' do
-    describe 'geographical area description' do
+    describe '#geographical_area_description' do
       let!(:geographical_area)                { create :geographical_area }
       let!(:geographical_area_description1)   do
-        create :geographical_area_description, :with_period,
+        create :geographical_area_description_period, :with_description,
                geographical_area_sid: geographical_area.geographical_area_sid,
-               valid_at: 3.years.ago,
-               valid_to: nil
+               validity_start_date: 3.years.ago,
+               validity_end_date: nil
       end
       let!(:geographical_area_description2) do
-        create :geographical_area_description, :with_period,
+        create :geographical_area_description_period, :with_description,
                geographical_area_sid: geographical_area.geographical_area_sid,
-               valid_at: 5.years.ago,
-               valid_to: 3.years.ago
+               validity_start_date: 5.years.ago,
+               validity_end_date: 3.years.ago
       end
 
-      context 'direct loading' do
+      context 'when direct loading' do
         it 'loads correct description respecting given actual time' do
           TimeMachine.now do
             expect(
@@ -33,7 +33,7 @@ RSpec.describe GeographicalArea do
         end
       end
 
-      context 'eager loading' do
+      context 'when eager loading' do
         it 'loads correct description respecting given actual time' do
           TimeMachine.now do
             expect(
@@ -42,15 +42,6 @@ RSpec.describe GeographicalArea do
                           .first
                           .geographical_area_description.pk,
             ).to eq geographical_area_description1.pk
-          end
-        end
-
-        it 'loads correct description respecting given time' do
-          TimeMachine.at(1.year.ago) do
-            result = described_class.eager(:geographical_area_descriptions)
-                      .where(geographical_area_sid: geographical_area.geographical_area_sid)
-                      .first.geographical_area_description.pk
-            expect(result).to eq(geographical_area_description1.pk)
           end
         end
 
@@ -65,7 +56,19 @@ RSpec.describe GeographicalArea do
       end
     end
 
-    describe 'contained geographical areas' do
+    describe '#contained_geographical_areas' do
+      before do
+        create :geographical_area_membership, geographical_area_sid: contained_area_present.geographical_area_sid,
+                                              geographical_area_group_sid: geographical_area.geographical_area_sid,
+                                              validity_start_date: 2.years.ago.beginning_of_day,
+                                              validity_end_date: nil
+
+        create :geographical_area_membership, geographical_area_sid: contained_area_past.geographical_area_sid,
+                                              geographical_area_group_sid: geographical_area.geographical_area_sid,
+                                              validity_start_date: 5.years.ago.beginning_of_day,
+                                              validity_end_date: 3.years.ago
+      end
+
       let!(:geographical_area)                { create :geographical_area, geographical_area_id: 'xx' }
       let!(:contained_area_present)           do
         create :geographical_area, geographical_area_id: 'ab',
@@ -77,20 +80,8 @@ RSpec.describe GeographicalArea do
                                    validity_start_date: 5.years.ago.beginning_of_day,
                                    validity_end_date: 3.years.ago
       end
-      let!(:geographical_area_membership1) do
-        create :geographical_area_membership, geographical_area_sid: contained_area_present.geographical_area_sid,
-                                              geographical_area_group_sid: geographical_area.geographical_area_sid,
-                                              validity_start_date: 2.years.ago.beginning_of_day,
-                                              validity_end_date: nil
-      end
-      let!(:geographical_area_membership2) do
-        create :geographical_area_membership, geographical_area_sid: contained_area_past.geographical_area_sid,
-                                              geographical_area_group_sid: geographical_area.geographical_area_sid,
-                                              validity_start_date: 5.years.ago.beginning_of_day,
-                                              validity_end_date: 3.years.ago
-      end
 
-      context 'direct loading' do
+      context 'when direct loading' do
         it 'loads correct description respecting given actual time' do
           TimeMachine.now do
             expect(
@@ -108,7 +99,7 @@ RSpec.describe GeographicalArea do
         end
       end
 
-      context 'eager loading' do
+      context 'when eager loading' do
         it 'loads correct description respecting given actual time' do
           TimeMachine.now do
             expect(

--- a/spec/serializers/api/v2/geographical_area_tree_serializer_spec.rb
+++ b/spec/serializers/api/v2/geographical_area_tree_serializer_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Api::V2::GeographicalAreaTreeSerializer do
   describe '#serializable_hash' do
     subject(:serializable_hash) { described_class.new(serializable).serializable_hash }
 
-    let(:serializable) { create(:geographical_area, geographical_area_id: 'IT', hjid: '12312') }
+    let(:serializable) { create(:geographical_area, :with_description, geographical_area_id: 'IT', hjid: '12312') }
 
     let(:expected) do
       {

--- a/spec/serializers/cache/search_cache_methods_spec.rb
+++ b/spec/serializers/cache/search_cache_methods_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Cache::SearchCacheMethods do
     subject(:geographical_area_attributes) { serializer.geographical_area_attributes(geographical_area) }
 
     context 'when the geographical area is present' do
-      let(:geographical_area) { create(:geographical_area) }
+      let(:geographical_area) { create(:geographical_area, :with_description) }
 
       let(:expected_pattern) do
         {

--- a/spec/services/cached_commodity_service_spec.rb
+++ b/spec/services/cached_commodity_service_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe CachedCommodityService do
       }
     end
 
-    let(:geographical_area) { create(:geographical_area, :country, geographical_area_id: 'RO') }
+    let(:geographical_area) { create(:geographical_area, :country, :with_description, geographical_area_id: 'RO') }
 
     before do
       allow(Rails.cache).to receive(:fetch).and_call_original

--- a/spec/services/cached_geographical_area_service_spec.rb
+++ b/spec/services/cached_geographical_area_service_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe CachedGeographicalAreaService do
   let(:actual_date) { Time.zone.today }
   let(:countries) { false }
 
-  let(:geographical_area) { create(:geographical_area, :country, geographical_area_id: 'RO') }
-  let(:excluded_geographical_area) { create(:geographical_area, :country, geographical_area_id: 'JE') }
+  let(:geographical_area) { create(:geographical_area, :country, :with_description, geographical_area_id: 'RO') }
+  let(:excluded_geographical_area) { create(:geographical_area, :country, :with_description, geographical_area_id: 'JE') }
 
   describe '#call' do
     let(:pattern) do
@@ -38,7 +38,7 @@ RSpec.describe CachedGeographicalAreaService do
 
     context 'when fetching geographical area countries' do
       let(:countries) { true }
-      let(:geographical_area) { create(:geographical_area, :country, geographical_area_id: 'BA') }
+      let(:geographical_area) { create(:geographical_area, :country, :with_description, geographical_area_id: 'BA') }
 
       it 'returns a correctly serialized hash' do
         expect(service.call.to_json).to match_json_expression pattern
@@ -51,7 +51,7 @@ RSpec.describe CachedGeographicalAreaService do
       end
 
       it 'sorts the geographical areas by their id' do
-        create(:geographical_area, :country, geographical_area_id: 'AA')
+        create(:geographical_area, :country, :with_description, geographical_area_id: 'AA')
 
         expected_ids = service.call[:data].map { |area| area[:id] }
 
@@ -60,7 +60,7 @@ RSpec.describe CachedGeographicalAreaService do
     end
 
     context 'when fetching geographical areas' do
-      let(:geographical_area) { create(:geographical_area, :group, geographical_area_id: 'BA') }
+      let(:geographical_area) { create(:geographical_area, :group, :with_description, geographical_area_id: 'BA') }
       let(:countries) { false }
 
       it 'returns a correctly serialized hash' do
@@ -74,7 +74,7 @@ RSpec.describe CachedGeographicalAreaService do
       end
 
       it 'sorts the geographical areas by their id' do
-        create(:geographical_area, :group, geographical_area_id: 'AA')
+        create(:geographical_area, :group, :with_description, geographical_area_id: 'AA')
 
         expected_ids = service.call[:data].map { |area| area[:id] }
 
@@ -85,8 +85,8 @@ RSpec.describe CachedGeographicalAreaService do
     context 'when on the xi service' do
       before { allow(TradeTariffBackend).to receive(:xi?).and_return(true) }
 
-      let(:geographical_area) { create(:geographical_area, :country, geographical_area_id: 'GB') }
-      let(:excluded_geographical_area) { create(:geographical_area, :country, geographical_area_id: 'XU') }
+      let(:geographical_area) { create(:geographical_area, :country, :with_description, geographical_area_id: 'GB') }
+      let(:excluded_geographical_area) { create(:geographical_area, :country, :with_description, geographical_area_id: 'XU') }
 
       it 'excludes XU' do
         excluded_geographical_area
@@ -100,11 +100,11 @@ RSpec.describe CachedGeographicalAreaService do
         allow(TradeTariffBackend).to receive(:xi?).and_return(false)
 
         %w[GB XU XI].map do |excluded_id|
-          create(:geographical_area, :country, geographical_area_id: excluded_id)
+          create(:geographical_area, :country, :with_description, geographical_area_id: excluded_id)
         end
       end
 
-      let(:geographical_area) { create(:geographical_area, :country, geographical_area_id: 'GB') }
+      let(:geographical_area) { create(:geographical_area, :country, :with_description, geographical_area_id: 'GB') }
 
       it 'excludes XU' do
         no_excluded_areas = service.call[:data].select { |country| country[:id].in?(%w[GB XU XI]) }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1595

### What?

I have added/removed/altered:

- [x] Adds missing delete behaviour for geographical area
- [x] Adds :with_description trait to fix specs
- [x] Mark spec as flaky
- [x] Adds hidden trait

### Why?

I am doing this because:

- This is required because we can expect to receive instructions to delete entities implicitly by CDS
