### PR TITLE
HOTT-2829 Use depth for number_indents if available

### DIFF
--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -290,5 +290,9 @@ module TradeTariffBackend
     def opensearch_debug
       ENV.fetch('OPENSEARCH_DEBUG', 'false') == 'true'
     end
+
+    def use_nested_set?
+      ENV['USE_NESTED_SET'] == 'true'
+    end
   end
 end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -2,6 +2,8 @@ class Chapter < GoodsNomenclature
   plugin :oplog, primary_key: :goods_nomenclature_sid
   plugin :elasticsearch
 
+  prepend GoodsNomenclatures::Overrides::Chapter if TradeTariffBackend.use_nested_set?
+
   set_dataset filter('goods_nomenclatures.goods_nomenclature_item_id LIKE ?', '__00000000')
               .order(
                 Sequel.asc(:goods_nomenclature_item_id),

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -1,6 +1,7 @@
 class Commodity < GoodsNomenclature
   include TenDigitGoodsNomenclature
   include SearchReferenceable
+  prepend GoodsNomenclatures::Overrides::Commodity if TradeTariffBackend.use_nested_set?
 
   plugin :elasticsearch
 end

--- a/app/models/concerns/ten_digit_goods_nomenclature.rb
+++ b/app/models/concerns/ten_digit_goods_nomenclature.rb
@@ -96,9 +96,7 @@ module TenDigitGoodsNomenclature
     end
 
     def declarable?
-      cache_key = "commodity-#{goods_nomenclature_sid}-#{point_in_time&.to_date&.iso8601}-is-declarable?"
-
-      Rails.cache.fetch(cache_key) do
+      Rails.cache.fetch(declarable_cache_key) do
         non_grouping? && children.none?
       end
     end
@@ -209,6 +207,10 @@ module TenDigitGoodsNomenclature
 
     def preloaded_children
       Thread.current[:heading_commodities].try(:fetch, heading_short_code, {})
+    end
+
+    def declarable_cache_key
+      "commodity-#{goods_nomenclature_sid}-#{point_in_time&.to_date&.iso8601}-is-declarable?"
     end
   end
 end

--- a/app/models/goods_nomenclatures/overrides.rb
+++ b/app/models/goods_nomenclatures/overrides.rb
@@ -1,0 +1,67 @@
+module GoodsNomenclatures
+  module Overrides
+    module Chapter
+      # No op
+    end
+
+    module Heading
+      def commodities
+        @commodities ||= \
+          ns_descendants_dataset.exclude(
+            goods_nomenclatures__goods_nomenclature_item_id: HiddenGoodsNomenclature.codes,
+          ).all
+      end
+
+      def declarable?
+        ns_declarable?
+      end
+
+      def declarable
+        ns_declarable?
+      end
+    end
+
+    module Subheading
+      def commodities
+        @commodities ||= ancestors + [self] + ns_descendants_without_hidden
+      end
+
+    private
+
+      def ns_descendants_without_hidden
+        ns_descendants_dataset
+          .exclude(goods_nomenclatures__goods_nomenclature_item_id: HiddenGoodsNomenclature.codes)
+          .eager(:goods_nomenclature_indents)
+          .all
+      end
+    end
+
+    module Commodity
+      def ancestors
+        @ancestors ||= ns_ancestors.select { |ancestor| ancestor.depth > 2 }
+      end
+
+      def uptree
+        ns_ancestors + [self]
+      end
+
+      def children
+        @children ||= begin
+          ns_descendants # trigger loading of entire subtree
+
+          hidden_codes = HiddenGoodsNomenclature.codes
+
+          ns_children.reject do |child|
+            child.goods_nomenclature_item_id.in?(hidden_codes)
+          end
+        end
+      end
+
+      def declarable?
+        Rails.cache.fetch(declarable_cache_key) do
+          ns_declarable?
+        end
+      end
+    end
+  end
+end

--- a/app/models/goods_nomenclatures/overrides.rb
+++ b/app/models/goods_nomenclatures/overrides.rb
@@ -62,6 +62,16 @@ module GoodsNomenclatures
           ns_declarable?
         end
       end
+
+      def number_indents
+        if !values.key?(:depth)
+          super
+        elsif values[:depth] > 1
+          values[:depth] - 2
+        else
+          0
+        end
+      end
     end
   end
 end

--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -1,5 +1,6 @@
 class Heading < GoodsNomenclature
   include Declarable
+  prepend GoodsNomenclatures::Overrides::Heading if TradeTariffBackend.use_nested_set?
 
   plugin :oplog, primary_key: :goods_nomenclature_sid
   plugin :elasticsearch

--- a/app/models/subheading.rb
+++ b/app/models/subheading.rb
@@ -8,6 +8,11 @@ class Subheading < GoodsNomenclature
   include TenDigitGoodsNomenclature
   include SearchReferenceable
 
+  if TradeTariffBackend.use_nested_set?
+    prepend GoodsNomenclatures::Overrides::Commodity
+    prepend GoodsNomenclatures::Overrides::Subheading
+  end
+
   def to_admin_param
     to_param
   end

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -502,7 +502,7 @@ RSpec.describe Commodity do
       end
 
       let!(:ancestor_commodity) do
-        create :commodity, :with_description,
+        create :commodity, :with_description, :without_indent,
                goods_nomenclature_item_id: '2204218900',
                producline_suffix: '80',
                validity_start_date: Date.new(1995, 1, 1)

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -76,6 +76,8 @@ RSpec.describe Measure do
         (67883, 68304, '1998-01-01 00:00:00', 2, '0805201000', '80', '2013-08-02 20:03:55', NULL, 38832, 'C', NULL),
         (69920, 70329, '1999-01-01 00:00:00', 3, '0805201005', '80', '2013-08-02 20:04:48', NULL, 40421, 'C', NULL);
                              })
+
+        GoodsNomenclatures::TreeNode.refresh!
       end
 
       it { expect(described_class.with_modification_regulations.all.count).to eq 3 }


### PR DESCRIPTION
### Jira link

HOTT-2829

### What?

I have added/removed/altered:

- [x] Avoid fetch indents records if we already know `depth` 

### Why?

I am doing this because:

- It will potentially avoid N+1s
- If we've got `depth`, we can derive indent level from that without fetching data

### Deployment risks (optional)

- Low, behind feature flag
