### PR TITLE
HOTT-2813: Support quoted search queries

### DIFF
--- a/app/elastic_search_indexes/search/goods_nomenclature_index.rb
+++ b/app/elastic_search_indexes/search/goods_nomenclature_index.rb
@@ -61,6 +61,13 @@ module Search
                     english_stemmer
                   ],
                 },
+                english_shingle: {
+                  tokenizer: 'standard',
+                  filter: %w[
+                    lowercase
+                    shingle
+                  ],
+                },
               },
               filter: {
                 english_stop: {
@@ -74,6 +81,10 @@ module Search
                 english_possessive_stemmer: {
                   type: 'stemmer',
                   language: 'possessive_english',
+                },
+                shingle: {
+                  type: 'shingle',
+                  max_shingle_size: 3,
                 },
               },
               char_filter: {
@@ -115,6 +126,20 @@ module Search
             ancestor_11_description_indexed: { analyzer: 'english', type: 'text' },
             ancestor_12_description_indexed: { analyzer: 'english', type: 'text' },
             ancestor_13_description_indexed: { analyzer: 'english', type: 'text' },
+            description_indexed_shingled: { analyzer: 'english_shingle', type: 'text' },
+            ancestor_1_description_indexed_shingled: { analyzer: 'english_shingle', type: 'text' },
+            ancestor_2_description_indexed_shingled: { analyzer: 'english_shingle', type: 'text' },
+            ancestor_3_description_indexed_shingled: { analyzer: 'english_shingle', type: 'text' },
+            ancestor_4_description_indexed_shingled: { analyzer: 'english_shingle', type: 'text' },
+            ancestor_5_description_indexed_shingled: { analyzer: 'english_shingle', type: 'text' },
+            ancestor_6_description_indexed_shingled: { analyzer: 'english_shingle', type: 'text' },
+            ancestor_7_description_indexed_shingled: { analyzer: 'english_shingle', type: 'text' },
+            ancestor_8_description_indexed_shingled: { analyzer: 'english_shingle', type: 'text' },
+            ancestor_9_description_indexed_shingled: { analyzer: 'english_shingle', type: 'text' },
+            ancestor_10_description_indexed_shingled: { analyzer: 'english_shingle', type: 'text' },
+            ancestor_11_description_indexed_shingled: { analyzer: 'english_shingle', type: 'text' },
+            ancestor_12_description_indexed_shingled: { analyzer: 'english_shingle', type: 'text' },
+            ancestor_13_description_indexed_shingled: { analyzer: 'english_shingle', type: 'text' },
             filter_alcohol_volume: { type: 'keyword' },
             filter_animal_product_state: { type: 'keyword' },
             filter_animal_type: { type: 'keyword' },

--- a/app/models/beta/search/search_query_parser_result.rb
+++ b/app/models/beta/search/search_query_parser_result.rb
@@ -12,6 +12,7 @@ module Beta
                     :noun_chunks,
                     :original_search_query,
                     :corrected_search_query,
+                    :quoted,
                     :null_result
 
       class Standard
@@ -22,6 +23,7 @@ module Beta
 
           search_query_parser_result.original_search_query = attributes['original_search_query']
           search_query_parser_result.corrected_search_query = attributes['corrected_search_query']
+          search_query_parser_result.quoted = attributes.dig('tokens', 'quoted')
           search_query_parser_result.adjectives = attributes.dig('tokens', 'adjectives')
           search_query_parser_result.nouns = attributes.dig('tokens', 'nouns')
           search_query_parser_result.verbs = attributes.dig('tokens', 'verbs')
@@ -38,6 +40,7 @@ module Beta
 
           search_query_parser_result.original_search_query = attributes['original_search_query']
           search_query_parser_result.corrected_search_query = attributes['original_search_query']
+          search_query_parser_result.quoted = []
           search_query_parser_result.adjectives = []
           search_query_parser_result.nouns = []
           search_query_parser_result.verbs = []

--- a/app/serializers/api/beta/search_query_parser_result_serializer.rb
+++ b/app/serializers/api/beta/search_query_parser_result_serializer.rb
@@ -7,6 +7,7 @@ module Api
 
       attributes :corrected_search_query,
                  :original_search_query,
+                 :quoted,
                  :verbs,
                  :adjectives,
                  :nouns,

--- a/app/serializers/search/goods_nomenclature_serializer.rb
+++ b/app/serializers/search/goods_nomenclature_serializer.rb
@@ -12,29 +12,22 @@ module Search
         goods_nomenclature_class:,
         description:,
         description_indexed:,
+        description_indexed_shingled: description_indexed,
         formatted_description:,
         search_references:,
         search_intercept_terms:,
         ancestors:,
         validity_start_date:,
         validity_end_date:,
-        ancestor_1_description_indexed:, # Chapter
-        ancestor_2_description_indexed:, # Heading
-        ancestor_3_description_indexed:,
-        ancestor_4_description_indexed:,
-        ancestor_5_description_indexed:,
-        ancestor_6_description_indexed:,
-        ancestor_7_description_indexed:,
-        ancestor_8_description_indexed:,
-        ancestor_9_description_indexed:,
-        ancestor_10_description_indexed:,
-        ancestor_11_description_indexed:,
-        ancestor_12_description_indexed:,
-        ancestor_13_description_indexed:,
         guides:,
         guide_ids:,
         declarable: path_declarable?,
       }
+
+      1.upto(MAX_ANCESTORS) do |i|
+        serializable["ancestor_#{i}_description_indexed"] = send("ancestor_#{i}_description_indexed")
+        serializable["ancestor_#{i}_description_indexed_shingled"] = send("ancestor_#{i}_description_indexed_shingled")
+      end
 
       serializable.merge(serializable_classifications)
     end
@@ -129,6 +122,10 @@ module Search
 
     1.upto(MAX_ANCESTORS) do |ancestor_number|
       define_method("ancestor_#{ancestor_number}_description_indexed") do
+        ancestors[ancestor_number - 1].try(:[], :description_indexed)
+      end
+
+      define_method("ancestor_#{ancestor_number}_description_indexed_shingled") do
         ancestors[ancestor_number - 1].try(:[], :description_indexed)
       end
     end

--- a/spec/factories/goods_nomenclature_query_factory.rb
+++ b/spec/factories/goods_nomenclature_query_factory.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
     verbs {}
     filters { {} }
 
+    trait :quoted do
+      quoted { ["'cherry tomatoes'"] }
+    end
+
     trait :full_query do
       adjectives { %w[tall] }
       noun_chunks { ['tall running man'] }

--- a/spec/factories/search_query_parser_result_factory.rb
+++ b/spec/factories/search_query_parser_result_factory.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :search_query_parser_result, class: 'Beta::Search::SearchQueryParserResult' do
+    quoted { ["'something quoted'"] }
     adjectives { [] }
     nouns do
       %w[

--- a/spec/fixtures/beta/search/goods_nomenclatures/serialized_result.json
+++ b/spec/fixtures/beta/search/goods_nomenclatures/serialized_result.json
@@ -238,6 +238,7 @@
       "id": "0e956af30bdc0dcd5679f2249adc6d94",
       "type": "search_query_parser_result",
       "attributes": {
+        "quoted": ["'something quoted'"],
         "corrected_search_query": "ricotta",
         "original_search_query": "ricotta",
         "verbs": [],

--- a/spec/models/beta/search/goods_nomenclature_query_spec.rb
+++ b/spec/models/beta/search/goods_nomenclature_query_spec.rb
@@ -274,6 +274,39 @@ RSpec.describe Beta::Search::GoodsNomenclatureQuery do
         expect(Api::Beta::GoodsNomenclatureFilterGeneratorService).to have_received(:new).with('cheese_type' => 'fresh')
       end
     end
+
+    context 'when there are quoted phrases' do
+      subject(:goods_nomenclature_query) { build(:goods_nomenclature_query, :quoted).query }
+
+      let(:expected_query) do
+        {
+          size: '10',
+          query: {
+            bool: {
+              filter: { bool: { must: [{ term: { declarable: true } }] } },
+              should: [
+                { match_phrase: { 'description_indexed_shingled' => { query: 'cherry tomatoes', slop: 0 } } },
+                { match_phrase: { 'ancestor_2_description_indexed_shingled' => { query: 'cherry tomatoes', slop: 0 } } },
+                { match_phrase: { 'ancestor_3_description_indexed_shingled' => { query: 'cherry tomatoes', slop: 0 } } },
+                { match_phrase: { 'ancestor_4_description_indexed_shingled' => { query: 'cherry tomatoes', slop: 0 } } },
+                { match_phrase: { 'ancestor_5_description_indexed_shingled' => { query: 'cherry tomatoes', slop: 0 } } },
+                { match_phrase: { 'ancestor_6_description_indexed_shingled' => { query: 'cherry tomatoes', slop: 0 } } },
+                { match_phrase: { 'ancestor_7_description_indexed_shingled' => { query: 'cherry tomatoes', slop: 0 } } },
+                { match_phrase: { 'ancestor_8_description_indexed_shingled' => { query: 'cherry tomatoes', slop: 0 } } },
+                { match_phrase: { 'ancestor_9_description_indexed_shingled' => { query: 'cherry tomatoes', slop: 0 } } },
+                { match_phrase: { 'ancestor_10_description_indexed_shingled' => { query: 'cherry tomatoes', slop: 0 } } },
+                { match_phrase: { 'ancestor_11_description_indexed_shingled' => { query: 'cherry tomatoes', slop: 0 } } },
+                { match_phrase: { 'ancestor_12_description_indexed_shingled' => { query: 'cherry tomatoes', slop: 0 } } },
+                { match_phrase: { 'ancestor_13_description_indexed_shingled' => { query: 'cherry tomatoes', slop: 0 } } },
+              ],
+              minimum_should_match: 1,
+            },
+          },
+        }
+      end
+
+      it { is_expected.to eq(expected_query) }
+    end
   end
 
   describe '#goods_nomenclature_item_id' do

--- a/spec/models/beta/search/search_query_parser_result/null_spec.rb
+++ b/spec/models/beta/search/search_query_parser_result/null_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Beta::Search::SearchQueryParserResult::Null do
 
     it { is_expected.to be_a(Beta::Search::SearchQueryParserResult) }
     it { expect(result.adjectives).to eq([]) }
+    it { expect(result.quoted).to eq([]) }
     it { expect(result.nouns).to eq([]) }
     it { expect(result.noun_chunks).to eq(['ash trees']) }
     it { expect(result.verbs).to eq([]) }

--- a/spec/models/beta/search/search_query_parser_result/standard_spec.rb
+++ b/spec/models/beta/search/search_query_parser_result/standard_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Beta::Search::SearchQueryParserResult::Standard do
           'nouns' => %w[man],
           'noun_chunks' => ['tall man'],
           'verbs' => [],
+          'quoted' => ["'something quoted'"],
         },
         'original_search_query' => 'tall man',
         'corrected_search_query' => 'tall man',
@@ -16,6 +17,7 @@ RSpec.describe Beta::Search::SearchQueryParserResult::Standard do
     end
 
     it { is_expected.to be_a(Beta::Search::SearchQueryParserResult) }
+    it { expect(result.quoted).to eq(["'something quoted'"]) }
     it { expect(result.adjectives).to eq(%w[tall]) }
     it { expect(result.nouns).to eq(%w[man]) }
     it { expect(result.noun_chunks).to eq(['tall man']) }

--- a/spec/serializers/api/beta/search_query_parser_result_serializer_spec.rb
+++ b/spec/serializers/api/beta/search_query_parser_result_serializer_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Api::Beta::SearchQueryParserResultSerializer do
           id: '240ad90c8bd0e29cc402ff257d033747',
           type: :search_query_parser_result,
           attributes: {
+            quoted: ["'something quoted'"],
             corrected_search_query: 'halibut sausage stenolepis cheese binocular parsnip pharmacy paper',
             original_search_query: 'halbiut sausadge stenolepsis chese bnoculars parnsip farmacy pape',
             verbs: [],

--- a/spec/serializers/search/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/search/goods_nomenclature_serializer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Search::GoodsNomenclatureSerializer, flaky: true do
           goods_nomenclature_class: 'Commodity',
           description: 'Horses, other than lemmings',
           description_indexed: 'Horses',
+          description_indexed_shingled: 'Horses',
           formatted_description: 'Horses, other than lemmings',
           search_references: 'chapter search reference heading search reference commodity search reference',
           search_intercept_terms: 'donkey baz',
@@ -72,6 +73,19 @@ RSpec.describe Search::GoodsNomenclatureSerializer, flaky: true do
           ancestor_11_description_indexed: nil,
           ancestor_12_description_indexed: nil,
           ancestor_13_description_indexed: nil,
+          ancestor_1_description_indexed_shingled: 'Live horses, asses, mules and hinnies',
+          ancestor_2_description_indexed_shingled: 'Live animals',
+          ancestor_3_description_indexed_shingled: nil,
+          ancestor_4_description_indexed_shingled: nil,
+          ancestor_5_description_indexed_shingled: nil,
+          ancestor_6_description_indexed_shingled: nil,
+          ancestor_7_description_indexed_shingled: nil,
+          ancestor_8_description_indexed_shingled: nil,
+          ancestor_9_description_indexed_shingled: nil,
+          ancestor_10_description_indexed_shingled: nil,
+          ancestor_11_description_indexed_shingled: nil,
+          ancestor_12_description_indexed_shingled: nil,
+          ancestor_13_description_indexed_shingled: nil,
           guides: [
             {
               id: 1, title: 'Aircraft parts', image: 'aircraft.png', url: 'https://www.gov.uk/guidance/classifying-aircraft-parts-and-accessories', strapline: 'Get help to classify drones and aircraft parts for import and export.'

--- a/spec/services/api/beta/search_query_parser_service_spec.rb
+++ b/spec/services/api/beta/search_query_parser_service_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Api::Beta::SearchQueryParserService do
             corrected_search_query: 'aaa bib',
             original_search_query: 'aaa bbb',
             tokens: {
+              quoted: ["'something quoted'"],
               adjectives: [],
-              all: %w[aaa bib],
               noun_chunks: %w[aaa bib],
               nouns: %w[aaa bib],
               verbs: [],
@@ -37,6 +37,7 @@ RSpec.describe Api::Beta::SearchQueryParserService do
       it { is_expected.to be_a(Beta::Search::SearchQueryParserResult) }
 
       it { expect(result.id).to eq('ca476c11a9e6c7dea1e75d14ad4cbb10') }
+      it { expect(result.quoted).to eq(["'something quoted'"]) }
       it { expect(result.corrected_search_query).to eq('aaa bib') }
       it { expect(result.original_search_query).to eq('aaa bbb') }
       it { expect(result.adjectives).to eq([]) }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2813

### What?

I have added/removed/altered:

- [x] Adds shingle analyzer and fields to beta index
- [x] Populate beta index with shingled tokens
- [x] Assign the new quoted field to search_query_parser_result
- [x] Adds support for quoted beta queries
- [x] Reflect adjustments to serialized results

### Why?

I am doing this because:

- This is actually a feature request from HMRC and allows them to bypass lemmatization, spelling correction and just do match phrase queries against the index
