### PR TITLE
HOTT-2951 Added custom measure sorting method

### DIFF
--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -192,13 +192,11 @@ module GoodsNomenclatures
     end
 
     def applicable_measures
-      (ns_ancestors.flat_map(&:ns_measures) + ns_measures)
-        .sort(&Measure.method(:sorter))
+      (ns_ancestors.flat_map(&:ns_measures) + ns_measures).sort
     end
 
     def applicable_overview_measures
-      (ns_ancestors.flat_map(&:ns_overview_measures) + ns_overview_measures)
-        .sort(&Measure.method(:sorter))
+      (ns_ancestors.flat_map(&:ns_overview_measures) + ns_overview_measures).sort
     end
   end
 end

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -112,28 +112,6 @@ class Measure < Sequel::Model
 
   delegate :gsp?, to: :geographical_area, allow_nil: true
 
-  class << self
-    def sorter(left, right)
-      right_key = right.sort_key
-
-      left.sort_key.each.with_index do |value, index|
-        if value.nil?
-          next if right_key[index].nil?
-
-          return 1
-        elsif right_key[index].nil?
-          return -1
-        else
-          comparison_result = value <=> right_key[index]
-
-          return comparison_result unless comparison_result.zero?
-        end
-      end
-
-      0
-    end
-  end
-
   def universal_waiver_applies?
     measure_conditions.any?(&:universal_waiver_applies?)
   end
@@ -576,16 +554,34 @@ class Measure < Sequel::Model
   end
 
   def sort_key
-    end_date_key = values.key?(:effective_end_date) ? :effective_end_date : :validity_end_date
-
-    [
+    @sort_key ||= [
       geographical_area_id,
       measure_type_id,
       additional_code_type_id,
       additional_code_id,
       ordernumber,
-      values[end_date_key],
+      values[
+        values.key?(:effective_end_date) ? :effective_end_date : :validity_end_date
+      ],
     ]
+  end
+
+  def <=>(other)
+    sort_key.each.with_index do |value, index|
+      if value.nil?
+        next if other.sort_key[index].nil?
+
+        return 1
+      elsif other.sort_key[index].nil?
+        return -1
+      else
+        comparison_result = value <=> other.sort_key[index]
+
+        return comparison_result unless comparison_result.zero?
+      end
+    end
+
+    0
   end
 
   private

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -53,29 +53,6 @@ RSpec.describe Measure do
     it { is_expected.to have_attributes args: coalesced_columns }
   end
 
-  describe '.sorter' do
-    subject(:sorted) { [first, second, third].sort(&described_class.method(:sorter)) }
-
-    let(:first) { build :measure, geographical_area_id: 'FR', measure_type_id: 2 }
-    let(:second) { build :measure, geographical_area_id: 'ES', measure_type_id: 1 }
-    let(:third) { build :measure, geographical_area_id: 'ES', measure_type_id: 2 }
-
-    it { is_expected.to eq [second, third, first] }
-
-    context 'with nil values on one side of comparison' do
-      let(:second) { build :measure, geographical_area_id: nil, measure_type_id: 1 }
-
-      it { is_expected.to eq [third, first, second] }
-    end
-
-    context 'with nils on both sides of comparison' do
-      let(:first) { build :measure, geographical_area_id: nil, measure_type_id: 2 }
-      let(:second) { build :measure, geographical_area_id: nil, measure_type_id: 1 }
-
-      it { is_expected.to eq [third, second, first] }
-    end
-  end
-
   shared_examples 'includes measure type' do |measure_type, geographical_area|
     context %(with measures of type #{MeasureType.const_get(measure_type).first} are included#{" for #{geographical_area}" if geographical_area}) do
       let(:geographical_area_id) { geographical_area } if geographical_area
@@ -1527,6 +1504,29 @@ RSpec.describe Measure do
       end
 
       it { is_expected.to eq sort_key }
+    end
+  end
+
+  describe '#<=>' do
+    subject(:sorted) { [first, second, third].sort }
+
+    let(:first) { build :measure, geographical_area_id: 'FR', measure_type_id: 2 }
+    let(:second) { build :measure, geographical_area_id: 'ES', measure_type_id: 1 }
+    let(:third) { build :measure, geographical_area_id: 'ES', measure_type_id: 2 }
+
+    it { is_expected.to eq [second, third, first] }
+
+    context 'with nil values on one side of comparison' do
+      let(:second) { build :measure, geographical_area_id: nil, measure_type_id: 1 }
+
+      it { is_expected.to eq [third, first, second] }
+    end
+
+    context 'with nils on both sides of comparison' do
+      let(:first) { build :measure, geographical_area_id: nil, measure_type_id: 2 }
+      let(:second) { build :measure, geographical_area_id: nil, measure_type_id: 1 }
+
+      it { is_expected.to eq [third, second, first] }
     end
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-2091

### What?

I have added/removed/altered:

- [x] Added custom sorting method for measures

### Why?

I am doing this because:

- It more accurately replicates ORDER BY in database sorting

### Deployment risks (optional)

- Low, affects as yet unused `NestedSet#applicable_measures` and `NestedSet#applicable_overview_measures`