### PR TITLE
HOTT-2561 Update proofs data

### DIFF
--- a/app/models/rules_of_origin/proof.rb
+++ b/app/models/rules_of_origin/proof.rb
@@ -3,13 +3,21 @@ module RulesOfOrigin
     include ActiveModel::Model
     include ContentAddressableId
 
-    content_addressable_fields 'summary', 'proof_class'
-
     attr_accessor :scheme, :summary, :detail, :proof_class, :subtext
-    attr_writer :id
+    attr_writer :id, :content
+
+    content_addressable_fields 'scheme_code', 'proof_class'
+    delegate :scheme_code, :scheme_set, to: :scheme
+    delegate :read_referenced_file, to: :scheme_set
 
     def url
       all_proof_urls[proof_class] if proof_class.present?
+    end
+
+    def content
+      @content ||= read_referenced_file('proofs', scheme_code, "#{proof_class}.md")
+    rescue Errno::ENOENT
+      nil
     end
 
   private

--- a/app/serializers/api/v2/rules_of_origin/proof_serializer.rb
+++ b/app/serializers/api/v2/rules_of_origin/proof_serializer.rb
@@ -6,7 +6,7 @@ module Api
 
         set_type :rules_of_origin_proof
 
-        attributes :summary, :subtext, :url
+        attributes :summary, :subtext, :url, :content
       end
     end
   end

--- a/db/rules_of_origin/roo_schemes_uk.json
+++ b/db/rules_of_origin/roo_schemes_uk.json
@@ -15,13 +15,13 @@
                     "summary": "Statement on origin",
                     "subtext": "",
                     "proof_class": "origin-declaration",
-                    "detail": "statement-on-origin.md"
+                    "detail": ""
                 },
                 {
                     "summary": "Importer's knowledge",
                     "subtext": "",
                     "proof_class": "importers-knowledge",
-                    "detail": "importers-knowledge.md"
+                    "detail": ""
                 }
             ],
             "cumulation_methods": {
@@ -94,7 +94,8 @@
                 "absorption": true,
                 "tolerances": false,
                 "sets": true,
-                "cumulation": true
+                "cumulation": true,
+                "drawback": false
             },
             "introductory_notes_file": "eu_intro.md",
             "fta_intro_file": "eu.md",
@@ -146,6 +147,1898 @@
             ]
         },
         {
+            "scheme_code": "albania",
+            "title": "UK-Albania Partnership, Trade and Cooperation Agreement",
+            "proofs": [
+                {
+                    "summary": "EUR.1 movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur1",
+                    "detail": ""
+                },
+                {
+                    "summary": "EUR-MED movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur-med",
+                    "detail": ""
+                },
+                {
+                    "summary": "Origin declaration",
+                    "subtext": "or origin declaration EUR-MED including UK Approved Exporter number for consignments with a value over £5500  / 6000 euros",
+                    "proof_class": "origin-declaration",
+                    "detail": ""
+                }
+            ],
+            "cumulation_methods": {
+                "bilateral": {
+                    "countries": [
+                        "GB",
+                        "AL"
+                    ]
+                },
+                "extended": {
+                    "countries": [
+                        "EU",
+                        "AD",
+                        "SM",
+                        "XK",
+                        "DZ",
+                        "BA",
+                        "FO",
+                        "GE",
+                        "IL",
+                        "JO",
+                        "EG",
+                        "LB",
+                        "MD",
+                        "ME",
+                        "MA",
+                        "MK",
+                        "PS",
+                        "XS",
+                        "SY",
+                        "UA",
+                        "CH",
+                        "LI",
+                        "IS",
+                        "NO",
+                        "TR"
+                    ]
+                }
+            },
+            "ord": {
+                "ord_title": "Origin Reference Document implementing the Partnership, Trade and Cooperation Agreement between the United Kingdom of Great Britain and Northern Ireland and the Republic of Albania, signed on 5th February 2021 ('the Albania Origin Reference Document')",
+                "ord_version": "1.1",
+                "ord_date": "28 November 2021",
+                "ord_original": "211228_ORD_Albania_V1.1.odt"
+            },
+            "articles": {
+                "article 1": "definitions",
+                "article 2": "general requirements",
+                "article 3": "cumulation",
+                "article 4": "cumulation",
+                "article 5": "wholly obtained",
+                "article 6": "sufficient working",
+                "article 7": "insufficient working",
+                "article 8": "unit of qualification",
+                "article 9": "accessories",
+                "article 10": "sets",
+                "article 11": "neutral elements",
+                "article 12": "principle of territoriality",
+                "article 13": "direct transport",
+                "article 14": "exhibitions",
+                "Annex II": "sufficient working"
+            },
+            "features": {
+                "absorption": true,
+                "tolerances": true,
+                "sets": true,
+                "cumulation": true,
+                "drawback": true
+            },
+            "introductory_notes_file": "albania_intro.md",
+            "fta_intro_file": "albania.md",
+            "links": [
+                {
+                    "text": "UK-Albania partnership, Trade and Cooperation Agreement",
+                    "url": "https://www.gov.uk/government/collections/uk-albania-partnership-trade-and-cooperation-agreement"
+                },
+                {
+                    "text": "Continuing the United Kingdom’s trade relationship with Albania",
+                    "url": "https://www.gov.uk/government/publications/continuing-the-uks-trade-relationship-with-albania-parliamentary-report/continuing-the-united-kingdoms-trade-relationship-with-albania-web-version"
+                }
+            ],
+            "countries": [
+                "AL"
+            ]
+        },
+        {
+            "scheme_code": "andean",
+            "title": "UK-Andean Countries Trade Agreement",
+            "proofs": [
+                {
+                    "summary": "EUR.1 movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur1",
+                    "detail": ""
+                },
+                {
+                    "summary": "Invoice declaration",
+                    "subtext": "including UK Approved Exporter number for consignments with a value over £5500/6000 euros",
+                    "proof_class": "invoice-declaration",
+                    "detail": ""
+                }
+            ],
+            "cumulation_methods": {
+                "bilateral": {
+                    "countries": [
+                        "GB",
+                        "CO",
+                        "EC",
+                        "PE"
+                    ]
+                },
+                "extended": {
+                    "countries": [
+                        "EU",
+                        "AD",
+                        "SM",
+                        "AG",
+                        "BB",
+                        "BS",
+                        "BZ",
+                        "DM",
+                        "DO",
+                        "GD",
+                        "GY",
+                        "JM",
+                        "KN",
+                        "LC",
+                        "SR",
+                        "TT",
+                        "VC",
+                        "MX",
+                        "GT",
+                        "HO",
+                        "NI",
+                        "SV",
+                        "CR",
+                        "PA",
+                        "BR",
+                        "VE",
+                        "GF",
+                        "BO",
+                        "PY",
+                        "UY",
+                        "AR",
+                        "CL"
+                    ]
+                }
+            },
+            "ord": {
+                "ord_title": "The Andean Countries Origin Reference Document Version 1.3, Dated 28th December 2021",
+                "ord_version": "1.3",
+                "ord_date": "31 May 2022",
+                "ord_original": "310522_Andean_ORD.odt"
+            },
+            "articles": {
+                "article 1": "definitions",
+                "article 2": "general requirements",
+                "article 3": "cumulation",
+                "article 3a": "cumulation",
+                "article 4": "cumulation",
+                "article 5": "wholly obtained",
+                "article 6": "sufficient working",
+                "article 7": "insufficient working",
+                "article 8": "unit of qualification",
+                "article 9": "accessories",
+                "article 10": "sets",
+                "article 11": "neutral elements",
+                "article 12": "principle of territoriality",
+                "article 13": "direct transport",
+                "article 14": "exhibitions",
+                "Annex II": "sufficient working"
+            },
+            "features": {
+                "absorption": true,
+                "tolerances": false,
+                "sets": true,
+                "cumulation": true,
+                "drawback": false
+            },
+            "introductory_notes_file": "andean_intro.md",
+            "fta_intro_file": "andean.md",
+            "links": [
+                {
+                    "text": "UK-Andean countries trade agreement",
+                    "url": "https://www.gov.uk/government/collections/uk-andean-countries-trade-agreement"
+                },
+                {
+                    "text": "Trade with the Andean countries",
+                    "url": "https://www.gov.uk/guidance/summary-of-uk-andean-countries-trade-agreement"
+                }
+            ],
+            "countries": [
+                "andean",
+                "CO",
+                "PE",
+                "EC"
+            ]
+        },
+        {
+            "scheme_code": "canada",
+            "title": "UK-Canada Trade Continuity Agreement",
+            "proofs": [
+                {
+                    "summary": "Origin declaration",
+                    "subtext": "",
+                    "proof_class": "origin-declaration",
+                    "detail": ""
+                }
+            ],
+            "cumulation_methods": {
+                "bilateral": {
+                    "countries": [
+                        "GB",
+                        "CA"
+                    ]
+                },
+                "extended": {
+                    "countries": [
+                        "EU",
+                        "AD",
+                        "SM",
+                        "XX",
+                        "JP",
+                        "MX",
+                        "SG",
+                        "VN",
+                        "CL",
+                        "CO",
+                        "CR",
+                        "IS",
+                        "LI",
+                        "NO",
+                        "CH",
+                        "HO",
+                        "IL",
+                        "KR",
+                        "PE",
+                        "UA"
+                    ]
+                }
+            },
+            "ord": {
+                "ord_title": "The Canada Origin Reference Document",
+                "ord_version": "1.1",
+                "ord_date": "28 December 2021",
+                "ord_original": "211223_ORD_Canada_V1.1.odt"
+            },
+            "articles": {
+                "article 1": "definitions",
+                "article 2": "general requirements",
+                "article 3": "cumulation",
+                "article 4": "wholly obtained",
+                "article 5": "sufficient working",
+                "article 6": "tolerances",
+                "article 7": "insufficient working",
+                "article 8": "unit of qualification",
+                "article 9": "packing materials - shipment",
+                "article 10": "accounting segregation",
+                "article 11": "accessories",
+                "article 12": "sets",
+                "Annex II": "sufficient working"
+            },
+            "features": {
+                "absorption": true,
+                "tolerances": false,
+                "sets": true,
+                "cumulation": true,
+                "drawback": false
+            },
+            "introductory_notes_file": "canada_intro.md",
+            "fta_intro_file": "canada.md",
+            "links": [
+                {
+                    "text": "Trade with Canada",
+                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-canada-trade-continuity-agreement"
+                },
+                {
+                    "text": "UK-Canada Trade Continuity Agreement (TCA)",
+                    "url": "https://www.gov.uk/guidance/uk-canada-trade-continuity-agreement-tca"
+                }
+            ],
+            "countries": [
+                "CA"
+            ]
+        },
+        {
+            "scheme_code": "cameroon",
+            "title": "UK-Cameroon Economic Partnership Agreement",
+            "proofs": [
+                {
+                    "summary": "EUR.1 movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur1",
+                    "detail": ""
+                },
+                {
+                    "summary": "Invoice declaration",
+                    "subtext": "",
+                    "proof_class": "invoice-declaration",
+                    "detail": ""
+                }
+            ],
+            "cumulation_methods": {
+                "bilateral": {
+                    "countries": [
+                        "GB",
+                        "CM"
+                    ]
+                },
+                "extended": {
+                    "countries": [
+                        "EU",
+                        "AD",
+                        "SM",
+                        "AG",
+                        "BS",
+                        "BB",
+                        "BZ",
+                        "BW",
+                        "CI",
+                        "DM",
+                        "DO",
+                        "FJ",
+                        "GH",
+                        "GD",
+                        "GY",
+                        "JM",
+                        "KE",
+                        "LS",
+                        "MG",
+                        "MU",
+                        "MZ",
+                        "NA",
+                        "PG",
+                        "KN",
+                        "LC",
+                        "VC",
+                        "SC",
+                        "SR",
+                        "SZ",
+                        "TT",
+                        "ZW",
+                        "GL",
+                        "NC",
+                        "PF",
+                        "PM",
+                        "BL",
+                        "TF",
+                        "WF",
+                        "AW",
+                        "CW",
+                        "SX",
+                        "AI",
+                        "BM",
+                        "KY",
+                        "FK",
+                        "GS",
+                        "MS",
+                        "PN",
+                        "SH",
+                        "ZU",
+                        "IO",
+                        "TC",
+                        "VG"
+                    ]
+                }
+            },
+            "ord": {
+                "ord_title": "The Cameroon Origin Reference Document",
+                "ord_version": "1.3",
+                "ord_date": "28 December 2021",
+                "ord_original": "211223_Cameroon_ORD__HS_UPDATE__.odt"
+            },
+            "articles": {
+                "article 1": "definitions",
+                "article 2": "general requirements",
+                "article 3": "wholly obtained",
+                "article 4": "sufficient working",
+                "article 5": "insufficient working",
+                "article 7": "unit of qualification",
+                "article 8": "accessories",
+                "article 9": "sets",
+                "article 10": "neutral elements",
+                "article 11": "principle of territoriality",
+                "article 12": "direct transport",
+                "article 13": "exhibitions",
+                "Annex II": "sufficient working"
+            },
+            "features": {
+                "absorption": true,
+                "tolerances": false,
+                "sets": true,
+                "cumulation": true,
+                "drawback": false
+            },
+            "introductory_notes_file": "cameroon_intro.md",
+            "fta_intro_file": "cameroon.md",
+            "links": [
+                {
+                    "text": "UK-Cameroon Economic Partnership Agreement",
+                    "url": "https://www.gov.uk/government/collections/uk-cameroon-economic-partnership-agreement"
+                },
+                {
+                    "text": "Trade with Cameroon",
+                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-cameroon-economic-partnership-agreement"
+                }
+            ],
+            "countries": [
+                "CM"
+            ]
+        },
+        {
+            "scheme_code": "cariforum",
+            "title": "CARIFORUM-UK Economic Partnership Agreement",
+            "proofs": [
+                {
+                    "summary": "EUR.1 movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur1",
+                    "detail": ""
+                },
+                {
+                    "summary": "Invoice declaration",
+                    "subtext": "",
+                    "proof_class": "invoice-declaration",
+                    "detail": ""
+                }
+            ],
+            "cumulation_methods": {
+                "bilateral": {
+                    "countries": [
+                        "GB",
+                        "AG",
+                        "BS",
+                        "BB",
+                        "BZ",
+                        "DM",
+                        "DO",
+                        "GD",
+                        "GY",
+                        "JM",
+                        "KN",
+                        "LC",
+                        "VC",
+                        "SR",
+                        "TT",
+                        "AO",
+                        "BJ",
+                        "BW",
+                        "BF",
+                        "BI",
+                        "CM",
+                        "CV",
+                        "CF",
+                        "TD",
+                        "CK",
+                        "KM",
+                        "CI",
+                        "CD",
+                        "DJ",
+                        "GQ",
+                        "ER",
+                        "ET",
+                        "FM",
+                        "FJ",
+                        "GA",
+                        "GM",
+                        "GH",
+                        "GN",
+                        "GW",
+                        "KE",
+                        "KI",
+                        "LS",
+                        "LR",
+                        "MG",
+                        "MW",
+                        "ML",
+                        "MH",
+                        "MR",
+                        "MU",
+                        "MZ",
+                        "NA",
+                        "NR",
+                        "NE",
+                        "NU",
+                        "NG",
+                        "PW",
+                        "PG",
+                        "CG",
+                        "RW",
+                        "WS",
+                        "ST",
+                        "SN",
+                        "SC",
+                        "SL",
+                        "SB",
+                        "SO",
+                        "SD",
+                        "SZ",
+                        "TZ",
+                        "TG",
+                        "TO",
+                        "TV",
+                        "UG",
+                        "VU",
+                        "ZM",
+                        "ZW",
+                        "GL",
+                        "NC",
+                        "PF",
+                        "PM",
+                        "BL",
+                        "TF",
+                        "WF",
+                        "AW",
+                        "BQ",
+                        "CW",
+                        "BQ",
+                        "SX",
+                        "AI",
+                        "BM",
+                        "KY",
+                        "FK",
+                        "GS",
+                        "MS",
+                        "PN",
+                        "SH",
+                        "ZU",
+                        "IO",
+                        "TC",
+                        "VG"
+                    ]
+                },
+                "extended": {
+                    "countries": [
+                        "EU",
+                        "AD",
+                        "SM"
+                    ]
+                }
+            },
+            "ord": {
+                "ord_title": "The CARIFORUM Origin Reference Document",
+                "ord_version": "1.2",
+                "ord_date": "28 December 2021",
+                "ord_original": "211223_ORD_CARIFORUM_V1.2.odt"
+            },
+            "articles": {
+                "article 1": "definitions",
+                "article 2": "general requirements",
+                "article 3": "cumulation",
+                "article 4": "cumulation",
+                "article 5": "cumulation",
+                "article 6": "wholly obtained",
+                "article 7": "sufficient working",
+                "article 8": "insufficient working",
+                "article 9": "unit of qualification",
+                "article 10": "accessories",
+                "article 11": "sets",
+                "article 12": "neutral elements",
+                "article 13": "principle of territoriality",
+                "article 14": "direct transport",
+                "article 15": "exhibitions",
+                "Annex II": "sufficient working"
+            },
+            "features": {
+                "absorption": true,
+                "tolerances": false,
+                "sets": true,
+                "cumulation": true,
+                "drawback": false
+            },
+            "introductory_notes_file": "cariforum_intro.md",
+            "fta_intro_file": "cariforum.md",
+            "links": [
+                {
+                    "text": "CARIFORUM-UK economic partnership agreement",
+                    "url": "https://www.gov.uk/government/collections/cariforum-uk-economic-partnership-agreement"
+                },
+                {
+                    "text": "Trade with the CARIFORUM States",
+                    "url": "https://www.gov.uk/guidance/summary-of-the-cariforum-uk-economic-partnership-agreement-epa"
+                }
+            ],
+            "countries": [
+                "AG",
+                "BB",
+                "BS",
+                "BZ",
+                "DM",
+                "DO",
+                "GD",
+                "GY",
+                "JM",
+                "KN",
+                "LC",
+                "SR",
+                "TT",
+                "VC"
+            ]
+        },
+        {
+            "scheme_code": "central-america",
+            "title": "UK-Central America Association Agreement",
+            "proofs": [
+                {
+                    "summary": "EUR.1 movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur1",
+                    "detail": ""
+                },
+                {
+                    "summary": "Invoice declaration",
+                    "subtext": "",
+                    "proof_class": "invoice-declaration",
+                    "detail": ""
+                }
+            ],
+            "cumulation_methods": {
+                "bilateral": {
+                    "countries": [
+                        "GB",
+                        "HO",
+                        "NI",
+                        "SV",
+                        "GT",
+                        "PA",
+                        "CR"
+                    ]
+                },
+                "extended": {
+                    "countries": [
+                        "EU",
+                        "AD",
+                        "SM",
+                        "VE",
+                        "CO",
+                        "EC",
+                        "PE",
+                        "BO",
+                        "CL",
+                        "AR",
+                        "UR",
+                        "BR",
+                        "GF",
+                        "SR",
+                        "GY",
+                        "MX",
+                        "ID",
+                        "AG",
+                        "BB",
+                        "BS",
+                        "BZ",
+                        "DM",
+                        "DO",
+                        "GD",
+                        "GY",
+                        "JM",
+                        "KN",
+                        "LC",
+                        "SR",
+                        "TT",
+                        "VC"
+                    ]
+                }
+            },
+            "ord": {
+                "ord_title": "The Origin Reference Document implementing the Agreement between the United Kingdom and Central America signed on 18 July 2019 ('the Central America Origin Reference Document')",
+                "ord_version": "1.2",
+                "ord_date": "22 February 2022",
+                "ord_original": "220214_ORD_Central_America_V1.2.odt"
+            },
+            "articles": {
+                "article 1": "definitions",
+                "article 2": "general requirements",
+                "article 3": "cumulation",
+                "article 3a": "cumulation",
+                "article 4": "wholly obtained",
+                "article 5": "sufficient working",
+                "article 6": "insufficient working",
+                "article 7": "unit of qualification",
+                "article 8": "accessories",
+                "article 9": "sets",
+                "article 10": "neutral elements",
+                "article 11": "principle of territoriality",
+                "article 12": "direct transport",
+                "article 13": "exhibitions",
+                "Annex II": "sufficient working"
+            },
+            "features": {
+                "absorption": true,
+                "tolerances": false,
+                "sets": true,
+                "cumulation": true,
+                "drawback": false
+            },
+            "introductory_notes_file": "central_america_intro.md",
+            "fta_intro_file": "central_america.md",
+            "links": [
+                {
+                    "text": "UK-Central America association agreement",
+                    "url": "https://www.gov.uk/government/collections/uk-central-america-association-agreement"
+                },
+                {
+                    "text": "Trade with Central America",
+                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-central-america-association-agreement"
+                }
+            ],
+            "countries": [
+                "central-america",
+                "CR",
+                "GT",
+                "HN",
+                "NI",
+                "PA",
+                "SV"
+            ]
+        },
+        {
+            "scheme_code": "chile",
+            "title": "UK-Chile Association Agreement",
+            "proofs": [
+                {
+                    "summary": "EUR.1 movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur1",
+                    "detail": ""
+                },
+                {
+                    "summary": "Invoice declaration",
+                    "subtext": "",
+                    "proof_class": "invoice-declaration",
+                    "detail": ""
+                }
+            ],
+            "cumulation_methods": {
+                "bilateral": {
+                    "countries": [
+                        "GB",
+                        "CL"
+                    ]
+                },
+                "diagonal": {
+                    "countries": [
+                        "EU",
+                        "AD",
+                        "SM"
+                    ]
+                }
+            },
+            "ord": {
+                "ord_title": "Origin Reference Document implementing the Agreement establishing an Association between the United Kingdom of Great Britain and Northern Ireland and the Republic of Chile signed on 30 January 2019 ('the Chile Origin Reference Document')",
+                "ord_version": "1.2",
+                "ord_date": "22 February 2022",
+                "ord_original": "220214_ORD_Chile__v1.2.odt"
+            },
+            "articles": {
+                "article 1": "definitions",
+                "article 2": "general requirements",
+                "article 3": "cumulation",
+                "article 3a": "cumulation",
+                "article 4": "wholly obtained",
+                "article 5": "sufficient working",
+                "article 6": "insufficient working",
+                "article 7": "unit of qualification",
+                "article 8": "accessories",
+                "article 9": "sets",
+                "article 10": "neutral elements",
+                "article 11": "principle of territoriality",
+                "article 12": "direct transport",
+                "article 13": "exhibitions",
+                "Annex II": "sufficient working"
+            },
+            "features": {
+                "absorption": true,
+                "tolerances": false,
+                "sets": true,
+                "cumulation": true,
+                "drawback": true
+            },
+            "introductory_notes_file": "chile_intro.md",
+            "fta_intro_file": "chile.md",
+            "links": [
+                {
+                    "text": "UK-Chile Association Agreement",
+                    "url": "https://www.gov.uk/government/collections/uk-chile-association-agreement"
+                },
+                {
+                    "text": "Trade with Chile",
+                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-chile-association-agreement"
+                }
+            ],
+            "countries": [
+                "CL"
+            ]
+        },
+        {
+            "scheme_code": "cotedivoire",
+            "title": "UK-Côte d'Ivoire Stepping Stone Economic Partnership Agreement",
+            "proofs": [
+                {
+                    "summary": "EUR.1 movement certificate",
+                    "subtext": "issued in Cote d’Ivoire",
+                    "proof_class": "eur1",
+                    "detail": ""
+                },
+                {
+                    "summary": "Origin declaration",
+                    "subtext": "issued in UK",
+                    "proof_class": "origin-declaration",
+                    "detail": ""
+                }
+            ],
+            "cumulation_methods": {
+                "bilateral": {
+                    "countries": [
+                        "GB",
+                        "CI"
+                    ]
+                },
+                "extended": {
+                    "countries": [
+                        "EU",
+                        "AD",
+                        "SM",
+                        "BJ",
+                        "BF",
+                        "CV",
+                        "GM",
+                        "GH",
+                        "GN",
+                        "GW",
+                        "LR",
+                        "ML",
+                        "MR",
+                        "NE",
+                        "NG",
+                        "SN",
+                        "SL",
+                        "TG",
+                        "FJ",
+                        "PG",
+                        "WS",
+                        "SB",
+                        "CM",
+                        "KE",
+                        "BW",
+                        "ZW",
+                        "ZA",
+                        "LS",
+                        "SZ",
+                        "MZ",
+                        "SC",
+                        "MU",
+                        "ZA",
+                        "AG",
+                        "BS",
+                        "BB",
+                        "BZ",
+                        "DM",
+                        "DO",
+                        "GD",
+                        "GY",
+                        "JM",
+                        "LC",
+                        "VC",
+                        "KN",
+                        "SR",
+                        "TT",
+                        "GL",
+                        "NC",
+                        "PF",
+                        "PM",
+                        "BL",
+                        "TF",
+                        "WF",
+                        "AW",
+                        "CW",
+                        "SX",
+                        "AI",
+                        "BM",
+                        "KY",
+                        "FK",
+                        "GS",
+                        "MS",
+                        "PN",
+                        "SH",
+                        "ZU",
+                        "IO",
+                        "TC",
+                        "VG"
+                    ]
+                }
+            },
+            "ord": {
+                "ord_title": "Origin Reference Document implementing the Stepping Stone Economic Partnership Agreement between the Republic of Côte d'Ivoire and the United Kingdom of Great Britain and Northern Ireland, signed on 15 October 2020 ('the Côte d'Ivoire Origin Reference Document')",
+                "ord_version": "1.1",
+                "ord_date": "28 November 2021",
+                "ord_original": "211223_ORD_Cote_d_Ivoire_-__HS_UPDATE_.odt"
+            },
+            "articles": {
+                "article 1": "definitions",
+                "article 2": "general requirements",
+                "article 3": "wholly obtained",
+                "article 4": "sufficient working",
+                "article 5": "insufficient working",
+                "article 6": "duty-free",
+                "article 7": "cumulation",
+                "article 8": "cumulation",
+                "article 9": "unit of qualification",
+                "article 10": "accessories",
+                "article 11": "sets",
+                "article 12": "neutral elements",
+                "article 13": "accounting segregation",
+                "article 14": "principle of territoriality",
+                "article 15": "non-alteration",
+                "article 16": "exhibitions",
+                "Annex II": "sufficient working"
+            },
+            "features": {
+                "absorption": true,
+                "tolerances": false,
+                "sets": true,
+                "cumulation": true,
+                "drawback": false
+            },
+            "introductory_notes_file": "cotedivoire_intro.md",
+            "fta_intro_file": "cotedivoire.md",
+            "links": [
+                {
+                    "text": "UK-Côte d’Ivoire Stepping Stone Economic Partnership Agreement",
+                    "url": "https://www.gov.uk/government/collections/uk-cote-divoire-stepping-stone-economic-partnership-agreement"
+                },
+                {
+                    "text": "Trade with Côte d’Ivoire",
+                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-cote-divoire-stepping-stone-economic-partnership-agreement"
+                }
+            ],
+            "countries": [
+                "CI"
+            ]
+        },
+        {
+            "scheme_code": "egypt",
+            "title": "UK-Egypt Association Agreement",
+            "proofs": [
+                {
+                    "summary": "EUR.1 movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur1",
+                    "detail": ""
+                },
+                {
+                    "summary": "EUR-MED movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur-med",
+                    "detail": ""
+                },
+                {
+                    "summary": "Origin declaration",
+                    "subtext": "or origin declaration EUR-MED including UK Approved Exporter number for consignments with a value over £5500  / 6000 euros",
+                    "proof_class": "origin-declaration",
+                    "detail": ""
+                }
+            ],
+            "cumulation_methods": {
+                "bilateral": {
+                    "countries": [
+                        "GB",
+                        "EG"
+                    ]
+                },
+                "extended": {
+                    "countries": [
+                        "EU",
+                        "AD",
+                        "SM",
+                        "AL",
+                        "DZ",
+                        "BA",
+                        "FO",
+                        "GE",
+                        "IL",
+                        "JO",
+                        "XK",
+                        "LB",
+                        "MD",
+                        "ME",
+                        "MA",
+                        "MK",
+                        "PS",
+                        "XS",
+                        "SY",
+                        "UA",
+                        "CH",
+                        "LI",
+                        "IS",
+                        "NO",
+                        "TR"
+                    ]
+                }
+            },
+            "ord": {
+                "ord_title": "Origin Reference Document implementing the Agreement establishing an Association between the United Kingdom of Great Britain and Northern Ireland and the Arab Republic of Egypt, signed on 5th December 2020 ('the Egypt Origin Reference Document')",
+                "ord_version": "1.1",
+                "ord_date": "28 December 2021",
+                "ord_original": "20211223_ORD_Egypt_V1.1.odt"
+            },
+            "articles": {
+                "article 1": "definitions",
+                "article 2": "general requirements",
+                "article 3": "cumulation",
+                "article 4": "cumulation",
+                "article 5": "wholly obtained",
+                "article 6": "sufficient working",
+                "article 7": "insufficient working",
+                "article 8": "unit of qualification",
+                "article 9": "accessories",
+                "article 10": "sets",
+                "article 11": "neutral elements",
+                "article 12": "principle of territoriality",
+                "article 13": "direct transport",
+                "article 14": "exhibitions",
+                "Annex II": "sufficient working"
+            },
+            "features": {
+                "absorption": true,
+                "tolerances": false,
+                "sets": true,
+                "cumulation": true,
+                "drawback": true
+            },
+            "introductory_notes_file": "egypt_intro.md",
+            "fta_intro_file": "egypt.md",
+            "links": [
+                {
+                    "text": "UK-Egypt Association Agreement",
+                    "url": "https://www.gov.uk/government/collections/uk-egypt-associationagreement"
+                },
+                {
+                    "text": "Trade with Egypt",
+                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-egypt-association-agreement"
+                }
+            ],
+            "countries": [
+                "EG"
+            ]
+        },
+        {
+            "scheme_code": "esa",
+            "title": "ESA-UK Economic Partnership Agreement (EPA)",
+            "proofs": [
+                {
+                    "summary": "EUR.1 certificate",
+                    "subtext": "",
+                    "proof_class": "eur1",
+                    "detail": ""
+                },
+                {
+                    "summary": "Invoice declaration",
+                    "subtext": "",
+                    "proof_class": "invoice-declaration",
+                    "detail": ""
+                }
+            ],
+            "cumulation_methods": {
+                "bilateral": {
+                    "countries": [
+                        "GB",
+                        "ZW",
+                        "SC",
+                        "MU"
+                    ]
+                },
+                "extended": {
+                    "countries": [
+                        "EU",
+                        "AD",
+                        "SM",
+                        "AO",
+                        "AG",
+                        "BS",
+                        "BB",
+                        "BZ",
+                        "BJ",
+                        "BW",
+                        "BF",
+                        "BI",
+                        "CM",
+                        "CV",
+                        "CF",
+                        "TD",
+                        "CK",
+                        "CI",
+                        "CD",
+                        "DJ",
+                        "DM",
+                        "DO",
+                        "GQ",
+                        "ER",
+                        "SZ",
+                        "ET",
+                        "FM",
+                        "FJ",
+                        "GA",
+                        "GM",
+                        "GH",
+                        "GD",
+                        "GN",
+                        "GW",
+                        "GY",
+                        "HT",
+                        "JM",
+                        "KE",
+                        "KI",
+                        "LS",
+                        "LR",
+                        "MW",
+                        "ML",
+                        "MH",
+                        "MR",
+                        "MZ",
+                        "NA",
+                        "NR",
+                        "NE",
+                        "NU",
+                        "NG",
+                        "PW",
+                        "PG",
+                        "CG",
+                        "RW",
+                        "KN",
+                        "LC",
+                        "VC",
+                        "WS",
+                        "ST",
+                        "SN",
+                        "SL",
+                        "SB",
+                        "SO",
+                        "SD",
+                        "SR",
+                        "TZ",
+                        "TG",
+                        "TO",
+                        "TT",
+                        "TV",
+                        "UG",
+                        "VU",
+                        "GL",
+                        "NC",
+                        "PF",
+                        "TF",
+                        "WF",
+                        "YT",
+                        "PM",
+                        "AW",
+                        "AN",
+                        "CW",
+                        "SX",
+                        "AI",
+                        "KY",
+                        "FK",
+                        "GS",
+                        "MS",
+                        "PN",
+                        "SH",
+                        "ZU",
+                        "IO",
+                        "TC",
+                        "VG",
+                        "DZ",
+                        "EG",
+                        "LY",
+                        "MA",
+                        "TN",
+                        "MV"
+                    ]
+                }
+            },
+            "ord": {
+                "ord_title": "Origin Reference Document implementing the Agreement establishing an Economic Partnership Agreement between the Eastern and Southern African States, on the one part, and the United Kingdom of Great Britain and Northern Ireland, on the other part, signed by the Republic of Mauritius, the Republic of the Seychelles and the Republic of Zimbabwe on 31st January 2019 ('the Eastern and Southern African States Origin Reference Document')",
+                "ord_version": "1.1",
+                "ord_date": "28th December 2021",
+                "ord_original": "211223_ORD_ESA_V1.1.odt"
+            },
+            "articles": {
+                "article 1": "definitions",
+                "article 2": "general requirements",
+                "article 3": "cumulation",
+                "article 4": "cumulation",
+                "article 5": "cumulation",
+                "article 6": "wholly obtained",
+                "article 7": "sufficient working",
+                "article 8": "insufficient working",
+                "article 9": "unit of qualification",
+                "article 10": "accessories",
+                "article 11": "sets",
+                "article 12": "neutral elements",
+                "article 13": "principle of territoriality",
+                "article 14": "direct transport",
+                "article 15": "exhibitions",
+                "Annex II": "sufficient working"
+            },
+            "features": {
+                "absorption": true,
+                "tolerances": false,
+                "sets": true,
+                "cumulation": true,
+                "drawback": false
+            },
+            "introductory_notes_file": "esa_intro.md",
+            "fta_intro_file": "esa.md",
+            "links": [
+                {
+                    "text": "ESA-UK economic partnership agreement (EPA)",
+                    "url": "https://www.gov.uk/government/collections/esa-uk-economic-partnership-agreement-epa--2"
+                },
+                {
+                    "text": "Trade with Eastern and Southern African (ESA) States",
+                    "url": "https://www.gov.uk/guidance/summary-of-the-esa-uk-economic-partnership-agreement-epa"
+                }
+            ],
+            "countries": [
+                "SC",
+                "MU",
+                "ZW"
+            ]
+        },
+        {
+            "scheme_code": "faroe-islands",
+            "title": "UK-Faroe Islands Free Trade Agreement (FTA)",
+            "proofs": [
+                {
+                    "summary": "EUR.1 movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur1",
+                    "detail": ""
+                },
+                {
+                    "summary": "EUR-MED movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur-med",
+                    "detail": ""
+                },
+                {
+                    "summary": "Origin declaration",
+                    "subtext": "or origin declaration EUR-MED including UK Approved Exporter number for consignments with a value over £5500  / 6000 euros",
+                    "proof_class": "origin-declaration",
+                    "detail": ""
+                }
+            ],
+            "cumulation_methods": {
+                "bilateral": {
+                    "countries": [
+                        "GB",
+                        "FO"
+                    ]
+                },
+                "extended": {
+                    "countries": [
+                        "EU",
+                        "AD",
+                        "SM",
+                        "AL",
+                        "DZ",
+                        "BA",
+                        "FO",
+                        "GE",
+                        "IL",
+                        "JO",
+                        "EG",
+                        "XK",
+                        "LB",
+                        "MD",
+                        "ME",
+                        "MA",
+                        "MK",
+                        "PS",
+                        "XS",
+                        "SY",
+                        "UA",
+                        "CH",
+                        "LI",
+                        "IS",
+                        "NO",
+                        "TR"
+                    ]
+                }
+            },
+            "ord": {
+                "ord_title": "Origin Reference Document implementing the Free Trade Agreement between the United Kingdom of Great Britain and Northern Ireland and the Kingdom of Denmark in respect of the Faroe Islands, signed on 31st January 2019 ('the Faroe Islands Origin Reference Document')",
+                "ord_version": "1.1",
+                "ord_date": "28 December 2021",
+                "ord_original": "20121223_ORD_Faroe_Islands_V1.1.odt"
+            },
+            "articles": {
+                "article 1": "definitions",
+                "article 2": "general requirements",
+                "article 3": "cumulation",
+                "article 4": "cumulation",
+                "article 5": "wholly obtained",
+                "article 6": "sufficient working",
+                "article 7": "insufficient working",
+                "article 8": "unit of qualification",
+                "article 9": "accessories",
+                "article 10": "sets",
+                "article 11": "neutral elements",
+                "article 12": "principle of territoriality",
+                "article 13": "direct transport",
+                "article 14": "exhibitions",
+                "Annex II": "sufficient working"
+            },
+            "features": {
+                "absorption": true,
+                "tolerances": false,
+                "sets": true,
+                "cumulation": true,
+                "drawback": true
+            },
+            "introductory_notes_file": "faroe-islands_intro.md",
+            "fta_intro_file": "faroe-islands.md",
+            "links": [
+                {
+                    "text": "UK-Faroe Islands free trade agreement (FTA)",
+                    "url": "https://www.gov.uk/government/collections/uk-faroe-islands-free-trade-agreement-fta"
+                },
+                {
+                    "text": "Trade with the Faroe Islands",
+                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-faroe-islands-free-trade-agreement-fta"
+                }
+            ],
+            "countries": [
+                "FO"
+            ]
+        },
+        {
+            "scheme_code": "georgia",
+            "title": "UK-Georgia Strategic Partnership and Cooperation Agreement",
+            "proofs": [
+                {
+                    "summary": "EUR.1 movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur1",
+                    "detail": ""
+                },
+                {
+                    "summary": "EUR-MED movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur-med",
+                    "detail": ""
+                },
+                {
+                    "summary": "Origin declaration",
+                    "subtext": "or origin declaration EUR-MED including UK Approved Exporter number for consignments with a value over £5500  / 6000 euros",
+                    "proof_class": "origin-declaration",
+                    "detail": ""
+                }
+            ],
+            "cumulation_methods": {
+                "bilateral": {
+                    "countries": [
+                        "GB",
+                        "GE"
+                    ]
+                },
+                "extended": {
+                    "countries": [
+                        "EU",
+                        "AD",
+                        "SM",
+                        "CH",
+                        "LI",
+                        "NO",
+                        "IS",
+                        "TR",
+                        "FO",
+                        "DZ",
+                        "TN",
+                        "MA",
+                        "IL",
+                        "PS",
+                        "EG",
+                        "JO",
+                        "LB",
+                        "SY",
+                        "MK",
+                        "AL",
+                        "BA",
+                        "ME",
+                        "XS",
+                        "XK",
+                        "MD",
+                        "UA",
+                        "AL",
+                        "MX",
+                        "CL",
+                        "PE",
+                        "CO",
+                        "EC",
+                        "GT",
+                        "HO",
+                        "NI",
+                        "SV",
+                        "CR",
+                        "PA",
+                        "KR",
+                        "CA",
+                        "JP",
+                        "SG",
+                        "VN",
+                        "AI",
+                        "BM",
+                        "KY",
+                        "FK",
+                        "GS",
+                        "MS",
+                        "PN",
+                        "SH",
+                        "ZU",
+                        "IO",
+                        "TC",
+                        "VG",
+                        "AN",
+                        "PF",
+                        "TF",
+                        "ZF",
+                        "GL",
+                        "NC",
+                        "BQ",
+                        "BL",
+                        "BQ",
+                        "SX",
+                        "PM",
+                        "AG",
+                        "BS",
+                        "BB",
+                        "BZ",
+                        "DM",
+                        "DO",
+                        "GD",
+                        "GY",
+                        "JM",
+                        "KN",
+                        "LC",
+                        "VC",
+                        "SR",
+                        "TT",
+                        "BW",
+                        "LS",
+                        "NA",
+                        "ZA",
+                        "SZ",
+                        "MZ",
+                        "KM",
+                        "MG",
+                        "MU",
+                        "SC",
+                        "ZW",
+                        "FJ",
+                        "PG",
+                        "WS",
+                        "SB",
+                        "CM",
+                        "CI",
+                        "KE",
+                        "GH"
+                    ]
+                }
+            },
+            "ord": {
+                "ord_title": "The Origin Reference Document implementing the Agreement establishing a Strategic Partnership and Cooperation Agreement between the United Kingdom of Great Britain and Northern Ireland and Georgia signed on 21st October 2019 ('the Georgia Origin Reference Document')",
+                "ord_version": "1.2",
+                "ord_date": "22 February 2022",
+                "ord_original": "220214_ORD_Georgia_V1.2.odt"
+            },
+            "articles": {
+                "article 1": "definitions",
+                "article 2": "general requirements",
+                "article 3": "cumulation",
+                "article 4": "cumulation",
+                "article 5": "wholly obtained",
+                "article 6": "sufficient working",
+                "article 7": "insufficient working",
+                "article 8": "unit of qualification",
+                "article 9": "accessories",
+                "article 10": "sets",
+                "article 11": "neutral elements",
+                "article 12": "principle of territoriality",
+                "article 13": "direct transport",
+                "article 14": "exhibitions",
+                "Annex II": "sufficient working"
+            },
+            "features": {
+                "absorption": true,
+                "tolerances": false,
+                "sets": true,
+                "cumulation": true,
+                "drawback": true
+            },
+            "introductory_notes_file": "georgia_intro.md",
+            "fta_intro_file": "georgia.md",
+            "links": [
+                {
+                    "text": "UK-Georgia strategic partnership and cooperation agreement",
+                    "url": "https://www.gov.uk/government/collections/uk-georgia-strategic-partnership-and-cooperation-agreement--2"
+                },
+                {
+                    "text": "Trade with Georgia",
+                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-georgia-strategic-partnership-and-cooperation-agreement"
+                }
+            ],
+            "countries": [
+                "GE"
+            ]
+        },
+        {
+            "scheme_code": "ghana",
+            "title": "UK-Ghana Interim Trade Partnership Agreement",
+            "proofs": [
+                {
+                    "summary": "EUR.1 movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur1",
+                    "detail": ""
+                },
+                {
+                    "summary": "Origin declaration",
+                    "subtext": "",
+                    "proof_class": "origin-declaration",
+                    "detail": ""
+                }
+            ],
+            "cumulation_methods": {
+                "bilateral": {
+                    "countries": [
+                        "GB",
+                        "GH"
+                    ]
+                },
+                "extended": {
+                    "countries": [
+                        "EU",
+                        "SM",
+                        "AD",
+                        "BJ",
+                        "BF",
+                        "CV",
+                        "GM",
+                        "CI",
+                        "GN",
+                        "GW",
+                        "LR",
+                        "ML",
+                        "MR",
+                        "NE",
+                        "NG",
+                        "SN",
+                        "SL",
+                        "TG",
+                        "FJ",
+                        "PG",
+                        "WS",
+                        "SB",
+                        "CM",
+                        "KE",
+                        "BW",
+                        "ZW",
+                        "ZA",
+                        "LS",
+                        "SZ",
+                        "MZ",
+                        "SC",
+                        "MU",
+                        "ZA",
+                        "AG",
+                        "BS",
+                        "BB",
+                        "BZ",
+                        "DM",
+                        "DO",
+                        "GD",
+                        "GY",
+                        "JM",
+                        "LC",
+                        "VC",
+                        "KN",
+                        "SR",
+                        "TT",
+                        "GL",
+                        "NC",
+                        "PF",
+                        "PM",
+                        "BL",
+                        "TF",
+                        "WF",
+                        "AW",
+                        "CW",
+                        "SX",
+                        "AI",
+                        "BM",
+                        "KY",
+                        "FK",
+                        "GS",
+                        "MS",
+                        "PN",
+                        "SH",
+                        "ZU",
+                        "IO",
+                        "TC",
+                        "VG"
+                    ]
+                }
+            },
+            "ord": {
+                "ord_title": "Origin Reference Document implementing the Interim Trade Partnership Agreement between the Republic of Ghana, of the one part, and the United Kingdom of Great Britain and Northern Ireland, of the other part, signed on 2nd March 2021 ('the Ghana Origin Reference Document')",
+                "ord_version": "1.1",
+                "ord_date": "28 December 2021",
+                "ord_original": "211223_ORD_Ghana_-_HS.odt"
+            },
+            "articles": {
+                "article 1": "definitions",
+                "article 2": "general requirements",
+                "article 3": "wholly obtained",
+                "article 4": "sufficient working",
+                "article 5": "insufficient working",
+                "article 6": "duty-free",
+                "article 7": "cumulation",
+                "article 8": "cumulation",
+                "article 9": "unit of qualification",
+                "article 10": "sets",
+                "article 11": "neutral elements",
+                "article 12": "accounting segregation",
+                "article 13": "principle of territoriality",
+                "article 14": "non-alteration",
+                "Annex II": "sufficient working"
+            },
+            "features": {
+                "absorption": true,
+                "tolerances": false,
+                "sets": true,
+                "cumulation": true,
+                "drawback": false
+            },
+            "introductory_notes_file": "ghana_intro.md",
+            "fta_intro_file": "ghana.md",
+            "links": [
+                {
+                    "text": "UK-Ghana Interim Trade Partnership Agreement",
+                    "url": "https://www.gov.uk/government/collections/uk-ghana-interim-trade-partnership-agreement"
+                },
+                {
+                    "text": "",
+                    "url": ""
+                }
+            ],
+            "countries": [
+                "GH"
+            ]
+        },
+        {
+            "scheme_code": "iceland-norway",
+            "title": "Agreement on Trade in Goods between Iceland, Norway and the UK",
+            "proofs": [
+                {
+                    "summary": "EUR.1 movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur1",
+                    "detail": ""
+                },
+                {
+                    "summary": "EUR-MED movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur-med",
+                    "detail": ""
+                },
+                {
+                    "summary": "Origin declaration",
+                    "subtext": "or origin declaration EUR-MED including UK Approved Exporter number for consignments with a value over £5500  / 6000 euros",
+                    "proof_class": "origin-declaration",
+                    "detail": ""
+                }
+            ],
+            "cumulation_methods": {
+                "bilateral": {
+                    "countries": [
+                        "GB",
+                        "IS",
+                        "NO"
+                    ]
+                },
+                "extended": {
+                    "countries": [
+                        "EU",
+                        "AD",
+                        "SM",
+                        "XK",
+                        "DZ",
+                        "BA",
+                        "FO",
+                        "GE",
+                        "IL",
+                        "JO",
+                        "EG",
+                        "LB",
+                        "XS",
+                        "ME",
+                        "MA",
+                        "MK",
+                        "PS",
+                        "AL",
+                        "SY",
+                        "UA",
+                        "CH",
+                        "LI",
+                        "TR"
+                    ]
+                }
+            },
+            "ord": {
+                "ord_title": "Origin Reference Document implementing the Agreement between the United Kingdom of Great Britain and Northern Ireland, Iceland and the Kingdom of Norway on Trade in Goods, dated 8th December 2020 ('the Iceland Origin Reference Document')",
+                "ord_version": "1.1",
+                "ord_date": "28 December 2021",
+                "ord_original": "050822_Iceland_Norway_ORD.odt"
+            },
+            "articles": {
+                "article 1": "definitions",
+                "article 2": "general requirements",
+                "article 3": "cumulation",
+                "article 4": "wholly obtained",
+                "article 5": "sufficient working",
+                "article 6": "insufficient working",
+                "article 7": "unit of qualification",
+                "article 8": "accessories",
+                "article 9": "sets",
+                "article 10": "neutral elements",
+                "article 11": "principle of territoriality",
+                "article 12": "direct transport",
+                "article 13": "exhibitions",
+                "Annex II": "sufficient working"
+            },
+            "features": {
+                "absorption": true,
+                "tolerances": false,
+                "sets": true,
+                "cumulation": true,
+                "drawback": false
+            },
+            "introductory_notes_file": "iceland-norway_intro.md",
+            "fta_intro_file": "iceland-norway.md",
+            "links": [
+                {
+                    "text": "Agreement on trade in goods between Iceland, Norway and the UK",
+                    "url": "https://www.gov.uk/government/collections/agreement-on-trade-in-goods-between-iceland-norway-and-the-uk"
+                },
+                {
+                    "text": "Trade with Iceland and Norway",
+                    "url": "https://www.gov.uk/guidance/summary-of-agreement-on-trade-in-goods-between-iceland-norway-and-the-uk"
+                }
+            ],
+            "countries": [
+                "IS",
+                "NO"
+            ]
+        },
+        {
+            "scheme_code": "israel",
+            "title": "UK-Israel Trade and Partnership Agreement",
+            "proofs": [
+                {
+                    "summary": "EUR.1 movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur1",
+                    "detail": ""
+                },
+                {
+                    "summary": "EUR-MED movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur-med",
+                    "detail": ""
+                },
+                {
+                    "summary": "Origin declaration",
+                    "subtext": "or origin declaration EUR-MED including UK Approved Exporter number for consignments with a value over £5500  / 6000 euros",
+                    "proof_class": "origin-declaration",
+                    "detail": ""
+                }
+            ],
+            "cumulation_methods": {
+                "bilateral": {
+                    "countries": [
+                        "GB",
+                        "IL"
+                    ]
+                },
+                "extended": {
+                    "countries": [
+                        "EU",
+                        "AD",
+                        "SM",
+                        "AL",
+                        "DZ",
+                        "BA",
+                        "FO",
+                        "GE",
+                        "JO",
+                        "EG",
+                        "XK",
+                        "LB",
+                        "MD",
+                        "ME",
+                        "MA",
+                        "MK",
+                        "PS",
+                        "XS",
+                        "SY",
+                        "UA",
+                        "CH",
+                        "LI",
+                        "IS",
+                        "NO",
+                        "TR"
+                    ]
+                }
+            },
+            "ord": {
+                "ord_title": "Origin Reference Document implementing the Trade and Partnership Agreement between the United Kingdom of Great Britain and Northern Ireland and the Government of the State of Israel, signed on 18th February 2019 (“the Israel Origin Reference Document”)",
+                "ord_version": "1.1",
+                "ord_date": "28 December 2021",
+                "ord_original": "20211202_ORD_Israel_V1.1.odt"
+            },
+            "articles": {
+                "article 1": "definitions",
+                "article 2": "general requirements",
+                "article 3": "cumulation",
+                "article 4": "cumulation",
+                "article 5": "wholly obtained",
+                "article 6": "sufficient working",
+                "article 7": "insufficient working",
+                "article 8": "unit of qualification",
+                "article 9": "accessories",
+                "article 10": "sets",
+                "article 11": "neutral elements",
+                "article 12": "principle of territoriality",
+                "article 13": "direct transport",
+                "article 14": "exhibitions",
+                "Annex II": "sufficient working"
+            },
+            "features": {
+                "absorption": true,
+                "tolerances": false,
+                "sets": true,
+                "cumulation": true,
+                "drawback": false
+            },
+            "introductory_notes_file": "israel_intro.md",
+            "fta_intro_file": "israel.md",
+            "links": [
+                {
+                    "text": "UK-Israel trade and partnership agreement",
+                    "url": "https://www.gov.uk/government/collections/uk-israel-trade-and-partnership-agreement"
+                },
+                {
+                    "text": "https://www.gov.uk/guidance/summary-of-the-uk-israel-trade-and-partnership-agreement",
+                    "url": "Trade with Israel"
+                }
+            ],
+            "countries": [
+                "IL"
+            ]
+        },
+        {
             "scheme_code": "japan",
             "title": "UK-Japan Comprehensive Economic Partnership Agreement",
             "proofs": [
@@ -153,13 +2046,13 @@
                     "summary": "Statement on origin",
                     "subtext": "",
                     "proof_class": "origin-declaration",
-                    "detail": "statement-on-origin.md"
+                    "detail": ""
                 },
                 {
                     "summary": "Importer's knowledge",
                     "subtext": "",
                     "proof_class": "importers-knowledge",
-                    "detail": "importers-knowledge.md"
+                    "detail": ""
                 }
             ],
             "cumulation_methods": {
@@ -205,7 +2098,8 @@
                 "absorption": true,
                 "tolerances": true,
                 "sets": true,
-                "cumulation": true
+                "cumulation": true,
+                "drawback": false
             },
             "introductory_notes_file": "japan_intro.md",
             "fta_intro_file": "japan.md",
@@ -298,27 +2192,33 @@
             ]
         },
         {
-            "scheme_code": "albania",
-            "title": "UK-Albania Partnership, Trade and Cooperation Agreement",
+            "scheme_code": "jordan",
+            "title": "UK-Jordan Association Agreement",
             "proofs": [
                 {
-                    "summary": "EUR1 or EUR.MED movement certificate",
+                    "summary": "EUR.1 movement certificate",
                     "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
+                    "proof_class": "eur1",
+                    "detail": ""
+                },
+                {
+                    "summary": "EUR-MED movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur-med",
+                    "detail": ""
                 },
                 {
                     "summary": "Origin declaration",
-                    "subtext": "",
+                    "subtext": "or origin declaration EUR-MED including UK Approved Exporter number for consignments with a value over £5500  / 6000 euros",
                     "proof_class": "origin-declaration",
-                    "detail": "origin-declaration.md"
+                    "detail": ""
                 }
             ],
             "cumulation_methods": {
                 "bilateral": {
                     "countries": [
                         "GB",
-                        "AL"
+                        "JO"
                     ]
                 },
                 "extended": {
@@ -326,14 +2226,14 @@
                         "EU",
                         "AD",
                         "SM",
-                        "XK",
+                        "AL",
                         "DZ",
                         "BA",
                         "FO",
                         "GE",
                         "IL",
-                        "JO",
                         "EG",
+                        "XK",
                         "LB",
                         "MD",
                         "ME",
@@ -352,10 +2252,10 @@
                 }
             },
             "ord": {
-                "ord_title": "Origin Reference Document implementing the Partnership, Trade and Cooperation Agreement between the United Kingdom of Great Britain and Northern Ireland and the Republic of Albania, signed on 5th February 2021 ('the Albania Origin Reference Document')",
+                "ord_title": "Origin Reference Document implementing the Agreement Establishing an Association between the United Kingdom of Great Britain and Northern Ireland and the Hashemite Kingdom of Jordan, signed on 5 November 2019 ('the Jordan Origin Reference Document')",
                 "ord_version": "1.1",
-                "ord_date": "28 November 2021",
-                "ord_original": "211228_ORD_Albania_V1.1.odt"
+                "ord_date": "28 December 2021",
+                "ord_original": "20211202_ORD_Jordan__HS_UPDATE_.odt"
             },
             "articles": {
                 "article 1": "definitions",
@@ -376,184 +2276,25 @@
             },
             "features": {
                 "absorption": true,
-                "tolerances": true,
-                "sets": true,
-                "cumulation": true
-            },
-            "introductory_notes_file": "albania_intro.md",
-            "fta_intro_file": "albania.md",
-            "links": [
-                {
-                    "text": "UK-Albania partnership, Trade and Cooperation Agreement",
-                    "url": "https://www.gov.uk/government/collections/uk-albania-partnership-trade-and-cooperation-agreement"
-                },
-                {
-                    "text": "Continuing the United Kingdom’s trade relationship with Albania",
-                    "url": "https://www.gov.uk/government/publications/continuing-the-uks-trade-relationship-with-albania-parliamentary-report/continuing-the-united-kingdoms-trade-relationship-with-albania-web-version"
-                }
-            ],
-            "countries": [
-                "AL"
-            ]
-        },
-        {
-            "scheme_code": "canada",
-            "title": "UK-Canada Trade Continuity Agreement",
-            "proofs": [
-                {
-                    "summary": "Statement on origin",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "statement-on-origin.md"
-                }
-            ],
-            "cumulation_methods": {
-                "bilateral": {
-                    "countries": [
-                        "GB",
-                        "CA"
-                    ]
-                },
-                "extended": {
-                    "countries": [
-                        "EU",
-                        "AD",
-                        "SM",
-                        "XX",
-                        "JP",
-                        "MX",
-                        "SG",
-                        "VN",
-                        "CL",
-                        "CO",
-                        "CR",
-                        "IS",
-                        "LI",
-                        "NO",
-                        "CH",
-                        "HO",
-                        "IL",
-                        "KR",
-                        "PE",
-                        "UA"
-                    ]
-                }
-            },
-            "ord": {
-                "ord_title": "The Canada Origin Reference Document",
-                "ord_version": "1.1",
-                "ord_date": "28 December 2021",
-                "ord_original": "211223_ORD_Canada_V1.1.odt"
-            },
-            "articles": {
-                "article 1": "definitions",
-                "article 2": "general requirements",
-                "article 3": "cumulation",
-                "article 4": "wholly obtained",
-                "article 5": "sufficient working",
-                "article 6": "tolerances",
-                "article 7": "insufficient working",
-                "article 8": "unit of qualification",
-                "article 9": "packing materials - shipment",
-                "article 10": "accounting segregation",
-                "article 11": "accessories",
-                "article 12": "sets",
-                "Annex II": "sufficient working"
-            },
-            "features": {
-                "absorption": true,
                 "tolerances": false,
                 "sets": true,
-                "cumulation": true
+                "cumulation": true,
+                "drawback": true
             },
-            "introductory_notes_file": "canada_intro.md",
-            "fta_intro_file": "canada.md",
+            "introductory_notes_file": "jordan_intro.md",
+            "fta_intro_file": "jordan.md",
             "links": [
                 {
-                    "text": "Trade with Canada",
-                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-canada-trade-continuity-agreement"
+                    "text": "UK-Jordan association agreement",
+                    "url": "https://www.gov.uk/government/collections/uk-jordan-association-agreement"
                 },
                 {
-                    "text": "UK-Canada Trade Continuity Agreement (TCA)",
-                    "url": "https://www.gov.uk/guidance/uk-canada-trade-continuity-agreement-tca"
+                    "text": "Trade with Jordan",
+                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-jordanassociationagreement"
                 }
             ],
             "countries": [
-                "CA"
-            ]
-        },
-        {
-            "scheme_code": "south-korea",
-            "title": "UK-South Korea Trade Agreement",
-            "proofs": [
-                {
-                    "summary": "Origin declaration",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "origin-declaration.md"
-                }
-            ],
-            "cumulation_methods": {
-                "bilateral": {
-                    "countries": [
-                        "GB",
-                        "KR"
-                    ]
-                },
-                "diagonal": {
-                    "countries": [
-                        "EU",
-                        "AD",
-                        "SM"
-                    ]
-                }
-            },
-            "ord": {
-                "ord_title": "Origin Reference Document implementing the Free Trade Agreement between the United Kingdom of Great Britain and Northern Ireland, of the one part, and the Republic of  Korea, of the other part, signed on 22 August 2019 ('the Korea Origin Reference Document')",
-                "ord_version": "1.1",
-                "ord_date": "28th December 2021",
-                "ord_original": "211208_ORD_Korea__HS_UPDATE_.odt"
-            },
-            "articles": {
-                "article 1": "definitions",
-                "article 2": "general requirements",
-                "article 3": "cumulation",
-                "article 4": "wholly obtained",
-                "article 5": "sufficient working",
-                "article 6": "insufficient working",
-                "article 7": "unit of qualification",
-                "article 8": "accessories",
-                "article 9": "sets",
-                "article 10": "neutral elements",
-                "article 11": "accounting segregation",
-                "article 12": "principle of territoriality",
-                "article 13": "direct transport",
-                "Annex II": "sufficient working"
-            },
-            "features": {
-                "absorption": true,
-                "tolerances": false,
-                "sets": true,
-                "cumulation": true
-            },
-            "introductory_notes_file": "south-korea_intro.md",
-            "fta_intro_file": "south-korea.md",
-            "links": [
-                {
-                    "text": "UK-South Korea trade agreement",
-                    "url": "https://www.gov.uk/government/collections/uk-south-korea-trade-agreement"
-                },
-                {
-                    "text": "Trade with South Korea",
-                    "url": "https://www.gov.uk/guidance/summary-of-uk-south-korea-trade-agreement"
-                },
-                {
-                    "text": "Continuing the UK's trade relationship with South Korea: parliamentary report",
-                    "url": "https://www.gov.uk/government/publications/continuing-the-uks-trade-relationship-with-south-korea-parliamentary-report"
-                }
-            ],
-            "countries": [
-                "KR"
+                "JO"
             ]
         },
         {
@@ -561,16 +2302,16 @@
             "title": "Comprehensive Economic Partnership Agreement UK Kenya",
             "proofs": [
                 {
-                    "summary": "EUR1 or EUR.MED movement certificate",
+                    "summary": "EUR.1 movement certificate",
                     "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
+                    "proof_class": "eur1",
+                    "detail": ""
                 },
                 {
-                    "summary": "Invoice declaration",
+                    "summary": "Origin declaration",
                     "subtext": "",
                     "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
+                    "detail": ""
                 }
             ],
             "cumulation_methods": {
@@ -726,7 +2467,8 @@
                 "absorption": true,
                 "tolerances": false,
                 "sets": true,
-                "cumulation": true
+                "cumulation": true,
+                "drawback": false
             },
             "footnote": "This agreement is open to accession by other members of East African Community.",
             "introductory_notes_file": "kenya_intro.md",
@@ -746,1676 +2488,26 @@
             ]
         },
         {
-            "scheme_code": "esa",
-            "title": "ESA-UK Economic Partnership Agreement (EPA)",
-            "proofs": [
-                {
-                    "summary": "EUR1 or EUR.MED movement certificate",
-                    "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
-                },
-                {
-                    "summary": "Invoice declaration",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
-                }
-            ],
-            "cumulation_methods": {
-                "bilateral": {
-                    "countries": [
-                        "GB",
-                        "ZW",
-                        "SC",
-                        "MU"
-                    ]
-                },
-                "extended": {
-                    "countries": [
-                        "EU",
-                        "AD",
-                        "SM",
-                        "AO",
-                        "AG",
-                        "BS",
-                        "BB",
-                        "BZ",
-                        "BJ",
-                        "BW",
-                        "BF",
-                        "BI",
-                        "CM",
-                        "CV",
-                        "CF",
-                        "TD",
-                        "CK",
-                        "CI",
-                        "CD",
-                        "DJ",
-                        "DM",
-                        "DO",
-                        "GQ",
-                        "ER",
-                        "SZ",
-                        "ET",
-                        "FM",
-                        "FJ",
-                        "GA",
-                        "GM",
-                        "GH",
-                        "GD",
-                        "GN",
-                        "GW",
-                        "GY",
-                        "HT",
-                        "JM",
-                        "KE",
-                        "KI",
-                        "LS",
-                        "LR",
-                        "MW",
-                        "ML",
-                        "MH",
-                        "MR",
-                        "MZ",
-                        "NA",
-                        "NR",
-                        "NE",
-                        "NU",
-                        "NG",
-                        "PW",
-                        "PG",
-                        "CG",
-                        "RW",
-                        "KN",
-                        "LC",
-                        "VC",
-                        "WS",
-                        "ST",
-                        "SN",
-                        "SL",
-                        "SB",
-                        "SO",
-                        "SD",
-                        "SR",
-                        "TZ",
-                        "TG",
-                        "TO",
-                        "TT",
-                        "TV",
-                        "UG",
-                        "VU",
-                        "GL",
-                        "NC",
-                        "PF",
-                        "TF",
-                        "WF",
-                        "YT",
-                        "PM",
-                        "AW",
-                        "AN",
-                        "CW",
-                        "SX",
-                        "AI",
-                        "KY",
-                        "FK",
-                        "GS",
-                        "MS",
-                        "PN",
-                        "SH",
-                        "ZU",
-                        "IO",
-                        "TC",
-                        "VG",
-                        "DZ",
-                        "EG",
-                        "LY",
-                        "MA",
-                        "TN",
-                        "MV"
-                    ]
-                }
-            },
-            "ord": {
-                "ord_title": "Origin Reference Document implementing the Agreement establishing an Economic Partnership Agreement between the Eastern and Southern African States, on the one part, and the United Kingdom of Great Britain and Northern Ireland, on the other part, signed by the Republic of Mauritius, the Republic of the Seychelles and the Republic of Zimbabwe on 31st January 2019 ('the Eastern and Southern African States Origin Reference Document')",
-                "ord_version": "1.1",
-                "ord_date": "28th December 2021",
-                "ord_original": "211223_ORD_ESA_V1.1.odt"
-            },
-            "articles": {
-                "article 1": "definitions",
-                "article 2": "general requirements",
-                "article 3": "cumulation",
-                "article 4": "cumulation",
-                "article 5": "cumulation",
-                "article 6": "wholly obtained",
-                "article 7": "sufficient working",
-                "article 8": "insufficient working",
-                "article 9": "unit of qualification",
-                "article 10": "accessories",
-                "article 11": "sets",
-                "article 12": "neutral elements",
-                "article 13": "principle of territoriality",
-                "article 14": "direct transport",
-                "article 15": "exhibitions",
-                "Annex II": "sufficient working"
-            },
-            "features": {
-                "absorption": true,
-                "tolerances": false,
-                "sets": true,
-                "cumulation": true
-            },
-            "introductory_notes_file": "esa_intro.md",
-            "fta_intro_file": "esa.md",
-            "links": [
-                {
-                    "text": "ESA-UK economic partnership agreement (EPA)",
-                    "url": "https://www.gov.uk/government/collections/esa-uk-economic-partnership-agreement-epa--2"
-                },
-                {
-                    "text": "Trade with Eastern and Southern African (ESA) States",
-                    "url": "https://www.gov.uk/guidance/summary-of-the-esa-uk-economic-partnership-agreement-epa"
-                }
-            ],
-            "countries": [
-                "SC",
-                "MU",
-                "ZW"
-            ]
-        },
-        {
-            "scheme_code": "central-america",
-            "title": "UK-Central America Association Agreement",
-            "proofs": [
-                {
-                    "summary": "EUR1 or EUR.MED movement certificate",
-                    "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
-                },
-                {
-                    "summary": "Invoice declaration",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
-                }
-            ],
-            "cumulation_methods": {
-                "bilateral": {
-                    "countries": [
-                        "GB",
-                        "HO",
-                        "NI",
-                        "SV",
-                        "GT",
-                        "PA",
-                        "CR"
-                    ]
-                },
-                "extended": {
-                    "countries": [
-                        "EU",
-                        "AD",
-                        "SM",
-                        "VE",
-                        "CO",
-                        "EC",
-                        "PE",
-                        "BO",
-                        "CL",
-                        "AR",
-                        "UR",
-                        "BR",
-                        "GF",
-                        "SR",
-                        "GY",
-                        "MX",
-                        "ID",
-                        "AG",
-                        "BB",
-                        "BS",
-                        "BZ",
-                        "DM",
-                        "DO",
-                        "GD",
-                        "GY",
-                        "JM",
-                        "KN",
-                        "LC",
-                        "SR",
-                        "TT",
-                        "VC"
-                    ]
-                }
-            },
-            "ord": {
-                "ord_title": "The Origin Reference Document implementing the Agreement between the United Kingdom and Central America signed on 18 July 2019 ('the Central America Origin Reference Document')",
-                "ord_version": "1.2",
-                "ord_date": "22 February 2022",
-                "ord_original": "220214_ORD_Central_America_V1.2.odt"
-            },
-            "articles": {
-                "article 1": "definitions",
-                "article 2": "general requirements",
-                "article 3": "cumulation",
-                "article 3a": "cumulation",
-                "article 4": "wholly obtained",
-                "article 5": "sufficient working",
-                "article 6": "insufficient working",
-                "article 7": "unit of qualification",
-                "article 8": "accessories",
-                "article 9": "sets",
-                "article 10": "neutral elements",
-                "article 11": "principle of territoriality",
-                "article 12": "direct transport",
-                "article 13": "exhibitions",
-                "Annex II": "sufficient working"
-            },
-            "features": {
-                "absorption": true,
-                "tolerances": false,
-                "sets": true,
-                "cumulation": true
-            },
-            "introductory_notes_file": "central_america_intro.md",
-            "fta_intro_file": "central_america.md",
-            "links": [
-                {
-                    "text": "UK-Central America association agreement",
-                    "url": "https://www.gov.uk/government/collections/uk-central-america-association-agreement"
-                },
-                {
-                    "text": "Trade with Central America",
-                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-central-america-association-agreement"
-                }
-            ],
-            "countries": [
-                "central-america",
-                "CR",
-                "GT",
-                "HN",
-                "NI",
-                "PA",
-                "SV"
-            ]
-        },
-        {
-            "scheme_code": "andean",
-            "title": "UK-Andean Countries Trade Agreement",
-            "proofs": [
-                {
-                    "summary": "EUR1 or EUR.MED movement certificate",
-                    "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
-                },
-                {
-                    "summary": "Invoice declaration",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
-                }
-            ],
-            "cumulation_methods": {
-                "bilateral": {
-                    "countries": [
-                        "GB",
-                        "CO",
-                        "EC",
-                        "PE"
-                    ]
-                },
-                "extended": {
-                    "countries": [
-                        "EU",
-                        "AD",
-                        "SM",
-                        "AG",
-                        "BB",
-                        "BS",
-                        "BZ",
-                        "DM",
-                        "DO",
-                        "GD",
-                        "GY",
-                        "JM",
-                        "KN",
-                        "LC",
-                        "SR",
-                        "TT",
-                        "VC",
-                        "MX",
-                        "GT",
-                        "HO",
-                        "NI",
-                        "SV",
-                        "CR",
-                        "PA",
-                        "BR",
-                        "VE",
-                        "GF",
-                        "BO",
-                        "PY",
-                        "UY",
-                        "AR",
-                        "CL"
-                    ]
-                }
-            },
-            "ord": {
-                "ord_title": "The Andean Countries Origin Reference Document Version 1.3, Dated 28th December 2021",
-                "ord_version": "1.3",
-                "ord_date": "31 May 2022",
-                "ord_original": "310522_Andean_ORD.odt"
-            },
-            "articles": {
-                "article 1": "definitions",
-                "article 2": "general requirements",
-                "article 3": "cumulation",
-                "article 3a": "cumulation",
-                "article 4": "cumulation",
-                "article 5": "wholly obtained",
-                "article 6": "sufficient working",
-                "article 7": "insufficient working",
-                "article 8": "unit of qualification",
-                "article 9": "accessories",
-                "article 10": "sets",
-                "article 11": "neutral elements",
-                "article 12": "principle of territoriality",
-                "article 13": "direct transport",
-                "article 14": "exhibitions",
-                "Annex II": "sufficient working"
-            },
-            "features": {
-                "absorption": true,
-                "tolerances": false,
-                "sets": true,
-                "cumulation": true
-            },
-            "introductory_notes_file": "andean_intro.md",
-            "fta_intro_file": "andean.md",
-            "links": [
-                {
-                    "text": "UK-Andean countries trade agreement",
-                    "url": "https://www.gov.uk/government/collections/uk-andean-countries-trade-agreement"
-                },
-                {
-                    "text": "Trade with the Andean countries",
-                    "url": "https://www.gov.uk/guidance/summary-of-uk-andean-countries-trade-agreement"
-                }
-            ],
-            "countries": [
-                "andean",
-                "CO",
-                "PE",
-                "EC"
-            ]
-        },
-        {
-            "scheme_code": "cameroon",
-            "title": "UK-Cameroon Economic Partnership Agreement",
-            "proofs": [
-                {
-                    "summary": "EUR1 or EUR.MED movement certificate",
-                    "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
-                },
-                {
-                    "summary": "Invoice declaration",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
-                }
-            ],
-            "cumulation_methods": {
-                "bilateral": {
-                    "countries": [
-                        "GB",
-                        "CM"
-                    ]
-                },
-                "extended": {
-                    "countries": [
-                        "EU",
-                        "AD",
-                        "SM",
-                        "AG",
-                        "BS",
-                        "BB",
-                        "BZ",
-                        "BW",
-                        "CI",
-                        "DM",
-                        "DO",
-                        "FJ",
-                        "GH",
-                        "GD",
-                        "GY",
-                        "JM",
-                        "KE",
-                        "LS",
-                        "MG",
-                        "MU",
-                        "MZ",
-                        "NA",
-                        "PG",
-                        "KN",
-                        "LC",
-                        "VC",
-                        "SC",
-                        "SR",
-                        "SZ",
-                        "TT",
-                        "ZW",
-                        "GL",
-                        "NC",
-                        "PF",
-                        "PM",
-                        "BL",
-                        "TF",
-                        "WF",
-                        "AW",
-                        "CW",
-                        "SX",
-                        "AI",
-                        "BM",
-                        "KY",
-                        "FK",
-                        "GS",
-                        "MS",
-                        "PN",
-                        "SH",
-                        "ZU",
-                        "IO",
-                        "TC",
-                        "VG"
-                    ]
-                }
-            },
-            "ord": {
-                "ord_title": "The Cameroon Origin Reference Document",
-                "ord_version": "1.3",
-                "ord_date": "28 December 2021",
-                "ord_original": "211223_Cameroon_ORD__HS_UPDATE__.odt"
-            },
-            "articles": {
-                "article 1": "definitions",
-                "article 2": "general requirements",
-                "article 3": "wholly obtained",
-                "article 4": "sufficient working",
-                "article 5": "insufficient working",
-                "article 7": "unit of qualification",
-                "article 8": "accessories",
-                "article 9": "sets",
-                "article 10": "neutral elements",
-                "article 11": "principle of territoriality",
-                "article 12": "direct transport",
-                "article 13": "exhibitions",
-                "Annex II": "sufficient working"
-            },
-            "features": {
-                "absorption": true,
-                "tolerances": false,
-                "sets": true,
-                "cumulation": true
-            },
-            "introductory_notes_file": "cameroon_intro.md",
-            "fta_intro_file": "cameroon.md",
-            "links": [
-                {
-                    "text": "UK-Cameroon Economic Partnership Agreement",
-                    "url": "https://www.gov.uk/government/collections/uk-cameroon-economic-partnership-agreement"
-                },
-                {
-                    "text": "Trade with Cameroon",
-                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-cameroon-economic-partnership-agreement"
-                }
-            ],
-            "countries": [
-                "CM"
-            ]
-        },
-        {
-            "scheme_code": "cariforum",
-            "title": "CARIFORUM-UK Economic Partnership Agreement",
-            "proofs": [
-                {
-                    "summary": "EUR1 or EUR.MED movement certificate",
-                    "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
-                },
-                {
-                    "summary": "Invoice declaration",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
-                }
-            ],
-            "cumulation_methods": {
-                "bilateral": {
-                    "countries": [
-                        "GB",
-                        "AG",
-                        "BS",
-                        "BB",
-                        "BZ",
-                        "DM",
-                        "DO",
-                        "GD",
-                        "GY",
-                        "JM",
-                        "KN",
-                        "LC",
-                        "VC",
-                        "SR",
-                        "TT",
-                        "AO",
-                        "BJ",
-                        "BW",
-                        "Faso BF",
-                        "BI",
-                        "CM",
-                        "CV",
-                        "CF",
-                        "TD",
-                        "CK",
-                        "KM",
-                        "CI",
-                        "CD",
-                        "DJ",
-                        "GQ",
-                        "ER",
-                        "ET",
-                        "FM",
-                        "FJ",
-                        "GA",
-                        "GM",
-                        "GH",
-                        "GN",
-                        "GW",
-                        "KE",
-                        "KI",
-                        "LS",
-                        "LR",
-                        "MG",
-                        "MW",
-                        "ML",
-                        "MH",
-                        "MR",
-                        "MU",
-                        "MZ",
-                        "NA",
-                        "NR",
-                        "NE",
-                        "NU",
-                        "NG",
-                        "PW",
-                        "PG",
-                        "CG",
-                        "RW",
-                        "WS",
-                        "ST",
-                        "SN",
-                        "SC",
-                        "SL",
-                        "SB",
-                        "SO",
-                        "SD",
-                        "SZ",
-                        "TZ",
-                        "TG",
-                        "TO",
-                        "TV",
-                        "UG",
-                        "VU",
-                        "ZM",
-                        "ZW",
-                        "GL",
-                        "NC",
-                        "PF",
-                        "PM",
-                        "BL",
-                        "TF",
-                        "WF",
-                        "AW",
-                        "BQ",
-                        "CW",
-                        "BQ",
-                        "SX",
-                        "AI",
-                        "BM",
-                        "KY",
-                        "FK",
-                        "GS",
-                        "MS",
-                        "PN",
-                        "SH",
-                        "ZU",
-                        "IO",
-                        "TC",
-                        "VG"
-                    ]
-                },
-                "extended": {
-                    "countries": [
-                        "EU",
-                        "AD",
-                        "SM"
-                    ]
-                }
-            },
-            "ord": {
-                "ord_title": "The CARIFORUM Origin Reference Document",
-                "ord_version": "1.2",
-                "ord_date": "28 December 2021",
-                "ord_original": "211223_ORD_CARIFORUM_V1.2.odt"
-            },
-            "articles": {
-                "article 1": "definitions",
-                "article 2": "general requirements",
-                "article 3": "cumulation",
-                "article 4": "cumulation",
-                "article 5": "cumulation",
-                "article 6": "wholly obtained",
-                "article 7": "sufficient working",
-                "article 8": "insufficient working",
-                "article 9": "unit of qualification",
-                "article 10": "accessories",
-                "article 11": "sets",
-                "article 12": "neutral elements",
-                "article 13": "principle of territoriality",
-                "article 14": "direct transport",
-                "article 15": "exhibitions",
-                "Annex II": "sufficient working"
-            },
-            "features": {
-                "absorption": true,
-                "tolerances": false,
-                "sets": true,
-                "cumulation": true
-            },
-            "introductory_notes_file": "cariforum_intro.md",
-            "fta_intro_file": "cariforum.md",
-            "links": [
-                {
-                    "text": "CARIFORUM-UK economic partnership agreement",
-                    "url": "https://www.gov.uk/government/collections/cariforum-uk-economic-partnership-agreement"
-                },
-                {
-                    "text": "Trade with the CARIFORUM States",
-                    "url": "https://www.gov.uk/guidance/summary-of-the-cariforum-uk-economic-partnership-agreement-epa"
-                }
-            ],
-            "countries": [
-                "AG",
-                "BB",
-                "BS",
-                "BZ",
-                "DM",
-                "DO",
-                "GD",
-                "GY",
-                "JM",
-                "KN",
-                "LC",
-                "SR",
-                "TT",
-                "VC"
-            ]
-        },
-        {
-            "scheme_code": "chile",
-            "title": "UK-Chile Association Agreement",
-            "proofs": [
-                {
-                    "summary": "EUR1 or EUR.MED movement certificate",
-                    "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
-                },
-                {
-                    "summary": "Invoice declaration",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
-                }
-            ],
-            "cumulation_methods": {
-                "bilateral": {
-                    "countries": [
-                        "GB",
-                        "CL"
-                    ]
-                },
-                "diagonal": {
-                    "countries": [
-                        "EU",
-                        "AD",
-                        "SM"
-                    ]
-                }
-            },
-            "ord": {
-                "ord_title": "Origin Reference Document implementing the Agreement establishing an Association between the United Kingdom of Great Britain and Northern Ireland and the Republic of Chile signed on 30 January 2019 ('the Chile Origin Reference Document')",
-                "ord_version": "1.2",
-                "ord_date": "22 February 2022",
-                "ord_original": "220214_ORD_Chile__v1.2.odt"
-            },
-            "articles": {
-                "article 1": "definitions",
-                "article 2": "general requirements",
-                "article 3": "cumulation",
-                "article 3a": "cumulation",
-                "article 4": "wholly obtained",
-                "article 5": "sufficient working",
-                "article 6": "insufficient working",
-                "article 7": "unit of qualification",
-                "article 8": "accessories",
-                "article 9": "sets",
-                "article 10": "neutral elements",
-                "article 11": "principle of territoriality",
-                "article 12": "direct transport",
-                "article 13": "exhibitions",
-                "Annex II": "sufficient working"
-            },
-            "features": {
-                "absorption": true,
-                "tolerances": false,
-                "sets": true,
-                "cumulation": true
-            },
-            "introductory_notes_file": "chile_intro.md",
-            "fta_intro_file": "chile.md",
-            "links": [
-                {
-                    "text": "UK-Chile Association Agreement",
-                    "url": "https://www.gov.uk/government/collections/uk-chile-association-agreement"
-                },
-                {
-                    "text": "Trade with Chile",
-                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-chile-association-agreement"
-                }
-            ],
-            "countries": [
-                "CL"
-            ]
-        },
-        {
-            "scheme_code": "cotedivoire",
-            "title": "UK-Côte d’Ivoire Stepping Stone Economic Partnership Agreement",
-            "proofs": [
-                {
-                    "summary": "Origin declaration",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "origin-declaration.md"
-                },
-                {
-                    "summary": "EUR1 or EUR.MED movement certificate",
-                    "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
-                }
-            ],
-            "cumulation_methods": {
-                "bilateral": {
-                    "countries": [
-                        "GB",
-                        "CI"
-                    ]
-                },
-                "extended": {
-                    "countries": [
-                        "EU",
-                        "AD",
-                        "SM",
-                        "BJ",
-                        "BF",
-                        "CV",
-                        "GM",
-                        "GH",
-                        "GN",
-                        "GW",
-                        "LR",
-                        "ML",
-                        "MR",
-                        "NE",
-                        "NG",
-                        "SN",
-                        "SL",
-                        "TG",
-                        "FJ",
-                        "PG",
-                        "WS",
-                        "SB",
-                        "CM",
-                        "KE",
-                        "BW",
-                        "ZW",
-                        "ZA",
-                        "LS",
-                        "SZ",
-                        "MZ",
-                        "SC",
-                        "MU",
-                        "ZA",
-                        "AG",
-                        "BS",
-                        "BB",
-                        "BZ",
-                        "DM",
-                        "DO",
-                        "GD",
-                        "GY",
-                        "JM",
-                        "LC",
-                        "VC",
-                        "KN",
-                        "SR",
-                        "TT",
-                        "GL",
-                        "NC",
-                        "PF",
-                        "PM",
-                        "BL",
-                        "TF",
-                        "WF",
-                        "AW",
-                        "CW",
-                        "SX",
-                        "AI",
-                        "BM",
-                        "KY",
-                        "FK",
-                        "GS",
-                        "MS",
-                        "PN",
-                        "SH",
-                        "ZU",
-                        "IO",
-                        "TC",
-                        "VG"
-                    ]
-                }
-            },
-            "ord": {
-                "ord_title": "Origin Reference Document implementing the Stepping Stone Economic Partnership Agreement between the Republic of Côte d'Ivoire and the United Kingdom of Great Britain and Northern Ireland, signed on 15 October 2020 ('the Côte d'Ivoire Origin Reference Document')",
-                "ord_version": "1.1",
-                "ord_date": "28 November 2021",
-                "ord_original": "211223_ORD_Cote_d_Ivoire_-__HS_UPDATE_.odt"
-            },
-            "articles": {
-                "article 1": "definitions",
-                "article 2": "general requirements",
-                "article 3": "wholly obtained",
-                "article 4": "sufficient working",
-                "article 5": "insufficient working",
-                "article 6": "duty-free",
-                "article 7": "cumulation",
-                "article 8": "cumulation",
-                "article 9": "unit of qualification",
-                "article 10": "accessories",
-                "article 11": "sets",
-                "article 12": "neutral elements",
-                "article 13": "accounting segregation",
-                "article 14": "principle of territoriality",
-                "article 15": "non-alteration",
-                "article 16": "exhibitions",
-                "Annex II": "sufficient working"
-            },
-            "features": {
-                "absorption": true,
-                "tolerances": false,
-                "sets": true,
-                "cumulation": true
-            },
-            "introductory_notes_file": "cotedivoire_intro.md",
-            "fta_intro_file": "cotedivoire.md",
-            "links": [
-                {
-                    "text": "UK-Côte d’Ivoire Stepping Stone Economic Partnership Agreement",
-                    "url": "https://www.gov.uk/government/collections/uk-cote-divoire-stepping-stone-economic-partnership-agreement"
-                },
-                {
-                    "text": "Trade with Côte d’Ivoire",
-                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-cote-divoire-stepping-stone-economic-partnership-agreement"
-                }
-            ],
-            "countries": [
-                "CI"
-            ]
-        },
-        {
-            "scheme_code": "egypt",
-            "title": "UK-Egypt Association Agreement",
-            "proofs": [
-                {
-                    "summary": "EUR1 or EUR.MED movement certificate",
-                    "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
-                },
-                {
-                    "summary": "Invoice declaration",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
-                }
-            ],
-            "cumulation_methods": {
-                "bilateral": {
-                    "countries": [
-                        "GB",
-                        "EG"
-                    ]
-                },
-                "extended": {
-                    "countries": [
-                        "EU",
-                        "AD",
-                        "SM",
-                        "AL",
-                        "DZ",
-                        "BA",
-                        "FO",
-                        "GE",
-                        "IL",
-                        "JO",
-                        "XK",
-                        "LB",
-                        "MD",
-                        "ME",
-                        "MA",
-                        "MK",
-                        "PS",
-                        "XS",
-                        "SY",
-                        "UA",
-                        "CH",
-                        "LI",
-                        "IS",
-                        "NO",
-                        "TR"
-                    ]
-                }
-            },
-            "ord": {
-                "ord_title": "Origin Reference Document implementing the Agreement establishing an Association between the United Kingdom of Great Britain and Northern Ireland and the Arab Republic of Egypt, signed on 5th December 2020 ('the Egypt Origin Reference Document')",
-                "ord_version": "1.1",
-                "ord_date": "28 December 2021",
-                "ord_original": "20211223_ORD_Egypt_V1.1.odt"
-            },
-            "articles": {
-                "article 1": "definitions",
-                "article 2": "general requirements",
-                "article 3": "cumulation",
-                "article 4": "cumulation",
-                "article 5": "wholly obtained",
-                "article 6": "sufficient working",
-                "article 7": "insufficient working",
-                "article 8": "unit of qualification",
-                "article 9": "accessories",
-                "article 10": "sets",
-                "article 11": "neutral elements",
-                "article 12": "principle of territoriality",
-                "article 13": "direct transport",
-                "article 14": "exhibitions",
-                "Annex II": "sufficient working"
-            },
-            "features": {
-                "absorption": true,
-                "tolerances": false,
-                "sets": true,
-                "cumulation": true
-            },
-            "introductory_notes_file": "egypt_intro.md",
-            "fta_intro_file": "egypt.md",
-            "links": [
-                {
-                    "text": "UK-Egypt Association Agreement",
-                    "url": "https://www.gov.uk/government/collections/uk-egypt-associationagreement"
-                },
-                {
-                    "text": "Trade with Egypt",
-                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-egypt-association-agreement"
-                }
-            ],
-            "countries": [
-                "EG"
-            ]
-        },
-        {
-            "scheme_code": "faroe-islands",
-            "title": "UK-Faroe Islands Free Trade Agreement (FTA)",
-            "proofs": [
-                {
-                    "summary": "EUR1 or EUR.MED movement certificate",
-                    "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
-                },
-                {
-                    "summary": "Invoice declaration",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
-                }
-            ],
-            "cumulation_methods": {
-                "bilateral": {
-                    "countries": [
-                        "GB",
-                        "FO"
-                    ]
-                },
-                "extended": {
-                    "countries": [
-                        "EU",
-                        "AD",
-                        "SM",
-                        "AL",
-                        "DZ",
-                        "BA",
-                        "FO",
-                        "GE",
-                        "IL",
-                        "JO",
-                        "EG",
-                        "XK",
-                        "LB",
-                        "MD",
-                        "ME",
-                        "MA",
-                        "MK",
-                        "PS",
-                        "XS",
-                        "SY",
-                        "UA",
-                        "CH",
-                        "LI",
-                        "IS",
-                        "NO",
-                        "TR"
-                    ]
-                }
-            },
-            "ord": {
-                "ord_title": "Origin Reference Document implementing the Free Trade Agreement between the United Kingdom of Great Britain and Northern Ireland and the Kingdom of Denmark in respect of the Faroe Islands, signed on 31st January 2019 ('the Faroe Islands Origin Reference Document')",
-                "ord_version": "1.1",
-                "ord_date": "28 December 2021",
-                "ord_original": "20121223_ORD_Faroe_Islands_V1.1.odt"
-            },
-            "articles": {
-                "article 1": "definitions",
-                "article 2": "general requirements",
-                "article 3": "cumulation",
-                "article 4": "cumulation",
-                "article 5": "wholly obtained",
-                "article 6": "sufficient working",
-                "article 7": "insufficient working",
-                "article 8": "unit of qualification",
-                "article 9": "accessories",
-                "article 10": "sets",
-                "article 11": "neutral elements",
-                "article 12": "principle of territoriality",
-                "article 13": "direct transport",
-                "article 14": "exhibitions",
-                "Annex II": "sufficient working"
-            },
-            "features": {
-                "absorption": true,
-                "tolerances": false,
-                "sets": true,
-                "cumulation": true
-            },
-            "introductory_notes_file": "faroe-islands_intro.md",
-            "fta_intro_file": "faroe-islands.md",
-            "links": [
-                {
-                    "text": "UK-Faroe Islands free trade agreement (FTA)",
-                    "url": "https://www.gov.uk/government/collections/uk-faroe-islands-free-trade-agreement-fta"
-                },
-                {
-                    "text": "Trade with the Faroe Islands",
-                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-faroe-islands-free-trade-agreement-fta"
-                }
-            ],
-            "countries": [
-                "FO"
-            ]
-        },
-        {
-            "scheme_code": "georgia",
-            "title": "UK-Georgia Strategic Partnership and Cooperation Agreement",
-            "proofs": [
-                {
-                    "summary": "EUR1 or EUR.MED movement certificate",
-                    "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
-                },
-                {
-                    "summary": "",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
-                }
-            ],
-            "cumulation_methods": {
-                "bilateral": {
-                    "countries": [
-                        "GB",
-                        "GE"
-                    ]
-                },
-                "extended": {
-                    "countries": [
-                        "EU",
-                        "AD",
-                        "SM",
-                        "CH",
-                        "LI",
-                        "NO",
-                        "IS",
-                        "TR",
-                        "FO",
-                        "DZ",
-                        "TN",
-                        "MA",
-                        "IL",
-                        "PS",
-                        "EG",
-                        "JO",
-                        "LB",
-                        "SY",
-                        "MK",
-                        "AL",
-                        "BA",
-                        "ME",
-                        "XS",
-                        "XK",
-                        "MD",
-                        "UA",
-                        "AL",
-                        "MX",
-                        "CL",
-                        "PE",
-                        "CO",
-                        "EC",
-                        "GT",
-                        "HO",
-                        "NI",
-                        "SV",
-                        "CR",
-                        "PA",
-                        "KR",
-                        "CA",
-                        "JP",
-                        "SG",
-                        "VN",
-                        "AI",
-                        "BM",
-                        "KY",
-                        "FK",
-                        "GS",
-                        "MS",
-                        "PN",
-                        "SH",
-                        "ZU",
-                        "IO",
-                        "TC",
-                        "VG",
-                        "AN",
-                        "PF",
-                        "TF",
-                        "ZF",
-                        "GL",
-                        "NC",
-                        "BQ",
-                        "BL",
-                        "BQ",
-                        "SX",
-                        "PM",
-                        "AG",
-                        "BS",
-                        "BB",
-                        "BZ",
-                        "DM",
-                        "DO",
-                        "GD",
-                        "GY",
-                        "JM",
-                        "KN",
-                        "LC",
-                        "VC",
-                        "SR",
-                        "TT",
-                        "BW",
-                        "LS",
-                        "NA",
-                        "ZA",
-                        "SZ",
-                        "MZ",
-                        "KM",
-                        "MG",
-                        "MU",
-                        "SC",
-                        "ZW",
-                        "FJ",
-                        "PG",
-                        "WS",
-                        "SB",
-                        "CM",
-                        "CI",
-                        "KE",
-                        "GH"
-                    ]
-                }
-            },
-            "ord": {
-                "ord_title": "The Origin Reference Document implementing the Agreement establishing a Strategic Partnership and Cooperation Agreement between the United Kingdom of Great Britain and Northern Ireland and Georgia signed on 21st October 2019 ('the Georgia Origin Reference Document')",
-                "ord_version": "1.2",
-                "ord_date": "22 February 2022",
-                "ord_original": "220214_ORD_Georgia_V1.2.odt"
-            },
-            "articles": {
-                "article 1": "definitions",
-                "article 2": "general requirements",
-                "article 3": "cumulation",
-                "article 4": "cumulation",
-                "article 5": "wholly obtained",
-                "article 6": "sufficient working",
-                "article 7": "insufficient working",
-                "article 8": "unit of qualification",
-                "article 9": "accessories",
-                "article 10": "sets",
-                "article 11": "neutral elements",
-                "article 12": "principle of territoriality",
-                "article 13": "direct transport",
-                "article 14": "exhibitions",
-                "Annex II": "sufficient working"
-            },
-            "features": {
-                "absorption": true,
-                "tolerances": false,
-                "sets": true,
-                "cumulation": true
-            },
-            "introductory_notes_file": "georgia_intro.md",
-            "fta_intro_file": "georgia.md",
-            "links": [
-                {
-                    "text": "UK-Georgia strategic partnership and cooperation agreement",
-                    "url": "https://www.gov.uk/government/collections/uk-georgia-strategic-partnership-and-cooperation-agreement--2"
-                },
-                {
-                    "text": "Trade with Georgia",
-                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-georgia-strategic-partnership-and-cooperation-agreement"
-                }
-            ],
-            "countries": [
-                "GE"
-            ]
-        },
-        {
-            "scheme_code": "ghana",
-            "title": "UK-Ghana Interim Trade Partnership Agreement",
-            "proofs": [
-                {
-                    "summary": "EUR1 or EUR.MED movement certificate",
-                    "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
-                },
-                {
-                    "summary": "Invoice declaration",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
-                }
-            ],
-            "cumulation_methods": {
-                "bilateral": {
-                    "countries": [
-                        "GB",
-                        "GH"
-                    ]
-                },
-                "extended": {
-                    "countries": [
-                        "EU",
-                        "SM",
-                        "AD",
-                        "BJ",
-                        "BF",
-                        "CV",
-                        "GM",
-                        "CI",
-                        "GN",
-                        "GW",
-                        "LR",
-                        "ML",
-                        "MR",
-                        "NE",
-                        "NG",
-                        "SN",
-                        "SL",
-                        "TG",
-                        "FJ",
-                        "PG",
-                        "WS",
-                        "SB",
-                        "CM",
-                        "KE",
-                        "BW",
-                        "ZW",
-                        "ZA",
-                        "LS",
-                        "SZ",
-                        "MZ",
-                        "SC",
-                        "MU",
-                        "ZA",
-                        "AG",
-                        "BS",
-                        "BB",
-                        "BZ",
-                        "DM",
-                        "DO",
-                        "GD",
-                        "GY",
-                        "JM",
-                        "LC",
-                        "VC",
-                        "KN",
-                        "SR",
-                        "TT",
-                        "GL",
-                        "NC",
-                        "PF",
-                        "PM",
-                        "BL",
-                        "TF",
-                        "WF",
-                        "AW",
-                        "CW",
-                        "SX",
-                        "AI",
-                        "BM",
-                        "KY",
-                        "FK",
-                        "GS",
-                        "MS",
-                        "PN",
-                        "SH",
-                        "ZU",
-                        "IO",
-                        "TC",
-                        "VG"
-                    ]
-                }
-            },
-            "ord": {
-                "ord_title": "Origin Reference Document implementing the Interim Trade Partnership Agreement between the Republic of Ghana, of the one part, and the United Kingdom of Great Britain and Northern Ireland, of the other part, signed on 2nd March 2021 ('the Ghana Origin Reference Document')",
-                "ord_version": "1.1",
-                "ord_date": "28 December 2021",
-                "ord_original": "211223_ORD_Ghana_-_HS.odt"
-            },
-            "articles": {
-                "article 1": "definitions",
-                "article 2": "general requirements",
-                "article 3": "wholly obtained",
-                "article 4": "sufficient working",
-                "article 5": "insufficient working",
-                "article 6": "duty-free",
-                "article 7": "cumulation",
-                "article 8": "cumulation",
-                "article 9": "unit of qualification",
-                "article 10": "sets",
-                "article 11": "neutral elements",
-                "article 12": "accounting segregation",
-                "article 13": "principle of territoriality",
-                "article 14": "non-alteration",
-                "Annex II": "sufficient working"
-            },
-            "features": {
-                "absorption": true,
-                "tolerances": false,
-                "sets": true,
-                "cumulation": true
-            },
-            "introductory_notes_file": "ghana_intro.md",
-            "fta_intro_file": "ghana.md",
-            "links": [
-                {
-                    "text": "UK-Ghana Interim Trade Partnership Agreement",
-                    "url": "https://www.gov.uk/government/collections/uk-ghana-interim-trade-partnership-agreement"
-                },
-                {
-                    "text": "",
-                    "url": ""
-                }
-            ],
-            "countries": [
-                "GH"
-            ]
-        },
-        {
-            "scheme_code": "iceland-norway",
-            "title": "Agreement on Trade in Goods between Iceland, Norway and the UK",
-            "proofs": [
-                {
-                    "summary": "EUR1 or EUR.MED movement certificate",
-                    "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
-                },
-                {
-                    "summary": "Invoice declaration",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
-                }
-            ],
-            "cumulation_methods": {
-                "bilateral": {
-                    "countries": [
-                        "GB",
-                        "IS",
-                        "NO"
-                    ]
-                },
-                "extended": {
-                    "countries": [
-                        "EU",
-                        "AD",
-                        "SM",
-                        "XK",
-                        "DZ",
-                        "BA",
-                        "FO",
-                        "GE",
-                        "IL",
-                        "JO",
-                        "EG",
-                        "LB",
-                        "XS",
-                        "ME",
-                        "MA",
-                        "MK",
-                        "PS",
-                        "AL",
-                        "SY",
-                        "UA",
-                        "CH",
-                        "LI",
-                        "TR"
-                    ]
-                }
-            },
-            "ord": {
-                "ord_title": "Origin Reference Document implementing the Agreement between the United Kingdom of Great Britain and Northern Ireland, Iceland and the Kingdom of Norway on Trade in Goods, dated 8th December 2020 ('the Iceland Origin Reference Document')",
-                "ord_version": "1.1",
-                "ord_date": "28 December 2021",
-                "ord_original": "050822_Iceland_Norway_ORD.odt"
-            },
-            "articles": {
-                "article 1": "definitions",
-                "article 2": "general requirements",
-                "article 3": "cumulation",
-                "article 4": "wholly obtained",
-                "article 5": "sufficient working",
-                "article 6": "insufficient working",
-                "article 7": "unit of qualification",
-                "article 8": "accessories",
-                "article 9": "sets",
-                "article 10": "neutral elements",
-                "article 11": "principle of territoriality",
-                "article 12": "direct transport",
-                "article 13": "exhibitions",
-                "Annex II": "sufficient working"
-            },
-            "features": {
-                "absorption": true,
-                "tolerances": false,
-                "sets": true,
-                "cumulation": true
-            },
-            "introductory_notes_file": "iceland-norway_intro.md",
-            "fta_intro_file": "iceland-norway.md",
-            "links": [
-                {
-                    "text": "Agreement on trade in goods between Iceland, Norway and the UK",
-                    "url": "https://www.gov.uk/government/collections/agreement-on-trade-in-goods-between-iceland-norway-and-the-uk"
-                },
-                {
-                    "text": "Trade with Iceland and Norway",
-                    "url": "https://www.gov.uk/guidance/summary-of-agreement-on-trade-in-goods-between-iceland-norway-and-the-uk"
-                }
-            ],
-            "countries": [
-                "IS",
-                "NO"
-            ]
-        },
-        {
-            "scheme_code": "israel",
-            "title": "UK-Israel Trade and Partnership Agreement",
-            "proofs": [
-                {
-                    "summary": "EUR1 or EUR.MED movement certificate",
-                    "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
-                },
-                {
-                    "summary": "Invoice declaration",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
-                }
-            ],
-            "cumulation_methods": {
-                "bilateral": {
-                    "countries": [
-                        "GB",
-                        "IL"
-                    ]
-                },
-                "extended": {
-                    "countries": [
-                        "EU",
-                        "AD",
-                        "SM",
-                        "AL",
-                        "DZ",
-                        "BA",
-                        "FO",
-                        "GE",
-                        "JO",
-                        "EG",
-                        "XK",
-                        "LB",
-                        "MD",
-                        "ME",
-                        "MA",
-                        "MK",
-                        "PS",
-                        "XS",
-                        "SY",
-                        "UA",
-                        "CH",
-                        "LI",
-                        "IS",
-                        "NO",
-                        "TR"
-                    ]
-                }
-            },
-            "ord": {
-                "ord_title": "Origin Reference Document implementing the Trade and Partnership Agreement between the United Kingdom of Great Britain and Northern Ireland and the Government of the State of Israel, signed on 18th February 2019 (“the Israel Origin Reference Document”)",
-                "ord_version": "1.1",
-                "ord_date": "28 December 2021",
-                "ord_original": "20211202_ORD_Israel_V1.1.odt"
-            },
-            "articles": {
-                "article 1": "definitions",
-                "article 2": "general requirements",
-                "article 3": "cumulation",
-                "article 4": "cumulation",
-                "article 5": "wholly obtained",
-                "article 6": "sufficient working",
-                "article 7": "insufficient working",
-                "article 8": "unit of qualification",
-                "article 9": "accessories",
-                "article 10": "sets",
-                "article 11": "neutral elements",
-                "article 12": "principle of territoriality",
-                "article 13": "direct transport",
-                "article 14": "exhibitions",
-                "Annex II": "sufficient working"
-            },
-            "features": {
-                "absorption": true,
-                "tolerances": false,
-                "sets": true,
-                "cumulation": true
-            },
-            "introductory_notes_file": "israel_intro.md",
-            "fta_intro_file": "israel.md",
-            "links": [
-                {
-                    "text": "UK-Israel trade and partnership agreement",
-                    "url": "https://www.gov.uk/government/collections/uk-israel-trade-and-partnership-agreement"
-                },
-                {
-                    "text": "https://www.gov.uk/guidance/summary-of-the-uk-israel-trade-and-partnership-agreement",
-                    "url": "Trade with Israel"
-                }
-            ],
-            "countries": [
-                "IL"
-            ]
-        },
-        {
             "scheme_code": "kosovo",
             "title": "UK-Kosovo Partnership, Trade and Cooperation Agreement",
             "proofs": [
                 {
-                    "summary": "EUR1 or EUR.MED movement certificate",
+                    "summary": "EUR.1 movement certificate",
                     "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
+                    "proof_class": "eur1",
+                    "detail": ""
                 },
                 {
-                    "summary": "Invoice declaration",
+                    "summary": "EUR-MED movement certificate",
                     "subtext": "",
+                    "proof_class": "eur-med",
+                    "detail": ""
+                },
+                {
+                    "summary": "Origin declaration",
+                    "subtext": "or origin declaration EUR-MED including UK Approved Exporter number for consignments with a value over £5500  / 6000 euros",
                     "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
+                    "detail": ""
                 }
             ],
             "cumulation_methods": {
@@ -2482,7 +2574,8 @@
                 "absorption": true,
                 "tolerances": false,
                 "sets": true,
-                "cumulation": true
+                "cumulation": true,
+                "drawback": true
             },
             "introductory_notes_file": "kosovo_intro.md",
             "fta_intro_file": "kosovo.md",
@@ -2501,119 +2594,20 @@
             ]
         },
         {
-            "scheme_code": "jordan",
-            "title": "UK-Jordan Association Agreement",
-            "proofs": [
-                {
-                    "summary": "EUR1 or EUR.MED movement certificate",
-                    "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
-                },
-                {
-                    "summary": "Origin declaration",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "origin-declaration.md"
-                }
-            ],
-            "cumulation_methods": {
-                "bilateral": {
-                    "countries": [
-                        "GB",
-                        "JO"
-                    ]
-                },
-                "extended": {
-                    "countries": [
-                        "EU",
-                        "AD",
-                        "SM",
-                        "AL",
-                        "DZ",
-                        "BA",
-                        "FO",
-                        "GE",
-                        "IL",
-                        "EG",
-                        "XK",
-                        "LB",
-                        "MD",
-                        "ME",
-                        "MA",
-                        "MK",
-                        "PS",
-                        "XS",
-                        "SY",
-                        "UA",
-                        "CH",
-                        "LI",
-                        "IS",
-                        "NO",
-                        "TR"
-                    ]
-                }
-            },
-            "ord": {
-                "ord_title": "Origin Reference Document implementing the Agreement Establishing an Association between the United Kingdom of Great Britain and Northern Ireland and the Hashemite Kingdom of Jordan, signed on 5 November 2019 ('the Jordan Origin Reference Document')",
-                "ord_version": "1.1",
-                "ord_date": "28 December 2021",
-                "ord_original": "20211202_ORD_Jordan__HS_UPDATE_.odt"
-            },
-            "articles": {
-                "article 1": "definitions",
-                "article 2": "general requirements",
-                "article 3": "cumulation",
-                "article 4": "cumulation",
-                "article 5": "wholly obtained",
-                "article 6": "sufficient working",
-                "article 7": "insufficient working",
-                "article 8": "unit of qualification",
-                "article 9": "accessories",
-                "article 10": "sets",
-                "article 11": "neutral elements",
-                "article 12": "principle of territoriality",
-                "article 13": "direct transport",
-                "article 14": "exhibitions",
-                "Annex II": "sufficient working"
-            },
-            "features": {
-                "absorption": true,
-                "tolerances": false,
-                "sets": true,
-                "cumulation": true
-            },
-            "introductory_notes_file": "jordan_intro.md",
-            "fta_intro_file": "jordan.md",
-            "links": [
-                {
-                    "text": "UK-Jordan association agreement",
-                    "url": "https://www.gov.uk/government/collections/uk-jordan-association-agreement"
-                },
-                {
-                    "text": "Trade with Jordan",
-                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-jordanassociationagreement"
-                }
-            ],
-            "countries": [
-                "JO"
-            ]
-        },
-        {
             "scheme_code": "lebanon",
             "title": "UK-Lebanon Association Agreement",
             "proofs": [
                 {
-                    "summary": "EUR1 or EUR.MED movement certificate",
+                    "summary": "EUR.1 movement certificate",
                     "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
+                    "proof_class": "eur1",
+                    "detail": ""
                 },
                 {
                     "summary": "Invoice declaration",
                     "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
+                    "proof_class": "invoice-declaration",
+                    "detail": ""
                 }
             ],
             "cumulation_methods": {
@@ -2665,7 +2659,8 @@
                 "absorption": true,
                 "tolerances": false,
                 "sets": true,
-                "cumulation": true
+                "cumulation": true,
+                "drawback": true
             },
             "introductory_notes_file": "lebanon_intro.md",
             "fta_intro_file": "lebanon.md",
@@ -2688,16 +2683,16 @@
             "title": "UK-Mexico Trade Continuity Agreement",
             "proofs": [
                 {
-                    "summary": "EUR1 or EUR.MED movement certificate",
+                    "summary": "EUR.1 movement certificate",
                     "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
+                    "proof_class": "eur1",
+                    "detail": ""
                 },
                 {
                     "summary": "Invoice declaration",
                     "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
+                    "proof_class": "invoice-declaration",
+                    "detail": ""
                 }
             ],
             "cumulation_methods": {
@@ -2742,7 +2737,8 @@
                 "absorption": true,
                 "tolerances": false,
                 "sets": true,
-                "cumulation": true
+                "cumulation": true,
+                "drawback": true
             },
             "introductory_notes_file": "mexico_intro.md",
             "fta_intro_file": "mexico.md",
@@ -2761,120 +2757,26 @@
             ]
         },
         {
-            "scheme_code": "switzerland-liechtenstein",
-            "title": "UK-Switzerland-Liechtenstein Trade Agreement",
-            "proofs": [
-                {
-                    "summary": "EUR1 or EUR.MED movement certificate",
-                    "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
-                },
-                {
-                    "summary": "Invoice declaration",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
-                }
-            ],
-            "cumulation_methods": {
-                "bilateral": {
-                    "countries": [
-                        "GB",
-                        "CH",
-                        "LI"
-                    ]
-                },
-                "extended": {
-                    "countries": [
-                        "EU",
-                        "AD",
-                        "SM",
-                        "XK",
-                        "DZ",
-                        "BA",
-                        "FO",
-                        "GE",
-                        "IL",
-                        "JO",
-                        "EG",
-                        "LB",
-                        "XS",
-                        "ME",
-                        "MA",
-                        "MK",
-                        "PS",
-                        "AL",
-                        "SY",
-                        "UA",
-                        "NO",
-                        "IS",
-                        "TR"
-                    ]
-                }
-            },
-            "ord": {
-                "ord_title": "Origin Reference Document implementing the Trade Agreement between the United Kingdom of Great Britain and Northern Ireland and the Swiss Confederation signed on 11 February 2019 and the Additional Agreement between the United Kingdom of Great Britain and Northern Ireland, the Swiss Confederation and the Principality of Liechtenstein signed on 11 February 2019 ('the Switzerland and Liechtenstein Origin Reference Document')",
-                "ord_version": "1.0",
-                "ord_date": "22 February 2022",
-                "ord_original": "220215_ORD_Switzerland_and_Liechtenstein_v.1.odt"
-            },
-            "articles": {
-                "article 1": "definitions",
-                "article 2": "general requirements",
-                "article 3": "wholly obtained",
-                "article 4": "sufficient working",
-                "article 5": "tolerances",
-                "article 6": "insufficient working",
-                "article 7": "cumulation",
-                "article 8": "cumulation - conditions",
-                "article 9": "unit of qualification",
-                "article 10": "sets",
-                "article 11": "neutral elements",
-                "article 12": "accounting segregation",
-                "article 13": "principle of territoriality",
-                "article 14": "non-alteration",
-                "article 15": "exhibitions",
-                "Annex II": "sufficient working"
-            },
-            "features": {
-                "absorption": true,
-                "tolerances": false,
-                "sets": true,
-                "cumulation": true
-            },
-            "introductory_notes_file": "switzerland-liechtenstein_intro.md",
-            "fta_intro_file": "switzerland-liechtenstein.md",
-            "links": [
-                {
-                    "text": "UK-Switzerland-Liechtenstein Trade Agreement",
-                    "url": "https://www.gov.uk/government/collections/uk-switzerland-liechtenstein-trade-agreement"
-                },
-                {
-                    "text": "Trade with Switzerland",
-                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-switzerland-trade-agreement"
-                }
-            ],
-            "countries": [
-                "CH",
-                "LI"
-            ]
-        },
-        {
             "scheme_code": "moldova",
             "title": "UK-Moldova Strategic Partnership, Trade and Cooperation Agreement",
             "proofs": [
                 {
-                    "summary": "EUR1 or EUR.MED movement certificate",
+                    "summary": "EUR.1 movement certificate",
                     "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
+                    "proof_class": "eur1",
+                    "detail": ""
                 },
                 {
-                    "summary": "Invoice declaration",
+                    "summary": "EUR-MED movement certificate",
                     "subtext": "",
+                    "proof_class": "eur-med",
+                    "detail": ""
+                },
+                {
+                    "summary": "Origin declaration",
+                    "subtext": "or origin declaration EUR-MED including UK Approved Exporter number for consignments with a value over £5500  / 6000 euros",
                     "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
+                    "detail": ""
                 }
             ],
             "cumulation_methods": {
@@ -2941,7 +2843,8 @@
                 "absorption": true,
                 "tolerances": false,
                 "sets": true,
-                "cumulation": true
+                "cumulation": true,
+                "drawback": true
             },
             "introductory_notes_file": "moldova_intro.md",
             "fta_intro_file": "moldova.md",
@@ -2964,16 +2867,22 @@
             "title": "UK-Morocco Association Agreement",
             "proofs": [
                 {
-                    "summary": "EUR1 or EUR.MED movement certificate",
+                    "summary": "EUR.1 movement certificate",
                     "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
+                    "proof_class": "eur1",
+                    "detail": ""
+                },
+                {
+                    "summary": "EUR-MED movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur-med",
+                    "detail": ""
                 },
                 {
                     "summary": "Invoice declaration",
                     "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
+                    "proof_class": "invoice-declaration",
+                    "detail": ""
                 }
             ],
             "cumulation_methods": {
@@ -3035,7 +2944,8 @@
                 "absorption": true,
                 "tolerances": false,
                 "sets": true,
-                "cumulation": true
+                "cumulation": true,
+                "drawback": true
             },
             "introductory_notes_file": "morocco_intro.md",
             "fta_intro_file": "morocco.md",
@@ -3058,16 +2968,22 @@
             "title": "UK-North Macedonia Partnership, Trade and Cooperation Agreement",
             "proofs": [
                 {
-                    "summary": "EUR1 or EUR.MED movement certificate",
+                    "summary": "EUR.1 movement certificate",
                     "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
+                    "proof_class": "eur1",
+                    "detail": ""
                 },
                 {
-                    "summary": "Invoice declaration",
+                    "summary": "EUR-MED movement certificate",
                     "subtext": "",
+                    "proof_class": "eur-med",
+                    "detail": ""
+                },
+                {
+                    "summary": "Origin declaration",
+                    "subtext": "or origin declaration EUR-MED including UK Approved Exporter number for consignments with a value over £5500  / 6000 euros",
                     "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
+                    "detail": ""
                 }
             ],
             "cumulation_methods": {
@@ -3135,7 +3051,8 @@
                 "absorption": true,
                 "tolerances": false,
                 "sets": true,
-                "cumulation": true
+                "cumulation": true,
+                "drawback": true
             },
             "introductory_notes_file": "north-macedonia_intro.md",
             "fta_intro_file": "north-macedonia.md",
@@ -3158,16 +3075,16 @@
             "title": "UK-Pacific Economic Partnership Agreement (EPA)",
             "proofs": [
                 {
-                    "summary": "EUR1 or EUR.MED movement certificate",
+                    "summary": "EUR.1",
                     "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
+                    "proof_class": "eur1",
+                    "detail": ""
                 },
                 {
                     "summary": "Invoice declaration",
                     "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
+                    "proof_class": "invoice-declaration",
+                    "detail": ""
                 }
             ],
             "cumulation_methods": {
@@ -3310,7 +3227,8 @@
                 "absorption": true,
                 "tolerances": false,
                 "sets": true,
-                "cumulation": true
+                "cumulation": true,
+                "drawback": false
             },
             "footnote": "Samoa and the Solomon Islands have not yet acceded to the Pacific States-UK Interim Economic Partnership Agreement (pending a decision on their accession), however preferences under the agreement took effect on 1 January 2021 through a Memorandum of Understanding.",
             "introductory_notes_file": "pacific_intro.md",
@@ -3328,7 +3246,6 @@
             "countries": [
                 "FJ",
                 "PG",
-                "SB",
                 "WS"
             ]
         },
@@ -3337,16 +3254,22 @@
             "title": "UK-Palestinian Authority Political, Trade and Partnership Agreement",
             "proofs": [
                 {
-                    "summary": "EUR1 or EUR.MED movement certificate",
+                    "summary": "EUR.1 movement certificate",
                     "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
+                    "proof_class": "eur1",
+                    "detail": ""
                 },
                 {
-                    "summary": "Invoice declaration",
+                    "summary": "EUR-MED movement certificate",
                     "subtext": "",
+                    "proof_class": "eur-med",
+                    "detail": ""
+                },
+                {
+                    "summary": "Origin declaration",
+                    "subtext": "or origin declaration EUR-MED including UK Approved Exporter number for consignments with a value over £5500  / 6000 euros",
                     "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
+                    "detail": ""
                 }
             ],
             "cumulation_methods": {
@@ -3396,7 +3319,8 @@
                 "absorption": true,
                 "tolerances": false,
                 "sets": true,
-                "cumulation": true
+                "cumulation": true,
+                "drawback": true
             },
             "introductory_notes_file": "palestinian-authority_intro.md",
             "fta_intro_file": "palestinian-authority.md",
@@ -3415,205 +3339,20 @@
             ]
         },
         {
-            "scheme_code": "singapore",
-            "title": "UK-Singapore Trade Agreement",
-            "proofs": [
-                {
-                    "summary": "Origin declaration",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "origin-declaration.md"
-                },
-                {
-                    "summary": "Approved exporter for consignments with a value over £5500 / 6000 euros",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "approved-exporter.md"
-                }
-            ],
-            "cumulation_methods": {
-                "bilateral": {
-                    "countries": [
-                        "GB",
-                        "SG"
-                    ]
-                },
-                "extended": {
-                    "countries": [
-                        "EU",
-                        "AD",
-                        "SM",
-                        "BN",
-                        "KH",
-                        "ID",
-                        "LA",
-                        "MY",
-                        "MM",
-                        "PH",
-                        "VN",
-                        "TH"
-                    ]
-                }
-            },
-            "ord": {
-                "ord_title": "Origin Reference Document implementing the Free Trade Agreement between the United Kingdom of Great Britain and Northern Ireland and the Republic of Singapore, signed on 10th December 2020 ('the Singapore Origin Reference Document')",
-                "ord_version": "1.1",
-                "ord_date": "28 December 2021",
-                "ord_original": "211204_ORD_Singapore_V1.1.odt"
-            },
-            "articles": {
-                "article 1": "definitions",
-                "article 2": "general requirements",
-                "article 3": "cumulation",
-                "article 4": "wholly obtained",
-                "article 5": "sufficient working",
-                "article 6": "insufficient working",
-                "article 7": "unit of qualification",
-                "article 8": "accessories",
-                "article 9": "sets",
-                "article 10": "neutral elements",
-                "article 11": "accounting segregation",
-                "article 12": "principle of territoriality",
-                "article 13": "non-alteration",
-                "article 14": "exhibitions",
-                "Annex II": "sufficient working"
-            },
-            "features": {
-                "absorption": true,
-                "tolerances": false,
-                "sets": true,
-                "cumulation": true
-            },
-            "introductory_notes_file": "singapore_intro.md",
-            "fta_intro_file": "singapore.md",
-            "links": [
-                {
-                    "text": "UK-Singapore Trade Agreement",
-                    "url": "https://www.gov.uk/government/collections/uk-singapore-trade-agreement"
-                },
-                {
-                    "text": "Trade with Singapore",
-                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-singapore-agreement"
-                }
-            ],
-            "countries": [
-                "SG"
-            ]
-        },
-        {
-            "scheme_code": "serbia",
-            "title": "UK-Serbia Partnership, Trade and Cooperation Agreement ",
-            "proofs": [
-                {
-                    "summary": "EUR1 or EUR.MED movement certificate",
-                    "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
-                },
-                {
-                    "summary": "Invoice declaration",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
-                }
-            ],
-            "cumulation_methods": {
-                "bilateral": {
-                    "countries": [
-                        "GB",
-                        "XS"
-                    ]
-                },
-                "extended": {
-                    "countries": [
-                        "EU",
-                        "AD",
-                        "SM",
-                        "XK",
-                        "DZ",
-                        "BA",
-                        "FO",
-                        "GE",
-                        "IL",
-                        "JO",
-                        "EG",
-                        "LB",
-                        "MD",
-                        "ME",
-                        "MA",
-                        "MK",
-                        "PS",
-                        "AL",
-                        "SY",
-                        "UA",
-                        "CH",
-                        "LI",
-                        "IS",
-                        "NO",
-                        "TR"
-                    ]
-                }
-            },
-            "ord": {
-                "ord_title": "Origin Reference Document implementing the Agreement between the United Kingdom of Great Britain and Northern Ireland and the Republic of Serbia signed on 16th April 2021 ('the Serbia Origin Reference Document')",
-                "ord_version": "1.1",
-                "ord_date": "28 December 2021",
-                "ord_original": "211204_Serbia_ORD_V1.1.odt"
-            },
-            "articles": {
-                "article 1": "definitions",
-                "article 2": "general requirements",
-                "article 3": "cumulation",
-                "article 4": "cumulation",
-                "article 5": "wholly obtained",
-                "article 6": "sufficient working",
-                "article 7": "insufficient working",
-                "article 8": "unit of qualification",
-                "article 9": "accessories",
-                "article 10": "sets",
-                "article 11": "neutral elements",
-                "article 12": "principle of territoriality",
-                "article 13": "direct transport",
-                "article 14": "exhibitions",
-                "Annex II": "sufficient working"
-            },
-            "features": {
-                "absorption": true,
-                "tolerances": false,
-                "sets": true,
-                "cumulation": true
-            },
-            "introductory_notes_file": "serbia_intro.md",
-            "fta_intro_file": "serbia.md",
-            "links": [
-                {
-                    "text": "UK-Serbia partnership, trade and cooperation agreement",
-                    "url": "https://www.gov.uk/government/collections/uk-serbia-partnership-trade-and-cooperation-agreement"
-                },
-                {
-                    "text": "Trade with Serbia",
-                    "url": "https://www.gov.uk/guidance/trade-with-serbia"
-                }
-            ],
-            "countries": [
-                "XS"
-            ]
-        },
-        {
             "scheme_code": "sacum",
             "title": "SACUM-UK Economic Partnership Agreement (EPA)",
             "proofs": [
                 {
-                    "summary": "EUR1 or EUR.MED movement certificate",
+                    "summary": "EUR.1 movement certificate",
                     "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
+                    "proof_class": "eur1",
+                    "detail": ""
                 },
                 {
-                    "summary": "Invoice declaration",
+                    "summary": "Origin declaration",
                     "subtext": "",
                     "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
+                    "detail": ""
                 }
             ],
             "cumulation_methods": {
@@ -3722,7 +3461,8 @@
                 "absorption": true,
                 "tolerances": false,
                 "sets": true,
-                "cumulation": true
+                "cumulation": true,
+                "drawback": false
             },
             "introductory_notes_file": "sacum_intro.md",
             "fta_intro_file": "sacum.md",
@@ -3746,20 +3486,389 @@
             ]
         },
         {
+            "scheme_code": "serbia",
+            "title": "UK-Serbia Partnership, Trade and Cooperation Agreement ",
+            "proofs": [
+                {
+                    "summary": "EUR.1 movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur1",
+                    "detail": ""
+                },
+                {
+                    "summary": "EUR-MED movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur-med",
+                    "detail": ""
+                },
+                {
+                    "summary": "Origin declaration",
+                    "subtext": "or origin declaration EUR-MED including UK Approved Exporter number for consignments with a value over £5500  / 6000 euros",
+                    "proof_class": "origin-declaration",
+                    "detail": ""
+                }
+            ],
+            "cumulation_methods": {
+                "bilateral": {
+                    "countries": [
+                        "GB",
+                        "XS"
+                    ]
+                },
+                "extended": {
+                    "countries": [
+                        "EU",
+                        "AD",
+                        "SM",
+                        "XK",
+                        "DZ",
+                        "BA",
+                        "FO",
+                        "GE",
+                        "IL",
+                        "JO",
+                        "EG",
+                        "LB",
+                        "MD",
+                        "ME",
+                        "MA",
+                        "MK",
+                        "PS",
+                        "AL",
+                        "SY",
+                        "UA",
+                        "CH",
+                        "LI",
+                        "IS",
+                        "NO",
+                        "TR"
+                    ]
+                }
+            },
+            "ord": {
+                "ord_title": "Origin Reference Document implementing the Agreement between the United Kingdom of Great Britain and Northern Ireland and the Republic of Serbia signed on 16th April 2021 ('the Serbia Origin Reference Document')",
+                "ord_version": "1.1",
+                "ord_date": "28 December 2021",
+                "ord_original": "211204_Serbia_ORD_V1.1.odt"
+            },
+            "articles": {
+                "article 1": "definitions",
+                "article 2": "general requirements",
+                "article 3": "cumulation",
+                "article 4": "cumulation",
+                "article 5": "wholly obtained",
+                "article 6": "sufficient working",
+                "article 7": "insufficient working",
+                "article 8": "unit of qualification",
+                "article 9": "accessories",
+                "article 10": "sets",
+                "article 11": "neutral elements",
+                "article 12": "principle of territoriality",
+                "article 13": "direct transport",
+                "article 14": "exhibitions",
+                "Annex II": "sufficient working"
+            },
+            "features": {
+                "absorption": true,
+                "tolerances": false,
+                "sets": true,
+                "cumulation": true,
+                "drawback": true
+            },
+            "introductory_notes_file": "serbia_intro.md",
+            "fta_intro_file": "serbia.md",
+            "links": [
+                {
+                    "text": "UK-Serbia partnership, trade and cooperation agreement",
+                    "url": "https://www.gov.uk/government/collections/uk-serbia-partnership-trade-and-cooperation-agreement"
+                },
+                {
+                    "text": "Trade with Serbia",
+                    "url": "https://www.gov.uk/guidance/trade-with-serbia"
+                }
+            ],
+            "countries": [
+                "XS"
+            ]
+        },
+        {
+            "scheme_code": "singapore",
+            "title": "UK-Singapore Trade Agreement",
+            "proofs": [
+                {
+                    "summary": "Origin declaration",
+                    "subtext": "",
+                    "proof_class": "origin-declaration",
+                    "detail": ""
+                }
+            ],
+            "cumulation_methods": {
+                "bilateral": {
+                    "countries": [
+                        "GB",
+                        "SG"
+                    ]
+                },
+                "extended": {
+                    "countries": [
+                        "EU",
+                        "AD",
+                        "SM",
+                        "BN",
+                        "KH",
+                        "ID",
+                        "LA",
+                        "MY",
+                        "MM",
+                        "PH",
+                        "VN",
+                        "TH"
+                    ]
+                }
+            },
+            "ord": {
+                "ord_title": "Origin Reference Document implementing the Free Trade Agreement between the United Kingdom of Great Britain and Northern Ireland and the Republic of Singapore, signed on 10th December 2020 ('the Singapore Origin Reference Document')",
+                "ord_version": "1.1",
+                "ord_date": "28 December 2021",
+                "ord_original": "211204_ORD_Singapore_V1.1.odt"
+            },
+            "articles": {
+                "article 1": "definitions",
+                "article 2": "general requirements",
+                "article 3": "cumulation",
+                "article 4": "wholly obtained",
+                "article 5": "sufficient working",
+                "article 6": "insufficient working",
+                "article 7": "unit of qualification",
+                "article 8": "accessories",
+                "article 9": "sets",
+                "article 10": "neutral elements",
+                "article 11": "accounting segregation",
+                "article 12": "principle of territoriality",
+                "article 13": "non-alteration",
+                "article 14": "exhibitions",
+                "Annex II": "sufficient working"
+            },
+            "features": {
+                "absorption": true,
+                "tolerances": false,
+                "sets": true,
+                "cumulation": true,
+                "drawback": true
+            },
+            "introductory_notes_file": "singapore_intro.md",
+            "fta_intro_file": "singapore.md",
+            "links": [
+                {
+                    "text": "UK-Singapore Trade Agreement",
+                    "url": "https://www.gov.uk/government/collections/uk-singapore-trade-agreement"
+                },
+                {
+                    "text": "Trade with Singapore",
+                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-singapore-agreement"
+                }
+            ],
+            "countries": [
+                "SG"
+            ]
+        },
+        {
+            "scheme_code": "south-korea",
+            "title": "UK-South Korea Trade Agreement",
+            "proofs": [
+                {
+                    "summary": "Origin declaration",
+                    "subtext": "",
+                    "proof_class": "origin-declaration",
+                    "detail": ""
+                }
+            ],
+            "cumulation_methods": {
+                "bilateral": {
+                    "countries": [
+                        "GB",
+                        "KR"
+                    ]
+                },
+                "diagonal": {
+                    "countries": [
+                        "EU",
+                        "AD",
+                        "SM"
+                    ]
+                }
+            },
+            "ord": {
+                "ord_title": "Origin Reference Document implementing the Free Trade Agreement between the United Kingdom of Great Britain and Northern Ireland, of the one part, and the Republic of  Korea, of the other part, signed on 22 August 2019 ('the Korea Origin Reference Document')",
+                "ord_version": "1.1",
+                "ord_date": "28th December 2021",
+                "ord_original": "211208_ORD_Korea__HS_UPDATE_.odt"
+            },
+            "articles": {
+                "article 1": "definitions",
+                "article 2": "general requirements",
+                "article 3": "cumulation",
+                "article 4": "wholly obtained",
+                "article 5": "sufficient working",
+                "article 6": "insufficient working",
+                "article 7": "unit of qualification",
+                "article 8": "accessories",
+                "article 9": "sets",
+                "article 10": "neutral elements",
+                "article 11": "accounting segregation",
+                "article 12": "principle of territoriality",
+                "article 13": "direct transport",
+                "Annex II": "sufficient working"
+            },
+            "features": {
+                "absorption": true,
+                "tolerances": false,
+                "sets": true,
+                "cumulation": true,
+                "drawback": false
+            },
+            "introductory_notes_file": "south-korea_intro.md",
+            "fta_intro_file": "south-korea.md",
+            "links": [
+                {
+                    "text": "UK-South Korea trade agreement",
+                    "url": "https://www.gov.uk/government/collections/uk-south-korea-trade-agreement"
+                },
+                {
+                    "text": "Trade with South Korea",
+                    "url": "https://www.gov.uk/guidance/summary-of-uk-south-korea-trade-agreement"
+                },
+                {
+                    "text": "Continuing the UK's trade relationship with South Korea: parliamentary report",
+                    "url": "https://www.gov.uk/government/publications/continuing-the-uks-trade-relationship-with-south-korea-parliamentary-report"
+                }
+            ],
+            "countries": [
+                "KR"
+            ]
+        },
+        {
+            "scheme_code": "switzerland-liechtenstein",
+            "title": "UK-Switzerland-Liechtenstein Trade Agreement",
+            "proofs": [
+                {
+                    "summary": "EUR.1 movement certificate",
+                    "subtext": "",
+                    "proof_class": "eur1",
+                    "detail": ""
+                },
+                {
+                    "summary": "Origin declaration",
+                    "subtext": "",
+                    "proof_class": "origin-declaration",
+                    "detail": ""
+                }
+            ],
+            "cumulation_methods": {
+                "bilateral": {
+                    "countries": [
+                        "GB",
+                        "CH",
+                        "LI"
+                    ]
+                },
+                "extended": {
+                    "countries": [
+                        "EU",
+                        "AD",
+                        "SM",
+                        "XK",
+                        "DZ",
+                        "BA",
+                        "FO",
+                        "GE",
+                        "IL",
+                        "JO",
+                        "EG",
+                        "LB",
+                        "XS",
+                        "ME",
+                        "MA",
+                        "MK",
+                        "PS",
+                        "AL",
+                        "SY",
+                        "UA",
+                        "NO",
+                        "IS",
+                        "TR"
+                    ]
+                }
+            },
+            "ord": {
+                "ord_title": "Origin Reference Document implementing the Trade Agreement between the United Kingdom of Great Britain and Northern Ireland and the Swiss Confederation signed on 11 February 2019 and the Additional Agreement between the United Kingdom of Great Britain and Northern Ireland, the Swiss Confederation and the Principality of Liechtenstein signed on 11 February 2019 ('the Switzerland and Liechtenstein Origin Reference Document')",
+                "ord_version": "1.0",
+                "ord_date": "22 February 2022",
+                "ord_original": "220215_ORD_Switzerland_and_Liechtenstein_v.1.odt"
+            },
+            "articles": {
+                "article 1": "definitions",
+                "article 2": "general requirements",
+                "article 3": "wholly obtained",
+                "article 4": "sufficient working",
+                "article 5": "tolerances",
+                "article 6": "insufficient working",
+                "article 7": "cumulation",
+                "article 8": "cumulation - conditions",
+                "article 9": "unit of qualification",
+                "article 10": "sets",
+                "article 11": "neutral elements",
+                "article 12": "accounting segregation",
+                "article 13": "principle of territoriality",
+                "article 14": "non-alteration",
+                "article 15": "exhibitions",
+                "Annex II": "sufficient working"
+            },
+            "features": {
+                "absorption": true,
+                "tolerances": false,
+                "sets": true,
+                "cumulation": true,
+                "drawback": true
+            },
+            "introductory_notes_file": "switzerland-liechtenstein_intro.md",
+            "fta_intro_file": "switzerland-liechtenstein.md",
+            "links": [
+                {
+                    "text": "UK-Switzerland-Liechtenstein Trade Agreement",
+                    "url": "https://www.gov.uk/government/collections/uk-switzerland-liechtenstein-trade-agreement"
+                },
+                {
+                    "text": "Trade with Switzerland",
+                    "url": "https://www.gov.uk/guidance/summary-of-the-uk-switzerland-trade-agreement"
+                }
+            ],
+            "countries": [
+                "CH",
+                "LI"
+            ]
+        },
+        {
             "scheme_code": "tunisia",
             "title": "UK-Tunisia Association Agreement",
             "proofs": [
                 {
-                    "summary": "EUR1 or EUR.MED movement certificate",
+                    "summary": "EUR.1 movement certificate",
                     "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
+                    "proof_class": "eur1",
+                    "detail": ""
                 },
                 {
-                    "summary": "Invoice declaration",
+                    "summary": "EUR-MED movement certificate",
                     "subtext": "",
+                    "proof_class": "eur-med",
+                    "detail": ""
+                },
+                {
+                    "summary": "Origin declaration",
+                    "subtext": "or origin declaration EUR-MED including UK Approved Exporter number for consignments with a value over £5500  / 6000 euros",
                     "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
+                    "detail": ""
                 }
             ],
             "cumulation_methods": {
@@ -3900,7 +4009,8 @@
                 "absorption": true,
                 "tolerances": false,
                 "sets": true,
-                "cumulation": true
+                "cumulation": true,
+                "drawback": true
             },
             "introductory_notes_file": "tunisia_intro.md",
             "fta_intro_file": "tunisia.md",
@@ -3926,7 +4036,7 @@
                     "summary": "Origin declaration",
                     "subtext": "",
                     "proof_class": "origin-declaration",
-                    "detail": "origin-declaration.md"
+                    "detail": ""
                 }
             ],
             "cumulation_methods": {
@@ -3972,7 +4082,8 @@
                 "absorption": true,
                 "tolerances": false,
                 "sets": true,
-                "cumulation": true
+                "cumulation": true,
+                "drawback": true
             },
             "introductory_notes_file": "turkey_intro.md",
             "fta_intro_file": "turkey.md",
@@ -3995,17 +4106,24 @@
             "title": "UK-Ukraine Political, Free Trade and Strategic Partnership Agreement",
             "proofs": [
                 {
-                    "summary": "EUR1 or EUR.MED movement certificate",
+                    "summary": "EUR.1 movement certificate",
                     "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
+                    "proof_class": "eur1",
+                    "detail": ""
                 },
                 {
-                    "summary": "Invoice declaration",
+                    "summary": "EUR-MED movement certificate",
                     "subtext": "",
+                    "proof_class": "eur-med",
+                    "detail": ""
+                },
+                {
+                    "summary": "Origin declaration",
+                    "subtext": "or origin declaration EUR-MED including UK Approved Exporter number for consignments with a value over £5500  / 6000 euros",
                     "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
+                    "detail": ""
                 }
+
             ],
             "cumulation_methods": {
                 "bilateral": {
@@ -4145,7 +4263,8 @@
                 "absorption": true,
                 "tolerances": false,
                 "sets": true,
-                "cumulation": true
+                "cumulation": true,
+                "drawback": false
             },
             "introductory_notes_file": "ukraine_intro.md",
             "fta_intro_file": "ukraine.md",
@@ -4168,16 +4287,16 @@
             "title": "UK-Vietnam Free Trade Agreement",
             "proofs": [
                 {
-                    "summary": "EUR1 or EUR.MED movement certificate",
+                    "summary": "EUR.1 movement certificate",
                     "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
+                    "proof_class": "eur1",
+                    "detail": ""
                 },
                 {
                     "summary": "Origin declaration",
                     "subtext": "",
                     "proof_class": "origin-declaration",
-                    "detail": "origin-declaration.md"
+                    "detail": ""
                 }
             ],
             "cumulation_methods": {
@@ -4231,7 +4350,8 @@
                 "absorption": true,
                 "tolerances": false,
                 "sets": true,
-                "cumulation": true
+                "cumulation": true,
+                "drawback": false
             },
             "introductory_notes_file": "vietnam_intro.md",
             "fta_intro_file": "vietnam.md",
@@ -4254,16 +4374,16 @@
             "title": "Arrangement for import duty on trade in goods from certain British Overseas Territories",
             "proofs": [
                 {
-                    "summary": "EUR1 or EUR.MED movement certificate",
+                    "summary": "EUR.1 movement certificate",
                     "subtext": "",
-                    "proof_class": "eur1-eur-med",
-                    "detail": "eur1.md"
+                    "proof_class": "eur1",
+                    "detail": ""
                 },
                 {
                     "summary": "Origin declaration",
                     "subtext": "",
                     "proof_class": "origin-declaration",
-                    "detail": "invoice-declaration.md"
+                    "detail": ""
                 }
             ],
             "cumulation_methods": {
@@ -4422,7 +4542,8 @@
                 "absorption": true,
                 "tolerances": false,
                 "sets": true,
-                "cumulation": true
+                "cumulation": true,
+                "drawback": true
             },
             "introductory_notes_file": "oct_intro.md",
             "fta_intro_file": "oct.md",
@@ -4455,13 +4576,13 @@
                     "summary": "Generalised Scheme of Preferences form A",
                     "subtext": "",
                     "proof_class": "gsp-form-a",
-                    "detail": "gsp.md"
+                    "detail": ""
                 },
                 {
-                    "summary": "Invoice declaration",
+                    "summary": "Origin declaration",
                     "subtext": "",
                     "proof_class": "origin-declaration",
-                    "detail": "origin-declaration.md"
+                    "detail": ""
                 }
             ],
             "cumulation_methods": {
@@ -4549,7 +4670,7 @@
                 }
             },
             "ord": {
-                "ord_title": "",
+                "ord_title": "Generalised Scheme of Preferences (GSP)",
                 "ord_version": "",
                 "ord_date": "",
                 "ord_original": ""
@@ -4575,7 +4696,8 @@
                 "absorption": true,
                 "tolerances": false,
                 "sets": true,
-                "cumulation": true
+                "cumulation": true,
+                "drawback": true
             },
             "footnote": "Scheme incorporates:</p><ul class='govuk-list govuk-list--bullet govuk-body-s'><li>the GSP Least Developed Countries Framework</li><li>the GSP General Framework</li><li>the GSP Enhanced Framework</li></ul>",
             "introductory_notes_file": "gsp_intro.md",
@@ -4607,27 +4729,27 @@
                 "CF",
                 "CG",
                 "CK",
-                "CMx",
+                "CM",
                 "DJ",
                 "DZ",
                 "ER",
                 "ET",
                 "FM",
-                "GHx",
+                "GH",
                 "GM",
                 "GN",
                 "GW",
                 "HT",
                 "ID",
                 "IN",
-                "KEx",
+                "KE",
                 "KH",
                 "KI",
                 "KM",
                 "LA",
                 "LR",
                 "LS",
-                "MDx",
+                "MD",
                 "MG",
                 "ML",
                 "MM",

--- a/db/rules_of_origin/roo_schemes_uk/proofs/albania/eur-med.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/albania/eur-med.md
@@ -1,0 +1,6 @@
+Use form EUR-MED to record preferential trade in goods between the UK and participating countries.
+
+- [Download a copy of the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+For detailed procedures, see EUR.1.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/albania/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/albania/eur1.md
@@ -1,0 +1,80 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1 or EUR-MED
+1. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities of the exporting Party on application having been made in writing by the exporter or, under the exporter’s responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative shall fill in both the movement certificate EUR.1 or EUR-MED and the application form, specimens of which appear in the Annexes IIIa and b. These forms shall be completed in one of the languages in which the United Kingdom-Albania Agreement is drawn up and in accordance with the provisions of the national law of the exporting country. If the completion of the forms is done in handwriting, they shall be completed in ink in printed characters. The description of the products shall be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line shall be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 or EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the United Kingdom or Albania where the movement certificate EUR.1 or EUR-MED is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. Without prejudice to paragraph 5, a movement certificate EUR.1 shall be issued by the customs authorities of the United Kingdom or of Albania in the following cases:
+
+    (a) if the products concerned can be considered as products originating in the United Kingdom or in Albania, without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey, one of the countries referred to in Articles 3(2) and 4(2) and fulfil the other requirements of this Origin Reference Document; or
+
+    (b) if the products concerned can be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an origin declaration EUR-MED has been issued in the country of origin.
+
+5. A movement certificate EUR-MED shall be issued by the customs authorities of the United Kingdom or of Albania, if the products concerned can be considered as products originating in the United Kingdom, in Albania or in one of the countries referred to in Articles 3 and 4 with which cumulation is applicable, fulfil the requirements of this Origin Reference Document and:
+
+    (a) cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries referred to in Articles 3(2) and 4(2); or
+
+    (b) the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the countries referred to in Articles 3 and 4; or
+
+    (c) the products may be re-exported from the country of destination to one of the countries referred to in Articles 3 and 4. 
+
+6. A movement certificate EUR-MED shall contain one of the following statements in English in Box 7:
+
+    (a) if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+    
+    ‘CUMULATION APPLIED WITH … (name of the country/countries)’
+
+    (b) if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘NO CUMULATION APPLIED’
+
+7. The customs authorities issuing movement certificates EUR.1 or EUR-MED shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter’s accounts or any other check considered appropriate. They shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+8. The date of issue of the movement certificate EUR.1 or EUR-MED shall be indicated in Box 11 of the certificate.
+
+9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement certificates EUR.1 or EUR-MED issued retrospectively
+1. Notwithstanding Article 17(9), a movement certificate EUR.1 or EUR-MED may exceptionally be issued after exportation of the products to which it relates if:
+
+    (a) it was not issued at the time of exportation because of errors, involuntary omissions or special circumstances; or
+
+    (b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 or EUR-MED was issued but was not accepted at importation for technical reasons.
+
+2. Notwithstanding Article 17(9), a movement certificate EUR-MED may be issued after exportation of the products to which it relates and for which a movement certificate EUR.1 was issued at the time of exportation, provided that it is demonstrated to the satisfaction of the customs authorities that the conditions referred to in Article 17(5) are satisfied.
+
+3. For the implementation of paragraphs 1 and 2, the exporter shall indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 or EUR-MED relates, and state the reasons for his request.
+
+4. The customs authorities may issue a movement certificate EUR.1 or EUR-MED retrospectively only after verifying that the information supplied in the exporter’s application complies with that in the corresponding file.
+
+5. Movement certificates EUR.1 or EUR-MED issued retrospectively by application of paragraph 1 shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY’
+
+    Movement certificates EUR-MED issued retrospectively by application of paragraph 2 shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY (Original EUR.1 No … [date and place of issue])’
+
+6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
+
+#### Issue of a duplicate movement certificate EUR.1 or EUR-MED
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1 or EUR-MED, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way shall be endorsed with the following word in English:
+
+    ‘DUPLICATE’
+
+3. The endorsement referred to in paragraph 2 shall be inserted in Box 7 of the duplicate movement certificate EUR.1 or EUR-MED.
+
+4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
+
+#### Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously
+
+When originating products are placed under the control of a customs office in the United Kingdom or Albania, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or Albania. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/albania/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/albania/origin-declaration.md
@@ -1,0 +1,61 @@
+The origin declaration is provided on an invoice or any other commercial document that describes the originating product in sufficient detail to enable its identification. The texts of the origin declarations appear in Annexes IVa and b of the [Origin Reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an origin declaration or an origin declaration EUR-MED
+
+1. An origin declaration or an origin declaration EUR-MED as referred to in Article 16(1)(c) may be made out:
+
+    (a) by an approved exporter within the meaning of Article 23; or
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products the total value of which does not exceed EUR 6 000.
+
+2. Without prejudice to paragraph 3, an origin declaration may be made out in the following cases:
+
+    (a) if the products concerned may be considered as products originating in the United Kingdom, in Albania without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2), and fulfil the other requirements of this Origin Reference Document; or
+
+    (b) if the products concerned may be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an origin declaration EUR-MED has been issued in the country of origin.
+
+3. An origin declaration EUR-MED may be made out if the products concerned can be considered as products originating in the United Kingdom, in Albania or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, and fulfil the requirements of this Origin Reference Document, in the following cases:
+
+    (a) cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2); or
+
+    (b) the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the other countries referred to in Articles 3 and 4; or
+
+    (c) the products may be re-exported from the country of destination to one of the other countries referred to in Articles 3 and 4.
+
+4. An origin declaration EUR-MED shall contain one of the following statements in English:
+
+    (a) if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘CUMULATION APPLIED WITH …  (name of the country/countries)’; 
+
+    (b) if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘NO CUMULATION APPLIED’
+
+5. The exporter making out an origin declaration or an origin declaration EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting Party, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+6. An origin declaration or an origin declaration EUR-MED shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the texts of which appear in Annexes IVa and b, using one of the linguistic versions set out in those Annexes and in accordance with the provisions of the national law of the exporting country. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+7. Origin declarations and origin declarations EUR-MED shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 23 shall not be required to sign such declarations provided that he gives the customs authorities of the exporting Party a written undertaking that he accepts full responsibility for any origin declaration which identifies him as if it had been signed in manuscript by him.
+
+8. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
+
+#### Approved exporter
+
+1. The customs authorities of the exporting Party may authorise any exporter (hereinafter referred to as ‘approved exporter’), who makes frequent shipments of products in accordance to the provisions of the United Kingdom-Albania Agreement to make out origin declarations or origin declarations EUR-MED irrespective of the value of the products concerned. An exporter seeking such authorisation shall offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the origin declaration or on the origin declaration EUR-MED.
+
+4. The customs authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/andean/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/andean/eur1.md
@@ -1,0 +1,60 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the Issuance of a Movement Certificate EUR.1
+
+1. A movement certificate EUR.1 shall be issued by the competent authorities or customs authorities of the exporting Party on application having been made in writing by the exporter or, under the exporter's responsibility, by his/her authorised representative.
+
+2. For the purposes of paragraph 1, the exporter or his/her authorised representative shall fill out both the movement certificate EUR.1 and the application form, specimens of which appear in Appendix 3. These forms shall be completed in Spanish or English and in accordance with the provisions of the domestic law of the exporting Party. If they are hand-written, they shall be completed in ink in printed characters. The description of the products must be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line must be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 shall be prepared to submit at any time, at the request of the competent authorities or customs authorities of the exporting Party where the movement certificate EUR.1 is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. A movement certificate EUR.1 shall be issued by the competent authorities or customs authorities of a Member State of the European Union or of the signatory Andean Countries if the products concerned can be considered as products originating in the European Union or in the signatory Andean Countries and fulfil the other requirements of this Origin Reference Document.
+
+5. The competent authorities or customs authorities issuing movement certificates EUR.1 shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, such authorities shall have the right to call for any evidence and to carry out any inspection of the exporter's accounts or any other check considered appropriate. The said authorities shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, the competent authorities or customs authorities shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+6. The date of issue of the movement certificate EUR.1 shall be indicated in box 11 of the certificate.
+
+7. A movement certificate EUR.1 shall be issued by the competent authorities or customs authorities and made available to the exporter as soon as the actual exportation has been effected or ensured.
+
+
+#### Movement Certificate EUR.1 Issued Retrospectively
+
+1. Notwithstanding Article 16, paragraph 7, a movement certificate EUR.1 may exceptionally be issued after the exportation of the products to which it relates if: 
+
+(a) a movement certificate was not issued at the time of exportation because of errors or involuntary omissions or special circumstances; or 
+
+(b) it is demonstrated to the satisfaction of the competent authorities or customs authorities that a movement certificate EUR.1 was issued but was not accepted at importation for technical reasons.
+
+1. For the implementation of paragraph 1, the exporter shall indicate in his/her application the place and date of exportation of the products to which the movement certificate EUR.1 relates and state the reasons for his/her request.
+
+2. The competent authorities or customs authorities may issue a movement certificate EUR.1 retrospectively only after verifying that the information supplied in the exporter's application coincides with that in the corresponding file. 
+
+3. Movement certificates EUR 1 issued retrospectively shall be endorsed with one of the following phrases: 
+
+    ES ‘EXPEDIDO A POSTERIORI’ 
+
+    EN ‘ISSUED RETROSPECTIVELY’
+ 
+5. The endorsement referred to in paragraph 4 shall be inserted in the 'Remarks' box of the movement certificate EUR.1.
+
+
+#### Issuance of a Duplicate Movement Certificate EUR.1
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1, the exporter may apply to the competent authority or customs authority which issued such certificate for a duplicate made out on the basis of the export documents in their possession. 
+
+2. The duplicate issued pursuant to paragraph 1 shall be endorsed with one of the following words: 
+
+    ES ‘DUPLICADO’ 
+
+    EN ‘DUPLICATE’ 
+
+3. The endorsement referred to in paragraph 2 shall be inserted in the 'Remarks' box of the duplicate movement certificate EUR.1. 
+
+4. The duplicate, which must bear the date of issue of the original movement certificate EUR.1 shall take effect as from that date.
+
+#### Issuance of Movement Certificates EUR.1 on the Basis of a Proof of Origin Previously Issued or Made Out
+
+When originating products are placed under the control of a customs authority in the UK, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 for the purpose of sending all or some of these products elsewhere within the UK or the signatory Andean Countries. The replacement movement certificate(s) EUR.1 shall be issued by the competent authority or by the customs authority, in this last case, under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/andean/invoice-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/andean/invoice-declaration.md
@@ -1,0 +1,39 @@
+An 'invoice declaration', given by the exporter on an invoice, a delivery note or any other commercial document describes the products concerned in sufficient detail to enable them to be identified. The text of the invoice declaration appears in Appendix 4 of the [origin reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Invoice declarations are also known as origin declarations. Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for Making Out an Invoice Declaration
+
+1. An invoice declaration as referred to in Article 15, subparagraph 1(b), may be made out: 
+
+    (a) by an approved exporter within the meaning of Article 21, or 
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed 6 000 euro. 
+
+2. An invoice declaration may be made out if the products concerned can be considered as products originating in a Party and fulfil the other requirements of this Origin Reference Document. 
+
+3. The exporter making out an invoice declaration shall be prepared to submit at any time, at the request of the competent authorities or customs authorities of the exporting Party, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document. 
+
+4. An invoice declaration shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration the text of which appears in Appendix 4, using one of the linguistic versions set out in that Appendix and in accordance with the provisions of the domestic law of the exporting Party. If the declaration is hand-written, it shall be written in ink in printed characters. 
+
+5. Invoice declarations shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 21 shall not be required to sign such declarations provided that the exporter gives the competent authorities or customs authorities of the exporting Party a written undertaking that s/he accepts full responsibility for any invoice declaration which identifies him/her as if it had been signed in manuscript by him/her. 
+
+6. An invoice declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing Party no longer than two years after the importation of the products to which it relates.
+
+#### Approved exporter
+
+1. The competent authorities or customs authorities of the exporting Party may authorise any exporter (hereinafter referred to as "approved exporter") who makes frequent shipments of products under the Agreement, to make out invoice declarations irrespective of the value of the products concerned. An exporter seeking such authorisation must offer to the satisfaction of the competent auth-orities or customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The competent authorities or customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate. 
+
+3. The competent authorities or customs authorities shall grant the approved exporter an authorisation number which shall appear on the invoice declaration. 
+
+4. The competent authorities or customs authorities shall monitor the use of the authorisation by the approved exporter. 
+
+5. The competent authorities or customs authorities may withdraw the auth-orisation at any time. Such authorities shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/cameroon/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/cameroon/eur1.md
@@ -1,0 +1,54 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1
+
+1. A movement certificate EUR.1 shall be issued by the customs authorities of Cameroon on application having been made in writing by the exporter or, under the exporter's responsibility, by the authorised representative of the exporter.
+
+2. For that purpose, the exporter or the authorised representative of the exporter shall fill out both the movement certificate EUR.1 and the application form, specimens of which appear in Appendix 3. Those forms shall be completed in accordance with the provisions of Part A of this Origin Reference Document. If they are handwritten, they shall be completed in ink in printed characters. The description of the products shall be given in the box reserved for that purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line shall be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 shall be prepared to submit at any time, at the request of the customs authorities of Cameroon, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of Part A of this Origin Reference Document.
+
+4. A movement certificate EUR.1 shall be issued by the customs authorities of Cameroon if the products concerned can be considered as products originating in Cameroon or in one of the other countries or territories referred to in Article 6, and fulfil the other requirements of Part A of this Origin Reference Document.
+
+5. The issuing customs authorities shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of Part A of this Origin Reference Document. For that purpose they shall have the right to call for any evidence and to carry out any inspection of the exporter's accounts or any other check considered appropriate. The issuing customs authorities shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+6. The date of issue of the movement certificate EUR.1 shall be indicated in box 11 of the certificate.
+
+7. A movement certificate EUR.1 shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement certificates EUR.1 issued retrospectively
+
+1. Notwithstanding Article 15(7), a movement certificate EUR.1 may exceptionally be issued after exportation of the products to which it relates if:
+
+    (a) it was not issued at the time of exportation because of errors or involuntary omissions or special circumstances; or
+
+    (b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 was issued but was not accepted at importation for technical reasons.
+
+2. For the implementation of paragraph 1, the exporter shall indicate in the application the place and date of exportation of the products to which the movement certificate EUR.1 relates, and state the reasons for that request.
+
+3. The customs authorities may issue a movement certificate EUR.1 retrospectively only after verifying that the information supplied in the exporter's application complies with that in the corresponding file.
+
+4. Movement certificates EUR.1 issued retrospectively shall be endorsed with the following phrase:
+
+    'ISSUED RETROSPECTIVELY'
+
+5. The endorsement referred to in paragraph 4 shall be inserted in box 7 of the movement certificate EUR.1.
+
+#### Issue of a duplicate movement certificate EUR.1
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way shall be endorsed with the following word:
+
+    'DUPLICATE'
+
+3. The endorsement referred to in paragraph 2 shall be inserted in box 7 of the duplicate movement certificate EUR.1.
+
+4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1, shall take effect as from that date.
+
+#### Issue of movement certificates EUR.1 on the basis of a proof of origin issued or made out previously
+
+When originating products are placed under the control of a customs office in Cameroon or in the United Kingdom, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 for the purpose of sending all or some of those products elsewhere within Cameroon or within the United Kingdom. The replacement movement certificate or certificates EUR.1 shall be issued by the customs office under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/cameroon/invoice-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/cameroon/invoice-declaration.md
@@ -1,0 +1,39 @@
+An 'invoice declaration', given by the exporter on an invoice, a delivery note or any other commercial document describes the products concerned in sufficient detail to enable them to be identified. The text of the invoice declaration appears in Appendix 4 of the [origin reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Invoice declarations are also known as origin declarations. Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an invoice declaration
+
+1. An invoice declaration as referred to in point (b) of Article 14(1) may be made out:
+
+    (a) by an approved exporter within the meaning of Article 20; or
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed EUR 6 000.
+
+2. An invoice declaration may be made out if the products concerned can be considered as products originating in Cameroon or in one of the other countries or territories referred to in Article 6 and fulfil the other requirements of Part A of this Origin Reference Document.
+
+3. The exporter making out an invoice declaration shall be prepared to submit at any time, at the request of the customs authorities of Cameroon, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of Part A of this Origin Reference Document.
+
+4. An invoice declaration shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document the declaration the text of which appears in Appendix 4, using one of the linguistic versions set out in that Appendix and in accordance with the provisions of the domestic law of Cameroon. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+5. Invoice declarations shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 20 shall not be required to sign such declarations provided that he or she gives the customs authorities of Cameroon a written undertaking that he or she accepts full responsibility for any invoice declaration which identifies him or her as if it had been signed in manuscript by him or her.
+
+6. An invoice declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the United Kingdom no longer than two years after the importation of the products to which it relates.
+
+#### Approved exporter
+
+1. The customs authorities of Cameroon may authorise any exporter who makes frequent shipments of products under the provisions of the United Kingdom-Cameroon Agreement to make out invoice declarations irrespective of the value of the products concerned. An exporter seeking such authorisation shall offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of Part A of this Origin Reference Document.
+
+2. The customs authorities of Cameroon may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities of Cameroon shall grant to the approved exporter a customs authorisation number which shall appear on the invoice declaration.
+
+4. The customs authorities of Cameroon shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities of Cameroon may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, does not fulfil the conditions referred to in paragraph 2 or otherwise makes incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/canada/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/canada/origin-declaration.md
@@ -1,0 +1,7 @@
+The origin declaration is provided on an invoice or any other commercial document that describes the originating product in sufficient detail to enable its identification.
+
+The text of the origin declaration is set out in Annex 2 of the [origin document](ord).
+
+In the UK, the exporter’s reference number will be the EORI number. If you do not have one, you can [apply for an EORI number](https://www.gov.uk/eori). 
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).

--- a/db/rules_of_origin/roo_schemes_uk/proofs/cariforum/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/cariforum/eur1.md
@@ -1,0 +1,54 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1
+
+1. A movement certificate EUR.1 shall be issued by the customs authorities of the exporting country on application having been made in writing by the exporter or, under the exporter's responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative shall fill out both the movement certificate EUR.1 and the application form, specimens of which appear in Annex III. These forms shall be completed in accordance with the provisions of this Origin Reference Document. If they are handwritten, they shall be completed in ink in printed characters. The description of the products must be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line must be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 shall be prepared to submit at any time, at the request of the customs authorities of the exporting country where the movement certificate EUR.1 is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. A movement certificate EUR.1 shall be issued by the customs authorities of the United Kingdom or of a CARIFORUM State if the products concerned can be considered as products originating in the United Kingdom or in a CARIFORUM State or in one of the other countries or territories referred to in Articles 3, 4 and 5 and fulfil the other requirements of this Origin Reference Document.
+
+5. The issuing customs authorities shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter's accounts or any other check considered appropriate. The issuing customs authorities shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+6. The date of issue of the movement certificate EUR.1 shall be indicated in Box 11 of the certificate.
+
+7. A movement certificate EUR.1 shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been affected or ensured.
+
+#### Movement certificates EUR.1 issued retrospectively
+
+1. Notwithstanding Article 17(7), a movement certificate EUR.1 may exceptionally be issued after exportation of the products to which it relates if:
+
+    (a) it was not issued at the time of exportation because of errors or involuntary omissions or special circumstances; or
+
+    (b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 was issued but was not accepted at importation for technical reasons.
+
+2. For the implementation of paragraph 1, the exporter must indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 relates and state the reasons for his request.
+
+3. The customs authorities may issue a movement certificate EUR.1 retrospectively only after verifying that the information supplied in the exporter's application agrees with that in the corresponding file.
+
+4. Movement certificates EUR.1 issued retrospectively must be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY’.
+
+5. The endorsement referred to in paragraph 4 shall be inserted in the ‘Remarks’ box of the movement certificate EUR.1.
+
+#### Issue of a duplicate movement certificate EUR.1
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way must be endorsed with the following word in English: 
+
+    ‘DUPLICATE’.
+
+3. The endorsement referred to in paragraph 2 shall be inserted in the ‘Remarks’ box of the duplicate movement certificate EUR.1.
+
+4. The duplicate, which must bear the date of issue of the original movement certificate EUR.1, shall take effect as from that date.
+
+#### Issue of movement certificates EUR.1 on the basis of a proof of origin issued or made out previously
+
+When originating products are placed under the control of a customs office in a CARIFORUM State or in the United Kingdom, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 for the purpose of sending all or some of these products elsewhere within the CARIFORUM States or within the United Kingdom. The replacement movement certificate(s) EUR.1 shall be issued by the customs office under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/cariforum/invoice-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/cariforum/invoice-declaration.md
@@ -1,0 +1,39 @@
+An 'invoice declaration', given by the exporter on an invoice, a delivery note or any other commercial document describes the products concerned in sufficient detail to enable them to be identified. The text of the invoice declaration appears in Annex IV of the [origin reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Invoice declarations are also known as origin declarations. Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an invoice declaration
+
+1. An invoice declaration as referred to in Article 16(1)(b) may be made out:
+
+    (a) by an approved exporter within the meaning of Article 22; or
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed EUR 6 000.
+
+2. An invoice declaration may be made out if the products concerned can be considered as products originating in the CARIFORUM States or in the United Kingdom and fulfil the other requirements of this Origin Reference Document.
+
+3. The exporter making out an invoice declaration shall be prepared to submit at any time, at the request of the customs authorities of the exporting country, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. An invoice declaration shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the text of which appears in Annex IV to this Origin Reference Document, using one of the linguistic versions set out in that Annex and in accordance with the provisions of the domestic law of the exporting country. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+5. Invoice declarations shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 22 shall not be required to sign such declarations provided that he gives the customs authorities of the exporting country a written undertaking that he accepts full responsibility for any invoice declaration which identifies him as if it had been signed in manuscript by him.
+
+6. An invoice declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country no longer than two years after the importation of the products to which it relates.
+
+#### Approved exporter
+
+1. The customs authorities of the exporting country may authorise any exporter who makes frequent shipments of products under the trade cooperation provisions of the UK-CARIFORUM EPA to make out invoice declarations irrespective of the value of the products concerned. An exporter seeking such authorisation must offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the invoice declaration.
+
+4. The customs authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, does not fulfil the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/central-america/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/central-america/eur1.md
@@ -1,0 +1,6 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+

--- a/db/rules_of_origin/roo_schemes_uk/proofs/central-america/invoice-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/central-america/invoice-declaration.md
@@ -1,0 +1,9 @@
+An 'invoice declaration', given by the exporter on an invoice, a delivery note or any other commercial document describes the products concerned in sufficient detail to enable them to be identified. The text of the invoice declaration appears in Appendix 4 of the [origin reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Invoice declarations are also known as origin declarations. Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).

--- a/db/rules_of_origin/roo_schemes_uk/proofs/chile/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/chile/eur1.md
@@ -1,0 +1,59 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1
+
+1. A movement certificate EUR.1 shall be issued by the customs authorities or competent governmental authorities of Chile on application having been made in writing by the exporter or, under the exporter's responsibility, by his authorised representative.
+
+2. The procedure for the completion of both the movement certificate EUR.1 and the application form is set out in Appendix III.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 shall be prepared to submit at any time, at the request of the customs authorities or competent governmental authorities of Chile where the movement certificate EUR.1 is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. A movement certificate EUR.1 shall be issued by the customs authorities or competent governmental authorities of the United Kingdom or Chile if the products concerned can be considered as products originating in the United Kingdom or Chile  and fulfil the other requirements of this Origin Reference Document.
+
+5. The issuing customs authorities or competent governmental authorities shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter's accounts or any other check considered appropriate. The issuing customs authorities or competent governmental authorities shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+6. The date of issue of the movement certificate EUR.1 shall be indicated in Box 11 of the certificate.
+
+7. A movement certificate EUR.1 shall be issued by the customs authorities or competent governmental authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement certificate EUR.1 issued retrospectively
+
+1. Notwithstanding Article 16(7), a movement certificate EUR.1 may exceptionally be issued after exportation of the products to which it relates if:
+
+    a. it was not issued at the time of exportation because of errors or involuntary omissions or special circumstances, or
+
+    b. it is demonstrated to the satisfaction of the customs authorities or competent governmental authorities that a movement certificate EUR.1 was issued but was not accepted at importation for technical reasons.
+
+2. For the implementation of paragraph 1, the exporter must indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 relates and state the reasons for his request.
+
+3. The customs authorities or competent governmental authorities may issue a movement certificate EUR.1 retrospectively only after verifying that the information supplied in the exporter's application agrees with that in the corresponding file.
+
+4. Movement certificates EUR 1 issued retrospectively shall be endorsed with one of the following phrases:
+
+    ES ‘EXPEDIDO A POSTERIORI’
+
+    EN ‘ISSUED RETROSPECTIVELY’
+
+5. The endorsement referred to in paragraph 4 shall be inserted in the ‘Remarks’ box of the movement certificate EUR.1.
+
+#### Issue of a duplicate movement certificate EUR.1
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1, the exporter by stating the reasons for his request may apply to the customs authorities or competent governmental authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued pursuant to paragraph 1 shall be endorsed with one of the following words:
+
+    ES ‘DUPLICADO’
+
+    EN ‘DUPLICATE’
+
+3. The endorsement referred to in paragraph 2 shall be inserted in the ‘Remarks’ box of the duplicate movement certificate EUR.1.
+
+4. The duplicate, which must bear the date of issue of the original movement certificate EUR.1, shall take effect as from that date.
+
+#### Issue of movement certificates EUR.1 on the basis of a proof of origin issued or made out previously
+
+When originating products are placed under the control of a customs office in the United Kingdom or in Chile, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 for the purpose of sending all or some of these products elsewhere within the United Kingdom or Chile. The replacement movement certificate(s) EUR.1 shall be issued by the customs office of first entry in the United Kingdom or in Chile under whose control the products are placed.
+

--- a/db/rules_of_origin/roo_schemes_uk/proofs/chile/invoice-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/chile/invoice-declaration.md
@@ -1,0 +1,39 @@
+An 'invoice declaration', given by the exporter on an invoice, a delivery note or any other commercial document describes the products concerned in sufficient detail to enable them to be identified. The text of the invoice declaration appears in Annex IV of the [origin reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Invoice declarations are also known as origin declarations. Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an invoice declaration
+
+1. An invoice declaration as referred to in Article 15(1)(b) may be made out:
+
+    a. by an approved exporter within the meaning of Article 21; or
+
+    b. by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed EUR 6 000.
+
+2. An invoice declaration may be made out if the products concerned can be considered as products originating in the United Kingdom or in Chile and fulfil the other requirements of this Origin Reference Document.
+
+3. The exporter making out an invoice declaration shall be prepared to submit at any time, at the request of the customs authorities or competent governmental authorities of Chile, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. An invoice declaration shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the text of which appears in Appendix IV. Specific requirements as for the making out of an invoice declaration are set out in Appendix IV.
+
+5. Invoice declarations shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 21 shall not be required to sign such declarations provided that he gives the customs authorities or competent governmental authorities of Chile a written undertaking that he accepts full responsibility for any invoice declaration which identifies him as if it had been signed in manuscript by him.
+
+6. An invoice declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented to the customs authorities of the importing country no longer than two years after the importation of the products to which it relates.
+
+#### Approved exporter
+
+1. The customs authorities or competent governmental authorities of Chile may authorise any exporter, hereinafter referred to as 'approved exporter', who makes frequent shipments of originating products under the United Kingdom-Chile Agreement to make out invoice declarations irrespective of the value of the products concerned. An exporter seeking such authorisation must offer to the satisfaction of the customs authorities or competent governmental authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities or competent governmental authorities may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities or competent governmental authorities shall grant to the approved exporter a customs authorisation number, which shall appear on the invoice declaration.
+
+4. The customs authorities or competent governmental authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities or competent governmental authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/cotedivoire/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/cotedivoire/eur1.md
@@ -1,0 +1,50 @@
+Use form EUR.1 to claim preferential duty rates on goods imported to the UK from Côte&nbsp;d'Ivoire (not valid for exports from UK to Côte&nbsp;d'Ivoire).
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1
+
+1. A movement certificate EUR.1 shall be issued by the customs authorities of the exporting country on application having been made in writing by the exporter or, under the exporter's responsibility, by the authorised representative of the exporter.
+
+2. For this purpose, the exporter or his authorised representative shall fill in both the movement certificate EUR.1 and the application form, specimens of which appear in Annex III to this Origin Reference Document. These forms shall be completed in accordance with the provisions of this Origin Reference Document. If they are handwritten, they shall be completed in ink in printed characters. The description of the products must be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line must be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 shall be prepared to submit at any time, at the request of the customs authorities of the exporting country where the movement certificate EUR.1 is issued, all appropriate documents proving the originating status of the products concerned as well as compliance with the other requirements of this Origin Reference Document.
+
+4. A movement certificate EUR.1 shall be issued by the customs authorities of the United Kingdom or of Côte d'Ivoire if the products concerned can be considered as products originating in the United Kingdom, in Côte d'Ivoire or in one of the other countries or territories referred to in Articles 6, 7 and 8 of this Origin Reference Document and fulfil the other requirements of this Origin Reference Document.
+
+5. The issuing customs authorities shall take any steps necessary to verify the originating status of the products and compliance with the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter's accounts or any other check considered appropriate. The issuing customs authorities shall also ensure that the forms referred to in paragraph 2 of this Article are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+6. The date of issue of the movement certificate EUR.1 shall be indicated in box 11 of the certificate.
+
+7. A movement certificate EUR.1 shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement certificates EUR.1 issued retrospectively
+
+1. Notwithstanding Article 18(7) of this Origin Reference Document, a movement certificate EUR.1 may exceptionally be issued after exportation of the products to which it relates if:
+
+    (a) it was not issued at the time of exportation because of errors or involuntary omissions or special circumstances; or
+
+    (b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 was issued but was not accepted at importation for technical reasons.
+
+2. For the implementation of paragraph 1 of this Article, the exporter must indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 relates, and state the reasons for his request.
+
+3. The customs authorities may issue a movement certificate EUR.1 retrospectively only after verifying that the information supplied in the exporter's application complies with that in the corresponding file.
+
+4. Movement certificates EUR.1 issued retrospectively shall be endorsed with the following entry:
+
+    'DÉLIVRÉ A POSTERIORI'.
+
+5. The endorsement referred to in paragraph 4 of this Article shall be inserted in the 'Remarks' box of the movement certificate EUR.1.
+
+#### Issue of a duplicate movement certificate EUR.1
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way shall be endorsed with the following entry:
+
+    'DUPLICATA'
+
+3. The entry referred to in paragraph 2 of this Article shall be inserted in the 'Remarks' box of the duplicate movement certificate EUR.1.
+
+4. The duplicate, which must bear the date of issue of the original movement certificate EUR.1, shall take effect as from that date.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/cotedivoire/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/cotedivoire/origin-declaration.md
@@ -1,0 +1,44 @@
+An 'origin declaration', given by the exporter on an invoice, a delivery note or any other commercial document describes the products concerned in sufficient detail to enable them to be identified. The text of the invoice declaration appears in Annex IV of the [origin reference document](ord).
+
+The origin declaration may be used for movements in both directions between UK and Côte&nbsp;d'Ivoire. An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an origin declaration
+1. An origin declaration may be made out:
+
+    (a) in the cases referred to in Article 17(1), by an exporter registered in accordance with the relevant provisions of the law of the United Kingdom;
+
+    (b) in the cases referred to in point (b) of Article 17(2):
+
+    — within a period of three years from the entry into force of Protocol 1 concerning the concept of ‘originating products’ and methods of administrative cooperation of the EU-Côte d’Ivoire Stepping Stone EPA, by an exporter within the meaning of Article 22;
+
+    — after the expiry of that period, by an exporter registered in accordance with the relevant provisions of Ivorian law;
+
+    (c) by any exporter, for any consignment consisting of one or more packages containing originating products, the total value of which does not exceed EUR 6 000.
+
+2. An origin declaration may be made out if the products concerned can be considered as products originating in Côte d'Ivoire, in the United Kingdom or in one of the other countries or territories referred to in Articles 6, 7 and 8 of this Origin Reference Document and fulfil the other requirements of this Origin Reference Document.
+
+3. The exporter making out an origin declaration shall be prepared to submit at any time, at the request of the customs authorities of the exporting country, all appropriate documents proving the originating status of the products concerned as well as compliance with the other requirements of this Origin Reference Document.
+
+4. An origin declaration shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the text of which appears in Annex IV to this Origin Reference Document, using one of the linguistic versions set out in that Annex and in accordance with the provisions of the domestic law of the exporting country. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+5. Origin declarations shall bear the original signature of the exporter in manuscript. However, a registered exporter as defined in paragraph 1 of this Article, or an approved exporter within the meaning of Article 22 of this Origin Reference Document shall not be required to sign such declarations provided that he gives the customs authorities of the exporting country a written undertaking that he accepts full responsibility for any origin declaration which identifies him as if it had been signed in manuscript by him.
+
+6. An origin declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country no longer than two (2) years after the importation of the products to which it relates.
+
+#### Approved exporter
+
+1. The customs authorities of the exporting country may authorise any exporter (hereinafter referred to as ‘approved exporter’) who makes frequent shipments of products under the trade cooperation provisions of the United Kingdom-Côte d'Ivoire Agreement to make out origin declarations irrespective of the value of the products concerned. An exporter seeking such authorisation shall offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as compliance with the other requirements of this Origin Reference Document.
+
+2. The customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the origin declaration.
+
+4. The customs authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1 of this Article, no longer fulfils the conditions referred to in paragraph 2 of this Article or otherwise makes incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/egypt/eur-med.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/egypt/eur-med.md
@@ -1,0 +1,6 @@
+Use form EUR-MED to record preferential trade in goods between the UK and participating countries.
+
+- [Download a copy of the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+For detailed procedures, see EUR.1.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/egypt/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/egypt/eur1.md
@@ -1,0 +1,82 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1 or EUR-MED
+
+1. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities of the exporting Party on application having been made in writing by the exporter or, under the exporter’s responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative shall fill in both the movement certificate EUR.1 or EUR-MED and the application form, specimens of which appear in Annexes IIIa and IIIb. These forms shall be completed in one of the languages in which the United Kingdom-Egypt Agreement is drawn up and in accordance with the provisions of the national law of the exporting country. If the completion of the forms is done in handwriting, they shall be completed in ink in printed characters. The description of the products shall be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line shall be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 or EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the United Kingdom or Egypt where the movement certificate EUR.1 or EUR-MED is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. Without prejudice to paragraph 5, a movement certificate EUR.1 shall be issued by the customs authorities of the United Kingdom or of Egypt in the following cases:
+
+    (a) if the products concerned can be considered as products originating in the United Kingdom or in Egypt, without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries referred to in Articles 3(2) and 4(2) and fulfil the other requirements of this Origin Reference Document; or
+
+    (b) if the products concerned can be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an origin declaration EUR-MED has been issued in the country of origin.
+
+5. A movement certificate EUR-MED shall be issued by the customs authorities of the United Kingdom or of Egypt if the products concerned can be considered as products originating in the United Kingdom, in Egypt or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, fulfil the requirements of this Origin Reference Document and:
+
+    (a) cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries referred to in Articles 3(2) and 4(2); or
+
+    (b) the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the countries referred to in Articles 3 and 4; or 
+
+    (c) the products may be re-exported from the country of destination to one of the countries referred to in Articles 3 and 4. 
+    
+6. A movement certificate EUR-MED shall contain one of the following statements in English in box 7:
+
+    (a) if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘CUMULATION APPLIED WITH … (name of the country/countries)’
+
+    (b) if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘NO CUMULATION APPLIED’
+
+7. The customs authorities issuing movement certificates EUR.1 or EUR-MED shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter’s accounts or any other check considered appropriate. They shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+8. The date of issue of the movement certificate EUR.1 or EUR-MED shall be indicated in Box 11 of the certificate.
+
+9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement certificates EUR.1 or EUR-MED issued retrospectively
+
+1. Notwithstanding Article 17(9), a movement certificate EUR.1 or EUR-MED may exceptionally be issued after exportation of the products to which it relates if:
+
+(a) it was not issued at the time of exportation because of errors, involuntary omissions or special circumstances; or
+
+(b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 or EUR-MED was issued but was not accepted at importation for technical reasons.
+
+2. Notwithstanding Article 17(9), a movement certificate EUR-MED may be issued after exportation of the products to which it relates and for which a movement certificate EUR.1 was issued at the time of exportation, provided that it is demonstrated to the satisfaction of the customs authorities that the conditions referred to in Article 17(5) are satisfied.
+
+3. For the implementation of paragraphs 1 and 2, the exporter shall indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 or EUR-MED relates, and state the reasons for his request.
+
+4. The customs authorities may issue a movement certificate EUR.1 or EUR-MED retrospectively only after verifying that the information supplied in the exporter’s application complies with that in the corresponding file.
+
+5. Movement certificates EUR.1 or EUR-MED issued retrospectively by application of paragraph 1 shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY’
+
+    Movement certificates EUR-MED issued retrospectively by application of paragraph 2 shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY (Original EUR.1 No … [date and place of issue])’
+
+6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
+
+#### Issue of a duplicate movement certificate EUR.1 or EUR-MED
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1 or EUR-MED, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way shall be endorsed with the following word in English:
+
+    ‘DUPLICATE’
+
+3. The endorsement referred to in paragraph 2 shall be inserted in Box 7 of the duplicate movement certificate EUR.1 or EUR-MED.
+
+4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
+
+#### Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously 
+
+When originating products are placed under the control of a customs office in the United Kingdom or Egypt, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or Egypt. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/egypt/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/egypt/origin-declaration.md
@@ -1,0 +1,62 @@
+The origin declaration is provided on an invoice or any other commercial document that describes the originating product in sufficient detail to enable its identification. The texts of the origin declarations appear in Annexes IVa and IVb of the [Origin Reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an origin declaration or an origin declaration EUR-MED
+
+1. An origin declaration or an origin declaration EUR-MED as referred to in Article 16(1)(c) may be made out:
+
+    (a) by an approved exporter within the meaning of Article 23; or
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products the total value of which does not exceed EUR 6 000.
+
+2. Without prejudice to paragraph 3, an origin declaration may be made out in the following cases:
+
+(a) if the products concerned may be considered as products originating in the United Kingdom or in Egypt without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2), and fulfil the other requirements of this Origin Reference Document; or
+
+(b) if the products concerned may be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an origin declaration EUR-MED has been issued in the country of origin.
+
+3. An origin declaration EUR-MED may be made out if the products concerned can be considered as products originating in the United Kingdom, in Egypt or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, and fulfil the requirements of this Origin Reference Document, in the following cases:
+
+    (a) cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2); or
+
+    (b) the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the other countries referred to in Articles 3 and 4; or
+
+    (c) the products may be re-exported from the country of destination to one of the other countries referred to in Articles 3 and 4.
+
+4. An origin declaration EUR-MED shall contain one of the following statements in English:
+
+    (a) if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘CUMULATION APPLIED WITH … (name of the country/countries)’
+
+    (b) if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘NO CUMULATION APPLIED’
+
+5. The exporter making out an origin declaration or an origin declaration EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting Party, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+6. An origin declaration or an origin declaration EUR-MED shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the texts of which appear in Annexes IVa and IVb, using one of the linguistic versions set out in those Annexes and in accordance with the provisions of the national law of the exporting country. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+7. Origin declarations and origin declarations EUR-MED shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 23 shall not be required to sign such declarations provided that he gives the customs authorities of the exporting Party a written undertaking that he accepts full responsibility for any origin declaration which identifies him as if it had been signed in manuscript by him.
+
+8. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
+
+
+#### Approved exporter
+
+1. The customs authorities of the exporting Party may authorise any exporter (hereinafter referred to as ‘approved exporter’), who makes frequent shipments of products in accordance to the provisions of the United Kingdom-Egypt Agreement to make out origin declarations or origin declarations EUR-MED irrespective of the value of the products concerned. An exporter seeking such authorisation shall offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the origin declaration or on the origin declaration EUR-MED.
+
+4. The customs authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/esa/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/esa/eur1.md
@@ -1,0 +1,6 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+

--- a/db/rules_of_origin/roo_schemes_uk/proofs/esa/invoice-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/esa/invoice-declaration.md
@@ -1,0 +1,9 @@
+An 'invoice declaration', given by the exporter on an invoice, a delivery note or any other commercial document describes the products concerned in sufficient detail to enable them to be identified. The text of the invoice declaration appears in Annex IV of the [origin reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Invoice declarations are also known as origin declarations. Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).

--- a/db/rules_of_origin/roo_schemes_uk/proofs/eu/importers-knowledge.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/eu/importers-knowledge.md
@@ -1,0 +1,6 @@
+The importer's knowledge that a product is originating in the exporting Party will be based on information demonstrating that the product is originating and satisfies the requirements provided for in the Origin Reference Document.
+
+Find out more about:
+
+- [general processes for using 'importer's knowledge'](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#importers-knowledge)
+- [using importer's knowledge for trade between the UK and the EU](https://www.gov.uk/guidance/proving-originating-status-and-claiming-a-reduced-rate-of-customs-duty-for-trade-between-the-uk-and-eu#applying-for-preference-using-importers-knowledge).

--- a/db/rules_of_origin/roo_schemes_uk/proofs/eu/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/eu/origin-declaration.md
@@ -1,0 +1,5 @@
+A statement on origin is needed if the exporter exports consignments with a total value of more than £5,500 / 6,000 euros.
+
+In the UK, the exporter’s reference number will be the EORI number. If you do not have one, you can [apply for an EORI number](https://www.gov.uk/eori). In the EU, the exporter’s reference number will be the exporter’s registered exporter (REX) number.
+
+Statements on origin are also known as origin declarations. Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).

--- a/db/rules_of_origin/roo_schemes_uk/proofs/faroe-islands/eur-med.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/faroe-islands/eur-med.md
@@ -1,0 +1,6 @@
+Use form EUR-MED to record preferential trade in goods between the UK and participating countries.
+
+- [Download a copy of the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+For detailed procedures, see EUR.1.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/faroe-islands/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/faroe-islands/eur1.md
@@ -1,0 +1,82 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+Procedure for the issue of a movement certificate EUR.1 or EUR-MED
+
+1. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities of the exporting Party on application having been made in writing by the exporter or, under the exporter’s responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative shall fill in both the movement certificate EUR.1 or EUR-MED and the application form, specimens of which appear in Annexes III a and b. These forms shall be completed in one of the languages in which the United Kingdom-Faroe Islands Agreement is drawn up and in accordance with the provisions of the national law of the exporting country. If the completion of the forms is done in handwriting, they shall be completed in ink in printed characters. The description of the products shall be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line shall be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 or EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the United Kingdom or the Faroe Islands where the movement certificate EUR.1 or EUR-MED is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. Without prejudice to paragraph 5, a movement certificate EUR.1 shall be issued by the customs authorities of the United Kingdom or of the Faroe Islands in the following cases:
+
+    (a) if the products concerned can be considered as products originating in the United Kingdom or in the Faroe Islands with which cumulation is applicable, without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries referred to in Articles 3(2) and 4(2), and fulfil the other requirements of this Origin Reference Document; or
+
+    (b) if the products concerned can be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an invoice declaration EUR-MED has been issued in the country of origin.
+
+5. A movement certificate EUR-MED shall be issued by the customs authorities of the United Kingdom or of the Faroe Islands in the following cases:
+
+    (a) cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries referred to in Articles 3(2) and 4(2); or
+
+    (b) the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the countries referred to in Articles 3 and 4; or
+
+    (c) the products may be re-exported from the country of destination to one of the countries referred to in Articles 3 and 4.
+
+6. A movement certificate EUR-MED shall contain one of the following statements in English in box 7:
+
+    (a) if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘CUMULATION APPLIED WITH … (name of the country/countries)’
+
+    (b) if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘NO CUMULATION APPLIED’
+
+7. The customs authorities issuing movement certificates EUR.1 or EUR-MED shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter’s accounts or any other check considered appropriate. They shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+8. The date of issue of the movement certificate EUR.1 or EUR-MED shall be indicated in Box 11 of the certificate.
+
+9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement certificates EUR.1 or EUR-MED issued retrospectively
+
+1. Notwithstanding Article 17(9), a movement certificate EUR.1 or EUR-MED may exceptionally be issued after exportation of the products to which it relates if:
+
+    (a) it was not issued at the time of exportation because of errors, involuntary omissions or special circumstances; or
+
+    (b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 or EUR-MED was issued but was not accepted at importation for technical reasons.
+
+2. Notwithstanding Article 17(9), a movement certificate EUR-MED may be issued after exportation of the products to which it relates and for which a movement certificate EUR.1 was issued at the time of exportation, provided that it is demonstrated to the satisfaction of the customs authorities that the conditions referred to in Article 17(5) are satisfied.
+
+3. For the implementation of paragraphs 1 and 2, the exporter shall indicate in his  application the place and date of exportation of the products to which the movement certificate EUR.1 or EUR-MED relates, and state the reasons for his request.
+
+4. The customs authorities may issue a movement certificate EUR.1 or EUR-MED retrospectively only after verifying that the information supplied in the exporter’s application complies with that in the corresponding file.
+
+5. Movement certificates EUR.1 or EUR-MED issued retrospectively shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY’
+
+    Movement certificates EUR-MED issued retrospectively by application of paragraph 2 shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY (Original EUR.1 No … [date  and  place  of issue])’
+
+6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
+
+#### Issue of a duplicate movement certificate EUR.1 or EUR-MED
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1 or EUR-MED, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way shall be endorsed with the following word in English:
+
+    ‘DUPLICATE’
+
+3. The endorsement referred to in paragraph 2 shall be inserted in Box 7 of the duplicate movement certificate EUR.1 or EUR-MED.
+
+4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
+
+#### Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously
+
+When originating products are placed under the control of a customs office in the United Kingdom or the Faroe Islands, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or the Faroe Islands. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/faroe-islands/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/faroe-islands/origin-declaration.md
@@ -1,0 +1,61 @@
+The origin declaration is provided on an invoice or any other commercial document that describes the originating product in sufficient detail to enable its identification. The texts of the origin declarations appear in Annexes IVa and IVb of the [Origin Reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an origin declaration or an origin declaration EUR-MED
+
+1. An origin declaration or an origin declaration EUR-MED as referred to in Article 16(1)(c) may be made out:
+
+    (a) by an approved exporter within the meaning of Article 23; or
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products the total value of which does not exceed EUR 6 000.
+
+2. Without prejudice to paragraph 3, an origin declaration may be made out in the following cases:
+
+    — (a) if the products concerned may be considered as products originating in the United Kingdom or in the Faroe Islands without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2), and fulfil the other requirements of this Origin Reference Document; or
+
+    — (b) if the products concerned may be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an invoice declaration EUR-MED has been issued in the country of origin.
+
+3. An origin declaration EUR-MED may be made out if the products concerned can be considered as products originating in the United Kingdom, in the Faroe Islands or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable,  and fulfil the requirements of this Origin Reference Document, in the following cases:
+
+    — (a) cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2); or
+
+    — (b) the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the other countries referred to in Articles 3 and 4; or
+
+    — (c) the products may be re-exported from the country of destination to one of the other countries referred to in Articles 3 and 4.
+
+4. An origin declaration EUR-MED shall contain one of the following statements in English:
+
+    (a) if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘CUMULATION APPLIED WITH …  (name of the country/countries)’
+
+    (b) if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘NO CUMULATION APPLIED’
+
+5. The exporter making out an origin declaration or an origin declaration EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting Party, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+6. An origin declaration or an origin declaration EUR-MED shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the texts of which appear in Annexes IVa and b, using one of the linguistic versions set out in those Annexes and in accordance with the provisions of the national law of the exporting country. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+7. Origin declarations and origin declarations EUR-MED shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 23 shall not be required to sign such declarations provided that he gives the customs authorities of the exporting Party a written undertaking that he accepts full responsibility for any origin declaration which identifies him as if it had been signed in manuscript by him.
+
+8. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
+
+#### Approved exporter
+
+1. The customs authorities of the exporting Party may authorise any exporter (hereinafter referred to as ‘approved exporter’), who makes frequent shipments of products in accordance to the provisions of the United Kingdom-Faroe Islands Agreement to make out origin declarations or origin declarations EUR-MED irrespective of the value of the products concerned. An exporter seeking such authorisation shall offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the origin declaration or on the origin declaration EUR-MED.
+
+4. The customs authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/georgia/eur-med.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/georgia/eur-med.md
@@ -1,0 +1,6 @@
+Use form EUR-MED to record preferential trade in goods between the UK and participating countries.
+
+- [Download a copy of the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+For detailed procedures, see EUR.1.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/georgia/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/georgia/eur1.md
@@ -1,0 +1,83 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1 or EUR-MED
+
+1. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities of the exporting Party on application having been made in writing by the exporter or, under the exporter’s responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative shall fill in both the movement certificate EUR.1 or EUR-MED and the application form, specimens of which appear in Annexes IIIa and b. These forms shall be completed in one of the languages in which the United Kingdom-Georgia Agreement is drawn up and in accordance with the provisions of the national law of the exporting country. If the completion of the forms is done in handwriting, they shall be completed in ink in printed characters. The description of the products shall be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line shall be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 or EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the United Kingdom or Georgia where the movement certificate EUR.1 or EUR-MED is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. Without prejudice to paragraph 5, a movement certificate EUR.1 shall be issued by the customs authorities of the United Kingdom or of Georgia in the following cases:
+
+    a. if the products concerned can be considered as products originating in the United Kingdom or in Georgia, without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries referred to in Articles 3(2) and 4(2), and fulfil the other requirements of this Origin Reference Document; or
+
+    b. if the products concerned can be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an invoice declaration EUR-MED has been issued in the country of origin.
+
+
+5. A movement certificate EUR-MED shall be issued by the customs authorities of the United Kingdom or of Georgia, if the products concerned can be considered as products originating in the United Kingdom, Georgia or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, fulfil the requirements of this Origin Reference Document and :
+
+    a. cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries referred to in Articles 3(2) and 4(2); or
+
+    b. the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the countries referred to in Articles 3 and 4; or
+
+    c. the products may be re-exported from the country of destination to one of the countries referred to in Articles 3 and 4. 
+
+6. A movement certificate EUR-MED shall contain one of the following statements in English in box 7:
+
+    a. if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘CUMULATION APPLIED WITH … (name of the country/countries)’
+
+    b. if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘NO CUMULATION APPLIED’
+
+7. The customs authorities issuing movement certificates EUR.1 or EUR-MED shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter’s accounts or any other check considered appropriate. They shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+8. The date of issue of the movement certificate EUR.1 or EUR-MED shall be indicated in Box 11 of the certificate.
+
+9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement certificates EUR.1 or EUR-MED issued retrospectively
+
+1. Notwithstanding Article 17(9), a movement certificate EUR.1 or EUR-MED may exceptionally be issued after exportation of the products to which it relates if:
+
+    a. it was not issued at the time of exportation because of errors, involuntary omissions or special circumstances; or
+
+    b. it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 or EUR-MED was issued but was not accepted at importation for technical reasons.
+
+2. Notwithstanding Article 17(9), a movement certificate EUR-MED may be issued after exportation of the products to which it relates and for which a movement certificate EUR.1 was issued at the time of exportation, provided that it is demonstrated to the satisfaction of the customs authorities that the conditions referred to in Article 17(5) are satisfied.
+
+3. For the implementation of paragraphs 1 and 2, the exporter shall indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 or EUR-MED relates, and state the reasons for his request.
+
+4. The customs authorities may issue a movement certificate EUR.1 or EUR-MED retrospectively only after verifying that the information supplied in the exporter’s application complies with that in the corresponding file.
+
+5. Movement certificates EUR.1 or EUR-MED issued retrospectively by application of paragraph 1 shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY’
+
+    Movement certificates EUR-MED issued retrospectively by application of paragraph 2 shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY (Original EUR.1 No … [date and place of issue])’
+
+6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
+
+#### Issue of a duplicate movement certificate EUR.1 or EUR-MED
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1 or EUR-MED, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way shall be endorsed with the following word in English:
+
+    ‘DUPLICATE’
+
+3. The endorsement referred to in paragraph 2 shall be inserted in Box 7 of the duplicate movement certificate EUR.1 or EUR-MED.
+
+4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
+
+#### Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously
+
+When originating products are placed under the control of a customs office in the United Kingdom or Georgia, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or Georgia. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/georgia/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/georgia/origin-declaration.md
@@ -1,0 +1,62 @@
+The origin declaration is provided on an invoice or any other commercial document that describes the originating product in sufficient detail to enable its identification. The texts of the origin declarations appear in Annexes IVa and IVb of the [Origin Reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an origin declaration or an origin declaration EUR-MED
+
+1. An origin declaration or an origin declaration EUR-MED as referred to in Article 16(1)(c) may be made out:
+
+    a. by an approved exporter within the meaning of Article 23; or
+
+    b. by any exporter for any consignment consisting of one or more packages containing originating products the total value of which does not exceed EUR 6 000.
+
+2. Without prejudice to paragraph 3, an origin declaration may be made out in the following cases:
+
+    a. if the products concerned may be considered as products originating in the United Kingdom or in Georgia without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2), and fulfil the other requirements of this Origin Reference Document; or
+
+    b. if the products concerned may be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an invoice declaration EUR-MED has been issued in the country of origin.
+
+
+3. An origin declaration EUR-MED may be made out if the products concerned can be considered as products originating in the United Kingdom, in Georgia or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable,  and fulfil the requirements of this Origin Reference Document, in the following cases:
+
+    a. cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2); or
+
+    b. the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the other countries referred to in Articles 3 and 4; or
+
+    c. the products may be re-exported from the country of destination to one of the other countries referred to in Articles 3 and 4.
+
+4. An origin declaration EUR-MED shall contain one of the following statements in English:
+
+    a. if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘CUMULATION APPLIED WITH …  (name of the country/countries)’
+
+    b. if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘NO CUMULATION APPLIED’
+
+5. The exporter making out an origin declaration or an origin declaration EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting Party, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+6. An origin declaration or an origin declaration EUR-MED shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the texts of which appear in Annexes IVa and b, using one of the linguistic versions set out in those Annexes and in accordance with the provisions of the national law of the exporting country. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+7. Origin declarations and origin declarations EUR-MED shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 23 shall not be required to sign such declarations provided that he gives the customs authorities of the exporting Party a written undertaking that he accepts full responsibility for any origin declaration which identifies him as if it had been signed in manuscript by him.
+
+8. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
+
+#### Approved exporter
+
+1. The customs authorities of the exporting Party may authorise any exporter (hereinafter referred to as ‘approved exporter’), who makes frequent shipments of products in accordance to the provisions of the United Kingdom-Georgia Agreement to make out origin declarations or origin declarations EUR-MED irrespective of the value of the products concerned. An exporter seeking such authorisation shall offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the origin declaration or on the origin declaration EUR-MED.
+
+4. The customs authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/ghana/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/ghana/eur1.md
@@ -1,0 +1,50 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1
+
+1. A movement certificate EUR.1 shall be issued by the customs authorities of the exporting country on application having been made in writing by the exporter or, under the exporter's responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative shall fill out both the movement certificate EUR.1 and the application form, specimens of which appear in Annex III to this Origin Reference Document. These forms shall be completed in accordance with the provisions of this Origin Reference Document. If the forms are handwritten, they shall be completed in ink in printed characters. The description of the products must be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line shall be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 shall be prepared to submit at any time, at the request of the customs authorities of the exporting country where the movement certificate EUR.1 is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. A movement certificate EUR.1 shall be issued by the customs authorities of the UK or of Ghana if the products concerned can be considered as products originating in the UK, Ghana or one of the other countries or territories referred to in Articles 6, 7 and 8 of this Origin Reference Document and fulfil the other requirements of this Origin Reference Document.
+
+5. The issuing customs authorities shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter's accounts or any other check considered appropriate. The issuing customs authorities shall also ensure that the forms referred to in paragraph 2 of this Article are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+6. The date of issue of the movement certificate EUR.1 shall be indicated in Box 11 of the certificate.
+
+7. A movement certificate EUR.1 shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement certificates EUR.1 issued retrospectively
+
+1. Notwithstanding Article 18(7) of this Origin Reference Document, a movement certificate EUR.1 may exceptionally be issued after exportation of the products to which it relates if:
+
+    (a) it was not issued at the time of exportation because of errors or involuntary omissions or special circumstances; or
+
+    (b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 was issued but was not accepted at importation for technical reasons.
+
+2. For the implementation of paragraph 1 of this Article, the exporter must indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 relates, and state the reasons for his request.
+
+3. The customs authorities may issue a movement certificate EUR.1 retrospectively only after verifying that the information supplied in the exporter's application agrees with that in the corresponding file.
+
+4. Movement certificates EUR.1 issued retrospectively must be endorsed with the following phrase:
+
+    "ISSUED RETROSPECTIVELY".
+
+5. The endorsement referred to in paragraph 4 of this Article shall be inserted in the "Remarks" box of the movement certificate EUR.1.
+
+#### Issue of a duplicate movement certificate EUR.1
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way must be endorsed with the following:
+
+    "DUPLICATE".
+
+3. The endorsement referred to in paragraph 2 of this Article shall be inserted in the "Remarks" box of the duplicate movement certificate EUR.1.
+
+4. The duplicate, which must bear the date of issue of the original movement certificate EUR.1, shall take effect as from that date.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/ghana/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/ghana/origin-declaration.md
@@ -1,0 +1,45 @@
+An 'origin declaration', given by the exporter on an invoice, a delivery note or any other commercial document describes the products concerned in sufficient detail to enable them to be identified. The text of the invoice declaration appears in Annex IV of the [origin reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an origin declaration
+
+1. An origin declaration may be made out:
+
+    (a) as referred to in Article 17(1) of this Origin Reference Document by a registered exporter in conformity with the internal legislation of the UK;
+
+    (b) in the cases referred to Article 17(2)(b):
+
+      - (i) up to three (3) years after the entry into force of Protocol No. 1 concerning the definition of the concept of 'originating products' and the methods of administrative cooperation to the EU-Ghana Free Trade Agreement, by an exporter as provided for in Article 22;
+
+      - (ii) three (3) years after the entry into force of Protocol No. 1 concerning the definition of the concept of 'originating products' and the methods of administrative cooperation to the EU-Ghana Free Trade Agreement, by a registered exporter in accordance with the internal legislation of Ghana;
+
+    (c) by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed EUR 6 000.
+
+2. An origin declaration may be made out if the products concerned can be considered as products originating in Ghana, in the UK or in one of the other countries referred to in Articles 6, 7 and 8 of this Origin Reference Document and fulfil the other requirements of this Origin Reference Document.
+
+3. The exporter making out an origin declaration shall be prepared to submit at any time, at the request of the customs authorities of the exporting country, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. An origin declaration shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the text of which appears in Annex IV to this Origin Reference Document, using one of the linguistic versions set out in that Annex and in accordance with the provisions of the domestic law of the exporting country. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+5. Origin declarations shall bear the original signature of the exporter in manuscript. However, origin declarations shall not be signed by a registered exporter within the meaning of paragraph 1 of this Article or by an approved exporter within the meaning of Article 22 of this Origin Reference Document (“E”) provided that E gives the customs authorities of the exporting country a written undertaking that E accepts full responsibility for any origin declaration which identifies E as if it had been signed in manuscript by E. 
+
+6. An origin declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country no longer than two (2) years after the importation of the products to which it relates.
+
+#### Approved exporter
+
+1. The customs authorities of the exporting country may authorise any exporter (hereinafter referred to as "approved exporter") who makes frequent shipments of products under the trade cooperation provisions of the United Kingdom-Ghana Agreement to make out origin declarations irrespective of the value of the products concerned. An exporter seeking such authorisation must offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the origin declaration.
+
+4. The customs authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 of this Article or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/gsp/gsp-form-a.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/gsp/gsp-form-a.md
@@ -1,0 +1,5 @@
+Generalised Scheme of Preferences Form A is used to give proof of origin for goods being imported from countries covered by the UK Generalised Scheme of Preferences.
+
+The form does not need to be stamped or signed by an authority designated by the Generalised Scheme of Preference beneficiary country (you may submit a copy).
+
+[Completing Generalised Scheme of Preferences Form A](https://www.gov.uk/guidance/completing-generalised-scheme-of-preferences-form-a)

--- a/db/rules_of_origin/roo_schemes_uk/proofs/gsp/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/gsp/origin-declaration.md
@@ -1,0 +1,3 @@
+An 'origin declaration', given by the exporter on an invoice, a delivery note or any other commercial document describes the products concerned in sufficient detail to enable them to be identified. The text of the invoice declaration appears in Annex IV of the [origin reference document](ord).
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).

--- a/db/rules_of_origin/roo_schemes_uk/proofs/iceland-norway/eur-med.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/iceland-norway/eur-med.md
@@ -1,0 +1,6 @@
+Use form EUR-MED to record preferential trade in goods between the UK and participating countries.
+
+- [Download a copy of the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+For detailed procedures, see EUR.1.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/iceland-norway/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/iceland-norway/eur1.md
@@ -1,0 +1,81 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the Issue of a Movement Certificate EUR.1 or EUR-MED
+1. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities of the exporting Party on application having been made in writing by the exporter or, under the exporter's responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative shall fill in both the movement certificate EUR.1 or EUR-MED and the application form, specimens of which appear in Annexes IIIa and b. These forms shall be completed in English, Icelandic or Norwegian and in accordance with the provisions of the national law of the exporting Party. If the forms are handwritten, they shall be completed in ink in printed characters. The description of the products shall be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line shall be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 or EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting Party where the movement certificate EUR.1 or EUR-MED is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. Without prejudice to paragraph 5, a movement certificate EUR.1 shall be issued by the customs authorities of the exporting Party in the following cases:
+
+   - if the products concerned can be considered as products originating in the exporting Party or in one of the countries referred to in Article 3(1) with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Article 3(2), and fulfil the other requirements of this Origin Reference Document,
+
+   - if the products concerned can be considered as products originating in one of the countries referred to in Article 3(2) with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Article 3 and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an origin declaration EUR-MED has been issued in the country of origin.
+
+5. A movement certificate EUR-MED shall be issued by the customs authorities of the exporting Party, if the products concerned can be considered as products originating in the exporting Party or in one of the countries referred to in Article 3 with which cumulation is applicable, fulfil the requirements of this Origin Reference Document and:
+
+   - cumulation was applied with materials originating in one of the countries referred to in Article 3(2), or
+
+   - the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the countries referred to in Article 3(2), or
+
+   - the products may be re-exported from the country of destination to one of the countries referred to in Article 3(2).
+
+6. A movement certificate EUR-MED shall contain one of the following statements in English in box 7:
+
+   - if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Article 3:
+
+   “CUMULATION APPLIED WITH …” (name of the country/countries)
+
+   - if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Article 3:
+
+   “NO CUMULATION APPLIED”
+
+7. The customs authorities issuing movement certificates EUR.1 or EUR-MED shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter's accounts or any other check considered appropriate. They shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+8. The date of issue of the movement certificate EUR.1 or EUR-MED shall be indicated in Box 11 of the certificate.
+
+9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement Certificates EUR.1 or EUR-MED issued Retrospectively
+
+1. Notwithstanding Article 16(9), a movement certificate EUR.1 or EUR-MED may exceptionally be issued after exportation of the products to which it relates if:
+
+    (a) it was not issued at the time of exportation because of errors or involuntary omissions or special circumstances; or
+
+    (b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 or EUR-MED was issued but was not accepted at importation for technical reasons.
+
+2. Notwithstanding Article 16(9), a movement certificate EUR-MED may be issued after exportation of the products to which it relates and for which a movement certificate EUR.1 was issued at the time of exportation, provided that it is demonstrated to the satisfaction of the customs authorities that the conditions referred to in Article 16(5) are satisfied.
+
+3. For the implementation of paragraphs 1 and 2, the exporter must indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 or EUR-MED relates, and state the reasons for his request.
+
+4. The customs authorities may issue a movement certificate EUR.1 or EUR-MED retrospectively only after verifying that the information supplied in the exporter's application complies with that in the corresponding file.
+
+5. Movement certificates EUR.1 or EUR-MED issued retrospectively shall be endorsed with the following phrase in English:
+
+    “ISSUED RETROSPECTIVELY”
+
+    Movement certificates EUR-MED issued retrospectively by application of paragraph 2 shall be endorsed with the following phrase in English:
+
+    ISSUED RETROSPECTIVELY (Original EUR.1 No …(date and place of issue)
+
+6. The endorsement referred to in paragraph 5 shall be inserted in box 7 of the movement certificate EUR.1 or EUR-MED.
+
+#### Issue of a Duplicate Movement Certificate EUR.1 or EUR-MED
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1 or EUR-MED, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way shall be endorsed with the following word in English:
+
+    “DUPLICATE”
+
+3. The endorsement referred to in paragraph 2 shall be inserted in box 7 of the duplicate movement certificate EUR.1 or EUR-MED.
+
+4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
+
+#### Issue of Movement Certificates EUR.1 or EUR-MED on the Basis of a Proof of Origin issued or made out previously
+
+When originating products are placed under the control of a customs office in a Party, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within that Party. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/iceland-norway/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/iceland-norway/origin-declaration.md
@@ -1,0 +1,56 @@
+The origin declaration is provided on an invoice or any other commercial document that describes the originating product in sufficient detail to enable its identification. The texts of the origin declarations appear in Annexes IVa and IVb of the [Origin Reference document](ord).
+
+In the UK, the exporter’s reference number will be the EORI number. If you do not have one, you can [apply for an EORI number](https://www.gov.uk/eori). In Iceland or Norway, Approved Exporters should use their Approved Exporter number as the authorisation number. Other exporters should leave the authorisation number blank.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an Origin Declaration or an Origin Declaration EUR-MED
+1. An origin declaration or an origin declaration EUR-MED as referred to in Article 15(1)(c) may be made out:
+
+    (a) by an approved exporter within the meaning of Article 22; or
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed EUR 6 000.
+
+2. Without prejudice to paragraph 3, an origin declaration may be made out in the following cases:
+
+   - if the products concerned may be considered as products originating in a Party or in one of the countries referred to in Article 3(1) with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Article 3(2), and fulfil the other requirements of this Origin Reference Document;
+
+   - if the products concerned may be considered as products originating in one of the countries referred to in Article 3(2) with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Article 3 and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an origin declaration EUR-MED has been issued in the country of origin.
+
+3. An origin declaration EUR-MED may be made out if the products concerned may be considered as products originating in a Party or in one of the countries referred to in Article 3 with which cumulation is applicable, fulfil the requirements of this Origin Reference Document and:
+
+   - cumulation was applied with materials originating in one of the countries referred to in Article 3(2), or
+
+   - the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the countries referred to in Article 3(2), or
+
+   - the products may be re-exported from the country of destination to one of the countries referred to in Article 3(2).
+
+4. An origin declaration EUR-MED shall contain one of the following statements in English:
+
+   - if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Article 3:
+
+   “CUMULATION APPLIED WITH …” (name of the country/countries)
+
+   - if origin has been obtained without application of cumulation with materials originating in one or more of the countries referred to in Article 3:
+
+   “NO CUMULATION APPLIED”.
+
+5. The exporter making out an origin declaration or an origin declaration EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting Party, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+6. An origin declaration or an origin declaration EUR-MED shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the texts of which appear in Annexes IVa and b, using one of the linguistic versions set out in these Annexes and in accordance with the provisions of the national law of the exporting Party. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+7. Origin declarations and origin declarations EUR-MED shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 22 shall not be required to sign such declarations provided that he gives the customs authorities of the exporting Party a written undertaking that he accepts full responsibility for any origin declaration which identifies him as if it had been signed in manuscript by him.
+
+8. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing Party at the latest two years after the importation of the products to which it relates.
+
+#### Approved Exporter
+
+1. The customs authorities of the exporting Party may authorise any exporter (hereinafter referred to as “approved exporter”) who makes frequent shipments of products under the United Kingdom-Iceland Agreement to make out origin declarations or origin declarations EUR-MED irrespective of the value of the products concerned. An exporter seeking such authorisation shall offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the origin declaration or on the origin declaration EUR-MED.
+
+4. The customs authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/israel/eur-med.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/israel/eur-med.md
@@ -1,0 +1,6 @@
+Use form EUR-MED to record preferential trade in goods between the UK and participating countries.
+
+- [Download a copy of the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+For detailed procedures, see EUR.1.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/israel/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/israel/eur1.md
@@ -1,0 +1,82 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1 or EUR-MED
+
+1. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities of the exporting country on application having been made in writing by the exporter or, under the exporter's responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative shall fill in both the movement certificate EUR.1 or EUR-MED and the application form, specimens of which appear in the Annexes IIIa and b to this Origin Reference Document. These forms shall be completed in one of the languages in which the UK-Israel Agreement is drawn up and in accordance with the provisions of the national law of the exporting country. If the forms are handwritten, they shall be completed in ink in printed characters. The description of the products shall be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line shall be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 or EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting country where the movement certificate EUR.1 or EUR-MED is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. Without prejudice to paragraph 5, a movement certificate EUR.1 shall be issued by the customs authorities of the UK in the following cases:
+
+— if the products concerned can be considered as products originating in the UK or in Israel, without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries referred to in Articles 3(2) and 4(2), and fulfil the other requirements of this Origin Reference Document, or
+
+— if the products concerned can be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an invoice declaration EUR-MED has been issued in the country of origin.
+
+5. A movement certificate EUR-MED shall be issued by the customs authorities of the UK or of Israel if the products concerned can be considered as products originating in the UK, in Israel or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, fulfil the requirements of this Origin Reference Document and:
+
+— cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2), or
+
+— the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the other countries referred to in Articles 3 and 4, or
+
+— the products may be re-exported from the country of destination to one of the other countries referred to in Articles 3 and 4.
+
+6. A movement certificate EUR-MED shall contain one of the following statements in English in Box 7:
+
+— if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+‘CUMULATION APPLIED WITH …’ (name of the country/countries)
+
+— if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+‘NO CUMULATION APPLIED’
+
+7. The customs authorities issuing movement certificates EUR.1 or EUR-MED shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter's accounts or any other check considered appropriate. They shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+8. The date of issue of the movement certificate EUR.1 or EUR-MED shall be indicated in Box 11 of the certificate.
+
+9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement certificates EUR.1 or EUR-MED issued retrospectively
+
+1. Notwithstanding Article 17(9), a movement certificate EUR.1 or EUR-MED may exceptionally be issued after exportation of the products to which it relates if:
+
+(a)  it was not issued at the time of exportation because of errors or involuntary omissions or special circumstances; or
+
+(b)  it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 or EUR-MED was issued but was not accepted at importation for technical reasons.
+
+2. Notwithstanding Article 17(9), a movement certificate EUR-MED may be issued after exportation of the products to which it relates and for which a movement certificate EUR.1 was issued at the time of exportation, provided that it is demonstrated to the satisfaction of the customs authorities that the conditions referred to in Article 17(5) are satisfied.
+
+3. For the implementation of paragraphs 1 and 2, the exporter shall indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 or EUR-MED relates, and state the reasons for his request.
+
+4. The customs authorities may issue a movement certificate EUR.1 or EUR-MED retrospectively only after verifying that the information supplied in the exporter's application complies with that in the corresponding file.
+
+5. Movement certificates EUR.1 or EUR-MED issued retrospectively shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY’
+
+    Movement certificates EUR-MED issued retrospectively by application of paragraph 2 shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY (Original EUR.1 No … [date and place of issue])’
+
+6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
+
+#### Issue of a duplicate movement certificate EUR.1 or EUR-MED
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1 or EUR-MED, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way shall be endorsed with the following word in English:
+
+    ‘DUPLICATE’
+
+3. The endorsement referred to in paragraph 2 shall be inserted in Box 7 of the duplicate movement certificate EUR.1 or EUR-MED.
+
+4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
+
+#### Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously
+
+When originating products are placed under the control of a customs office in the UK or in Israel, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the UK or Israel. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/israel/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/israel/origin-declaration.md
@@ -1,0 +1,61 @@
+The origin declaration is provided on an invoice or any other commercial document that describes the originating product in sufficient detail to enable its identification. The texts of the origin declarations appear in Annexes IVa and IVb of the [Origin Reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an invoice declaration or an invoice declaration EUR-MED
+
+1. An invoice declaration or an invoice declaration EUR-MED as referred to in Article 16(1)(c) may be made out:
+
+    (a) by an approved exporter within the meaning of Article 23; or
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed EUR 6 000.
+
+2. Without prejudice to paragraph 3, an invoice declaration may be made out in the following cases:
+
+    — if the products concerned may be considered as products originating in the UK, or in Israel without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2), and fulfil the other requirements of this Origin Reference Document, or
+
+    — if the products concerned may be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an invoice declaration EUR-MED has been issued in the country of origin.
+
+3. An invoice declaration EUR-MED may be made out if the products concerned may be considered as products originating in the UK, in Israel or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, fulfil the requirements of this Origin Reference Document and:
+
+    — cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2), or
+
+    — the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the other countries referred to in Articles 3 and 4, or
+
+    — the products may be re-exported from the country of destination to one of the other countries referred to in Articles 3 and 4.
+
+4. An invoice declaration EUR-MED shall contain one of the following statements in English:
+
+    — if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘CUMULATION APPLIED WITH …’ (name of the country/countries)
+
+    — if origin has been obtained without application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘NO CUMULATION APPLIED’
+
+5. The exporter making out an invoice declaration or an invoice declaration EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting country, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+6. An invoice declaration or an invoice declaration EUR-MED shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the texts of which appear in Annexes IVa and b to this Origin Reference Document, using one of the linguistic versions set out in these Annexes and in accordance with the provisions of the national law of the exporting country. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+7. Invoice declarations and invoice declarations EUR-MED shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 23 shall not be required to sign such declarations provided that he gives the customs authorities of the exporting country a written undertaking that he accepts full responsibility for any invoice declaration which identifies him as if it had been signed in manuscript by him.
+
+8. An invoice declaration or an invoice declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
+
+#### Approved exporter
+
+1. The customs authorities of the exporting country may authorise any exporter (hereinafter referred to as ‘approved exporter’) who makes frequent shipments of products under the UK-Israel Agreement to make out invoice declarations or invoice declarations EUR-MED irrespective of the value of the products concerned. An exporter seeking such authorisation shall offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the invoice declaration or on the invoice declaration EUR-MED.
+
+4. The customs authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/japan/importers-knowledge.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/japan/importers-knowledge.md
@@ -1,0 +1,5 @@
+The importer's knowledge that a product is originating in the exporting Party will be based on information demonstrating that the product is originating and satisfies the requirements provided for in the Origin Reference Document.
+
+Find about more about:
+- [general processes for using 'importer's knowledge'](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#importers-knowledge)
+- [using Importer's Knowledge for trade between UK and Japan](https://www.gov.uk/government/publications/uk-japan-cepa-guidance-on-importers-knowledge/uk-japan-cepa-guidance-on-importers-knowledge)

--- a/db/rules_of_origin/roo_schemes_uk/proofs/japan/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/japan/origin-declaration.md
@@ -1,0 +1,8 @@
+Goods do not require a statement of origin if they are:
+
+- entering Japan from the UK and below 200,000 yen in value
+- entering the UK from Japan and below £1,000 in value.
+
+In the UK, the exporter’s reference number will be the EORI number. If you do not have one, you can [apply for an EORI number](https://www.gov.uk/eori). 
+
+Statements on origin are also known as origin declarations. Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).

--- a/db/rules_of_origin/roo_schemes_uk/proofs/jordan/eur-med.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/jordan/eur-med.md
@@ -1,0 +1,6 @@
+Use form EUR-MED to record preferential trade in goods between the UK and participating countries.
+
+- [Download a copy of the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+For detailed procedures, see EUR.1.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/jordan/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/jordan/eur1.md
@@ -1,0 +1,82 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1 or EUR-MED
+
+1. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities of the exporting country on application having been made in writing by the exporter or, under the exporter's responsibility, by his authorised representative. 
+
+2. For this purpose, the exporter or his authorised representative shall fill in both the movement certificate EUR.1 or EUR-MED and the application form, specimens of which appear in the Annexes IIIa and b. These forms shall be completed in one of the languages in which the United Kingdom-Jordan Agreement is drawn up and in accordance with the provisions of the national law of the exporting country. If the forms are handwritten, they shall be completed in ink in printed characters. The description of the products shall be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line shall be drawn below the last line of the description, the empty space being crossed through. 
+
+3. The exporter applying for the issue of a movement certificate EUR.1 or EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting country where the movement certificate EUR.1 or EUR-MED is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document. 
+
+4. Without prejudice to paragraph 5, a movement certificate EUR.1 shall be issued by the customs authorities of the United Kingdom or of Jordan in the following cases: 
+
+    —  if the products concerned can be considered as products originating in the United Kingdom or in Jordan without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey, or one of the countries referred to in Articles 3(2) and 4(2) and fulfil the other requirements of this Origin Reference Document, or
+
+    —  if the products concerned can be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4 and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an invoice declaration EUR-MED has been issued in the country of origin. 
+
+5. A movement certificate EUR-MED shall be issued by the customs authorities of the United Kingdom or of Jordan, if the products concerned can be considered as products originating in the United Kingdom, in Jordan or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, fulfil the requirements of this Origin Reference Document and: 
+
+    —  cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey, or one of the countries referred to in Articles 3(2) and 4(2), or 
+
+    — the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the other countries referred to in Articles 3 and 4, or 
+
+    — the products may be re-exported from the country of destination to one of the other countries referred to in Articles 3 and 4. 
+
+6. A movement certificate EUR-MED shall contain one of the following statements in English in box 7: 
+
+    — if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4: 
+
+    ‘CUMULATION APPLIED WITH ……….’ (name of the country/countries) 
+
+    — if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4: 
+
+    ‘NO CUMULATION APPLIED’. 
+
+7. The customs authorities issuing movement certificates EUR.1 or EUR-MED shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter's accounts or any other check considered appropriate. They shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+8. The date of issue of the movement certificate EUR.1 or EUR-MED shall be indicated in Box 11 of the certificate. 
+
+9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured. 
+
+#### Movement certificates EUR.1 or EUR-MED issued retrospectively
+
+1. Notwithstanding Article 17(9), a movement certificate EUR.1 or EUR-MED may exceptionally be issued after exportation of the products to which it relates if: 
+
+    (a) it was not issued at the time of exportation because of errors or involuntary omissions or special circumstances; or 
+
+    (b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 or EUR-MED was issued but was not accepted at importation for technical reasons. 
+
+2. Notwithstanding Article 17(9), a movement certificate EUR-MED may be issued after exportation of the products to which it relates and for which a movement certificate EUR.1 was issued at the time of exportation, provided that it is demonstrated to the satisfaction of the customs authorities that the conditions referred to in Article 17(5) are satisfied. 
+
+3. For the implementation of paragraphs 1 and 2, the exporter shall indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 or EUR-MED relates and state the reasons for his request. 
+
+4. The customs authorities may issue a movement certificate EUR.1 or EUR-MED retrospectively only after verifying that the information supplied in the exporter's application complies with that in the corresponding file. 
+
+5. Movement certificates EUR.1 or EUR-MED issued retrospectively shall be endorsed with the following phrase in English: 
+
+    ‘ISSUED RETROSPECTIVELY’ 
+
+    Movement certificates EUR-MED issued retrospectively by application of paragraph 2 shall be endorsed with the following phrase in English: 
+
+    ‘ISSUED RETROSPECTIVELY (Original EUR.1 No ………. (date and place of issue))’ 
+
+6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED. 
+
+#### Issue of a duplicate movement certificate EUR.1 or EUR-MED
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1 or EUR-MED, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession. 
+
+2. The duplicate issued in this way shall be endorsed with the following word in English: 
+
+    ‘DUPLICATE’
+
+3. The endorsement referred to in paragraph 2 shall be inserted in Box 7 of the duplicate movement certificate EUR.1 or EUR-MED. 
+
+4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date. 
+
+#### Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously
+
+When originating products are placed under the control of a customs office in the United Kingdom or in Jordan, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or Jordan. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed. 

--- a/db/rules_of_origin/roo_schemes_uk/proofs/jordan/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/jordan/origin-declaration.md
@@ -1,0 +1,61 @@
+The origin declaration is provided on an invoice or any other commercial document that describes the originating product in sufficient detail to enable its identification. The texts of the origin declarations appear in Annexes IVa and IVb of the [Origin Reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an invoice declaration or an invoice declaration EUR-MED
+
+1. An invoice declaration or an invoice declaration EUR-MED as referred to in Article 16(1)(c) may be made out:
+
+    (a) by an approved exporter within the meaning of Article 23, or 
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed EUR 6 000. 
+
+2. Without prejudice to paragraph 3, an invoice declaration may be made out in the following cases: 
+
+    — if the products concerned may be considered as products originating in the United Kingdom or in Jordan without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2), and fulfil the other requirements of this Origin Reference Document, 
+
+    — if the products concerned may be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4 and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an invoice declaration EUR-MED has been issued in the country of origin. 
+
+3. An invoice declaration EUR-MED may be made out if the products concerned may be considered as products originating in the United Kingdom, in Jordan or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, fulfil the requirements of this Origin Reference Document and: 
+
+    — cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey, or one of the countries referred to in Articles 3(2) and 4(2), or 
+
+    — the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the other countries referred to in Articles 3 and 4, or 
+
+    — the products may be re-exported from the country of destination to one of the other countries referred to in Articles 3 and 4. 
+
+4. An invoice declaration EUR-MED shall contain one of the following statements in English: 
+
+    — if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4: 
+
+    ‘CUMULATION APPLIED WITH……….’ (name of the country/countries)
+
+    — if origin has been obtained without application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4: 
+
+    ‘NO CUMULATION APPLIED’. 
+
+5. The exporter making out an invoice declaration or an invoice declaration EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting country, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document. 
+
+6. An invoice declaration or an invoice declaration EUR-MED shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the texts of which appear in Annexes IVa and b, using one of the linguistic versions set out in these Annexes and in accordance with the provisions of the national law of the exporting country. If the declaration is handwritten, it shall be written in ink in printed characters. 
+
+7. Invoice declarations and invoice declarations EUR-MED shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 23 shall not be required to sign such declarations provided that he gives the customs authorities of the exporting country a written undertaking that he accepts full responsibility for any invoice declaration which identifies him as if it had been signed in manuscript by him. 
+
+8. An invoice declaration or an invoice declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates. 
+
+#### Approved exporter
+
+1. The customs authorities of the exporting country may authorise any exporter (hereinafter referred to as approved exporter) who makes frequent shipments of products under the United Kingdom-Jordan Agreement to make out invoice declarations or invoice declarations EUR-MED irrespective of the value of the products concerned. An exporter seeking such authorisation shall offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document. 
+
+2. The customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate. 
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the invoice declaration or on the invoice declaration EUR-MED. 
+
+4. The customs authorities shall monitor the use of the authorisation by the approved exporter. 
+
+5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation. 

--- a/db/rules_of_origin/roo_schemes_uk/proofs/kenya/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/kenya/eur1.md
@@ -1,0 +1,6 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+

--- a/db/rules_of_origin/roo_schemes_uk/proofs/kenya/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/kenya/origin-declaration.md
@@ -1,0 +1,9 @@
+An origin declaration describes the products concerned in sufficient detail to enable them to be identified. It may be given by the exporter on an invoice, a delivery note or any other commercial document .
+
+The text of the origin declaration appears in Annex IV of the [origin reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/kosovo/eur-med.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/kosovo/eur-med.md
@@ -1,0 +1,6 @@
+Use form EUR-MED to record preferential trade in goods between the UK and participating countries.
+
+- [Download a copy of the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+For detailed procedures, see EUR.1.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/kosovo/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/kosovo/eur1.md
@@ -1,0 +1,82 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1 or EUR-MED
+
+1. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities of the exporting Party on application having been made in writing by the exporter or, under the exporter’s responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative shall fill in both the movement certificate EUR.1 or EUR-MED and the application form, specimens of which appear in the Annexes IIIa and b. These forms shall be completed in one of the languages in which the United Kingdom-Kosovo Agreement is drawn up and in accordance with the provisions of the national law of the exporting country. If the completion of the forms is done in handwriting, they shall be completed in ink in printed characters. The description of the products shall be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line shall be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 or EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the United Kingdom or Kosovo where the movement certificate EUR.1 or EUR-MED is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. Without prejudice to paragraph 5, a movement certificate EUR.1 shall be issued by the customs authorities of the United Kingdom or of Kosovo in the following cases:
+
+    (a) if the products concerned can be considered as products originating in the United Kingdom or in Kosovo, without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries referred to in Articles 3(2) and 4(2) and fulfil the other requirements of this Origin Reference Document; or
+
+    (b) if the products concerned can be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an invoice declaration EUR-MED has been issued in the country of origin.
+
+5. A movement certificate EUR-MED shall be issued by the customs authorities of the United Kingdom or of Kosovo, if the products concerned can be considered as products originating in the United Kingdom, in Kosovo or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, fulfil the requirements of this Origin Reference Document and:
+
+    (a) cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries referred to in Articles 3(2) and 4(2); or
+
+    (b) the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the countries referred to in Articles 3 and 4; or 
+
+    (c) the products may be re-exported from the country of destination to one of the countries referred to in Articles 3 and 4. 
+
+6. A movement certificate EUR-MED shall contain one of the following statements in English in Box 7:
+
+    (a) if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘CUMULATION APPLIED WITH … (name of the country/countries)’
+
+    (b) if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘NO CUMULATION APPLIED’
+
+7. The customs authorities issuing movement certificates EUR.1 or EUR-MED shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter’s accounts or any other check considered appropriate. They shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+8. The date of issue of the movement certificate EUR.1 or EUR-MED shall be indicated in Box 11 of the certificate.
+
+9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement certificates EUR.1 or EUR-MED issued retrospectively
+
+1. Notwithstanding Article 17(9), a movement certificate EUR.1 or EUR-MED may exceptionally be issued after exportation of the products to which it relates if:
+
+    (a) it was not issued at the time of exportation because of errors, involuntary omissions or special circumstances; or
+
+    (b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 or EUR-MED was issued but was not accepted at importation for technical reasons.
+
+2. Notwithstanding Article 17(9), a movement certificate EUR-MED may be issued after exportation of the products to which it relates and for which a movement certificate EUR.1 was issued at the time of exportation, provided that it is demonstrated to the satisfaction of the customs authorities that the conditions referred to in Article 17(5) are satisfied.
+
+3. For the implementation of paragraphs 1 and 2, the exporter shall indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 or EUR-MED relates, and state the reasons for his request.
+
+4. The customs authorities may issue a movement certificate EUR.1 or EUR-MED retrospectively only after verifying that the information supplied in the exporter’s application complies with that in the corresponding file.
+
+5. Movement certificates EUR.1 or EUR-MED issued retrospectively by application of paragraph 1 shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY’
+
+    Movement certificates EUR-MED issued retrospectively by application of paragraph 2 shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY (Original EUR.1 No … [date and place of issue])’
+
+6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
+
+#### Issue of a duplicate movement certificate EUR.1 or EUR-MED
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1 or EUR-MED, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way shall be endorsed with the following word in English:
+
+    ‘DUPLICATE’
+
+3. The endorsement referred to in paragraph 2 shall be inserted in Box 7 of the duplicate movement certificate EUR.1 or EUR-MED.
+
+4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
+
+#### Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously
+
+When originating products are placed under the control of a customs office in the United Kingdom or Kosovo, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or Kosovo. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/kosovo/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/kosovo/origin-declaration.md
@@ -1,0 +1,61 @@
+The origin declaration is provided on an invoice or any other commercial document that describes the originating product in sufficient detail to enable its identification. The texts of the origin declarations appear in Annexes IVa and IVb of the [Origin Reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an origin declaration or an origin declaration EUR-MED
+
+1. An origin declaration or an origin declaration EUR-MED as referred to in Article 16(1)(c) may be made out:
+
+    (a) by an approved exporter within the meaning of Article 23; or
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products the total value of which does not exceed EUR 6,000.
+
+2. Without prejudice to paragraph 3, an origin declaration may be made out in the following cases:
+
+    (a) if the products concerned may be considered as products originating in the United Kingdom or in Kosovo, without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2), and fulfil the other requirements of this Origin Reference Document; or
+
+    (b) if the products concerned may be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an invoice declaration EUR-MED has been issued in the country of origin.
+
+3. An origin declaration EUR-MED may be made out if the products concerned can be considered as products originating in the United Kingdom, in Kosovo or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, and fulfil the requirements of this Origin Reference Document, in the following cases:
+
+    (a) cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2); or
+
+    (b) the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the other countries referred to in Articles 3 and 4; or
+
+    (c) the products may be re-exported from the country of destination to one of the other countries referred to in Articles 3 and 4.
+
+4. An origin declaration EUR-MED shall contain one of the following statements in English:
+
+    (a) if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘CUMULATION APPLIED WITH …  (name of the country/countries)’
+
+    (b) if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘NO CUMULATION APPLIED’
+
+5. The exporter making out an origin declaration or an origin declaration EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting Party, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+6. An origin declaration or an origin declaration EUR-MED shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the texts of which appear in Annexes IVa and b, using one of the linguistic versions set out in those Annexes and in accordance with the provisions of the national law of the exporting country. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+7. Origin declarations and origin declarations EUR-MED shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 23 shall not be required to sign such declarations provided that he gives the customs authorities of the exporting Party a written undertaking that he accepts full responsibility for any origin declaration which identifies him as if it had been signed in manuscript by him.
+
+8. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
+
+#### Approved exporter
+
+1. The customs authorities of the exporting Party may authorise any exporter (hereinafter referred to as ‘approved exporter’), who makes frequent shipments of products in accordance to the provisions of the United Kingdom-Kosovo Agreement to make out origin declarations or origin declarations EUR-MED irrespective of the value of the products concerned. An exporter seeking such authorisation shall offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the origin declaration or on the origin declaration EUR-MED.
+
+4. The customs authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/lebanon/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/lebanon/eur1.md
@@ -1,0 +1,58 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1
+
+1. A movement certificate EUR.1 shall be issued by the customs authorities of the exporting country on application having been made in writing by the exporter or, under the exporter’s responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative shall fill out both the movement certificate EUR.1 and the application form, specimens of which appear in Annex IV. These forms shall be completed in one of the languages in which the United Kingdom-Lebanon Agreement is drawn up and in accordance with the provisions of the domestic law of the exporting country. If they are handwritten, they shall be completed in ink in printed characters. The description of the products must be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line must be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 shall be prepared to submit at any time, at the request of the customs authorities of the exporting country where the movement certificate EUR.1 is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. A movement certificate EUR.1 shall be issued by the customs authorities of the United Kingdom or Lebanon if the products concerned can be considered as products originating in the United Kingdom, Lebanon or in one of the other countries referred to in Article 4 and fulfil the other requirements of this Origin Reference Document.
+
+5. The issuing customs authorities shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter’s accounts or any other check considered appropriate. The issuing customs authorities shall also ensure that the forms referred to in paragraph 2 are duly completed.
+
+    In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+6. The date of issue of the movement certificate EUR.1 shall be indicated in Box 11 of the certificate.
+
+7. A movement certificate EUR.1 shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+
+#### Movement certificates EUR.1 issued retrospectively
+
+1. Notwithstanding Article 17(7), a movement certificate EUR.1 may exceptionally be issued after exportation of the products to which it relates if:
+
+    (a) it was not issued at the time of exportation because of errors or involuntary omissions or special circumstances; or
+
+    (b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 was issued but was not accepted at importation for technical reasons.
+
+2. For the implementation of paragraph 1, the exporter must indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 relates, and state the reasons for his request.
+
+3. The customs authorities may issue a movement certificate EUR.1 retrospectively only after verifying that the information supplied in the exporter’s application agrees with that in the corresponding file.
+
+4. Movement certificates EUR.1 issued retrospectively must be endorsed with one of the following phrases:
+
+    ‘ISSUED RETROSPECTIVELY’, 
+
+5. The endorsement referred to in paragraph 4 shall be inserted in the ‘Remarks’ box of the movement certificate EUR.1.
+
+
+#### Issue of a duplicate movement certificate EUR.1
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way must be endorsed with one of the following words:
+
+    ‘DUPLICATE’
+
+3. The endorsement referred to in paragraph 2 shall be inserted in the ‘Remarks’ box of the duplicate movement certificate EUR.1.
+
+4. The duplicate, which must bear the date of issue of the original movement certificate EUR.1, shall take effect as from that date.
+
+#### Issue of movement certificates EUR.1 on the basis of a proof of origin issued or made out previously
+
+When originating products are placed under the control of a customs office in the United Kingdom or Lebanon, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 for the purpose of sending all or some of these products elsewhere within the United Kingdom or Lebanon. The replacement movement certificate(s) EUR.1 shall be issued by the customs office under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/lebanon/invoice-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/lebanon/invoice-declaration.md
@@ -1,0 +1,9 @@
+An 'invoice declaration', given by the exporter on an invoice, a delivery note or any other commercial document describes the products concerned in sufficient detail to enable them to be identified. The text of the invoice declaration appears in Appendix 4 of the [origin reference document](ord).
+
+The invoice declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Invoice declarations are also known as origin declarations. Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).

--- a/db/rules_of_origin/roo_schemes_uk/proofs/mexico/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/mexico/eur1.md
@@ -1,0 +1,62 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of an EUR.1 movement certificate
+
+1. An EUR.1 movement certificate shall be issued by the customs authorities or the competent governmental authority of the exporting country on application having been made in writing by the exporter or, under the exporter's responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative shall fill out both the EUR.1 movement certificate and the application form, specimens of which appear in Appendix III. These forms shall be completed in English or Spanish and in accordance with the provisions of the domestic law of the exporting country. If they are handwritten, they shall be completed in ink in printed characters. The description of the products must be given in the box reserved for this purpose without leaving any lines blank. Where the box is not completely filled, a horizontal line must be drawn below the last line of the description and the empty space must be crossed through.
+
+3. The exporter applying for the issue of an EUR.1 movement certificate shall be prepared to submit at any time, at the request of the customs authorities or the competent governmental authority of the exporting country where the EUR.1 movement certificate is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. An EUR.1 movement certificate shall be issued by the customs authorities or competent governmental authority if the products concerned can be considered as products originating in Mexico or the United Kingdom and fulfil the other requirements of this Origin Reference Document.
+
+5. The issuing customs authorities or the competent governmental authority shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to request any evidence and to carry out any inspection of the exporter's accounts or any other check considered appropriate. The issuing customs authorities or competent governmental authority shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+6. The date of issue of the EUR.1 movement certificate shall be indicated in box 11 of the certificate.
+
+7. An EUR.1 movement certificate shall be issued by the customs authority or the competent governmental authority and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### EUR.1 movement certificates issued retrospectively
+
+1. Notwithstanding Article 16(7), an EUR.1 movement certificate may exceptionally be issued after exportation of the products to which it relates if:
+
+    (a) it was not issued at the time of exportation because of errors or involuntary omissions or special circumstances, or
+
+    (b) it is demonstrated to the satisfaction of the customs authorities or the competent governmental authority that an EUR.1 movement certificate was issued but was not accepted at importation for technical reasons.
+
+2. For the implementation of paragraph 1, the exporter must indicate in his application the place and date of exportation of the products to which the EUR.1 movement certificate relates, and state the reasons for his request.
+
+3. The customs authorities or the competent governmental authority may issue an EUR.1 movement certificate retrospectively only after verifying that the information supplied in the exporter's application agrees with that in the corresponding file, and will be accepted by the customs authority of the importing country, in accordance with the domestic law of each Party, as set out under Appendix V.
+
+4. EUR.1 movement certificates issued retrospectively must be endorsed with one of the following phrases:
+
+    ES 'EXPEDIDO A POSTERIORI',
+
+    EN 'ISSUED RETROSPECTIVELY'
+
+5. The endorsement referred to in paragraph 4 shall be inserted in the 'Remarks' box of the EUR.1 movement certificate.
+
+#### Issue of a duplicate EUR.1 movement certificate
+
+1. In the event of theft, loss or destruction of an EUR.1 movement certificate, the exporter may apply to the customs authorities or the competent governmental authority which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way must be endorsed with one of the following words:
+
+    ES  ‘DUPLICADO’
+
+    EN  ‘DUPLICATE’
+
+3. The endorsement referred to in paragraph 2 shall be inserted in the 'Remarks' box of the duplicate EUR.1 movement certificate.
+
+4. The duplicate, which must bear the date of issue of the original EUR.1 movement certificate, shall take effect as from that date.
+
+#### Issue of EUR.1 movement certificates on the basis of proof of origin issued or made out previously
+
+1. It shall at any time be possible to replace one or more EUR.1 movement certificates by one or more other certificates provided that this is done by the customs office or the competent governmental authority responsible for controlling the goods.
+
+2. The replacement certificate shall be regarded as a definitive EUR.1 movement certificate for the purpose of the application of this Origin Reference Document, including the provisions of this Article.
+
+3. The replacement certificate shall be issued on the basis of a written request from the re-exporter, after the authorities concerned have verified the information supplied in the applicant's request.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/mexico/invoice-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/mexico/invoice-declaration.md
@@ -1,0 +1,39 @@
+An 'invoice declaration', given by the exporter on an invoice, a delivery note or any other commercial document describes the products concerned in sufficient detail to enable them to be identified. The text of the invoice declaration appears in Appendix 4 of the [origin reference document](ord).
+
+The invoice declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Invoice declarations are also known as origin declarations. Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an invoice declaration
+
+1. An invoice declaration as referred to in Article 15(1)(b) may be made out:
+
+    (a) by an approved exporter within the meaning of Article 21, or
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed EUR 6 000.
+
+2. An invoice declaration may be made out if the products concerned can be considered as products originating in Mexico or the United Kingdom and fulfil the other requirements of this Origin Reference Document.
+
+3. The exporter making out an invoice declaration shall be prepared to submit at any time, at the request of the customs authorities or the competent governmental authority of the exporting country, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. An invoice declaration shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the text of which appears in Appendix IV, using one of the linguistic versions set out in that Appendix and in accordance with the provisions of the domestic law of the exporting country. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+5. Invoice declarations shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 21 shall not be required to sign such declarations provided that he gives the customs authorities or the competent governmental authority of the exporting country a written undertaking that he accepts full responsibility for any invoice declaration which identifies him as if it had been signed in manuscript by him.
+
+6. An invoice declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented to the customs authority of the importing country no longer than the period established in the domestic law of each Party, as set out under Appendix V.
+
+#### Approved exporter
+
+1. The customs authorities or the competent governmental authority of the exporting country may authorise any exporter who makes frequent shipments of products under the United Kingdom—Mexico Agreement to make out invoice declarations irrespective of the value of the products concerned. An exporter seeking such authorisation must offer to the satisfaction of the customs authorities or the competent governmental authority all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities or the competent governmental authority may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities or the competent governmental authority shall grant to the approved exporter an authorisation number which shall appear on the invoice declaration.
+
+4. The customs authorities or the competent governmental authority shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities or the competent governmental authority may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, does not fulfil the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/moldova/eur-med.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/moldova/eur-med.md
@@ -1,0 +1,6 @@
+Use form EUR-MED to record preferential trade in goods between the UK and participating countries.
+
+- [Download a copy of the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+For detailed procedures, see EUR.1.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/moldova/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/moldova/eur1.md
@@ -1,0 +1,82 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1 or EUR-MED
+
+1. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities of the exporting Party on application having been made in writing by the exporter or, under the exporter’s responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative shall fill in both the movement certificate EUR.1 or EUR-MED and the application form, specimens of which appear in the Annexes IIIa and b. These forms shall be completed in one of the languages in which the United Kingdom-Moldova Agreement is drawn up and in accordance with the provisions of the national law of the exporting country. If the completion of the forms is done in handwriting, they shall be completed in ink in printed characters. The description of the products shall be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line shall be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 or EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the UK or the Republic of Moldova where the movement certificate EUR.1 or EUR-MED is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. Without prejudice to paragraph 5, a movement certificate EUR.1 shall be issued by the customs authorities of the UK or of the Republic of Moldova in the following cases:
+
+    (a) if the products concerned can be considered as products originating in the UK or in the Republic of Moldova without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries referred to in Articles 3(2) and 4(2) and fulfil the other requirements of this Origin Reference Document; or
+
+    (b) if the products concerned can be considered as products originating in one of the other countries referred to in Articles 3 and 4, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an invoice declaration EUR-MED has been issued in the country of origin.
+
+5. A movement certificate EUR-MED shall be issued by the customs authorities of the UK or of the Republic of Moldova, if the products concerned can be considered as products originating in the UK, in the Republic of Moldova or in one of the other countries referred to in Articles 3 and 4, fulfil the requirements of this Origin Reference Document and:
+
+    (a) cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries referred to in Articles 3(2) and 4(2); or
+
+    (b) the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the countries referred to in Articles 3 and 4; or
+
+    (c) the products may be re-exported from the country of destination to one of the countries referred to in Articles 3 and 4.
+
+6. A movement certificate EUR-MED shall contain one of the following statements in English in box 7:
+
+    (a) if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘CUMULATION APPLIED WITH … (name of the country/countries)’
+
+    (b) if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘NO CUMULATION APPLIED’
+
+7. The customs authorities issuing movement certificates EUR.1 or EUR-MED shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter’s accounts or any other check considered appropriate. They shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+8. The date of issue of the movement certificate EUR.1 or EUR-MED shall be indicated in Box 11 of the certificate.
+
+9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement certificates EUR.1 or EUR-MED issued retrospectively
+
+1. Notwithstanding Article 17(9), a movement certificate EUR.1 or EUR-MED may exceptionally be issued after exportation of the products to which it relates if:
+
+    (a) it was not issued at the time of exportation because of errors, involuntary omissions or special circumstances; or
+
+    (b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 or EUR-MED was issued but was not accepted at importation for technical reasons.
+
+2. Notwithstanding Article 17(9), a movement certificate EUR-MED may be issued after exportation of the products to which it relates and for which a movement certificate EUR.1 was issued at the time of exportation, provided that it is demonstrated to the satisfaction of the customs authorities that the conditions referred to in Article 17(5) are satisfied.
+
+3. For the implementation of paragraphs 1 and 2, the exporter shall indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 or EUR-MED relates, and state the reasons for his request.
+
+4. The customs authorities may issue a movement certificate EUR.1 or EUR-MED retrospectively only after verifying that the information supplied in the exporter’s application complies with that in the corresponding file.
+
+5. Movement certificates EUR.1 or EUR-MED issued retrospectively by application of paragraph 1 shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY’
+
+    Movement certificates EUR-MED issued retrospectively by application of paragraph 2 shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY (Original EUR.1 No … [date and place of issue])’
+
+6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
+
+#### Issue of a duplicate movement certificate EUR.1 or EUR-MED
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1 or EUR-MED, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way shall be endorsed with the following word in English:
+
+    ‘DUPLICATE’
+
+3. The endorsement referred to in paragraph 2 shall be inserted in Box 7 of the duplicate movement certificate EUR.1 or EUR-MED.
+
+4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
+
+#### Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously
+
+When originating products are placed under the control of a customs office in the UK or the Republic of Moldova, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the UK or the Republic of Moldova. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/moldova/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/moldova/origin-declaration.md
@@ -1,0 +1,61 @@
+The origin declaration is provided on an invoice or any other commercial document that describes the originating product in sufficient detail to enable its identification. The texts of the origin declarations appear in Annexes IVa and b of the [Origin Reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an origin declaration or an origin declaration EUR-MED
+
+1. An origin declaration or an origin declaration EUR-MED as referred to in Article 16(1)(c) may be made out:
+
+    (a) by an approved exporter within the meaning of Article 23; or
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products the total value of which does not exceed EUR 6 000.
+
+2. Without prejudice to paragraph 3, an origin declaration may be made out in the following cases:
+
+    (a) if the products concerned may be considered as products originating in the UK or in the Republic of Moldova, without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2), and fulfil the other requirements of this Origin Reference Document; or
+
+    (b) if the products concerned may be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an invoice declaration EUR-MED has been issued in the country of origin.
+
+3. An origin declaration EUR-MED may be made out if the products concerned can be considered as products originating in the UK, in the Republic of Moldova or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, and fulfil the requirements of this Origin Reference Document, in the following cases:
+
+    (a) cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2); or
+
+    (b) the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the other countries referred to in Articles 3 and 4; or
+
+    (c) the products may be re-exported from the country of destination to one of the other countries referred to in Articles 3 and 4.
+
+4. An origin declaration EUR-MED shall contain one of the following statements in English:
+
+    (a) if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘CUMULATION APPLIED WITH …  (name of the country/countries)’
+
+    (b) if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘NO CUMULATION APPLIED’
+
+5. The exporter making out an origin declaration or an origin declaration EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting Party, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+6. An origin declaration or an origin declaration EUR-MED shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the texts of which appear in Annexes IVa and b, using one of the linguistic versions set out in those Annexes and in accordance with the provisions of the national law of the exporting country. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+7. Origin declarations and origin declarations EUR-MED shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 23 shall not be required to sign such declarations provided that he gives the customs authorities of the exporting Party a written undertaking that he accepts full responsibility for any origin declaration which identifies him as if it had been signed in manuscript by him.
+
+8. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
+
+#### Approved exporter
+
+1. The customs authorities of the exporting Party may authorise any exporter (hereinafter referred to as ‘approved exporter’), who makes frequent shipments of products in accordance to the provisions of the United Kingdom-Moldova Agreement to make out origin declarations or origin declarations EUR-MED irrespective of the value of the products concerned. An exporter seeking such authorisation shall offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the origin declaration or on the origin declaration EUR-MED.
+
+4. The customs authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/morocco/eur-med.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/morocco/eur-med.md
@@ -1,0 +1,6 @@
+Use form EUR-MED to record preferential trade in goods between the UK and participating countries.
+
+- [Download a copy of the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+For detailed procedures, see EUR.1.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/morocco/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/morocco/eur1.md
@@ -1,0 +1,84 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1 or EUR-MED
+
+1. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities of the exporting country on application having been made in writing by the exporter or, under the exporter's responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative shall fill in both the movement certificate EUR.1 or EUR-MED and the application form, specimens of which appear in the Annexes IIIa and b. These forms shall be completed in one of the languages in which the United Kingdom-Morocco Agreement is drawn up and in accordance with the provisions of the national law of the exporting country. If the forms are handwritten, they shall be completed in ink in printed characters. The description of the products shall be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line shall be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 or EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting country where the movement certificate EUR.1 or EUR-MED is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. Without prejudice to paragraph 5, a movement certificate EUR.1 shall be issued by the customs authorities of the United Kingdom or of Morocco in the following cases:
+
+    - if the products concerned can be considered as products originating in the United Kingdom, or in Morocco, without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries referred to in Articles 3(2) and 4(2), and fulfil the other requirements of this Origin Reference Document,
+
+    - if the products concerned can be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an invoice declaration EUR-MED has been issued in the country of origin,
+
+    - if the products concerned can be considered as products originating in the United Kingdom or in Morocco, with application of the cumulation referred to in Articles 3(4a) and 4(4a), and fulfil the other requirements of this Origin Reference Document.
+
+5. A movement certificate EUR-MED shall be issued by the customs authorities of the United Kingdom or of Morocco, if the products concerned can be considered as products originating in the United Kingdom, in Morocco or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, fulfil the requirements of this Origin Reference Document and:
+
+    - cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries referred to in Articles 3(2) and 4(2), or
+
+    - the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the other countries referred to in Articles 3 and 4, or
+
+    - the products may be re-exported from the country of destination to one of the other countries referred to in Articles 3 and 4.
+
+6. A movement certificate EUR-MED shall contain one of the following statements in English in box 7:
+
+    - if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+    
+        ‘CUMULATION APPLIED WITH …’ (name of the country/countries)
+
+    - if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+    
+        ‘NO CUMULATION APPLIED’
+
+7. The customs authorities issuing movement certificates EUR.1 or EUR-MED shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter's accounts or any other check considered appropriate. They shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+8. The date of issue of the movement certificate EUR.1 or EUR-MED shall be indicated in Box 11 of the certificate.
+
+9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement certificates EUR.1 or EUR-MED issued retrospectively
+
+1. Notwithstanding Article 17(9), a movement certificate EUR.1 or EUR-MED may exceptionally be issued after exportation of the products to which it relates if:
+
+    (a) it was not issued at the time of exportation because of errors or involuntary omissions or special circumstances; or
+
+    (b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 or EUR-MED was issued but was not accepted at importation for technical reasons.
+
+2. Notwithstanding Article 17(9), a movement certificate EUR-MED may be issued after exportation of the products to which it relates and for which a movement certificate EUR.1 was issued at the time of exportation, provided that it is demonstrated to the satisfaction of the customs authorities that the conditions referred to in Article 17(5) are satisfied.
+
+3. For the implementation of paragraphs 1 and 2, the exporter shall indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 or EUR-MED relates, and state the reasons for his request.
+
+4. The customs authorities may issue a movement certificate EUR.1 or EUR-MED retrospectively only after verifying that the information supplied in the exporter's application complies with that in the corresponding file.
+
+5. Movement certificates EUR.1 or EUR-MED issued retrospectively shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY’
+
+    Movement certificates EUR-MED issued retrospectively by application of paragraph 2 shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY (Original EUR.1 No [date and place of issue])’
+
+6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
+
+#### Issue of a duplicate movement certificate EUR.1 or EUR-MED
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1 or EUR-MED, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way shall be endorsed with the following word in English:
+
+    ‘DUPLICATE’
+
+3. The endorsement referred to in paragraph 2 shall be inserted in Box 7 of the duplicate movement certificate EUR.1 or EUR-MED.
+
+4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
+
+#### Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously
+
+When originating products are placed under the control of a customs office in the United Kingdom or in Morocco, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or Morocco. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/morocco/invoice-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/morocco/invoice-declaration.md
@@ -1,0 +1,63 @@
+The invoice declaration is provided on an invoice or any other commercial document that describes the originating product in sufficient detail to enable its identification. The texts of the origin declarations appear in Annexes IVa and IVb of the [Origin Reference document](ord).
+
+An invoice declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Invoice declarations are also known as origin declarations. Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an invoice declaration or an invoice declaration EUR-MED
+
+1. An invoice declaration or an invoice declaration EUR-MED as referred to in Article 16(1)(c) may be made out:
+
+    (a) by an approved exporter within the meaning of Article 23; or
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed EUR 6 000.
+
+2. Without prejudice to paragraph 3, an invoice declaration may be made out in the following cases:
+
+    - if the products concerned may be considered as products originating in the United Kingdom, or in Morocco, without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries referred to in Articles 3(2) and 4(2), and fulfil the other requirements of this Origin Reference Document;
+
+    - if the products concerned may be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an invoice declaration EUR-MED has been issued in the country of origin;
+
+    - if the products concerned may be considered as products originating in the United Kingdom or in Morocco, with application of the cumulation referred to in Articles 3(4a) and 4(4a), and fulfil the other requirements of this Origin Reference Document.
+
+3. An invoice declaration EUR-MED may be made out if the products concerned may be considered as products originating in the United Kingdom, in Morocco or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, fulfil the requirements of this Origin Reference Document and:
+
+    - cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries referred to in Articles 3(2) and 4(2), or
+
+    - the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the other countries referred to in Articles 3 and 4, or
+
+    - the products may be re-exported from the country of destination to one of the other countries referred to in Articles 3 and 4.
+
+4. An invoice declaration EUR-MED shall contain one of the following statements in English:
+
+    - if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+        ‘CUMULATION APPLIED WITH …’ (name of the country/countries)
+
+    - if origin has been obtained without application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+        ‘NO CUMULATION APPLIED’
+
+5. The exporter making out an invoice declaration or an invoice declaration EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting country, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+6. An invoice declaration or an invoice declaration EUR-MED shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the texts of which appear in Annexes IVa and b, using one of the linguistic versions set out in these Annexes and in accordance with the provisions of the national law of the exporting country. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+7. Invoice declarations and invoice declarations EUR-MED shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 23 shall not be required to sign such declarations provided that he gives the customs authorities of the exporting country a written undertaking that he accepts full responsibility for any invoice declaration which identifies him as if it had been signed in manuscript by him.
+
+8. An invoice declaration or an invoice declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
+
+#### Approved exporter
+
+1. The customs authorities of the exporting country may authorise any exporter (hereinafter referred to as approved exporter), who makes frequent shipments of products under the United Kingdom-Morocco Agreement to make out invoice declarations or invoice declarations EUR-MED irrespective of the value of the products concerned. An exporter seeking such authorisation shall offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the invoice declaration or on the invoice declaration EUR-MED.
+
+4. The customs authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/north-macedonia/eur-med.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/north-macedonia/eur-med.md
@@ -1,0 +1,6 @@
+Use form EUR-MED to record preferential trade in goods between the UK and participating countries.
+
+- [Download a copy of the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+For detailed procedures, see EUR.1.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/north-macedonia/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/north-macedonia/eur1.md
@@ -1,0 +1,82 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1 or EUR-MED
+
+1. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities of the exporting Party on application having been made in writing by the exporter or, under the exporter’s responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative shall fill in both the movement certificate EUR.1 or EUR-MED and the application form, specimens of which appear in the Annexes IIIa and b. These forms shall be completed in one of the languages in which the United Kingdom-North Macedonia Agreement is drawn up and in accordance with the provisions of the national law of the exporting country. If the completion of the forms is done in handwriting, they shall be completed in ink in printed characters. The description of the products shall be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line shall be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 or EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the United Kingdom or North Macedonia where the movement certificate EUR.1 or EUR-MED is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. Without prejudice to paragraph 5, a movement certificate EUR.1 shall be issued by the customs authorities of the United Kingdom or North Macedonia in the following cases:
+
+    (a) if the products concerned can be considered as products originating in the United Kingdom or North Macedonia, without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries referred to in Articles 3(2) and 4(2) and fulfil the other requirements of this Origin Reference Document; or
+
+    (b) if the products concerned can be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an origin declaration EUR-MED has been issued in the country of origin.
+
+5. A movement certificate EUR-MED shall be issued by the customs authorities of the United Kingdom or of North Macedonia, if the products concerned can be considered as products originating in the United Kingdom, in North Macedonia or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, fulfil the requirements of this Origin Reference Document and:
+
+    (a) cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries referred to in Articles 3(2) and 4(2); or
+
+    (b) the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the countries referred to in Articles 3 and 4; or
+
+    (c) the products may be re-exported from the country of destination to one of the countries referred to in Articles 3 and 4. 
+
+6. A movement certificate EUR-MED shall contain one of the following statements in English in box 7:
+
+    (a) if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘CUMULATION APPLIED WITH … (name of the country/countries)’
+
+    (b) if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘NO CUMULATION APPLIED’
+
+7. The customs authorities issuing movement certificates EUR.1 or EUR-MED shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter’s accounts or any other check considered appropriate. They shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+8. The date of issue of the movement certificate EUR.1 or EUR-MED shall be indicated in Box 11 of the certificate.
+
+9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement certificates EUR.1 or EUR-MED issued retrospectively
+
+1. Notwithstanding Article 17(9), a movement certificate EUR.1 or EUR-MED may exceptionally be issued after exportation of the products to which it relates if:
+
+    (a) it was not issued at the time of exportation because of errors, involuntary omissions or special circumstances; or
+
+    (b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 or EUR-MED was issued but was not accepted at importation for technical reasons.
+
+2. Notwithstanding Article 17(9), a movement certificate EUR-MED may be issued after exportation of the products to which it relates and for which a movement certificate EUR.1 was issued at the time of exportation, provided that it is demonstrated to the satisfaction of the customs authorities that the conditions referred to in Article 17(5) are satisfied.
+
+3. For the implementation of paragraphs 1 and 2, the exporter shall indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 or EUR-MED relates, and state the reasons for his request.
+
+4. The customs authorities may issue a movement certificate EUR.1 or EUR-MED retrospectively only after verifying that the information supplied in the exporter’s application complies with that in the corresponding file.
+
+5. Movement certificates EUR.1 or EUR-MED issued retrospectively by application of paragraph 1 shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY’
+
+    Movement certificates EUR-MED issued retrospectively by application of paragraph 2 shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY (Original EUR.1 No … [date and place of issue])’
+
+6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
+
+#### Issue of a duplicate movement certificate EUR.1 or EUR-MED
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1 or EUR-MED, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way shall be endorsed with the following word in English:
+
+    ‘DUPLICATE’
+
+3. The endorsement referred to in paragraph 2 shall be inserted in Box 7 of the duplicate movement certificate EUR.1 or EUR-MED.
+
+4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
+
+#### Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously 
+
+When originating products are placed under the control of a customs office in the United Kingdom or North Macedonia, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or North Macedonia. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/north-macedonia/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/north-macedonia/origin-declaration.md
@@ -1,0 +1,61 @@
+The origin declaration is provided on an invoice or any other commercial document that describes the originating product in sufficient detail to enable its identification. The texts of the origin declarations appear in Annexes IVa and IVb of the [Origin Reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an origin declaration or an origin declaration EUR-MED
+
+1. An origin declaration or an origin declaration EUR-MED as referred to in Article 16(1)(c) may be made out:
+
+    (a) by an approved exporter within the meaning of Article 23; or
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products the total value of which does not exceed EUR 6,000.
+
+2. Without prejudice to paragraph 3, an origin declaration may be made out in the following cases:
+
+    — (a) if the products concerned may be considered as products originating in the United Kingdom or in North Macedonia without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2), and fulfil the other requirements of this Origin Reference Document; or
+
+    — (b) if the products concerned may be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an origin declaration EUR-MED has been issued in the country of origin.
+
+3. An origin declaration EUR-MED may be made out if the products concerned can be considered as products originating in the United Kingdom, in North Macedonia or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, and fulfil the requirements of this Origin Reference Document, in the following cases:
+
+    — (a) cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2); or
+
+    — (b) the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the other countries referred to in Articles 3 and 4; or
+
+    — (c) the products may be re-exported from the country of destination to one of the other countries referred to in Articles 3 and 4.
+
+4. An origin declaration EUR-MED shall contain one of the following statements in English:
+
+    (a) if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘CUMULATION APPLIED WITH … (name of the country/countries)’
+
+    (b) if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘NO CUMULATION APPLIED’
+
+5. The exporter making out an origin declaration or an origin declaration EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting Party, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+6. An origin declaration or an origin declaration EUR-MED shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the texts of which appear in Annexes IVa and b, using one of the linguistic versions set out in those Annexes and in accordance with the provisions of the national law of the exporting country. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+7. Origin declarations and origin declarations EUR-MED shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 23 shall not be required to sign such declarations provided that he gives the customs authorities of the exporting Party a written undertaking that he accepts full responsibility for any origin declaration which identifies him as if it had been signed in manuscript by him.
+
+8. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
+
+#### Approved exporter
+
+1. The customs authorities of the exporting Party may authorise any exporter (hereinafter referred to as ‘approved exporter’), who makes frequent shipments of products in accordance to the provisions of the United Kingdom-North Macedonia Agreement to make out origin declarations or origin declarations EUR-MED irrespective of the value of the products concerned. An exporter seeking such authorisation shall offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the origin declaration or on the origin declaration EUR-MED.
+
+4. The customs authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/oct/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/oct/eur1.md
@@ -1,0 +1,58 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1
+
+1. A movement certificate EUR.1 will be issued by the customs authorities of the exporting Overseas Territory on application having been made in writing by the exporter or, under the exporter’s responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative will fill out both the movement certificate EUR.1 and the application form, specimens of which appear in Appendix III and IV. These forms will be completed in accordance with this Annex. If they are hand-written, they will be completed in ink in printed characters. The description of the products must be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line must be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 will be prepared to submit at any time, at the request of the customs authorities of the exporting Overseas Territory where the movement certificate EUR.1 is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Annex.
+
+4. A movement certificate EUR.1 will be issued by the customs authorities of the exporting Overseas Territories if the products concerned can be considered as products originating in an Overseas Territory, in the UK or in an EPA country and fulfil the other requirements of this Annex.
+
+5. The issuing customs authorities will take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Annex. For this purpose, they will be permitted to call for any evidence and to carry out any inspection of the exporter’s accounts or any other check considered appropriate. The issuing customs authorities will also ensure that the forms referred to in subparagraph 2 are duly completed. In particular, they will check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+6. The date of issue of the movement certificate EUR.1 will be indicated in Box 11 of the certificate.
+
+7. A movement certificate EUR.1 will be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement certificate EUR.1 issued retrospectively
+
+1. Notwithstanding paragraph 22, a movement certificate EUR.1 may be issued after exportation of the products to which it relates if:
+
+    (a) it was not issued at the time of exportation because of errors or involuntary omissions or special circumstances;
+
+    (b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 was issued but was not accepted at importation for technical reasons;
+
+    (c) a movement certificate EUR.1 was issued at the time of exportation for a consignment which was subsequently split in a third country of storage, in accordance with paragraph 18 of this Annex, provided that the initial EUR.1 certificate is returned to the customs authorities who issued it; or
+
+    (d) it was not issued at the time of exportation because the final destination of the consignment was not known at the time, and the destination was determined during its storage and after possible splitting of the consignment in a third country in accordance with paragraph 18 of this Annex.
+
+2. For the implementation of subparagraph 1, the exporter must indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 relates, and state the reasons for his request.
+
+3. The customs authorities may issue a movement certificate EUR.1 retrospectively only after verifying that the information supplied in the exporter’s application agrees with that in the corresponding file.
+
+4. Movement certificates EUR.1 issued retrospectively must be endorsed with the following phrases in the ‘Remarks’ box (Box 7) of the movement certificate EUR.1.
+
+    ‘ISSUED RETROSPECTIVELY’
+
+5. The endorsement referred to in subparagraph 4 will be inserted in the ‘Remarks’ box of the movement certificate EUR.1.
+
+#### Issue of duplicate movement certificate EUR.1
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate movement certificate EUR.1 will be endorsed in the ‘Remarks’ box (Box 7) with the following word:
+
+    ‘DUPLICATE’.
+
+3. The endorsement referred to in subparagraph 2 will be inserted in the ‘Remarks’ box of the duplicate movement certificate EUR.1.
+
+4. The duplicate, which must bear the date of issue of the original movement certificate EUR.1, will take effect as from that date.
+
+#### Issue of movement certificates EUR.1 on the basis of a proof of origin issued or made out previously
+
+When originating products are placed under the control of a customs office in the UK or in an Overseas Territory, it will be possible to replace the original proof of origin by one or more movement certificates EUR.1 for the purpose of sending all or some of these products elsewhere within the UK or an Overseas Territory. The replacement movement certificate(s) EUR.1 will be issued by the customs office under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/oct/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/oct/origin-declaration.md
@@ -1,0 +1,33 @@
+An 'invoice declaration', given by the exporter on an invoice, a delivery note or any other commercial document describes the products concerned in sufficient detail to enable them to be identified. The text of the invoice declaration appears in Annex IV of the [origin reference document](ord).
+
+Invoice declarations are also known as origin declarations. Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Criteria for making out an origin declaration
+
+1. An origin declaration as referred to in paragraph 21 (b) of this Annex may be made out:
+
+    (a) by an approved exporter as referred to in paragraph 27 of this Annex; or
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products the total value of which does not exceed £10,000.
+
+2. An origin declaration may be made out if the products concerned can be considered as products originating in an Overseas Territory, in an EPA country or in the UK and fulfil the other requirements of this Annex.
+
+3. The exporter making out an origin declaration will be prepared to submit at any time, at the request of the customs authorities of the exporting Overseas Territory, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Annex.
+
+4. An origin declaration will be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the origin declaration described in paragraph 21 and in accordance with the provisions of the domestic law of the exporting Overseas Territory. If the declaration is hand-written, it will be written in ink in printed characters.
+
+5. Origin declarations will bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of paragraph 27 of this Annex will not be required to sign such declarations provided that he gives the customs authorities of the exporting Overseas Territory a written undertaking that he accepts full responsibility for any origin declaration which identifies him as if it had been signed in manuscript by him.
+
+6. An origin declaration may be made out by the exporter when the products to which it relates are exported, or after exportation provided that it is presented in the UK no longer than two years after the importation of the products to which it relates.
+
+#### Approved exporter
+
+1. The customs authorities of the exporting Overseas Territory may authorise any exporter to make out origin declarations irrespective of the value of the products concerned. An exporter seeking such authorisation will offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Annex.
+
+2. The customs authorities may grant the status of approved exporter subject to any provisions which they consider appropriate.
+
+3. The customs authorities will grant to the approved exporter a customs authorisation number which will appear on the origin declaration.
+
+4. The customs authorities will monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities may withdraw the authorisation at any time. They will do so where the approved exporter no longer offers the guarantees referred to in subparagraph 1, does not fulfil the provisions referred to in subparagraph 2 or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/pacific/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/pacific/eur1.md
@@ -1,0 +1,54 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1
+
+1. A movement certificate EUR.1 shall be issued by the customs authorities of the exporting country on application having been made in writing by the exporter or, under the exporter’s responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative shall fill out both the movement certificate EUR.1 and the application form, specimens of which appear in Annex III. These forms shall be completed in accordance with the provisions of this Origin Reference Document. If they are handwritten, they shall be completed in ink and in printed characters. The description of the products must be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line must be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 shall be prepared to submit at any time, at the request of the customs authorities of the exporting country where the movement certificate EUR.1 is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. A movement certificate EUR.1 shall be issued by the customs authorities of the UK if the products concerned can be considered as products originating in the UK or in a Pacific State or in one of the other countries or territories referred to in Articles 3 and 4 and fulfill the other requirements of this Origin Reference Document.
+
+5. The issuing customs authorities shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter’s accounts or any other check considered appropriate. The issuing customs authorities shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+6. The date of issue of the movement certificate EUR.1 shall be indicated in Box 11 of the certificate.
+
+7. A movement certificate EUR.1 shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement certificates EUR.1 issued retrospectively
+
+1. Notwithstanding Article 16(7), a movement certificate EUR.1 may exceptionally be issued after exportation of the products to which it relates if:
+
+    (a) it was not issued at the time of exportation because of errors or involuntary omissions or special circumstances; or
+
+    (b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 was issued but was not accepted at importation for technical reasons.
+
+2. For the implementation of paragraph 1, the exporter must indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 relates, and state the reasons for his request.
+
+3. The customs authorities may issue a movement certificate EUR.1 retrospectively only after verifying that the information supplied in the exporter’s application agrees with that in the corresponding file.
+
+4. Movement certificates EUR.1 issued retrospectively must be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY’
+
+5. The endorsement referred to in paragraph 4 shall be inserted in the ‘Remarks’ box of the movement certificate EUR.1.
+
+#### Issue of a duplicate movement certificate EUR.1
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way must be endorsed with the following word in English:
+
+    ‘DUPLICATE’
+
+3. The endorsement referred to in paragraph 2 shall be inserted in the ‘Remarks’ box of the duplicate movement certificate EUR.1.
+
+4. The duplicate, which must bear the date of issue of the original movement certificate EUR.1, shall take effect as from that date.
+
+#### Issue of movement certificates EUR.1 on the basis of a proof of origin issued or made out previously
+
+When originating products are placed under the control of a customs office in a Pacific State Party or the UK, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 for the purpose of sending all or some of these products elsewhere within the Pacific States or the UK. The replacement movement certificate(s) EUR.1 shall be issued by the customs office in the UK or in a Pacific State Party under whose control the products are placed and endorsed by the customs authority under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/pacific/invoice-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/pacific/invoice-declaration.md
@@ -1,0 +1,39 @@
+An 'invoice declaration', given by the exporter on an invoice, a delivery note or any other commercial document describes the products concerned in sufficient detail to enable them to be identified. The text of the invoice declaration appears in Appendix 4 of the [origin reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Invoice declarations are also known as origin declarations. Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an invoice declaration
+
+1. An invoice declaration as referred to in Article 15(1)(b) may be made out:
+
+    (a) by an approved exporter within the meaning of Article 21, or
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed EUR 6 000.
+
+2. An invoice declaration may be made out if the products concerned can be considered as products originating in a Pacific State or in the UK or in one of the other countries or territories referred to in Articles 3 and 4 and fulfil the other requirements of this Origin Reference Document.
+
+3. The exporter making out an invoice declaration shall be prepared to submit at any time, at the request of the customs authorities of the exporting country, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. An invoice declaration shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the text of which appears in Annex IV to this Origin Reference Document, using one of the linguistic versions set out in that Annex and in accordance with the provisions of the domestic law of the exporting country. If the declaration is handwritten, it shall be written in ink and in printed characters.
+
+5. Invoice declarations shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 21 shall not be required to sign such declarations provided that he gives the customs authorities of the exporting country a written undertaking that he accepts full responsibility for any invoice declaration which identifies him as if it had been signed in manuscript by him.
+
+6. An invoice declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country no longer than two years after the importation of the products to which it relates.
+
+#### Approved exporter
+
+1. The customs authorities of the exporting country may authorise any exporter who makes frequent shipments of products under the trade cooperation provisions of the United Kingdom – Pacific States Agreement to make out invoice declarations irrespective of the value of the products concerned. An exporter seeking such authorisation must offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the invoice declaration.
+
+4. The customs authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, does not fulfil the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/palestinian-authority/eur-med.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/palestinian-authority/eur-med.md
@@ -1,0 +1,6 @@
+Use form EUR-MED to record preferential trade in goods between the UK and participating countries.
+
+- [Download a copy of the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+For detailed procedures, see EUR.1.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/palestinian-authority/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/palestinian-authority/eur1.md
@@ -1,0 +1,82 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1 or EUR-MED
+
+1. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities of the exporting Party on application having been made in writing by the exporter or, under the exporter’s responsibility, by its authorised representative.
+
+2. For this purpose, the exporter or his or her authorised representative shall fill in both the movement certificate EUR.1 or EUR-MED and the application form, specimens of which appear in Annexes III a and III b. These forms shall be completed in one of the languages in which the United Kingdom-Palestinian Authority Agreement is drawn up and in accordance with the provisions of the domestic law of the exporting country or territory. If the completion of the forms is done in handwriting, they shall be completed in ink in printed characters. The description of the products shall be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line shall be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 or EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting Party where the movement certificate EUR.1 or EUR-MED is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. Without prejudice to paragraph 5, a movement certificate EUR.1 shall be issued by the customs authorities of the United Kingdom or of the Palestinian Authority in the following cases:
+
+    (a) if the products concerned can be considered as products originating in the United Kingdom or in the West Bank and the Gaza Strip with which cumulation is applicable, without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries or territories referred to in Articles 3(2) and 4(2) and fulfil the other requirements of this Origin Reference Document; or 
+
+    (b) if the products concerned can be considered as products originating in one of the other countries or territories referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries or territories referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an invoice declaration EUR-MED has been issued in the country or territory of origin.
+
+5. A movement certificate EUR-MED shall be issued by the customs authorities of the United Kingdom or of the Palestinian Authority in the following cases:
+
+    (a) cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries or territories referred to in Articles 3(2) and 4(2);
+
+    (b) the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the countries or territories referred to in Articles 3 and 4; or 
+
+    (c) the products may be re-exported from the country or territory of destination to one of the countries or territories referred to in Articles 3 and 4. 
+
+6. A movement certificate EUR-MED shall contain one of the following statements in English in box 7:
+
+    (a) if origin has been obtained by application of cumulation with materials originating in one or more of the countries or territories referred to in Articles 3 and 4:
+
+    ‘CUMULATION APPLIED WITH … (name of the country/countries)’
+
+    (b) if origin has been obtained without the application of cumulation with materials originating in one or more of the countries or territories referred to in Articles 3 and 4:
+
+    ‘NO CUMULATION APPLIED’
+
+7. The customs authorities issuing movement certificates EUR.1 or EUR-MED shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter's accounts or any other check considered appropriate. They shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+8. The date of issue of the movement certificate EUR.1 or EUR-MED shall be indicated in box 11 of the certificate.
+
+9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement certificates EUR.1 or EUR-MED issued retrospectively
+
+1. Notwithstanding Article 17(9), a movement certificate EUR.1 or EUR-MED may exceptionally be issued after exportation of the products to which it relates if:
+
+    (a) it was not issued at the time of exportation because of errors, involuntary omissions or special circumstances; or
+
+    (b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 or EUR-MED was issued but was not accepted at importation for technical reasons.
+
+2. Notwithstanding Article 17(9), a movement certificate EUR-MED may be issued after exportation of the products to which it relates and for which a movement certificate EUR.1 was issued at the time of exportation, provided that it is demonstrated to the satisfaction of the customs authorities that the conditions referred to in Article 17(5) are satisfied.
+
+3. For the implementation of paragraphs 1 and 2, the exporter shall indicate in the application the place and date of exportation of the products to which the movement certificate EUR.1 or EUR-MED relates and state the reasons for his request.
+
+4. The customs authorities may issue a movement certificate EUR.1 or EUR-MED retrospectively only after verifying that the information supplied in the exporter’s application complies with that in the corresponding file.
+
+5. Movement certificates EUR.1 or EUR-MED issued retrospectively by application of paragraph 1 shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY’
+
+    Movement certificates EUR-MED issued retrospectively by application of paragraph 2 shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY (Original EUR.1 No … [date  and  place  of  issue])’
+
+6. The endorsement referred to in paragraph 5 shall be inserted in box 7 of the movement certificate EUR.1 or EUR-MED.
+
+#### Issue of a duplicate movement certificate EUR.1 or EUR-MED
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1 or EUR-MED, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way shall be endorsed with the following word in English:
+
+    ‘DUPLICATE’
+
+3. The endorsement referred to in paragraph 2 shall be inserted in Box 7 of the duplicate movement certificate EUR.1 or EUR-MED.
+
+4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
+
+#### Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously
+
+When originating products are placed under the control of a customs office in the United Kingdom or the West Bank and the Gaza Strip, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or the West Bank and the Gaza Strip. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/palestinian-authority/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/palestinian-authority/origin-declaration.md
@@ -1,0 +1,62 @@
+The origin declaration is provided on an invoice or any other commercial document that describes the originating product in sufficient detail to enable its identification. The texts of the origin declarations appear in Annexes IVa and IVb of the [Origin Reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an origin declaration or an origin declaration EUR-MED
+
+1. An origin declaration or an origin declaration EUR-MED as referred to in Article 16(1)(c) may be made out:
+
+    (a) by an approved exporter within the meaning of Article 23; or
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products the total value of which does not exceed EUR 6000.
+
+2. Without prejudice to paragraph 3, an origin declaration may be made out in the following cases:
+
+    (a) if the products concerned may be considered as products originating in the United Kingdom , in the West Bank and the Gaza Strip without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries or territories referred to in Articles 3(2) and 4(2), and fulfil the other requirements of this Origin Reference Document; or
+
+    (b) if the products concerned may be considered as products originating in one of the other countries or territories referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries or territories referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an invoice declaration EUR-MED has been issued in the country or territory of origin.
+
+3. An origin declaration EUR-MED may be made out if the products concerned can be considered as products originating in the United Kingdom, in the West Bank and the Gaza Strip or in one of the other countries or territories referred to in Articles 3 and 4 with which cumulation is applicable, and fulfil the requirements of this Origin Reference Document, in the following cases:
+
+    (a) cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries or territories referred to in Articles 3(2) and 4(2); or
+
+    (b) the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the other countries or territories referred to in Articles 3 and 4; or
+
+    (c) the products may be re-exported from the country or territory of destination to one of the other countries or territories referred to in Articles 3 and 4.
+
+4. An origin declaration EUR-MED shall contain one of the following statements in English:
+
+    (a) if origin has been obtained by application of cumulation with materials originating in one or more of the countries or territories referred to in Articles 3 and 4:
+
+    ‘CUMULATION APPLIED WITH … (name of the country/countries)’
+
+    (b) if origin has been obtained without the application of cumulation with materials originating in one or more of the countries or territories referred to in Articles 3 and 4:
+
+    ‘NO CUMULATION APPLIED’
+
+5. The exporter making out an origin declaration or an origin declaration EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting Party, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+6. An origin declaration or an origin declaration EUR-MED shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the texts of which appear in Annexes IV a and IV b, using one of the linguistic versions set out in those Annexes and in accordance with the provisions of the domestic law of the exporting country or territory. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+7. Origin declarations and origin declarations EUR-MED shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 23 shall not be required to sign such declarations provided that he gives the customs authorities of the exporting Party a written undertaking that he or she accepts full responsibility for any origin declaration which identifies him or her as if it had been signed in manuscript by him.
+
+8. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country or territory at the latest two years after the importation of the products to which it relates.
+
+#### Approved exporter
+
+1. The customs authorities of the exporting Party may authorise any exporter (hereinafter referred to as ‘approved exporter’) who makes frequent shipments of products in accordance with the provisions of the United Kingdom-Palestinian Authority Agreement to make out origin declarations or origin declarations EUR-MED irrespective of the value of the products concerned. An exporter seeking such authorisation shall offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the origin declaration or the origin declaration EUR-MED.
+
+4. The customs authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
+

--- a/db/rules_of_origin/roo_schemes_uk/proofs/sacum/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/sacum/eur1.md
@@ -1,0 +1,50 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1
+
+1. A movement certificate EUR.1 shall be issued by the customs authorities of the exporting country on application having been made in writing by the exporter or, under the exporter's responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative shall fill out both the movement certificate EUR.1 and the application form, specimens of which appear in Annex III. These forms shall be completed in accordance with the provisions of this Origin Reference Document. If they are handwritten, they shall be completed in ink in printed characters. The description of the products must be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line must be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 shall be prepared to submit at any time, at the request of the customs authorities of the exporting country where the movement certificate EUR.1 is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. A movement certificate EUR.1 shall be issued by the customs authorities of the UK or of a SACU Member State or Mozambique if the products concerned can be considered as products originating in the UK or in the SACU Member States and Mozambique in one of the other countries or territories referred to in Article 4 of this Origin Reference Document and fulfil the other requirements of this Origin Reference Document.
+
+5. The issuing customs authorities shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter's accounts or any other check considered appropriate. The issuing customs authorities shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+6. The date of issue of the movement certificate EUR.1 shall be indicated in Box 11 of the certificate.
+
+7. A movement certificate EUR.1 shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement certificates EUR.1 issued retrospectively
+
+1. Notwithstanding Article 20(7) of this Origin Reference Document, a movement certificate EUR.1 may exceptionally be issued after exportation of the products to which it relates if:
+
+(a) it was not issued at the time of exportation because of errors or involuntary omissions or special circumstances; or
+
+(b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 was issued but was not accepted at importation for technical reasons.
+
+2. For the implementation of paragraph 1, the exporter must indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 relates, and state the reasons for his request.
+
+3. The customs authorities may issue a movement certificate EUR.1 retrospectively only after verifying that the information supplied in the exporter's application agrees with that in the corresponding file.
+
+4. Movement certificates EUR.1 issued retrospectively must be endorsed with the following phrase in English: ‘ISSUED RETROSPECTIVELY’ or in Portuguese: ‘EMITIDO RETROSPECTIVAMENTE’
+
+5. The endorsement referred to in paragraph 4 shall be inserted in Box 7 of the movement certificate EUR.1.
+
+#### Issue of a duplicate movement certificate EUR.1
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way must be endorsed with the following word in English: ‘DUPLICATE’ or in Portuguese: ‘SEGUNDA VIA’
+
+3. The endorsement referred to in paragraph 2 shall be inserted in Box 7 of the duplicate movement certificate EUR.1.
+
+4. The duplicate, which must bear the date of issue of the original movement certificate EUR.1, shall take effect as from that date.
+
+#### Issue of movement certificates EUR.1 on the basis of a proof of origin issued or made out previously
+
+When originating products are placed under the control of a customs office in a SACU Member State or Mozambique or in the UK, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 for the purpose of sending all or some of these products elsewhere within the SACU Member States or Mozambique or within the UK. The replacement movement certificate(s) EUR.1 shall be issued by the customs office under whose control the products are placed and endorsed by the customs authority under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/sacum/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/sacum/origin-declaration.md
@@ -1,0 +1,39 @@
+An origin declaration’, given by the exporter on an invoice, a delivery note or any other commercial document describes the products concerned in sufficient detail to enable them to be identified. The text of the invoice declaration appears in Appendix 4 of the [origin reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an origin declaration
+
+1. An origin declaration as referred to in Article 19(1)(a) of this Origin Reference Document may be made out by:
+
+    (a) an approved exporter within the meaning of Article 25 of this Origin Reference Document, or
+
+    (b) any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed EUR 6 000.
+
+2. An origin declaration may be made out if the products concerned can be considered as products originating in the SACU Member States, Mozambique, or in the UK or in one of the other countries or territories referred to in Article 4 of this Origin Reference Document and fulfil the other requirements of this Origin Reference Document.
+
+3. The exporter making out an origin declaration shall be prepared to submit at any time, at the request of the customs authorities of the exporting country, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. An origin declaration shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the text of which appears in Annex IV to this Origin Reference Document, using one of the linguistic versions set out in that Annex and in accordance with the provisions of the domestic law of the exporting country. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+5. Origin declarations shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 25 of this Origin Reference Document shall not be required to sign such declarations provided that he gives the customs authorities of the exporting country a written undertaking that he accepts full responsibility for any origin declaration which identifies him as if it had been signed in manuscript by him.
+
+6. An origin declaration may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country no longer than two (2) years after the importation of the products to which it relates.
+
+#### Approved exporter
+
+1. The customs authorities of the exporting country may authorise any exporter who makes frequent shipments of products under the trade cooperation provisions of the Agreement to make out origin declarations irrespective of the value of the products concerned. An exporter seeking such authorisation must offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the origin declaration.
+
+4. The customs authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, does not fulfil the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/serbia/eur-med.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/serbia/eur-med.md
@@ -1,0 +1,6 @@
+Use form EUR-MED to record preferential trade in goods between the UK and participating countries.
+
+- [Download a copy of the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+For detailed procedures, see EUR.1.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/serbia/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/serbia/eur1.md
@@ -1,0 +1,82 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1 or EUR-MED
+
+1. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities of the exporting Party on application having been made in writing by the exporter or, under the exporter’s responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative shall fill in both the movement certificate EUR.1 or EUR-MED and the application form, specimens of which appear in the Annexes IIIa and b. These forms shall be completed in one of the languages in which the United Kingdom-Serbia Agreement is drawn up and in accordance with the provisions of the national law of the exporting country or territory. If the completion of the forms is done in handwriting, they shall be completed in ink in printed characters. The description of the products shall be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line shall be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 or EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the United Kingdom or Serbia where the movement certificate EUR.1 or EUR-MED is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. Without prejudice to paragraph 5, a movement certificate EUR.1 shall be issued by the customs authorities of the United Kingdom or of Serbia in the following cases:
+
+    (a) if the products concerned can be considered as products originating in the United Kingdom or in Serbia without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey, or one of the countries or territory referred to in Articles 3(2) and 4(2) and fulfil the other requirements of this Origin Reference Document; or
+
+    (b) if the products concerned can be considered as products originating in one of the other countries or territory referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries or territory referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an origin declaration EUR-MED has been issued in the country or territory of origin.
+
+5. A movement certificate EUR-MED shall be issued by the customs authorities of the United Kingdom or of Serbia if the products concerned can be considered as products originating in the United Kingdom, in Serbia or in one of the countries or territory referred to in Articles 3 and 4 with which cumulation is applicable, fulfil the requirements of this Origin Reference Document and:
+
+    (a) cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries or territory referred to in Articles 3(2) and 4(2); or
+
+    (b) the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the countries or territory referred to in Articles 3 and 4; or
+
+    (c) the products may be re-exported from the country or territory of destination to one of the countries or territory referred to in Articles 3 and 4. 
+
+6. A movement certificate EUR-MED shall contain one of the following statements in English in Box 7:
+
+    (a) if origin has been obtained by application of cumulation with materials originating in one or more of the countries or territory referred to in Articles 3 and 4:
+
+        ‘CUMULATION APPLIED WITH … (name of the country/countries/territory)’
+
+    (b) if origin has been obtained without the application of cumulation with materials originating in one or more of the countries or territory referred to in Articles 3 and 4:
+
+        ‘NO CUMULATION APPLIED’
+
+7. The customs authorities issuing movement certificates EUR.1 or EUR-MED shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter’s accounts or any other check considered appropriate. They shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+8. The date of issue of the movement certificate EUR.1 or EUR-MED shall be indicated in Box 11 of the certificate.
+
+9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement certificates EUR.1 or EUR-MED issued retrospectively
+
+1. Notwithstanding Article 17(9), a movement certificate EUR.1 or EUR-MED may exceptionally be issued after exportation of the products to which it relates if:
+
+    (a) it was not issued at the time of exportation because of errors, involuntary omissions or special circumstances; or
+
+    (b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 or EUR-MED was issued but was not accepted at importation for technical reasons.
+
+2. Notwithstanding Article 17(9), a movement certificate EUR-MED may be issued after exportation of the products to which it relates and for which a movement certificate EUR.1 was issued at the time of exportation, provided that it is demonstrated to the satisfaction of the customs authorities that the conditions referred to in Article 17(5) are satisfied.
+
+3. For the implementation of paragraphs 1 and 2, the exporter shall indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 or EUR-MED relates, and state the reasons for his request.
+
+4. The customs authorities may issue a movement certificate EUR.1 or EUR-MED retrospectively only after verifying that the information supplied in the exporter’s application complies with that in the corresponding file.
+
+5. Movement certificates EUR.1 or EUR-MED issued retrospectively by application of paragraph 1 shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY’
+
+    Movement certificates EUR-MED issued retrospectively by application of paragraph 2 shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY (Original EUR.1 No … [date and place of issue])’
+
+6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
+
+#### Issue of a duplicate movement certificate EUR.1 or EUR-MED
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1 or EUR-MED, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way shall be endorsed with the following word in English:
+
+    ‘DUPLICATE’
+
+3. The endorsement referred to in paragraph 2 shall be inserted in Box 7 of the duplicate movement certificate EUR.1 or EUR-MED.
+
+4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
+
+#### Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously
+
+When originating products are placed under the control of a customs office in the United Kingdom or Serbia, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or Serbia. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/serbia/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/serbia/origin-declaration.md
@@ -1,0 +1,61 @@
+The origin declaration is provided on an invoice or any other commercial document that describes the originating product in sufficient detail to enable its identification. The texts of the origin declarations appear in Annexes IVa and IVb of the [Origin Reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an origin declaration or an origin declaration EUR-MED
+
+1. An origin declaration or an origin declaration EUR-MED as referred to in Article 16(1)(c) may be made out:
+
+    (a) by an approved exporter within the meaning of Article 23; or
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products the total value of which does not exceed EUR 6 000.
+
+2. Without prejudice to paragraph 3, an origin declaration may be made out in the following cases:
+
+    (a) if the productions concerned may be considered as products originating in the United Kingdom or in Serbia without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries or territory referred to in Articles 3(2) and 4(2), and fulfil the other requirements of this Origin Reference Document; or 
+
+    (b) if the products concerned may be considered as products originating in one of the other countries or territory referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries or territory referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an origin declaration EUR-MED has been issued in the country or territory of origin.
+ 
+3. An origin declaration EUR-MED may be made out if the products concerned can be considered as products originating in the United Kingdom, in Serbia or in one of the other countries or territory referred to in Articles 3 and 4 with which cumulation is applicable, and fulfil the requirements of this Origin Reference Document, in the following cases:
+
+    (a) cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries or territory referred to in Articles 3(2) and 4(2); or 
+
+    (b) the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the other countries or territory referred to in Articles 3 and 4; or
+
+    (c) the products may be re-exported from the country or territory of destination to one of the other countries or territory referred to in Articles 3 and 4.
+
+4. An origin declaration EUR-MED shall contain one of the following statements in English:
+
+    (a) if origin has been obtained by application of cumulation with materials originating in one or more of the countries or territory referred to in Articles 3 and 4:
+
+    ‘CUMULATION APPLIED WITH …  (name of the country/countries/territory)’
+
+    (b) if origin has been obtained without the application of cumulation with materials originating in one or more of the countries or territory referred to in Articles 3 and 4:
+
+    ‘NO CUMULATION APPLIED’
+
+5. The exporter making out an origin declaration or an origin declaration EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting Party, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+6. An origin declaration or an origin declaration EUR-MED shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the texts of which appear in Annexes IVa and b, using one of the linguistic versions set out in those Annexes and in accordance with the provisions of the national law of the exporting country or territory. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+7. Origin declarations and origin declarations EUR-MED shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 23 shall not be required to sign such declarations provided that he gives the customs authorities of the exporting Party a written undertaking that he accepts full responsibility for any origin declaration which identifies him as if it had been signed in manuscript by him.
+
+8. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country or territory at the latest two years after the importation of the products to which it relates.
+
+#### Approved exporter
+
+1. The customs authorities of the exporting Party may authorise any exporter (hereinafter referred to as ‘approved exporter’), who makes frequent shipments of products in accordance to the provisions of the United Kingdom-Serbia Agreement to make out origin declarations or origin declarations EUR-MED irrespective of the value of the products concerned. An exporter seeking such authorisation shall offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the origin declaration or on the origin declaration EUR-MED.
+
+4. The customs authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/singapore/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/singapore/origin-declaration.md
@@ -1,0 +1,70 @@
+An 'origin declaration', given by the exporter on an invoice, a delivery note or any other commercial document describes the products concerned in sufficient detail to enable them to be identified. The text of the invoice declaration appears in Annex IV of the [origin reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for Making Out an Origin Declaration
+1. An origin declaration as referred to in Article 16 (General Requirements) may be made out:
+
+    (a) in the UK:
+
+    - (i) by an exporter within the meaning of Article 18 (Approved Exporter); or
+
+    - (ii) by an exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed 6 000 euro.
+
+    (b) in Singapore by an exporter who is:
+
+    - (i) registered with the competent authority and who has received a Unique Entity Number; and
+
+    - (ii) complying with relevant regulatory provisions in Singapore pertaining to making out of origin declarations.
+
+2. An origin declaration may be made out if the products concerned can be considered as products originating in the UK or in Singapore and fulfil the other requirements of this Origin Reference Document.
+
+3. The exporter making out an origin declaration shall be prepared at all times to submit, at the request of the customs authorities of the exporting Party, all appropriate documents as referred to under Article 23 (Supporting Documents) proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. An origin declaration shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery Note or another commercial document, the declaration, the text of which appears in Annex E to this Origin Reference Document, in accordance with the domestic law of the exporting Party. If the declaration is hand-written, it shall be written in ink in capital characters in English.
+
+5. Origin declarations shall bear the original signature of the exporter in manuscript. An approved exporter as referred to in Article 18 (Approved Exporter) shall not be required to sign such declarations provided that he gives the customs authorities of the exporting Party a written undertaking that he accepts full responsibility for any origin declaration which identifies him as if it had been signed in manuscript by him.
+
+6. By derogation from paragraph 1, an origin declaration may exceptionally be made out after exportation ("retrospective statement") on condition that it is presented in the importing Party no later than two years, in the case of the UK, and one year, in the case of Singapore, after the entry of the goods into the territory.
+
+#### Approved Exporter
+
+1. The customs authorities of the UK may authorise any exporter who exports products under the United Kingdom-Singapore Agreement to make out origin declarations irrespective of the value of the products concerned (hereinafter referred to as "approved exporter"). An exporter seeking such authorisation must offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities of the UK may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities of the UK shall grant to the approved exporter a customs authorisation number which shall appear on the origin declaration.
+
+4. The customs authorities of the UK shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities of the UK may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.
+
+#### Validity of Origin Declaration
+
+1. An origin declaration shall be valid for twelve months from the date of issue in the exporting Party. Preferential tariff treatment shall be claimed within such period to the customs authorities of the importing Party.
+
+2. Origin declarations which are submitted to the customs authorities of the importing Party after the final date for presentation specified in paragraph 1 may be accepted for the purposes of applying preferential treatment, where the failure to submit these documents by the final date set is due to exceptional circumstances.
+
+3. In cases of belated presentation other than those of paragraph 2, the customs authorities of the importing Party may accept the origin declarations where the products have been submitted before such final date.
+
+#### Submission of Origin Declaration
+
+For the purposes of claiming preferential tariff treatment, origin declarations shall be submitted to the customs authorities of the importing Party in accordance with the procedures applicable in that Party.
+
+#### Importation in Instalments
+
+Where, at the request of the importer and on the conditions laid down by the customs authorities of the importing Party, dismantled or non-assembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XVI and XVII or headings 7308 and 9406 of HS 2017 are imported in instalments, a single origin declaration for such products shall be submitted to the customs authorities upon importation of the first instalment.
+
+#### Exemptions from Origin Declaration
+
+1. Products which are sent as small packages from private persons to private persons, or which form part of travellers' personal luggage, shall be admitted as originating products without requiring the submission of an origin declaration, provided that such products are not imported by way of trade and have been declared as meeting the requirements of this Origin Reference Document, and provided that there is no doubt as to the veracity of such a declaration. In the case of products sent by post, this declaration can be made on the customs declaration CN22/CN23 or on a sheet of paper annexed to that document.
+
+2. Imports which are occasional and consist solely of products for the personal use of the recipients or of travellers or their families shall not be considered as imports by way of trade if it is evident from the nature and quantity of the products that no commercial purpose is intended.
+
+3. The total value of these products shall not exceed 500 euro in the case of small packages or 1 200 euro in the case of products forming part of travellers' personal luggage.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/south-korea/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/south-korea/origin-declaration.md
@@ -1,0 +1,6 @@
+An origin declaration may be made out:
+
+- by an approved exporter _or_
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).

--- a/db/rules_of_origin/roo_schemes_uk/proofs/switzerland-liechtenstein/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/switzerland-liechtenstein/eur1.md
@@ -1,0 +1,70 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for issuing of a movement certificate EUR.1
+
+1. A movement certificate EUR.1 shall be issued by the customs authorities of the exporting Party on application having been made in writing by the exporter or, under the exporter’s responsibility, by his authorised representative.
+
+2. For that purpose, the exporter or his authorised representative shall fill in both the movement certificate EUR.1 and the application form, specimens of which appear in Annex IV to this Origin Reference Document. Those forms shall be completed in an official language of a Party and in accordance with the provisions of the national law of the exporting Party. If the completion of the forms is done in handwriting, they shall be completed in ink in printed characters. The description of the products shall be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line shall be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 shall be prepared to submit at any time, at the request of the customs authorities of the exporting Party where the movement certificate EUR.1 is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. A movement certificate EUR.1 shall be issued by the customs authorities of the exporting Party if the products concerned can be considered as products originating in a Party and fulfil the other requirements of this Origin Reference Document.
+
+5. The customs authorities issuing movement certificates EUR.1 shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For that purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter’s accounts or any other check considered appropriate. They shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+6. The date of issue of the movement certificate EUR.1 shall be indicated in Box 11 of the movement certificate EUR.1.
+
+7. A movement certificate EUR.1 shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Electronically issued movement certificates EUR.1
+
+1. As an alternative to the provisions regarding the issuance of movement certificates, the Parties shall accept electronically issued movement certificates EUR.1. Considering the digitalised system to issue movement certificates EUR.1, the formal requirements of electronically issued movement certificates EUR.1 are stated in paragraph 3. 
+
+2. The Parties shall inform each other about the readiness of the issuance of electronic movement certificates EUR.1 and all technical issues related to such implementation (issuance, submission and verification of an electronic certificate).
+
+3. Paragraphs 1 and 2 of Annex IV shall not apply if the movement certificate is issued and validated electronically, and the following applies: 
+
+    (a) ink stamps used by the customs or competent governmental authorities for the validation of the movement certificate EUR.1 (Box 11) may be replaced with an image or electronic stamps;
+
+    (b) Boxes 11 and 12 may contain facsimile or electronic signatures instead of original signatures; 
+
+    (c) the information in Box 11 concerning the form and number of the export document shall be indicated only where requested by the domestic legislation of the exporting Party;
+
+    (d) it shall bear a serial number or a code by which it can be identified; and
+
+    (e) it may be issued in any of the official languages of the Parties or in English.
+
+#### Movement certificates EUR.1 issued retrospectively
+
+1. Notwithstanding Article 20(8), a movement certificate EUR.1 may be issued after exportation of the products to which it relates if:
+
+    (a) it was not issued at the time of exportation because of errors or involuntary omissions or special circumstances;
+
+    (b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 was issued but was not accepted at importation for technical reasons;
+
+    (c) the final destination of the products concerned was not known at the time of exportation and was determined during their transportation or storage and after possible splitting of consignments in accordance with Article 14(3);
+
+    (d) a movement certificate EUR.1 or EUR.MED was issued in accordance with the rules of the PEM Convention for products that are also originating in accordance with this Origin Reference Document; the exporter shall take all necessary steps to ensure that the conditions to apply cumulation are fulfilled and be prepared to submit to the customs authorities all relevant documents proving that the product is originating in accordance with this Origin Reference Document; or
+
+    (e) a movement certificate EUR.1 was issued on the basis of Article 8(5) and the application of Article 8(4) is required at importation in any country referred to in Annex VIII.
+
+2. For the implementation of paragraph 1, the exporter shall indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 relates, and state the reasons for his request.
+
+3. The customs authorities may issue a movement certificate EUR.1 retrospectively within two years from the date of exportation and only after verifying that the information supplied in the exporter’s application complies with that in the corresponding file.
+
+4. In addition to the requirement under Article 20(3), movement certificates EUR.1 issued retrospectively shall be endorsed with the following phrase: “ISSUED RETROSPECTIVELY”.
+
+5. The endorsement referred to in paragraph 4 shall be inserted in Box 7 of the movement certificate EUR.1.
+
+#### Issue of a duplicate movement certificate EUR.1
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. In addition to the requirement under Article 20(3), the duplicate issued in accordance with paragraph 1 shall be endorsed with the following word: “DUPLICATE”.
+
+3. The endorsement referred to in paragraph 2 shall be inserted in Box 7 of the duplicate movement certificate EUR.1.
+
+4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1, shall take effect as from that date.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/switzerland-liechtenstein/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/switzerland-liechtenstein/origin-declaration.md
@@ -1,0 +1,39 @@
+An 'origin declaration', given by the exporter on an invoice, a delivery note or any other commercial document describes the products concerned in sufficient detail to enable them to be identified. The text of the invoice declaration appears in Appendix 4 of the [origin reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an origin declaration
+
+1. An origin declaration as referred to in subparagraph (b) of Article 17(1) may be made out:
+
+    (a) by an approved exporter within the meaning of Article 19; or
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products the total value of which does not exceed EUR 6 000.
+
+2. An origin declaration may be made out if the products can be considered as originating in a Party and fulfil the other requirements of this Origin Reference Document.
+
+3. The exporter making out an origin declaration shall be prepared to submit at any time, at the request of the customs authorities of the exporting Party, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. An origin declaration shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the text of which appears in Annex III to this Origin Reference Document, using one of the linguistic versions set out in that Annex and in accordance with the provisions of the national law of the exporting country. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+5. Origin declarations shall bear the signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 19 shall not be required to sign such declarations provided that he gives the customs authorities of the exporting Party a written undertaking that he accepts full responsibility for any origin declaration which identifies him as if it had been signed in manuscript by him. Each Party shall permit an origin declaration to be sent electronically and directly from the exporter in one Party to an importer in the other Party. Such an approach will allow the use of electronic signatures or identification codes.
+
+6. An origin declaration may be made out by the exporter when the products to which it relates are exported, or after exportation (the “retrospective origin declaration”) on condition that it is presented in the importing country within two years after the importation of the products to which it relates.
+
+Where the splitting of a consignment takes place in accordance with Article 14(3) and provided that the same two-year deadline is respected, the retrospective origin declaration shall be made out by the approved exporter of the exporting Party of the products.
+
+#### Approved exporter
+
+1. The customs authorities of the exporting Party may, subject to national requirements, authorise any exporter established in that Party (the “approved exporter”), to make out origin declarations irrespective of the value of the products concerned.
+
+2. An exporter who requests such authorisation must offer, to the satisfaction of the customs authorities, all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the origin declaration.
+
+4. The customs authorities shall verify the proper use of an authorisation. They may withdraw the authorisation if the approved exporter makes improper use of it and shall do so if the approved exporter no longer offers the guarantees referred to in paragraph 2.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/tunisia/eur-med.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/tunisia/eur-med.md
@@ -1,0 +1,6 @@
+Use form EUR-MED to record preferential trade in goods between the UK and participating countries.
+
+- [Download a copy of the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+For detailed procedures, see EUR.1.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/tunisia/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/tunisia/eur1.md
@@ -1,0 +1,84 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the Issue of a Movement Certificate EUR.1 or EUR-MED
+
+1. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities of the exporting country on application having been made in writing by the exporter or, under the exporter's responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative shall fill in both the movement certificate EUR.1 or EUR-MED and the application form, specimens of which appear in the Annexes IIIa and b. These forms shall be completed in one of the languages in which the Agreement is drawn up and in accordance with the provisions of the national law of the exporting country. If the forms are handwritten, they shall be completed in ink in printed characters. The description of the products shall be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line shall be drawn below the last line of the description, the empty space being crossed through.
+
+3.    The exporter applying for the issue of a movement certificate EUR.1 or EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting country where the movement certificate EUR.1 or EUR-MED is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. Without prejudice to paragraph 5, a movement certificate EUR.1 shall be issued by the customs authorities of the United Kingdom or of Tunisia in the following cases:
+
+   - if the products concerned can be considered as products originating in the United Kingdom, or in Tunisia, without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2), and fulfil the other requirements of this Origin Reference Document; or
+
+   - if the products concerned can be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an invoice declaration EUR-MED has been issued in the country of origin; or
+
+   - if the products concerned can be considered as products originating in the United Kingdom or in Tunisia, with application of the cumulation referred to in Articles 3(4a) and 4(4a), and fulfil the other requirements of this Origin Reference Document.
+
+5. A movement certificate EUR-MED shall be issued by the customs authorities of the United Kingdom or of Tunisia if the products concerned can be considered as products originating in the United Kingdom, in Tunisia or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, fulfil the requirements of this Origin Reference Document and:
+
+    - cumulation was applied with materials originating Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2), or
+
+    - the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the other countries referred to in Articles 3 and 4, or
+
+    - the products may be re-exported from the country of destination to one of the other countries referred to in Articles 3 and 4.
+
+6. A movement certificate EUR-MED shall contain one of the following statements in English in Box 7:
+
+    - if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+        ‘CUMULATION APPLIED WITH ……’ (name of the country/countries),
+
+    - if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+        ‘NO CUMULATION APPLIED’.
+
+7. The customs authorities issuing movement certificates EUR.1 or EUR-MED shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter's accounts or any other check considered appropriate. They shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+8. The date of issue of the movement certificate EUR.1 or EUR-MED shall be indicated in Box 11 of the certificate.
+
+9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement Certificates EUR.1 or EUR-MED Issued Retrospectively
+
+1. Notwithstanding Article 17(9), a movement certificate EUR.1 or EUR-MED may exceptionally be issued after exportation of the products to which it relates if:
+
+    (a) it was not issued at the time of exportation because of errors or    involuntary omissions or special circumstances; or
+
+    (b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 or EUR-MED was issued but was not accepted at importation for technical reasons.
+
+2. Notwithstanding Article 17(9), a movement certificate EUR-MED may be issued after exportation of the products to which it relates and for which a movement certificate EUR.1 was issued at the time of exportation, provided that it is demonstrated to the satisfaction of the customs authorities that the conditions referred to in Article 17(5) are satisfied.
+
+3. For the implementation of paragraphs 1 and 2, the exporter shall indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 or EUR-MED relates, and state the reasons for his request.
+
+4. The customs authorities may issue a movement certificate EUR.1 or EUR-MED retrospectively only after verifying that the information supplied in the exporter's application complies with that in the corresponding file.
+
+5. Movement certificates EUR.1 or EUR-MED issued retrospectively by application of paragraph 1, shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY’
+
+    Movement certificates EUR-MED issued retrospectively by application of paragraph 2 shall be endorsed with the following phrase in English:
+
+    ‘ISSUED RETROSPECTIVELY (Original EUR.1 No ……….[date and place of issue]’ 
+
+6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
+
+#### Issue of a Duplicate Movement Certificate EUR.1 or EUR-MED
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1 or EUR-MED, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way shall be endorsed with the following word in English:
+
+    ‘DUPLICATE’
+
+3. The endorsement referred to in paragraph 2 shall be inserted in Box 7 of the duplicate movement certificate EUR.1 or EUR-MED.
+
+4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
+
+#### Issue of Movement Certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously
+
+When originating products are placed under the control of a customs office in the United Kingdom or in Tunisia, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or Tunisia. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/tunisia/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/tunisia/origin-declaration.md
@@ -1,0 +1,63 @@
+The origin declaration is provided on an invoice or any other commercial document that describes the originating product in sufficient detail to enable its identification. The texts of the origin declarations appear in Annexes IVa and IVb of the [Origin Reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an Invoice Declaration or an Invoice Declaration EUR-MED
+
+1. An invoice declaration or an invoice declaration EUR-MED as referred to in Article 16(1)(c) may be made out:
+
+    (a) by an approved exporter within the meaning of Article 23, or
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed EUR 6 000.
+
+2. Without prejudice to paragraph 3, an invoice declaration may be made out in the following cases:
+
+   - if the products concerned may be considered as products originating in the United Kingdom, or in Tunisia, without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2), and fulfil the other requirements of this Origin Reference Document;
+
+   - if the products concerned may be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an invoice declaration EUR-MED has been issued in the country of origin; or
+
+   - if the products concerned may be considered as products originating in the United Kingdom or in Tunisia, with application of the cumulation referred to in Articles 3(4a) and 4(4a), and fulfil the other requirements of this Origin Reference Document.
+
+3. An invoice declaration EUR-MED may be made out if the products concerned may be considered as products originating in the United Kingdom, in Tunisia or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, fulfil the requirements of this Origin Reference Document and:
+
+   - cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2), or
+
+   - the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the other countries referred to in Articles 3 and 4, or
+
+   - the products may be re-exported from the country of destination to one of the other countries referred to in Articles 3 and 4.
+
+4. An invoice declaration EUR-MED shall contain one of the following statements in English:
+
+   - if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    ‘CUMULATION APPLIED WITH …’ (name of the country/countries);
+
+   - if origin has been obtained without application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+       ‘NO CUMULATION APPLIED’ 
+
+5. The exporter making out an invoice declaration or an invoice declaration EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting country, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+6. An invoice declaration or an invoice declaration EUR-MED shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the text of which appears in Annexes IVa and b, using one of the linguistic versions set out in these Annexes and in accordance with the provisions of the national law of the exporting country. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+7. Invoice declarations and invoice declarations EUR-MED shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 23 shall not be required to sign such declarations provided that he gives the customs authorities of the exporting country a written undertaking that he accepts full responsibility for any invoice declaration which identifies him as if it had been signed in manuscript by him.
+
+8. An invoice declaration or an invoice declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
+
+#### Approved Exporter
+
+1. The customs authorities of the exporting country may authorise any exporter (hereinafter referred to as ‘approved exporter’) who makes frequent shipments of products under the Agreement to make out invoice declarations or invoice declarations EUR-MED irrespective of the value of the products concerned. An exporter seeking such authorisation shall offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the invoice declaration or on the invoice declaration EUR-MED.
+
+4. The customs authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/turkey/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/turkey/origin-declaration.md
@@ -1,0 +1,36 @@
+The origin declaration is provided on an invoice or any other commercial document that describes the originating product in sufficient detail to enable its identification. The texts of the origin declarations appear in Annexes IVa and b of the [Origin Reference document](ord).
+
+In the UK, the exporter’s reference number will be the EORI number. If you do not have one, you can [apply for an EORI number](https://www.gov.uk/eori). In Turkey, Approved Exporters should use their Approved Exporter number as the authorisation number. Other exporters should leave the authorisation number blank.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+
+1. An origin declaration shall:
+
+    (a) take the form of a written self-declaration of origin which may be in the form set out in Annex 4 (Text of the Origin Declaration) made by the exporter which clearly states that the goods imported meet the conditions required for preferential treatment under the terms of the United Kingdom-Turkey Agreement; and
+
+    (b) be provided on, or attached to, an invoice or any other commercial document that describes the goods concerned in sufficient detail to enable them to be identified.
+
+2. Each Party shall permit an origin declaration to be sent electronically and directly from the exporter in one Party to an importer in the other Party. Such an approach will allow the use of electronic signatures or identification codes. 
+
+#### Validity of the origin declaration
+
+1. Each Party shall provide that an origin declaration shall be valid for 12 months from the date it was completed, or for such longer period of time as provided by the importing Party. The preferential treatment may be claimed, within this validity period, from the customs authority of the importing Party.
+
+2. Each Party shall provide that an origin declaration may apply to:
+
+    (a) a single shipment of originating goods into the territory of a Party; or 
+
+    (b) multiple shipments of identical originating goods within any period specified in the origin declaration not exceeding 12 months.
+
+1. The importing Party may accept an origin declaration submitted to its customs authority after the validity period for the purpose of preferential treatment in accordance with that Party's laws and regulations.
+
+2. If unassembled or disassembled products within the meaning of paragraph 2(a) of Part Two, Section 1, of the Tariff of the United Kingdom falling within Sections XV to XXI of HS 2017 are imported by instalments, a single origin declaration for such products may be used on request of the importer and in accordance with the requirements laid down by the customs authority of the importing Party. 
+
+#### Exemptions from origin declaration requirements
+
+1. Each Party may, in conformity with its laws and regulations, waive the requirement to present an origin declaration for low value importations of originating goods from the other Party.
+
+2. Each Party may exclude any importation from the provisions of paragraph 1 when the importation is part of a series of importations that may reasonably be considered to have been undertaken or arranged for the purpose of avoiding the requirements of this Origin Reference Document related to origin declarations.
+
+3. Each Party may set value limits for products referred to in paragraph 1, and shall exchange information with the other Party regarding those limits.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/ukraine/eur-med.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/ukraine/eur-med.md
@@ -1,0 +1,6 @@
+Use form EUR-MED to record preferential trade in goods between the UK and participating countries.
+
+- [Download a copy of the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR-MED movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+For detailed procedures, see EUR.1.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/ukraine/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/ukraine/eur1.md
@@ -1,0 +1,82 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the issue of a movement certificate EUR.1 or EUR-MED
+
+1. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities of the exporting Party on application having been made in writing by the exporter or, under the exporter's responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative shall fill in both the movement certificate EUR.1 or EUR-MED and the application form, specimens of which appear in the Annexes IIIa and b. These forms shall be completed in one of the languages in which the United Kingdom-Ukraine Agreement is drawn up and in accordance with the provisions of the national law of the exporting country. If the completion of the forms is done in handwriting, they shall be completed in ink in printed characters. The description of the products shall be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line shall be drawn below the last line of the description, the empty space being crossed through.
+
+3. The exporter applying for the issue of a movement certificate EUR.1 or EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the United Kingdom or Ukraine where the movement certificate EUR.1 or EUR-MED is issued, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. Without prejudice to paragraph 5, a movement certificate EUR.1 shall be issued by the customs authorities of the United Kingdom or of Ukraine in the following cases:
+
+    (a) if the products concerned can be considered as products originating in the United Kingdom or in Ukraine, without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries referred to in Articles 3(2) and 4(2) and fulfil the other requirements of this Origin Reference Document; or
+
+    (b) if the products concerned can be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an invoice declaration EUR-MED has been issued in the country of origin.
+
+5. A movement certificate EUR-MED shall be issued by the customs authorities of the United Kingdom or of Ukraine if the products concerned can be considered as products originating in the United Kingdom, in Ukraine or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, fulfil the requirements of this Origin Reference Document and:
+
+    (a) cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the countries referred to in Articles 3(2) and 4(2); or
+
+    (b) the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the countries referred to in Articles 3 and 4; or
+
+    (c) the products may be re-exported from the country of destination to one of the countries referred to in Articles 3 and 4. 
+
+6. A movement certificate EUR-MED shall contain one of the following statements in English in box 7:
+
+    (a) if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    'CUMULATION APPLIED WITH … (name of the country/countries)'
+
+    (b) if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    'NO CUMULATION APPLIED'
+
+7. The customs authorities issuing movement certificates EUR.1 or EUR-MED shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter's accounts or any other check considered appropriate. They shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+8. The date of issue of the movement certificate EUR.1 or EUR-MED shall be indicated in Box 11 of the certificate.
+
+9. A movement certificate EUR.1 or EUR-MED shall be issued by the customs authorities and made available to the exporter as soon as actual exportation has been effected or ensured.
+
+#### Movement certificates EUR.1 or EUR-MED issued retrospectively
+
+1. Notwithstanding Article 17(9), a movement certificate EUR.1 or EUR-MED may exceptionally be issued after exportation of the products to which it relates if:
+
+    (a) it was not issued at the time of exportation because of errors, involuntary omissions or special circumstances; or
+
+    (b) it is demonstrated to the satisfaction of the customs authorities that a movement certificate EUR.1 or EUR-MED was issued but was not accepted at importation for technical reasons.
+
+2. Notwithstanding Article 17(9), a movement certificate EUR-MED may be issued after exportation of the products to which it relates and for which a movement certificate EUR.1 was issued at the time of exportation, provided that it is demonstrated to the satisfaction of the customs authorities that the conditions referred to in Article 17(5) are satisfied.
+
+3. For the implementation of paragraphs 1 and 2, the exporter shall indicate in his application the place and date of exportation of the products to which the movement certificate EUR.1 or EUR-MED relates, and state the reasons for his request.
+
+4. The customs authorities may issue a movement certificate EUR.1 or EUR-MED retrospectively only after verifying that the information supplied in the exporter's application complies with that in the corresponding file.
+
+5. Movement certificates EUR.1 or EUR-MED issued retrospectively by application of paragraph 1 shall be endorsed with the following phrase in English:
+
+    'ISSUED RETROSPECTIVELY'
+
+    Movement certificates EUR-MED issued retrospectively by application of paragraph 2 shall be endorsed with the following phrase in English:
+
+    'ISSUED RETROSPECTIVELY (Original EUR.1 No … [date and place of issue])'
+
+6. The endorsement referred to in paragraph 5 shall be inserted in Box 7 of the movement certificate EUR.1 or EUR-MED.
+
+#### Issue of a duplicate movement certificate EUR.1 or EUR-MED
+
+1. In the event of theft, loss or destruction of a movement certificate EUR.1 or EUR-MED, the exporter may apply to the customs authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way shall be endorsed with the following word in English:
+
+    'DUPLICATE'
+
+3. The endorsement referred to in paragraph 2 shall be inserted in Box 7 of the duplicate movement certificate EUR.1 or EUR-MED.
+
+4. The duplicate, which shall bear the date of issue of the original movement certificate EUR.1 or EUR-MED, shall take effect as from that date.
+
+#### Issue of movement certificates EUR.1 or EUR-MED on the basis of a proof of origin issued or made out previously 
+
+When originating products are placed under the control of a customs office in the United Kingdom or Ukraine, it shall be possible to replace the original proof of origin by one or more movement certificates EUR.1 or EUR-MED for the purpose of sending all or some of these products elsewhere within the United Kingdom or Ukraine. The replacement movement certificate(s) EUR.1 or EUR-MED shall be issued by the customs office under whose control the products are placed.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/ukraine/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/ukraine/origin-declaration.md
@@ -1,0 +1,61 @@
+The origin declaration is provided on an invoice or any other commercial document that describes the originating product in sufficient detail to enable its identification. The texts of the origin declarations appear in Annexes IVa and IVb of the [Origin Reference document](ord).
+
+An origin declaration may be made out:
+
+- by an approved exporter, _or_
+
+- by any exporter for any consignment consisting of one or more packages containing originating products whose total value does not exceed £5,500 / 6,000 euros.
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for making out an origin declaration or an origin declaration EUR-MED
+
+1. An origin declaration or an origin declaration EUR-MED as referred to in Article 16(1)(c) may be made out:
+
+    (a) by an approved exporter within the meaning of Article 23; or
+
+    (b) by any exporter for any consignment consisting of one or more packages containing originating products the total value of which does not exceed EUR 6 000.
+
+2. Without prejudice to paragraph 3, an origin declaration may be made out in the following cases:
+
+    (a) if the products concerned may be considered as products originating in the United Kingdom, in Ukraine without application of cumulation with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2), and fulfil the other requirements of this Origin Reference Document; or
+
+    (b) if the products concerned may be considered as products originating in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, without application of cumulation with materials originating in one of the countries referred to in Articles 3 and 4, and fulfil the other requirements of this Origin Reference Document, provided a certificate EUR-MED or an invoice declaration EUR-MED has been issued in the country of origin.
+
+3. An origin declaration EUR-MED may be made out if the products concerned can be considered as products originating in the United Kingdom, in Ukraine or in one of the other countries referred to in Articles 3 and 4 with which cumulation is applicable, and fulfil the requirements of this Origin Reference Document, in the following cases:
+
+    (a) cumulation was applied with materials originating in Switzerland (including Liechtenstein), Turkey or one of the other countries referred to in Articles 3(2) and 4(2); or
+
+    (b) the products may be used as materials in the context of cumulation for the manufacture of products for export to one of the other countries referred to in Articles 3 and 4; or
+
+    (c) the products may be re-exported from the country of destination to one of the other countries referred to in Articles 3 and 4.
+
+4. An origin declaration EUR-MED shall contain one of the following statements in English:
+
+    (a) if origin has been obtained by application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    'CUMULATION APPLIED WITH …  (name of the country/countries)'
+
+    (b) if origin has been obtained without the application of cumulation with materials originating in one or more of the countries referred to in Articles 3 and 4:
+
+    'NO CUMULATION APPLIED'
+
+5. The exporter making out an origin declaration or an origin declaration EUR-MED shall be prepared to submit at any time, at the request of the customs authorities of the exporting Party, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+6. An origin declaration or an origin declaration EUR-MED shall be made out by the exporter by typing, stamping or printing on the invoice, the delivery note or another commercial document, the declaration, the texts of which appear in Annexes IVa and b, using one of the linguistic versions set out in those Annexes and in accordance with the provisions of the national law of the exporting country. If the declaration is handwritten, it shall be written in ink in printed characters.
+
+7. Origin declarations and origin declarations EUR-MED shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 23 shall not be required to sign such declarations provided that he gives the customs authorities of the exporting Party a written undertaking that he accepts full responsibility for any origin declaration which identifies him as if it had been signed in manuscript by him.
+
+8. An origin declaration or an origin declaration EUR-MED may be made out by the exporter when the products to which it relates are exported, or after exportation on condition that it is presented in the importing country at the latest two years after the importation of the products to which it relates.
+
+#### Approved exporter
+
+1. The customs authorities of the exporting Party may authorise any exporter (hereinafter referred to as 'approved exporter'), who makes frequent shipments of products in accordance to the provisions of the United Kingdom-Ukraine Agreement to make out origin declarations or origin declarations EUR-MED irrespective of the value of the products concerned. An exporter seeking such authorisation shall offer to the satisfaction of the customs authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The customs authorities may grant the status of approved exporter subject to any conditions which they consider appropriate.
+
+3. The customs authorities shall grant to the approved exporter a customs authorisation number which shall appear on the origin declaration or on the origin declaration EUR-MED.
+
+4. The customs authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The customs authorities may withdraw the authorisation at any time. They shall do so where the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/vietnam/eur1.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/vietnam/eur1.md
@@ -1,0 +1,52 @@
+Use form EUR.1 to claim preferential duty rates on goods exported to or imported from countries that have a preferential trading agreement with the European Community.
+
+- [Download a copy of the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate)
+- [How to complete the EUR.1 movement certificate](https://www.gov.uk/government/publications/eur1-and-eur-med-movement-certificate/how-to-complete-the-movement-certificate)
+
+#### Procedure for the Issuance of a Certificate of Origin
+
+1. A certificate of origin shall be issued by the competent authorities of the exporting Party on application having been made in writing by the exporter or, under the exporter's responsibility, by his authorised representative.
+
+2. For this purpose, the exporter or his authorised representative shall fill out both the certificate of origin, specimen of which appears in Annex VII to this Origin Reference Document, and the application form. The specimen of the application form to be used for exports from the UK to Viet Nam appears in Annex VII to this Origin Reference Document; the specimen of the application form to be used for exports from Viet Nam to the UK shall be determined in the domestic legislation of Viet Nam. These forms shall be completed in one of the languages in which the United Kingdom-Viet Nam Agreement is drawn up and in accordance with the domestic law of the exporting Party. If they are hand-written, they shall be completed in ink in printed characters. The description of the products must be given in the box reserved for this purpose without leaving any blank lines. Where the box is not completely filled, a horizontal line must be drawn below the last line of the description, the empty space being crossed through to prevent any subsequent addition.
+
+3. The exporter applying for the issuance of a certificate of origin shall be prepared to submit at any time, at the request of the competent authorities of the exporting Party, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+4. A certificate of origin shall be issued by the competent authorities of the exporting Party if the products concerned can be considered as products originating in the UK or in Viet Nam and fulfil the other requirements of this Origin Reference Document.
+
+5. The competent authorities issuing certificates of origin shall take any steps necessary to verify the originating status of the products and the fulfilment of the other requirements of this Origin Reference Document. For this purpose, they shall have the right to call for any evidence and to carry out any inspection of the exporter's accounts or any other check considered appropriate. They shall also ensure that the forms referred to in paragraph 2 are duly completed. In particular, they shall check whether the space reserved for the description of the products has been completed in such a manner as to exclude all possibility of fraudulent additions.
+
+6. The date of issuance of the certificate of origin shall be indicated in Box 11 of the certificate.
+
+7. The certificate of origin shall be issued as soon as possible to but not later than three working days after the date of exportation (the declared shipment date).
+
+#### Certificates of Origin Issued Retrospectively
+
+1. Notwithstanding paragraph 7 of Article 16 (Procedure for the Issuance of a Certificate of Origin), a certificate of origin may also be issued after exportation of the products to which it relates in specific situations where:
+
+    (a) it was not issued at the time of exportation because of errors, involuntary omissions or other valid reasons;
+
+    (b) it is demonstrated to the competent authorities that a certificate of origin was issued but was not accepted at importation for technical reasons; or
+
+    (c) the final destination of the products concerned was not known at the time of exportation and was determined during their transportation, storage or after splitting of consignments in accordance with Article 13 (Non-Alteration).
+
+2. For the implementation of paragraph 1, the exporter shall indicate in his application the place and date of exportation of the products to which the certificate of origin relates, and state the reasons for his request.
+
+3. The competent authorities may issue a certificate of origin retrospectively only after verifying that the information supplied in the exporter's application conforms with that in the corresponding file.
+
+4. Certificates of origin issued retrospectively shall be endorsed with the following phrase in English:
+
+    "ISSUED RETROSPECTIVELY".
+
+5. The endorsement referred to in paragraph 4 shall be inserted in Box 7 of the certificate of origin. 
+
+#### Issuance of a Duplicate Certificate of Origin
+
+1. In the event of theft, loss or destruction of a certificate of origin, the exporter may apply to the competent authorities which issued it for a duplicate made out on the basis of the export documents in their possession.
+
+2. The duplicate issued in this way must be endorsed with the following word in English: 
+
+    "DUPLICATE".
+
+3. The endorsement referred to in paragraph 2 shall be inserted in Box 7 of the duplicate certificate of origin.
+
+4. The duplicate, which must bear the date of issue of the original certificate of origin, shall take effect as from that date.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/vietnam/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/vietnam/origin-declaration.md
@@ -1,0 +1,31 @@
+An 'origon declaration', given by the exporter on an invoice, a delivery note or any other commercial document describes the products concerned in sufficient detail to enable them to be identified. The text of the invoice declaration appears in Appendix 4 of the [origin reference document](ord).
+
+In the UK, the exporter’s reference number will be the EORI number. If you do not have one, you can [apply for an EORI number](https://www.gov.uk/eori). 
+
+Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+
+#### Conditions for Making out an Origin Declaration
+
+1. An origin declaration may be made out if the products concerned can be considered as products originating in the UK or in Viet Nam and fulfil the other requirements of this Origin Reference Document.
+
+2. The exporter making out an origin declaration shall be prepared to submit at any time, at the request of the competent authorities of the exporting Party, all appropriate documents proving the originating status of the products concerned as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+3. An origin declaration shall be made out by the exporter on the invoice, the delivery note or any other commercial document which describes the products concerned in sufficient details to enable them to be identified, by typing, stamping or printing on that document the declaration, the text of which appears in Annex VI to this Origin Reference Document,  in accordance with the provisions of the domestic law of the exporting Party. If the declaration is hand-written, it shall be written in ink in capital characters.
+
+4. Origin declarations shall bear the original signature of the exporter in manuscript. However, an approved exporter within the meaning of Article 20 (Approved Exporter) shall not be required to sign such declarations provided that he gives the competent authorities of the exporting Party a written undertaking that he accepts full responsibility for any origin declaration which identifies him as if it had been signed in manuscript by him.
+
+5. An origin declaration may be made out after exportation provided that it is presented in the importing Party no later than two years, or the period specified in the legislation of the importing Party, after the entry of the goods into the territory.
+
+6. The conditions for making out an origin declaration referred to in paragraphs 1 to 5 apply mutatis mutandis to statements of origin made out by an exporter registered as provided for in subparagraphs 1(c) and 2(c) of Article 15 (General Requirements). 
+
+#### Approved Exporter
+
+1. The competent authorities of the exporting Party may authorise any exporter (hereinafter referred to as "approved exporter") who exports products under the United Kingdom-Viet Nam Agreement to make out origin declarations irrespective of the value of the products concerned. An exporter seeking such authorisation shall offer to the satisfaction of the competent authorities all guarantees necessary to verify the originating status of the products as well as the fulfilment of the other requirements of this Origin Reference Document.
+
+2. The competent authorities may grant the status of approved exporter subject to any conditions specified in domestic legislation which they consider appropriate.
+
+3. The competent authorities shall grant to the approved exporter an authorisation number which shall appear on the origin declaration.
+
+4. The competent authorities shall monitor the use of the authorisation by the approved exporter.
+
+5. The competent authorities may withdraw the authorisation at any time. They shall do so when the approved exporter no longer offers the guarantees referred to in paragraph 1, no longer fulfils the conditions referred to in paragraph 2 or otherwise makes an incorrect use of the authorisation. 

--- a/db/rules_of_origin/roo_schemes_uk/proofs/vietnam/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/vietnam/origin-declaration.md
@@ -1,4 +1,4 @@
-An 'origon declaration', given by the exporter on an invoice, a delivery note or any other commercial document describes the products concerned in sufficient detail to enable them to be identified. The text of the invoice declaration appears in Appendix 4 of the [origin reference document](ord).
+An 'origin declaration', given by the exporter on an invoice, a delivery note or any other commercial document describes the products concerned in sufficient detail to enable them to be identified. The text of the invoice declaration appears in Appendix 4 of the [origin reference document](ord).
 
 In the UK, the exporter’s reference number will be the EORI number. If you do not have one, you can [apply for an EORI number](https://www.gov.uk/eori). 
 

--- a/spec/factories/rules_of_origin/proof_factory.rb
+++ b/spec/factories/rules_of_origin/proof_factory.rb
@@ -2,7 +2,12 @@ FactoryBot.define do
   factory :rules_of_origin_proof, class: 'RulesOfOrigin::Proof' do
     sequence(:summary) { |n| "Proof #{n}" }
     sequence(:detail)  { |n| "proof-#{n}.md" }
-    proof_class { 'origin-declaration' }
+    sequence(:proof_class) { |n| "origin-declaration-#{n}" }
     subtext { 'subtext' }
+    content { "Opening paragraph\n\n* Some\n* Bullet\n* Points" }
+
+    trait :with_scheme do
+      scheme { build :rules_of_origin_scheme }
+    end
   end
 end

--- a/spec/serializers/api/v2/rules_of_origin/full_scheme_serializer_spec.rb
+++ b/spec/serializers/api/v2/rules_of_origin/full_scheme_serializer_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe Api::V2::RulesOfOrigin::FullSchemeSerializer do
             summary: scheme.proofs[0].summary,
             url: scheme.proofs[0].url,
             subtext: scheme.proofs[0].subtext,
+            content: scheme.proofs[0].content,
           },
         },
         {
@@ -125,8 +126,9 @@ RSpec.describe Api::V2::RulesOfOrigin::FullSchemeSerializer do
           type: :rules_of_origin_proof,
           attributes: {
             summary: scheme.proofs[1].summary,
-            url: scheme.proofs[0].url,
-            subtext: scheme.proofs[0].subtext,
+            url: scheme.proofs[1].url,
+            subtext: scheme.proofs[1].subtext,
+            content: scheme.proofs[1].content,
           },
         },
         {

--- a/spec/serializers/api/v2/rules_of_origin/proof_serializer_spec.rb
+++ b/spec/serializers/api/v2/rules_of_origin/proof_serializer_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe Api::V2::RulesOfOrigin::ProofSerializer do
   subject(:serializable) { described_class.new(proof).serializable_hash }
 
   let(:scheme_set) { instance_double RulesOfOrigin::SchemeSet, proof_urls: urls }
-  let(:scheme) { build :rules_of_origin_scheme, scheme_set: scheme_set }
-  let(:proof) { build :rules_of_origin_proof, scheme: scheme }
+  let(:scheme) { build :rules_of_origin_scheme, scheme_set: }
+  let(:proof) { build :rules_of_origin_proof, scheme: }
   let(:urls) { { 'origin-declaration' => 'https://www.gov.uk/' } }
 
   let :expected do
@@ -15,6 +15,7 @@ RSpec.describe Api::V2::RulesOfOrigin::ProofSerializer do
           summary: proof.summary,
           subtext: proof.subtext,
           url: proof.url,
+          content: proof.content,
         },
       },
     }


### PR DESCRIPTION
### Jira link

HOTT-2561 and HOTT-2569

### What?

I have added/removed/altered:

- [x] Added markdown files for the content for the proofs API (HOTT-2569)
- [x] Extended the proofs API to include that content
- [x] Updated the UK schemes file to refer to the new markdown content

### Why?

I am doing this because:

- We want to show the proofs content on the new rules of origin tab

### Deployment risks (optional)

- Switches the required proofs for a lot of schemes, and the new proofs do not have reference URLs
- They do have content available in the API though and the frontend has a corresponding PR to switch to using that content
