### PR TITLE
Revert "HOTT-2574: Kill totally unused/misleading tag"

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.filter_run :focus
   config.run_all_when_everything_filtered = true
   config.expose_dsl_globally = false
 


### PR DESCRIPTION
This reverts commit 4ed74faabef2488cf7b661f807406546461ad2ec.

Standard RSpec feature - in use by developers
