### PR TITLE
HOTT-2732 Fix missing eager load rename

### DIFF
--- a/app/elastic_search_indexes/search/goods_nomenclature_index.rb
+++ b/app/elastic_search_indexes/search/goods_nomenclature_index.rb
@@ -13,7 +13,7 @@ module Search
         goods_nomenclature_indents
         chapter
         heading
-        ancestors
+        path_ancestors
       ]
     end
 


### PR DESCRIPTION
### Jira link

HOTT-2732

### What?

I have added/removed/altered:

- [x] Fixed eager load of ancestors

### Why?

I am doing this because:

- it was broken by the rename from `ancestors` to `path_ancestors`

### Deployment risks (optional)

- Low
