### PR TITLE
HOTT-2622: Adds succeeding/preceeding relationships for origins

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -119,10 +119,12 @@ class GoodsNomenclature < Sequel::Model
 
   delegate :description, :description_indexed, :formatted_description, to: :goods_nomenclature_description, allow_nil: true
 
-  one_to_one :goods_nomenclature_origin, key: %i[goods_nomenclature_item_id
-                                                 productline_suffix],
-                                         primary_key: %i[goods_nomenclature_item_id
-                                                         producline_suffix]
+  # Find goods nomenclature where I am the origin (e.g. who succeed me)
+  one_to_many :derived_goods_nomenclature_origins, key: %i[derived_goods_nomenclature_item_id derived_productline_suffix],
+                                                   primary_key: %i[goods_nomenclature_item_id producline_suffix]
+
+  # Find goods nomenclature that I originate from (e.g. who preceded me)
+  one_to_many :goods_nomenclature_origins, key: :goods_nomenclature_sid
 
   one_to_many :goods_nomenclature_successors, key: %i[absorbed_goods_nomenclature_item_id
                                                       absorbed_productline_suffix],

--- a/app/models/goods_nomenclature_origin.rb
+++ b/app/models/goods_nomenclature_origin.rb
@@ -1,6 +1,5 @@
 class GoodsNomenclatureOrigin < Sequel::Model
-  plugin :oplog, primary_key: %i[oid
-                                 goods_nomenclature_sid
+  plugin :oplog, primary_key: %i[goods_nomenclature_sid
                                  derived_goods_nomenclature_item_id
                                  derived_productline_suffix
                                  goods_nomenclature_item_id
@@ -12,5 +11,11 @@ class GoodsNomenclatureOrigin < Sequel::Model
                      goods_nomenclature_item_id
                      productline_suffix]
 
+  # The new goods nomenclature
   many_to_one :goods_nomenclature, key: :goods_nomenclature_sid
+
+  # The goods nomenclature where the new goods nomenclature used to be in the tariff
+  many_to_one :derived_goods_nomenclature, primary_key: %i[goods_nomenclature_item_id producline_suffix],
+                                           key: %i[derived_goods_nomenclature_item_id derived_productline_suffix],
+                                           class: 'GoodsNomenclature'
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2622

### What?

I have added/removed/altered:

- [x] Added succeeding/preceding associations to the goods nomenclature model

### Why?

I am doing this because:

- This enables us to ask the goods nomenclature whether it is an origin of
any other goods nomenclature and for their validity start/end dates
