### PR TITLE
Revert using self-hosted cf binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,26 +9,6 @@ orbs:
   tariff: trade-tariff/trade-tariff-ci-orb@0 # can also change to @dev:<gitsha> for specific version or @dev:alpha to test dev branches
 
 commands:
-  cf-install:
-    parameters:
-      space:
-        type: string
-      version:
-        type: string
-        default: "7.6.0"
-    steps:
-      - run:
-          name: "Setup CF CLI"
-          command: |
-            curl -L -o cf.deb --retry 3 'https://trade-tariff-hosted-binaries.s3.eu-west-2.amazonaws.com/cf7-cli-installer_7.4.0_x86-64.deb'
-            sudo dpkg -i cf.deb
-            cf -v
-            cf api "$CF_ENDPOINT"
-            cf auth "$CF_USER" "$CF_PASSWORD"
-            cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
-            cf install-plugin app-autoscaler-plugin -r CF-Community -f
-            cf target -o "$CF_ORG" -s "<< parameters.space >>"
-
   cf_deploy_docker:
     parameters:
       docker_image_tag:
@@ -43,8 +23,7 @@ commands:
         type: string
     steps:
       - checkout
-      - aws-cli/install
-      - cf-install:
+      - tariff/cf-install:
           space: << parameters.space >>
           version: "7.6.0"
       - run:
@@ -153,8 +132,7 @@ commands:
         type: string
     steps:
       - checkout
-      - aws-cli/install
-      - cf-install:
+      - tariff/cf-install:
           space: << parameters.space >>
           version: "7.6.0"
       - run:
@@ -180,8 +158,7 @@ commands:
         type: string
     steps:
       - checkout
-      - aws-cli/install
-      - cf-install:
+      - tariff/cf-install:
           space: << parameters.space >>
           version: "7.6.0"
       - run:
@@ -277,8 +254,7 @@ jobs:
       - image: cimg/base:current-22.04
     steps:
       - checkout
-      - aws-cli/install
-      - cf-install:
+      - tariff/cf-install:
           space: << parameters.from_environment_key >>
           version: "7.6.0"
       - run:
@@ -308,7 +284,7 @@ jobs:
     steps:
       - checkout
       - aws-cli/install
-      - cf-install:
+      - tariff/cf-install:
           space: << parameters.space >>
           version: "7.6.0"
       - run:
@@ -348,8 +324,7 @@ jobs:
       - image: cimg/base:current-22.04
     steps:
       - checkout
-      - aws-cli/install
-      - cf-install:
+      - tariff/cf-install:
           space: << parameters.from_environment_key >>
           version: "7.6.0"
       - run:


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Mostly revert https://github.com/trade-tariff/trade-tariff-backend/pull/1150

### Why?

I am doing this because:

- The original method of using a deb repo is now working since the User-Agent requirement is now skipped
