### PR TITLE
HOTT-2980: Surface measurement unit for quota definitions

### DIFF
--- a/app/controllers/api/admin/quota_order_numbers/quota_definitions_controller.rb
+++ b/app/controllers/api/admin/quota_order_numbers/quota_definitions_controller.rb
@@ -5,16 +5,18 @@ module Api
         before_action :authenticate_user!
         around_action :skip_time_machine
 
-        DEFAULT_EAGER_LOAD_GRAPH = %i[
-          quota_balance_events
-          quota_critical_events
-          quota_exhaustion_events
-          quota_reopening_events
-          quota_unblocking_events
-          quota_unsuspension_events
+        DEFAULT_EAGER_LOAD_GRAPH = [
+          { measurement_unit: %i[measurement_unit_description measurement_unit_abbreviations] },
+          :quota_balance_events,
+          :quota_critical_events,
+          :quota_exhaustion_events,
+          :quota_reopening_events,
+          :quota_unblocking_events,
+          :quota_unsuspension_events,
         ].freeze
 
         DEFAULT_INCLUDES = %w[
+          measurement_unit
           quota_order_number
           quota_balance_events
           quota_critical_events
@@ -55,7 +57,7 @@ module Api
               quota_order_number_id: params[:quota_order_number_id],
               quota_definition_sid: params[:id],
             )
-            .eager(DEFAULT_EAGER_LOAD_GRAPH)
+            .eager(*DEFAULT_EAGER_LOAD_GRAPH)
             .take
         end
 

--- a/app/models/quota_definition.rb
+++ b/app/models/quota_definition.rb
@@ -79,6 +79,10 @@ class QuotaDefinition < Sequel::Model
 
   delegate :description, :abbreviation, to: :measurement_unit, prefix: true, allow_nil: true
 
+  def measurement_unit_id
+    measurement_unit_code
+  end
+
   def formatted_measurement_unit
     "#{measurement_unit_description} (#{measurement_unit_abbreviation})" if measurement_unit_description.present?
   end

--- a/app/serializers/api/admin/quota_order_numbers/measurement_unit_serializer.rb
+++ b/app/serializers/api/admin/quota_order_numbers/measurement_unit_serializer.rb
@@ -1,13 +1,12 @@
 module Api
-  module V2
-    module Measures
+  module Admin
+    module QuotaOrderNumbers
       class MeasurementUnitSerializer
         include JSONAPI::Serializer
 
-        set_id :measurement_unit_code
         set_type :measurement_unit
 
-        attributes :description, :measurement_unit_code
+        attributes :description, :measurement_unit_code, :abbreviation
       end
     end
   end

--- a/app/serializers/api/admin/quota_order_numbers/quota_definition_serializer.rb
+++ b/app/serializers/api/admin/quota_order_numbers/quota_definition_serializer.rb
@@ -14,10 +14,10 @@ module Api
                    :quota_order_number_id,
                    :quota_type,
                    :critical_state,
-                   :critical_threshold
+                   :critical_threshold,
+                   :formatted_measurement_unit
 
-        attribute :measurement_unit, &:formatted_measurement_unit
-
+        has_one :measurement_unit, serializer: Api::Admin::QuotaOrderNumbers::MeasurementUnitSerializer
         has_one :quota_order_number, serializer: Api::Admin::QuotaOrderNumbers::QuotaOrderNumberSerializer
         has_many :quota_balance_events, serializer: Api::Admin::QuotaOrderNumbers::QuotaBalanceEventSerializer
         has_many :quota_order_number_origins, serializer: Api::Admin::QuotaOrderNumbers::QuotaOrderNumberOriginSerializer

--- a/spec/serializers/api/admin/quota_order_numbers/measurement_unit_serializer_spec.rb
+++ b/spec/serializers/api/admin/quota_order_numbers/measurement_unit_serializer_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Api::Admin::QuotaOrderNumbers::MeasurementUnitSerializer do
+  describe '#serializable_hash' do
+    subject(:serialized) { described_class.new(serializable).serializable_hash }
+
+    let(:serializable) { create(:measurement_unit, :with_description) }
+
+    let(:expected) do
+      {
+        data: {
+          id: serializable.measurement_unit_code,
+          type: eq(:measurement_unit),
+          attributes: {
+            description: be_a(String),
+            measurement_unit_code: be_a(String),
+            abbreviation: be_a(String),
+          },
+        },
+      }
+    end
+
+    it { is_expected.to include_json(expected) }
+  end
+end

--- a/spec/serializers/api/admin/quota_order_numbers/quota_definition_serializer_spec.rb
+++ b/spec/serializers/api/admin/quota_order_numbers/quota_definition_serializer_spec.rb
@@ -17,9 +17,10 @@ RSpec.describe Api::Admin::QuotaOrderNumbers::QuotaDefinitionSerializer do
             quota_type: 'First Come First Served',
             critical_state: 'N',
             critical_threshold: serializable.critical_threshold,
-            measurement_unit: nil,
+            formatted_measurement_unit: nil,
           },
           relationships: {
+            measurement_unit: { data: { id: serializable.measurement_unit_id, type: eq(:measurement_unit) } },
             quota_order_number: { data: { id: serializable.quota_order_number_id, type: eq(:quota_order_number) } },
             quota_balance_events: { data: [] },
             quota_order_number_origins: { data: [] },


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2980

![image](https://user-images.githubusercontent.com/8156884/230073134-e2b85917-390e-4dbe-a64f-d9f9e3ed52e8.png)

### What?

I have added/removed/altered:

- [x] Added measurement_unit with abbreviation to quota definition response
- [x] Added test coverage

### Why?

I am doing this because:

- This is required to show consistent abbreviations in the UI of the admin area
