### PR TITLE
HOTT-2812: Filter out entity classifications

### DIFF
--- a/app/models/beta/search/search_facet_classifier_configuration.rb
+++ b/app/models/beta/search/search_facet_classifier_configuration.rb
@@ -72,6 +72,7 @@ module Beta
 
         def each_classification
           file_paths = Dir.glob(CLASSIFIER_FILE_PATH)
+          file_paths = file_paths.grep_v(/entity/)
 
           if block_given?
             file_paths.each do |file_path|

--- a/spec/models/beta/search/search_facet_classifier_configuration_spec.rb
+++ b/spec/models/beta/search/search_facet_classifier_configuration_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Beta::Search::SearchFacetClassifierConfiguration do
   describe '.each_classification' do
     context 'when passed a block' do
-      it { expect { |block| described_class.each_classification(&block) }.to yield_control.exactly(69).times }
+      it { expect { |block| described_class.each_classification(&block) }.to yield_control.exactly(68).times }
     end
 
     context 'when not passed a block' do

--- a/spec/services/api/beta/classification_converter_service_spec.rb
+++ b/spec/services/api/beta/classification_converter_service_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe Api::Beta::ClassificationConverterService do
         egg_shell_state
         electrical_output
         electricity_type
-        entity
         fat_content
         fish_classification
         fish_preparation

--- a/spec/services/api/beta/goods_nomenclature_filter_generator_service_spec.rb
+++ b/spec/services/api/beta/goods_nomenclature_filter_generator_service_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe Api::Beta::GoodsNomenclatureFilterGeneratorService do
       it { is_expected.to eq(expected_filters) }
     end
 
-    context 'when generating filters for dynamic filters that have a custom boost' do
+    # TODO: Reinstate this test once we've reviewed the entity classification
+    xcontext 'when generating filters for dynamic filters that have a custom boost' do
       let(:filters) do
         {
           'entity' => 'live animal',


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2812

### What?

I have added/removed/altered:

- [x] Removed entity classification

### Why?

I am doing this because:

- This classification category needs a bit of work/is misfiring a bit and could probably benefit from filtering on certain headings a bit more specifically
