### PR TITLE
HOTT-2736 Avoid creation of data outside spec lifecycle

### DIFF
--- a/spec/models/beta/search/direct_hit_spec.rb
+++ b/spec/models/beta/search/direct_hit_spec.rb
@@ -1,7 +1,9 @@
 RSpec.describe Beta::Search::DirectHit do
   describe '#build' do
-    shared_examples 'a direct hit' do |search_result|
+    shared_examples 'a direct hit' do |*search_result_traits|
       subject(:direct_hit) { described_class.build(search_result) }
+
+      let(:search_result) { build(:search_result, *search_result_traits) }
 
       it { is_expected.to be_a(described_class) }
       it { expect(direct_hit.goods_nomenclature_class).to be_in(%w[Heading Chapter Subheading Commodity]) }
@@ -13,16 +15,18 @@ RSpec.describe Beta::Search::DirectHit do
       it { expect(direct_hit.ancestors).to be_empty }
     end
 
-    shared_examples 'not a direct hit' do |search_result|
+    shared_examples 'not a direct hit' do |*search_result_traits|
       subject(:direct_hit) { described_class.build(search_result) }
+
+      let(:search_result) { build(:search_result, *search_result_traits) }
 
       it { is_expected.to be_nil }
     end
 
-    it_behaves_like 'a direct hit', FactoryBot.build(:search_result, :single_hit)
-    it_behaves_like 'a direct hit', FactoryBot.build(:search_result, :with_search_reference)
-    it_behaves_like 'a direct hit', FactoryBot.build(:search_result, :with_numeric_search_query)
-    it_behaves_like 'not a direct hit', FactoryBot.build(:search_result, :multiple_hits)
-    it_behaves_like 'not a direct hit', FactoryBot.build(:search_result, :no_hits)
+    it_behaves_like 'a direct hit', :single_hit
+    it_behaves_like 'a direct hit', :with_search_reference
+    it_behaves_like 'a direct hit', :with_numeric_search_query
+    it_behaves_like 'not a direct hit', :multiple_hits
+    it_behaves_like 'not a direct hit', :no_hits
   end
 end

--- a/spec/models/search_reference_spec.rb
+++ b/spec/models/search_reference_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe SearchReference do
-  shared_examples_for 'a setter callback' do |referenced|
+  shared_examples_for 'a setter callback' do |referenced_factory|
     subject(:search_reference) { described_class.new(title: 'foo', referenced:) }
+
+    let(:referenced) { create(referenced_factory) }
 
     it 'assigns the correct attributes' do
       expect(search_reference).to have_attributes(
@@ -13,9 +15,9 @@ RSpec.describe SearchReference do
     end
   end
 
-  it_behaves_like 'a setter callback', FactoryBot.create(:chapter)
-  it_behaves_like 'a setter callback', FactoryBot.create(:heading)
-  it_behaves_like 'a setter callback', FactoryBot.create(:commodity)
+  it_behaves_like 'a setter callback', :chapter
+  it_behaves_like 'a setter callback', :heading
+  it_behaves_like 'a setter callback', :commodity
 
   describe '#referenced' do
     subject(:search_reference) { described_class.find(title: 'foo') }


### PR DESCRIPTION
### Jira link

HOTT-2736

### What?

I have added/removed/altered:

- [x] Delayed creation of data until inside the spec lifecycle

### Why?

I am doing this because:

- It gets immediately binned by the `TRUNCATE` at the start of the lifecycle
- It breaks the materialized view work

### Deployment risks (optional)

- None - spec changes
