### PR TITLE
HOTT-2323: Integrate alpine updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -853,6 +853,7 @@ workflows:
             branches:
               only:
                 - main
+
   ci:
     jobs:
       - linters:
@@ -871,8 +872,8 @@ workflows:
             branches:
               ignore:
                 - main
+                - /^dependabot\/(?!docker\/).*/
                 - /^hotfix\/.+/
-                - /^dependabot\/.*/
       - deploy_dev:
           matrix:
             parameters:
@@ -884,7 +885,7 @@ workflows:
             branches:
               ignore:
                 - main
-                - /^dependabot\/.*/
+                - /^dependabot\/(?!docker\/).*/
                 - /^hotfix\/.+/
           requires:
             - test
@@ -897,7 +898,7 @@ workflows:
             branches:
               ignore:
                 - main
-                - /^dependabot\/.*/
+                - /^dependabot\/(?!docker\/).*/
                 - /^hotfix\/.+/
       - smoketest_dev:
           name: smoketest_dev
@@ -907,7 +908,7 @@ workflows:
               ignore:
                 - main
                 - /^hotfix\/.+/
-                - /^dependabot\/.*/
+                - /^dependabot\/(?!docker\/).*/
           requires:
             - deploy_dev
             - sync_synonyms_dev


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2323

https://github.com/trade-tariff/trade-tariff-backend/pull/1060 - fully integrating docker dependabot branch
https://github.com/trade-tariff/trade-tariff-backend/pull/1062 - partially integrating ruby dependabot branch
https://github.com/trade-tariff/trade-tariff-backend/pull/1061 - partially integrating npm_and_yarn dependabot branch

### What?

I have added/removed/altered:

- [x] Excluded the dependabot/docker updates from the ignore filter when doing a build/deploy/release/smoke test to dev environment

### Why?

I am doing this because:

- This enables us to save time debugging docker os updates as part of our standard process
