### PR TITLE
HOTT-2835: Adds support for fallback queries

### DIFF
--- a/app/models/beta/search/goods_nomenclature_query.rb
+++ b/app/models/beta/search/goods_nomenclature_query.rb
@@ -58,6 +58,8 @@ module Beta
       def query
         @query ||= if numeric?
                      goods_nomenclature_item_id_term_query
+                   elsif untokenised?
+                     fallback_query
                    else
                      multi_match_query
                    end
@@ -71,6 +73,14 @@ module Beta
 
           original_search_query + '0' * padding
         end
+      end
+
+      def untokenised?
+        @quoted.none? &&
+          @nouns.none? &&
+          @noun_chunks.none? &&
+          @verbs.none? &&
+          @adjectives.none?
       end
 
       def numeric?
@@ -88,6 +98,17 @@ module Beta
               },
             },
           },
+        }
+      end
+
+      def fallback_query
+        {
+          query: {
+            query_string: {
+              query: original_search_query,
+            },
+          },
+          size:,
         }
       end
 

--- a/spec/factories/goods_nomenclature_query_factory.rb
+++ b/spec/factories/goods_nomenclature_query_factory.rb
@@ -1,11 +1,12 @@
 FactoryBot.define do
   factory :goods_nomenclature_query, class: 'Beta::Search::GoodsNomenclatureQuery' do
     original_search_query {}
-    adjectives {}
-    noun_chunks {}
-    nouns {}
-    verbs {}
+    adjectives { [] }
+    noun_chunks { [] }
+    nouns { [] }
+    verbs { [] }
     filters { {} }
+    quoted { [] }
 
     trait :quoted do
       quoted { ["'cherry tomatoes'"] }
@@ -16,6 +17,19 @@ FactoryBot.define do
       noun_chunks { ['tall running man'] }
       nouns { %w[man] }
       verbs { %w[run] }
+    end
+
+    trait :nouns do
+      noun_chunks { %w[ricotta] }
+      nouns { %w[ricotta] }
+    end
+
+    trait :adjectives do
+      adjectives { %w[ricotta] }
+    end
+
+    trait :verbs do
+      verbs { %w[ricotta] }
     end
 
     trait :single_hit do
@@ -31,6 +45,16 @@ FactoryBot.define do
     trait :filter do
       single_hit
       filters { { 'cheese_type' => 'fresh' } }
+    end
+
+    trait :untokenised do
+      original_search_query { 'qwdwefwfwWWWWWWWWRGRGEWGEWGEWGEWG' }
+      adjectives { [] }
+      noun_chunks { [] }
+      nouns { [] }
+      verbs { [] }
+      filters { {} }
+      quoted { [] }
     end
   end
 end

--- a/spec/models/beta/search/goods_nomenclature_query_spec.rb
+++ b/spec/models/beta/search/goods_nomenclature_query_spec.rb
@@ -53,6 +53,23 @@ RSpec.describe Beta::Search::GoodsNomenclatureQuery do
       it { is_expected.to eq(expected_query) }
     end
 
+    context 'when the search query includes no tokens' do
+      subject(:goods_nomenclature_query) { build(:goods_nomenclature_query, :untokenised).query }
+
+      let(:expected_query) do
+        {
+          query: {
+            query_string: {
+              query: 'qwdwefwfwWWWWWWWWRGRGEWGEWGEWGEWG',
+            },
+          },
+          size: '10',
+        }
+      end
+
+      it { is_expected.to eq(expected_query) }
+    end
+
     context 'when there are nouns, noun_chunks, verbs and adjectives' do
       subject(:goods_nomenclature_query) { build(:goods_nomenclature_query, :full_query).query }
 
@@ -336,6 +353,26 @@ RSpec.describe Beta::Search::GoodsNomenclatureQuery do
       subject(:goods_nomenclature_query) { build(:goods_nomenclature_query) }
 
       it { is_expected.not_to be_numeric }
+    end
+  end
+
+  describe '#untokenised?' do
+    shared_examples 'a tokenized query' do |trait|
+      subject(:goods_nomenclature_query) { build(:goods_nomenclature_query, trait) }
+
+      it { is_expected.not_to be_untokenised }
+    end
+
+    it_behaves_like 'a tokenized query', :full_query
+    it_behaves_like 'a tokenized query', :quoted
+    it_behaves_like 'a tokenized query', :nouns
+    it_behaves_like 'a tokenized query', :adjectives
+    it_behaves_like 'a tokenized query', :verbs
+
+    context 'when there are no tokens set' do
+      subject(:goods_nomenclature_query) { build(:goods_nomenclature_query, :untokenised) }
+
+      it { is_expected.to be_untokenised }
     end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2835

### What?

I have added/removed/altered:

- [x] Added support for fallback queries when the tokeniser returns no tokens

### Why?

I am doing this because:

- This is required to handle generally garbage content that might be thrown at spacy/textblob in the search query parser and have performance implications. The idea is, sometimes we might have some non-garbage content and we still want performant search results for these
