### PR TITLE
HOTT-2640 Add tree node relationships

### DIFF
--- a/app/lib/sequel/plugins/time_machine.rb
+++ b/app/lib/sequel/plugins/time_machine.rb
@@ -47,7 +47,7 @@ module Sequel
         def validity_dates_filter(table = self,
                                   start_column: :validity_start_date,
                                   end_column: :validity_end_date)
-          return self if point_in_time.blank?
+          return Sequel.expr(true) if point_in_time.blank?
 
           table_name = if table.is_a?(Class) && table < Sequel::Model
                          table.table_name
@@ -121,6 +121,8 @@ module Sequel
         def with_validity_dates(table = model.table_name,
                                 start_column: :validity_start_date,
                                 end_column: :validity_end_date)
+          return self if model.point_in_time.blank?
+
           where do |_query|
             model.validity_dates_filter(table, start_column:, end_column:)
           end

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -24,6 +24,8 @@ class GoodsNomenclature < Sequel::Model
     end
   }
 
+  include GoodsNomenclatures::NestedSet
+
   one_to_one :chapter, class_name: name, class: self do |_ds|
     Chapter
       .actual

--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -9,6 +9,35 @@ module GoodsNomenclatures
                              read_only: true do |ds|
         ds.with_actual(GoodsNomenclatures::TreeNode)
       end
+
+      many_to_many :ns_ancestors,
+                   left_primary_key: :goods_nomenclature_sid,
+                   left_key: Sequel.qualify(:origin_nodes, :goods_nomenclature_sid),
+                   right_primary_key: :goods_nomenclature_sid,
+                   right_key: :goods_nomenclature_sid,
+                   class_name: '::GoodsNomenclature',
+                   join_table: Sequel.as(:goods_nomenclature_tree_nodes, :ancestor_nodes),
+                   read_only: true do |ds|
+        ds.order(:ancestor_nodes__depth)
+          .with_validity_dates(:ancestor_nodes)
+          .select_append(:ancestor_nodes__depth)
+          .join(Sequel.as(:goods_nomenclature_tree_nodes, :origin_nodes)) do |origin_table, ancestors_table, _join_clauses|
+            ancestors_position = Sequel.qualify(ancestors_table, :position)
+            ancestors_depth    = Sequel.qualify(ancestors_table, :depth)
+            origin_position    = Sequel.qualify(origin_table, :position)
+            origin_depth       = Sequel.qualify(origin_table, :depth)
+
+            (ancestors_depth < origin_depth) &
+              (ancestors_position < origin_position) &
+              (ancestors_position >= TreeNode.start_of_chapter(origin_position)) &
+              model.validity_dates_filter(origin_table) &
+              (ancestors_position =~ TreeNode.previous_sibling(origin_position, ancestors_depth))
+          end
+      end
+    end
+
+    def depth
+      values.key?(:depth) ? values[:depth] : tree_node.depth
     end
   end
 end

--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -20,7 +20,7 @@ module GoodsNomenclatures
                    class_name: '::GoodsNomenclature',
                    join_table: Sequel.as(:goods_nomenclature_tree_nodes, :ancestor_nodes),
                    read_only: true do |ds|
-        ds.order(:ancestor_nodes__depth)
+        ds.order(:ancestor_nodes__position)
           .with_validity_dates(:ancestor_nodes)
           .select_append(:ancestor_nodes__depth)
           .join(Sequel.as(:goods_nomenclature_tree_nodes, :origin_nodes)) do |origin_table, ancestors_table, _join_clauses|
@@ -40,7 +40,8 @@ module GoodsNomenclatures
                       class_name: '::GoodsNomenclature',
                       join_table: Sequel.as(:goods_nomenclature_tree_nodes, :parent_nodes),
                       read_only: true do |ds|
-        ds.with_validity_dates(:parent_nodes)
+        ds.order(:parent_nodes__position)
+          .with_validity_dates(:parent_nodes)
           .select_append(:parent_nodes__depth)
           .join(Sequel.as(:goods_nomenclature_tree_nodes, :origin_nodes)) do |origin_table, parents_table, _join_clauses|
             parents = TreeNodeAlias.new(parents_table)

--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -1,8 +1,8 @@
+# See docs/goods-nomenclature-nested-set.md for an explanation of this
+
 module GoodsNomenclatures
   module NestedSet
     extend ActiveSupport::Concern
-
-    END_OF_TREE = 1_000_000_000_000
 
     included do
       one_to_one :tree_node, key: :goods_nomenclature_sid,
@@ -24,16 +24,11 @@ module GoodsNomenclatures
           .with_validity_dates(:ancestor_nodes)
           .select_append(:ancestor_nodes__depth)
           .join(Sequel.as(:goods_nomenclature_tree_nodes, :origin_nodes)) do |origin_table, ancestors_table, _join_clauses|
-            ancestors_position = Sequel.qualify(ancestors_table, :position)
-            ancestors_depth    = Sequel.qualify(ancestors_table, :depth)
-            origin_position    = Sequel.qualify(origin_table, :position)
-            origin_depth       = Sequel.qualify(origin_table, :depth)
+            ancestors = TreeNodeAlias.new(ancestors_table)
+            origin    = TreeNodeAlias.new(origin_table)
 
-            (ancestors_depth < origin_depth) &
-              (ancestors_position < origin_position) &
-              (ancestors_position >= TreeNode.start_of_chapter(origin_position)) &
-              model.validity_dates_filter(origin_table) &
-              (ancestors_position =~ TreeNode.previous_sibling(origin_position, ancestors_depth))
+            (ancestors.depth < origin.depth) &
+              TreeNode.ancestor_node_constraints(origin, ancestors)
           end
       end
 
@@ -47,17 +42,12 @@ module GoodsNomenclatures
                       read_only: true do |ds|
         ds.with_validity_dates(:parent_nodes)
           .select_append(:parent_nodes__depth)
-          .join(Sequel.as(:goods_nomenclature_tree_nodes, :origin_nodes)) do |origin_table, ancestors_table, _join_clauses|
-            ancestors_position = Sequel.qualify(ancestors_table, :position)
-            ancestors_depth    = Sequel.qualify(ancestors_table, :depth)
-            origin_position    = Sequel.qualify(origin_table, :position)
-            origin_depth       = Sequel.qualify(origin_table, :depth)
+          .join(Sequel.as(:goods_nomenclature_tree_nodes, :origin_nodes)) do |origin_table, parents_table, _join_clauses|
+            parents = TreeNodeAlias.new(parents_table)
+            origin  = TreeNodeAlias.new(origin_table)
 
-            (ancestors_depth =~ (origin_depth - 1)) &
-              (ancestors_position < origin_position) &
-              (ancestors_position >= TreeNode.start_of_chapter(origin_position)) &
-              model.validity_dates_filter(origin_table) &
-              (ancestors_position =~ TreeNode.previous_sibling(origin_position, ancestors_depth))
+            (parents.depth =~ (origin.depth - 1)) &
+              TreeNode.ancestor_node_constraints(origin, parents)
           end
       end
 
@@ -73,21 +63,11 @@ module GoodsNomenclatures
           .with_validity_dates(:descendant_nodes)
           .select_append(:descendant_nodes__depth)
           .join(Sequel.as(:goods_nomenclature_tree_nodes, :origin_nodes)) do |origin_table, descendants_table, _join_clauses|
-            descendants_position = Sequel.qualify(descendants_table, :position)
-            descendants_depth    = Sequel.qualify(descendants_table, :depth)
-            origin_position      = Sequel.qualify(origin_table, :position)
-            origin_depth         = Sequel.qualify(origin_table, :depth)
+            descendants = TreeNodeAlias.new(descendants_table)
+            origin      = TreeNodeAlias.new(origin_table)
 
-            (descendants_depth > origin_depth) &
-              (descendants_position > origin_position) &
-              model.validity_dates_filter(origin_table) &
-              (descendants_position <
-                Sequel.function(
-                  :coalesce,
-                  TreeNode.next_sibling(origin_position, origin_depth),
-                  END_OF_TREE,
-                )
-              )
+            (descendants.depth > origin.depth) &
+              TreeNode.descendant_node_constraints(origin, descendants)
           end
       end
 
@@ -102,22 +82,12 @@ module GoodsNomenclatures
         ds.order(:child_nodes__position)
           .with_validity_dates(:child_nodes)
           .select_append(:child_nodes__depth)
-          .join(Sequel.as(:goods_nomenclature_tree_nodes, :origin_nodes)) do |origin_table, descendants_table, _join_clauses|
-            descendants_position = Sequel.qualify(descendants_table, :position)
-            descendants_depth    = Sequel.qualify(descendants_table, :depth)
-            origin_position      = Sequel.qualify(origin_table, :position)
-            origin_depth         = Sequel.qualify(origin_table, :depth)
+          .join(Sequel.as(:goods_nomenclature_tree_nodes, :origin_nodes)) do |origin_table, children_table, _join_clauses|
+            children = TreeNodeAlias.new(children_table)
+            origin   = TreeNodeAlias.new(origin_table)
 
-            (descendants_depth =~ (origin_depth + 1)) &
-              (descendants_position > origin_position) &
-              model.validity_dates_filter(origin_table) &
-              (descendants_position <
-                Sequel.function(
-                  :coalesce,
-                  TreeNode.next_sibling(origin_position, origin_depth),
-                  END_OF_TREE,
-                )
-              )
+            (children.depth =~ (origin.depth + 1)) &
+              TreeNode.descendant_node_constraints(origin, children)
           end
       end
     end

--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -1,0 +1,14 @@
+module GoodsNomenclatures
+  module NestedSet
+    extend ActiveSupport::Concern
+
+    included do
+      one_to_one :tree_node, key: :goods_nomenclature_sid,
+                             class_name: 'GoodsNomenclatures::TreeNode',
+                             reciprocal: :goods_nomenclature,
+                             read_only: true do |ds|
+        ds.with_actual(GoodsNomenclatures::TreeNode)
+      end
+    end
+  end
+end

--- a/app/models/goods_nomenclatures/tree_node.rb
+++ b/app/models/goods_nomenclatures/tree_node.rb
@@ -17,6 +17,25 @@ module GoodsNomenclatures
       def refresh!(concurrently: true)
         db.refresh_view(:goods_nomenclature_tree_nodes, concurrently:)
       end
+
+      def previous_sibling(origin_position, origin_depth)
+        siblings_position = Sequel.qualify(:siblings, :position)
+        siblings_depth    = Sequel.qualify(:siblings, :depth)
+        siblings_table    = Sequel.as(table_name, :siblings)
+
+        from(siblings_table)
+          .select { Sequel.as(max(siblings_position), :previous_sibling) }
+          .where do |_query|
+            (siblings_depth =~ origin_depth) &
+              (siblings_position < origin_position) &
+              (siblings_position >= TreeNode.start_of_chapter(origin_position)) &
+              validity_dates_filter(:siblings)
+          end
+      end
+
+      def start_of_chapter(position_column)
+        (position_column / 10_000_000_000) * 10_000_000_000
+      end
     end
   end
 end

--- a/app/models/goods_nomenclatures/tree_node.rb
+++ b/app/models/goods_nomenclatures/tree_node.rb
@@ -1,5 +1,7 @@
 module GoodsNomenclatures
   class TreeNode < Sequel::Model(:goods_nomenclature_tree_nodes)
+    set_primary_key :goods_nomenclature_indent_sid
+
     class << self
       # Defaults to concurrent refresh to avoid blocking other queries
       # If the Materialized View has never been populated, eg after a

--- a/app/models/goods_nomenclatures/tree_node.rb
+++ b/app/models/goods_nomenclatures/tree_node.rb
@@ -1,6 +1,13 @@
 module GoodsNomenclatures
   class TreeNode < Sequel::Model(:goods_nomenclature_tree_nodes)
+    plugin :time_machine
     set_primary_key :goods_nomenclature_indent_sid
+
+    one_to_one :goods_nomenclature, primary_key: :goods_nomenclature_sid,
+                                    key: :goods_nomenclature_sid,
+                                    class_name: '::GoodsNomenclature',
+                                    reciprocal: :tree_node,
+                                    read_only: true
 
     class << self
       # Defaults to concurrent refresh to avoid blocking other queries

--- a/app/models/goods_nomenclatures/tree_node.rb
+++ b/app/models/goods_nomenclatures/tree_node.rb
@@ -36,6 +36,20 @@ module GoodsNomenclatures
       def start_of_chapter(position_column)
         (position_column / 10_000_000_000) * 10_000_000_000
       end
+
+      def next_sibling(origin_position, origin_depth)
+        siblings_position = Sequel.qualify(:siblings, :position)
+        siblings_depth    = Sequel.qualify(:siblings, :depth)
+        siblings_table    = Sequel.as(table_name, :siblings)
+
+        from(siblings_table)
+          .select { Sequel.as(min(siblings_position), :next_sibling) }
+          .where do |_query|
+            (siblings_depth =~ origin_depth) &
+              (siblings_position > origin_position) &
+              validity_dates_filter(:siblings)
+          end
+      end
     end
   end
 end

--- a/app/models/goods_nomenclatures/tree_node_alias.rb
+++ b/app/models/goods_nomenclatures/tree_node_alias.rb
@@ -1,0 +1,17 @@
+module GoodsNomenclatures
+  class TreeNodeAlias
+    attr_reader :table
+
+    def initialize(table)
+      @table = table
+    end
+
+    def position
+      @position ||= Sequel.qualify(@table, :position)
+    end
+
+    def depth
+      @depth ||= Sequel.qualify(@table, :depth)
+    end
+  end
+end

--- a/spec/factories/chapter_factory.rb
+++ b/spec/factories/chapter_factory.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :chapter, parent: :goods_nomenclature, class: 'Chapter' do
     goods_nomenclature_item_id { "#{generate(:chapter_short_code)}00000000" }
+    indents { 0 }
 
     trait :with_section do
       after(:create) do |chapter, _evaluator|

--- a/spec/factories/goods_nomenclature_factory.rb
+++ b/spec/factories/goods_nomenclature_factory.rb
@@ -36,7 +36,6 @@ FactoryBot.define do
             1,
             goods_nomenclature: gono,
             number_indents: evaluator.indents,
-            productline_suffix: gono.producline_suffix,
           )
       end
     end

--- a/spec/factories/heading_factory.rb
+++ b/spec/factories/heading_factory.rb
@@ -1,6 +1,14 @@
 FactoryBot.define do
   factory :heading, parent: :goods_nomenclature, class: 'Heading' do
-    goods_nomenclature_item_id { "#{generate(:heading_short_code)}000000" }
+    indents { 0 }
+
+    goods_nomenclature_item_id do
+      if parent
+        "#{parent.goods_nomenclature_item_id.first(2)}01000000"
+      else
+        "#{generate(:heading_short_code)}000000"
+      end
+    end
 
     trait :declarable do
       producline_suffix { '80' }

--- a/spec/lib/sequel/plugins/time_machine_spec.rb
+++ b/spec/lib/sequel/plugins/time_machine_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe Sequel::Plugins::TimeMachine do
+  shared_context 'with TimeMachine' do
+    around do |example|
+      TimeMachine.at(10.minutes.ago) { example.run }
+    end
+  end
+
+  shared_context 'without TimeMachine' do
+    around do |example|
+      TimeMachine.no_time_machine { example.run }
+    end
+  end
+
+  describe '#point_in_time' do
+    subject { Commodity.point_in_time }
+
+    context 'when inside time machine' do
+      include_context 'with TimeMachine'
+
+      it { is_expected.to be_present }
+    end
+
+    context 'when outside time machine' do
+      include_context 'without TimeMachine'
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#with_validity_dates' do
+    subject { Commodity.dataset.with_validity_dates.sql }
+
+    context 'when inside time machine' do
+      include_context 'with TimeMachine'
+
+      it { is_expected.to match '"validity_end_date" IS NULL' }
+    end
+
+    context 'when outside time machine' do
+      include_context 'without TimeMachine'
+
+      it { is_expected.not_to match 'validity_end_date' }
+    end
+  end
+
+  describe '#validity_dates_filter' do
+    subject do
+      Commodity.dataset
+               .where { Commodity.validity_dates_filter(:testtable) }
+               .sql
+    end
+
+    context 'when inside time machine' do
+      include_context 'with TimeMachine'
+
+      it { is_expected.to match '"validity_end_date" IS NULL' }
+    end
+
+    context 'when outside time machine' do
+      include_context 'without TimeMachine'
+
+      it { is_expected.not_to match 'validity_end_date' }
+      it { is_expected.to match 'AND true' }
+    end
+  end
+end

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -43,5 +43,153 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         end
       end
     end
+
+    describe 'hierarchy' do
+      let :tree do
+        chapter = create(:chapter)
+        heading = create(:heading, parent: chapter)
+        subheading = create(:commodity, parent: heading)
+        subsubheading = create(:commodity, parent: subheading)
+        commodity1 = create(:commodity, parent: subsubheading)
+        commodity2 = create(:commodity, parent: subsubheading)
+        commodity3 = create(:commodity, parent: subheading)
+        second_tree = create(:commodity, :with_chapter_and_heading, :with_children)
+
+        {
+          chapter:,
+          heading:,
+          subheading:,
+          subsubheading:,
+          commodity1:,
+          commodity2:,
+          commodity3:,
+          second_tree:,
+        }
+      end
+
+      describe '#ns_ancestors' do
+        let(:third_tier_ancestors) { tree.values_at(:chapter, :heading, :subheading) }
+
+        context 'with chapter' do
+          subject { tree[:chapter].ns_ancestors.map(&:goods_noemnclature_sid) }
+
+          it { is_expected.to be_empty }
+        end
+
+        context 'with heading' do
+          subject { tree[:heading].ns_ancestors.map(&:goods_nomenclature_sid) }
+
+          it { is_expected.to eq [tree[:chapter].goods_nomenclature_sid] }
+        end
+
+        context 'with subheading' do
+          subject { tree[:subheading].ns_ancestors.map(&:goods_nomenclature_sid) }
+
+          it { is_expected.to eq tree.values_at(:chapter, :heading).map(&:goods_nomenclature_sid) }
+        end
+
+        context 'with nested subheading' do
+          subject { tree[:subsubheading].ns_ancestors.map(&:goods_nomenclature_sid) }
+
+          it { is_expected.to eq third_tier_ancestors.map(&:goods_nomenclature_sid) }
+        end
+
+        context 'for leaf commodity' do
+          subject { tree[:commodity1].ns_ancestors.map(&:goods_nomenclature_sid) }
+
+          let :ancestors do
+            tree.values_at(:chapter, :heading, :subheading, :subsubheading)
+          end
+
+          it { is_expected.to eq ancestors.map(&:goods_nomenclature_sid) }
+        end
+
+        context 'for second leaf commodity' do
+          subject { tree[:commodity3].ns_ancestors.map(&:goods_nomenclature_sid) }
+
+          it { is_expected.to eq third_tier_ancestors.map(&:goods_nomenclature_sid) }
+        end
+
+        context 'for second tree' do
+          subject { tree[:second_tree].ns_ancestors.map(&:goods_nomenclature_item_id) }
+
+          let(:commodity) { tree[:second_tree] }
+
+          let(:expected_ancestor_item_ids) do
+            [
+              "#{commodity.goods_nomenclature_item_id.first(2)}00000000",
+              "#{commodity.goods_nomenclature_item_id.first(4)}000000",
+            ]
+          end
+
+          it { is_expected.to eq expected_ancestor_item_ids }
+        end
+      end
+
+      describe 'with time machine' do
+        before do
+          create :goods_nomenclature_indent,
+                 goods_nomenclature: tree[:subsubheading],
+                 validity_start_date: 1.week.ago.at_beginning_of_day,
+                 number_indents: 1
+
+          create :goods_nomenclature_indent,
+                 goods_nomenclature: tree[:commodity1],
+                 validity_start_date: 1.week.ago.at_beginning_of_day,
+                 number_indents: 2
+
+          create :goods_nomenclature_indent,
+                 goods_nomenclature: tree[:commodity2],
+                 validity_start_date: 1.week.ago.at_beginning_of_day,
+                 number_indents: 2
+        end
+
+        describe '#ancestors' do
+          context 'with subsubheading' do
+            subject { tree[:subsubheading].ns_ancestors.map(&:goods_nomenclature_sid) }
+
+            it { is_expected.to eq tree.values_at(:chapter, :heading).map(&:goods_nomenclature_sid) }
+          end
+
+          context 'with commodity under subsubheading' do
+            subject { tree[:commodity1].ns_ancestors.map(&:goods_nomenclature_sid) }
+
+            it { is_expected.to eq tree.values_at(:chapter, :heading, :subsubheading).map(&:goods_nomenclature_sid) }
+          end
+
+          context 'with commodity under subheading' do
+            subject { tree[:commodity3].ns_ancestors.map(&:goods_nomenclature_sid) }
+
+            it { is_expected.to eq tree.values_at(:chapter, :heading, :subsubheading).map(&:goods_nomenclature_sid) }
+          end
+        end
+
+        context 'when accessing historical data via TimeMachine' do
+          around { |example| TimeMachine.at(2.weeks.ago) { example.run } }
+
+          context 'with nested subheading' do
+            subject { tree[:subsubheading].ns_ancestors.map(&:goods_nomenclature_sid) }
+
+            it { is_expected.to eq tree.values_at(:chapter, :heading, :subheading).map(&:goods_nomenclature_sid) }
+          end
+
+          context 'for leaf commodity' do
+            subject { tree[:commodity1].ns_ancestors.map(&:goods_nomenclature_sid) }
+
+            let :ancestors do
+              tree.values_at(:chapter, :heading, :subheading, :subsubheading)
+            end
+
+            it { is_expected.to eq ancestors.map(&:goods_nomenclature_sid) }
+          end
+
+          context 'for second leaf commodity' do
+            subject { tree[:commodity3].ns_ancestors.map(&:goods_nomenclature_sid) }
+
+            it { is_expected.to eq tree.values_at(:chapter, :heading, :subheading).map(&:goods_nomenclature_sid) }
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe GoodsNomenclatures::NestedSet do
+  around { |example| TimeMachine.now { example.run } }
+
+  describe 'relationships' do
+    describe '#tree_node' do
+      subject(:tree_node) { commodity.reload.tree_node }
+
+      let :commodity do
+        create :commodity, :with_indent, goods_nomenclature_item_id: '0101010101',
+                                         indents: 1
+      end
+
+      let(:indent) { commodity.goods_nomenclature_indent }
+
+      it { is_expected.to be_instance_of GoodsNomenclatures::TreeNode }
+      it { is_expected.to have_attributes goods_nomenclature_sid: commodity.goods_nomenclature_sid }
+      it { is_expected.to have_attributes depth: 3 }
+      it { is_expected.to have_attributes goods_nomenclature_indent_sid: indent.pk }
+
+      it 'reciprocates correctly' do
+        expect(tree_node.goods_nomenclature.object_id).to eq commodity.object_id
+      end
+
+      context 'with time machine' do
+        before { new_indent && commodity.reload }
+
+        let :new_indent do
+          create :goods_nomenclature_indent, goods_nomenclature: commodity,
+                                             validity_start_date: 1.week.ago,
+                                             number_indents: 2
+        end
+
+        it { is_expected.to have_attributes goods_nomenclature_indent_sid: new_indent.pk }
+        it { is_expected.to have_attributes depth: 4 }
+
+        context 'with date in the past' do
+          around { |example| TimeMachine.at(2.weeks.ago) { example.run } }
+
+          it { is_expected.to have_attributes goods_nomenclature_indent_sid: indent.pk }
+          it { is_expected.to have_attributes depth: 3 }
+        end
+      end
+    end
+  end
+end

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -99,6 +99,18 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         end
       end
 
+      shared_examples 'it supports eager loading' do |relationship|
+        subject do
+          commodities.eager(relationship).all.first.associations[relationship]
+        end
+
+        let :commodities do
+          GoodsNomenclature.where(goods_nomenclature_sid: tree[:subsubheading].goods_nomenclature_sid)
+        end
+
+        it { is_expected.not_to be_nil }
+      end
+
       describe '#ns_ancestors' do
         let(:third_tier_ancestors) { tree.values_at(:chapter, :heading, :subheading) }
 
@@ -108,6 +120,8 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         it_behaves_like 'it has ancestors', 'nested subheading', :subsubheading, %i[chapter heading subheading]
         it_behaves_like 'it has ancestors', 'leaf commodity', :commodity1, %i[chapter heading subheading subsubheading]
         it_behaves_like 'it has ancestors', 'second leaf commodity', :commodity3, %i[chapter heading subheading]
+
+        it_behaves_like 'it supports eager loading', :ns_ancestors
 
         context 'for second tree' do
           subject { tree[:second_tree].ns_ancestors.map(&:goods_nomenclature_item_id) }
@@ -133,6 +147,8 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         it_behaves_like 'it has parent', 'leaf commodity', :commodity1, :subsubheading
         it_behaves_like 'it has parent', 'second leaf commodity', :commodity3, :subheading
 
+        it_behaves_like 'it supports eager loading', :ns_parent
+
         context 'for second tree' do
           subject { tree[:second_tree].ns_parent.goods_nomenclature_item_id }
 
@@ -150,6 +166,8 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         it_behaves_like 'it has descendants', 'leaf commodity', :commodity1, %i[]
         it_behaves_like 'it has descendants', 'second leaf commodity', :commodity3, %i[]
 
+        it_behaves_like 'it supports eager loading', :ns_descendants
+
         context 'for second tree' do
           subject { tree[:second_tree].ns_descendants.map(&:goods_nomenclature_item_id) }
 
@@ -164,6 +182,8 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         it_behaves_like 'it has children', 'nested subheading', :subsubheading, %i[commodity1 commodity2]
         it_behaves_like 'it has children', 'leaf commodity', :commodity1, %i[]
         it_behaves_like 'it has children', 'second leaf commodity', :commodity3, %i[]
+
+        it_behaves_like 'it supports eager loading', :ns_children
 
         context 'for second tree' do
           subject { tree[:second_tree].ns_children.map(&:goods_nomenclature_item_id) }

--- a/spec/models/goods_nomenclatures/tree_node_alias_spec.rb
+++ b/spec/models/goods_nomenclatures/tree_node_alias_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe GoodsNomenclatures::TreeNodeAlias do
+  subject(:instance) { described_class.new :aliased_table }
+
+  describe '#position' do
+    subject { instance.position }
+
+    it { is_expected.to be_instance_of Sequel::SQL::QualifiedIdentifier }
+    it { is_expected.to have_attributes table: :aliased_table }
+    it { is_expected.to have_attributes column: :position }
+  end
+
+  describe '#depth' do
+    subject { instance.depth }
+
+    it { is_expected.to be_instance_of Sequel::SQL::QualifiedIdentifier }
+    it { is_expected.to have_attributes table: :aliased_table }
+    it { is_expected.to have_attributes column: :depth }
+  end
+end

--- a/spec/models/goods_nomenclatures/tree_node_spec.rb
+++ b/spec/models/goods_nomenclatures/tree_node_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe GoodsNomenclatures::TreeNode do
+  around { |example| TimeMachine.now { example.run } }
+
   describe 'Sequel::Model config' do
     subject { described_class }
 

--- a/spec/models/goods_nomenclatures/tree_node_spec.rb
+++ b/spec/models/goods_nomenclatures/tree_node_spec.rb
@@ -132,6 +132,24 @@ RSpec.describe GoodsNomenclatures::TreeNode do
     end
   end
 
+  describe '.ancestor_node_constraints' do
+    subject { described_class.ancestor_node_constraints(table1, table2) }
+
+    let(:table1) { GoodsNomenclatures::TreeNodeAlias.new(:table1) }
+    let(:table2) { GoodsNomenclatures::TreeNodeAlias.new(:table2) }
+
+    it { is_expected.to be_instance_of Sequel::SQL::BooleanExpression }
+  end
+
+  describe '.descendant_node_constraints' do
+    subject { described_class.descendant_node_constraints(table1, table2) }
+
+    let(:table1) { GoodsNomenclatures::TreeNodeAlias.new(:table1) }
+    let(:table2) { GoodsNomenclatures::TreeNodeAlias.new(:table2) }
+
+    it { is_expected.to be_instance_of Sequel::SQL::BooleanExpression }
+  end
+
   describe '#goods_nomenclature relationship' do
     subject(:commodity) { tree_node.goods_nomenclature }
 

--- a/spec/models/goods_nomenclatures/tree_node_spec.rb
+++ b/spec/models/goods_nomenclatures/tree_node_spec.rb
@@ -55,4 +55,66 @@ RSpec.describe GoodsNomenclatures::TreeNode do
     it { is_expected.to have_attributes position: expected_position }
     it { is_expected.to have_attributes number_indents: commodity.number_indents }
   end
+
+  describe '.previous_sibling' do
+    let(:subheading) { create :commodity, :with_chapter_and_heading }
+    let(:siblings) { create_list :commodity, 3, parent: subheading }
+
+    context 'with first sibling' do
+      subject do
+        described_class.previous_sibling(siblings.first.tree_node.position,
+                                         siblings.first.tree_node.depth)
+                       .first
+                       .values[:previous_sibling]
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with second sibling' do
+      subject do
+        described_class.previous_sibling(siblings.second.tree_node.position,
+                                         siblings.second.tree_node.depth)
+                       .first
+                       .values[:previous_sibling]
+      end
+
+      it { is_expected.to eq siblings.first.tree_node.position }
+    end
+
+    context 'with third sibling' do
+      subject do
+        described_class.previous_sibling(siblings.third.tree_node.position,
+                                         siblings.third.tree_node.depth)
+                       .first
+                       .values[:previous_sibling]
+      end
+
+      it { is_expected.to eq siblings.second.tree_node.position }
+    end
+  end
+
+  describe '#goods_nomenclature relationship' do
+    subject(:commodity) { tree_node.goods_nomenclature }
+
+    let(:indent) { commodity.goods_nomenclature_indent }
+
+    let :tree_node do
+      commodity = create :commodity,
+                         :with_indent,
+                         goods_nomenclature_item_id: '0101010101',
+                         indents: 1
+
+      described_class
+        .actual
+        .first(goods_nomenclature_sid: commodity.goods_nomenclature_sid)
+    end
+
+    it { is_expected.to be_instance_of Commodity }
+    it { is_expected.to have_attributes goods_nomenclature_sid: tree_node.goods_nomenclature_sid }
+
+    it 'reciprocates correctly' do
+      expect(commodity.tree_node.object_id).to eq tree_node.object_id
+    end
+  end
 end

--- a/spec/models/goods_nomenclatures/tree_node_spec.rb
+++ b/spec/models/goods_nomenclatures/tree_node_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe GoodsNomenclatures::TreeNode do
+  describe 'Sequel::Model config' do
+    subject { described_class }
+
+    it { is_expected.to have_attributes primary_key: :goods_nomenclature_indent_sid }
+  end
+
   describe 'attributes' do
     it { is_expected.to respond_to :goods_nomenclature_sid }
     it { is_expected.to respond_to :position }

--- a/spec/models/goods_nomenclatures/tree_node_spec.rb
+++ b/spec/models/goods_nomenclatures/tree_node_spec.rb
@@ -94,6 +94,44 @@ RSpec.describe GoodsNomenclatures::TreeNode do
     end
   end
 
+  describe '.next_sibling' do
+    let(:subheading) { create :commodity, :with_chapter_and_heading }
+    let(:siblings) { create_list :commodity, 3, parent: subheading }
+
+    context 'with first sibling' do
+      subject do
+        described_class.next_sibling(siblings.first.tree_node.position,
+                                     siblings.first.tree_node.depth)
+                       .first
+                       .values[:next_sibling]
+      end
+
+      it { is_expected.to eq siblings.second.tree_node.position }
+    end
+
+    context 'with second sibling' do
+      subject do
+        described_class.next_sibling(siblings.second.tree_node.position,
+                                     siblings.second.tree_node.depth)
+                       .first
+                       .values[:next_sibling]
+      end
+
+      it { is_expected.to eq siblings.third.tree_node.position }
+    end
+
+    context 'with third sibling' do
+      subject do
+        described_class.next_sibling(siblings.third.tree_node.position,
+                                     siblings.third.tree_node.depth)
+                       .first
+                       .values[:next_sibling]
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe '#goods_nomenclature relationship' do
     subject(:commodity) { tree_node.goods_nomenclature }
 


### PR DESCRIPTION
### Jira link

HOTT-2640

### What?

I have added/removed/altered:

- [x] Added a more generic mechanism for adding TimeMachine constraints to queries
- [x] Added a query generated for previous sibling
- [x] Added a query generated for next sibling
- [x] Added nested set parent relationship to Goods Nomenclature
- [x] Added nested set ancestors relationship to Goods Nomenclature
- [x] Added nested set children relationship to Goods Nomenclature
- [x] Added nested set descendants relationship to Goods Nomenclature

### Why?

I am doing this because:

- I want fast time machine compatible mechanisms to query the hierarchy

### Deployment risks (optional)

- Purely addition of unused relationships so should be safe
