### PR TITLE
HOTT-2769 Allow overriding generating regulation for Measure factory

### DIFF
--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -18,38 +18,41 @@ FactoryBot.define do
       monetary_unit_code { nil }
       measure_type_series_id { 'S' }
       base_regulation_effective_end_date { nil }
+      generating_regulation { nil }
+      default_start_date { 3.years.ago.beginning_of_day }
     end
 
     filename { build(:cds_update, issue_date: operation_date || validity_start_date).filename }
 
     measure_sid { generate(:measure_sid) }
     measure_type_id { generate(:measure_type_id) }
-    measure_generating_regulation_id { generate(:base_regulation_sid) }
-    measure_generating_regulation_role { Measure::BASE_REGULATION_ROLE }
+    measure_generating_regulation_id { generating_regulation&.regulation_id || generate(:base_regulation_sid) }
+    measure_generating_regulation_role { generating_regulation&.role || Measure::BASE_REGULATION_ROLE }
     additional_code_type_id { generate(:additional_code_type_id) }
-    goods_nomenclature_sid { generate(:goods_nomenclature_sid) }
-    goods_nomenclature_item_id { 10.times.map { Random.rand(9) }.join }
+    goods_nomenclature_sid { goods_nomenclature&.goods_nomenclature_sid || generate(:goods_nomenclature_sid) }
+    goods_nomenclature_item_id { goods_nomenclature&.goods_nomenclature_item_id || 10.times.map { Random.rand(9) }.join }
     geographical_area_sid { generate(:geographical_area_sid) }
     geographical_area_id { generate(:geographical_area_id) }
-    validity_start_date { 3.years.ago.beginning_of_day }
+    validity_start_date { default_start_date }
     validity_end_date   { nil }
     reduction_indicator { [nil, 1, 2, 3].sample }
 
     measure_type do
       create :measure_type, measure_type_id:,
-                            validity_start_date: validity_start_date - 1.day,
+                            validity_start_date: (validity_start_date || default_start_date) - 1.day,
                             measure_explosion_level: type_explosion_level,
                             order_number_capture_code:,
                             trade_movement_code: MeasureType::IMPORT_MOVEMENT_CODES.sample,
                             measure_type_series_id:
     end
+
     geographical_area do
       create(
         :geographical_area,
         :with_description,
         geographical_area_sid:,
         geographical_area_id:,
-        validity_start_date: validity_start_date - 1.day,
+        validity_start_date: (validity_start_date || default_start_date) - 1.day,
       )
     end
 
@@ -142,8 +145,6 @@ FactoryBot.define do
       goods_nomenclature do
         create(:goods_nomenclature,
                validity_start_date: validity_start_date - 1.day,
-               goods_nomenclature_item_id:,
-               goods_nomenclature_sid:,
                producline_suffix: gono_producline_suffix,
                indents: gono_number_indents)
       end

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -8,16 +8,15 @@ RSpec.describe Measure do
   end
 
   describe 'methods delegated to measure_type' do
-    it do
-      expect(build(:measure)).to respond_to :rules_of_origin_apply?,
-                                            :third_country?,
-                                            :excise?,
-                                            :vat?,
-                                            :preferential_quota?,
-                                            :tariff_preference?,
-                                            :trade_remedy?,
-                                            :excise?
-    end
+    subject { build :measure }
+
+    it { is_expected.to respond_to :rules_of_origin_apply? }
+    it { is_expected.to respond_to :third_country? }
+    it { is_expected.to respond_to :excise? }
+    it { is_expected.to respond_to :vat? }
+    it { is_expected.to respond_to :preferential_quota? }
+    it { is_expected.to respond_to :tariff_preference? }
+    it { is_expected.to respond_to :trade_remedy? }
   end
 
   describe '#goods_nomenclature' do

--- a/spec/services/quota_search_service_spec.rb
+++ b/spec/services/quota_search_service_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe QuotaSearchService do
   let!(:duplicate_measure) { create :measure, :with_goods_nomenclature, ordernumber: quota_order_number1.quota_order_number_id, validity_start_date: validity_start_date + 1.hour }
 
   let(:quota_order_number2) { create :quota_order_number }
-  let!(:measure2) { create :measure, :with_goods_nomenclature, ordernumber: quota_order_number2.quota_order_number_id, validity_start_date: }
+  let(:goods_nomenclature2) { create :goods_nomenclature, parent: create(:heading) }
+  let!(:measure2) { create :measure, goods_nomenclature: goods_nomenclature2, ordernumber: quota_order_number2.quota_order_number_id, validity_start_date: }
   let!(:quota_definition2) do
     create :quota_definition,
            quota_order_number_sid: quota_order_number2.quota_order_number_sid,


### PR DESCRIPTION
### Jira link

HOTT-2769

### What?

I have added/removed/altered:

- [x] Extraction of factory changes from main 2769 branch

### Why?

I am doing this because:

- This will simplify the specs for HOTT-2874 

### Deployment risks (optional)

- Low - spec changes only
