### PR TITLE
HOTT-2305: Exposed news collection API endpoints

### DIFF
--- a/app/controllers/api/admin/news/collections_controller.rb
+++ b/app/controllers/api/admin/news/collections_controller.rb
@@ -52,6 +52,7 @@ module Api
             :priority,
             :description,
             :name,
+            :slug,
           )
         end
 

--- a/app/controllers/api/admin/news/collections_controller.rb
+++ b/app/controllers/api/admin/news/collections_controller.rb
@@ -10,6 +10,58 @@ module Api
           render json: Api::Admin::News::CollectionSerializer.new(collections)
                                                              .serializable_hash
         end
+
+        def show
+          news_collection = ::News::Collection.where(id: params[:id]).take
+
+          render json: serialize(news_collection)
+        end
+
+        def create
+          news_collection = ::News::Collection.new(news_collection_params)
+
+          if news_collection.valid? && news_collection.save
+            render json: serialize(news_collection),
+                   location: api_admin_news_collection_url(news_collection.id),
+                   status: :created
+          else
+            render json: serialize_errors(news_collection),
+                   status: :unprocessable_entity
+          end
+        end
+
+        def update
+          news_collection = ::News::Collection.with_pk!(params[:id])
+          news_collection.set news_collection_params
+
+          if news_collection.valid? && news_collection.save
+            render json: serialize(news_collection),
+                   location: api_admin_news_collection_url(news_collection.id),
+                   status: :ok
+          else
+            render json: serialize_errors(news_collection),
+                   status: :unprocessable_entity
+          end
+        end
+
+        private
+
+        def news_collection_params
+          params.require(:data).require(:attributes).permit(
+            :published,
+            :priority,
+            :description,
+            :name,
+          )
+        end
+
+        def serialize(*args)
+          Api::Admin::News::CollectionSerializer.new(*args).serializable_hash
+        end
+
+        def serialize_errors(news_collection)
+          Api::Admin::ErrorSerializationService.new(news_collection).call
+        end
       end
     end
   end

--- a/app/serializers/api/admin/news/collection_serializer.rb
+++ b/app/serializers/api/admin/news/collection_serializer.rb
@@ -9,7 +9,6 @@ module Api
         set_id :id
 
         attributes :name, :slug, :created_at, :updated_at, :description, :priority, :published
-
       end
     end
   end

--- a/app/serializers/api/admin/news/collection_serializer.rb
+++ b/app/serializers/api/admin/news/collection_serializer.rb
@@ -8,7 +8,8 @@ module Api
 
         set_id :id
 
-        attributes :name, :slug, :created_at, :updated_at
+        attributes :name, :slug, :created_at, :updated_at, :description, :priority, :published
+
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,7 +53,7 @@ Rails.application.routes.draw do
       if TradeTariffBackend.uk?
         namespace :news do
           resources :items, only: %i[index show create update destroy]
-          resources :collections, only: %i[index show create update edit]
+          resources :collections, only: %i[index show create update]
         end
 
         resources :news_items, only: %i[index show create update destroy],

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,7 +53,7 @@ Rails.application.routes.draw do
       if TradeTariffBackend.uk?
         namespace :news do
           resources :items, only: %i[index show create update destroy]
-          resources :collections, only: %i[index]
+          resources :collections, only: %i[index show create update edit]
         end
 
         resources :news_items, only: %i[index show create update destroy],

--- a/spec/requests/api/admin/news/collections_controller_spec.rb
+++ b/spec/requests/api/admin/news/collections_controller_spec.rb
@@ -3,6 +3,8 @@ RSpec.describe Api::Admin::News::CollectionsController do
 
   let(:json_response) { JSON.parse(page_response.body) }
 
+  let(:news_collection) { create :news_collection }
+
   describe 'GET to #index' do
     let :make_request do
       authenticated_get api_admin_news_collections_path(format: :json)
@@ -16,6 +18,99 @@ RSpec.describe Api::Admin::News::CollectionsController do
 
     context 'without any news collections' do
       it_behaves_like 'a successful jsonapi response', 0
+    end
+  end
+
+  describe 'GET to #show' do
+    let(:make_request) do
+      authenticated_get api_admin_news_collection_path(news_collection_id, format: :json)
+    end
+
+    context 'with existent news collection' do
+      let(:news_collection_id) { news_collection.id }
+
+      it { is_expected.to have_http_status :success }
+      it { expect(json_response).to include('data') }
+    end
+
+    context 'with non-existent news collection' do
+      let(:news_collection_id) { 9999 }
+
+      it { is_expected.to have_http_status :not_found }
+    end
+  end
+
+  describe 'POST to #create' do
+    let(:make_request) do
+      authenticated_post api_admin_news_collections_path(format: :json), params: news_collection_data
+    end
+
+    let :news_collection_data do
+      {
+        data: {
+          type: :news_collection,
+          attributes: news_collection_attrs,
+        },
+      }
+    end
+
+    context 'with valid params' do
+      let(:news_collection_attrs) { attributes_for :news_collection }
+
+      it { is_expected.to have_http_status :created }
+      it { is_expected.to have_attributes location: api_admin_news_collection_url(News::Collection.last.id) }
+      it { expect { page_response }.to change(News::Collection, :count).by(1) }
+    end
+
+    context 'with invalid params' do
+      let(:news_collection_attrs) { attributes_for :news_collection, name: nil }
+
+      it { is_expected.to have_http_status :unprocessable_entity }
+
+      it 'returns errors for news collection' do
+        expect(json_response).to include('errors')
+      end
+
+      it { expect { page_response }.not_to change(News::Collection, :count) }
+    end
+  end
+
+  describe 'PATCH to #update' do
+    let(:news_collection_id) { news_collection.id }
+    let(:updated_name) { 'Updated name' }
+
+    let(:make_request) do
+      authenticated_patch api_admin_news_collection_path(news_collection_id, format: :json), params: {
+        data: {
+          type: :news_collection,
+          attributes: { name: updated_name },
+        },
+      }
+    end
+
+    context 'with valid params' do
+      it { is_expected.to have_http_status :success }
+      it { is_expected.to have_attributes location: api_admin_news_collection_url(news_collection.id) }
+      it { expect { page_response }.not_to change(news_collection.reload, :name) }
+    end
+
+    context 'with invalid params' do
+      let(:updated_name) { '' }
+
+      it { is_expected.to have_http_status :unprocessable_entity }
+
+      it 'returns errors for news collection' do
+        expect(json_response).to include('errors')
+      end
+
+      it { expect { page_response }.not_to change(news_collection.reload, :name) }
+    end
+
+    context 'with unknown news collection' do
+      let(:news_collection_id) { 9999 }
+
+      it { is_expected.to have_http_status :not_found }
+      it { expect { page_response }.not_to change(news_collection.reload, :name) }
     end
   end
 end

--- a/spec/serializers/api/admin/news/collection_serializer_spec.rb
+++ b/spec/serializers/api/admin/news/collection_serializer_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe Api::Admin::News::CollectionSerializer do
             slug: 'serialized',
             created_at: collection.created_at,
             updated_at: collection.updated_at,
+            description: collection.description,
+            priority: collection.priority,
+            published: collection.published,
           },
         },
       }


### PR DESCRIPTION
### Jira link

[HOTT-<TODO>](https://transformuk.atlassian.net/browse/HOTT-2305)

### What?

I have added/removed/altered:

- [ ] Exposed news collection API endpoints

### Why?

I am doing this because:

- We need access to this API so we can Display, create, update data on admin

### Have you? (optional)

- [ ] Added documentation for new apis

### Deployment risks (optional)

- Changes an api that is used in production

<img width="776" alt="Screenshot 2023-02-20 at 15 54 18" src="https://user-images.githubusercontent.com/12201130/220152193-881a7000-eddf-40ed-97a3-851809edd986.png">
