### PR TITLE
HOTT-2605: Migrate to opensearch client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,8 +26,7 @@ gem 'sidekiq'
 gem 'sidekiq-scheduler'
 
 # Elasticsearch
-gem 'elasticsearch', '~> 7.9.0' # Bumping this causes failures
-gem 'elasticsearch-extensions'
+gem 'opensearch-ruby'
 
 # Helpers
 gem 'bootsnap', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,17 +141,6 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
-    elasticsearch (7.9.0)
-      elasticsearch-api (= 7.9.0)
-      elasticsearch-transport (= 7.9.0)
-    elasticsearch-api (7.9.0)
-      multi_json
-    elasticsearch-extensions (0.0.33)
-      ansi
-      elasticsearch
-    elasticsearch-transport (7.9.0)
-      faraday (~> 1)
-      multi_json
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
@@ -269,6 +258,14 @@ GEM
     omniauth-rails_csrf_protection (1.0.1)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
+    opensearch-api (2.1.0)
+      multi_json
+    opensearch-ruby (2.1.0)
+      opensearch-api (~> 2.1)
+      opensearch-transport (~> 2.0)
+    opensearch-transport (2.1.0)
+      faraday (>= 1.0, < 3)
+      multi_json
     parallel (1.22.1)
     parser (3.1.3.0)
       ast (~> 2.4.1)
@@ -451,8 +448,6 @@ DEPENDENCIES
   connection_pool
   database_cleaner-sequel
   dotenv-rails
-  elasticsearch (~> 7.9.0)
-  elasticsearch-extensions
   factory_bot_rails
   fakefs
   foreman
@@ -469,6 +464,7 @@ DEPENDENCIES
   newrelic_rpm
   nokogiri
   omniauth-rails_csrf_protection
+  opensearch-ruby
   pg
   plek
   pry-byebug

--- a/app/lib/sequel/plugins/elasticsearch.rb
+++ b/app/lib/sequel/plugins/elasticsearch.rb
@@ -19,7 +19,7 @@ module Sequel
 
           self.class.elasticsearch_indexes.each do |index_class|
             TradeTariffBackend.search_client.index(index_class, self)
-          rescue ::Elasticsearch::Transport::Transport::Errors::NotFound
+          rescue ::OpenSearch::Transport::Transport::Errors::NotFound
             false
           end
         end
@@ -29,7 +29,7 @@ module Sequel
 
           self.class.elasticsearch_indexes.each do |index_class|
             TradeTariffBackend.search_client.index(index_class, self)
-          rescue ::Elasticsearch::Transport::Transport::Errors::NotFound
+          rescue ::OpenSearch::Transport::Transport::Errors::NotFound
             false
           end
         end
@@ -39,7 +39,7 @@ module Sequel
 
           self.class.elasticsearch_indexes.each do |index_class|
             TradeTariffBackend.search_client.delete(index_class, self)
-          rescue ::Elasticsearch::Transport::Transport::Errors::NotFound
+          rescue ::OpenSearch::Transport::Transport::Errors::NotFound
             false
           end
         end

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -112,7 +112,7 @@ module TradeTariffBackend
 
     def search_client
       @search_client ||= SearchClient.new(
-        OpenSearch::Client.new,
+        OpenSearch::Client.new(opensearch_configuration),
         indexes: search_indexes,
         index_page_size: 500,
       )
@@ -120,7 +120,7 @@ module TradeTariffBackend
 
     def v2_search_client
       @v2_search_client ||= SearchClient.new(
-        OpenSearch::Client.new,
+        OpenSearch::Client.new(opensearch_configuration),
         indexes: v2_search_indexes,
         index_page_size: 2000,
       )
@@ -128,7 +128,7 @@ module TradeTariffBackend
 
     def cache_client
       @cache_client ||= SearchClient.new(
-        OpenSearch::Client.new,
+        OpenSearch::Client.new(opensearch_configuration),
         namespace: 'cache',
         indexes: cache_indexes,
         index_page_size: 5,
@@ -271,6 +271,21 @@ module TradeTariffBackend
 
     def aggregated_synonyms_file
       ENV.fetch('AGGREGATED_SYNONYMS_FILE', 'config/opensearch/synonyms_all.txt')
+    end
+
+    def opensearch_configuration
+      {
+        host: opensearch_host,
+        log: opensearch_debug,
+      }
+    end
+
+    def opensearch_host
+      ENV.fetch('ELASTICSEARCH_URL', 'http://localhost:9200')
+    end
+
+    def opensearch_debug
+      ENV.fetch('OPENSEARCH_DEBUG', 'false') == 'true'
     end
   end
 end

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -112,7 +112,7 @@ module TradeTariffBackend
 
     def search_client
       @search_client ||= SearchClient.new(
-        Elasticsearch::Client.new,
+        OpenSearch::Client.new,
         indexes: search_indexes,
         index_page_size: 500,
       )
@@ -120,7 +120,7 @@ module TradeTariffBackend
 
     def v2_search_client
       @v2_search_client ||= SearchClient.new(
-        Elasticsearch::Client.new,
+        OpenSearch::Client.new,
         indexes: v2_search_indexes,
         index_page_size: 2000,
       )
@@ -128,7 +128,7 @@ module TradeTariffBackend
 
     def cache_client
       @cache_client ||= SearchClient.new(
-        Elasticsearch::Client.new,
+        OpenSearch::Client.new,
         namespace: 'cache',
         indexes: cache_indexes,
         index_page_size: 5,

--- a/app/services/search_service/fuzzy_search.rb
+++ b/app/services/search_service/fuzzy_search.rb
@@ -17,7 +17,7 @@ class SearchService
             })
           end
         end
-      rescue Elasticsearch::Transport::Transport::Error
+      rescue OpenSearch::Transport::Transport::Error
         # rescue from malformed queries, return empty resultset in that case
         BLANK_RESULT
       end

--- a/app/services/search_service/fuzzy_search.rb
+++ b/app/services/search_service/fuzzy_search.rb
@@ -2,20 +2,18 @@ class SearchService
   class FuzzySearch < BaseSearch
     def search!
       begin
-        @results ||= begin
-          FuzzySearchResult.new(query_string, date).each_with_object({}) do |(match_type, search_index, results), memo|
-            results.uniq! do |result|
-              if result['_source'].has_key?('reference')
-                result['_source']['reference']['id']
-              else
-                result
-              end
+        @results ||= FuzzySearchResult.new(query_string, date).each_with_object({}) do |(match_type, search_index, results), memo|
+          results.uniq! do |result|
+            if result['_source'].key?('reference')
+              result['_source']['reference']['id']
+            else
+              result
             end
-
-            memo.deep_merge!({
-              match_type => { search_index.type.pluralize => results }
-            })
           end
+
+          memo.deep_merge!({
+            match_type => { search_index.type.pluralize => results },
+          })
         end
       rescue OpenSearch::Transport::Transport::Error
         # rescue from malformed queries, return empty resultset in that case

--- a/app/workers/build_index_page_worker.rb
+++ b/app/workers/build_index_page_worker.rb
@@ -4,7 +4,7 @@ class BuildIndexPageWorker
   sidekiq_options queue: :default, retry: false
 
   def perform(index_namespace, index_name, page_number, page_size)
-    client = Elasticsearch::Client.new
+    client = OpenSearch::Client.new
     index_name = "#{index_name}Index" unless index_name.ends_with?('Index')
     index = "#{index_namespace.camelize}::#{index_name}".constantize.new
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,30 +22,30 @@ services:
       - hmrc-postgres:/var/lib/postgresql/data
   hmrc-opensearch:
     container_name: hmrc-opensearch
-    image: opensearchproject/opensearch:1.2.4
+    image: opensearchproject/opensearch:2
     ports:
       - 127.0.0.1:9200:9200
       - 127.0.0.1:9300:9300
     environment:
-        - bootstrap.memory_lock=true
-        - discovery.type=single-node
-        - "OPENSEARCH_JAVA_OPTS=-Xms2g -Xmx2g"
-        - cluster.routing.allocation.disk.threshold_enabled=false
-        - plugins.security.disabled=true
+      - bootstrap.memory_lock=true
+      - discovery.type=single-node
+      - "OPENSEARCH_JAVA_OPTS=-Xms2g -Xmx2g"
+      - cluster.routing.allocation.disk.threshold_enabled=false
+      - plugins.security.disabled=true
     ulimits:
-        memlock:
-            soft: -1
-            hard: -1
-        nofile:
-          soft: 65536
-          hard: 65536
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
     healthcheck:
       interval: 60s
       retries: 10
       test: curl -s http://localhost:9200/_cluster/health | grep -vq '"status":"red"'
     volumes:
-    - hmrc-os:/usr/share/opensearch/data
-    - ./config/opensearch/synonyms_all.txt:/usr/share/opensearch/config/synonyms_all.txt
+      - hmrc-os:/usr/share/opensearch/data
+      - ./config/opensearch/synonyms_all.txt:/usr/share/opensearch/config/synonyms_all.txt
 
 volumes:
   dev-env-redis-volume:

--- a/spec/integration/tariff_synchronizer_spec.rb
+++ b/spec/integration/tariff_synchronizer_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe TariffSynchronizer do
       before do
         expect_any_instance_of(TaricImporter::Transaction).to receive(
           :persist,
-        ).and_raise Elasticsearch::Transport::Transport::SnifferTimeoutError
+        ).and_raise OpenSearch::Transport::Transport::SnifferTimeoutError
       end
 
       it 'stops syncing' do

--- a/spec/integration/tariff_synchronizer_spec.rb
+++ b/spec/integration/tariff_synchronizer_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe TariffSynchronizer do
   describe '#apply', truncation: true do
     let!(:taric_update_applied) { create :taric_update, :applied, example_date: example_date - 1.day }
-    let!(:taric_update) { create :taric_update, :pending, example_date: example_date }
+    let!(:taric_update) { create :taric_update, :pending, example_date: }
 
     before(:context) do
       prepare_synchronizer_folders

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,7 +15,6 @@ require 'rspec/rails'
 require 'json_expressions/rspec'
 require 'fakefs/spec_helpers'
 require 'sidekiq/testing'
-require 'elasticsearch/extensions/test/cluster'
 
 Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2605

### What?

You can see that the maintainers are the same for both gems - the api is also exactly the same:

![2023-01-31-150155_3392x1370_scrot](https://user-images.githubusercontent.com/8156884/215796531-dbe868f4-9bb9-47b3-bbca-c26c77fe0684.png)

I have added/removed/altered:

- [x] Upgrade to 2.x opensearch in docker-compose
- [x] Migrate from elasticsearch to opensearch client

### Why?

I am doing this because:

- We've been pinned to an older version of the elasticsearch gem (maintained by the same people and with the same api) for a long time now. I generally don't like not being able to upgrade gems and this solves that.
- In my local docker-compose I've been using 2.x for a while now - this reflects what we're using in aws, too

### AC

- [x] Can reindex beta search
- [x] Can view a heading retrieved from the opensearch cache on dev
- [x] Can perform legacy search on dev
- [x] Can perform beta search on dev
