### PR TITLE
HOTT-2639 add `goods_nomenclature_tree_nodes` materialized view

### DIFF
--- a/app/models/goods_nomenclatures/tree_node.rb
+++ b/app/models/goods_nomenclatures/tree_node.rb
@@ -1,0 +1,13 @@
+module GoodsNomenclatures
+  class TreeNode < Sequel::Model(:goods_nomenclature_tree_nodes)
+    class << self
+      # Defaults to concurrent refresh to avoid blocking other queries
+      # If the Materialized View has never been populated, eg after a
+      # rake db:test:prepare or rake db:structure:load then a non-concurrent
+      # refresh is required
+      def refresh!(concurrently: true)
+        db.refresh_view(:goods_nomenclature_tree_nodes, concurrently:)
+      end
+    end
+  end
+end

--- a/app/workers/rollback_worker.rb
+++ b/app/workers/rollback_worker.rb
@@ -9,5 +9,7 @@ class RollbackWorker
     else
       TariffSynchronizer.rollback(date, keep: redownload)
     end
+
+    GoodsNomenclatures::TreeNode.refresh!
   end
 end

--- a/app/workers/updates_synchronizer_worker.rb
+++ b/app/workers/updates_synchronizer_worker.rb
@@ -28,6 +28,7 @@ class UpdatesSynchronizerWorker
     end
 
     migrate_data if reapply_data_migrations
+    refresh_materialized_view
 
     Sidekiq::Client.enqueue(ClearInvalidSearchReferences)
     Sidekiq::Client.enqueue(GenerateMaterializedPathsWorker)
@@ -61,6 +62,10 @@ private
 
     require 'data_migrator' unless defined?(DataMigrator)
     DataMigrator.migrate_up!(nil)
+  end
+
+  def refresh_materialized_view
+    GoodsNomenclatures::TreeNode.refresh!
   end
 
   def attempt_reschedule!

--- a/db/migrate/20230210140401_add_goods_nomenclature_tree_nodes.rb
+++ b/db/migrate/20230210140401_add_goods_nomenclature_tree_nodes.rb
@@ -1,0 +1,44 @@
+Sequel.migration do
+  up do
+    create_view :goods_nomenclature_tree_nodes, <<~EOVIEW, materialized: true
+      SELECT
+        indents.goods_nomenclature_indent_sid,
+        indents.goods_nomenclature_sid,
+        indents.number_indents,
+        indents.goods_nomenclature_item_id,
+        indents.productline_suffix,
+        CONCAT(indents.goods_nomenclature_item_id, indents.productline_suffix)::bigint AS "position",
+        indents.validity_start_date,
+        COALESCE(indents.validity_end_date, MIN(replacement_indents.validity_start_date) - INTERVAL '1 second', nomenclatures.validity_end_date) as validity_end_date,
+        indents.oid,
+        indents.number_indents + 2 - (indents.goods_nomenclature_item_id LIKE '%00000000' AND indents.number_indents = 0)::integer AS "depth"
+      FROM public.goods_nomenclature_indents indents
+      INNER JOIN goods_nomenclatures nomenclatures ON
+        indents.goods_nomenclature_sid = nomenclatures.goods_nomenclature_sid
+      LEFT JOIN goods_nomenclature_indents replacement_indents ON
+        indents.goods_nomenclature_sid = replacement_indents.goods_nomenclature_sid
+        AND indents.validity_start_date < replacement_indents.validity_start_date
+        AND indents.validity_end_date IS NULL
+      GROUP BY
+        indents.goods_nomenclature_indent_sid,
+        indents.goods_nomenclature_sid,
+        indents.number_indents,
+        indents.goods_nomenclature_item_id,
+        indents.productline_suffix,
+        indents.validity_start_date,
+        indents.validity_end_date,
+        nomenclatures.validity_end_date,
+        indents.oid
+    EOVIEW
+
+    alter_table :goods_nomenclature_tree_nodes do
+      add_index :oid, unique: true # needed for concurrent view refresh
+      add_index %i[depth position] # primary index
+      add_index :goods_nomenclature_sid
+    end
+  end
+
+  down do
+    drop_view :goods_nomenclature_tree_nodes, materialized: true
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,11 @@
+# After a rake db:structure:load Materialized Views are unpopulated, causing
+# any concurrent refreshes to fail. Populating here should help avoid that.
+GoodsNomenclatures::TreeNode.refresh!(concurrently: false)
+
 # For API access
 dummy_api_user = User.new
-dummy_api_user.email = "dummyapiuser@domain.com"
-dummy_api_user.uid = "#{rand(10000)}"
-dummy_api_user.name = "Dummy API user created by gds-sso"
-dummy_api_user.permissions = ["signin"]
+dummy_api_user.email = 'dummyapiuser@domain.com'
+dummy_api_user.uid = rand(10_000).to_s
+dummy_api_user.name = 'Dummy API user created by gds-sso'
+dummy_api_user.permissions = %w[signin]
 dummy_api_user.save

--- a/docs/adr/2023-02-07_goods-nomenclature-nested-set.md
+++ b/docs/adr/2023-02-07_goods-nomenclature-nested-set.md
@@ -6,7 +6,7 @@ Present: Matt Lavis, William Fish, Jeremy Wilkins, Ata Dahri
 
 ## Context
 
-We currently access the Goods Nomenclature hierarchy in an inefficient manner. We load all relevant descents of the containing Heading from the database, then filter for what is relevant.
+We currently access the Goods Nomenclature hierarchy in an inefficient manner. We load all relevant descendants of the containing Heading from the database, then filter for what is relevant.
 
 We cannot eager load measures, because they need to do their own (non-eager loadable) queries to determine ancestors before they can know which measures to look for.
 

--- a/docs/adr/2023-02-07_goods-nomenclature-nested-set.md
+++ b/docs/adr/2023-02-07_goods-nomenclature-nested-set.md
@@ -1,0 +1,25 @@
+# Goods Nomenclature Nested Set
+
+Date: 7 February 2023
+Status: Accepted
+Present: Matt Lavis, William Fish, Jeremy Wilkins, Ata Dahri
+
+## Context
+
+We currently access the Goods Nomenclature hierarchy in an inefficient manner. We load all relevant descents of the containing Heading from the database, then filter for what is relevant.
+
+We cannot eager load measures, because they need to do their own (non-eager loadable) queries to determine ancestors before they can know which measures to look for.
+
+This leads to a complicated codebase that is hard to optimise because multiple work arounds are required to offset the N+1s caused by our current access to the hierarchy.
+
+## Decision
+
+Move to accessing the Goods Nomenclatures hierarchy via a modified nested set pattern as described in the [design doc](../goods-nomenclature-nested-set.md)
+
+## Consequences
+
+* We speed up access to commodities and subheadings pages
+* We can remove the slow overnight generation of the Headings cache in Elastic Search - replacing with direct querying of the database.
+* Our interpretation of the hierarchy when presented with invalid data via CDS or Taric may change, eg if indent levels are incorrect.
+* We have the tools to optimise other parts of the codebase such as Additional Code search
+

--- a/docs/goods-nomenclature-nested-set.md
+++ b/docs/goods-nomenclature-nested-set.md
@@ -65,7 +65,7 @@ The primary index used for hierarchy lookups is `depth` + `position`.
 
 There are also 2 other indexes
 * `goods_nomenclature_sid` - this allows for efficient JOINs to the goods_nomenclatures table
-* `oid` (unique) - this is the `oid` from the indents table is there to allow concurrent refreshes of the view
+* `oid` (unique) - this is the `oid` from the indents table. Refreshing a materialized view concurrently (ie without blocking reads from the view) requires the materialized view to have a unique index.
 
 ## Querying
 
@@ -73,7 +73,7 @@ There are also 2 other indexes
 
 ### Ancestors
 
-These can can be queried by fetching the maximium `position` at every `depth`, where -;
+These can be queried by fetching the maximium `position` at every `depth`, where -;
 * `depth` is less than the `depth` of the origin `tree_node` record
 * and the `position` is less than the `position` of the origin record
 

--- a/docs/goods-nomenclature-nested-set.md
+++ b/docs/goods-nomenclature-nested-set.md
@@ -1,0 +1,118 @@
+# Goods Nomenclature Nested Set
+
+## Tariff Data
+
+The Tariff data we receive from CDS or Taric contains an ordered list of all Goods Nomenclatures. The order is determined by the concatenation of their `goods_nomenclature_item_id` and their `producline_suffix`. Commodities position within the logical hierarchy is determined by any given commodities indentation. This data is held in a second table called `goods_nomenclatures_indents` - these indicate the depth of nesting of the Goods Nomenclatures they belong to, eg
+
+```
+0100000000-80 # Indent 0
+- 0101000000-80 # Indent 0
+- - 0101010000-10 # Indent 1
+- - - 0101010000-80 # Indent 2, note: item_id matches parent but suffix is higher
+- - - 0101010001-80 # Indent 2
+- - 0101010100-80 # Indent 1
+```
+
+## A classic Nested Set model
+
+The [Nested Set model](https://en.wikipedia.org/wiki/Nested_set_model) page on wikipedia explains this well.
+
+A Nested Set assumes an ordered identifier for records within the hierarchical database table.
+
+Those records hold left + right (or start + end) values defining a range exclusively containing the identifiers of descendent records within the hierarchy.
+
+Depth within the hierarchy must be dynamically computed by determining ancestors for a record. Ancestors are any other records whose own range fully encompasses the range (left + right) of the target record.
+
+## Reading the data
+
+The Tariff data's hierarchy can be thought of as a modified form of that Nested Set model.
+
+* The data is an ordered list of identifiers (item_id + suffix)
+* The 'start of range' value (or 'left') is defined as a records identifier + 1
+* We do not need to compute depth, that is provided by the indents table
+* The 'end of range' value is 1 less then the lowest identifier which has the same depth as the origin record, and which is greater than the records own identifier.
+
+Descendants and Ancestors can be fetched non-recursively by implementing the above rules.
+
+## Tree Nodes materialized view
+
+To facilitate fast retrieval of data, a `goods_nomenclature_tree_nodes` materialized view is added as a facade in front of the existing indents table. This provides an indexable ordered identifier (called `position`) for all goods nomenclatures which can be used for efficient `JOIN`-ing.
+
+There are 3 key changes in this `tree_nodes` view relative to the `goods_nomenclature_indents` db view sitting behind it.
+
+1. Added a `position` column - this is a string concatenation of the 10 digit `goods_nomenclature_item_id` and the 2 digit `producline_suffix` - then cast to an integer. The rationale behind this is -;
+    1. it provides an ordered identifier, that follows the correct sequence of the dataset.
+    2. it does not need to preserve the original information, it just needs to maintain the same order
+    3. it is a single field allowing for easy use of MAX/MIN sql operators
+    4. it is an integer for index performance - in initial prototyping this was a string because the source fields are strings but it was found queries were 4x faster when cast to an integer. Using a decimal instead (ie 1010101010.80) was found to be slower then using integers but faster than strings.
+2. Added a `depth` column - this is `number_indents + 2` for all Headings and their descendents.
+    1. Chapters are the exception to this, they have a position of `number_indents + 1`, ie `1`.
+    2. This makes the field an absolute definition of the depth, unlike the `number_indents` field which is 0 for both Chapters and Headings despite them being at different conceptual depths in the hierarchy
+    3. At present `depth == 0` is a single conceptual root of the hierarchy encompassing all Chapters and all of their descendants
+3. Populated `validity_end_date` in `tree_nodes` - this is never populated in the indents table
+    1. the missing end date means that we need to join the indents table on to itself to fetch only the most recent indent
+    2. this JOIN is instead done during the generation of the `tree_nodes` view to both simplify querying the `tree_nodes` data and to avoid repeatedly doing the JOIN during hierarchy lookups
+
+**Note:** The `position` identifier is not unique because there may be multiple `tree_nodes` records for a goods nomenclature, all with the same `position` but different validity dates. A unique identifier would be either the triple of the identifier and dates, ie `position + validity_start_date + validity_end_date` or the `goods_nomenclature_indent_sid` which refers to a `tree_nodes` record for a given point in time.
+
+### Indexing
+
+The primary index used for hierarchy lookups is `depth` + `position`.
+
+* Using `depth` as the first index key allows for efficient segmenting of the dataset and aligns with most lookups trying to min/max records at a specific depth. * `position` is the second index key to allow finding the min/max after the subset of records at the expected depth is selected
+
+`validity_start_date` and `validity_end_date` are not in the index because once the Postgres has filtered by `depth` and `position`, there are not many records to walk through so there is not much performance benefit. There would be a memory cost though, because every entry in the index would also require 2 dates that will be much larger then the `int` + `bigint` for `depth` + `position`
+
+There are also 2 other indexes
+* `goods_nomenclature_sid` - this allows for efficient JOINs to the goods_nomenclatures table
+* `oid` (unique) - this is the `oid` from the indents table is there to allow concurrent refreshes of the view
+
+## Querying
+
+**Note:** `origin` record references the `tree_nodes` record you are fetching relatives for, eg ancestors of `origin`, or children of `origin`
+
+### Ancestors
+
+These can can be queried by fetching the maximium `position` at every `depth`, where -;
+* `depth` is less than the `depth` of the origin `tree_node` record
+* and the `position` is less than the `position` of the origin record
+
+### Next sibling
+
+The `tree_nodes` record with
+* same `depth` as the origin record
+* the lowest `position` that is still greater than the origin records `position`
+
+### Previous sibling
+
+_Note: Due to how we read the tree this is less useful then next sibling_
+
+The `tree_nodes` record with
+* same `depth` as the origin record
+* and has the highest `position` that is still less than the origin records `position`
+
+### Children
+
+This is every `tree_nodes` record where -;
+* the child nodes `depth` is exactly 1 greater than the `depth` of the origin record
+* and the child nodes `position` is greater than the `position` of the origin `tree_nodes` record
+* and the child nodes `position` is less than the `position` of next sibling of the origin record
+
+### Descendents
+
+This is every `tree_nodes` record where -;
+* the child nodes `depth` is greater than the `depth` of the origin record
+* and the child nodes `position` is greater than the `position` of the origin `tree_nodes` record
+* and the child nodes `position` is less than the `position` of next sibling of the origin record
+
+### Goods Nomenclatures
+
+The above describes how `tree_nodes` can be related to each other. To find relatives on `goods_nomenclatures` records you can JOIN to `tree_nodes` via `goods_nomenclature_sid`, JOIN the `tree_nodes` to themselves via `position` and `depth`, then in turn back onto `goods_nomenclatures` via the relatives `goods_nomenclature_sid`.
+
+```
++----+    +----------+    +-----------+    +---------+
+| GN | -> |  Origin  | -> | Related   | -> | Related |
++----+    | TreeNode |    | TreeNodes |    |   GNs   |
+          +----------+    +-----------+    +---------+
+```
+

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -47,4 +47,16 @@ namespace :data do
               end
     ::DataMigrator.migrate_down! version
   end
+
+  namespace :views do
+    desc 'Refresh materialized views within the site'
+    task refresh: :environment do
+      GoodsNomenclatures::TreeNode.refresh!(concurrently: true)
+    end
+
+    desc 'Refresh materialized views within the site when unpopulated (does not use CONCURRENTLY)'
+    task populate: :environment do
+      GoodsNomenclatures::TreeNode.refresh!(concurrently: false)
+    end
+  end
 end

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -14,6 +14,8 @@ namespace :data do
         Rake::Task['data:rollback'].invoke
         Rake::Task['data:migrate'].invoke
       end
+
+      GoodsNomenclatures::TreeNode.refresh!
     end
 
     desc 'Runs the "up" for a given data migration VERSION.'
@@ -22,6 +24,8 @@ namespace :data do
       raise 'VERSION is required' unless version
 
       ::DataMigrator.migrate_up!(version)
+
+      GoodsNomenclatures::TreeNode.refresh!
     end
 
     desc 'Runs the "down" for a given data migration VERSION.'
@@ -30,12 +34,16 @@ namespace :data do
       raise 'VERSION is required' unless version
 
       ::DataMigrator.migrate_down!(version)
+
+      GoodsNomenclatures::TreeNode.refresh!
     end
   end
 
   desc 'Migrate data to the latest version - IMPORTANT ensure migrations are idempotent'
   task migrate: 'migrate:load' do
     ::DataMigrator.migrate_up!(ENV['VERSION'] ? ENV['VERSION'].to_i : nil)
+
+    GoodsNomenclatures::TreeNode.refresh!
   end
 
   desc 'Rollback the latest data migration file or down to specified VERSION=x'
@@ -46,6 +54,8 @@ namespace :data do
                 ::DataMigrator.previous_migration
               end
     ::DataMigrator.migrate_down! version
+
+    GoodsNomenclatures::TreeNode.refresh!
   end
 
   namespace :views do

--- a/spec/factories/goods_nomenclature_factory.rb
+++ b/spec/factories/goods_nomenclature_factory.rb
@@ -44,6 +44,7 @@ FactoryBot.define do
     after(:create) do |gono, _evaluator|
       if gono.associations[:goods_nomenclature_indents]
         gono.associations[:goods_nomenclature_indents].all?(&:save)
+        GoodsNomenclatures::TreeNode.refresh!
       end
     end
 
@@ -290,6 +291,8 @@ FactoryBot.define do
       productline_suffix             { Forgery(:basic).text(exactly: 2) }
       validity_end_date              { 1.year.ago.beginning_of_day }
     end
+
+    after(:create) { GoodsNomenclatures::TreeNode.refresh! }
   end
 
   factory :goods_nomenclature_description_period do

--- a/spec/models/goods_nomenclatures/tree_node_spec.rb
+++ b/spec/models/goods_nomenclatures/tree_node_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe GoodsNomenclatures::TreeNode do
+  describe 'attributes' do
+    it { is_expected.to respond_to :goods_nomenclature_sid }
+    it { is_expected.to respond_to :position }
+    it { is_expected.to respond_to :depth }
+    it { is_expected.to respond_to :validity_start_date }
+    it { is_expected.to respond_to :validity_end_date }
+  end
+
+  describe '.refresh!' do
+    before do
+      GoodsNomenclatureIndent.unrestrict_primary_key
+      GoodsNomenclatureIndent.create indent_attrs
+      GoodsNomenclatureIndent.restrict_primary_key
+    end
+
+    let(:commodity) { create :commodity }
+
+    let :indent_attrs do
+      attributes_for :goods_nomenclature_indent,
+                     goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+                     goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+                     productline_suffix: commodity.producline_suffix
+    end
+
+    it 'updates the tree nodes view from the indents table' do
+      expect { described_class.refresh! }.to change(described_class, :count)
+    end
+  end
+end

--- a/spec/models/goods_nomenclatures/tree_node_spec.rb
+++ b/spec/models/goods_nomenclatures/tree_node_spec.rb
@@ -29,4 +29,22 @@ RSpec.describe GoodsNomenclatures::TreeNode do
       expect { described_class.refresh! }.to change(described_class, :count)
     end
   end
+
+  describe 'materialized view content' do
+    subject do
+      described_class
+        .where(goods_nomenclature_sid: commodity.goods_nomenclature_sid)
+        .first
+    end
+
+    let(:commodity) { create :goods_nomenclature }
+
+    let :expected_position do
+      commodity.goods_nomenclature_item_id.to_i * 100 +
+        commodity.producline_suffix.to_i
+    end
+
+    it { is_expected.to have_attributes position: expected_position }
+    it { is_expected.to have_attributes number_indents: commodity.number_indents }
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,6 +47,11 @@ RSpec.configure do |config|
   end
 
   config.before(:suite) do
+    # Materialized Views need populating after a schema load before concurrent
+    # refresh can be used. Doing a blocking refresh to ensure the View is in a
+    # usable state. This is very fast since there is no data
+    GoodsNomenclatures::TreeNode.refresh!(concurrently: false)
+
     TradeTariffBackend.redis.flushdb
 
     MeasureTypeExclusion.load_from_file \

--- a/spec/workers/rollback_worker_spec.rb
+++ b/spec/workers/rollback_worker_spec.rb
@@ -1,6 +1,10 @@
 RSpec.describe RollbackWorker, type: :worker do
   let(:date) { '01-01-2020' }
 
+  before do
+    allow(GoodsNomenclatures::TreeNode).to receive(:refresh!).and_call_original
+  end
+
   describe '#perform' do
     context 'for all envs' do
       before do
@@ -11,6 +15,12 @@ RSpec.describe RollbackWorker, type: :worker do
         expect(TariffSynchronizer).to receive(:rollback).with(date, keep: false)
         expect(TariffSynchronizer).not_to receive(:rollback_cds)
         described_class.new.perform(date)
+      end
+
+      it 'refreshes materialized view' do
+        described_class.new.perform(date)
+
+        expect(GoodsNomenclatures::TreeNode).to have_received(:refresh!)
       end
     end
 
@@ -23,6 +33,12 @@ RSpec.describe RollbackWorker, type: :worker do
         expect(TariffSynchronizer).to receive(:rollback_cds).with(date, keep: false)
         expect(TariffSynchronizer).not_to receive(:rollback)
         described_class.new.perform(date)
+      end
+
+      it 'refreshes materialized view' do
+        described_class.new.perform(date)
+
+        expect(GoodsNomenclatures::TreeNode).to have_received(:refresh!)
       end
     end
   end

--- a/spec/workers/updates_synchronizer_worker_spec.rb
+++ b/spec/workers/updates_synchronizer_worker_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe UpdatesSynchronizerWorker, type: :worker do
       migrations_dir = Rails.root.join(file_fixture_path).join('data_migrations')
       allow(DataMigrator).to receive(:migrations_dir).and_return(migrations_dir)
       allow(DataMigrator).to receive(:migrate_up!).and_return(true)
+
+      allow(GoodsNomenclatures::TreeNode).to receive(:refresh!).and_call_original
     end
 
     let(:changes_applied) { true }
@@ -40,6 +42,8 @@ RSpec.describe UpdatesSynchronizerWorker, type: :worker do
       it { expect(TariffSynchronizer).not_to have_received(:apply_cds) }
 
       it { expect(DataMigrator).not_to have_received(:migrate_up!) }
+
+      it { expect(GoodsNomenclatures::TreeNode).to have_received(:refresh!) }
 
       it_behaves_like 'a synchronizer worker that queues other workers'
 
@@ -125,6 +129,8 @@ RSpec.describe UpdatesSynchronizerWorker, type: :worker do
           it { expect(TariffSynchronizer).not_to have_received(:download) }
           it { expect(TariffSynchronizer).not_to have_received(:apply) }
 
+          it { expect(GoodsNomenclatures::TreeNode).to have_received(:refresh!) }
+
           it_behaves_like 'a synchronizer worker that queues other workers'
 
           it { expect(described_class.jobs).to be_empty }
@@ -148,6 +154,8 @@ RSpec.describe UpdatesSynchronizerWorker, type: :worker do
 
           it { expect(TariffSynchronizer).not_to have_received(:download) }
           it { expect(TariffSynchronizer).not_to have_received(:apply) }
+
+          it { expect(GoodsNomenclatures::TreeNode).to have_received(:refresh!) }
 
           it_behaves_like 'a synchronizer worker that queues other workers'
 


### PR DESCRIPTION
### Jira link

HOTT-2639

### What?

I have added/removed/altered:

- [x] Added `goods_nomenclature_tree_nodes` materialized view
- [x] Added a `GoodsNomenclatures::TreeNode` data model
- [x] Added documententation for the nested set logic for addressing the hierarchy
- [x] Added Rake task to refresh the view
- [x] Hooked refreshing the view into the Tariff sync + rollback
- [x] Hooked refreshing the view into the data migrations
- [x] Hooked refreshing the view into the creation of indents in factories
- [x] Hooked non-concurrent refresh of view into specs

### Why?

I am doing this because:

- tree nodes view is a 'better' indents table which allows for 'nested set' access to the tariff hierarchy
- maintenance of this view should be low, hence integrating refreshing it with anything which modify the data
- normally we want a concurrent refresh since that doesn't block other queries, but we cannot use a concurrent refresh on a newly create view, so specs need a 'non-concurrent' refresh done at the start

### Have you? (optional)

- [x] Added documentation for new apis

### Deployment risks (optional)

- Should be low, its just adding adding a view, the only behavioural change should be tariff sync and data migrations refresh that view
