### PR TITLE
HOTT-2595: Fixes smelly design and reverse engineering attributes

### DIFF
--- a/app/lib/cds_importer/entity_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper.rb
@@ -37,11 +37,6 @@ class CdsImporter
     end
 
     class << self
-      # Constrains the applicable mappers in a primary node deletion operation
-      #
-      # This is required because CDS do not mark secondary and tertiary nested xml nodes for deletion
-      # themselves and we have to ignore importing them in the event of the primary xml node being deleted as
-      # this is managed by a separate callback process (see each primary entity mapper for what gets soft deleted).
       def applicable_mappers_for(key, xml_node)
         mappers = all_mappers.select { |mapper| mapper&.mapping_root == key }.sort_by(&:sort_key)
         mappers.map { |mapper| mapper.new(xml_node) }

--- a/app/lib/cds_importer/entity_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper.rb
@@ -19,8 +19,18 @@ class CdsImporter
 
         instances = mapper.parse
 
-        instances.each do |model_instance|
-          mapper.before_oplog_inserts_callbacks.each { |callback| callback.call(xml_node, mapper, model_instance) }
+        instances.each do |model_configuration|
+          model_instance = model_configuration[:instance]
+          expanded_model_values = model_configuration[:expanded_attributes]
+
+          mapper.before_oplog_inserts_callbacks.each do |callback|
+            callback.call(
+              xml_node,
+              mapper,
+              model_instance,
+              expanded_model_values,
+            )
+          end
 
           record_inserter = CdsImporter::RecordInserter.new(model_instance, mapper, @filename)
 

--- a/app/lib/cds_importer/entity_mapper/base_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/base_mapper.rb
@@ -182,22 +182,6 @@ class CdsImporter
         expanded.map(&method(:build_instance))
       end
 
-      def destroy_operation?
-        @xml_node.dig('metainfo', 'opType') == Sequel::Plugins::Oplog::DESTROY_OPERATION &&
-          primary?
-      end
-
-      # In the CDS file we treat the parent node differently from the
-      # secondary child nodes when it comes to support for the destroy operation.
-      #
-      # Each entity mapper represents either a child or a parent node in the xml file.
-      #
-      # Parent nodes have the same assigned entity class as their derived class. Our internal naming
-      # for this has been to name this parent node the primary.
-      def primary?
-        derived_entity_class == entity_class
-      end
-
       def filename
         @xml_node['filename']
       end

--- a/spec/lib/cds_importer/entity_mapper/base_mapper_spec.rb
+++ b/spec/lib/cds_importer/entity_mapper/base_mapper_spec.rb
@@ -130,20 +130,6 @@ RSpec.describe CdsImporter::EntityMapper::BaseMapper do
     end
   end
 
-  describe '#primary?' do
-    context 'when the mapper entity class matches the derived entity class' do
-      subject(:mapper) { primary_mocked_mapper.new({}) }
-
-      it { is_expected.to be_primary }
-    end
-
-    context 'when the mapper entity class does not match the derived entity class' do
-      subject(:mapper) { secondary_mocked_mapper.new({}) }
-
-      it { is_expected.not_to be_primary }
-    end
-  end
-
   describe '#parse' do
     subject(:parsed) { secondary_mocked_mapper.new(xml_node).parse.first }
 
@@ -195,66 +181,29 @@ RSpec.describe CdsImporter::EntityMapper::BaseMapper do
       ]
     end
 
-    it { is_expected.to be_a(MockedModel) }
-    it { expect(parsed.values).to eq(expected_values) }
-    it { expect(parsed.fields).to eq(expected_fields) }
-  end
-
-  describe '#destroy_operation?' do
-    context 'when the mapper is a primary mapper and the operation is destroy' do
-      subject(:mapper) do
-        primary_mocked_mapper.new(
-          'metainfo' => {
-            'opType' => 'D',
-            'origin' => 'T',
-            'status' => 'L',
+    let(:expected_expanded_attributes) do
+      {
+        'sid' => '123',
+        'flibble' => 'Pratchett',
+        'mockedModel' => {
+          'validityStartDate' => '1970-01-01T00:00:00',
+          'validityEndDate' => '1972-01-01T00:00:00',
+          'foo' => {
+            'bar' => true,
+            'baz' => false,
           },
-        )
-      end
-
-      it { is_expected.to be_destroy_operation }
-    end
-
-    shared_examples_for 'an xml node and mapper that are not a destroy operation' do |operation|
-      subject(:mapper) do
-        mapper_class.new(
           'metainfo' => {
-            'opType' => operation,
-            'origin' => 'T',
-            'status' => 'L',
+            'opType' => 'U',
+            'origin' => 'N',
+            'transactionDate' => '2021-01-29T20:04:37',
           },
-        )
-      end
-
-      it { is_expected.not_to be_destroy_operation }
+        },
+      }
     end
 
-    it_behaves_like 'an xml node and mapper that are not a destroy operation', 'U' do
-      let(:mapper_class) { primary_mocked_mapper }
-    end
-
-    it_behaves_like 'an xml node and mapper that are not a destroy operation', 'C' do
-      let(:mapper_class) { primary_mocked_mapper }
-    end
-
-    it_behaves_like 'an xml node and mapper that are not a destroy operation', 'foo' do
-      let(:mapper_class) { primary_mocked_mapper }
-    end
-
-    it_behaves_like 'an xml node and mapper that are not a destroy operation', 'U' do
-      let(:mapper_class) { secondary_mocked_mapper }
-    end
-
-    it_behaves_like 'an xml node and mapper that are not a destroy operation', 'C' do
-      let(:mapper_class) { secondary_mocked_mapper }
-    end
-
-    it_behaves_like 'an xml node and mapper that are not a destroy operation', 'D' do
-      let(:mapper_class) { secondary_mocked_mapper }
-    end
-
-    it_behaves_like 'an xml node and mapper that are not a destroy operation', 'foo' do
-      let(:mapper_class) { secondary_mocked_mapper }
-    end
+    it { expect(parsed[:instance]).to be_a(MockedModel) }
+    it { expect(parsed[:instance].values).to eq(expected_values) }
+    it { expect(parsed[:instance].fields).to eq(expected_fields) }
+    it { expect(parsed[:expanded_attributes]).to eq(expected_expanded_attributes) }
   end
 end

--- a/spec/lib/cds_importer/entity_mapper/base_mapper_spec.rb
+++ b/spec/lib/cds_importer/entity_mapper/base_mapper_spec.rb
@@ -181,8 +181,12 @@ RSpec.describe CdsImporter::EntityMapper::BaseMapper do
       ]
     end
 
-    let(:expected_expanded_attributes) do
-      {
+    it { expect(parsed[:instance]).to be_a(MockedModel) }
+    it { expect(parsed[:instance].values).to eq(expected_values) }
+    it { expect(parsed[:instance].fields).to eq(expected_fields) }
+
+    it 'returns the correct expanded_attributes' do
+      expected_expanded_attributes = {
         'sid' => '123',
         'flibble' => 'Pratchett',
         'mockedModel' => {
@@ -199,11 +203,8 @@ RSpec.describe CdsImporter::EntityMapper::BaseMapper do
           },
         },
       }
-    end
 
-    it { expect(parsed[:instance]).to be_a(MockedModel) }
-    it { expect(parsed[:instance].values).to eq(expected_values) }
-    it { expect(parsed[:instance].fields).to eq(expected_fields) }
-    it { expect(parsed[:expanded_attributes]).to eq(expected_expanded_attributes) }
+      expect(parsed[:expanded_attributes]).to eq(expected_expanded_attributes)
+    end
   end
 end

--- a/spec/support/shared_examples/an_entity_mapper.rb
+++ b/spec/support/shared_examples/an_entity_mapper.rb
@@ -14,7 +14,8 @@ RSpec.shared_examples_for 'an entity mapper' do |expected_entity_class, expected
   describe '#parse' do
     subject(:parsed) { described_class.new(xml_node).parse.first }
 
-    it { expect(parsed.values).to eq(expected_values) }
-    it { is_expected.to be_a(expected_entity_class.constantize) }
+    it { expect(parsed[:instance].values).to eq(expected_values) }
+    it { expect(parsed[:instance]).to be_a(expected_entity_class.constantize) }
+    it { expect(parsed[:expanded_attributes]).to be_a(Hash) }
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2595

### What?

I have added/removed/altered:

- [x] Adds support for passing expanded attributes to callback functions
- [x] Removes unused code

### Why?

I am doing this because:

- This is required to simplify any reverse engineering of the attributes that are applicable for the current invocation of a before insert callback. Where before we tried to determine surrounding attributes of a given model instance, now we can just ask for them from the passed in expanded attributes
