### PR TITLE
HOTT-2811: Removes negation from search reference titles

### DIFF
--- a/app/models/goods_nomenclature_description.rb
+++ b/app/models/goods_nomenclature_description.rb
@@ -29,7 +29,7 @@ class GoodsNomenclatureDescription < Sequel::Model
   end
 
   def description_indexed
-    (super.match(DESCRIPTION_NEGATION_REGEX).try(:[], :keep).presence || description).try(:gsub, NO_BREAKING_SPACE, ' ')
+    SearchNegationService.new(description).call
   end
 
   def formatted_description

--- a/app/models/search_reference.rb
+++ b/app/models/search_reference.rb
@@ -1,6 +1,10 @@
 class SearchReference < Sequel::Model
-  DEFAULT_PRODUCTLINE_SUFFIX = '80'.freeze
-  VALID_REFERENCED_CLASSES = %w[Chapter Heading Subheading Commodity].freeze
+  VALID_REFERENCED_CLASSES = %w[
+    Chapter
+    Heading
+    Subheading
+    Commodity
+  ].freeze
 
   extend ActiveModel::Naming
 
@@ -42,6 +46,10 @@ class SearchReference < Sequel::Model
 
   def referenced_id
     referenced.to_admin_param
+  end
+
+  def title_indexed
+    SearchNegationService.new(title).call
   end
 
   def validate

--- a/app/serializers/search/goods_nomenclature_serializer.rb
+++ b/app/serializers/search/goods_nomenclature_serializer.rb
@@ -63,7 +63,7 @@ module Search
     end
 
     def search_references
-      ancestors.reverse.each_with_object([declarable_search_references]) { |serialized_ancestor, acc|
+      ancestors.reverse.each_with_object([search_references_for(goods_nomenclature_sid)]) { |serialized_ancestor, acc|
         acc.prepend(serialized_ancestor[:search_references])
       }.join(' ')
     end
@@ -94,7 +94,7 @@ module Search
           formatted_description: ancestor.formatted_description,
           ancestor_ids: [], # We are not interested in ancestor ancestors
           ancestors: [], # We are not interested in ancestor ancestors
-          search_references: search_references_for(ancestor),
+          search_references: search_references_for(ancestor.goods_nomenclature_sid),
           intercept_terms: ancestor.intercept_terms,
         }
       end
@@ -147,12 +147,12 @@ module Search
                                 end
     end
 
-    def search_references_for(ancestor)
-      SearchReference.where(goods_nomenclature_sid: ancestor.goods_nomenclature_sid).pluck(:title).join(' ')
-    end
-
-    def declarable_search_references
-      SearchReference.where(goods_nomenclature_sid:).pluck(:title).join(' ')
+    def search_references_for(goods_nomenclature_sid)
+      SearchReference
+        .where(goods_nomenclature_sid:)
+        .map(&:title_indexed)
+        .compact
+        .join(' ')
     end
   end
 end

--- a/app/services/search_negation_service.rb
+++ b/app/services/search_negation_service.rb
@@ -1,0 +1,13 @@
+class SearchNegationService
+  NEGATION_REGEX = /, (?<excluded-term>neither|other than|excluding|not|except) .*/
+  NO_BREAKING_SPACE = "\u00A0".freeze
+
+  def initialize(text)
+    @text = text
+  end
+
+  def call
+    result = @text.to_s.gsub(NO_BREAKING_SPACE, ' ')
+    result.gsub(NEGATION_REGEX, '')
+  end
+end

--- a/config/opensearch/stemming_exclusions_all.txt
+++ b/config/opensearch/stemming_exclusions_all.txt
@@ -41,3 +41,4 @@ stretched => stretched
 stretcher => stretcher
 white => white
 whiting => whiting
+merling => merling

--- a/spec/models/goods_nomenclature_description_spec.rb
+++ b/spec/models/goods_nomenclature_description_spec.rb
@@ -41,33 +41,13 @@ RSpec.describe GoodsNomenclatureDescription do
   end
 
   describe '#description_indexed' do
-    shared_examples_for 'a description that includes a negation' do |description, expected_description|
-      subject(:description_indexed) { build(:goods_nomenclature_description, description:).description_indexed }
+    it 'removes negation' do
+      goods_nomenclature_description = build(
+        :goods_nomenclature_description,
+        description: 'some text, not other text',
+      )
 
-      it { is_expected.to eq(expected_description) }
-    end
-
-    it_behaves_like 'a description that includes a negation', 'Hop cones, neither ground nor powdered nor in the form of pellets', 'Hop cones'
-    it_behaves_like 'a description that includes a negation', 'Other fish, excluding livers and roes', 'Other fish'
-    it_behaves_like 'a description that includes a negation', 'Bulls of the Schwyz, Fribourg and spotted Simmental breeds, other than for slaughter', 'Bulls of the Schwyz, Fribourg and spotted Simmental breeds'
-    it_behaves_like 'a description that includes a negation', 'Tulles and other net fabrics, not including woven, knitted or crocheted fabrics', 'Tulles and other net fabrics'
-
-    context 'when the description value is nil' do
-      subject(:description_indexed) { build(:goods_nomenclature_description, description: nil).description_indexed }
-
-      it { is_expected.to eq('') }
-    end
-
-    context 'when the description value does not include a negation' do
-      subject(:description_indexed) { build(:goods_nomenclature_description, description: 'I do not include a handled negation').description_indexed }
-
-      it { is_expected.to eq('I do not include a handled negation') }
-    end
-
-    context 'when the description value has a non-breaking space character' do
-      subject(:description_indexed) { build(:goods_nomenclature_description, description: "I have a\u00A0non-breaking space").description_indexed }
-
-      it { is_expected.to eq('I have a non-breaking space') }
+      expect(goods_nomenclature_description.description_indexed).to eq('some text')
     end
   end
 

--- a/spec/models/search_reference_spec.rb
+++ b/spec/models/search_reference_spec.rb
@@ -75,4 +75,10 @@ RSpec.describe SearchReference do
       end
     end
   end
+
+  describe '#title_indexed' do
+    subject(:search_reference) { build(:search_reference, title: 'foo, not bar') }
+
+    it { expect(search_reference.title_indexed).to eq('foo') }
+  end
 end

--- a/spec/serializers/search/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/search/goods_nomenclature_serializer_spec.rb
@@ -94,7 +94,11 @@ RSpec.describe Search::GoodsNomenclatureSerializer, flaky: true do
           validity_start_date: Date.parse('2020-06-29'),
         )
 
-        create(:search_reference, referenced: commodity, title: 'commodity search reference')
+        create(
+          :search_reference,
+          referenced: commodity,
+          title: 'commodity search reference, except something else',
+        )
       end
 
       it { is_expected.to include_json(pattern) }

--- a/spec/services/search_negation_service_spec.rb
+++ b/spec/services/search_negation_service_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe SearchNegationService do
+  describe '#call' do
+    shared_examples 'a service which removes negation' do |text, expected|
+      it 'removes negation' do
+        expect(described_class.new(text).call).to eq(expected)
+      end
+    end
+
+    it_behaves_like 'a service which removes negation', 'some text, not other text', 'some text'
+    it_behaves_like 'a service which removes negation', 'some text, neither other text', 'some text'
+    it_behaves_like 'a service which removes negation', 'some text, other than other text', 'some text'
+    it_behaves_like 'a service which removes negation', 'some text, excluding other text', 'some text'
+    it_behaves_like 'a service which removes negation', 'some text, except other text', 'some text'
+
+    context 'when text does not contain negation' do
+      let(:text) { 'some text' }
+
+      it { expect(described_class.new(text).call).to eq('some text') }
+    end
+
+    context 'when text contains negation but no comma' do
+      let(:text) { 'some text not other text' }
+
+      it { expect(described_class.new(text).call).to eq('some text not other text') }
+    end
+
+    context 'when there is a non-breaking space' do
+      let(:text) { "I have a\u00A0non-breaking space" }
+
+      it { expect(described_class.new(text).call).to eq('I have a non-breaking space') }
+    end
+
+    context 'when there are multiple negations over multiple lines' do
+      let(:text) do
+        "some text, not other text.\nsome text, other than other text."
+      end
+
+      it { expect(described_class.new(text).call).to eq("some text\nsome text") }
+    end
+
+    context 'when a nil value is passed' do
+      let(:text) { nil }
+
+      it { expect(described_class.new(text).call).to eq('') }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2811

### What?

I have added/removed/altered:

- [x] Adds service for text negation
- [x] Use negation service in goods_nomenclature_description
- [x] Adds negation service in search references
- [x] Serialize goods nomenclature docs using negated titles
- [x] Adds merling as an excluded stemming term

### Why?

I am doing this because:

- This is required to remove a bunch of broken search results that result from negated terms in titles
