### PR TITLE
HOTT-2643 Use nested set for headings

### DIFF
--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -272,6 +272,10 @@ module TradeTariffBackend
       ENV['NESTED_SET_SUBHEADINGS'] == 'true'
     end
 
+    def nested_set_headings?
+      ENV['NESTED_SET_HEADINGS'] == 'true'
+    end
+
     def beta_search_max_hits
       ENV['BETA_SEARCH_MAX_HITS']
     end

--- a/app/presenters/api/v2/headings/chapter_presenter.rb
+++ b/app/presenters/api/v2/headings/chapter_presenter.rb
@@ -1,6 +1,6 @@
 module Api
   module V2
-    module Subheadings
+    module Headings
       class ChapterPresenter < SimpleDelegator
         def chapter_note
           super&.content

--- a/app/presenters/api/v2/headings/commodity_presenter.rb
+++ b/app/presenters/api/v2/headings/commodity_presenter.rb
@@ -9,7 +9,9 @@ module Api
         end
 
         def parent_sid
-          ns_parent&.goods_nomenclature_sid if depth > 3
+          if ns_parent.is_a?(Commodity) || ns_parent.is_a?(Subheading)
+            ns_parent.goods_nomenclature_sid
+          end
         end
 
         def overview_measures

--- a/app/presenters/api/v2/headings/commodity_presenter.rb
+++ b/app/presenters/api/v2/headings/commodity_presenter.rb
@@ -1,6 +1,6 @@
 module Api
   module V2
-    module Subheadings
+    module Headings
       class CommodityPresenter < SimpleDelegator
         class << self
           def wrap(commodities)

--- a/app/presenters/api/v2/headings/heading_presenter.rb
+++ b/app/presenters/api/v2/headings/heading_presenter.rb
@@ -2,6 +2,8 @@ module Api
   module V2
     module Headings
       class HeadingPresenter < SimpleDelegator
+        delegate :id, to: :section, prefix: true
+
         def chapter_id
           chapter.goods_nomenclature_sid
         end
@@ -11,11 +13,12 @@ module Api
         end
 
         def section
-          SectionPresenter.new(super)
+          SectionPresenter.new(chapter.section)
         end
 
         def chapter
-          ChapterPresenter.new(super)
+          @chapter ||= \
+            ChapterPresenter.new(ns_ancestors.find { |a| a.is_a? Chapter })
         end
 
         def commodities

--- a/app/presenters/api/v2/headings/heading_presenter.rb
+++ b/app/presenters/api/v2/headings/heading_presenter.rb
@@ -1,0 +1,31 @@
+module Api
+  module V2
+    module Headings
+      class HeadingPresenter < SimpleDelegator
+        def chapter_id
+          chapter.goods_nomenclature_sid
+        end
+
+        def footnote_ids
+          footnotes.map(&:footnote_id)
+        end
+
+        def section
+          SectionPresenter.new(super)
+        end
+
+        def chapter
+          ChapterPresenter.new(super)
+        end
+
+        def commodities
+          @commodities ||= CommodityPresenter.wrap(ns_descendants)
+        end
+
+        def commodity_ids
+          commodities.map(&:goods_nomenclature_sid)
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/api/v2/headings/section_presenter.rb
+++ b/app/presenters/api/v2/headings/section_presenter.rb
@@ -1,6 +1,6 @@
 module Api
   module V2
-    module Subheadings
+    module Headings
       class SectionPresenter < SimpleDelegator
         def section_note
           super&.content

--- a/app/presenters/api/v2/subheadings/subheading_presenter.rb
+++ b/app/presenters/api/v2/subheadings/subheading_presenter.rb
@@ -2,6 +2,8 @@ module Api
   module V2
     module Subheadings
       class SubheadingPresenter < SimpleDelegator
+        delegate :id, to: :section, prefix: true
+
         def footnote_ids
           footnotes.map(&:id)
         end
@@ -33,11 +35,20 @@ module Api
         end
 
         def section
-          Headings::SectionPresenter.new(super)
+          Headings::SectionPresenter.new(chapter.section)
         end
 
         def chapter
-          Headings::ChapterPresenter.new(super)
+          @chapter ||= \
+            Headings::ChapterPresenter.new(ns_ancestors.find { |a| a.is_a? Chapter })
+        end
+
+        def heading
+          @heading ||= ns_ancestors.find { |a| a.is_a? Heading }
+        end
+
+        def number_indents
+          ns_number_indents
         end
       end
     end

--- a/app/presenters/api/v2/subheadings/subheading_presenter.rb
+++ b/app/presenters/api/v2/subheadings/subheading_presenter.rb
@@ -15,7 +15,7 @@ module Api
         end
 
         def commodities
-          @commodities ||= CommodityPresenter.wrap(ancestors + [self] + ns_descendants)
+          @commodities ||= Headings::CommodityPresenter.wrap(ancestors + [self] + ns_descendants)
         end
 
         def commodity_ids
@@ -33,11 +33,11 @@ module Api
         end
 
         def section
-          SectionPresenter.new(super)
+          Headings::SectionPresenter.new(super)
         end
 
         def chapter
-          ChapterPresenter.new(super)
+          Headings::ChapterPresenter.new(super)
         end
       end
     end

--- a/app/services/heading_service/heading_serialization_service.rb
+++ b/app/services/heading_service/heading_serialization_service.rb
@@ -1,5 +1,7 @@
 module HeadingService
   class HeadingSerializationService
+    delegate :nested_set_headings?, to: TradeTariffBackend
+
     def initialize(heading, actual_date, filters = {})
       @heading = heading
       @actual_date = actual_date
@@ -20,6 +22,9 @@ module HeadingService
       if heading.declarable?
         HeadingService::Serialization::DeclarableService
           .new(heading, filters)
+      elsif nested_set_headings?
+        HeadingService::Serialization::NsNondeclarableService
+          .new(heading)
       else
         HeadingService::Serialization::NondeclarableService
           .new(heading, actual_date)

--- a/app/services/heading_service/heading_serialization_service.rb
+++ b/app/services/heading_service/heading_serialization_service.rb
@@ -1,5 +1,7 @@
 module HeadingService
   class HeadingSerializationService
+    CACHE_VERSION = 'v1'.freeze
+
     delegate :nested_set_headings?, to: TradeTariffBackend
 
     def initialize(heading, actual_date, filters = {})
@@ -32,7 +34,9 @@ module HeadingService
     end
 
     def heading_cache_key
-      "heading-#{TradeTariffBackend.service}-#{heading.goods_nomenclature_sid}-#{actual_date}-#{heading.declarable?}-#{filters_hash}"
+      cache_key = "heading-#{TradeTariffBackend.service}-#{heading.goods_nomenclature_sid}-#{actual_date}-#{heading.declarable?}-#{filters_hash}"
+      cache_key += "-#{CACHE_VERSION}" if nested_set_headings?
+      cache_key
     end
 
     def filters_hash

--- a/app/services/heading_service/serialization/ns_nondeclarable_service.rb
+++ b/app/services/heading_service/serialization/ns_nondeclarable_service.rb
@@ -16,6 +16,42 @@ module HeadingService
         ],
       }.freeze
 
+      MEASURES_EAGER_LOAD = {
+        measure_components: {
+          duty_expression: :duty_expression_description,
+          measurement_unit: %i[measurement_unit_description
+                               measurement_unit_abbreviations],
+          monetary_unit: :monetary_unit_description,
+          measurement_unit_qualifier: [],
+        },
+        measure_type: %i[measure_type_description
+                         measure_type_series
+                         measure_type_series_description],
+        additional_code: [],
+      }.freeze
+
+      HEADING_EAGER_LOAD = [
+        :goods_nomenclature_descriptions,
+        {
+          footnotes: :footnote_descriptions,
+          ns_overview_measures: MEASURES_EAGER_LOAD,
+          ns_ancestors: [
+            :goods_nomenclature_descriptions,
+            {
+              ns_overview_measures: MEASURES_EAGER_LOAD,
+              footnotes: :footnote_descriptions,
+            },
+          ],
+          ns_descendants: [
+            :goods_nomenclature_descriptions,
+            {
+              ns_overview_measures: MEASURES_EAGER_LOAD,
+              footnotes: :footnote_descriptions,
+            },
+          ],
+        },
+      ].freeze
+
       attr_reader :heading
 
       delegate :serializable_hash, to: :serializer
@@ -27,12 +63,22 @@ module HeadingService
     private
 
       def presented_heading
-        Api::V2::Headings::HeadingPresenter.new(heading)
+        Api::V2::Headings::HeadingPresenter.new(eager_loaded_heading)
       end
 
       def serializer
         Api::V2::Headings::HeadingSerializer
           .new(presented_heading, OPTIONS)
+      end
+
+      def eager_loaded_heading
+        Heading.actual
+               .non_hidden
+               .where(goods_nomenclature_sid: heading.goods_nomenclature_sid)
+               .eager(*HEADING_EAGER_LOAD)
+               .limit(1)
+               .all
+               .first
       end
     end
   end

--- a/app/services/heading_service/serialization/ns_nondeclarable_service.rb
+++ b/app/services/heading_service/serialization/ns_nondeclarable_service.rb
@@ -1,5 +1,39 @@
 module HeadingService
   module Serialization
-    class NsNondeclarableService < NondeclarableService; end
+    class NsNondeclarableService
+      OPTIONS = {
+        is_collection: false,
+        include: [
+          :section,
+          :chapter,
+          'chapter.guides',
+          :footnotes,
+          :commodities,
+          'commodities.overview_measures',
+          'commodities.overview_measures.duty_expression',
+          'commodities.overview_measures.measure_type',
+          'commodities.overview_measures.additional_code',
+        ],
+      }.freeze
+
+      attr_reader :heading
+
+      delegate :serializable_hash, to: :serializer
+
+      def initialize(heading)
+        @heading = heading
+      end
+
+    private
+
+      def presented_heading
+        Api::V2::Headings::HeadingPresenter.new(heading)
+      end
+
+      def serializer
+        Api::V2::Headings::HeadingSerializer
+          .new(presented_heading, OPTIONS)
+      end
+    end
   end
 end

--- a/app/services/heading_service/serialization/ns_nondeclarable_service.rb
+++ b/app/services/heading_service/serialization/ns_nondeclarable_service.rb
@@ -1,0 +1,5 @@
+module HeadingService
+  module Serialization
+    class NsNondeclarableService < NondeclarableService; end
+  end
+end

--- a/spec/controllers/api/v2/headings_controller_spec.rb
+++ b/spec/controllers/api/v2/headings_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Api::V2::HeadingsController, type: :controller do
     let(:heading) do
       create(
         :heading,
+        :with_chapter,
         :non_grouping,
         :non_declarable,
         :with_description,

--- a/spec/controllers/api/v2/headings_controller_spec.rb
+++ b/spec/controllers/api/v2/headings_controller_spec.rb
@@ -18,116 +18,124 @@ RSpec.describe Api::V2::HeadingsController, type: :controller do
       allow(Rails.cache).to receive(:fetch).and_call_original
     end
 
-    it 'calls the Rails cache with the correct key' do
-      do_response
-
-      expected_hash = Digest::MD5.hexdigest('{}')
-
-      expect(Rails.cache).to have_received(:fetch).with(
-        "_heading-uk-#{heading.goods_nomenclature_sid}-#{Time.zone.today.iso8601}-false-#{expected_hash}",
-        { expires_in: 24.hours },
-      )
-    end
-
-    context 'when filtering by a specific geographical area' do
-      let(:filter) { { geographical_area_id: 'BR' } }
-
+    shared_examples 'a heading json response' do
       it 'calls the Rails cache with the correct key' do
         do_response
 
-        expected_hash = Digest::MD5.hexdigest(filter.to_json)
+        expected_hash = Digest::MD5.hexdigest('{}')
 
         expect(Rails.cache).to have_received(:fetch).with(
           "_heading-uk-#{heading.goods_nomenclature_sid}-#{Time.zone.today.iso8601}-false-#{expected_hash}",
           { expires_in: 24.hours },
         )
       end
-    end
 
-    context 'when the heading does not exist' do
-      let(:id) { heading.short_code.next }
+      context 'when filtering by a specific geographical area' do
+        let(:filter) { { geographical_area_id: 'BR' } }
 
-      it { expect(do_response).to have_http_status(:not_found) }
-    end
+        it 'calls the Rails cache with the correct key' do
+          do_response
 
-    context 'when the heading is not declarable' do
-      before { chapter }
+          expected_hash = Digest::MD5.hexdigest(filter.to_json)
 
-      let(:heading) do
-        create(
-          :heading,
-          :non_grouping,
-          :non_declarable,
-          :with_description,
-        )
-      end
-
-      let(:chapter) do
-        create(
-          :chapter,
-          :with_section, :with_description,
-          goods_nomenclature_item_id: heading.chapter_id
-        )
-      end
-
-      context 'when record is present' do
-        let(:pattern) do
-          {
-            data: {
-              id: String,
-              type: String,
-              attributes: {
-                goods_nomenclature_item_id: heading.code,
-                description: String,
-              }.ignore_extra_keys!,
-              relationships: {
-                commodities: Hash,
-                chapter: Hash,
-              }.ignore_extra_keys!,
-            }.ignore_extra_keys!,
-          }.ignore_extra_keys!
-        end
-
-        it { expect(do_response.body).to match_json_expression(pattern) }
-      end
-
-      context 'when heading is present and commodity has hidden commodities' do
-        let(:heading) { create(:heading, :non_declarable, :with_description) }
-
-        let(:hidden_commodity) do
-          create(
-            :commodity,
-            :with_description,
-            goods_nomenclature_item_id: "#{heading.short_code}020000",
+          expect(Rails.cache).to have_received(:fetch).with(
+            "_heading-uk-#{heading.goods_nomenclature_sid}-#{Time.zone.today.iso8601}-false-#{expected_hash}",
+            { expires_in: 24.hours },
           )
         end
-
-        let(:hidden_goods_nomenclature) do
-          create(
-            :hidden_goods_nomenclature,
-            goods_nomenclature_item_id: hidden_commodity.goods_nomenclature_item_id,
-          )
-        end
-
-        before do
-          hidden_goods_nomenclature
-        end
-
-        it 'does not return the hidden commodity' do
-          parsed_body = JSON.parse(do_response.body)
-          resources = parsed_body['included']
-          commodities = resources.select { |resource| resource['type'] == 'commodity' }
-          actual_commodity_codes = commodities.map { |commodity| commodity['attributes']['goods_nomenclature_item_id'] }
-
-          expect(actual_commodity_codes).not_to include(hidden_goods_nomenclature.goods_nomenclature_item_id)
-        end
       end
 
-      context 'when the record is not present' do
+      context 'when the heading does not exist' do
         let(:id) { heading.short_code.next }
 
         it { expect(do_response).to have_http_status(:not_found) }
       end
+
+      context 'when the heading is not declarable' do
+        before { chapter }
+
+        let(:heading) do
+          create(
+            :heading,
+            :non_grouping,
+            :non_declarable,
+            :with_description,
+          )
+        end
+
+        let(:chapter) do
+          create(
+            :chapter,
+            :with_section, :with_description,
+            goods_nomenclature_item_id: heading.chapter_id
+          )
+        end
+
+        context 'when record is present' do
+          let(:pattern) do
+            {
+              data: {
+                id: String,
+                type: String,
+                attributes: {
+                  goods_nomenclature_item_id: heading.code,
+                  description: String,
+                }.ignore_extra_keys!,
+                relationships: {
+                  commodities: Hash,
+                  chapter: Hash,
+                }.ignore_extra_keys!,
+              }.ignore_extra_keys!,
+            }.ignore_extra_keys!
+          end
+
+          it { expect(do_response.body).to match_json_expression(pattern) }
+        end
+
+        context 'when heading is present and commodity has hidden commodities' do
+          let(:heading) { create(:heading, :non_declarable, :with_description) }
+
+          let(:hidden_commodity) do
+            create(
+              :commodity,
+              :hidden,
+              :with_description,
+              goods_nomenclature_item_id: "#{heading.short_code}020000",
+            )
+          end
+
+          it 'does not return the hidden commodity' do
+            parsed_body = JSON.parse(do_response.body)
+            resources = parsed_body['included']
+            commodities = resources.select { |resource| resource['type'] == 'commodity' }
+            actual_commodity_codes = commodities.map { |commodity| commodity['attributes']['goods_nomenclature_item_id'] }
+
+            expect(actual_commodity_codes).not_to include(hidden_commodity.goods_nomenclature_item_id)
+          end
+        end
+
+        context 'when the record is not present' do
+          let(:id) { heading.short_code.next }
+
+          it { expect(do_response).to have_http_status(:not_found) }
+        end
+      end
+    end
+
+    context 'with opensearch backed headings data' do
+      before do
+        allow(TradeTariffBackend).to receive(:nested_set_headings?).and_return false
+      end
+
+      it_behaves_like 'a heading json response'
+    end
+
+    context 'with nested set derived headings data' do
+      before do
+        allow(TradeTariffBackend).to receive(:nested_set_headings?).and_return true
+      end
+
+      it_behaves_like 'a heading json response'
     end
 
     context 'when the heading is declarable' do

--- a/spec/controllers/api/v2/headings_controller_spec.rb
+++ b/spec/controllers/api/v2/headings_controller_spec.rb
@@ -24,9 +24,10 @@ RSpec.describe Api::V2::HeadingsController, type: :controller do
         do_response
 
         expected_hash = Digest::MD5.hexdigest('{}')
+        cache_suffix = TradeTariffBackend.nested_set_headings? ? '-v1' : ''
 
         expect(Rails.cache).to have_received(:fetch).with(
-          "_heading-uk-#{heading.goods_nomenclature_sid}-#{Time.zone.today.iso8601}-false-#{expected_hash}",
+          "_heading-uk-#{heading.goods_nomenclature_sid}-#{Time.zone.today.iso8601}-false-#{expected_hash}#{cache_suffix}",
           { expires_in: 24.hours },
         )
       end
@@ -38,9 +39,10 @@ RSpec.describe Api::V2::HeadingsController, type: :controller do
           do_response
 
           expected_hash = Digest::MD5.hexdigest(filter.to_json)
+          cache_suffix = TradeTariffBackend.nested_set_headings? ? '-v1' : ''
 
           expect(Rails.cache).to have_received(:fetch).with(
-            "_heading-uk-#{heading.goods_nomenclature_sid}-#{Time.zone.today.iso8601}-false-#{expected_hash}",
+            "_heading-uk-#{heading.goods_nomenclature_sid}-#{Time.zone.today.iso8601}-false-#{expected_hash}#{cache_suffix}",
             { expires_in: 24.hours },
           )
         end

--- a/spec/factories/heading_factory.rb
+++ b/spec/factories/heading_factory.rb
@@ -16,10 +16,7 @@ FactoryBot.define do
 
     trait :non_declarable do
       after(:create) do |heading, _evaluator|
-        create(:goods_nomenclature,
-               :with_description,
-               :with_indent,
-               goods_nomenclature_item_id: "#{heading.short_code}#{6.times.map { Random.rand(9) }.join}")
+        create(:commodity, :with_description, parent: heading)
       end
     end
 

--- a/spec/presenters/api/v2/headings/chapter_presenter_spec.rb
+++ b/spec/presenters/api/v2/headings/chapter_presenter_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Api::V2::Subheadings::ChapterPresenter do
+RSpec.describe Api::V2::Headings::ChapterPresenter do
   subject(:presenter) { described_class.new chapter }
 
   let(:chapter) { create :chapter, :with_note }

--- a/spec/presenters/api/v2/headings/commodity_presenter_spec.rb
+++ b/spec/presenters/api/v2/headings/commodity_presenter_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Api::V2::Subheadings::CommodityPresenter do
+RSpec.describe Api::V2::Headings::CommodityPresenter do
   subject(:presenter) { described_class.new commodity }
 
   let(:commodity) { create :commodity }

--- a/spec/presenters/api/v2/headings/heading_presenter_spec.rb
+++ b/spec/presenters/api/v2/headings/heading_presenter_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Api::V2::Headings::HeadingPresenter do
+  subject(:presenter) { described_class.new heading }
+
+  let(:heading) { create :heading, :with_chapter, :non_declarable }
+
+  it { is_expected.to have_attributes goods_nomenclature_sid: heading.goods_nomenclature_sid }
+  it { is_expected.to have_attributes section_id: heading.section.id }
+  it { is_expected.to have_attributes chapter_id: heading.chapter.goods_nomenclature_sid }
+  it { is_expected.to have_attributes section: instance_of(Api::V2::Headings::SectionPresenter) }
+  it { is_expected.to have_attributes chapter: instance_of(Api::V2::Headings::ChapterPresenter) }
+
+  it 'maps commodities to their presenter' do
+    expect(presenter.commodities).to all be_instance_of Api::V2::Headings::CommodityPresenter
+  end
+
+  describe '#footnote_ids' do
+    let :heading do
+      create :heading, :with_chapter, :with_children, :with_footnote_association
+    end
+
+    it { is_expected.to have_attributes footnote_ids: heading.footnotes.map(&:footnote_id) }
+  end
+end

--- a/spec/presenters/api/v2/headings/heading_presenter_spec.rb
+++ b/spec/presenters/api/v2/headings/heading_presenter_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Api::V2::Headings::HeadingPresenter do
   let(:heading) { create :heading, :with_chapter, :non_declarable }
 
   it { is_expected.to have_attributes goods_nomenclature_sid: heading.goods_nomenclature_sid }
-  it { is_expected.to have_attributes section_id: heading.section.id }
+  it { is_expected.to have_attributes section_id: heading.chapter.section.id }
   it { is_expected.to have_attributes chapter_id: heading.chapter.goods_nomenclature_sid }
   it { is_expected.to have_attributes section: instance_of(Api::V2::Headings::SectionPresenter) }
   it { is_expected.to have_attributes chapter: instance_of(Api::V2::Headings::ChapterPresenter) }

--- a/spec/presenters/api/v2/headings/section_presenter_spec.rb
+++ b/spec/presenters/api/v2/headings/section_presenter_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Api::V2::Subheadings::SectionPresenter do
+RSpec.describe Api::V2::Headings::SectionPresenter do
   subject(:presenter) { described_class.new section }
 
   let(:section) { create :section, :with_note }

--- a/spec/presenters/api/v2/subheadings/subheading_presenter_spec.rb
+++ b/spec/presenters/api/v2/subheadings/subheading_presenter_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Api::V2::Subheadings::SubheadingPresenter do
   let(:subheading) { create :subheading, :with_chapter_and_heading, :with_children }
 
   it { is_expected.to have_attributes goods_nomenclature_sid: subheading.goods_nomenclature_sid }
+  it { is_expected.to have_attributes section_id: subheading.chapter.section.id }
   it { is_expected.to have_attributes heading_id: subheading.heading.goods_nomenclature_sid }
   it { is_expected.to have_attributes chapter_id: subheading.chapter.goods_nomenclature_sid }
   it { is_expected.to have_attributes section: instance_of(Api::V2::Headings::SectionPresenter) }

--- a/spec/presenters/api/v2/subheadings/subheading_presenter_spec.rb
+++ b/spec/presenters/api/v2/subheadings/subheading_presenter_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Api::V2::Subheadings::SubheadingPresenter do
   it { is_expected.to have_attributes goods_nomenclature_sid: subheading.goods_nomenclature_sid }
   it { is_expected.to have_attributes heading_id: subheading.heading.goods_nomenclature_sid }
   it { is_expected.to have_attributes chapter_id: subheading.chapter.goods_nomenclature_sid }
-  it { is_expected.to have_attributes section: instance_of(Api::V2::Subheadings::SectionPresenter) }
-  it { is_expected.to have_attributes chapter: instance_of(Api::V2::Subheadings::ChapterPresenter) }
+  it { is_expected.to have_attributes section: instance_of(Api::V2::Headings::SectionPresenter) }
+  it { is_expected.to have_attributes chapter: instance_of(Api::V2::Headings::ChapterPresenter) }
   it { is_expected.to have_attributes ancestors: [] }
 
   it 'includes ancestors and self in commodities' do
@@ -19,7 +19,7 @@ RSpec.describe Api::V2::Subheadings::SubheadingPresenter do
   end
 
   it 'maps commodities to their presenter' do
-    expect(presenter.commodities).to all be_instance_of Api::V2::Subheadings::CommodityPresenter
+    expect(presenter.commodities).to all be_instance_of Api::V2::Headings::CommodityPresenter
   end
 
   context 'for subsubheading' do


### PR DESCRIPTION
### Jira link

HOTT-2643 Use Nested set for headings

### What?

I have added/removed/altered:

- [x] Added an additional serialization service for non-declarable headings which utilises nested set
- [x] Refactored specs to run them against both nested set and pre-existing serialization services
- [x] Moved the headings related presenters under the Headings namespace
- [x] Use a separate cache key for cached nested set headings
- [x] Fixes incomplete serialization of measure types

### Why?

I am doing this because:

- It removes the reliance upon the headings getting cached into opensearch everynight
- It will significantly ease working on headings api
- We can precache both headings and subheadings in a signle job (this will come in a later PR)

### Deployment risks (optional)

- Low, feature flagged but when the flag is on this is a significant change to the code base
