### PR TITLE
HOTT-2989: Surface null additional codes

### DIFF
--- a/app/models/additional_code.rb
+++ b/app/models/additional_code.rb
@@ -69,8 +69,8 @@ class AdditionalCode < Sequel::Model
     def additional_codes
       @additional_codes ||=
         begin
-          file = File.join(::Rails.root, 'db', 'additional_codes.json').freeze
-          JSON.parse(File.read(file))
+          file_path = Rails.root.join('db/additional_codes.json').freeze
+          JSON.parse(File.read(file_path))
         end
     end
   end

--- a/app/models/additional_code.rb
+++ b/app/models/additional_code.rb
@@ -61,11 +61,17 @@ class AdditionalCode < Sequel::Model
     UNKNOWN_TYPE
   end
 
-  def self.additional_codes
-    @additional_codes ||=
-      begin
-        file = File.join(::Rails.root, 'db', 'additional_codes.json').freeze
-        JSON.parse(File.read(file))
-      end
+  class << self
+    def null_code
+      OpenStruct.new(code: 'none', description: 'No additional code')
+    end
+
+    def additional_codes
+      @additional_codes ||=
+        begin
+          file = File.join(::Rails.root, 'db', 'additional_codes.json').freeze
+          JSON.parse(File.read(file))
+        end
+    end
   end
 end

--- a/app/models/additional_code.rb
+++ b/app/models/additional_code.rb
@@ -66,6 +66,20 @@ class AdditionalCode < Sequel::Model
       OpenStruct.new(code: 'none', description: 'No additional code')
     end
 
+    def heading_for(type)
+      additional_codes.dig('headings', type)
+    end
+
+    def override_for(code)
+      overrides_for(code).dup
+    end
+
+    private
+
+    def overrides_for(code)
+      additional_codes.dig('code_overrides', code) || {}
+    end
+
     def additional_codes
       @additional_codes ||=
         begin

--- a/app/services/applicable_additional_code_service.rb
+++ b/app/services/applicable_additional_code_service.rb
@@ -23,7 +23,7 @@ class ApplicableAdditionalCodeService
 
       acc[measure_type_id] = {} if acc[measure_type_id].blank?
       acc[measure_type_id]['measure_type_description'] = measure&.measure_type&.description
-      acc[measure_type_id]['heading'] = heading_annotations_for(measure.additional_code.type)
+      acc[measure_type_id]['heading'] = heading_for(measure.additional_code.type)
       acc[measure_type_id]['additional_codes'] = [] if acc[measure_type_id]['additional_codes'].blank?
       acc[measure_type_id]['additional_codes'] << code_annotations_for(measure)
     end
@@ -44,23 +44,23 @@ class ApplicableAdditionalCodeService
   end
 
   def code_annotations_for(measure)
-    additional_code = measure.additional_code.presence || AdditionalCode.null_code
-    overriding_annotation = AdditionalCode.additional_codes['code_overrides'][additional_code.code]
+    additional_code = measure.additional_code.presence || null_code
+    overriding_annotation = override_for(additional_code.code)
 
     if overriding_annotation.present?
       overriding_annotation['measure_sid'] = measure.measure_sid
+      overriding_annotation['geographical_area_id'] = measure.geographical_area_id
       overriding_annotation
     else
       {
         'code' => additional_code.code,
         'overlay' => additional_code.description,
         'hint' => '',
+        'geographical_area_id' => measure.geographical_area_id,
         'measure_sid' => measure.measure_sid,
       }
     end
   end
 
-  def heading_annotations_for(type)
-    AdditionalCode.additional_codes['headings'][type]
-  end
+  delegate :heading_for, :override_for, :null_code, to: AdditionalCode
 end

--- a/db/additional_codes.json
+++ b/db/additional_codes.json
@@ -1,5 +1,10 @@
 {
   "code_overrides": {
+    "none": {
+      "code": "none",
+      "overlay": "Select no additional code",
+      "hint": ""
+    },
     "2600": {
       "code": "2600",
       "overlay": "The product I am importing is COVID-19 critical",

--- a/spec/models/additional_code_spec.rb
+++ b/spec/models/additional_code_spec.rb
@@ -10,6 +10,13 @@ RSpec.describe AdditionalCode do
 
   describe 'associations' do
     describe 'additional code description' do
+      before do
+        create :additional_code_description, :with_period,
+               additional_code_sid: additional_code.additional_code_sid,
+               valid_at: 6.years.ago.beginning_of_day,
+               valid_to: 1.year.ago.beginning_of_day
+      end
+
       let!(:additional_code)                { create :additional_code }
       let!(:additional_code_description1)   do
         create :additional_code_description, :with_period,
@@ -23,14 +30,8 @@ RSpec.describe AdditionalCode do
                valid_at: 5.years.ago.beginning_of_day,
                valid_to: 3.years.ago.beginning_of_day
       end
-      let!(:additional_code_description3) do
-        create :additional_code_description, :with_period,
-               additional_code_sid: additional_code.additional_code_sid,
-               valid_at: 6.years.ago.beginning_of_day,
-               valid_to: 1.year.ago.beginning_of_day
-      end
 
-      context 'direct loading' do
+      context 'when direct loading' do
         it 'loads correct description respecting given actual time' do
           TimeMachine.now do
             expect(
@@ -48,7 +49,7 @@ RSpec.describe AdditionalCode do
         end
       end
 
-      context 'eager loading' do
+      context 'when eager loading' do
         it 'loads correct description respecting given actual time' do
           TimeMachine.now do
             expect(

--- a/spec/models/additional_code_spec.rb
+++ b/spec/models/additional_code_spec.rb
@@ -125,4 +125,9 @@ RSpec.describe AdditionalCode do
       it { is_expected.to be_applicable }
     end
   end
+
+  describe '.null_code' do
+    it { expect(described_class.null_code.code).to eq('none') }
+    it { expect(described_class.null_code.description).to eq('No additional code') }
+  end
 end

--- a/spec/models/additional_code_spec.rb
+++ b/spec/models/additional_code_spec.rb
@@ -131,4 +131,36 @@ RSpec.describe AdditionalCode do
     it { expect(described_class.null_code.code).to eq('none') }
     it { expect(described_class.null_code.description).to eq('No additional code') }
   end
+
+  describe '.heading_for' do
+    subject(:heading) { described_class.heading_for(type) }
+
+    context 'when there is a heading for the given code' do
+      let(:type) { 'remedy' }
+
+      it { expect(heading.keys).to include('hint', 'overlay') }
+    end
+
+    context 'when there is no heading for the given code' do
+      let(:type) { 'foo' }
+
+      it { expect(heading).to be_nil }
+    end
+  end
+
+  describe '.annotation_for' do
+    subject(:annotations) { described_class.override_for(additional_code) }
+
+    context 'when there are ovverides for the given code' do
+      let(:additional_code) { '2600' }
+
+      it { expect(annotations).to include('code' => '2600') }
+    end
+
+    context 'when there are no ovverides for the given code' do
+      let(:additional_code) { 'foo' }
+
+      it { expect(annotations).to eq({}) }
+    end
+  end
 end

--- a/spec/services/applicable_additional_code_service_spec.rb
+++ b/spec/services/applicable_additional_code_service_spec.rb
@@ -4,16 +4,7 @@ RSpec.describe ApplicableAdditionalCodeService do
   describe '#call' do
     context 'when the measures have additional codes' do
       let(:measures) do
-        [
-          measure,
-          duplicate_measure,
-          measure_with_same_measure_and_code_type,
-          measure_with_different_measure_and_code_type,
-          measure_without_additional_code,
-        ]
-      end
-      let(:measure) do
-        create(
+        measure = create(
           :measure,
           :with_additional_code,
           :with_measure_type,
@@ -21,9 +12,7 @@ RSpec.describe ApplicableAdditionalCodeService do
           additional_code_type_id: '2',
           additional_code: '550',
         )
-      end
-      let(:duplicate_measure) do
-        create(
+        duplicate_measure = create(
           :measure,
           :with_additional_code,
           :with_measure_type,
@@ -32,9 +21,7 @@ RSpec.describe ApplicableAdditionalCodeService do
           additional_code: '550',
           measure_sid: measure.measure_sid,
         )
-      end
-      let(:measure_with_same_measure_and_code_type) do
-        create(
+        measure_with_same_measure_and_code_type = create(
           :measure,
           :with_additional_code,
           :with_measure_type,
@@ -42,59 +29,67 @@ RSpec.describe ApplicableAdditionalCodeService do
           additional_code_type_id: '2',
           additional_code: '551',
         )
-      end
-      let(:measure_with_different_measure_and_code_type) do
-        create(
+        measure_with_different_measure_and_code_type = create(
           :measure,
           :with_additional_code,
           :with_measure_type,
           measure_type_id: '103',
           additional_code_type_id: '8',
         )
-      end
-      let(:measure_without_additional_code) do
-        create(
+        measure_without_additional_code = create(
           :measure,
           :with_measure_type,
           measure_type_id: '103',
         )
+        [
+          measure,
+          duplicate_measure,
+          measure_with_same_measure_and_code_type,
+          measure_with_different_measure_and_code_type,
+          measure_without_additional_code,
+        ]
       end
-
       let(:expected_additional_codes) do
         {
           '105' => {
-            'measure_type_description' => be_a(String),
+            'measure_type_description' => be_present,
             'heading' => {
-              'overlay' => 'Describe your goods in more detail',
-              'hint' => 'To trade this commodity, you need to specify an additional 4 digits, known as an additional code',
+              'overlay' => be_present,
+              'hint' => be_present,
             },
             'additional_codes' => [
               {
                 'code' => '2550',
-                'overlay' => 'Imported by sea and arriving via the Atlantic Ocean or the Suez canal with the port of unloading on the Mediterranean Sea or on the Black Sea',
+                'overlay' => be_present,
                 'hint' => '',
-                'measure_sid' => measure.measure_sid,
+                'measure_sid' => be_a(Integer),
               },
               {
                 'code' => '2551',
-                'overlay' => 'Imported by sea and arriving via the Atlantic Ocean or the Suez canal with the port of unloading on the Mediterranean Sea or on the Black Sea',
+                'overlay' => be_present,
                 'hint' => '',
-                'measure_sid' => measure_with_same_measure_and_code_type.measure_sid,
+                'measure_sid' => be_a(Integer),
               },
             ],
           },
           '103' => {
-            'measure_type_description' => be_a(String),
+            'measure_type_description' => be_present,
             'heading' => {
-              'overlay' => 'From which company are you buying these goods?',
-              'hint' => 'Additional duties are levied against imports from certain companies in the form of anti-dumping or anti-subsidy duties.',
+              'overlay' => be_present,
+              'hint' => be_present,
             },
             'additional_codes' => [
               {
-                'code' => match(/\A8.{3}\z/),
-                'overlay' => be_a(String),
-                'hint' => be_empty,
-                'measure_sid' => measure_with_different_measure_and_code_type.measure_sid,
+                'code' => be_present,
+                'overlay' => be_present,
+                'hint' => '',
+                'measure_sid' => be_a(Integer),
+              },
+              {
+                'code' => 'none',
+                'overlay' => 'Select no additional code',
+                'hint' => '',
+                'measure_sid' => be_a(Integer),
               },
             ],
           },


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2989

### What?

I have added/removed/altered:

- [x] Added support for surfacing none additional codes

### Why?

I am doing this because:

- This enables the duty calculator to filter these if the user picks not to use one of the borked additional codes
