### PR TITLE
HOTT-2940 Use subheading links for subheadings

### DIFF
--- a/app/controllers/api/v2/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/goods_nomenclatures_controller.rb
@@ -59,19 +59,23 @@ module Api
         respond_with(@goods_nomenclatures)
       end
 
-      def self.api_path_builder(object)
+      def self.api_path_builder(object, check_for_subheadings: false)
         gnid = object.goods_nomenclature_item_id
         return nil unless gnid
 
-        case GoodsNomenclature.class_determinator.call(object)
-        when 'Chapter'
+        case object
+        when Chapter
           "/api/v2/chapters/#{gnid.first(2)}"
-        when 'Heading'
+        when Heading
           "/api/v2/headings/#{gnid.first(4)}"
-        when 'Commodity'
-          "/api/v2/commodities/#{gnid.first(10)}"
+        when Subheading
+          "/api/v2/subheadings/#{object.to_param}"
         else
-          "/api/v2/commodities/#{gnid.first(10)}"
+          if check_for_subheadings && !object.ns_declarable?
+            "/api/v2/subheadings/#{object.to_param}"
+          else
+            "/api/v2/commodities/#{gnid.first(10)}"
+          end
         end
       end
       helper_method :api_path_builder

--- a/app/serializers/api/v2/csv/goods_nomenclature_serializer.rb
+++ b/app/serializers/api/v2/csv/goods_nomenclature_serializer.rb
@@ -11,7 +11,8 @@ module Api
         column :producline_suffix, column_name: 'Product Line Suffix'
 
         column :href, column_name: 'Href' do |goods_nomenclature, _options|
-          Api::V2::GoodsNomenclaturesController.api_path_builder(goods_nomenclature)
+          Api::V2::GoodsNomenclaturesController
+            .api_path_builder(goods_nomenclature, check_for_subheadings: true)
         end
 
         column :formatted_description, column_name: 'Formatted description'

--- a/app/serializers/api/v2/goods_nomenclatures/goods_nomenclature_extended_serializer.rb
+++ b/app/serializers/api/v2/goods_nomenclatures/goods_nomenclature_extended_serializer.rb
@@ -9,7 +9,7 @@ module Api
 
         attributes :goods_nomenclature_item_id, :goods_nomenclature_sid, :producline_suffix, :description, :number_indents
         attribute :href do |c|
-          GoodsNomenclaturesController.api_path_builder(c)
+          GoodsNomenclaturesController.api_path_builder(c, check_for_subheadings: true)
         end
 
         attributes :formatted_description, :validity_start_date, :validity_end_date

--- a/spec/serializers/api/v2/csv/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/api/v2/csv/goods_nomenclature_serializer_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Api::V2::Csv::GoodsNomenclatureSerializer do
-  describe '#serializable_array' do
+  describe '#serializable_csv' do
     subject(:rows) { serialized.lines.map(&:strip) }
 
     let(:serialized) { described_class.new(serializable).serialized_csv }
@@ -40,6 +40,12 @@ RSpec.describe Api::V2::Csv::GoodsNomenclatureSerializer do
           'true',
         ],
       )
+    end
+
+    context 'with subheading' do
+      let(:goods_nomenclature) { create :commodity, :with_children }
+
+      it { expect(rows[1]).to match "api/v2/subheadings/#{goods_nomenclature.to_param}" }
     end
   end
 end

--- a/spec/serializers/api/v2/goods_nomenclatures/goods_nomenclature_extended_serializer_spec.rb
+++ b/spec/serializers/api/v2/goods_nomenclatures/goods_nomenclature_extended_serializer_spec.rb
@@ -57,9 +57,9 @@ RSpec.describe Api::V2::GoodsNomenclatures::GoodsNomenclatureExtendedSerializer 
       end
 
       context 'with subheading' do
-        let(:gn) { create :subheading }
+        let(:gn) { create :subheading, :with_children }
 
-        it { is_expected.to include href: "/api/v2/commodities/#{gn.goods_nomenclature_item_id}" }
+        it { is_expected.to include href: "/api/v2/subheadings/#{gn.to_param}" }
         it { is_expected.to include declarable: false }
       end
     end


### PR DESCRIPTION
### Jira link

HOTT-2940

### What?

I have added/removed/altered:

- [x] Use subheading links for for non-declarable commodities (ie subheadings) in goods nomenclature api

### Why?

I am doing this because:

- The current links are wrong

### Deployment risks (optional)

- Changes an api that is used in production
