### PR TITLE
HOTT-2911 Hide goods nomenclature from nested set

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -146,7 +146,7 @@ class GoodsNomenclature < Sequel::Model
     end
 
     def non_hidden
-      filter(Sequel.~(goods_nomenclature_item_id: HiddenGoodsNomenclature.codes))
+      filter(Sequel.~(goods_nomenclatures__goods_nomenclature_item_id: HiddenGoodsNomenclature.codes))
     end
 
     def indexable

--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -64,7 +64,8 @@ module GoodsNomenclatures
                    join_table: Sequel.as(:goods_nomenclature_tree_nodes, :descendant_nodes),
                    after_load: :recursive_descendant_populator,
                    read_only: true do |ds|
-        ds.order(:descendant_nodes__position)
+        ds.non_hidden
+          .order(:descendant_nodes__position)
           .with_validity_dates(:descendant_nodes)
           .select_append(:descendant_nodes__depth)
           .join(Sequel.as(:goods_nomenclature_tree_nodes, :origin_nodes)) do |origin_table, descendants_table, _join_clauses|
@@ -84,7 +85,8 @@ module GoodsNomenclatures
                    class_name: '::GoodsNomenclature',
                    join_table: Sequel.as(:goods_nomenclature_tree_nodes, :child_nodes),
                    read_only: true do |ds|
-        ds.order(:child_nodes__position)
+        ds.non_hidden
+          .order(:child_nodes__position)
           .with_validity_dates(:child_nodes)
           .select_append(:child_nodes__depth)
           .join(Sequel.as(:goods_nomenclature_tree_nodes, :origin_nodes)) do |origin_table, children_table, _join_clauses|

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -212,6 +212,15 @@ RSpec.describe GoodsNomenclatures::NestedSet do
           it { is_expected.to have_attributes length: 3 }
         end
 
+        context 'with hidden_goods_nomenclatures' do
+          before do
+            create :hidden_goods_nomenclature,
+                   goods_nomenclature_item_id: tree[:commodity2].goods_nomenclature_item_id
+          end
+
+          it_behaves_like 'it has descendants', 'nested subheading', :subsubheading, %i[commodity1]
+        end
+
         context 'when eager loading' do
           let(:eager_loaded) { commodities.eager(:ns_descendants).all.first }
 
@@ -294,6 +303,15 @@ RSpec.describe GoodsNomenclatures::NestedSet do
           subject { tree[:second_tree].ns_children.map(&:goods_nomenclature_item_id) }
 
           it { is_expected.to have_attributes length: 1 }
+        end
+
+        context 'with hidden_goods_nomenclatures' do
+          before do
+            create :hidden_goods_nomenclature,
+                   goods_nomenclature_item_id: tree[:commodity3].goods_nomenclature_item_id
+          end
+
+          it_behaves_like 'it has children', 'subheading', :subheading, %i[subsubheading]
         end
       end
 


### PR DESCRIPTION
### Jira link

HOTT-2911

### What?

I have added/removed/altered:

- [x] Exclude hidden goods_nomenclature from nested set descendant and children results

### Why?

I am doing this because:

- We don't want them to show up in the relationships
- It makes eager loading the relationships easier

### Deployment risks (optional)

- Removes the default ordering from the HiddenGoodsNomenclature model - I can't see a purpose since its never exposed to the end user to this and forces a subselect into the relationship join so just removing instead
