### PR TITLE
HOTT-2690 Fix for after_load step

### DIFF
--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -121,7 +121,8 @@ module GoodsNomenclatures
     end
 
     def recursive_ancestor_populator(ancestors)
-      @associations ||= { ns_ancestors: ancestors }
+      @associations ||= {}
+      @associations[:ns_ancestors] ||= ancestors
 
       parents_ancestors = ancestors.dup
       parent = parents_ancestors.pop
@@ -132,7 +133,8 @@ module GoodsNomenclatures
     end
 
     def recursive_descendant_populator(descendants, parent = nil)
-      @associations ||= { ns_descendants: descendants }
+      @associations ||= {}
+      @associations[:ns_descendants] ||= descendants
 
       if parent
         @associations[:ns_parent] ||= parent

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe GoodsNomenclatures::NestedSet do
 
       shared_examples 'it supports eager loading' do |relationship|
         subject do
-          commodities.eager(relationship).all.first.associations[relationship]
+          commodities.eager(:tree_node, relationship).all.first.associations[relationship]
         end
 
         let :commodities do


### PR DESCRIPTION
### Jira link

HOTT-2690

### What?

I have added/removed/altered:

- [x] Fix after loader when there is a complex eager load tree

### Why?

I am doing this because:

- If the internal `@associations` variable was already populated, then `ns_ancestors` was not being populated, but `ns_parent` was
- Theoretically the same may have happened with descendants but I didn't observer that

### Deployment risks (optional)

- Low, not currently in use - fixes existing bug
