### PR TITLE
HOTT-2690 custom loader for descendants

### DIFF
--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -168,5 +168,9 @@ module GoodsNomenclatures
     def depth
       values.key?(:depth) ? values[:depth] : tree_node.depth
     end
+
+    def ns_declarable?
+      producline_suffix == GoodsNomenclatureIndent::NON_GROUPING_PRODUCTLINE_SUFFIX && ns_children.empty?
+    end
   end
 end

--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -19,6 +19,7 @@ module GoodsNomenclatures
                    right_key: :goods_nomenclature_sid,
                    class_name: '::GoodsNomenclature',
                    join_table: Sequel.as(:goods_nomenclature_tree_nodes, :ancestor_nodes),
+                   after_load: :recursive_ancestor_populator,
                    read_only: true do |ds|
         ds.order(:ancestor_nodes__depth)
           .with_validity_dates(:ancestor_nodes)
@@ -121,6 +122,17 @@ module GoodsNomenclatures
               )
           end
       end
+    end
+
+    def recursive_ancestor_populator(ancestors)
+      @associations ||= { ns_ancestors: ancestors }
+
+      parents_ancestors = ancestors.dup
+      parent = parents_ancestors.pop
+      @associations[:ns_parent] ||= parent
+      return if ancestors.empty?
+
+      parent.recursive_ancestor_populator(parents_ancestors)
     end
 
     def recursive_descendant_populator(descendants, parent = nil)

--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -140,6 +140,10 @@ module GoodsNomenclatures
 
       if parent
         @associations[:ns_parent] ||= parent
+
+        if parent.associations[:ns_ancestors]
+          @associations[:ns_ancestors] ||= (parent.associations[:ns_ancestors] + [parent])
+        end
       end
 
       if descendants.empty?

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -328,4 +328,24 @@ RSpec.describe GoodsNomenclatures::NestedSet do
       end
     end
   end
+
+  describe '#ns_declarable?' do
+    context 'with descendants' do
+      subject { create :commodity, :non_grouping, :with_children }
+
+      it { is_expected.not_to be_ns_declarable }
+    end
+
+    context 'without descendants' do
+      subject { create :commodity, :non_grouping, :without_children }
+
+      it { is_expected.to be_ns_declarable }
+    end
+
+    context 'with grouping productline suffix' do
+      subject { create :commodity, :grouping, :without_children }
+
+      it { is_expected.not_to be_ns_declarable }
+    end
+  end
 end

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -138,23 +138,29 @@ RSpec.describe GoodsNomenclatures::NestedSet do
           it { is_expected.to eq expected_ancestor_item_ids }
         end
 
-        xcontext 'when eager loading' do
+        context 'when eager loading' do
           let(:eager_loaded) { commodities.eager(:ns_ancestors).all.first }
 
           let :commodities do
-            GoodsNomenclature.where(goods_nomenclature_sid: tree[:subheading].goods_nomenclature_sid)
+            GoodsNomenclature.where(goods_nomenclature_sid: tree[:subsubheading].goods_nomenclature_sid)
           end
 
           context 'for eager loaded goods nomenclature' do
-            subject { eager_loaded.associations[:parent].goods_nomenclature_sid }
+            subject { eager_loaded.associations[:ns_parent] }
 
-            it { is_expected.to eq tree[:heading].goods_nomenclature_sid }
+            it { is_expected.to eq_pk tree[:subheading] }
           end
 
-          context 'for eager loaded goods nomenclatures child' do
-            subject { eager_loaded.children.first.associations[:parent].goods_nomenclature_sid }
+          context 'for eager loaded goods nomenclatures parents parent' do
+            subject { eager_loaded.associations[:ns_parent].associations[:ns_parent] }
 
-            it { is_expected.to eq tree[:chapter].goods_nomenclature_sid }
+            it { is_expected.to eq_pk tree[:heading] }
+          end
+
+          context 'for eager loaded goods nomenclatures parents ancestors' do
+            subject { eager_loaded.associations[:ns_parent].associations[:ns_ancestors] }
+
+            it { is_expected.to eq_pk tree.values_at(:chapter, :heading) }
           end
         end
       end

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -231,10 +231,39 @@ RSpec.describe GoodsNomenclatures::NestedSet do
             it { is_expected.to eq_pk tree[:subheading] }
           end
 
-          context 'for eager loaded goods nomenclatures childs chilrens parent' do
-            subject { eager_loaded.associations[:ns_children].first.associations[:ns_children].first.associations[:ns_parent] }
+          context 'for eager loaded goods nomenclatures childs childrens parent' do
+            subject do
+              eager_loaded.associations[:ns_children]
+                          .first
+                          .associations[:ns_children]
+                          .first
+                          .associations[:ns_parent]
+            end
 
             it { is_expected.to eq_pk tree[:subsubheading] }
+          end
+
+          context 'when including ancestors' do
+            let(:eager_loaded) do
+              commodities.eager(:ns_ancestors, :ns_descendants).all.first
+            end
+
+            context 'for eager loaded goods nomenclatures childs childrens parent' do
+              subject(:leaf) do
+                eager_loaded.associations[:ns_children]
+                            .first
+                            .associations[:ns_children]
+                            .first
+                            .associations[:ns_ancestors]
+              end
+
+              it 'populates descendant ancestors automatically' do
+                expect(leaf).to eq_pk tree.values_at(:chapter,
+                                                     :heading,
+                                                     :subheading,
+                                                     :subsubheading)
+              end
+            end
           end
         end
       end

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -69,9 +69,9 @@ RSpec.describe GoodsNomenclatures::NestedSet do
 
       shared_examples 'it has ancestors' do |context_name, node, ancestors|
         context "with #{context_name}" do
-          subject { tree[node].ns_ancestors.map(&:goods_nomenclature_sid) }
+          subject { tree[node].ns_ancestors }
 
-          it { is_expected.to eq tree.values_at(*ancestors).map(&:goods_nomenclature_sid) }
+          it { is_expected.to eq_pk tree.values_at(*ancestors) }
         end
       end
 
@@ -85,17 +85,17 @@ RSpec.describe GoodsNomenclatures::NestedSet do
 
       shared_examples 'it has descendants' do |context_name, node, descendants|
         context "with #{context_name}" do
-          subject { tree[node].ns_descendants.map(&:goods_nomenclature_sid) }
+          subject { tree[node].ns_descendants }
 
-          it { is_expected.to eq tree.values_at(*descendants).map(&:goods_nomenclature_sid) }
+          it { is_expected.to eq_pk tree.values_at(*descendants) }
         end
       end
 
       shared_examples 'it has children' do |context_name, node, children|
         context "with #{context_name}" do
-          subject { tree[node].ns_children.map(&:goods_nomenclature_sid) }
+          subject { tree[node].ns_children }
 
-          it { is_expected.to eq tree.values_at(*children).map(&:goods_nomenclature_sid) }
+          it { is_expected.to eq_pk tree.values_at(*children) }
         end
       end
 

--- a/spec/support/matchers/eq_pk.rb
+++ b/spec/support/matchers/eq_pk.rb
@@ -1,0 +1,28 @@
+RSpec::Matchers.define :eq_pk do
+  match do |actual|
+    if actual.respond_to?(:map)
+      actual.map(&:class) == expected.map(&:class) &&
+        actual.map(&:pk) == expected.map(&:pk)
+    else
+      actual.instance_of?(expected.class) && actual.pk == expected.pk
+    end
+  end
+
+  failure_message do |actual|
+    if actual.respond_to?(:map)
+      "expected #{model_ids(actual)} to == #{model_ids(expected)}"
+    else
+      "expected #{model_id(actual)} to == #{model_id(expected)}"
+    end
+  end
+
+  private
+
+  def model_id(model)
+    "#{model.class}:#{model.pk}"
+  end
+
+  def model_ids(models)
+    "[#{models.map(&method(:model_id)).join(', ')}]"
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-2690

### What?

I have added/removed/altered:

- [x] Added an RSpec matcher to compare models just by primary keys rather then all values
- [x] Added a custom loader for descendants to recursively populate children relationship, together with their descendants, children and parents
- [x] Added a custom loader for ancestors to recursively populate, parents and ancestors of all ancestors
- [x] Added a nested set version of `declarable?`

### Why?

I am doing this because:

- Objects returned via relationships have an additional `depth` value - and just fetching out SIDs to compare objects can be DRYed out
- This avoids unneeded relationship queries for objects we can already derive from the descendants we have already loaded
- This avoids unneeded relationship queries for objects we can already derive from the ancestors we have already loaded
- This version can operate without querying the database if children are already loaded (eg via an eager load of descendants)

### Deployment risks (optional)

- Low, shouldn't change any in use code
