### PR TITLE
HOTT-2631: Fix bug in Taric importer

### DIFF
--- a/app/lib/cds_importer/xml_parser.rb
+++ b/app/lib/cds_importer/xml_parser.rb
@@ -1,7 +1,7 @@
 class CdsImporter
   module XmlParser
     class Reader < Nokogiri::XML::SAX::Document
-      EXTRA_CONTENT = /\n\s+/ # Uncompressed XML has a bunch of contiguous newline-starting strings in between each tag - we skip assigning these bits
+      EXTRA_CONTENT = /^\n\s+/
       CONTENT_KEY = :__content__
 
       def initialize(stringio, target_handler)
@@ -31,6 +31,8 @@ class CdsImporter
       end
 
       def characters(val)
+        # The XML we receive has a bunch of contiguous newline-starting strings that get passed to this callback so we
+        # skip assigning any values that start with newline characters
         return if !@in_target || val =~ EXTRA_CONTENT
 
         @node[CONTENT_KEY] = val

--- a/app/lib/taric_importer/xml_parser.rb
+++ b/app/lib/taric_importer/xml_parser.rb
@@ -1,7 +1,7 @@
 class TaricImporter
   module XmlParser
     class Reader < Nokogiri::XML::SAX::Document
-      EXTRA_CONTENT = /\n\s+/
+      EXTRA_CONTENT = /^\n\s+/
       CONTENT_KEY = :__content__
 
       def initialize(stringio, target, target_handler)
@@ -23,12 +23,15 @@ class TaricImporter
         key = strip_namespace(key)
 
         @in_target = true if key == @target
+        @description = true if key == 'description'
         return unless @in_target
 
         @stack << @node = {}
       end
 
       def characters(val)
+        # The XML we receive has a bunch of contiguous newline-starting strings that get passed to this callback so we
+        # skip assigning any values that start with newline characters
         return if !@in_target || val =~ EXTRA_CONTENT
 
         @node[CONTENT_KEY] = val

--- a/spec/lib/cds_importer/xml_parser_spec.rb
+++ b/spec/lib/cds_importer/xml_parser_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe CdsImporter::XmlParser::Reader do
+  describe '#characters' do
+    shared_examples 'a characters callback' do |in_target, val, expected_result|
+      subject(:reader) { described_class.new(xml_io, handler) }
+
+      let(:xml_io) { StringIO.new }
+      let(:stack) { [{}] }
+      let(:handler) { OpenStruct.new { def process_xml_node(_key, _attributes); end } }
+
+      before do
+        reader.instance_variable_set('@in_target', in_target)
+        reader.instance_variable_set('@stack', stack)
+        reader.instance_variable_set('@node', stack.first)
+      end
+
+      it { expect(reader.characters(val)).to eq(expected_result) }
+    end
+
+    it_behaves_like 'a characters callback', true, "hello\nfoo", "hello\nfoo"
+    it_behaves_like 'a characters callback', true, "\n        ", nil
+    it_behaves_like 'a characters callback', true, '', ''
+    it_behaves_like 'a characters callback', true, nil, nil
+    it_behaves_like 'a characters callback', false, 'foobarbazqux', nil
+  end
+end

--- a/spec/lib/taric_importer/xml_parser_spec.rb
+++ b/spec/lib/taric_importer/xml_parser_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe TaricImporter::XmlParser::Reader do
+  describe '#characters' do
+    shared_examples 'a characters callback' do |in_target, val, expected_result|
+      subject(:reader) { described_class.new(xml_io, 'record', handler) }
+
+      let(:xml_io) { StringIO.new }
+      let(:stack) { [{}] }
+      let(:handler) { OpenStruct.new { def process_xml_node(_attributes); end } }
+
+      before do
+        reader.instance_variable_set('@in_target', in_target)
+        reader.instance_variable_set('@stack', stack)
+        reader.instance_variable_set('@node', stack.first)
+      end
+
+      it { expect(reader.characters(val)).to eq(expected_result) }
+    end
+
+    it_behaves_like 'a characters callback', true, "hello\nfoo", "hello\nfoo"
+    it_behaves_like 'a characters callback', true, "\n        ", nil
+    it_behaves_like 'a characters callback', true, '', ''
+    it_behaves_like 'a characters callback', true, nil, nil
+    it_behaves_like 'a characters callback', false, 'foobarbazqux', nil
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2631

### What?

I have added/removed/altered:

- [x] Adds characters callback specs in the XmlParser::Reader implementations of both CDS and Taric
- [x] Fixes issue with the characters callback which was not checking the start of the line

### Why?

I am doing this because:

- This is causing footnote descriptions to not be imported in the XI service.
- We would have been alerted to this not working on the UK service although I'm sure we will encounter it eventually
