### PR TITLE
HOTT-2879: Cache chapter responses

### DIFF
--- a/app/controllers/api/v2/chapters_controller.rb
+++ b/app/controllers/api/v2/chapters_controller.rb
@@ -16,7 +16,7 @@ module Api
           end
 
           format.any do
-            cache_key = "_chapters-#{actual_date}/v#{CACHE_VERSION}-#{TradeTariffBackend.service}"
+            cache_key = "_chapters-#{actual_date}/v#{CACHE_VERSION}"
 
             serialized_result = Rails.cache.fetch(cache_key, expires_at: actual_date.end_of_day) do
               Api::V2::Chapters::ChapterListSerializer.new(chapters).serializable_hash.to_json
@@ -28,7 +28,7 @@ module Api
       end
 
       def show
-        cache_key = "_chapter-#{chapter_id}-#{actual_date}/v#{CACHE_VERSION}-#{TradeTariffBackend.service}"
+        cache_key = "_chapter-#{chapter_id}-#{actual_date}/v#{CACHE_VERSION}"
 
         serialized_result = Rails.cache.fetch(cache_key, expires_at: actual_date.end_of_day) do
           headings = chapter.headings_dataset
@@ -48,7 +48,7 @@ module Api
       end
 
       def changes
-        cache_key = "_chapter-#{chapter_id}-#{actual_date}/changes-v#{CACHE_VERSION}-#{TradeTariffBackend.service}"
+        cache_key = "_chapter-#{chapter_id}-#{actual_date}/changes-v#{CACHE_VERSION}"
         options = {}
         options[:include] = [:record, 'record.geographical_area', 'record.measure_type']
         serialized_result = Rails.cache.fetch(cache_key, expires_at: actual_date.end_of_day) do

--- a/spec/requests/api/v2/chapters_controller_spec.rb
+++ b/spec/requests/api/v2/chapters_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::V2::ChaptersController, type: :request do
       expect(Rails.cache)
         .to have_received(:fetch)
         .with(
-          "_chapters-#{now.iso8601}/v1-uk",
+          "_chapters-#{now.iso8601}/v1",
           expires_at:,
         )
     end
@@ -37,7 +37,7 @@ RSpec.describe Api::V2::ChaptersController, type: :request do
       expect(Rails.cache)
         .to have_received(:fetch)
         .with(
-          "_chapter-#{chapter.short_code}-#{now.iso8601}/v1-uk",
+          "_chapter-#{chapter.short_code}-#{now.iso8601}/v1",
           expires_at:,
         )
     end
@@ -52,7 +52,7 @@ RSpec.describe Api::V2::ChaptersController, type: :request do
       expect(Rails.cache)
         .to have_received(:fetch)
         .with(
-          "_chapter-#{chapter.short_code}-#{now.iso8601}/changes-v1-uk",
+          "_chapter-#{chapter.short_code}-#{now.iso8601}/changes-v1",
           expires_at:,
         )
     end

--- a/spec/requests/api/v2/chapters_controller_spec.rb
+++ b/spec/requests/api/v2/chapters_controller_spec.rb
@@ -1,5 +1,23 @@
-RSpec.describe Api::V2::ChaptersController do
+RSpec.describe Api::V2::ChaptersController, type: :request do
+  let(:now) { Time.zone.today }
+  let(:expires_at) { now.end_of_day }
+
+  before do
+    allow(Rails.cache).to receive(:fetch).and_call_original
+  end
+
   describe 'GET #index' do
+    it 'caches the serialized chapters' do
+      get '/chapters'
+
+      expect(Rails.cache)
+        .to have_received(:fetch)
+        .with(
+          "_chapters-#{now.iso8601}/v1-uk",
+          expires_at:,
+        )
+    end
+
     it_behaves_like 'a successful csv response' do
       let(:path) { '/chapters' }
       let(:expected_filename) { "uk-chapters-#{Time.zone.today.iso8601}.csv" }
@@ -7,6 +25,36 @@ RSpec.describe Api::V2::ChaptersController do
       before do
         create(:chapter)
       end
+    end
+  end
+
+  describe 'GET #show' do
+    let(:chapter) { create :chapter, :with_section }
+
+    it 'caches the serialized chapters' do
+      get "/chapters/#{chapter.short_code}"
+
+      expect(Rails.cache)
+        .to have_received(:fetch)
+        .with(
+          "_chapter-#{chapter.short_code}-#{now.iso8601}/v1-uk",
+          expires_at:,
+        )
+    end
+  end
+
+  describe 'GET #changes' do
+    let(:chapter) { create :chapter, :with_section }
+
+    it 'caches the serialized chapter changes' do
+      get changes_api_chapter_path(chapter)
+
+      expect(Rails.cache)
+        .to have_received(:fetch)
+        .with(
+          "_chapter-#{chapter.short_code}-#{now.iso8601}/changes-v1-uk",
+          expires_at:,
+        )
     end
   end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2879

### What?

I have added/removed/altered:

- [x] Adds caching to v2 chapter responses
- [x] Adds specs for the caching

### Why?

I am doing this because:

- This is a temporary fix just to diminish the impacts of users scripting concurrent requests to chapter endpoints
