### PR TITLE
HOTT-2992 Update Footnote ids

### DIFF
--- a/app/services/heading_service/cached_heading_service.rb
+++ b/app/services/heading_service/cached_heading_service.rb
@@ -42,7 +42,7 @@ module HeadingService
         has_valid_dates(footnote)
       end
       result.footnote_ids = result.footnotes.map do |footnote|
-        footnote.footnote_id
+        footnote.id
       end
     end
 


### PR DESCRIPTION
### Jira link

HOTT-2992

### What?

I have added/removed/altered:

- [x] Updated footnote ids on non-nested-set headings version

### Why?

I am doing this because:

- The footnote serializer was using `#id` but the heading serializer was using `#footnote_id` which meant they didn't link up

### Deployment risks (optional)

- Low, fixes bug
