### PR TITLE
HOTT-2732 Fix for use of GoodsNomenclature#declarable?

### DIFF
--- a/app/serializers/api/admin/headings/commodity_serializer.rb
+++ b/app/serializers/api/admin/headings/commodity_serializer.rb
@@ -13,7 +13,7 @@ module Api
                    :goods_nomenclature_item_id,
                    :producline_suffix
 
-        attribute :declarable, &:declarable?
+        attribute :declarable, &:path_declarable?
       end
     end
   end


### PR DESCRIPTION
### Jira link

HOTT-2732

### What?

I have added/removed/altered:

- [x] Fixed call to `declarable?` in serializer missed in original changes

### Why?

I am doing this because:

- The rename has broken the commodity search refs screens in the admin area
