### PR TITLE
HOTT-2806: Order quota definitions

### DIFF
--- a/app/models/quota_order_number.rb
+++ b/app/models/quota_order_number.rb
@@ -8,7 +8,9 @@ class QuotaOrderNumber < Sequel::Model
     ds.with_actual(QuotaDefinition)
   end
 
-  one_to_many :quota_definitions, key: :quota_order_number_sid, primary_key: :quota_order_number_sid
+  one_to_many :quota_definitions, key: :quota_order_number_sid, primary_key: :quota_order_number_sid do |ds|
+    ds.order(Sequel.desc(:validity_start_date))
+  end
 
   dataset_module do
     def by_order_number(order_number)


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2806

### What?

I have added/removed/altered:

- [x] Added a default order to quota definitions

### Why?

I am doing this because:

- This is required so that they are sensibly ordered for the admin UI
