### PR TITLE
HOTT-3029 Drop ns_number_indents

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -107,7 +107,9 @@ class GoodsNomenclature < Sequel::Model
   end
 
   def number_indents
-    if goods_nomenclature_indent.present?
+    if values.key?(:number_indents)
+      values[:number_indents]
+    elsif goods_nomenclature_indent.present?
       goods_nomenclature_indent.number_indents
     else
       reload && goods_nomenclature_indent&.number_indents

--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -24,6 +24,7 @@ module GoodsNomenclatures
         ds.order(:ancestor_nodes__position)
           .with_validity_dates(:ancestor_nodes)
           .select_append(:ancestor_nodes__depth)
+          .select_append(:ancestor_nodes__number_indents)
           .select_append(Sequel.as(false, :leaf))
           .join(Sequel.as(:goods_nomenclature_tree_nodes, :origin_nodes)) do |origin_table, ancestors_table, _join_clauses|
             ancestors = TreeNodeAlias.new(ancestors_table)
@@ -45,6 +46,7 @@ module GoodsNomenclatures
         ds.order(:parent_nodes__position)
           .with_validity_dates(:parent_nodes)
           .select_append(:parent_nodes__depth)
+          .select_append(:parent_nodes__number_indents)
           .select_append(Sequel.as(false, :leaf))
           .join(Sequel.as(:goods_nomenclature_tree_nodes, :origin_nodes)) do |origin_table, parents_table, _join_clauses|
             parents = TreeNodeAlias.new(parents_table)
@@ -68,6 +70,7 @@ module GoodsNomenclatures
           .order(:descendant_nodes__position)
           .with_validity_dates(:descendant_nodes)
           .select_append(:descendant_nodes__depth)
+          .select_append(:descendant_nodes__number_indents)
           .join(Sequel.as(:goods_nomenclature_tree_nodes, :origin_nodes)) do |origin_table, descendants_table, _join_clauses|
             descendants = TreeNodeAlias.new(descendants_table)
             origin      = TreeNodeAlias.new(origin_table)
@@ -89,6 +92,7 @@ module GoodsNomenclatures
           .order(:child_nodes__position)
           .with_validity_dates(:child_nodes)
           .select_append(:child_nodes__depth)
+          .select_append(:child_nodes__number_indents)
           .join(Sequel.as(:goods_nomenclature_tree_nodes, :origin_nodes)) do |origin_table, children_table, _join_clauses|
             children = TreeNodeAlias.new(children_table)
             origin   = TreeNodeAlias.new(origin_table)
@@ -179,16 +183,6 @@ module GoodsNomenclatures
 
     def ns_leaf?
       values.key?(:leaf) ? values[:leaf] : ns_children.empty?
-    end
-
-    def ns_number_indents
-      if !values.key?(:depth)
-        number_indents
-      elsif values[:depth] > 1
-        values[:depth] - 2
-      else
-        0
-      end
     end
 
     def applicable_measures

--- a/app/presenters/api/v2/headings/commodity_presenter.rb
+++ b/app/presenters/api/v2/headings/commodity_presenter.rb
@@ -31,10 +31,6 @@ module Api
         def declarable
           ns_declarable?
         end
-
-        def number_indents
-          ns_number_indents
-        end
       end
     end
   end

--- a/app/presenters/api/v2/subheadings/subheading_presenter.rb
+++ b/app/presenters/api/v2/subheadings/subheading_presenter.rb
@@ -25,9 +25,7 @@ module Api
         end
 
         def ancestors
-          @ancestors ||= ns_ancestors.select do |ancestor|
-            ancestor.ns_number_indents.positive?
-          end
+          @ancestors ||= ns_ancestors.select { |ancestor| ancestor.is_a?(Commodity) }
         end
 
         def ancestor_ids
@@ -45,10 +43,6 @@ module Api
 
         def heading
           @heading ||= ns_ancestors.find { |a| a.is_a? Heading }
-        end
-
-        def number_indents
-          ns_number_indents
         end
       end
     end

--- a/app/serializers/api/admin/csv/goods_nomenclature_serializer.rb
+++ b/app/serializers/api/admin/csv/goods_nomenclature_serializer.rb
@@ -10,7 +10,7 @@ module Api
         column :description, column_name: 'Description'
         column :validity_start_date, column_name: 'Start date'
         column :validity_end_date, column_name: 'End date'
-        column :number_indents, column_name: 'Indentation', &:ns_number_indents
+        column :number_indents, column_name: 'Indentation'
         column :end_line, column_name: 'End line', &:ns_declarable?
 
         # Uses materialized path to determine declarability of goods nomenclature to avoid slow csv generation


### PR DESCRIPTION
### Jira link

HOTT-3029

### What?

I have added/removed/altered:

- [x] Dropped `NestedSet#ns_number_indents`
- [x] Changed `GoodsNomenclature#number_indents` to just use `values[:number_indents]` if populated
- [x] Pull `values[:number_indents]` back from `tree_nodes` table for nested set relationships

### Why?

I am doing this because:

- The existing mechanism didn't work for headings and their descendants if `number_indents != 0` which is the case for heading 9919
- Anything loaded via the nested set relationships will automatically benefit from the `number_indents` value being loaded and potentially fix N+1s on endpoints which should be eager loading `goods_nomenclature_indents` but aren't

### Deployment risks (optional)

- Changes core method but in quite a conservative manner - shouldn't have impact on any endpoints unless they are already converted to use nested set
