### PR TITLE
HOTT-2985: Use leaf to determine declarability of commodity

### DIFF
--- a/app/serializers/api/v2/headings/commodity_serializer.rb
+++ b/app/serializers/api/v2/headings/commodity_serializer.rb
@@ -18,8 +18,11 @@ module Api
                    :description_plain,
                    :parent_sid,
                    :validity_start_date,
-                   :validity_end_date,
-                   :declarable
+                   :validity_end_date
+
+        attribute :declarable do |commodity|
+          commodity.leaf && commodity.producline_suffix == '80'
+        end
 
         has_many :overview_measures, serializer: Api::V2::Measures::OverviewMeasureSerializer
       end

--- a/spec/serializers/api/v2/headings/commodity_serializer_spec.rb
+++ b/spec/serializers/api/v2/headings/commodity_serializer_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe Api::V2::Headings::CommoditySerializer do
+  subject(:serializer) { described_class.new(serializable).serializable_hash.as_json }
+
+  let(:serializable) do
+    Hashie::TariffMash.new(
+      leaf:,
+      producline_suffix:,
+    )
+  end
+
+  describe '#serializable_hash' do
+    context 'when the commodity is declarable' do
+      let(:leaf) { true }
+      let(:producline_suffix) { '80' }
+
+      it { expect(serializer.dig('data', 'attributes', 'declarable')).to eq(true) }
+    end
+
+    context 'when the commodity is not declarable' do
+      let(:leaf) { false }
+      let(:producline_suffix) { '80' }
+
+      it { expect(serializer.dig('data', 'attributes', 'declarable')).to eq(false) }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2985

![image](https://user-images.githubusercontent.com/8156884/229746453-7d3b428b-7dae-44a6-80b4-3de5b2be8648.png)


### What?

I have added/removed/altered:

- [x] Added new declarable implementation to the heading commodity serializer
- [x] Added new specs for the commodity serializer

### Why?

I am doing this because:

- This is required because materialized path requires time machine is applied on the headings cache in order to determine declarability. We've opted to just use leaf over fast_declarable? to avoid this requirement
