### PR TITLE
HOTT-2852: Support more sensible digit search suggestions

### DIFF
--- a/spec/models/search_suggestion_spec.rb
+++ b/spec/models/search_suggestion_spec.rb
@@ -2,40 +2,42 @@ RSpec.describe SearchSuggestion do
   describe '.fuzzy_search' do
     subject(:fuzzy_search) { described_class.fuzzy_search(query) }
 
-    let(:query) { 'aluminum' }
+    context 'when the query is a similar but mispelled word' do
+      let(:query) { 'aluminum' }
 
-    before do
-      create(:search_suggestion, value: 'aluminium wire')
-      create(:search_suggestion, value: 'nuts, aluminium')
-      create(:search_suggestion, value: 'bars - aluminium')
-      create(:search_suggestion, value: 'alu')
-      create(:search_suggestion, value: 'test')
-    end
+      before do
+        create(:search_suggestion, value: 'aluminium wire')
+        create(:search_suggestion, value: 'nuts, aluminium')
+        create(:search_suggestion, value: 'bars - aluminium')
+        create(:search_suggestion, value: 'alu')
+        create(:search_suggestion, value: 'test')
+      end
 
-    it 'returns search suggestions' do
-      expect(fuzzy_search.pluck(:value)).to eq(
-        [
-          'aluminium wire',
-          'nuts, aluminium',
-          'bars - aluminium',
-          'alu',
-        ],
-      )
-    end
+      it 'returns search suggestions' do
+        expect(fuzzy_search.pluck(:value)).to eq(
+          [
+            'aluminium wire',
+            'nuts, aluminium',
+            'bars - aluminium',
+            'alu',
+          ],
+        )
+      end
 
-    it 'returns search suggestions with a score' do
-      expect(fuzzy_search.pluck(:score)).to include_json(
-        [
-          be_within(0.2).of(0.411765),
-          be_within(0.2).of(0.411765),
-          be_within(0.2).of(0.411765),
-          be_within(0.2).of(0.3),
-        ],
-      )
-    end
+      it 'returns search suggestions with a score' do
+        expect(fuzzy_search.pluck(:score)).to include_json(
+          [
+            be_within(0.2).of(0.411765),
+            be_within(0.2).of(0.411765),
+            be_within(0.2).of(0.411765),
+            be_within(0.2).of(0.3),
+          ],
+        )
+      end
 
-    it 'returns search suggestions with a query' do
-      expect(fuzzy_search.pluck(:query)).to all(eq(query))
+      it 'returns search suggestions with a query' do
+        expect(fuzzy_search.pluck(:query)).to all(eq(query))
+      end
     end
 
     context 'when the query is a 10 digit number' do
@@ -53,6 +55,48 @@ RSpec.describe SearchSuggestion do
             1234567890
           ],
         )
+      end
+    end
+
+    context 'when the query is a number that is not 10 digits' do
+      let(:query) { '123' }
+
+      before do
+        create(:search_suggestion, value: '1234567890')
+        create(:search_suggestion, value: '1234')
+        create(:search_suggestion, value: '1235')
+        create(:search_suggestion, value: '1234567891')
+      end
+
+      it 'returns search suggestions' do
+        expect(fuzzy_search.pluck(:value)).to eq(
+          %w[
+            1234
+            1235
+            1234567890
+            1234567891
+          ],
+        )
+      end
+    end
+
+    context 'when the query is an empty string' do
+      let(:query) { '' }
+
+      before do
+        create(:search_suggestion, value: '') # control
+      end
+
+      it 'returns an empty array' do
+        expect(fuzzy_search).to be_empty
+      end
+    end
+
+    context 'when the query is nil' do
+      let(:query) { nil }
+
+      it 'returns an empty array' do
+        expect(fuzzy_search).to be_empty
       end
     end
   end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2852

### What?

I have added/removed/altered:

- [x] Added support for a custom digit search suggestion implementation

### Why?

I am doing this because:

- This is required to make sure we're returning results that make sense for goods nomenclature short codes and full item ids
- Using a similarity filter on the short codes made no sense from a user perspective
