### PR TITLE
HOTT-2393: Adds direct hit to search result

### DIFF
--- a/app/controllers/api/beta/search_controller.rb
+++ b/app/controllers/api/beta/search_controller.rb
@@ -9,6 +9,7 @@ module Api
         :guide,
         :intercept_message,
         'facet_filter_statistics.facet_classification_statistics',
+        :direct_hit,
       ].freeze
 
       def index

--- a/app/models/beta/search/direct_hit.rb
+++ b/app/models/beta/search/direct_hit.rb
@@ -5,13 +5,24 @@ module Beta
                     :goods_nomenclature_item_id,
                     :producline_suffix
 
-      attr_reader :description,
-                  :formatted_description,
-                  :validity_start_date,
-                  :validity_end_date
-
       def id
         "#{goods_nomenclature_item_id}-#{producline_suffix}"
+      end
+
+      def method_missing(method_name, *_arguments)
+        if method_name.to_s.start_with?('search_references')
+          []
+        elsif method_name.to_s.start_with?('guide')
+          []
+        elsif method_name.to_s.start_with?('ancestors')
+          []
+        end
+      end
+
+      def respond_to_missing?(method_name, _include_private = false)
+        method_name.to_s.start_with?('search_references') ||
+          method_name.to_s.start_with?('guide') ||
+          method_name.to_s.start_with?('ancestors')
       end
 
       def self.build(search_result)
@@ -39,7 +50,6 @@ module Beta
 
           direct_hit
         end
-
       end
     end
   end

--- a/app/models/beta/search/direct_hit.rb
+++ b/app/models/beta/search/direct_hit.rb
@@ -1,0 +1,46 @@
+module Beta
+  module Search
+    class DirectHit
+      attr_accessor :goods_nomenclature_class,
+                    :goods_nomenclature_item_id,
+                    :producline_suffix
+
+      attr_reader :description,
+                  :formatted_description,
+                  :validity_start_date,
+                  :validity_end_date
+
+      def id
+        "#{goods_nomenclature_item_id}-#{producline_suffix}"
+      end
+
+      def self.build(search_result)
+        direct_hit = new
+
+        if search_result.hits.one?
+          direct_hit.goods_nomenclature_class = search_result.hits.first.goods_nomenclature_class
+          direct_hit.goods_nomenclature_item_id = search_result.hits.first.goods_nomenclature_item_id
+          direct_hit.producline_suffix = search_result.hits.first.producline_suffix
+
+          direct_hit
+        elsif search_result.search_reference.present?
+          direct_hit.goods_nomenclature_class = search_result.search_reference.referenced_class
+          direct_hit.goods_nomenclature_item_id = search_result.search_reference.goods_nomenclature_item_id
+          direct_hit.producline_suffix = search_result.search_reference.productline_suffix
+
+          direct_hit
+        elsif search_result.numeric?
+          short_code = search_result.short_code
+          goods_nomenclature_class, goods_nomenclature_item_id, productline_suffix = ShortCodeClassificationService.new(short_code).call
+
+          direct_hit.goods_nomenclature_class = goods_nomenclature_class
+          direct_hit.goods_nomenclature_item_id = goods_nomenclature_item_id
+          direct_hit.producline_suffix = productline_suffix
+
+          direct_hit
+        end
+
+      end
+    end
+  end
+end

--- a/app/models/beta/search/open_search_result.rb
+++ b/app/models/beta/search/open_search_result.rb
@@ -9,6 +9,7 @@ module Beta
       delegate :id, to: :goods_nomenclature_query, prefix: true, allow_nil: true
       delegate :id, to: :guide, prefix: true, allow_nil: true
       delegate :id, to: :intercept_message, prefix: true, allow_nil: true
+      delegate :id, to: :direct_hit, prefix: true, allow_nil: true
 
       delegate :goods_nomenclature_item_id, :numeric?, :short_code, to: :goods_nomenclature_query, allow_nil: true
 
@@ -216,6 +217,10 @@ module Beta
 
       def intercept_message
         @intercept_message ||= ::Beta::Search::InterceptMessage.build(search_query_parser_result.original_search_query)
+      end
+
+      def direct_hit
+        @direct_hit ||= DirectHit.build(self)
       end
     end
   end

--- a/app/serializers/api/beta/search_result_serializer.rb
+++ b/app/serializers/api/beta/search_result_serializer.rb
@@ -25,6 +25,10 @@ module Api
         end
       }
 
+      has_one :direct_hit, serializer: proc { |record, _params|
+        "Api::Beta::#{record.goods_nomenclature_class}Serializer".constantize
+      }
+
       has_many :heading_statistics, serializer: Api::Beta::HeadingStatisticsSerializer
       has_many :chapter_statistics, serializer: Api::Beta::ChapterStatisticsSerializer
       has_one :guide, serializer: Api::Beta::GuideSerializer

--- a/app/services/short_code_classification_service.rb
+++ b/app/services/short_code_classification_service.rb
@@ -1,0 +1,31 @@
+class ShortCodeClassificationService
+  def initialize(short_code)
+    @short_code = short_code
+  end
+
+  def call
+    goods_nomenclature_item_id = short_code.ljust(10, '0')
+    productline_suffix = '80'
+
+    return ['Chapter', goods_nomenclature_item_id, productline_suffix] if short_code.length == 1
+    return ['Chapter', goods_nomenclature_item_id, productline_suffix] if short_code.length == 2
+    return ['Subheading', goods_nomenclature_item_id, productline_suffix] if short_code.length == 6 || short_code.length == 8
+    return ['Commodity', goods_nomenclature_item_id, productline_suffix] if short_code.length == 10
+
+    if short_code.match?(/\d{10}-\d{2}/)
+      goods_nomenclature_item_id = short_code.first(10)
+      productline_suffix = short_code.last(2)
+
+      return ['Subheading', goods_nomenclature_item_id, productline_suffix]
+    end
+
+    goods_nomenclature_item_id = short_code.first(4).ljust(10, '0')
+    goods_nomenclature_class = 'Heading'
+
+    [goods_nomenclature_class, goods_nomenclature_item_id, productline_suffix]
+  end
+
+  private
+
+  attr_reader :short_code
+end

--- a/spec/factories/search_result_factory.rb
+++ b/spec/factories/search_result_factory.rb
@@ -136,6 +136,16 @@ FactoryBot.define do
       end
     end
 
+    trait :with_numeric_search_query do
+      goods_nomenclature_query do
+        build(
+          :goods_nomenclature_query,
+          :numeric,
+          original_search_query: goods_nomenclature_item_id || '0101',
+        )
+      end
+    end
+
     initialize_with do
       fixture_filename = Rails.root.join("spec/fixtures/beta/search/goods_nomenclatures/#{result_fixture}.json")
       search_result = JSON.parse(File.read(fixture_filename))

--- a/spec/fixtures/beta/search/goods_nomenclatures/serialized_result.json
+++ b/spec/fixtures/beta/search/goods_nomenclatures/serialized_result.json
@@ -26,6 +26,12 @@
           }
         ]
       },
+      "direct_hit": {
+        "data": {
+          "id": "0406105090-80",
+          "type": "commodity"
+        }
+      },
       "heading_statistics": {
         "data": [
           {
@@ -78,14 +84,10 @@
       },
       "relationships": {
         "ancestors": {
-          "data": [
-
-          ]
+          "data": []
         },
         "guides": {
-          "data": [
-
-          ]
+          "data": []
         }
       }
     },
@@ -108,14 +110,10 @@
       },
       "relationships": {
         "ancestors": {
-          "data": [
-
-          ]
+          "data": []
         },
         "guides": {
-          "data": [
-
-          ]
+          "data": []
         }
       }
     },
@@ -140,9 +138,7 @@
       },
       "relationships": {
         "ancestors": {
-          "data": [
-
-          ]
+          "data": []
         }
       }
     },
@@ -167,9 +163,7 @@
       },
       "relationships": {
         "ancestors": {
-          "data": [
-
-          ]
+          "data": []
         }
       }
     },
@@ -194,9 +188,7 @@
       },
       "relationships": {
         "ancestors": {
-          "data": [
-
-          ]
+          "data": []
         }
       }
     },
@@ -252,15 +244,9 @@
       "attributes": {
         "corrected_search_query": "ricotta",
         "original_search_query": "ricotta",
-        "verbs": [
-
-        ],
-        "adjectives": [
-
-        ],
-        "nouns": [
-
-        ],
+        "verbs": [],
+        "adjectives": [],
+        "nouns": [],
         "noun_chunks": [
           "ricotta"
         ],
@@ -316,6 +302,31 @@
               "type": "facet_classification_statistic"
             }
           ]
+        }
+      }
+    },
+    {
+      "id": "0406105090-80",
+      "type": "commodity",
+      "attributes": {
+        "goods_nomenclature_item_id": "0406105090",
+        "producline_suffix": "80",
+        "formatted_description": null,
+        "description": null,
+        "description_indexed": null,
+        "search_references": [],
+        "validity_start_date": null,
+        "validity_end_date": null,
+        "chapter_id": null,
+        "score": null,
+        "declarable": null,
+        "chapter_description": null,
+        "heading_description": null,
+        "heading_id": null
+      },
+      "relationships": {
+        "ancestors": {
+          "data": []
         }
       }
     }

--- a/spec/models/beta/search/direct_hit_spec.rb
+++ b/spec/models/beta/search/direct_hit_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe Beta::Search::DirectHit do
+  describe '#build' do
+    shared_examples 'a direct hit' do |search_result|
+      subject(:direct_hit) { described_class.build(search_result) }
+
+      it { is_expected.to be_a(described_class) }
+      it { expect(direct_hit.goods_nomenclature_class).to be_in(%w[Heading Chapter Subheading Commodity]) }
+      it { expect(direct_hit.id).to match(/^[0-9]{10}-[0-9]{2}$/) }
+      it { expect(direct_hit.goods_nomenclature_item_id).to match(/^[0-9]{10}$/) }
+      it { expect(direct_hit.producline_suffix).to match(/^[0-9]{2}$/) }
+      it { is_expected.to respond_to(:goods_nomenclature_item_id) }
+      it { is_expected.to respond_to(:producline_suffix) }
+      it { is_expected.to respond_to(:description) }
+      it { is_expected.to respond_to(:formatted_description) }
+      it { is_expected.to respond_to(:validity_start_date) }
+      it { is_expected.to respond_to(:validity_end_date) }
+    end
+
+    shared_examples 'not a direct hit' do |search_result|
+      subject(:direct_hit) { described_class.build(search_result) }
+
+      it { is_expected.to be_nil }
+    end
+
+    it_behaves_like 'a direct hit', FactoryBot.build(:search_result, :single_hit)
+    it_behaves_like 'a direct hit', FactoryBot.build(:search_result, :with_search_reference)
+    it_behaves_like 'a direct hit', FactoryBot.build(:search_result, :with_numeric_search_query)
+    it_behaves_like 'not a direct hit', FactoryBot.build(:search_result, :multiple_hits)
+    it_behaves_like 'not a direct hit', FactoryBot.build(:search_result, :no_hits)
+  end
+end

--- a/spec/models/beta/search/direct_hit_spec.rb
+++ b/spec/models/beta/search/direct_hit_spec.rb
@@ -8,12 +8,9 @@ RSpec.describe Beta::Search::DirectHit do
       it { expect(direct_hit.id).to match(/^[0-9]{10}-[0-9]{2}$/) }
       it { expect(direct_hit.goods_nomenclature_item_id).to match(/^[0-9]{10}$/) }
       it { expect(direct_hit.producline_suffix).to match(/^[0-9]{2}$/) }
-      it { is_expected.to respond_to(:goods_nomenclature_item_id) }
-      it { is_expected.to respond_to(:producline_suffix) }
-      it { is_expected.to respond_to(:description) }
-      it { is_expected.to respond_to(:formatted_description) }
-      it { is_expected.to respond_to(:validity_start_date) }
-      it { is_expected.to respond_to(:validity_end_date) }
+      it { expect(direct_hit.search_references).to be_empty }
+      it { expect(direct_hit.guides).to be_empty }
+      it { expect(direct_hit.ancestors).to be_empty }
     end
 
     shared_examples 'not a direct hit' do |search_result|

--- a/spec/requests/api/beta/search_controller_spec.rb
+++ b/spec/requests/api/beta/search_controller_spec.rb
@@ -43,11 +43,11 @@ RSpec.describe Api::Beta::SearchController, type: :request do
         response
       end
 
-      let(:actual_redirect_to) { JSON.parse(do_request.body).dig('data', 'meta', 'redirect_to') }
+      let(:redirect_to) { JSON.parse(do_request.body).dig('data', 'meta', 'redirect_to') }
 
       before { create(:search_reference, :with_heading, title: 'raw') }
 
-      it { expect(actual_redirect_to).to include('/headings/0101') }
+      it { expect(redirect_to).to include('/headings/0101') }
     end
   end
 end

--- a/spec/serializers/api/beta/search_result_serializer_spec.rb
+++ b/spec/serializers/api/beta/search_result_serializer_spec.rb
@@ -2,74 +2,111 @@ RSpec.describe Api::Beta::SearchResultSerializer do
   describe '#serializable_hash' do
     subject(:serializable_hash) { described_class.new(serializable).serializable_hash }
 
-    let(:serializable) do
-      build(
-        :search_result,
-        :clothing,
-        :generate_heading_and_chapter_statistics,
-        :generate_guide_statistics,
-        :generate_facet_statistics,
-      )
-    end
+    context 'when the search result has multiple hits' do
+      let(:serializable) do
+        build(
+          :search_result,
+          :clothing,
+          :generate_heading_and_chapter_statistics,
+          :generate_guide_statistics,
+          :generate_facet_statistics,
+        )
+      end
 
-    let(:expected) do
-      {
-        data: {
-          id: '6fc22ae4ee7f6fbe9b4988a4557dd3f9',
-          type: :search_result,
-          attributes: { took: 1, timed_out: false, max_score: 76.96534, total_results: 10 },
-          relationships: {
-            search_query_parser_result: {
-              data: {
-                id: '50cf19912960f65490b334ea9c196eea',
-                type: :search_query_parser_result,
+      let(:expected) do
+        {
+          data: {
+            id: '6fc22ae4ee7f6fbe9b4988a4557dd3f9',
+            type: :search_result,
+            attributes: { took: 1, timed_out: false, max_score: 76.96534, total_results: 10 },
+            relationships: {
+              search_query_parser_result: {
+                data: {
+                  id: '50cf19912960f65490b334ea9c196eea',
+                  type: :search_query_parser_result,
+                },
+              },
+              intercept_message: {
+                data: {
+                  id: 'be815ed834d0c282cab563ea73556f97',
+                  type: :intercept_message,
+                },
+              },
+              hits: {
+                data: [
+                  { id: '43821', type: :subheading },
+                  { id: '43606', type: :subheading },
+                  { id: '43607', type: :commodity },
+                  { id: '43608', type: :commodity },
+                  { id: '43609', type: :commodity },
+                  { id: '43522', type: :commodity },
+                  { id: '43530', type: :commodity },
+                  { id: '43486', type: :subheading },
+                  { id: '43487', type: :commodity },
+                  { id: '43488', type: :commodity },
+                ],
+              },
+              direct_hit: { data: nil },
+              heading_statistics: {
+                data: [
+                  { id: '6217', type: :heading_statistic },
+                  { id: '6209', type: :heading_statistic },
+                  { id: '6211', type: :heading_statistic },
+                  { id: '6307', type: :heading_statistic },
+                ],
+              },
+              chapter_statistics: {
+                data: [
+                  { id: '62', type: :chapter_statistic },
+                  { id: '63', type: :chapter_statistic },
+                ],
+              },
+              guide: { data: { id: '18', type: :guide } },
+              facet_filter_statistics: {
+                data: [
+                  { id: '2ecbb6c19ee6282b0c79dda2aeaf0192', type: :facet_filter_statistic },
+                  { id: 'b24e66a126ad13c1521cf6cda4b2c502', type: :facet_filter_statistic },
+                  { id: 'b030d559d41aee55d3cd439888aa5edf', type: :facet_filter_statistic },
+                ],
               },
             },
-            intercept_message: {
-              data: {
-                id: 'be815ed834d0c282cab563ea73556f97',
-                type: :intercept_message,
-              },
-            },
-            hits: {
-              data: [
-                { id: '43821', type: :subheading },
-                { id: '43606', type: :subheading },
-                { id: '43607', type: :commodity },
-                { id: '43608', type: :commodity },
-                { id: '43609', type: :commodity },
-                { id: '43522', type: :commodity },
-                { id: '43530', type: :commodity },
-                { id: '43486', type: :subheading },
-                { id: '43487', type: :commodity },
-                { id: '43488', type: :commodity },
-              ],
-            },
-            heading_statistics: {
-              data: [
-                { id: '6217', type: :heading_statistic },
-                { id: '6209', type: :heading_statistic },
-                { id: '6211', type: :heading_statistic },
-                { id: '6307', type: :heading_statistic },
-              ],
-            },
-            chapter_statistics: {
-              data: [{ id: '62', type: :chapter_statistic }, { id: '63', type: :chapter_statistic }],
-            },
-            guide: { data: { id: '18', type: :guide } },
-            facet_filter_statistics: {
-              data: [
-                { id: '2ecbb6c19ee6282b0c79dda2aeaf0192', type: :facet_filter_statistic },
-                { id: 'b24e66a126ad13c1521cf6cda4b2c502', type: :facet_filter_statistic },
-                { id: 'b030d559d41aee55d3cd439888aa5edf', type: :facet_filter_statistic },
-              ],
-            },
+            meta: { redirect: false, redirect_to: nil },
           },
-          meta: { redirect: false, redirect_to: nil },
-        },
-      }
+        }
+      end
+
+      it { is_expected.to eq(expected) }
     end
 
-    it { is_expected.to eq(expected) }
+    context 'when the search result has a direct hit' do
+      let(:serializable) { build(:search_result, :single_hit) }
+      let(:expected) do
+        {
+          data: {
+            id: '51579623029349bc57538b4773f5a1ed',
+            type: :search_result,
+            attributes: { took: 0, timed_out: false, max_score: 79.16452, total_results: 1 },
+            relationships: {
+              search_query_parser_result: {
+                data: {
+                  id: '0e956af30bdc0dcd5679f2249adc6d94',
+                  type: :search_query_parser_result,
+                },
+              },
+              intercept_message: { data: nil },
+              hits: { data: [{ id: '98910', type: :commodity }] },
+              direct_hit: { data: { id: '0406105090-80', type: :commodity } },
+              heading_statistics: { data: [] },
+              chapter_statistics: { data: [] },
+              guide: { data: nil },
+              facet_filter_statistics: { data: [] },
+            },
+            meta: { redirect: false, redirect_to: nil },
+          },
+        }
+      end
+
+      it { is_expected.to eq(expected) }
+    end
   end
 end

--- a/spec/services/short_code_classification_service_spec.rb
+++ b/spec/services/short_code_classification_service_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe ShortCodeClassificationService do
+  describe '#call' do
+    shared_examples 'a short code classification' do |short_code, expected_result|
+      it { expect(described_class.new(short_code).call).to eq(expected_result) }
+    end
+
+    it_behaves_like 'a short code classification', '1', %w[Chapter 1000000000 80]
+    it_behaves_like 'a short code classification', '12', %w[Chapter 1200000000 80]
+    it_behaves_like 'a short code classification', '123', %w[Heading 1230000000 80]
+    it_behaves_like 'a short code classification', '1234', %w[Heading 1234000000 80]
+    it_behaves_like 'a short code classification', '123456', %w[Subheading 1234560000 80]
+    it_behaves_like 'a short code classification', '12345678', %w[Subheading 1234567800 80]
+    it_behaves_like 'a short code classification', '1234567890', %w[Commodity 1234567890 80]
+    it_behaves_like 'a short code classification', '1234567890-10', %w[Subheading 1234567890 10]
+    it_behaves_like 'a short code classification', '1234567890-80', %w[Subheading 1234567890 80]
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2393

### What?

I have added/removed/altered:

- [x] Adds a short code classifier
- [x] Adds a direct hit model
- [x] Surface direct hit in the api
- [x] Adds test coverage

### Why?

I am doing this because:

- This is required to simplify single hit/search reference single hit and numeric single hit results into a single polymorphic form that the frontend can just redirect the user too
