### PR TITLE
HOTT-2992 Fix footnote ids

### DIFF
--- a/app/presenters/api/v2/commodities/commodity_presenter.rb
+++ b/app/presenters/api/v2/commodities/commodity_presenter.rb
@@ -29,7 +29,7 @@ module Api
         end
 
         def footnote_ids
-          footnotes.map(&:footnote_id)
+          footnotes.map(&:id)
         end
 
         def import_measure_ids

--- a/app/presenters/api/v2/headings/declarable_heading_presenter.rb
+++ b/app/presenters/api/v2/headings/declarable_heading_presenter.rb
@@ -33,7 +33,7 @@ module Api
         end
 
         def footnote_ids
-          footnotes.map(&:footnote_id)
+          footnotes.map(&:id)
         end
 
         def chapter_id

--- a/app/presenters/api/v2/headings/heading_presenter.rb
+++ b/app/presenters/api/v2/headings/heading_presenter.rb
@@ -9,7 +9,7 @@ module Api
         end
 
         def footnote_ids
-          footnotes.map(&:footnote_id)
+          footnotes.map(&:id)
         end
 
         def section

--- a/app/serializers/api/v2/headings/footnote_serializer.rb
+++ b/app/serializers/api/v2/headings/footnote_serializer.rb
@@ -6,7 +6,7 @@ module Api
 
         set_type :footnote
 
-        set_id :footnote_id
+        set_id :id
 
         attributes :code, :description, :formatted_description
       end

--- a/spec/presenters/api/v2/headings/heading_presenter_spec.rb
+++ b/spec/presenters/api/v2/headings/heading_presenter_spec.rb
@@ -18,6 +18,6 @@ RSpec.describe Api::V2::Headings::HeadingPresenter do
       create :heading, :with_chapter, :with_children, :with_footnote_association
     end
 
-    it { is_expected.to have_attributes footnote_ids: heading.footnotes.map(&:footnote_id) }
+    it { is_expected.to have_attributes footnote_ids: heading.footnotes.map(&:id) }
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-2992

### What?

I have added/removed/altered:

- [x] Use full footnote id in Headings endpoints
- [x] Use full footnote id in Subheadings endpoint
- [x] Use full footnote id in Commodities

### Why?

I am doing this because:

- When using only the `Footnote#footnote_id` discreet footnotes which share a `footnote_id` but with a different `footnote_type_id` get deduplicated during serialization to jsonapi, eg so **PN001** and **TN001** will get deduplicated to a single foot note which is incorrect.
- The commodities endpoint actually used a mix of `Footnote#id` and `Footnote#footnote_id` for different footnotes further confusing things

### Deployment risks (optional)

- Changes the ids used for footnotes in the jsonapi response on major endpoints.
