### PR TITLE
HOTT-2808: Sort quota balance events by occurrence_timestamp

### DIFF
--- a/app/models/quota_definition.rb
+++ b/app/models/quota_definition.rb
@@ -46,7 +46,8 @@ class QuotaDefinition < Sequel::Model
                                                             primary_key: :quota_definition_sid
   one_to_many :quota_balance_events,
               key: :quota_definition_sid,
-              primary_key: :quota_definition_sid
+              primary_key: :quota_definition_sid,
+              order: Sequel.desc(:occurrence_timestamp)
 
   one_to_many :quota_suspension_periods, key: :quota_definition_sid,
                                          primary_key: :quota_definition_sid do |ds|


### PR DESCRIPTION
### Jira link

[HOTT-<2808>](https://transformuk.atlassian.net/browse/HOTT-2808)

### What?

I have added/removed/altered:

- [ ] Sorted quota balance events by occurrence_timestamp

### Why?

I am doing this because:

- We need them in this order on the Admin app

<img width="420" alt="Screenshot 2023-03-10 at 12 22 52" src="https://user-images.githubusercontent.com/12201130/224315935-f7fb3064-a5b2-4027-b5d7-0678cc94a9c3.png">
