### PR TITLE
HOTT-2870 Default to non-concurrent refreshes

### DIFF
--- a/app/models/goods_nomenclatures/tree_node.rb
+++ b/app/models/goods_nomenclatures/tree_node.rb
@@ -5,7 +5,7 @@ module GoodsNomenclatures
       # If the Materialized View has never been populated, eg after a
       # rake db:test:prepare or rake db:structure:load then a non-concurrent
       # refresh is required
-      def refresh!(concurrently: true)
+      def refresh!(concurrently: false)
         db.refresh_view(:goods_nomenclature_tree_nodes, concurrently:)
       end
     end


### PR DESCRIPTION
To avoid deadlocks

### Jira link

HOTT-2870

### What?

I have added/removed/altered:

- [x] Use non-concurrent materialized view refreshes

### Why?

I am doing this because:

- If the refresh occurs under heavy read load (eg morning cache rebuild) it is causing dead locks in the workers

### Deployment risks (optional)

- Low, does mean page loads may pause for a couple of seconds during deploys and nightly syncs but we have plenty of pages loading slower then that anyway
