### PR TITLE
HOTT-2943 Add fields to Goods Nomenclature API

### DIFF
--- a/app/controllers/api/v2/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/goods_nomenclatures_controller.rb
@@ -85,7 +85,7 @@ module Api
         respond_to do |format|
           format.json do
             headers['Content-Type'] = 'application/json'
-            render json: Api::V2::GoodsNomenclatures::GoodsNomenclatureListSerializer.new(@goods_nomenclatures.to_a).serializable_hash
+            render json: Api::V2::GoodsNomenclatures::GoodsNomenclatureExtendedSerializer.new(@goods_nomenclatures.to_a).serializable_hash
           end
           format.csv do
             send_data(

--- a/app/serializers/api/v2/csv/goods_nomenclature_serializer.rb
+++ b/app/serializers/api/v2/csv/goods_nomenclature_serializer.rb
@@ -13,6 +13,11 @@ module Api
         column :href, column_name: 'Href' do |goods_nomenclature, _options|
           Api::V2::GoodsNomenclaturesController.api_path_builder(goods_nomenclature)
         end
+
+        column :formatted_description, column_name: 'Formatted description'
+        column :validity_start_date, column_name: 'Start date'
+        column :validity_end_date, column_name: 'End date'
+        column :declarable, column_name: 'Declarable', &:ns_declarable?
       end
     end
   end

--- a/app/serializers/api/v2/goods_nomenclatures/goods_nomenclature_extended_serializer.rb
+++ b/app/serializers/api/v2/goods_nomenclatures/goods_nomenclature_extended_serializer.rb
@@ -1,0 +1,20 @@
+module Api
+  module V2
+    module GoodsNomenclatures
+      class GoodsNomenclatureExtendedSerializer
+        include JSONAPI::Serializer
+
+        set_type :goods_nomenclature
+        set_id :goods_nomenclature_sid
+
+        attributes :goods_nomenclature_item_id, :goods_nomenclature_sid, :producline_suffix, :description, :number_indents
+        attribute :href do |c|
+          GoodsNomenclaturesController.api_path_builder(c)
+        end
+
+        attributes :formatted_description, :validity_start_date, :validity_end_date
+        attribute :declarable, &:ns_declarable?
+      end
+    end
+  end
+end

--- a/spec/serializers/api/shared/csv_serializer_spec.rb
+++ b/spec/serializers/api/shared/csv_serializer_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe Api::Shared::CsvSerializer do
+  subject(:serialized) { serializer.new([data]).serialized_csv }
+
+  let :data do
+    OpenStruct.new.tap do |data|
+      data.name = 'A String'
+      data.age = 1
+      data.date_of_birth = Date.parse('2000-01-01')
+      data.is_admin = true
+      data.bio = nil
+      data.created_at = Time.zone.parse('2010-01-01 23:59:59.999999')
+    end
+  end
+
+  let :serializer do
+    Class.new do
+      include Api::Shared::CsvSerializer
+
+      columns :name, :age, :date_of_birth
+      column :is_admin, column_name: 'admin'
+      column :bio, column_name: 'biography'
+      column :created_at
+    end
+  end
+
+  describe 'header row' do
+    subject { serialized.lines[0].strip.split(',') }
+
+    it { is_expected.to have_attributes length: 6 }
+    it { is_expected.to include 'name' }
+    it { is_expected.to include 'age' }
+    it { is_expected.to include 'date_of_birth' }
+    it { is_expected.to include 'admin' }
+    it { is_expected.to include 'biography' }
+    it { is_expected.to include 'created_at' }
+  end
+
+  describe 'data row' do
+    subject { serialized.lines[1].strip.split(',') }
+
+    it { is_expected.to have_attributes length: 6 }
+    it { is_expected.to include 'A String' }
+    it { is_expected.to include '1' }
+    it { is_expected.to include '2000-01-01' }
+    it { is_expected.to include 'true' }
+    it { is_expected.to include '' }
+    it { is_expected.to include '2010-01-01 23:59:59 UTC' }
+  end
+end

--- a/spec/serializers/api/v2/csv/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/api/v2/csv/goods_nomenclature_serializer_spec.rb
@@ -1,30 +1,43 @@
 RSpec.describe Api::V2::Csv::GoodsNomenclatureSerializer do
   describe '#serializable_array' do
-    subject(:serializable_array) { described_class.new(serializable).serializable_array }
+    subject(:rows) { serialized.lines.map(&:strip) }
 
+    let(:serialized) { described_class.new(serializable).serialized_csv }
     let(:serializable) { [goods_nomenclature] }
+    let(:goods_nomenclature) { create(:heading, :with_description) }
 
-    let(:goods_nomenclature) { build(:heading) }
+    it { is_expected.to have_attributes length: 2 }
 
-    it 'serializes correctly' do
-      expect(serializable_array).to eq(
+    it 'serializes heading correctly' do
+      expect(rows[0].split(',')).to eq(
         [
-          [
-            'SID',
-            'Goods Nomenclature Item ID',
-            'Indents',
-            'Description',
-            'Product Line Suffix',
-            'Href',
-          ],
-          [
-            goods_nomenclature.goods_nomenclature_sid,
-            goods_nomenclature.goods_nomenclature_item_id,
-            0,
-            '',
-            '80',
-            "/api/v2/headings/#{goods_nomenclature.short_code}",
-          ],
+          'SID',
+          'Goods Nomenclature Item ID',
+          'Indents',
+          'Description',
+          'Product Line Suffix',
+          'Href',
+          'Formatted description',
+          'Start date',
+          'End date',
+          'Declarable',
+        ],
+      )
+    end
+
+    it 'serializes row correctly' do
+      expect(rows[1].split(',')).to eq(
+        [
+          goods_nomenclature.goods_nomenclature_sid.to_s,
+          goods_nomenclature.goods_nomenclature_item_id,
+          '0',
+          goods_nomenclature.description,
+          '80',
+          "/api/v2/headings/#{goods_nomenclature.short_code}",
+          goods_nomenclature.description,
+          "#{goods_nomenclature.validity_start_date.to_date} 00:00:00 UTC",
+          '',
+          'true',
         ],
       )
     end

--- a/spec/serializers/api/v2/goods_nomenclatures/goods_nomenclature_extended_serializer_spec.rb
+++ b/spec/serializers/api/v2/goods_nomenclatures/goods_nomenclature_extended_serializer_spec.rb
@@ -1,0 +1,67 @@
+RSpec.describe Api::V2::GoodsNomenclatures::GoodsNomenclatureExtendedSerializer do
+  describe '#serializable_hash' do
+    subject(:serializable) { described_class.new(gn).serializable_hash[:data] }
+
+    let(:gn) do
+      create :commodity,
+             :with_description,
+             validity_start_date: 2.days.ago.beginning_of_day,
+             validity_end_date: 2.days.from_now.end_of_day
+    end
+
+    it { is_expected.to include type: :goods_nomenclature }
+    it { is_expected.to include id: gn.goods_nomenclature_sid.to_s }
+
+    describe 'attributes' do
+      subject { serializable[:attributes] }
+
+      let :attribute_keys do
+        %i[
+          goods_nomenclature_item_id
+          goods_nomenclature_sid
+          producline_suffix
+          description
+          number_indents
+          href
+          formatted_description
+          validity_start_date
+          validity_end_date
+          declarable
+        ]
+      end
+
+      it { is_expected.to have_attributes keys: attribute_keys }
+      it { is_expected.to include goods_nomenclature_item_id: gn.goods_nomenclature_item_id }
+      it { is_expected.to include goods_nomenclature_sid: gn.goods_nomenclature_sid }
+      it { is_expected.to include producline_suffix: gn.producline_suffix }
+      it { is_expected.to include description: gn.description }
+      it { is_expected.to include number_indents: gn.number_indents }
+      it { is_expected.to include href: "/api/v2/commodities/#{gn.goods_nomenclature_item_id}" }
+      it { is_expected.to include formatted_description: gn.formatted_description }
+      it { is_expected.to include validity_start_date: gn.validity_start_date }
+      it { is_expected.to include validity_end_date: gn.validity_end_date }
+      it { is_expected.to include declarable: true }
+
+      context 'with heading' do
+        let(:gn) { create :heading, :with_children }
+
+        it { is_expected.to include href: "/api/v2/headings/#{gn.short_code}" }
+        it { is_expected.to include declarable: false }
+      end
+
+      context 'with declarable heading' do
+        let(:gn) { create :heading }
+
+        it { is_expected.to include href: "/api/v2/headings/#{gn.short_code}" }
+        it { is_expected.to include declarable: true }
+      end
+
+      context 'with subheading' do
+        let(:gn) { create :subheading }
+
+        it { is_expected.to include href: "/api/v2/commodities/#{gn.goods_nomenclature_item_id}" }
+        it { is_expected.to include declarable: false }
+      end
+    end
+  end
+end

--- a/spec/serializers/api/v2/goods_nomenclatures/goods_nomenclature_list_serializer_spec.rb
+++ b/spec/serializers/api/v2/goods_nomenclatures/goods_nomenclature_list_serializer_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe Api::V2::GoodsNomenclatures::GoodsNomenclatureListSerializer do
+  describe '#serializable_hash' do
+    subject(:serializable) { described_class.new(gn).serializable_hash[:data] }
+
+    let(:gn) { build :commodity }
+
+    it { is_expected.to include type: :goods_nomenclature }
+    it { is_expected.to include id: gn.goods_nomenclature_sid.to_s }
+
+    describe 'attributes' do
+      subject { serializable[:attributes] }
+
+      let :attribute_keys do
+        %i[
+          goods_nomenclature_item_id
+          goods_nomenclature_sid
+          producline_suffix
+          description
+          number_indents
+          href
+        ]
+      end
+
+      it { is_expected.to have_attributes keys: attribute_keys }
+      it { is_expected.to include goods_nomenclature_item_id: gn.goods_nomenclature_item_id }
+      it { is_expected.to include goods_nomenclature_sid: gn.goods_nomenclature_sid }
+      it { is_expected.to include producline_suffix: gn.producline_suffix }
+      it { is_expected.to include description: gn.description }
+      it { is_expected.to include number_indents: gn.number_indents }
+      it { is_expected.to include href: "/api/v2/commodities/#{gn.goods_nomenclature_item_id}" }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-2943

### What?

I have added/removed/altered:

- [x] Added new jsonapi serializer extending existing one with `formatted_description`, `validity_start_date`, `validity_end_date` and `declarable?`
- [x] Extended CSV serializer for goods nomenclature with `formatted_description`, `validity_start_date`, `validity_end_date` and `declarable?` fields
- [x] Added missing specs for existing GoodsNomenclatureListSerializer
- [x] Added missing specs for CSV serializer base module

### Why?

I am doing this because:

- We want to expose these additional fields but the existing serializer was used in other locations
- The missing specs help avoid accidental regressions

### Deployment risks (optional)

- Low, changes format of CSV but only extends it
