### PR TITLE
HOTT-2692 Fix single table inheritance

### DIFF
--- a/app/lib/sequel/plugins/sti.rb
+++ b/app/lib/sequel/plugins/sti.rb
@@ -6,7 +6,7 @@ module Sequel
       def self.configure(model, opts = {})
         model.instance_eval do
           @class_determinator = opts[:class_determinator]
-          dataset.with_row_proc(lambda { |r| model.sti_load(r) })
+          @dataset = @dataset.with_row_proc(model.method(:sti_load))
         end
       end
 
@@ -25,12 +25,12 @@ module Sequel
           subclass.instance_eval do
             dataset.with_row_proc(rp)
             @class_determinator = cd
-            dataset.with_row_proc(lambda { |r| model.sti_load(r) })
+            @dataset = @dataset.with_row_proc(model.method(:sti_load))
           end
         end
 
-        def sti_load(r)
-          constantize(class_determinator.call(r)).call(r)
+        def sti_load(record)
+          constantize(class_determinator.call(record)).call(record)
         end
       end
     end

--- a/spec/controllers/api/v2/goods_nomenclatures_controller_spec.rb
+++ b/spec/controllers/api/v2/goods_nomenclatures_controller_spec.rb
@@ -82,8 +82,8 @@ RSpec.describe Api::V2::GoodsNomenclaturesController do
     }
   end
   let(:csv_first_row) { 'SID,Goods Nomenclature Item ID,Indents,Description,Product Line Suffix,Href' }
-  let(:csv_chapter_row) { "#{chapter.goods_nomenclature_sid},#{chapter.goods_nomenclature_item_id},1,\"\",#{chapter.producline_suffix},#{described_class.api_path_builder(chapter)}" }
-  let(:csv_heading_row) { "#{heading.goods_nomenclature_sid},#{heading.goods_nomenclature_item_id},1,\"\",#{heading.producline_suffix},#{described_class.api_path_builder(heading)}" }
+  let(:csv_chapter_row) { "#{chapter.goods_nomenclature_sid},#{chapter.goods_nomenclature_item_id},0,\"\",#{chapter.producline_suffix},#{described_class.api_path_builder(chapter)}" }
+  let(:csv_heading_row) { "#{heading.goods_nomenclature_sid},#{heading.goods_nomenclature_item_id},0,\"\",#{heading.producline_suffix},#{described_class.api_path_builder(heading)}" }
   let(:csv_commodity_row) { "#{goods_nomenclature.goods_nomenclature_sid},#{goods_nomenclature.goods_nomenclature_item_id},#{goods_nomenclature.number_indents},\"\",#{goods_nomenclature.producline_suffix},#{described_class.api_path_builder(goods_nomenclature)}" }
 
   context 'when GNs for a section are requested' do

--- a/spec/controllers/api/v2/quotas_controller_spec.rb
+++ b/spec/controllers/api/v2/quotas_controller_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Api::V2::QuotasController, type: :controller do
                 goods_nomenclature_item_id: String,
                 producline_suffix: String,
                 description: String,
-                formatted_description: nil,
+                formatted_description: String,
                 validity_start_date: String,
                 validity_end_date: nil,
               },

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -23,6 +23,24 @@ RSpec.describe GoodsNomenclature do
     it { expect(goods_nomenclatures).to eq(expected_goods_nomenclatures) }
   end
 
+  describe 'single table inheritance loader' do
+    shared_examples 'it loads data into the correct class' do |klass, *traits|
+      subject do
+        described_class.where(goods_nomenclature_sid: gn.goods_nomenclature_sid)
+                       .first
+      end
+
+      let(:gn) { create(:goods_nomenclature, *traits) }
+
+      it { is_expected.to be_instance_of klass }
+    end
+
+    it_behaves_like 'it loads data into the correct class', Chapter, :chapter
+    it_behaves_like 'it loads data into the correct class', Heading, :heading
+    it_behaves_like 'it loads data into the correct class', Commodity, :with_children
+    it_behaves_like 'it loads data into the correct class', Commodity
+  end
+
   describe 'associations' do
     describe 'goods nomenclature indent' do
       context 'when fetching with absolute date' do
@@ -429,7 +447,8 @@ RSpec.describe GoodsNomenclature do
     context 'when the goods nomenclature has ancestors' do
       subject(:ancestors) { create(:goods_nomenclature, :with_ancestors).path_ancestors }
 
-      it { expect(ancestors).to include(an_instance_of(described_class)) }
+      it { expect(ancestors).to include(an_instance_of(Chapter)) }
+      it { expect(ancestors).to include(an_instance_of(Heading)) }
     end
 
     context 'when the goods nomenclature has no ancestors' do
@@ -457,7 +476,7 @@ RSpec.describe GoodsNomenclature do
     context 'when the goods nomenclature has siblings' do
       subject(:siblings) { create(:goods_nomenclature, :with_siblings).path_siblings }
 
-      it { expect(siblings).to include(an_instance_of(described_class)) }
+      it { expect(siblings).to include(an_instance_of(Commodity)) }
     end
 
     context 'when the goods nomenclature has no siblings' do


### PR DESCRIPTION
### Jira link

HOTT-2692

### What?

I have added/removed/altered:

- [x] Fixed the Single Table Inheritance loader
- [x] Adds specs to ensure it continues to work

### Why?

I am doing this because:

- It makes it much easier to use eager loadable methods if they can return the correct classes

### Deployment risks (optional)

- Changes anywhere relying on GoodsNomenclature being returned to instead return Chapter/Heading/Commodity
- I _think_ this should only affect components using materialised path - which already utilise an additional attribute to describe their 'type'
    - Commodity CSV Report
    - Admin Headings optimisations
    - Beta search (not yet in use)
