### PR TITLE
Reduce noise around append 5a updates

### DIFF
--- a/app/services/appendix_5a_populator_service.rb
+++ b/app/services/appendix_5a_populator_service.rb
@@ -81,6 +81,8 @@ class Appendix5aPopulatorService
   end
 
   def notify
+    return if no_guidance_changes?
+
     message = "Appendix 5a has been updated with #{added_guidance.count} new, "
     message += "#{changed_guidance.count} changed and "
     message += "#{removed_guidance.count} removed guidance documents"
@@ -88,5 +90,9 @@ class Appendix5aPopulatorService
     logger.info message
 
     SlackNotifierService.call(message)
+  end
+
+  def no_guidance_changes?
+    added_guidance.empty? && changed_guidance.empty? && removed_guidance.empty?
   end
 end

--- a/spec/services/appendix_5a_populator_service_spec.rb
+++ b/spec/services/appendix_5a_populator_service_spec.rb
@@ -57,9 +57,7 @@ RSpec.describe Appendix5aPopulatorService do
       it 'notifies slack' do
         call
 
-        expect(SlackNotifierService)
-          .to have_received(:call)
-          .with('Appendix 5a has been updated with 0 new, 0 changed and 0 removed guidance documents')
+        expect(SlackNotifierService).not_to have_received(:call)
       end
     end
 


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Removed guidance change notifications when there are no changes

### Why?

I am doing this because:

- The majority of days are no change days and this is just noise
