### PR TITLE
HOTT-2732 Rename materialised path relationships

### DIFF
--- a/app/controllers/api/admin/headings_controller.rb
+++ b/app/controllers/api/admin/headings_controller.rb
@@ -21,7 +21,7 @@ module Api
                           .non_grouping
                           .non_hidden
                           .by_code(params[:id])
-                          .eager(descendants: %i[goods_nomenclature_descriptions descendants])
+                          .eager(path_descendants: %i[goods_nomenclature_descriptions path_descendants])
                           .limit(1)
                           .take
       end
@@ -35,7 +35,7 @@ module Api
       end
 
       def applicable_goods_nomenclature_sids
-        heading.descendants.pluck(:goods_nomenclature_sid).tap { |sids| sids << heading.goods_nomenclature_sid }
+        heading.path_descendants.pluck(:goods_nomenclature_sid).tap { |sids| sids << heading.goods_nomenclature_sid }
       end
     end
   end

--- a/app/models/concerns/ten_digit_goods_nomenclature.rb
+++ b/app/models/concerns/ten_digit_goods_nomenclature.rb
@@ -95,7 +95,7 @@ module TenDigitGoodsNomenclature
     end
 
     def fast_declarable?
-      non_grouping? && descendants_dataset.count.zero?
+      non_grouping? && path_descendants_dataset.count.zero?
     end
 
     def non_grouping?

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -49,7 +49,7 @@ class GoodsNomenclature < Sequel::Model
     end
   end
 
-  one_to_one :parent, class_name: name, class: self do |_ds|
+  one_to_one :path_parent, class_name: name, class: self do |_ds|
     parent_sid = !heading? ? path.last : chapter.goods_nomenclature_sid
 
     if parent_sid.present?
@@ -59,7 +59,7 @@ class GoodsNomenclature < Sequel::Model
     end
   end
 
-  one_to_many :siblings, class_name: name, class: self do |_ds|
+  one_to_many :path_siblings, class_name: name, class: self do |_ds|
     GoodsNomenclature
       .actual
       .exclude(goods_nomenclature_sid:)
@@ -74,7 +74,7 @@ class GoodsNomenclature < Sequel::Model
       .where(path: child_path)
   end
 
-  one_to_many :descendants, class_name: name, class: self do |_ds|
+  one_to_many :path_descendants, class_name: name, class: self do |_ds|
     GoodsNomenclature
       .actual
       .where('? = ANY(path)', goods_nomenclature_sid)

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -39,7 +39,7 @@ class GoodsNomenclature < Sequel::Model
   many_to_many :guides, left_key: :goods_nomenclature_sid,
                         join_table: :guides_goods_nomenclatures
 
-  one_to_many :ancestors, class_name: name, class: self do |_ds|
+  one_to_many :path_ancestors, class_name: name, class: self do |_ds|
     if path.present?
       GoodsNomenclature
         .actual
@@ -66,7 +66,7 @@ class GoodsNomenclature < Sequel::Model
       .where(path:)
   end
 
-  one_to_many :children, class_name: name, class: self do |_ds|
+  one_to_many :path_children, class_name: name, class: self do |_ds|
     child_path = Sequel.pg_array(path + [goods_nomenclature_sid], :integer)
 
     GoodsNomenclature
@@ -218,12 +218,12 @@ class GoodsNomenclature < Sequel::Model
     !!goods_nomenclature_item_id.match(/\A\d{2}00000000\z/)
   end
 
-  def declarable?
-    children.none? && producline_suffix == GoodsNomenclatureIndent::NON_GROUPING_PRODUCTLINE_SUFFIX
+  def path_declarable?
+    path_children.none? && producline_suffix == GoodsNomenclatureIndent::NON_GROUPING_PRODUCTLINE_SUFFIX
   end
 
   def classifiable_goods_nomenclatures
-    ancestors.dup.push(self).reverse
+    path_ancestors.dup.push(self).reverse
   end
 
   def intercept_terms

--- a/app/presenters/api/admin/headings/heading_presenter.rb
+++ b/app/presenters/api/admin/headings/heading_presenter.rb
@@ -21,7 +21,7 @@ module Api
         end
 
         def commodities
-          @commodities ||= CommodityPresenter.wrap(descendants, @search_reference_counts)
+          @commodities ||= CommodityPresenter.wrap(path_descendants, @search_reference_counts)
         end
 
         def commodity_ids

--- a/app/serializers/api/admin/csv/goods_nomenclature_serializer.rb
+++ b/app/serializers/api/admin/csv/goods_nomenclature_serializer.rb
@@ -11,7 +11,7 @@ module Api
         column :validity_start_date, column_name: 'Start date'
         column :validity_end_date, column_name: 'End date'
         column :number_indents, column_name: 'Indentation'
-        column :end_line, column_name: 'End line', &:declarable?
+        column :end_line, column_name: 'End line', &:path_declarable?
 
         # Uses materialized path to determine declarability of goods nomenclature to avoid slow csv generation
         column :goods_nomenclature_class, column_name: 'Class' do |goods_nomenclature|
@@ -20,7 +20,7 @@ module Api
           class_name = GoodsNomenclature.sti_load(goods_nomenclature_item_id:).class.name
 
           if class_name == 'Commodity'
-            goods_nomenclature.declarable? ? 'Commodity' : 'Subheading'
+            goods_nomenclature.path_declarable? ? 'Commodity' : 'Subheading'
           else
             class_name
           end
@@ -31,7 +31,7 @@ module Api
         end
 
         column :ancestors, column_name: 'Hierarchy' do |goods_nomenclature|
-          ancestor_ids = goods_nomenclature.ancestors.map do |ancestor|
+          ancestor_ids = goods_nomenclature.path_ancestors.map do |ancestor|
             "#{ancestor.goods_nomenclature_item_id}_#{ancestor.producline_suffix}"
           end
 

--- a/app/serializers/search/goods_nomenclature_serializer.rb
+++ b/app/serializers/search/goods_nomenclature_serializer.rb
@@ -33,7 +33,7 @@ module Search
         ancestor_13_description_indexed:,
         guides:,
         guide_ids:,
-        declarable: declarable?,
+        declarable: path_declarable?,
       }
 
       serializable.merge(serializable_classifications)
@@ -48,7 +48,7 @@ module Search
         .name
 
       if class_name == 'Commodity'
-        goods_nomenclature.declarable? ? 'Commodity' : 'Subheading'
+        goods_nomenclature.path_declarable? ? 'Commodity' : 'Subheading'
       else
         class_name
       end
@@ -63,13 +63,13 @@ module Search
     end
 
     def search_references
-      ancestors.reverse.each_with_object([declarable_search_references]) { |serialized_ancestor, acc|
+      path_ancestors.reverse.each_with_object([declarable_search_references]) { |serialized_ancestor, acc|
         acc.prepend(serialized_ancestor[:search_references])
       }.join(' ')
     end
 
     def search_intercept_terms
-      ancestors.reverse.each_with_object([intercept_terms]) { |serialized_ancestor, acc|
+      path_ancestors.reverse.each_with_object([intercept_terms]) { |serialized_ancestor, acc|
         next if serialized_ancestor[:intercept_terms].blank?
 
         acc.prepend(serialized_ancestor[:intercept_terms])
@@ -77,7 +77,7 @@ module Search
     end
 
     def ancestors
-      @ancestors ||= super.map do |ancestor|
+      @ancestors ||= path_ancestors.map do |ancestor|
         {
           id: ancestor.goods_nomenclature_sid,
           goods_nomenclature_item_id: ancestor.goods_nomenclature_item_id,
@@ -140,7 +140,7 @@ module Search
     end
 
     def facet_classification
-      @facet_classification ||= if declarable?
+      @facet_classification ||= if path_declarable?
                                   Beta::Search::FacetClassification::Declarable.build(self)
                                 else
                                   Beta::Search::FacetClassification::NonDeclarable.build(self)

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -439,29 +439,29 @@ RSpec.describe GoodsNomenclature do
     end
   end
 
-  describe '#parent' do
+  describe '#path_parent' do
     context 'when the goods nomenclature has an immediate parent' do
-      subject(:parent) { create(:goods_nomenclature, :with_parent).parent }
+      subject(:parent) { create(:goods_nomenclature, :with_parent).path_parent }
 
       it { expect(parent).to be_a(described_class) }
     end
 
     context 'when the goods nomenclature has no parent' do
-      subject(:parent) { create(:goods_nomenclature, :without_parent).parent }
+      subject(:parent) { create(:goods_nomenclature, :without_parent).path_parent }
 
       it { expect(parent).to be_nil }
     end
   end
 
-  describe '#siblings' do
+  describe '#path_siblings' do
     context 'when the goods nomenclature has siblings' do
-      subject(:siblings) { create(:goods_nomenclature, :with_siblings).siblings }
+      subject(:siblings) { create(:goods_nomenclature, :with_siblings).path_siblings }
 
       it { expect(siblings).to include(an_instance_of(described_class)) }
     end
 
     context 'when the goods nomenclature has no siblings' do
-      subject(:siblings) { create(:goods_nomenclature, :without_siblings).siblings }
+      subject(:siblings) { create(:goods_nomenclature, :without_siblings).path_siblings }
 
       it { expect(siblings).to be_empty }
     end
@@ -481,15 +481,15 @@ RSpec.describe GoodsNomenclature do
     end
   end
 
-  describe '#descendants' do
+  describe '#path_descendants' do
     context 'when the goods nomenclature has descendants' do
-      subject(:descendant_sids) { create(:goods_nomenclature, :with_descendants).descendants.length }
+      subject(:descendant_sids) { create(:goods_nomenclature, :with_descendants).path_descendants.length }
 
       it { is_expected.to eq(2) }
     end
 
     context 'when the goods nomenclature has no descendants' do
-      subject(:descendant_sids) { create(:goods_nomenclature, :without_descendants).descendants.length }
+      subject(:descendant_sids) { create(:goods_nomenclature, :without_descendants).path_descendants.length }
 
       it { is_expected.to be_zero }
     end

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -425,15 +425,15 @@ RSpec.describe GoodsNomenclature do
     end
   end
 
-  describe '#ancestors' do
+  describe '#path_ancestors' do
     context 'when the goods nomenclature has ancestors' do
-      subject(:ancestors) { create(:goods_nomenclature, :with_ancestors).ancestors }
+      subject(:ancestors) { create(:goods_nomenclature, :with_ancestors).path_ancestors }
 
       it { expect(ancestors).to include(an_instance_of(described_class)) }
     end
 
     context 'when the goods nomenclature has no ancestors' do
-      subject(:ancestors) { create(:goods_nomenclature, :without_ancestors).ancestors }
+      subject(:ancestors) { create(:goods_nomenclature, :without_ancestors).path_ancestors }
 
       it { expect(ancestors).to be_empty }
     end
@@ -467,15 +467,15 @@ RSpec.describe GoodsNomenclature do
     end
   end
 
-  describe '#children' do
+  describe '#path_children' do
     context 'when the goods nomenclature has children' do
-      subject(:child_sids) { create(:goods_nomenclature, :with_children).children.count }
+      subject(:child_sids) { create(:goods_nomenclature, :with_children).path_children.count }
 
       it { is_expected.to eq(1) }
     end
 
     context 'when the goods nomenclature has no children' do
-      subject(:child_sids) { create(:goods_nomenclature, :without_children).children.map(&:goods_nomenclature_sid) }
+      subject(:child_sids) { create(:goods_nomenclature, :without_children).path_children.map(&:goods_nomenclature_sid) }
 
       it { is_expected.to be_empty }
     end
@@ -523,29 +523,29 @@ RSpec.describe GoodsNomenclature do
     end
   end
 
-  describe '#declarable?' do
+  describe '#path_declarable?' do
     context 'when the goods nomenclature has children and a non grouping suffix' do
       subject(:goods_nomenclature) { create(:goods_nomenclature, :with_children, :non_grouping) }
 
-      it { is_expected.not_to be_declarable }
+      it { is_expected.not_to be_path_declarable }
     end
 
     context 'when the goods nomenclature has children and a grouping suffix' do
       subject(:goods_nomenclature) { create(:goods_nomenclature, :with_children, :grouping) }
 
-      it { is_expected.not_to be_declarable }
+      it { is_expected.not_to be_path_declarable }
     end
 
     context 'when the goods nomenclature has no children and a non grouping suffix' do
       subject(:goods_nomenclature) { create(:goods_nomenclature, :without_children, :non_grouping) }
 
-      it { is_expected.to be_declarable }
+      it { is_expected.to be_path_declarable }
     end
 
     context 'when the goods nomenclature has no children and a grouping suffix' do
       subject(:goods_nomenclature) { create(:goods_nomenclature, :without_children, :grouping) }
 
-      it { is_expected.not_to be_declarable }
+      it { is_expected.not_to be_path_declarable }
     end
   end
 

--- a/spec/presenters/api/admin/headings/heading_presenter_spec.rb
+++ b/spec/presenters/api/admin/headings/heading_presenter_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Api::Admin::Headings::HeadingPresenter do
   let(:counts) do
     {
       heading.goods_nomenclature_sid => 1,
-      heading.descendants.first.goods_nomenclature_sid => 3,
-      heading.descendants.last.goods_nomenclature_sid => 3,
+      heading.path_descendants.first.goods_nomenclature_sid => 3,
+      heading.path_descendants.last.goods_nomenclature_sid => 3,
     }
   end
 
@@ -27,7 +27,7 @@ RSpec.describe Api::Admin::Headings::HeadingPresenter do
     it { is_expected.to have_attributes values: heading.values }
     it { is_expected.to have_attributes search_references_count: 1 }
     it { expect(presented.commodities).to have_attributes length: 2 }
-    it { expect(presented.commodities.first).to have_attributes values: heading.descendants.first.values }
+    it { expect(presented.commodities.first).to have_attributes values: heading.path_descendants.first.values }
     it { expect(presented.commodities.first).to have_attributes search_references_count: 3 }
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-2732

### What?

I have added/removed/altered:

- [x] Renamed `GoodsNomenclature#ancestors` to `GoodsNomenclature#path_ancestors`
- [x] Renamed `GoodsNomenclature#parent` to `GoodsNomenclature#path_parent`
- [x] Renamed `GoodsNomenclature#siblings` to `GoodsNomenclature#path_siblings`
- [x] Renamed `GoodsNomenclature#children` to `GoodsNomenclature#path_children`
- [x] Renamed `GoodsNomenclature#descendants` to `GoodsNomenclature#path_descendants`
- [x] Renamed `GoodsNomenclature#declarable?` to `GoodsNomenclature#path_desclarable?`

### Why?

I am doing this because:

- It avoids them being shadowed by methods on on `Commodity` (which inherits from `GoodsNomenclature`)
- It unblocks fixing the single table inheritance loader

### Have you? (optional)

- [ ] Added documentation for new apis
- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks (optional)

- Does change code in use in production AFAICT, but its new code so should be covered by specs
