### PR TITLE
HOTT-2605: Consolidate all opensearch client configuration

### DIFF
--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -112,7 +112,7 @@ module TradeTariffBackend
 
     def search_client
       @search_client ||= SearchClient.new(
-        OpenSearch::Client.new(opensearch_configuration),
+        opensearch_client,
         indexes: search_indexes,
         index_page_size: 500,
       )
@@ -120,7 +120,7 @@ module TradeTariffBackend
 
     def v2_search_client
       @v2_search_client ||= SearchClient.new(
-        OpenSearch::Client.new(opensearch_configuration),
+        opensearch_client,
         indexes: v2_search_indexes,
         index_page_size: 2000,
       )
@@ -128,7 +128,7 @@ module TradeTariffBackend
 
     def cache_client
       @cache_client ||= SearchClient.new(
-        OpenSearch::Client.new(opensearch_configuration),
+        opensearch_client,
         namespace: 'cache',
         indexes: cache_indexes,
         index_page_size: 5,
@@ -271,6 +271,10 @@ module TradeTariffBackend
 
     def aggregated_synonyms_file
       ENV.fetch('AGGREGATED_SYNONYMS_FILE', 'config/opensearch/synonyms_all.txt')
+    end
+
+    def opensearch_client
+      @opensearch_client ||= OpenSearch::Client.new(opensearch_configuration)
     end
 
     def opensearch_configuration

--- a/app/workers/build_index_page_worker.rb
+++ b/app/workers/build_index_page_worker.rb
@@ -3,12 +3,13 @@ class BuildIndexPageWorker
 
   sidekiq_options queue: :default, retry: false
 
+  delegate :opensearch_client, to: TradeTariffBackend
+
   def perform(index_namespace, index_name, page_number, page_size)
-    client = OpenSearch::Client.new
     index_name = "#{index_name}Index" unless index_name.ends_with?('Index')
     index = "#{index_namespace.camelize}::#{index_name}".constantize.new
 
-    client.bulk(
+    opensearch_client.bulk(
       body: serialize_for(
         :index,
         index,


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2605

### What?

I have added/removed/altered:

- [x] Added consolidated client that is reused by all workers/indexers

### Why?

I am doing this because:

- This is required to make updating the client configuration simpler and to fix broken configuration I missed
