### PR TITLE
HOTT-2700 Fix database cleaner with rspec `around` hook

### DIFF
--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -5,23 +5,21 @@ RSpec.configure do |config|
     DatabaseCleaner.allow_remote_database_url = true
   end
 
+  DatabaseCleaner.strategy = :transaction
+
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
   end
 
-  config.before do
+  config.around(:each, truncation: true) do |example|
+    DatabaseCleaner.strategy = :truncation
+    example.run
     DatabaseCleaner.strategy = :transaction
   end
 
-  config.before(:each, truncation: true) do
-    DatabaseCleaner.strategy = :truncation
-  end
-
-  config.before do
+  config.around do |example|
     DatabaseCleaner.start
-  end
-
-  config.after do
+    example.run
     DatabaseCleaner.clean
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-2700

### What?

I have added/removed/altered:

- [x] Moved the DatabaseCleaner integration to an RSpec `around` block instead of `before` and `after` blocks

### Why?

I am doing this because:

- It solves data being left around by specs if they created the data in an `around` block

If factories are created in an RSpec `around` hook, they continue to persist after the RSpec example completes and DatabaseCleaner has supposedly cleaned the database.

This is because DatabaseCleaner currently runs in the `before` and `after` RSpec hooks, which run after the `around` hook.

This means the database transaction is started after the data is created and so the transaction rollback doesn't actually remove it.

Moving the transaction start to an `around` hook (and hence higher priority) solves this problem.

### Deployment risks (optional)

- None - changes to testing infrastructure
