### PR TITLE
HOTT-2622: Surface deriving goods nomenclatures

### DIFF
--- a/app/controllers/api/v2/validity_periods_controller.rb
+++ b/app/controllers/api/v2/validity_periods_controller.rb
@@ -2,41 +2,7 @@ module Api
   module V2
     class ValidityPeriodsController < ApiController
       def index
-        presented_goods_nomenclatures = goods_nomenclatures_in_all_periods.map do |goods_nomenclature|
-          Api::V2::ValidityPeriodPresenter.new(goods_nomenclature)
-        end
-
-        serializer = Api::V2::ValidityPeriodSerializer.new(
-          presented_goods_nomenclatures,
-          include: [:deriving_goods_nomenclatures],
-        )
-
-        render json: serializer.serializable_hash
-      end
-
-      private
-
-      def goods_nomenclatures_in_all_periods
-        goods_nomenclature_scope.exclude(validity_start_date: nil)
-          .limit(10)
-          .eager(deriving_goods_nomenclature_origins: :goods_nomenclature)
-          .order(Sequel.desc(:validity_start_date))
-          .to_a
-      end
-
-      def goods_nomenclature_scope
-        if params[:commodity_id].present?
-          # TODO: This can include subheadings - e.g. /commodities/0101290000/validity_periods is a subheading
-          Commodity.by_code(params[:commodity_id]).declarable
-        elsif params[:subheading_id].present?
-          code, producline_suffix = params[:subheading_id].split('-')
-
-          Subheading.by_code(code).by_productline_suffix(producline_suffix)
-        elsif params[:heading_id].present?
-          Heading.by_code("#{params[:heading_id]}000000").non_grouping
-        else
-          raise Sequel::RecordNotFound
-        end
+        render json: ValidityPeriodSerializerService.new(params).call
       end
     end
   end

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -120,7 +120,7 @@ class GoodsNomenclature < Sequel::Model
   delegate :description, :description_indexed, :formatted_description, to: :goods_nomenclature_description, allow_nil: true
 
   # Find goods nomenclature where I am the origin (e.g. who succeed me)
-  one_to_many :derived_goods_nomenclature_origins, key: %i[derived_goods_nomenclature_item_id derived_productline_suffix],
+  one_to_many :deriving_goods_nomenclature_origins, key: %i[derived_goods_nomenclature_item_id derived_productline_suffix],
                                                    primary_key: %i[goods_nomenclature_item_id producline_suffix],
                                                    class_name: 'GoodsNomenclatureOrigin'
 

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -121,8 +121,8 @@ class GoodsNomenclature < Sequel::Model
 
   # Find goods nomenclature where I am the origin (e.g. who succeed me)
   one_to_many :deriving_goods_nomenclature_origins, key: %i[derived_goods_nomenclature_item_id derived_productline_suffix],
-                                                   primary_key: %i[goods_nomenclature_item_id producline_suffix],
-                                                   class_name: 'GoodsNomenclatureOrigin'
+                                                    primary_key: %i[goods_nomenclature_item_id producline_suffix],
+                                                    class_name: 'GoodsNomenclatureOrigin'
 
   # Find goods nomenclature that I originate from (e.g. who preceded me)
   one_to_many :goods_nomenclature_origins, key: :goods_nomenclature_sid

--- a/app/presenters/api/v2/validity_period_presenter.rb
+++ b/app/presenters/api/v2/validity_period_presenter.rb
@@ -3,6 +3,10 @@ module Api
     class ValidityPeriodPresenter < SimpleDelegator
       include ContentAddressableId
 
+      def self.wrap(goods_nomenclatures)
+        Array.wrap(goods_nomenclatures).map { |goods_nomenclature| new(goods_nomenclature) }
+      end
+
       content_addressable_fields :to_param,
                                  :validity_start_date,
                                  :validity_end_date

--- a/app/presenters/api/v2/validity_period_presenter.rb
+++ b/app/presenters/api/v2/validity_period_presenter.rb
@@ -6,6 +6,16 @@ module Api
       content_addressable_fields :to_param,
                                  :validity_start_date,
                                  :validity_end_date
+
+      def deriving_goods_nomenclatures
+        deriving_goods_nomenclature_origins.map(&:goods_nomenclature)
+      end
+
+      def derived_goods_nomenclature_ids
+        deriving_goods_nomenclatures.map do |goods_nomenclature|
+          "#{goods_nomenclature.goods_nomenclature_item_id}-#{goods_nomenclature.producline_suffix}"
+        end
+      end
     end
   end
 end

--- a/app/presenters/api/v2/validity_period_presenter.rb
+++ b/app/presenters/api/v2/validity_period_presenter.rb
@@ -14,12 +14,6 @@ module Api
       def deriving_goods_nomenclatures
         deriving_goods_nomenclature_origins.map(&:goods_nomenclature)
       end
-
-      def derived_goods_nomenclature_ids
-        deriving_goods_nomenclatures.map do |goods_nomenclature|
-          "#{goods_nomenclature.goods_nomenclature_item_id}-#{goods_nomenclature.producline_suffix}"
-        end
-      end
     end
   end
 end

--- a/app/serializers/api/v2/shared/goods_nomenclature_serializer.rb
+++ b/app/serializers/api/v2/shared/goods_nomenclature_serializer.rb
@@ -9,7 +9,9 @@ module Api
         attributes :goods_nomenclature_item_id,
                    :producline_suffix,
                    :description,
-                   :formatted_description
+                   :formatted_description,
+                   :validity_start_date,
+                   :validity_end_date
       end
     end
   end

--- a/app/serializers/api/v2/validity_period_serializer.rb
+++ b/app/serializers/api/v2/validity_period_serializer.rb
@@ -9,7 +9,18 @@ module Api
                  :producline_suffix,
                  :validity_start_date,
                  :validity_end_date,
+                 :description,
+                 :formatted_description,
                  :to_param
+
+      has_many :deriving_goods_nomenclatures,
+               serializer: proc { |record, _params|
+                 if record && record.respond_to?(:goods_nomenclature_class)
+                   "Api::V2::Shared::#{record.goods_nomenclature_class}Serializer".constantize
+                 else
+                   Api::V2::Shared::GoodsNomenclatureSerializer
+                 end
+               }
     end
   end
 end

--- a/app/services/validity_period_serializer_service.rb
+++ b/app/services/validity_period_serializer_service.rb
@@ -1,0 +1,45 @@
+class ValidityPeriodSerializerService
+  INCLUDES = %i[deriving_goods_nomenclatures].freeze
+
+  def initialize(params)
+    @params = params
+  end
+
+  def call
+    Api::V2::ValidityPeriodSerializer.new(
+      presented_goods_nomenclatures,
+      include: INCLUDES,
+    ).serializable_hash
+  end
+
+  private
+
+  attr_reader :params
+
+  def presented_goods_nomenclatures
+    Api::V2::ValidityPeriodPresenter.wrap(goods_nomenclatures_in_all_periods)
+  end
+
+  def goods_nomenclatures_in_all_periods
+    goods_nomenclature_scope
+      .limit(10)
+      .eager(deriving_goods_nomenclature_origins: :goods_nomenclature)
+      .order(Sequel.desc(:validity_start_date))
+      .to_a
+  end
+
+  def goods_nomenclature_scope
+    if params[:commodity_id].present?
+      # TODO: This can include subheadings - e.g. /commodities/0101290000/validity_periods is a subheading
+      Commodity.by_code(params[:commodity_id]).declarable
+    elsif params[:subheading_id].present?
+      code, producline_suffix = params[:subheading_id].split('-')
+
+      Subheading.by_code(code).by_productline_suffix(producline_suffix)
+    elsif params[:heading_id].present?
+      Heading.by_code("#{params[:heading_id]}000000").non_grouping
+    else
+      raise Sequel::RecordNotFound
+    end
+  end
+end

--- a/spec/controllers/api/v2/additional_codes_controller_spec.rb
+++ b/spec/controllers/api/v2/additional_codes_controller_spec.rb
@@ -1,11 +1,6 @@
 RSpec.describe Api::V2::AdditionalCodesController, type: :controller do
-  context 'additional codes search' do
+  describe 'GET #search' do
     let!(:additional_code) { create :additional_code }
-    let!(:additional_code_description) { create :additional_code_description, :with_period, additional_code_sid: additional_code.additional_code_sid }
-    let!(:measure) { create :measure, :with_base_regulation, additional_code_sid: additional_code.additional_code_sid, goods_nomenclature: create(:heading) }
-    let!(:excluded_measure) { create :measure, :with_base_regulation, additional_code_sid: additional_code.additional_code_sid, goods_nomenclature: nil }
-    let!(:goods_nomenclature) { measure.goods_nomenclature }
-    let!(:goods_nomenclature_description) { create :goods_nomenclature_description, goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid }
 
     let(:pattern) do
       {
@@ -64,6 +59,8 @@ RSpec.describe Api::V2::AdditionalCodesController, type: :controller do
               description: String,
               formatted_description: String,
               producline_suffix: String,
+              validity_start_date: String,
+              validity_end_date: nil,
             },
           },
         ],
@@ -78,6 +75,28 @@ RSpec.describe Api::V2::AdditionalCodesController, type: :controller do
     end
 
     before do
+      measure = create(
+        :measure,
+        :with_base_regulation,
+        additional_code_sid: additional_code.additional_code_sid,
+        goods_nomenclature: create(:heading),
+      )
+      create(
+        :goods_nomenclature_description,
+        goods_nomenclature_sid: measure.goods_nomenclature.goods_nomenclature_sid,
+      )
+      create(
+        :measure,
+        :with_base_regulation,
+        additional_code_sid: additional_code.additional_code_sid,
+        goods_nomenclature: nil,
+      )
+      create(
+        :additional_code_description,
+        :with_period,
+        additional_code_sid: additional_code.additional_code_sid,
+      )
+
       Sidekiq::Testing.inline! do
         TradeTariffBackend.cache_client.reindex(Cache::AdditionalCodeIndex.new)
         sleep(1)

--- a/spec/controllers/api/v2/certificates_controller_search_spec.rb
+++ b/spec/controllers/api/v2/certificates_controller_search_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe Api::V2::CertificatesController, type: :controller do
               description: String,
               formatted_description: String,
               producline_suffix: String,
+              validity_start_date: String,
+              validity_end_date: nil,
             },
           },
         ],

--- a/spec/controllers/api/v2/quotas_controller_spec.rb
+++ b/spec/controllers/api/v2/quotas_controller_spec.rb
@@ -131,6 +131,8 @@ RSpec.describe Api::V2::QuotasController, type: :controller do
                 producline_suffix: String,
                 description: String,
                 formatted_description: nil,
+                validity_start_date: String,
+                validity_end_date: nil,
               },
             },
           ],
@@ -145,7 +147,7 @@ RSpec.describe Api::V2::QuotasController, type: :controller do
       end
 
       it 'returns rendered found quotas' do
-        get :search, params: params, format: :json
+        get :search, params:, format: :json
 
         expect(response.body).to match_json_expression pattern
       end
@@ -228,7 +230,7 @@ RSpec.describe Api::V2::QuotasController, type: :controller do
         let(:include_param) { 'quota_balance_events' }
 
         it 'returns rendered found quotas with the allowed resources' do
-          get :search, params: params, format: :json
+          get :search, params:, format: :json
 
           expect(response.body).to match_json_expression pattern
         end

--- a/spec/factories/goods_nomenclature_factory.rb
+++ b/spec/factories/goods_nomenclature_factory.rb
@@ -33,6 +33,20 @@ FactoryBot.define do
       # See implicit behaviour above
     end
 
+    trait :with_deriving_goods_nomenclatures do
+      after(:create) do |origin_goods_nomenclature|
+        successor_goods_nomenclature = create(:commodity, :with_heading)
+
+        create(
+          :goods_nomenclature_origin,
+          goods_nomenclature_sid: successor_goods_nomenclature.goods_nomenclature_sid,
+          productline_suffix: successor_goods_nomenclature.producline_suffix,
+          derived_goods_nomenclature_item_id: origin_goods_nomenclature.goods_nomenclature_item_id,
+          derived_productline_suffix: origin_goods_nomenclature.producline_suffix,
+        )
+      end
+    end
+
     trait :non_current do
       validity_end_date { 1.day.ago }
     end
@@ -206,11 +220,11 @@ FactoryBot.define do
     end
 
     trait :with_description do
-      before(:create) do |gono, evaluator|
-        create(:goods_nomenclature_description, goods_nomenclature_sid: gono.goods_nomenclature_sid,
-                                                goods_nomenclature_item_id: gono.goods_nomenclature_item_id,
-                                                validity_start_date: gono.validity_start_date,
-                                                validity_end_date: gono.validity_end_date,
+      before(:create) do |goods_nomenclature, evaluator|
+        create(:goods_nomenclature_description, goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
+                                                goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
+                                                validity_start_date: goods_nomenclature.validity_start_date,
+                                                validity_end_date: goods_nomenclature.validity_end_date,
                                                 description: evaluator.description)
       end
     end

--- a/spec/presenters/api/v2/validity_period_presenter_spec.rb
+++ b/spec/presenters/api/v2/validity_period_presenter_spec.rb
@@ -20,4 +20,20 @@ RSpec.describe Api::V2::ValidityPeriodPresenter do
       it { is_expected.to be_present }
     end
   end
+
+  describe '.wrap' do
+    subject(:wrap) { described_class.wrap(goods_nomenclatures) }
+
+    context 'when the goods nomenclature is a collection' do
+      let(:goods_nomenclatures) { build_list(:commodity, 2) }
+
+      it { is_expected.to all(be_a(described_class)) }
+    end
+
+    context 'when the goods nomenclature is a single goods nomenclature' do
+      let(:goods_nomenclatures) { build(:commodity) }
+
+      it { is_expected.to all(be_a(described_class)) }
+    end
+  end
 end

--- a/spec/presenters/api/v2/validity_period_presenter_spec.rb
+++ b/spec/presenters/api/v2/validity_period_presenter_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe Api::V2::ValidityPeriodPresenter do
     end
   end
 
+  describe '#deriving_goods_nomenclatures' do
+    subject(:deriving_goods_nomenclatures) { described_class.new(goods_nomenclature).deriving_goods_nomenclatures }
+
+    let(:goods_nomenclature) { build(:commodity, :with_deriving_goods_nomenclatures) }
+
+    it { is_expected.to all(be_a(Commodity)) }
+  end
+
   describe '.wrap' do
     subject(:wrap) { described_class.wrap(goods_nomenclatures) }
 

--- a/spec/serializers/api/v2/validity_period_serializer_spec.rb
+++ b/spec/serializers/api/v2/validity_period_serializer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Api::V2::ValidityPeriodSerializer do
     {
       data: {
         id: 'd259221ad1eee90454351c0fa0404179',
-        type: :validity_period,
+        type: eq(:validity_period),
         attributes: {
           goods_nomenclature_item_id: '0101000000',
           producline_suffix: '80',
@@ -27,12 +27,12 @@ RSpec.describe Api::V2::ValidityPeriodSerializer do
           formatted_description: '',
           to_param: '0101',
         },
-        relationships: { deriving_goods_nomenclatures: { data: [{ id: '2', type: :commodity }] } },
+        relationships: { deriving_goods_nomenclatures: { data: [{ id: match(/\d+/), type: eq(:commodity) }] } },
       },
     }
   end
 
   describe '#serializable_hash' do
-    it { is_expected.to eq(expected) }
+    it { is_expected.to include_json(expected) }
   end
 end

--- a/spec/serializers/api/v2/validity_period_serializer_spec.rb
+++ b/spec/serializers/api/v2/validity_period_serializer_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Api::V2::ValidityPeriodSerializer do
   let(:presented) do
     heading = create(
       :heading,
+      :with_deriving_goods_nomenclatures,
       goods_nomenclature_item_id: '0101000000',
       validity_start_date: '2021-01-01',
       validity_end_date: nil,
@@ -20,10 +21,13 @@ RSpec.describe Api::V2::ValidityPeriodSerializer do
         attributes: {
           goods_nomenclature_item_id: '0101000000',
           producline_suffix: '80',
-          validity_start_date: Date.parse('2021-01-01'),
+          validity_start_date: '2021-01-01T00:00:00.000Z',
           validity_end_date: nil,
+          description: '',
+          formatted_description: '',
           to_param: '0101',
         },
+        relationships: { deriving_goods_nomenclatures: { data: [{ id: '2', type: :commodity }] } },
       },
     }
   end

--- a/spec/services/validity_period_serializer_service_spec.rb
+++ b/spec/services/validity_period_serializer_service_spec.rb
@@ -1,0 +1,101 @@
+RSpec.describe ValidityPeriodSerializerService do
+  describe '#call' do
+    context 'when the goods nomenclature is a heading' do
+      subject(:call) { described_class.new(params).call }
+
+      before do
+        create(
+          :heading,
+          :with_deriving_goods_nomenclatures,
+          goods_nomenclature_item_id: '0101000000',
+          validity_start_date: Date.new(2023, 1, 1),
+          validity_end_date: Date.new(2023, 2, 1),
+        )
+        create(
+          :heading,
+          :with_deriving_goods_nomenclatures,
+          goods_nomenclature_item_id: '0101000000',
+          validity_start_date: Date.new(2023, 1, 2),
+          validity_end_date: Date.new(2023, 2, 1),
+        )
+      end
+
+      let(:params) { { heading_id: '0101' } }
+
+      it 'returns serialized validity periods that are sorted by validity start date' do
+        validity_start_dates = call[:data].map { |period| period[:attributes][:validity_start_date] }
+        expect(validity_start_dates).to eq(%w[2023-01-02 2023-01-01])
+      end
+    end
+
+    context 'when the goods nomenclature is a subheading' do
+      subject(:call) { described_class.new(params).call }
+
+      before do
+        create(
+          :commodity,
+          :with_deriving_goods_nomenclatures,
+          goods_nomenclature_item_id: '0101210000',
+          producline_suffix: '80',
+          validity_start_date: Date.new(2023, 1, 1),
+          validity_end_date: Date.new(2023, 2, 1),
+        )
+        create(
+          :commodity,
+          :with_deriving_goods_nomenclatures,
+          goods_nomenclature_item_id: '0101210000',
+          producline_suffix: '80',
+          validity_start_date: Date.new(2023, 1, 2),
+          validity_end_date: Date.new(2023, 2, 1),
+        )
+      end
+
+      let(:params) { { subheading_id: '0101210000-80' } }
+
+      it 'returns serialized validity periods that are sorted by validity start date' do
+        validity_start_dates = call[:data].map { |period| period[:attributes][:validity_start_date] }
+        expect(validity_start_dates).to eq(%w[2023-01-02 2023-01-01])
+      end
+    end
+
+    context 'when the goods nomenclature is a commodity' do
+      subject(:call) { described_class.new(params).call }
+
+      before do
+        create(
+          :commodity,
+          :with_deriving_goods_nomenclatures,
+          goods_nomenclature_item_id: '0101210000',
+          producline_suffix: '80',
+          validity_start_date: Date.new(2023, 1, 1),
+          validity_end_date: Date.new(2023, 2, 1),
+        )
+        create(
+          :commodity,
+          :with_deriving_goods_nomenclatures,
+          goods_nomenclature_item_id: '0101210000',
+          producline_suffix: '80',
+          validity_start_date: Date.new(2023, 1, 2),
+          validity_end_date: Date.new(2023, 2, 1),
+        )
+      end
+
+      let(:params) { { commodity_id: '0101210000' } }
+
+      it 'returns serialized validity periods that are sorted by validity start date' do
+        validity_start_dates = call[:data].map { |period| period[:attributes][:validity_start_date] }
+        expect(validity_start_dates).to eq(%w[2023-01-02 2023-01-01])
+      end
+    end
+
+    context 'when the goods nomenclature is not found' do
+      subject(:call) { described_class.new(params).call }
+
+      let(:params) { { heading_id: '0101' } }
+
+      it 'returns an empty array' do
+        expect(call[:data]).to eq([])
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/a_serialized_goods_nomenclature.rb
+++ b/spec/support/shared_examples/a_serialized_goods_nomenclature.rb
@@ -14,6 +14,8 @@ RSpec.shared_examples_for 'a serialized goods nomenclature' do |type|
             producline_suffix: match(/\d{2}/),
             description: '',
             formatted_description: nil,
+            validity_start_date: match(/\d{4}-\d{2}-\d{2}/),
+            validity_end_date: nil,
           },
         },
       }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2622

### What?

I have added/removed/altered:

- [x] Surface polymorphic goods nomenclatures that derive from a goods nomenclature that is currently missing
- [x] Encapsulate fetching of validity periods into a service
- [x] Extend test coverage to include the new surface goods nomenclature

### Why?

I am doing this because:

- This enables a full history review of where the goods nomenclatures have moved in the hierarchy
