### PR TITLE
HOTT-2699: Adds filtering to additional code dataset and serializer filter

### DIFF
--- a/app/controllers/api/v2/additional_codes_controller.rb
+++ b/app/controllers/api/v2/additional_codes_controller.rb
@@ -1,20 +1,16 @@
 module Api
   module V2
     class AdditionalCodesController < ApiController
-      before_action :find_additional_codes
-
       def search
         options = {}
         options[:include] = [:measures, 'measures.goods_nomenclature']
-        render json: Api::V2::AdditionalCodes::AdditionalCodeSerializer.new(@additional_codes, options.merge(serialization_meta)).serializable_hash
+        render json: Api::V2::AdditionalCodes::AdditionalCodeSerializer.new(additional_codes, options.merge(serialization_meta)).serializable_hash
       end
 
       private
 
-      def find_additional_codes
-        TimeMachine.now do
-          @additional_codes = search_service.perform
-        end
+      def additional_codes
+        search_service.call
       end
 
       def search_service
@@ -31,9 +27,9 @@ module Api
             pagination: {
               page: current_page,
               per_page:,
-              total_count: search_service.pagination_record_count
-            }
-          }
+              total_count: search_service.pagination_record_count,
+            },
+          },
         }
       end
     end

--- a/app/serializers/cache/additional_code_serializer.rb
+++ b/app/serializers/cache/additional_code_serializer.rb
@@ -44,12 +44,15 @@ module Cache
     end
 
     def measures
-      additional_code
-        .measures_dataset
-        .eager(:goods_nomenclature)
-        .exclude(goods_nomenclature_item_id: nil)
-        .all
-        .select { |measure| has_valid_dates(measure) && measure.goods_nomenclature.present? }
+      TimeMachine.now do
+        additional_code
+          .measures_dataset
+          .with_actual(Measure)
+          .eager(:goods_nomenclature)
+          .exclude(goods_nomenclature_item_id: nil)
+          .all
+          .select(&:goods_nomenclature)
+      end
     end
   end
 end

--- a/spec/controllers/api/v2/additional_codes_controller_spec.rb
+++ b/spec/controllers/api/v2/additional_codes_controller_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Api::V2::AdditionalCodesController, type: :controller do
   describe 'GET #search' do
-    let!(:additional_code) { create :additional_code }
+    let!(:additional_code) { create(:additional_code, :with_description) }
 
     let(:pattern) do
       {
@@ -75,21 +75,25 @@ RSpec.describe Api::V2::AdditionalCodesController, type: :controller do
     end
 
     before do
-      measure = create(
+      current_goods_nomenclature = create(:heading)
+
+      create(
         :measure,
         :with_base_regulation,
         additional_code_sid: additional_code.additional_code_sid,
-        goods_nomenclature: create(:heading),
+        goods_nomenclature_sid: current_goods_nomenclature.goods_nomenclature_sid,
+        goods_nomenclature_item_id: current_goods_nomenclature.goods_nomenclature_item_id,
       )
       create(
         :goods_nomenclature_description,
-        goods_nomenclature_sid: measure.goods_nomenclature.goods_nomenclature_sid,
+        goods_nomenclature_sid: current_goods_nomenclature.goods_nomenclature_sid,
       )
       create(
         :measure,
         :with_base_regulation,
         additional_code_sid: additional_code.additional_code_sid,
-        goods_nomenclature: nil,
+        goods_nomenclature_sid: nil,
+        goods_nomenclature_item_id: nil,
       )
       create(
         :additional_code_description,

--- a/spec/elastic_search_indexes/cache/additional_code_index_spec.rb
+++ b/spec/elastic_search_indexes/cache/additional_code_index_spec.rb
@@ -3,6 +3,83 @@ require 'rails_helper'
 RSpec.describe Cache::AdditionalCodeIndex do
   subject(:instance) { described_class.new 'testnamespace' }
 
+  describe '#dataset' do
+    subject(:dataset) { instance.dataset }
+
+    let(:additional_code) { create(:additional_code) }
+
+    before do
+      goods_nomenclature = create(:heading)
+
+      create(
+        :measure,
+        :with_base_regulation,
+        additional_code_sid: additional_code.additional_code_sid,
+        additional_code_type_id: additional_code.additional_code_type_id,
+        additional_code_id: additional_code.additional_code,
+        goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
+        goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
+      )
+
+      # Non current additional code
+      code = create(:additional_code, validity_end_date: Time.zone.yesterday)
+
+      create(
+        :measure,
+        :with_base_regulation,
+        additional_code_sid: code.additional_code_sid,
+        additional_code_type_id: code.additional_code_type_id,
+        additional_code_id: code.additional_code,
+        goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
+        goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
+      )
+
+      # No goods nomenclature
+      code = create(:additional_code)
+
+      create(
+        :measure,
+        :with_base_regulation,
+        additional_code_sid: code.additional_code_sid,
+        additional_code_type_id: code.additional_code_type_id,
+        additional_code_id: code.additional_code,
+        goods_nomenclature_sid: nil,
+        goods_nomenclature_item_id: nil,
+      )
+
+      # Non current measure
+      code = create(:additional_code)
+
+      create(
+        :measure,
+        :with_base_regulation,
+        additional_code_sid: code.additional_code_sid,
+        additional_code_type_id: code.additional_code_type_id,
+        additional_code_id: code.additional_code,
+        goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
+        goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
+        validity_end_date: Time.zone.yesterday,
+      )
+
+      # Excluded type
+      code = create(:additional_code, additional_code_type_id: '6')
+
+      create(
+        :measure,
+        :with_base_regulation,
+        additional_code_sid: code.additional_code_sid,
+        additional_code_type_id: code.additional_code_type_id,
+        additional_code_id: code.additional_code,
+        goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
+        goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
+      )
+    end
+
+    it { expect(dataset.count).to eq 1 }
+    it { expect(dataset).to all be_a AdditionalCode }
+    it { expect(dataset.first.additional_code_sid).to eq additional_code.additional_code_sid }
+  end
+
   it { is_expected.to have_attributes type: 'additional_code' }
   it { is_expected.to have_attributes name: 'testnamespace-additional_codes-uk-cache' }
   it { is_expected.to have_attributes name_without_namespace: 'AdditionalCodeIndex' }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2699

### What?

I have added/removed/altered:

- [x] Move to only indexing current additional codes (current additional codes have associated current measures where the additional code itself is also current)
- [x] Exclude indexing non-current goods nomenclatures
- [x] Exclude indexing additional codes that are either nonsense (are meursing additional codes and therefore have no goods nomenclatures) or that have explicitly been excluded from search in the frontend based on their type
- [x] Upgraded all of the specs to reflect these changes

### Why?

I am doing this because:

- We get a lot of garbage in the search results and have a lot of special snowflaking around meursing goods nomenclatures
- This should also significantly speed up ETL in the am
