### PR TITLE
Remove excess slack notifications on clearing search references

### DIFF
--- a/app/workers/clear_invalid_search_references.rb
+++ b/app/workers/clear_invalid_search_references.rb
@@ -12,8 +12,11 @@ class ClearInvalidSearchReferences
       search_reference.delete
     end
 
-    message = "Removed Search references #{cleared.to_json}"
-    logger.info(message)
-    SlackNotifierService.call(message)
+    if cleared.any?
+      message = "Removed Search references #{cleared.to_json}"
+
+      logger.info(message)
+      SlackNotifierService.call(message)
+    end
   end
 end

--- a/spec/workers/clear_invalid_search_references_spec.rb
+++ b/spec/workers/clear_invalid_search_references_spec.rb
@@ -1,22 +1,39 @@
 RSpec.describe ClearInvalidSearchReferences, type: :worker do
   subject(:do_perform) { silence { described_class.new.perform } }
 
-  before do
-    create(:search_reference, :with_non_current_commodity, title: 'foo')
-    create(:search_reference, :with_current_commodity, title: 'bar')
+  context 'when the are search references to clear' do
+    before do
+      create(:search_reference, :with_non_current_commodity, title: 'foo')
+      create(:search_reference, :with_current_commodity, title: 'bar')
+    end
+
+    it { expect { do_perform }.to change(SearchReference, :count).by(-1) }
+
+    it 'sends a slack notification about expiring search references' do
+      allow(SlackNotifierService).to receive(:call).and_call_original
+      do_perform
+      expect(SlackNotifierService).to have_received(:call).with(match(/foo/))
+    end
+
+    it 'does not send a slack notification about non-expiring search references' do
+      allow(SlackNotifierService).to receive(:call).and_call_original
+      do_perform
+      expect(SlackNotifierService).not_to have_received(:call).with(match(/bar/))
+    end
   end
 
-  it { expect { do_perform }.to change(SearchReference, :count).by(-1) }
+  context 'when there are no search references to clear' do
+    before do
+      create(:search_reference, :with_current_commodity, title: 'foo')
+      create(:search_reference, :with_current_commodity, title: 'bar')
+    end
 
-  it 'sends a slack notification about expiring search references' do
-    allow(SlackNotifierService).to receive(:call).and_call_original
-    do_perform
-    expect(SlackNotifierService).to have_received(:call).with(match(/foo/))
-  end
+    it { expect { do_perform }.not_to change(SearchReference, :count) }
 
-  it 'does not send a slack notification about non-expiring search references' do
-    allow(SlackNotifierService).to receive(:call).and_call_original
-    do_perform
-    expect(SlackNotifierService).not_to have_received(:call).with(match(/bar/))
+    it 'does not send a slack notification' do
+      allow(SlackNotifierService).to receive(:call).and_call_original
+      do_perform
+      expect(SlackNotifierService).not_to have_received(:call)
+    end
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Removed excess slack notifications on clearing search references
