### PR TITLE
HOTT-2716: Filter out non-erga omnes overview VAT measures

### DIFF
--- a/app/models/concerns/ten_digit_goods_nomenclature.rb
+++ b/app/models/concerns/ten_digit_goods_nomenclature.rb
@@ -23,12 +23,21 @@ module TenDigitGoodsNomenclature
     end
 
     one_to_many :overview_measures, key: {}, primary_key: {}, class_name: 'Measure', dataset: lambda {
-      measures_dataset
-        .filter(measures__measure_type_id: MeasureType.overview_measure_types)
+      dataset = measures_dataset
+        .filter(measures__measure_type_id: MeasureType::SUPPLEMENTARY_TYPES)
         .or(
           measures__measure_type_id: MeasureType::THIRD_COUNTRY,
           measures__geographical_area_id: GeographicalArea::ERGA_OMNES_ID,
         )
+
+      if TradeTariffBackend.uk?
+        dataset.or(
+          measures__measure_type_id: MeasureType::VAT_TYPES,
+          measures__geographical_area_id: GeographicalArea::ERGA_OMNES_ID,
+        )
+      else
+        dataset
+      end
     }
 
     delegate :section, :section_id, to: :chapter, allow_nil: true

--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -3,17 +3,10 @@
 # 1 2 3 4 5 6 7 8 9 0
 
 class MeasureType < Sequel::Model
-  # TODO: consider to refactor all the constants bellow with the use of enum
-  # Example:
-  # enum :measure_type, {
-  #     third_country: %w[103 105],
-  #     tariff_preference: %w[142 145],
-  #     preferential_quota: %w[143 146],
-  #   }
   IMPORT_MOVEMENT_CODES = [0, 2].freeze
   EXPORT_MOVEMENT_CODES = [1, 2].freeze
   THIRD_COUNTRY = %w[103 105].freeze # 105 measure types are for end use Third Country duties. 103 are for everything else
-  VAT_TYPES = %w[VTA VTE VTS VTZ 305].freeze # TODO: Remove dead VAT measure types from the old days of CHIEF
+  VAT_TYPES = %w[305].freeze
   SUPPLEMENTARY_TYPES = %w[109 110 111].freeze
   QUOTA_TYPES = %w[046 122 123 143 146 147 653 654].freeze
   NATIONAL_PR_TYPES = %w[AHC AIL ATT CEX CHM COE COI CVD DPO ECM EHC EQC EWP HOP HSE IWP PHC PRE PRT QRC SFS].freeze
@@ -126,15 +119,6 @@ class MeasureType < Sequel::Model
 
   def authorised_use_provisions_submission?
     measure_type_id.in?(AUTHORISED_USE_PROVISIONS_SUBMISSION)
-  end
-
-  # See Commodity#overview_measures
-  def self.overview_measure_types
-    if TradeTariffBackend.xi?
-      MeasureType::SUPPLEMENTARY_TYPES
-    else
-      MeasureType::VAT_TYPES + MeasureType::SUPPLEMENTARY_TYPES
-    end
   end
 
   def self.excluded_measure_types

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -221,6 +221,11 @@ FactoryBot.define do
       measure_type_id { '305' }
     end
 
+    trait :vat_overview do
+      vat
+      erga_omnes
+    end
+
     trait :supplementary do
       measure_type_id { MeasureType::SUPPLEMENTARY_TYPES.sample }
     end

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -197,12 +197,25 @@ RSpec.describe Commodity do
         it { is_expected.to include(measure) }
       end
 
-      context 'when a vat measure' do
+      context 'when a vat measure that is not explicitly erga omnes' do
         let(:measure) do
           create(
             :measure,
             :with_base_regulation,
             :vat,
+            goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+          )
+        end
+
+        it { is_expected.not_to include(measure) }
+      end
+
+      context 'when a vat measure that is explicitly erga omnes' do
+        let(:measure) do
+          create(
+            :measure,
+            :with_base_regulation,
+            :vat_overview,
             goods_nomenclature_sid: commodity.goods_nomenclature_sid,
           )
         end

--- a/spec/models/measure_type_spec.rb
+++ b/spec/models/measure_type_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe MeasureType do
     context 'when measure_type has measure_type_id of 103' do
       subject(:measure_type) { build :measure_type, measure_type_id: '103' }
 
-      it { is_expected.to be_third_country } 
+      it { is_expected.to be_third_country }
     end
 
     context 'when measure_type has measure_type_id of 105' do
@@ -174,26 +174,6 @@ RSpec.describe MeasureType do
       subject(:measure_type) { build :measure_type, measure_type_id: 'X' }
 
       it { is_expected.not_to be_rules_of_origin_apply }
-    end
-  end
-
-  describe '.overview_measures_types' do
-    subject(:measure_type) { described_class.overview_measure_types }
-
-    before do
-      allow(TradeTariffBackend).to receive(:service).and_return(service)
-    end
-
-    context 'when on the xi service' do
-      let(:service) { 'xi' }
-
-      it { is_expected.to eq(%w[109 110 111]) }
-    end
-
-    context 'when on the uk service' do
-      let(:service) { 'uk' }
-
-      it { is_expected.to eq(%w[VTA VTE VTS VTZ 305 109 110 111]) }
     end
   end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2716

### What?

I have added/removed/altered:

- [x] Filter out non-erga omnes VAT measures when looking at the measure overview

### Why?

I am doing this because:

- This is a feature request that resulted from strange data
