### PR TITLE
HOTT-2577: Prewarm quota order numbers after sync

### DIFF
--- a/app/controllers/api/v2/quota_order_numbers_controller.rb
+++ b/app/controllers/api/v2/quota_order_numbers_controller.rb
@@ -1,30 +1,8 @@
 module Api
   module V2
     class QuotaOrderNumbersController < ApiController
-      TTL = 1.day
-      DEFAULT_INCLUDES = [:quota_definition, 'quota_definition.measures'].freeze
-
       def index
-        render json: serialized_quota_order_numbers
-      end
-
-      private
-
-      def serialized_quota_order_numbers
-        Rails.cache.fetch(cache_key, expires_in: TTL) do
-          Api::V2::QuotaOrderNumbers::QuotaOrderNumberSerializer.new(
-            quota_order_numbers,
-            include: DEFAULT_INCLUDES,
-          ).serializable_hash
-        end
-      end
-
-      def cache_key
-        "_quota-order-numbers-#{actual_date.iso8601}"
-      end
-
-      def quota_order_numbers
-        QuotaOrderNumber.with_quota_definitions
+        render json: CachedQuotaOrderNumberService.new.call
       end
     end
   end

--- a/app/services/cached_quota_order_number_service.rb
+++ b/app/services/cached_quota_order_number_service.rb
@@ -14,10 +14,6 @@ class CachedQuotaOrderNumberService
 
   private
 
-  def cache_key
-    "_commodity-v#{CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}-#{geographical_area_id}-#{meursing_additional_code_id}"
-  end
-
   def quota_order_numbers
     QuotaOrderNumber.with_quota_definitions
   end

--- a/app/services/cached_quota_order_number_service.rb
+++ b/app/services/cached_quota_order_number_service.rb
@@ -1,0 +1,32 @@
+class CachedQuotaOrderNumberService
+  DEFAULT_INCLUDES = [:quota_definition, 'quota_definition.measures'].freeze
+
+  TTL = 1.day
+
+  def call
+    Rails.cache.fetch(cache_key, expires_in: TTL) do
+      Api::V2::QuotaOrderNumbers::QuotaOrderNumberSerializer.new(
+        quota_order_numbers,
+        include: DEFAULT_INCLUDES,
+      ).serializable_hash
+    end
+  end
+
+  private
+
+  def cache_key
+    "_commodity-v#{CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}-#{geographical_area_id}-#{meursing_additional_code_id}"
+  end
+
+  def quota_order_numbers
+    QuotaOrderNumber.with_quota_definitions
+  end
+
+  def cache_key
+    "_quota-order-numbers-#{actual_date}"
+  end
+
+  def actual_date
+    QuotaOrderNumber.point_in_time&.to_date&.iso8601
+  end
+end

--- a/app/workers/clear_cache_worker.rb
+++ b/app/workers/clear_cache_worker.rb
@@ -8,6 +8,7 @@ class ClearCacheWorker
     Rails.cache.clear
     logger.info 'Clearing Rails cache completed'
 
+    Sidekiq::Client.enqueue(PrewarmQuotaOrderNumbersWorker)
     Sidekiq::Client.enqueue(ReindexModelsWorker)
     Sidekiq::Client.enqueue(PrewarmSubheadingsWorker)
     # TODO: Recaching takes ages (c 5 hours) and shouldn't really take more than 20 minutes

--- a/app/workers/prewarm_quota_order_numbers_worker.rb
+++ b/app/workers/prewarm_quota_order_numbers_worker.rb
@@ -1,0 +1,11 @@
+class PrewarmQuotaOrderNumbersWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :default, retry: true
+
+  def perform
+    TimeMachine.now do
+      CachedQuotaOrderNumberService.new.call
+    end
+  end
+end

--- a/spec/controllers/api/v2/quota_order_numbers_controller_spec.rb
+++ b/spec/controllers/api/v2/quota_order_numbers_controller_spec.rb
@@ -2,9 +2,6 @@ RSpec.describe Api::V2::QuotaOrderNumbersController, type: :controller do
   describe '#index' do
     subject(:do_request) { get :index }
 
-    let(:json_body) { JSON.parse(do_request.body) }
-    let(:validity_end_date) { nil }
-
     before do
       create(
         :quota_order_number,
@@ -14,51 +11,15 @@ RSpec.describe Api::V2::QuotaOrderNumbersController, type: :controller do
         quota_definition_sid: 1,
         quota_order_number_sid: 5,
         quota_order_number_id: '000001',
-        validity_end_date:,
-      )
-
-      allow(TimeMachine).to receive(:at).and_call_original
-      allow(Rails.cache).to receive(:fetch).and_call_original
-    end
-
-    it { is_expected.to have_http_status(:success) }
-
-    it 'returns all the records' do
-      expect(json_body['data']).to eq(
-        [
-          {
-            'id' => '000001',
-            'type' => 'quota_order_number',
-            'attributes' => {
-              'quota_order_number_sid' => 5,
-              'validity_start_date' => 4.years.ago.beginning_of_day.as_json,
-              'validity_end_date' => nil,
-            },
-            'relationships' => {
-              'quota_definition' => { 'data' => { 'id' => '1', 'type' => 'quota_definition' } },
-            },
-          },
-        ],
       )
     end
 
-    context 'when the validity_end_date is set to a past date' do
-      let(:validity_end_date) { 1.day.ago }
+    it_behaves_like 'a successful jsonapi response'
 
-      it { expect(json_body['data']).to eq [] }
-    end
-
-    it 'returns all the includes' do
-      expect(json_body['included']).to include_json(
-        [
-          { 'id' => '1', 'type' => 'quota_definition' },
-        ],
-      )
-    end
-
-    it 'rails cache receives fetch with the correct key' do
+    it 'calls the CachedQuotaOrderNumberService' do
+      allow(CachedQuotaOrderNumberService).to receive(:new).and_call_original
       do_request
-      expect(Rails.cache).to have_received(:fetch).with("_quota-order-numbers-#{Time.zone.today.iso8601}", expires_in: 1.day)
+      expect(CachedQuotaOrderNumberService).to have_received(:new)
     end
   end
 end

--- a/spec/services/cached_quota_order_number_service_spec.rb
+++ b/spec/services/cached_quota_order_number_service_spec.rb
@@ -1,0 +1,92 @@
+RSpec.describe CachedQuotaOrderNumberService do
+  describe '#call' do
+    subject(:result) { described_class.new.call.as_json }
+
+    before do
+      create(
+        :quota_order_number,
+        :with_quota_definition,
+        :current,
+        :current_definition,
+        quota_definition_sid: 1,
+        quota_order_number_sid: 5,
+        quota_order_number_id: '000001',
+        validity_end_date:,
+      )
+    end
+
+    context 'when quota order numbers are current' do
+      let(:validity_end_date) { nil }
+      let(:pattern) do
+        {
+          'data' => [
+            {
+              'id' => match(/\d+/),
+              'type' => 'quota_order_number',
+              'attributes' => {
+                'quota_order_number_sid' => be_a(Integer),
+                'validity_start_date' => 4.years.ago.beginning_of_day.as_json,
+                'validity_end_date' => nil,
+              },
+              'relationships' => {
+                'quota_definition' => {
+                  'data' => {
+                    'id' => match(/\d+/),
+                    'type' => 'quota_definition',
+                  },
+                },
+              },
+            },
+          ],
+          'included' => [
+            {
+              'id' => match(/\d+/),
+              'type' => 'quota_definition',
+              'attributes' => {
+                'quota_order_number_id' => match(/\d+/),
+                'validity_start_date' => 4.years.ago.beginning_of_day.as_json,
+                'validity_end_date' => nil,
+                'initial_volume' => nil,
+                'measurement_unit_code' => be_present,
+                'measurement_unit_qualifier_code' => be_present,
+                'maximum_precision' => nil,
+                'critical_threshold' => be_a(Integer),
+                'measurement_unit' => nil,
+              },
+              'relationships' => { 'measures' => { 'data' => [] } },
+            },
+          ],
+        }
+      end
+
+      it { TimeMachine.now { expect(result).to include_json(pattern) } }
+
+      it 'rails cache receives fetch with the correct key' do
+        allow(Rails.cache).to receive(:fetch).and_call_original
+
+        TimeMachine.now { result }
+
+        expect(Rails.cache)
+          .to have_received(:fetch)
+          .with("_quota-order-numbers-#{Time.zone.today.iso8601}", expires_in: 1.day)
+      end
+    end
+
+    context 'when quota order numbers are not current' do
+      let(:validity_end_date) { 1.day.ago }
+      let(:pattern) { { 'data' => [], 'included' => [] } }
+
+      it { TimeMachine.now { expect(result).to eq(pattern) } }
+
+      it 'rails cache receives fetch with the correct key' do
+        allow(Rails.cache).to receive(:fetch).and_call_original
+
+        TimeMachine.now { result }
+
+        expect(Rails.cache)
+          .to have_received(:fetch)
+          .with("_quota-order-numbers-#{Time.zone.today.iso8601}", expires_in: 1.day)
+      end
+    end
+  end
+end

--- a/spec/workers/clear_cache_worker_spec.rb
+++ b/spec/workers/clear_cache_worker_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ClearCacheWorker, type: :worker do
   end
 
   it { expect(Rails.cache).to have_received(:clear) }
+  it { expect(Sidekiq::Client).to have_received(:enqueue).with(PrewarmQuotaOrderNumbersWorker) }
   it { expect(Sidekiq::Client).to have_received(:enqueue).with(PrewarmSubheadingsWorker) }
   it { expect(Sidekiq::Client).to have_received(:enqueue).with(RecacheModelsWorker) }
   it { expect(Sidekiq::Client).to have_received(:enqueue).with(ReindexModelsWorker) }

--- a/spec/workers/prewarm_quota_order_numbers_worker_spec.rb
+++ b/spec/workers/prewarm_quota_order_numbers_worker_spec.rb
@@ -18,44 +18,4 @@ RSpec.describe PrewarmQuotaOrderNumbersWorker do
       expect(TimeMachine).to have_received(:now)
     end
   end
-
-  context 'when there are subheadings to populate' do
-    before do
-      GoodsNomenclature.unrestrict_primary_key
-
-      create(:chapter, :with_section, :with_indent, :with_guide, goods_nomenclature_sid: 1, indents: 0, producline_suffix: '80', goods_nomenclature_item_id: '0100000000')       # Live animals
-      create(:heading, :with_indent, :with_description, goods_nomenclature_sid: 2, indents: 0, producline_suffix: '80', goods_nomenclature_item_id: '0101000000')   # Live horses, asses, mules and hinnies
-      create(:commodity, :with_indent, :with_description, goods_nomenclature_sid: 3, indents: 1, producline_suffix: '10', goods_nomenclature_item_id: '0101210000') # Horses
-      create(:commodity, :with_indent, :with_description, :with_overview_measures, goods_nomenclature_sid: 4, indents: 2, producline_suffix: '80', goods_nomenclature_item_id: '0101290000') # -- Other
-      create(:commodity, :with_indent, :with_description, goods_nomenclature_sid: 5, indents: 3, producline_suffix: '80', goods_nomenclature_item_id: '0101291000') # ---- For slaughter
-      create(:commodity, :with_indent, :with_description, goods_nomenclature_sid: 6, indents: 3, producline_suffix: '80', goods_nomenclature_item_id: '0101299000') # ---- Other
-    end
-
-    it 'invokes the CachedCommodityService' do
-      worker.perform
-
-      expect(CachedSubheadingService).to have_received(:new).with(an_instance_of(Subheading), Time.zone.today.iso8601).twice
-    end
-
-    it 'invokes the BufferHeadingCommoditiesService' do
-      worker.perform
-
-      expect(BufferHeadingCommoditiesService).to have_received(:new)
-    end
-
-    it 'caches the correct subheadings' do
-      worker.perform
-
-      today = Time.zone.today.iso8601
-
-      expected_cache_keys = [
-        "_subheading-3-#{today}", # Horses
-        "_subheading-4-#{today}", # -- Other
-      ]
-
-      expected_cache_keys.each do |cache_key|
-        expect(Rails.cache).to have_received(:fetch).with(cache_key, expires_in: 23.hours)
-      end
-    end
-  end
 end

--- a/spec/workers/prewarm_quota_order_numbers_worker_spec.rb
+++ b/spec/workers/prewarm_quota_order_numbers_worker_spec.rb
@@ -1,0 +1,61 @@
+RSpec.describe PrewarmQuotaOrderNumbersWorker do
+  subject(:worker) { described_class.new }
+
+  describe '#perform' do
+    it 'calls the CachedQuotaOrderNumberService' do
+      allow(CachedQuotaOrderNumberService).to receive(:new).and_call_original
+
+      worker.perform
+
+      expect(CachedQuotaOrderNumberService).to have_received(:new)
+    end
+
+    it 'uses the TimeMachine' do
+      allow(TimeMachine).to receive(:now).and_call_original
+
+      worker.perform
+
+      expect(TimeMachine).to have_received(:now)
+    end
+  end
+
+  context 'when there are subheadings to populate' do
+    before do
+      GoodsNomenclature.unrestrict_primary_key
+
+      create(:chapter, :with_section, :with_indent, :with_guide, goods_nomenclature_sid: 1, indents: 0, producline_suffix: '80', goods_nomenclature_item_id: '0100000000')       # Live animals
+      create(:heading, :with_indent, :with_description, goods_nomenclature_sid: 2, indents: 0, producline_suffix: '80', goods_nomenclature_item_id: '0101000000')   # Live horses, asses, mules and hinnies
+      create(:commodity, :with_indent, :with_description, goods_nomenclature_sid: 3, indents: 1, producline_suffix: '10', goods_nomenclature_item_id: '0101210000') # Horses
+      create(:commodity, :with_indent, :with_description, :with_overview_measures, goods_nomenclature_sid: 4, indents: 2, producline_suffix: '80', goods_nomenclature_item_id: '0101290000') # -- Other
+      create(:commodity, :with_indent, :with_description, goods_nomenclature_sid: 5, indents: 3, producline_suffix: '80', goods_nomenclature_item_id: '0101291000') # ---- For slaughter
+      create(:commodity, :with_indent, :with_description, goods_nomenclature_sid: 6, indents: 3, producline_suffix: '80', goods_nomenclature_item_id: '0101299000') # ---- Other
+    end
+
+    it 'invokes the CachedCommodityService' do
+      worker.perform
+
+      expect(CachedSubheadingService).to have_received(:new).with(an_instance_of(Subheading), Time.zone.today.iso8601).twice
+    end
+
+    it 'invokes the BufferHeadingCommoditiesService' do
+      worker.perform
+
+      expect(BufferHeadingCommoditiesService).to have_received(:new)
+    end
+
+    it 'caches the correct subheadings' do
+      worker.perform
+
+      today = Time.zone.today.iso8601
+
+      expected_cache_keys = [
+        "_subheading-3-#{today}", # Horses
+        "_subheading-4-#{today}", # -- Other
+      ]
+
+      expected_cache_keys.each do |cache_key|
+        expect(Rails.cache).to have_received(:fetch).with(cache_key, expires_in: 23.hours)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2577

### What?

I have added/removed/altered:

- [x] Extract caching quota order numbers into a service and add tests
- [x] Adds prewarm quota order numbers worker
- [x] Kick off prewarm quotas after sync

### Why?

I am doing this because:

- This is needed to make sure the change XLSX reports we generate for HMRC have the data they need ahead of a busy morning
