### PR TITLE
HOTT-2769 Eager loadable measures and overview measures

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -15,51 +15,55 @@ module Declarable
     Sequel.desc(:effective_start_date),
   ].freeze
 
+  MEASURES_SORT_ORDER = [
+    Sequel.asc(:measures__geographical_area_id),
+    Sequel.asc(:measures__measure_type_id),
+    Sequel.asc(:measures__additional_code_type_id),
+    Sequel.asc(:measures__additional_code_id),
+    Sequel.asc(:measures__ordernumber),
+    Sequel.desc(:effective_start_date),
+  ].freeze
+
   included do
-    one_to_many :measures, primary_key: {}, key: {}, dataset: -> {
+    one_to_many :measures, primary_key: {}, key: {}, dataset: lambda {
       Measure.join(
         Measure.with_base_regulations
                .with_actual(BaseRegulation)
                .where(measures__goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid))
-               .exclude(measures__measure_type_id: MeasureType.excluded_measure_types)
+               .without_excluded_types
                .order(*COMMON_UNION_MEASURE_ORDER)
        .union(
          Measure.with_modification_regulations
                 .with_actual(ModificationRegulation)
                 .where(measures__goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid))
-                .exclude(measures__measure_type_id: MeasureType.excluded_measure_types)
+                .without_excluded_types
                 .order(*COMMON_UNION_MEASURE_ORDER),
          alias: :measures,
        )
        .with_actual(Measure)
-       .order(Sequel.asc(:measures__geographical_area_id),
-              Sequel.asc(:measures__measure_type_id),
-              Sequel.asc(:measures__additional_code_type_id),
-              Sequel.asc(:measures__additional_code_id),
-              Sequel.asc(:measures__ordernumber),
-              Sequel.desc(:effective_start_date)),
+       .order(*MEASURES_SORT_ORDER),
         t1__measure_sid: :measures__measure_sid,
       )
     }
 
-    one_to_many :import_measures, key: {}, primary_key: {}, dataset: -> {
+    one_to_many :import_measures, key: {}, primary_key: {}, dataset: lambda {
       measures_dataset.join(:measure_types, measure_types__measure_type_id: :measures__measure_type_id)
                       .filter(measure_types__trade_movement_code: MeasureType::IMPORT_MOVEMENT_CODES)
     }, class_name: 'Measure'
 
-    one_to_many :export_measures, key: {}, primary_key: {}, dataset: -> {
+    one_to_many :export_measures, key: {}, primary_key: {}, dataset: lambda {
       measures_dataset.join(:measure_types, measure_types__measure_type_id: :measures__measure_type_id)
                       .filter(measure_types__trade_movement_code: MeasureType::EXPORT_MOVEMENT_CODES)
     }, class_name: 'Measure'
 
-    one_to_many :basic_duty_rate_components, primary_key: {}, key: {}, class_name: 'MeasureComponent', dataset: -> {
+    one_to_many :basic_duty_rate_components, primary_key: {}, key: {}, class_name: 'MeasureComponent', dataset: lambda {
       MeasureComponent.where(measure: import_measures_dataset.where(measures__measure_type_id: MeasureType::THIRD_COUNTRY).all)
     }
 
     custom_format :description_plain, with: DescriptionTrimFormatter,
-                               using: :description
+                                      using: :description
     custom_format :formatted_description, with: DescriptionFormatter,
-                                   using: :description
+                                          using: :description
   end
 
   def chapter_id

--- a/app/models/concerns/ten_digit_goods_nomenclature.rb
+++ b/app/models/concerns/ten_digit_goods_nomenclature.rb
@@ -23,21 +23,7 @@ module TenDigitGoodsNomenclature
     end
 
     one_to_many :overview_measures, key: {}, primary_key: {}, class_name: 'Measure', dataset: lambda {
-      dataset = measures_dataset
-        .filter(measures__measure_type_id: MeasureType::SUPPLEMENTARY_TYPES)
-        .or(
-          measures__measure_type_id: MeasureType::THIRD_COUNTRY,
-          measures__geographical_area_id: GeographicalArea::ERGA_OMNES_ID,
-        )
-
-      if TradeTariffBackend.uk?
-        dataset.or(
-          measures__measure_type_id: MeasureType::VAT_TYPES,
-          measures__geographical_area_id: GeographicalArea::ERGA_OMNES_ID,
-        )
-      else
-        dataset
-      end
+      measures_dataset.overview
     }
 
     delegate :section, :section_id, to: :chapter, allow_nil: true

--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -163,5 +163,9 @@ module GoodsNomenclatures
     def ns_declarable?
       producline_suffix == GoodsNomenclatureIndent::NON_GROUPING_PRODUCTLINE_SUFFIX && ns_children.empty?
     end
+
+    def applicable_measures
+      ns_ancestors.flat_map(&:ns_measures) + ns_measures
+    end
   end
 end

--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -93,6 +93,22 @@ module GoodsNomenclatures
               TreeNode.descendant_node_constraints(origin, children)
           end
       end
+
+      one_to_many :ns_measures,
+                  primary_key: :goods_nomenclature_sid,
+                  key: :goods_nomenclature_sid,
+                  class_name: '::Measure',
+                  read_only: true do |ds|
+        ds.with_actual(Measure)
+          .with_regulation_dates_query
+          .exclude(measures__measure_type_id: MeasureType.excluded_measure_types)
+          .order(Sequel.asc(:measures__geographical_area_id),
+                 Sequel.asc(:measures__measure_type_id),
+                 Sequel.asc(:measures__additional_code_type_id),
+                 Sequel.asc(:measures__additional_code_id),
+                 Sequel.asc(:measures__ordernumber),
+                 Sequel.desc(:effective_start_date))
+      end
     end
 
     def recursive_ancestor_populator(ancestors)

--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -101,13 +101,20 @@ module GoodsNomenclatures
                   read_only: true do |ds|
         ds.with_actual(Measure)
           .with_regulation_dates_query
-          .exclude(measures__measure_type_id: MeasureType.excluded_measure_types)
-          .order(Sequel.asc(:measures__geographical_area_id),
-                 Sequel.asc(:measures__measure_type_id),
-                 Sequel.asc(:measures__additional_code_type_id),
-                 Sequel.asc(:measures__additional_code_id),
-                 Sequel.asc(:measures__ordernumber),
-                 Sequel.desc(:effective_start_date))
+          .without_excluded_types
+          .order(*Declarable::MEASURES_SORT_ORDER)
+      end
+
+      one_to_many :ns_overview_measures,
+                  primary_key: :goods_nomenclature_sid,
+                  key: :goods_nomenclature_sid,
+                  class_name: '::Measure',
+                  read_only: true do |ds|
+        ds.with_actual(Measure)
+          .with_regulation_dates_query
+          .without_excluded_types
+          .overview
+          .order(*Declarable::MEASURES_SORT_ORDER)
       end
     end
 

--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -174,5 +174,9 @@ module GoodsNomenclatures
     def applicable_measures
       ns_ancestors.flat_map(&:ns_measures) + ns_measures
     end
+
+    def applicable_overview_measures
+      ns_ancestors.flat_map(&:ns_overview_measures) + ns_overview_measures
+    end
   end
 end

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -355,6 +355,31 @@ class Measure < Sequel::Model
           end
         end
     end
+
+    def without_excluded_types
+      exclude(measures__measure_type_id: MeasureType.excluded_measure_types)
+    end
+
+    def overview
+      where do
+        overview_types = [
+          { measures__measure_type_id: MeasureType::SUPPLEMENTARY_TYPES },
+          {
+            measures__measure_type_id: MeasureType::THIRD_COUNTRY,
+            measures__geographical_area_id: GeographicalArea::ERGA_OMNES_ID,
+          },
+        ]
+
+        if TradeTariffBackend.uk?
+          overview_types << {
+            measures__measure_type_id: MeasureType::VAT_TYPES,
+            measures__geographical_area_id: GeographicalArea::ERGA_OMNES_ID,
+          }
+        end
+
+        Sequel.|(*overview_types)
+      end
+    end
   end
 
   def_column_accessor :effective_end_date, :effective_start_date

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -317,6 +317,44 @@ class Measure < Sequel::Model
 
       query.where(measure_generating_regulation_role: role)
     end
+
+    def effective_start_date_column
+      Sequel.function(:coalesce,
+                      :measures__validity_start_date,
+                      :base_regulation__validity_start_date,
+                      :modification_regulation__validity_start_date)
+    end
+
+    def effective_end_date_column
+      Sequel.function(:coalesce,
+                      :measures__validity_end_date,
+                      :base_regulation__effective_end_date,
+                      :base_regulation__validity_end_date,
+                      :modification_regulation__effective_end_date,
+                      :modification_regulation__validity_end_date)
+    end
+
+    def with_regulation_dates_query
+      association_left_join(:base_regulation, :modification_regulation)
+        .select_append(Sequel.as(effective_start_date_column, :effective_start_date))
+        .select_append(Sequel.as(effective_end_date_column, :effective_end_date))
+        .where do |_query|
+          regulation_check = \
+            (Sequel.qualify(:base_regulation, :base_regulation_id) !~ nil) |
+            (Sequel.qualify(:modification_regulation, :modification_regulation_id) !~ nil)
+
+          if model.point_in_time
+            start_date = effective_start_date_column
+            end_date   = effective_end_date_column
+
+            regulation_check &
+              (start_date <= model.point_in_time) &
+              ((end_date >= model.point_in_time) | (end_date =~ nil))
+          else
+            regulation_check
+          end
+        end
+    end
   end
 
   def_column_accessor :effective_end_date, :effective_start_date

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -360,54 +360,18 @@ RSpec.describe GoodsNomenclatures::NestedSet do
     describe '#ns_measures' do
       subject { measure.goods_nomenclature.ns_measures.map(&:measure_sid) }
 
-      before { allow(TradeTariffBackend).to receive(:service).and_return(service) }
-
       let :measure do
         create :measure, :with_base_regulation, :with_goods_nomenclature, measure_type_id:
       end
 
-      context 'when the service version is the UK' do
-        let(:service) { 'uk' }
+      let(:measure_type_id) { MeasureType::QUOTA_TYPES.first }
 
-        context 'with measures that are excluded for the UK service' do
-          let(:measure_type_id) { MeasureType::DEFAULT_EXCLUDED_TYPES.first }
+      it { is_expected.to include measure.measure_sid }
 
-          it { is_expected.not_to include measure.measure_sid }
-        end
+      context 'with measures that are excluded' do
+        let(:measure_type_id) { MeasureType::DEFAULT_EXCLUDED_TYPES.first }
 
-        context 'with quota measures that are excluded for the XI service' do
-          let(:measure_type_id) { MeasureType::QUOTA_TYPES.first }
-
-          it { is_expected.to include measure.measure_sid }
-        end
-
-        context 'with P&R national measures that are excluded for the XI service' do
-          let(:measure_type_id) { MeasureType::NATIONAL_PR_TYPES.first }
-
-          it { is_expected.to include measure.measure_sid }
-        end
-      end
-
-      context 'when the service version is the XI' do
-        let(:service) { 'xi' }
-
-        context 'with measures that are excluded for the UK service' do
-          let(:measure_type_id) { MeasureType::DEFAULT_EXCLUDED_TYPES.first }
-
-          it { is_expected.not_to include measure.measure_sid }
-        end
-
-        context 'with quota measures that are excluded for the XI service' do
-          let(:measure_type_id) { MeasureType::QUOTA_TYPES.first }
-
-          it { is_expected.not_to include measure.measure_sid }
-        end
-
-        context 'with P&R national measures that are excluded for the XI service' do
-          let(:measure_type_id) { MeasureType::NATIONAL_PR_TYPES.first }
-
-          it { is_expected.not_to include measure.measure_sid }
-        end
+        it { is_expected.not_to include measure.measure_sid }
       end
 
       context 'with eager loading' do
@@ -422,8 +386,44 @@ RSpec.describe GoodsNomenclatures::NestedSet do
             .map(&:measure_sid)
         end
 
-        let(:service) { 'uk' }
+        it { is_expected.to include measure.measure_sid }
+      end
+    end
+
+    describe '#ns_overview_measures' do
+      subject { measure.goods_nomenclature.ns_overview_measures.map(&:measure_sid) }
+
+      let :measure do
+        create :measure, :with_base_regulation, :with_goods_nomenclature, measure_type_id:
+      end
+
+      let(:measure_type_id) { MeasureType::SUPPLEMENTARY_TYPES.first }
+
+      it { is_expected.to include measure.measure_sid }
+
+      context 'with non overview measure types' do
         let(:measure_type_id) { MeasureType::QUOTA_TYPES.first }
+
+        it { is_expected.not_to include measure.measure_sid }
+      end
+
+      context 'with measures that are excluded' do
+        let(:measure_type_id) { MeasureType::DEFAULT_EXCLUDED_TYPES.first }
+
+        it { is_expected.not_to include measure.measure_sid }
+      end
+
+      context 'with eager loading' do
+        subject do
+          GoodsNomenclature
+            .actual
+            .where(goods_nomenclature_sid: measure.goods_nomenclature_sid)
+            .eager(:ns_overview_measures)
+            .all
+            .first
+            .associations[:ns_overview_measures]
+            .map(&:measure_sid)
+        end
 
         it { is_expected.to include measure.measure_sid }
       end

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -449,4 +449,36 @@ RSpec.describe GoodsNomenclatures::NestedSet do
       it { is_expected.not_to be_ns_declarable }
     end
   end
+
+  describe '#applicable_measures' do
+    subject { measure.goods_nomenclature.applicable_measures }
+
+    let(:subheading) { create :commodity, :with_chapter_and_heading, :with_children }
+
+    let :measure do
+      create :measure,
+             :with_base_regulation,
+             goods_nomenclature: subheading.ns_children.first
+    end
+
+    it { is_expected.to eq_pk [measure] }
+
+    context 'with measures against ancestors' do
+      before { ancestor_measure && parent_measure }
+
+      let :ancestor_measure do
+        create :measure,
+               :with_base_regulation,
+               goods_nomenclature: subheading.ns_parent
+      end
+
+      let :parent_measure do
+        create :measure,
+               :with_base_regulation,
+               goods_nomenclature: subheading
+      end
+
+      it { is_expected.to eq_pk [ancestor_measure, parent_measure, measure] }
+    end
+  end
 end

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -481,4 +481,38 @@ RSpec.describe GoodsNomenclatures::NestedSet do
       it { is_expected.to eq_pk [ancestor_measure, parent_measure, measure] }
     end
   end
+
+  describe '#applicable_overview_measures' do
+    subject { measure.goods_nomenclature.applicable_overview_measures }
+
+    let(:subheading) { create :commodity, :with_chapter_and_heading, :with_children }
+
+    let :measure do
+      create :measure,
+             :supplementary,
+             :with_base_regulation,
+             goods_nomenclature: subheading.ns_children.first
+    end
+
+    it { is_expected.to eq_pk [measure] }
+
+    context 'with measures against ancestors' do
+      before { ancestor_measure && parent_measure }
+
+      let :ancestor_measure do
+        create :measure,
+               :supplementary,
+               :with_base_regulation,
+               goods_nomenclature: subheading.ns_parent
+      end
+
+      let :parent_measure do
+        create :measure,
+               :with_base_regulation,
+               goods_nomenclature: subheading
+      end
+
+      it { is_expected.to eq_pk [ancestor_measure, measure] }
+    end
+  end
 end

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -356,6 +356,78 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         end
       end
     end
+
+    describe '#ns_measures' do
+      subject { measure.goods_nomenclature.ns_measures.map(&:measure_sid) }
+
+      before { allow(TradeTariffBackend).to receive(:service).and_return(service) }
+
+      let :measure do
+        create :measure, :with_base_regulation, :with_goods_nomenclature, measure_type_id:
+      end
+
+      context 'when the service version is the UK' do
+        let(:service) { 'uk' }
+
+        context 'with measures that are excluded for the UK service' do
+          let(:measure_type_id) { MeasureType::DEFAULT_EXCLUDED_TYPES.first }
+
+          it { is_expected.not_to include measure.measure_sid }
+        end
+
+        context 'with quota measures that are excluded for the XI service' do
+          let(:measure_type_id) { MeasureType::QUOTA_TYPES.first }
+
+          it { is_expected.to include measure.measure_sid }
+        end
+
+        context 'with P&R national measures that are excluded for the XI service' do
+          let(:measure_type_id) { MeasureType::NATIONAL_PR_TYPES.first }
+
+          it { is_expected.to include measure.measure_sid }
+        end
+      end
+
+      context 'when the service version is the XI' do
+        let(:service) { 'xi' }
+
+        context 'with measures that are excluded for the UK service' do
+          let(:measure_type_id) { MeasureType::DEFAULT_EXCLUDED_TYPES.first }
+
+          it { is_expected.not_to include measure.measure_sid }
+        end
+
+        context 'with quota measures that are excluded for the XI service' do
+          let(:measure_type_id) { MeasureType::QUOTA_TYPES.first }
+
+          it { is_expected.not_to include measure.measure_sid }
+        end
+
+        context 'with P&R national measures that are excluded for the XI service' do
+          let(:measure_type_id) { MeasureType::NATIONAL_PR_TYPES.first }
+
+          it { is_expected.not_to include measure.measure_sid }
+        end
+      end
+
+      context 'with eager loading' do
+        subject do
+          GoodsNomenclature
+            .actual
+            .where(goods_nomenclature_sid: measure.goods_nomenclature_sid)
+            .eager(:ns_measures)
+            .all
+            .first
+            .associations[:ns_measures]
+            .map(&:measure_sid)
+        end
+
+        let(:service) { 'uk' }
+        let(:measure_type_id) { MeasureType::QUOTA_TYPES.first }
+
+        it { is_expected.to include measure.measure_sid }
+      end
+    end
   end
 
   describe '#ns_declarable?' do


### PR DESCRIPTION
### Jira link

HOTT-2769

### What?

I have added/removed/altered:

- [x] Added an `ns_measures` relationship - only returns direct measures, does not include those for ancestors
- [x] Added an `#applicable_measures`  method which lists both direct measures (from `ns_measures` and ancestor measures (from `ns_ancestors` -> `ns_measures`)
- [x] Added an `ns_overview` measures relationship - is similar to `ns_measures` but only includes 'overview' measures
- [x] Added `#applicable_overview_measures` ruby method which lists both direct overview measures and all ancestors overview measures
- [x] Abstracted out the definition of overview measures to allow sharing logic with the `ns_overview_measures` relationship
- [x] Added full specs for the various new methods/relationships/refactorings

### Why?

I am doing this because:

- building the relationship this way allows retrieving a particular measure from postgres once rather than once per commodity under the goods_nomenclature you are retrieving
- we similar interface to the existing `#measures` relationship which presents a list of all applicable measures
- we require equivalents for overview only measures
- we wish to reduce code duplication

### Deployment risks (optional)

- Relatively, this is mostly new code but does change the existing in-use `overview_measures` relationship to rely upon the new shared definition of an overview measure
