### PR TITLE
HOTT-2565 Include proofs in all schemes api

### DIFF
--- a/app/controllers/api/v2/rules_of_origin_controller.rb
+++ b/app/controllers/api/v2/rules_of_origin_controller.rb
@@ -1,6 +1,9 @@
 module Api
   module V2
     class RulesOfOriginController < ApiController
+      DEFAULT_INCLUDES = %i[links origin_reference_document].freeze
+      OPTIONAL_INCLUDES = %i[proofs].freeze
+
       def index
         query = ::RulesOfOrigin::Query.new(
           TradeTariffBackend.rules_of_origin,
@@ -38,10 +41,11 @@ module Api
       end
 
       def minimal_serializer(schemes)
-        Api::V2::RulesOfOrigin::SchemeSerializer.new schemes, include: %i[
-          links
-          origin_reference_document
-        ]
+        Api::V2::RulesOfOrigin::SchemeSerializer.new schemes, include: includes
+      end
+
+      def includes
+        (params[:include].to_s.split(/\s+/).map(&:to_sym) & OPTIONAL_INCLUDES) + DEFAULT_INCLUDES
       end
     end
   end

--- a/app/serializers/api/v2/rules_of_origin/scheme_serializer.rb
+++ b/app/serializers/api/v2/rules_of_origin/scheme_serializer.rb
@@ -11,6 +11,7 @@ module Api
         attributes :scheme_code, :title, :countries, :unilateral
 
         has_many :links, serializer: Api::V2::RulesOfOrigin::LinkSerializer
+        has_many :proofs, serializer: Api::V2::RulesOfOrigin::ProofSerializer
         has_one :origin_reference_document, serializer: Api::V2::RulesOfOrigin::OriginReferenceDocumentSerializer
       end
     end

--- a/spec/factories/rules_of_origin/scheme_set_factory.rb
+++ b/spec/factories/rules_of_origin/scheme_set_factory.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
       base_path { Rails.root.join('spec/fixtures/rules_of_origin') }
       scope { 'uk' }
       links { [attributes_for(:rules_of_origin_link)] }
-      schemes { [attributes_for(:rules_of_origin_scheme, :with_links)] }
+      schemes { [attributes_for(:rules_of_origin_scheme, :with_links, :with_proofs)] }
       proof_urls { { 'origin-declaration' => 'https://www.gov.uk/' } }
 
       scheme_data do

--- a/spec/requests/api/v2/rules_of_origin_controller_spec.rb
+++ b/spec/requests/api/v2/rules_of_origin_controller_spec.rb
@@ -50,6 +50,17 @@ RSpec.describe Api::V2::RulesOfOriginController do
       it_behaves_like 'a successful jsonapi response'
       it { expect(first_scheme).to include 'scheme_code' }
       it { expect(first_scheme).not_to include 'introductory_notes' }
+
+      context 'with custom includes' do
+        subject { JSON.parse(rendered.body)['included'] }
+
+        let :make_request do
+          get api_rules_of_origin_schemes_path(include: 'proofs', format: :json),
+              headers: { 'Accept' => 'application/vnd.uktt.v2' }
+        end
+
+        it { is_expected.to include include 'type' => 'rules_of_origin_proof' }
+      end
     end
 
     context 'with filtered list of schemes' do

--- a/spec/serializers/api/v2/rules_of_origin/scheme_serializer_spec.rb
+++ b/spec/serializers/api/v2/rules_of_origin/scheme_serializer_spec.rb
@@ -47,6 +47,9 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemeSerializer do
               type: :rules_of_origin_origin_reference_document,
             },
           },
+          proofs: {
+            data: [],
+          },
         },
       },
       included: [


### PR DESCRIPTION
### Jira link

HOTT-2565

### What?

I have added/removed/altered:

- [x] Optionally include proofs of origin in all schemes api

### Why?

I am doing this because:

- we need to show all schemes plus their proofs on a single page on the frontend

### Deployment risks (optional)

- Low