### PR TITLE
HOTT-2382: Handle null query

### DIFF
--- a/app/services/api/beta/search_service.rb
+++ b/app/services/api/beta/search_service.rb
@@ -5,7 +5,7 @@ module Api
       GOOD_NOMENCLATURE_ITEM_ID_SEARCH = /^(\d+)(-\d{2})?$/
 
       def initialize(search_query, search_params = {})
-        @search_query = search_query
+        @search_query = search_query.to_s
         @search_params = search_params
       end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2382

### What?

I have added/removed/altered:

- [x] Added handling for null q query param

### Why?

I am doing this because:

- This fixes: https://sentry.io/organizations/engine-le/issues/3812759750/?project=5557005&query=url%3A%22https%3A%2F%2Fwww.trade-tariff.service.gov.uk%2Fuk%2Fapi%2Fbeta%2Fsearch%22&referrer=issue-stream
