### PR TITLE
HOTT-2688 Refactored GoodsNomenclature factories

### DIFF
--- a/spec/controllers/api/v1/commodities_controller_spec.rb
+++ b/spec/controllers/api/v1/commodities_controller_spec.rb
@@ -3,8 +3,7 @@ RSpec.describe Api::V1::CommoditiesController, 'GET #show' do
 
   let!(:commodity) do
     create :commodity, :with_indent,
-           :with_chapter,
-           :with_heading,
+           :with_chapter_and_heading,
            :with_description,
            :declarable
   end
@@ -30,7 +29,7 @@ RSpec.describe Api::V1::CommoditiesController, 'GET #show' do
 
   context 'when record is not present' do
     it 'returns not found if record was not found' do
-      id = commodity.goods_nomenclature_item_id.to_i + 1
+      id = commodity.goods_nomenclature_item_id.next
       get :show, params: { id: }, format: :json
 
       expect(response.status).to eq 404
@@ -81,8 +80,7 @@ RSpec.describe Api::V1::CommoditiesController, 'GET #changes' do
   context 'changes happened after chapter creation' do
     let!(:commodity) do
       create :commodity, :with_indent,
-             :with_chapter,
-             :with_heading,
+             :with_chapter_and_heading,
              :with_description,
              :declarable,
              operation_date: Time.zone.today
@@ -115,8 +113,7 @@ RSpec.describe Api::V1::CommoditiesController, 'GET #changes' do
   context 'changes happened before requested date' do
     let!(:commodity) do
       create :commodity, :with_indent,
-             :with_chapter,
-             :with_heading,
+             :with_chapter_and_heading,
              :with_description,
              :declarable,
              operation_date: Time.zone.today
@@ -132,8 +129,7 @@ RSpec.describe Api::V1::CommoditiesController, 'GET #changes' do
   context 'changes include deleted record' do
     let!(:commodity) do
       create :commodity, :with_indent,
-             :with_chapter,
-             :with_heading,
+             :with_chapter_and_heading,
              :with_description,
              :declarable,
              operation_date: Time.zone.today

--- a/spec/controllers/api/v1/headings_controller_spec.rb
+++ b/spec/controllers/api/v1/headings_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Api::V1::HeadingsController, flaky: true do
 
       context 'when record is not present' do
         it 'returns not found if record was not found' do
-          id = heading.goods_nomenclature_item_id.first(4).to_i + 1
+          id = heading.goods_nomenclature_item_id.first(4).next
           get :show, params: { id: }, format: :json
 
           expect(response.status).to eq 404
@@ -117,7 +117,7 @@ RSpec.describe Api::V1::HeadingsController, flaky: true do
 
       context 'when record is not present' do
         it 'returns not found if record was not found' do
-          id = heading.goods_nomenclature_item_id.first(4).to_i + 1
+          id = heading.goods_nomenclature_item_id.first(4).next
           get :show, params: { id: }, format: :json
 
           expect(response.status).to eq 404

--- a/spec/controllers/api/v2/commodities_controller_spec.rb
+++ b/spec/controllers/api/v2/commodities_controller_spec.rb
@@ -3,8 +3,7 @@ RSpec.describe Api::V2::CommoditiesController do
     create(
       :commodity,
       :with_indent,
-      :with_chapter,
-      :with_heading,
+      :with_chapter_and_heading,
       :with_measures,
       :with_description,
       :declarable,
@@ -45,8 +44,7 @@ RSpec.describe Api::V2::CommoditiesController do
         create(
           :commodity,
           :with_indent,
-          :with_chapter,
-          :with_heading,
+          :with_chapter_and_heading,
           :with_description,
           :with_meursing_measures,
           :declarable,
@@ -70,7 +68,7 @@ RSpec.describe Api::V2::CommoditiesController do
     end
 
     context 'when fetching a commodity that does not exist' do
-      subject(:do_response) { get :show, params: { id: commodity.goods_nomenclature_item_id.to_i + 1 } }
+      subject(:do_response) { get :show, params: { id: commodity.goods_nomenclature_item_id.next } }
 
       it { is_expected.to have_http_status(:not_found) }
     end
@@ -118,8 +116,7 @@ RSpec.describe Api::V2::CommoditiesController, 'GET #changes' do
   context 'changes happened after chapter creation' do
     let!(:commodity) do
       create :commodity, :with_indent,
-             :with_chapter,
-             :with_heading,
+             :with_chapter_and_heading,
              :with_description,
              :declarable,
              operation_date: Time.zone.today
@@ -167,8 +164,7 @@ RSpec.describe Api::V2::CommoditiesController, 'GET #changes' do
   context 'changes happened before requested date' do
     let!(:commodity) do
       create :commodity, :with_indent,
-             :with_chapter,
-             :with_heading,
+             :with_chapter_and_heading,
              :with_description,
              :declarable,
              operation_date: Time.zone.today
@@ -191,8 +187,7 @@ RSpec.describe Api::V2::CommoditiesController, 'GET #changes' do
   context 'changes include deleted record' do
     let!(:commodity) do
       create :commodity, :with_indent,
-             :with_chapter,
-             :with_heading,
+             :with_chapter_and_heading,
              :with_description,
              :declarable,
              operation_date: Time.zone.today

--- a/spec/controllers/api/v2/goods_nomenclatures_controller_spec.rb
+++ b/spec/controllers/api/v2/goods_nomenclatures_controller_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe Api::V2::GoodsNomenclaturesController do
   let!(:goods_nomenclature) do
     create :commodity,
            :with_indent,
-           :with_chapter,
-           :with_heading
+           :with_chapter_and_heading
   end
   let(:chapter) { goods_nomenclature.reload.chapter }
   let(:heading) { goods_nomenclature.reload.heading }

--- a/spec/controllers/api/v2/headings_controller_spec.rb
+++ b/spec/controllers/api/v2/headings_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Api::V2::HeadingsController, type: :controller do
     end
 
     context 'when the heading does not exist' do
-      let(:id) { heading.short_code.to_i + 1 }
+      let(:id) { heading.short_code.next }
 
       it { expect(do_response).to have_http_status(:not_found) }
     end
@@ -124,7 +124,7 @@ RSpec.describe Api::V2::HeadingsController, type: :controller do
       end
 
       context 'when the record is not present' do
-        let(:id) { heading.short_code.to_i + 1 }
+        let(:id) { heading.short_code.next }
 
         it { expect(do_response).to have_http_status(:not_found) }
       end

--- a/spec/factories/chapter_factory.rb
+++ b/spec/factories/chapter_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :chapter, parent: :goods_nomenclature, class: 'Chapter' do
-    goods_nomenclature_item_id { "#{generate(:chapter_item_id)}00000000" }
+    goods_nomenclature_item_id { "#{generate(:chapter_short_code)}00000000" }
 
     trait :with_section do
       after(:create) do |chapter, _evaluator|

--- a/spec/factories/chapter_factory.rb
+++ b/spec/factories/chapter_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :chapter, parent: :goods_nomenclature, class: 'Chapter' do
-    goods_nomenclature_item_id { "#{2.times.map { Random.rand(9) }.join}00000000" }
+    goods_nomenclature_item_id { "#{generate(:chapter_item_id)}00000000" }
 
     trait :with_section do
       after(:create) do |chapter, _evaluator|
@@ -28,6 +28,10 @@ FactoryBot.define do
         chapter.add_guide guide
         chapter.save
       end
+    end
+
+    trait :chapter01 do
+      goods_nomenclature_item_id { '0100000000' }
     end
   end
 

--- a/spec/factories/goods_nomenclature_factory.rb
+++ b/spec/factories/goods_nomenclature_factory.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   sequence(:goods_nomenclature_sid, 100) # Some factories hard code SIDs, so avoid clashing
-  sequence(:commodity_item_id) { |n| sprintf '%06d', n }
-  sequence(:heading_item_id, 10) { |n| sprintf '01%02d', n }
-  sequence(:chapter_item_id, 10) { |n| sprintf '%02d', n }
+  sequence(:chapter_short_code, 10) { |n| sprintf '%02d', n }
+  sequence(:heading_short_code, 10) { |n| sprintf '01%02d', n }
+  sequence(:commodity_short_code) { |n| sprintf '%06d', n }
 
   factory :goods_nomenclature do
     transient do
@@ -18,7 +18,7 @@ FactoryBot.define do
 
     goods_nomenclature_item_id do
       heading_code = parent ? parent.goods_nomenclature_item_id.first(4) : '0101'
-      [heading_code, generate(:commodity_item_id)].join
+      [heading_code, generate(:commodity_short_code)].join
     end
 
     path do
@@ -122,12 +122,12 @@ FactoryBot.define do
     end
 
     trait :chapter do
-      goods_nomenclature_item_id { sprintf '%s00000000', generate(:chapter_item_id) }
+      goods_nomenclature_item_id { sprintf '%s00000000', generate(:chapter_short_code) }
       indents { 0 }
     end
 
     trait :heading do
-      goods_nomenclature_item_id { sprintf '%s000000', generate(:heading_item_id) }
+      goods_nomenclature_item_id { sprintf '%s000000', generate(:heading_short_code) }
       indents { 0 }
     end
 
@@ -279,7 +279,7 @@ FactoryBot.define do
     number_indents { Forgery(:basic).number }
 
     goods_nomenclature_item_id do
-      goods_nomenclature&.goods_nomenclature_item_id || "0101#{generate(:commodity_item_id)}"
+      goods_nomenclature&.goods_nomenclature_item_id || "0101#{generate(:commodity_short_code)}"
     end
 
     validity_start_date { goods_nomenclature&.validity_start_date || 3.years.ago.beginning_of_day }

--- a/spec/factories/heading_factory.rb
+++ b/spec/factories/heading_factory.rb
@@ -1,8 +1,6 @@
 FactoryBot.define do
   factory :heading, parent: :goods_nomenclature, class: 'Heading' do
-    # +1 is needed to avoid creating heading with gono id in form of
-    # xx00xxxxxx which is a Chapter
-    goods_nomenclature_item_id { "#{4.times.map { Random.rand(1..8) }.join}000000" }
+    goods_nomenclature_item_id { "#{generate(:heading_item_id)}000000" }
 
     trait :declarable do
       producline_suffix { '80' }
@@ -10,20 +8,28 @@ FactoryBot.define do
 
     trait :non_declarable do
       after(:create) do |heading, _evaluator|
-        create(:goods_nomenclature, :with_description,
-                          :with_indent,
-                          goods_nomenclature_item_id: "#{heading.short_code}#{6.times.map { Random.rand(9) }.join}")
+        create(:goods_nomenclature,
+               :with_description,
+               :with_indent,
+               goods_nomenclature_item_id: "#{heading.short_code}#{6.times.map { Random.rand(9) }.join}")
       end
     end
 
     trait :with_chapter do
-      after(:create) do |heading, _evaluator|
-        create(:chapter, :with_section,
-                          :with_note,
-                          :with_description,
-                          :with_guide,
-                          goods_nomenclature_item_id: heading.chapter_id)
+      before(:create) do |heading, _evaluator|
+        chapter = create(:chapter,
+                         :with_section,
+                         :with_note,
+                         :with_description,
+                         :with_guide,
+                         goods_nomenclature_item_id: heading.chapter_id)
+
+        heading.path = Sequel.pg_array([chapter.goods_nomenclature_sid])
       end
+    end
+
+    trait :heading101 do
+      goods_nomenclature_item_id { '0101000000' }
     end
   end
 end

--- a/spec/factories/heading_factory.rb
+++ b/spec/factories/heading_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :heading, parent: :goods_nomenclature, class: 'Heading' do
-    goods_nomenclature_item_id { "#{generate(:heading_item_id)}000000" }
+    goods_nomenclature_item_id { "#{generate(:heading_short_code)}000000" }
 
     trait :declarable do
       producline_suffix { '80' }

--- a/spec/lib/cds_importer/entity_mapper/goods_nomenclature_mapper_spec.rb
+++ b/spec/lib/cds_importer/entity_mapper/goods_nomenclature_mapper_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe CdsImporter::EntityMapper::GoodsNomenclatureMapper do
         create(
           :goods_nomenclature,
           :with_footnote_association,
-          :with_goods_nomenclature_indent,
+          :with_indent,
           :with_description,
           goods_nomenclature_sid: '87045',
         )

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -33,13 +33,15 @@ RSpec.describe GoodsNomenclature do
                  validity_end_date: 3.years.ago
         end
 
-        let!(:goods_nomenclature)                { create :goods_nomenclature }
-        let!(:goods_nomenclature_indent1)        do
+        let!(:goods_nomenclature) { create :goods_nomenclature, :without_indent }
+
+        let!(:goods_nomenclature_indent1) do
           create :goods_nomenclature_indent,
                  goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
                  validity_start_date: 2.years.ago,
                  validity_end_date: nil
         end
+
         let!(:goods_nomenclature_indent3) do
           create :goods_nomenclature_indent,
                  goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
@@ -558,13 +560,17 @@ RSpec.describe GoodsNomenclature do
     context 'when there are ancestors for the current goods nomenclature' do
       let(:goods_nomenclature) { create(:commodity, :with_ancestors) }
 
-      it { expect(classifiable_goods_nomenclatures).to eq([3, 2, 1]) }
+      let(:gn_sids) { [goods_nomenclature.goods_nomenclature_sid, 2, 1] }
+
+      it { expect(classifiable_goods_nomenclatures).to eq(gn_sids) }
     end
 
     context 'when there are no ancestors for the current goods nomenclature' do
-      let(:goods_nomenclature) { create(:commodity, goods_nomenclature_sid: 1) }
+      let(:goods_nomenclature) { create(:commodity) }
 
-      it { expect(classifiable_goods_nomenclatures).to eq([1]) }
+      let(:gn_sids) { [goods_nomenclature.goods_nomenclature_sid] }
+
+      it { expect(classifiable_goods_nomenclatures).to eq(gn_sids) }
     end
   end
 

--- a/spec/presenters/api/v2/commodities/commodity_presenter_spec.rb
+++ b/spec/presenters/api/v2/commodities/commodity_presenter_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe Api::V2::Commodities::CommodityPresenter do
     create(
       :commodity,
       :with_indent,
-      :with_chapter,
-      :with_heading,
+      :with_chapter_and_heading,
       :with_description,
       :declarable,
     )

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -57,6 +57,9 @@ RSpec.configure do |config|
     Rails.cache.clear
     Sidekiq::Worker.clear_all
 
+    # things like nomenclature item id's risk wrapping otherwise
+    FactoryBot.rewind_sequences
+
     TradeTariffBackend.clearable_models.map(&:clear_association_cache)
   end
 end

--- a/spec/serializers/api/v2/commodities/commodity_serializer_spec.rb
+++ b/spec/serializers/api/v2/commodities/commodity_serializer_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Api::V2::Commodities::CommoditySerializer do
   subject(:serializer) { described_class.new(serializable).serializable_hash.as_json }
 
   let(:serializable) { Api::V2::Commodities::CommodityPresenter.new(commodity, measures) }
-  let(:commodity) { create(:commodity, :with_heading, :with_chapter, :with_description).reload }
+  let(:commodity) { create(:commodity, :with_chapter_and_heading, :with_description) }
   let(:measures) { MeasureCollection.new [] }
 
   let(:expected_pattern) do

--- a/spec/services/cached_commodity_service_spec.rb
+++ b/spec/services/cached_commodity_service_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe CachedCommodityService do
   let!(:commodity) do
     create(
       :commodity,
-      :with_chapter,
-      :with_heading,
+      :with_chapter_and_heading,
     )
   end
 


### PR DESCRIPTION
### Jira link

HOTT-2688

### What?

I have added/removed/altered:

- [x] Removes use of rand in item ids
- [x] Removes hard coding of `.path` attribute
- [x] Removes hard coding of goods_nomenclature_sid
- [x] Creates indents by default since NestedSet will rely upon them

### Why?

I am doing this because:

The Nested Set relies heavily on the ability to create multiple hierarchies reliably 
- as part of that work I was running into both outright collisions on sids
- factories obscuring data they'd just created due to how the oplog handles duplicate sids
- fixing up some of this hardcoding in term broke a lot of existing specs relating to materialized path because the factories were hardcoding a hierarchy which was no longer correct. Hence I've refactored it to use a transient parent attribute and use that for dynamic generation of materialized paths `path` column
- NestedSet will rely on correct generation of `item_id` to support its hierarchy logic - ie creating 2 commodities should result in 2 siblings, not the second potentially occurring before the first once sorted

### Deployment risks (optional)

- Low - some minimal changes to specs but almost exclusively changes to just factories.
- No 'application code' is changed in this PR
