### PR TITLE
Converted nightly CSV to nested set

### DIFF
--- a/app/workers/generate_goods_nomenclatures_csv_report_worker.rb
+++ b/app/workers/generate_goods_nomenclatures_csv_report_worker.rb
@@ -21,10 +21,11 @@ class GenerateGoodsNomenclaturesCsvReportWorker
 
   def goods_nomenclatures
     Chapter
-      .dataset
-      .eager(:goods_nomenclature_indents)
-      .exclude(goods_nomenclature_item_id: HiddenGoodsNomenclature.codes)
+      .non_hidden
+      .eager(:goods_nomenclature_descriptions,
+             ns_ancestors: :goods_nomenclature_descriptions,
+             ns_descendants: :goods_nomenclature_descriptions)
       .all
-      .flat_map(&:goods_nomenclatures)
+      .flat_map(&:ns_descendants)
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-2927

### What?

I have added/removed/altered:

- [x] Converted the 'all goodsnomenclatures' csv generation to use nested set

### Why?

I am doing this because:

- It is faster and generates less queries
- It allows for good comparison of output between existing and nested set approaches
- It excludes hidden goods nomenclatures from the output
- It includes Heading 7019 in the ancestors list for commodities under Heading 7019

### Deployment risks (optional)

- Low - easy to compare/contrast new versus old, actual generation task runs in a background job
