### PR TITLE
HOTT-2946 Deduplicate similar measures

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -2,19 +2,6 @@ module Declarable
   extend ActiveSupport::Concern
   include Formatter
 
-  COMMON_UNION_MEASURE_ORDER = [
-    Sequel.desc(:measures__measure_generating_regulation_id),
-    Sequel.desc(:measures__measure_generating_regulation_role),
-    Sequel.desc(:measures__measure_type_id),
-    Sequel.desc(:measures__goods_nomenclature_sid),
-    Sequel.desc(:measures__geographical_area_id),
-    Sequel.desc(:measures__geographical_area_sid),
-    Sequel.desc(:measures__additional_code_type_id),
-    Sequel.desc(:measures__additional_code_id),
-    Sequel.desc(:measures__ordernumber),
-    Sequel.desc(:effective_start_date),
-  ].freeze
-
   MEASURES_SORT_ORDER = [
     Sequel.asc(:measures__geographical_area_id),
     Sequel.asc(:measures__measure_type_id),
@@ -31,13 +18,13 @@ module Declarable
                .with_actual(BaseRegulation)
                .where(measures__goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid))
                .without_excluded_types
-               .order(*COMMON_UNION_MEASURE_ORDER)
+               .order(*Measure::DEDUPE_SORT_ORDER)
        .union(
          Measure.with_modification_regulations
                 .with_actual(ModificationRegulation)
                 .where(measures__goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid))
                 .without_excluded_types
-                .order(*COMMON_UNION_MEASURE_ORDER),
+                .order(*Measure::DEDUPE_SORT_ORDER),
          alias: :measures,
        )
        .with_actual(Measure)

--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -104,9 +104,9 @@ module GoodsNomenclatures
                   class_name: '::Measure',
                   read_only: true do |ds|
         ds.with_actual(Measure)
+          .dedupe_similar
           .with_regulation_dates_query
           .without_excluded_types
-          .order(*Declarable::MEASURES_SORT_ORDER)
       end
 
       one_to_many :ns_overview_measures,
@@ -115,10 +115,10 @@ module GoodsNomenclatures
                   class_name: '::Measure',
                   read_only: true do |ds|
         ds.with_actual(Measure)
+          .dedupe_similar
           .with_regulation_dates_query
           .without_excluded_types
           .overview
-          .order(*Declarable::MEASURES_SORT_ORDER)
       end
     end
 

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -18,6 +18,19 @@ class Measure < Sequel::Model
     DEFINITIVE_ANTIDUMPING_ROLE,
   ].freeze
 
+  DEDUPE_SORT_ORDER = [
+    Sequel.desc(:measures__measure_generating_regulation_id),
+    Sequel.desc(:measures__measure_generating_regulation_role),
+    Sequel.desc(:measures__measure_type_id),
+    Sequel.desc(:measures__goods_nomenclature_sid),
+    Sequel.desc(:measures__geographical_area_id),
+    Sequel.desc(:measures__geographical_area_sid),
+    Sequel.desc(:measures__additional_code_type_id),
+    Sequel.desc(:measures__additional_code_id),
+    Sequel.desc(:measures__ordernumber),
+    Sequel.desc(:effective_start_date),
+  ].freeze
+
   set_primary_key [:measure_sid]
 
   plugin :time_machine
@@ -354,6 +367,21 @@ class Measure < Sequel::Model
             regulation_check
           end
         end
+    end
+
+    def dedupe_similar
+      # Needs with_regulation_dates_query and only works within time machine but should be used before not after
+      select(Sequel.expr(:measures).*)
+        .distinct(:measure_generating_regulation_id,
+                  :measure_generating_regulation_role,
+                  :measure_type_id,
+                  :goods_nomenclature_sid,
+                  :geographical_area_id,
+                  :geographical_area_sid,
+                  :additional_code_type_id,
+                  :additional_code_id,
+                  :ordernumber)
+        .order(*DEDUPE_SORT_ORDER)
     end
 
     def without_excluded_types


### PR DESCRIPTION
### Jira link

HOTT-2946

### What?

I have added/removed/altered:

- [x] Added de-dupe support to the `#ns_measures` and `#ns_overview_measures` relationships

### Why?

I am doing this because:

- this had been missed from the original work
- it needs to match existing behaviour and there were 6 commodities in the dataset relying upon this de-dupe behaviour
- with this all differences between nested set measures and current measures are resolved with the exception of two commodities that have incorrect indents defined on them and are schedule for end dating

### Deployment risks (optional)

- Low, not in use currently
- Does rename and move a constant which is in use
