### PR TITLE
Notify regression channel when flaky tests fail before release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -485,6 +485,14 @@ jobs:
       - ruby/rspec-test:
           label: 'Run flaky tests'
           tag: "flaky"
+      - slack/notify:
+          channel: tariffs-regression
+          event: fail
+          template: basic_fail_1
+      - slack/notify:
+          channel: tariffs-regression
+          event: pass
+          template: basic_success_1
   test:
     docker:
       - image: cimg/ruby:3.2.0


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Added slack notifications to flaky test workflow

### Why?

I am doing this because:

- This is to make sure we're aware of release day test failures
