### PR TITLE
HOTT-2912 Assign declarable for parent queries

### DIFF
--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -24,6 +24,7 @@ module GoodsNomenclatures
         ds.order(:ancestor_nodes__position)
           .with_validity_dates(:ancestor_nodes)
           .select_append(:ancestor_nodes__depth)
+          .select_append(Sequel.as(false, :leaf))
           .join(Sequel.as(:goods_nomenclature_tree_nodes, :origin_nodes)) do |origin_table, ancestors_table, _join_clauses|
             ancestors = TreeNodeAlias.new(ancestors_table)
             origin    = TreeNodeAlias.new(origin_table)
@@ -44,6 +45,7 @@ module GoodsNomenclatures
         ds.order(:parent_nodes__position)
           .with_validity_dates(:parent_nodes)
           .select_append(:parent_nodes__depth)
+          .select_append(Sequel.as(false, :leaf))
           .join(Sequel.as(:goods_nomenclature_tree_nodes, :origin_nodes)) do |origin_table, parents_table, _join_clauses|
             parents = TreeNodeAlias.new(parents_table)
             origin  = TreeNodeAlias.new(origin_table)
@@ -168,7 +170,11 @@ module GoodsNomenclatures
     end
 
     def ns_declarable?
-      producline_suffix == GoodsNomenclatureIndent::NON_GROUPING_PRODUCTLINE_SUFFIX && ns_children.empty?
+      producline_suffix == GoodsNomenclatureIndent::NON_GROUPING_PRODUCTLINE_SUFFIX && ns_leaf?
+    end
+
+    def ns_leaf?
+      values.key?(:leaf) ? values[:leaf] : ns_children.empty?
     end
 
     def applicable_measures

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -163,6 +163,12 @@ RSpec.describe GoodsNomenclatures::NestedSet do
             it { is_expected.to eq_pk tree.values_at(:chapter, :heading) }
           end
         end
+
+        describe 'leaf value from db query' do
+          subject { tree[:subheading].ns_ancestors.map(&:values) }
+
+          it { is_expected.to all include leaf: false }
+        end
       end
 
       describe '#ns_parent' do
@@ -181,6 +187,12 @@ RSpec.describe GoodsNomenclatures::NestedSet do
           let(:item_id) { "#{tree[:second_tree].goods_nomenclature_item_id.first(4)}000000" }
 
           it { is_expected.to eq item_id }
+        end
+
+        describe 'leaf value from db query' do
+          subject { tree[:subheading].ns_parent.values }
+
+          it { is_expected.to include leaf: false }
         end
       end
 

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -77,9 +77,9 @@ RSpec.describe GoodsNomenclatures::NestedSet do
 
       shared_examples 'it has parent' do |context_name, node, parent_node|
         context "with #{context_name}" do
-          subject { tree[node].ns_parent&.goods_nomenclature_sid }
+          subject { tree[node].ns_parent }
 
-          it { is_expected.to eq tree[parent_node]&.goods_nomenclature_sid }
+          it { is_expected.to eq_pk tree[parent_node] }
         end
       end
 

--- a/spec/support/matchers/eq_pk.rb
+++ b/spec/support/matchers/eq_pk.rb
@@ -4,7 +4,7 @@ RSpec::Matchers.define :eq_pk do
       actual.map(&:class) == expected.map(&:class) &&
         actual.map(&:pk) == expected.map(&:pk)
     else
-      actual.instance_of?(expected.class) && actual.pk == expected.pk
+      actual.instance_of?(expected.class) && actual&.pk == expected&.pk
     end
   end
 


### PR DESCRIPTION
### Jira link

HOTT-2912

### What?

I have added/removed/altered:

- [x] Mark all parents and ancestors as not being leaf goods_nomenclatures

### Why?

I am doing this because:

- This can be inferred by them being either the parent or ancestor of another goods nomenclature and helps avoid N+1 db queries

### Deployment risks (optional)

- Low, only impacts nested set
