### PR TITLE
HOTT-2622: Filter deriving goods nomenclatures that start after Brexit

### DIFF
--- a/app/presenters/api/v2/validity_period_presenter.rb
+++ b/app/presenters/api/v2/validity_period_presenter.rb
@@ -1,6 +1,8 @@
 module Api
   module V2
     class ValidityPeriodPresenter < SimpleDelegator
+      BREXIT_STARTING_DATE = Date.new(2021, 1, 1)
+
       include ContentAddressableId
 
       def self.wrap(goods_nomenclatures)
@@ -12,7 +14,8 @@ module Api
                                  :validity_end_date
 
       def deriving_goods_nomenclatures
-        deriving_goods_nomenclature_origins.map(&:goods_nomenclature)
+        candidate_goods_nomenclatures = deriving_goods_nomenclature_origins.map(&:goods_nomenclature)
+        candidate_goods_nomenclatures.reject { |gn| gn.validity_start_date < BREXIT_STARTING_DATE }
       end
     end
   end

--- a/spec/presenters/api/v2/validity_period_presenter_spec.rb
+++ b/spec/presenters/api/v2/validity_period_presenter_spec.rb
@@ -24,9 +24,23 @@ RSpec.describe Api::V2::ValidityPeriodPresenter do
   describe '#deriving_goods_nomenclatures' do
     subject(:deriving_goods_nomenclatures) { described_class.new(goods_nomenclature).deriving_goods_nomenclatures }
 
-    let(:goods_nomenclature) { build(:commodity, :with_deriving_goods_nomenclatures) }
+    context 'when the goods nomenclature has a validity start date before the Brexit starting date' do
+      let(:goods_nomenclature) { build(:commodity, validity_start_date: Date.new(2020, 1, 1)) }
 
-    it { is_expected.to all(be_a(Commodity)) }
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the goods nomenclature has a validity start date after the Brexit starting date' do
+      let(:goods_nomenclature) { build(:commodity, validity_start_date: Date.new(2021, 1, 2)) }
+
+      it { is_expected.to all(be_a(Commodity)) }
+    end
+
+    context 'when the goods nomenclature has a validity start date equal to the Brexit starting date' do
+      let(:goods_nomenclature) { build(:commodity, validity_start_date: Date.new(2021, 1, 1)) }
+
+      it { is_expected.to all(be_a(Commodity)) }
+    end
   end
 
   describe '.wrap' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2622

### What?

I have added/removed/altered:

- [x] Filter out deriving goods nomenclature that start before Brexit

### Why?

I am doing this because:

- On day 0 we started from EU goods nomenclature, measures, etc. Most of this data just isn't pertinent to changes made by the CDS and DIT teams
