### PR TITLE
HOTT-2576: Handle tariff downloader exceptions

### DIFF
--- a/app/lib/tariff_synchronizer/base_update.rb
+++ b/app/lib/tariff_synchronizer/base_update.rb
@@ -126,7 +126,7 @@ module TariffSynchronizer
     end
 
     def mark_as_applied
-      update(state: APPLIED_STATE, applied_at: Time.now, last_error: nil, last_error_at: nil, exception_backtrace: nil, exception_class: nil)
+      update(state: APPLIED_STATE, applied_at: Time.zone.now, last_error: nil, last_error_at: nil, exception_backtrace: nil, exception_class: nil)
     end
 
     def mark_as_failed

--- a/app/lib/tariff_synchronizer/base_update.rb
+++ b/app/lib/tariff_synchronizer/base_update.rb
@@ -19,15 +19,6 @@ module TariffSynchronizer
     plugin :single_table_inheritance, :update_type
     plugin :validation_class_methods
 
-    class InvalidContents < StandardError
-      attr_reader :original
-
-      def initialize(msg, original)
-        @original = original
-        super(msg)
-      end
-    end
-
     APPLIED_STATE = 'A'.freeze
     PENDING_STATE = 'P'.freeze
     FAILED_STATE  = 'F'.freeze

--- a/spec/unit/tariff_synchronizer/tariff_downloader_spec.rb
+++ b/spec/unit/tariff_synchronizer/tariff_downloader_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TariffSynchronizer::TariffDownloader do
     let(:date) { Date.current }
     let(:update_klass) { TariffSynchronizer::CdsUpdate }
 
-    context 'when the any part of the download process propagates an exception' do
+    context 'when any part of the download process propagates an exception' do
       before do
         allow(TariffSynchronizer::TariffUpdatesRequester)
           .to receive(:perform)

--- a/spec/unit/tariff_synchronizer/tariff_downloader_spec.rb
+++ b/spec/unit/tariff_synchronizer/tariff_downloader_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe TariffSynchronizer::TariffDownloader do
     let(:date) { Date.current }
     let(:update_klass) { TariffSynchronizer::CdsUpdate }
 
-
     context 'when the any part of the download process propagates an exception' do
       before do
         allow(TariffSynchronizer::TariffUpdatesRequester)


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2576

### What?

I have added/removed/altered:

- [x] Added more generic handling for propagated exceptions in the tariff downloader
- [x] Added test to highlight functionality working

### Why?

I am doing this because:

- Rather than being specific about an error that will never be raised this moves us to more general handling of generally uncaught exceptions below StandardError and attaches their details to the specific update that we're failing to download. The idea is that this will give us more information about what has gone wrong with the downloader
