### PR TITLE
HOTT-2495: Adds start/end dates to footnote api

### DIFF
--- a/app/controllers/api/v2/footnotes_controller.rb
+++ b/app/controllers/api/v2/footnotes_controller.rb
@@ -31,9 +31,9 @@ module Api
             pagination: {
               page: current_page,
               per_page:,
-              total_count: search_service.pagination_record_count
-            }
-          }
+              total_count: search_service.pagination_record_count,
+            },
+          },
         }
       end
     end

--- a/app/serializers/api/v2/footnotes/footnote_serializer.rb
+++ b/app/serializers/api/v2/footnotes/footnote_serializer.rb
@@ -8,7 +8,14 @@ module Api
 
         set_id :code
 
-        attributes :code, :footnote_type_id, :footnote_id, :description, :formatted_description, :extra_large_measures
+        attributes :code,
+                   :footnote_type_id,
+                   :footnote_id,
+                   :description,
+                   :formatted_description,
+                   :extra_large_measures,
+                   :validity_start_date,
+                   :validity_end_date
 
         has_many :measures, serializer: Api::V2::Shared::MeasureSerializer
         has_many :goods_nomenclatures,

--- a/spec/controllers/api/v2/footnotes_controller_spec.rb
+++ b/spec/controllers/api/v2/footnotes_controller_spec.rb
@@ -2,108 +2,6 @@ RSpec.describe Api::V2::FootnotesController, type: :controller do
   subject(:do_response) { get :search, params: query, format: :json && response }
 
   let(:footnote) { create(:footnote, :with_description) }
-  let(:pattern) do
-    {
-      data: [
-        {
-          id: String,
-          type: 'footnote',
-          attributes: {
-            code: String,
-            footnote_type_id: String,
-            footnote_id: String,
-            description: String,
-            formatted_description: String,
-            extra_large_measures: false,
-          },
-          relationships: {
-            measures: {
-              data: [
-                {
-                  id: String,
-                  type: 'measure',
-                },
-              ],
-            },
-            goods_nomenclatures: {
-              data: [
-                {
-                  id: String,
-                  type: 'heading',
-                },
-                {
-                  id: String,
-                  type: 'chapter',
-                },
-              ],
-            },
-          },
-        },
-      ],
-      included: [
-        {
-          id: String,
-          type: 'chapter',
-          attributes: {
-            goods_nomenclature_item_id: String,
-            description: String,
-            formatted_description: String,
-            producline_suffix: String,
-          },
-        },
-        {
-          id: String,
-          type: 'heading',
-          attributes: {
-            goods_nomenclature_item_id: String,
-            description: String,
-            formatted_description: String,
-            producline_suffix: String,
-          },
-        },
-        {
-          id: String,
-          type: 'heading',
-          attributes: {
-            goods_nomenclature_item_id: String,
-            description: String,
-            formatted_description: String,
-            producline_suffix: String,
-          },
-        },
-        {
-          id: String,
-          type: 'measure',
-          attributes: {
-            goods_nomenclature_item_id: String,
-            validity_start_date: String,
-            validity_end_date: String,
-          },
-          relationships: {
-            goods_nomenclature: {
-              data: {
-                id: String,
-                type: 'heading',
-              },
-            },
-            geographical_area: {
-              data: {
-                id: String,
-                type: 'geographical_area',
-              },
-            },
-          },
-        },
-      ],
-      meta: {
-        pagination: {
-          page: Integer,
-          per_page: Integer,
-          total_count: Integer,
-        },
-      },
-    }
-  end
 
   before do
     measure_with_goods_nomenclature = create(:measure, :with_base_regulation, goods_nomenclature: create(:heading, :with_description))
@@ -125,19 +23,19 @@ RSpec.describe Api::V2::FootnotesController, type: :controller do
   context 'when searching by the code' do
     let(:query) { { code: footnote.footnote_id } }
 
-    it { expect(do_response.body).to match_json_expression pattern }
+    it_behaves_like 'a successful jsonapi response'
   end
 
   context 'when searching by type' do
     let(:query) { { type: footnote.footnote_type_id } }
 
-    it { expect(do_response.body).to match_json_expression pattern }
+    it_behaves_like 'a successful jsonapi response'
   end
 
   context 'when searching by description' do
     let(:query) { { description: footnote.description } }
 
-    it { expect(do_response.body).to match_json_expression pattern }
+    it_behaves_like 'a successful jsonapi response'
   end
 
   context 'when no footnotes are found' do

--- a/spec/serializers/api/v2/footnotes/footnote_serializer_spec.rb
+++ b/spec/serializers/api/v2/footnotes/footnote_serializer_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe Api::V2::Footnotes::FootnoteSerializer do
               description: String,
               formatted_description: String,
               extra_large_measures: false,
+              validity_start_date: /\d{4}-\d{2}-\d{2}T00:00:00.000Z/,
+              validity_end_date: nil,
             },
             relationships: {
               measures: { data: [{ id: String, type: 'measure' }] },
@@ -76,6 +78,8 @@ RSpec.describe Api::V2::Footnotes::FootnoteSerializer do
               description: String,
               formatted_description: String,
               extra_large_measures: false,
+              validity_start_date: /\d{4}-\d{2}-\d{2}T00:00:00.000Z/,
+              validity_end_date: nil,
             },
             relationships: {
               goods_nomenclatures: { data: [] },


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2495

![image](https://user-images.githubusercontent.com/8156884/216084952-f35ac60b-e24c-4eb3-8990-98e773df24d8.png)

### What?

I have added/removed/altered:

- [x] Added start and end dates to footnote api response

### Why?

I am doing this because:

- This is a feature request
