### PR TITLE
HOTT-2750: Fixed footnotes HTML using regex

### DIFF
--- a/app/formatters/description_formatter.rb
+++ b/app/formatters/description_formatter.rb
@@ -1,6 +1,6 @@
 class DescriptionFormatter
   def self.format(opts = {})
-    raise ArgumentError.new('DescriptionFormatter expects :using arg to be a single value') if opts.keys.many?
+    raise ArgumentError, 'DescriptionFormatter expects :using arg to be a single value' if opts.keys.many?
 
     str = opts.values.first
     return '' if str.blank?
@@ -26,11 +26,11 @@ class DescriptionFormatter
       str.gsub!(/ized/i, 'ised')
       str.gsub!(/(\d),(\d)/, '\1.\2')
     end
-    str.gsub! /@(.)/ do
-      "<sub>#{$1}</sub>"
+    str.gsub!(/@(.)/) do
+      "<sub>#{::Regexp.last_match(1)}</sub>"
     end
-    str.gsub! /\$(.)/ do
-      "<sup>#{$1}</sup>"
+    str.gsub!(/\$(.)/) do
+      "<sup>#{::Regexp.last_match(1)}</sup>"
     end
     str.gsub!(/<sub>([a-z])<\/sub>/i, '@\1')
     str.gsub!(/<br><li>/, '<li>')

--- a/app/formatters/description_formatter.rb
+++ b/app/formatters/description_formatter.rb
@@ -33,6 +33,11 @@ class DescriptionFormatter
       "<sup>#{$1}</sup>"
     end
     str.gsub!(/<sub>([a-z])<\/sub>/i, '@\1')
+    str.gsub!(/<br><li>/, '<li>')
+    str.gsub!(/<br><br><ul>/, '<ul>')
+    str.gsub!(/<br><\/ul><br>/, '</ul>')
+    str.gsub!(/(<br>){3,}/, '<br><br>')
+
     str.strip
     str.html_safe
   end

--- a/spec/formatters/description_formatter_spec.rb
+++ b/spec/formatters/description_formatter_spec.rb
@@ -148,6 +148,36 @@ RSpec.describe DescriptionFormatter do
       ).to eq ' email@hse.gov.uk '
     end
 
+    it 'removes br before li' do
+      expect(
+        described_class.format(description: ' <br><li> '),
+      ).to eq ' <li> '
+    end
+
+    it 'removes br before ul' do
+      expect(
+        described_class.format(description: ' <br><br><ul> '),
+      ).to eq ' <ul> '
+    end
+
+    it 'removes br surrounding ul' do
+      expect(
+        described_class.format(description: ' <br></ul><br> '),
+      ).to eq ' </ul> '
+    end
+
+    it 'replaces 3 or more br with 2' do
+      expect(
+        described_class.format(description: ' <br><br><br> '),
+      ).to eq ' <br><br> '
+    end
+
+    it 'replaces 4 br with 2' do
+      expect(
+        described_class.format(description: ' <br><br><br><br> '),
+      ).to eq ' <br><br> '
+    end
+
     context 'when xi' do
       before do
         allow(TradeTariffBackend).to receive(:uk?).and_return(false)

--- a/spec/formatters/description_formatter_spec.rb
+++ b/spec/formatters/description_formatter_spec.rb
@@ -1,16 +1,18 @@
 RSpec.describe DescriptionFormatter do
   describe '.format' do
-    it 'corrects inconsistent newlines in lists' do
+    it 'correctly escapes lists' do
       description = '-| bread -| butter'
 
       expect(
         described_class.format(description:),
       ).to eq '<br/>- bread <br/>- butter'
+    end
 
-      description2 = "\n-| bread -| butter"
+    it 'corrects inconsistent newlines in lists' do
+      description = "\n-| bread -| butter"
 
       expect(
-        described_class.format(description: description2),
+        described_class.format(description:),
       ).to eq '<br/>- bread <br/>- butter'
     end
 
@@ -104,15 +106,25 @@ RSpec.describe DescriptionFormatter do
       ).to eq ' <sup>1</sup> '
     end
 
-    it 'return empty string for empty description' do
+    it 'replaces @<anycharacter> with html sub tag' do
+      expect(
+        described_class.format(description: ' @2 '),
+      ).to eq ' <sub>2</sub> '
+    end
+
+    it 'returns empty string for nil description' do
       expect(
         described_class.format(description: nil),
       ).to eq ''
+    end
 
+    it 'returns empty string for empty description' do
       expect(
         described_class.format(description: ''),
       ).to eq ''
+    end
 
+    it 'returns empty string for nothing but spaces' do
       expect(
         described_class.format(description: '    '),
       ).to eq ''


### PR DESCRIPTION
### Jira link

[HOTT-<TODO>](https://transformuk.atlassian.net/browse/HOTT-2750)

### What?

I have added/removed/altered:

- [ ] Added regex to fix footnotes HTML

### Why?

I am doing this because:

- the HTML is broken and we need to fix it on our end
