### PR TITLE
HOTT-2721: Adds syonym expansion plumbing

### DIFF
--- a/app/controllers/api/beta/search_controller.rb
+++ b/app/controllers/api/beta/search_controller.rb
@@ -31,7 +31,7 @@ module Api
       end
 
       def search_params
-        { spell:, filters: }
+        { expand_synonyms:, spell:, filters: }
       end
 
       def filters
@@ -52,6 +52,10 @@ module Api
 
       def spell
         params[:spell].presence || '1'
+      end
+
+      def expand_synonyms
+        params[:expand_synonyms].presence || '1'
       end
     end
   end

--- a/app/models/beta/search/search_query_parser_result.rb
+++ b/app/models/beta/search/search_query_parser_result.rb
@@ -12,6 +12,7 @@ module Beta
                     :noun_chunks,
                     :original_search_query,
                     :corrected_search_query,
+                    :expanded_search_query,
                     :null_result
 
       class Standard
@@ -22,6 +23,7 @@ module Beta
 
           search_query_parser_result.original_search_query = attributes['original_search_query']
           search_query_parser_result.corrected_search_query = attributes['corrected_search_query']
+          search_query_parser_result.expanded_search_query = attributes['expanded_search_query']
           search_query_parser_result.adjectives = attributes.dig('tokens', 'adjectives')
           search_query_parser_result.nouns = attributes.dig('tokens', 'nouns')
           search_query_parser_result.verbs = attributes.dig('tokens', 'verbs')
@@ -38,6 +40,7 @@ module Beta
 
           search_query_parser_result.original_search_query = attributes['original_search_query']
           search_query_parser_result.corrected_search_query = attributes['original_search_query']
+          search_query_parser_result.expanded_search_query = attributes['original_search_query']
           search_query_parser_result.adjectives = []
           search_query_parser_result.nouns = []
           search_query_parser_result.verbs = []

--- a/app/serializers/api/beta/search_query_parser_result_serializer.rb
+++ b/app/serializers/api/beta/search_query_parser_result_serializer.rb
@@ -7,6 +7,7 @@ module Api
 
       attributes :corrected_search_query,
                  :original_search_query,
+                 :expanded_search_query,
                  :verbs,
                  :adjectives,
                  :nouns,

--- a/app/services/api/beta/search_query_parser_service.rb
+++ b/app/services/api/beta/search_query_parser_service.rb
@@ -3,9 +3,10 @@ module Api
     class SearchQueryParserService
       delegate :client, to: :class
 
-      def initialize(original_search_query, spell: '1', should_search: true)
+      def initialize(original_search_query, spell: '1', expand_synonyms: '1', should_search: true)
         @original_search_query = original_search_query
         @spell = spell
+        @expand_synonyms = expand_synonyms
         @should_search = should_search
       end
 
@@ -13,7 +14,12 @@ module Api
         if null_result?
           ::Beta::Search::SearchQueryParserResult::Null.build('original_search_query' => original_search_query)
         else
-          result_attributes = client.get('tokens', q: original_search_query, spell:).body
+          result_attributes = client.get(
+            'tokens',
+            q: original_search_query,
+            spell:,
+            expand_synonyms:,
+          ).body
 
           ::Beta::Search::SearchQueryParserResult::Standard.build(result_attributes)
         end
@@ -28,7 +34,7 @@ module Api
 
       private
 
-      attr_reader :original_search_query, :spell
+      attr_reader :original_search_query, :spell, :expand_synonyms
 
       def null_result?
         original_search_query.blank? || !@should_search || AggregatedSynonym.exists?(@original_search_query)

--- a/app/services/api/beta/search_service.rb
+++ b/app/services/api/beta/search_service.rb
@@ -52,7 +52,12 @@ module Api
       end
 
       def search_query_parser_result
-        @search_query_parser_result ||= Api::Beta::SearchQueryParserService.new(@search_query, spell: @search_params[:spell], should_search: should_search?).call
+        @search_query_parser_result ||= Api::Beta::SearchQueryParserService.new(
+          @search_query,
+          spell: @search_params[:spell],
+          expand_synonyms: @search_params[:expand_synonyms],
+          should_search: should_search?,
+        ).call
       end
 
       def should_search?
@@ -76,7 +81,7 @@ module Api
       end
 
       def normalised_search_query
-        @normalised_search_query ||= @search_query.downcase.scan(/\w+/).join(' ')
+        @normalised_search_query ||= @search_query.downcase
       end
     end
   end

--- a/spec/factories/search_query_parser_result_factory.rb
+++ b/spec/factories/search_query_parser_result_factory.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
     noun_chunks { ['halibut sausage stenolepis cheese binocular parsnip pharmacy paper'] }
     original_search_query { 'halbiut sausadge stenolepsis chese bnoculars parnsip farmacy pape' }
     corrected_search_query { 'halibut sausage stenolepis cheese binocular parsnip pharmacy paper' }
+    expanded_search_query { 'fish sausage stenolepis cheese binocular root vegetables pharmacy paper' }
     null_result { false }
 
     trait :no_hits do

--- a/spec/serializers/api/beta/search_query_parser_result_serializer_spec.rb
+++ b/spec/serializers/api/beta/search_query_parser_result_serializer_spec.rb
@@ -10,8 +10,9 @@ RSpec.describe Api::Beta::SearchQueryParserResultSerializer do
           id: '240ad90c8bd0e29cc402ff257d033747',
           type: :search_query_parser_result,
           attributes: {
-            corrected_search_query: 'halibut sausage stenolepis cheese binocular parsnip pharmacy paper',
             original_search_query: 'halbiut sausadge stenolepsis chese bnoculars parnsip farmacy pape',
+            corrected_search_query: 'halibut sausage stenolepis cheese binocular parsnip pharmacy paper',
+            expanded_search_query: 'fish sausage stenolepis cheese binocular root vegetables pharmacy paper',
             verbs: [],
             adjectives: [],
             nouns: %w[halibut sausage stenolepis cheese binocular parsnip pharmacy paper],


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2721

### What?

I have added/removed/altered:

- [x] Added plumbing for expanded synonyms coming back from the search query parser

### Why?

I am doing this because:

- This is new functionality we want to be configurable in the frontend in future
