### PR TITLE
HOTT-2840: Clear expired goods nomenclature from suggestions

### DIFF
--- a/app/services/api/v2/suggestions_service.rb
+++ b/app/services/api/v2/suggestions_service.rb
@@ -18,10 +18,6 @@ module Api
       def handle_search_reference_record(search_reference)
         Api::V2::SuggestionPresenter.new(search_reference.id, search_reference.title)
       end
-
-      def handle_chemical_record(chemical)
-        Api::V2::SuggestionPresenter.new(chemical.id, chemical.cas)
-      end
     end
   end
 end

--- a/app/services/search_suggestion_populator_service.rb
+++ b/app/services/search_suggestion_populator_service.rb
@@ -1,12 +1,37 @@
 class SearchSuggestionPopulatorService
   def call
     SearchSuggestion.unrestrict_primary_key
-    Api::V2::SuggestionsService.new.perform.each do |suggestion|
-      SearchSuggestion.find_or_create(
-        id: suggestion.id.to_s,
-        value: suggestion.value.to_s,
-      )
+    TimeMachine.now do
+      Api::V2::SuggestionsService.new.perform.each do |suggestion|
+        SearchSuggestion.find_or_create(
+          id: suggestion.id.to_s,
+          value: suggestion.value.to_s,
+        )
+      end
+
+      clear_old_suggestions
     end
     SearchSuggestion.restrict_primary_key
+  end
+
+  private
+
+  def clear_old_suggestions
+    candidate_goods_nomenclature_sids = SearchSuggestion.where("id ~ '^[0-9]+$'").pluck(:id)
+
+    all_goods_nomenclature_sids = GoodsNomenclature
+      .where(goods_nomenclature_sid: candidate_goods_nomenclature_sids)
+      .pluck(:goods_nomenclature_sid)
+
+    current_goods_nomenclature_sids = GoodsNomenclature
+      .where(goods_nomenclature_sid: all_goods_nomenclature_sids)
+      .actual
+      .pluck(:goods_nomenclature_sid)
+
+    expired_goods_nomenclature_sids = all_goods_nomenclature_sids - current_goods_nomenclature_sids
+
+    SearchSuggestion
+      .where(id: expired_goods_nomenclature_sids.map(&:to_s))
+      .map(&:destroy)
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2840

### What?

I have added/removed/altered:

- [x] Move to generating only current goods nomenclature as suggestions
- [x] Add test coverage for new behaviour

### Why?

I am doing this because:

- We have a bunch of expired search suggestions that are cluttering up the typeahead
