### PR TITLE
HOTT-2622: Fix goods nomenclature origins relationship

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -121,7 +121,8 @@ class GoodsNomenclature < Sequel::Model
 
   # Find goods nomenclature where I am the origin (e.g. who succeed me)
   one_to_many :derived_goods_nomenclature_origins, key: %i[derived_goods_nomenclature_item_id derived_productline_suffix],
-                                                   primary_key: %i[goods_nomenclature_item_id producline_suffix]
+                                                   primary_key: %i[goods_nomenclature_item_id producline_suffix],
+                                                   class_name: 'GoodsNomenclatureOrigin'
 
   # Find goods nomenclature that I originate from (e.g. who preceded me)
   one_to_many :goods_nomenclature_origins, key: :goods_nomenclature_sid


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2622

### What?

I have added/removed/altered:

- [x] Added succeeding/preceding associations to the goods nomenclature model

### Why?

I am doing this because:

- This enables us to ask the goods nomenclature whether it is an origin of
any other goods nomenclature and for their validity start/end dates
