### PR TITLE
HOTT-2915 Fix sorting for NestedSet#applicable_measures

### DIFF
--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -180,11 +180,11 @@ module GoodsNomenclatures
     end
 
     def applicable_measures
-      ns_ancestors.flat_map(&:ns_measures) + ns_measures
+      (ns_ancestors.flat_map(&:ns_measures) + ns_measures).sort_by(&:sort_key)
     end
 
     def applicable_overview_measures
-      ns_ancestors.flat_map(&:ns_overview_measures) + ns_overview_measures
+      (ns_ancestors.flat_map(&:ns_overview_measures) + ns_overview_measures).sort_by(&:sort_key)
     end
   end
 end

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -18,6 +18,8 @@ class Measure < Sequel::Model
     DEFINITIVE_ANTIDUMPING_ROLE,
   ].freeze
 
+  FAR_FUTURE_END_DATE = Date.parse('3023-12-31').end_of_day.freeze
+
   set_primary_key [:measure_sid]
 
   plugin :time_machine
@@ -551,6 +553,19 @@ class Measure < Sequel::Model
 
   def meursing_measures
     @meursing_measures ||= MeursingMeasureFinderService.new(self, meursing_additional_code_id).call
+  end
+
+  def sort_key
+    end_date_key = values.key?(:effective_end_date) ? :effective_end_date : :validity_end_date
+
+    [
+      geographical_area_id,
+      measure_type_id,
+      additional_code_type_id,
+      additional_code_id,
+      ordernumber,
+      values[end_date_key] || FAR_FUTURE_END_DATE,
+    ]
   end
 
   private

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -463,13 +463,15 @@ RSpec.describe GoodsNomenclatures::NestedSet do
   end
 
   describe '#applicable_measures' do
-    subject { measure.goods_nomenclature.applicable_measures }
+    subject(:applied_measures) { measure.goods_nomenclature.applicable_measures }
 
     let(:subheading) { create :commodity, :with_chapter_and_heading, :with_children }
 
     let :measure do
       create :measure,
              :with_base_regulation,
+             geographical_area_id: 'ES',
+             measure_type_id: 2,
              goods_nomenclature: subheading.ns_children.first
     end
 
@@ -481,21 +483,26 @@ RSpec.describe GoodsNomenclatures::NestedSet do
       let :ancestor_measure do
         create :measure,
                :with_base_regulation,
+               geographical_area_id: 'FR',
                goods_nomenclature: subheading.ns_parent
       end
 
       let :parent_measure do
         create :measure,
                :with_base_regulation,
+               geographical_area_id: 'ES',
+               measure_type_id: 4,
                goods_nomenclature: subheading
       end
 
-      it { is_expected.to eq_pk [ancestor_measure, parent_measure, measure] }
+      it 'has correct and sorted measures' do
+        expect(applied_measures).to eq_pk [measure, parent_measure, ancestor_measure]
+      end
     end
   end
 
   describe '#applicable_overview_measures' do
-    subject { measure.goods_nomenclature.applicable_overview_measures }
+    subject(:applied_measures) { measure.goods_nomenclature.applicable_overview_measures }
 
     let(:subheading) { create :commodity, :with_chapter_and_heading, :with_children }
 
@@ -503,6 +510,7 @@ RSpec.describe GoodsNomenclatures::NestedSet do
       create :measure,
              :supplementary,
              :with_base_regulation,
+             :erga_omnes,
              goods_nomenclature: subheading.ns_children.first
     end
 
@@ -513,18 +521,23 @@ RSpec.describe GoodsNomenclatures::NestedSet do
 
       let :ancestor_measure do
         create :measure,
-               :supplementary,
+               :vat,
                :with_base_regulation,
+               :erga_omnes,
                goods_nomenclature: subheading.ns_parent
       end
 
       let :parent_measure do
         create :measure,
+               :tariff_preference,
                :with_base_regulation,
+               :erga_omnes,
                goods_nomenclature: subheading
       end
 
-      it { is_expected.to eq_pk [ancestor_measure, measure] }
+      it 'has correct and sorted measures' do
+        expect(applied_measures).to eq_pk [measure, ancestor_measure]
+      end
     end
   end
 end

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -1459,4 +1459,51 @@ RSpec.describe Measure do
       it { is_expected.to eq '100%' }
     end
   end
+
+  describe '#sort_key' do
+    subject { measure.sort_key }
+
+    let :measure do
+      create :measure,
+             :with_additional_code,
+             :with_additional_code_type,
+             geographical_area_id: 'FR',
+             ordernumber: '10',
+             validity_end_date:
+    end
+
+    context 'with end date' do
+      let(:validity_end_date) { 10.days.from_now.end_of_day }
+
+      let :sort_key do
+        [
+          'FR',
+          measure.measure_type_id,
+          measure.additional_code_type_id,
+          measure.additional_code_id,
+          '10',
+          measure.values[:validity_end_date],
+        ]
+      end
+
+      it { is_expected.to eq sort_key }
+    end
+
+    context 'without end date' do
+      let(:validity_end_date) { nil }
+
+      let :sort_key do
+        [
+          'FR',
+          measure.measure_type_id,
+          measure.additional_code_type_id,
+          measure.additional_code_id,
+          '10',
+          Measure::FAR_FUTURE_END_DATE,
+        ]
+      end
+
+      it { is_expected.to eq sort_key }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

HOTT-2915

### What?

I have added/removed/altered:

- [x] Added `Measure#sort_key` to allow sorting measures in ruby the same way we do in SQL
- [x] Change `NestedSet#applicable_measures` to sort the measures using the new `#sort_key`
- [x] Change `NestedSet#applicable_overview_measures` to sort the measures using the new `#sort_key`

### Why?

I am doing this because:

- We want to maintain the same ordering for the new `#applicable_measures` as the existing `#measures` it replaces
- We want to maintain the same ordering for the new `#applicable_overview_measures` as the existing `#overview_measures` it replaces

### Deployment risks (optional)

- Low, impacts nested set which currently is not in use
