### PR TITLE
HOTT-2945 add parent to goods nomenclature api

### DIFF
--- a/app/controllers/api/v2/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/goods_nomenclatures_controller.rb
@@ -7,7 +7,8 @@ module Api
 
       def index
         commodities = Chapter.non_hidden
-                             .eager(:ns_descendants)
+                             .eager(:ns_ancestors,
+                                    ns_descendants: :goods_nomenclature_descriptions)
                              .all
                              .flat_map(&:ns_descendants)
 
@@ -20,6 +21,7 @@ module Api
                           .non_hidden
                           .eager(:goods_nomenclature_descriptions,
                                  :goods_nomenclature_indents,
+                                 :ns_ancestors,
                                  ns_descendants: :goods_nomenclature_descriptions)
                           .all
 
@@ -32,7 +34,8 @@ module Api
         chapter = Chapter.actual
                          .non_hidden
                          .by_code(params[:chapter_id])
-                         .eager(ns_descendants: :goods_nomenclature_descriptions)
+                         .eager(:ns_ancestors,
+                                ns_descendants: :goods_nomenclature_descriptions)
                          .limit(1)
                          .all
                          .first
@@ -47,7 +50,8 @@ module Api
         headings = Heading.actual
                           .non_hidden
                           .by_code(params[:heading_id])
-                          .eager(ns_descendants: :goods_nomenclature_descriptions)
+                          .eager(:ns_ancestors,
+                                 ns_descendants: :goods_nomenclature_descriptions)
                           .all
 
         raise Sequel::RecordNotFound if headings.empty?

--- a/app/serializers/api/v2/csv/goods_nomenclature_serializer.rb
+++ b/app/serializers/api/v2/csv/goods_nomenclature_serializer.rb
@@ -19,6 +19,10 @@ module Api
         column :validity_start_date, column_name: 'Start date'
         column :validity_end_date, column_name: 'End date'
         column :declarable, column_name: 'Declarable', &:ns_declarable?
+
+        column :parent_sid, column_name: 'Parent SID' do |goods_nomenclature|
+          goods_nomenclature.ns_parent&.goods_nomenclature_sid
+        end
       end
     end
   end

--- a/app/serializers/api/v2/goods_nomenclatures/goods_nomenclature_extended_serializer.rb
+++ b/app/serializers/api/v2/goods_nomenclatures/goods_nomenclature_extended_serializer.rb
@@ -14,6 +14,8 @@ module Api
 
         attributes :formatted_description, :validity_start_date, :validity_end_date
         attribute :declarable, &:ns_declarable?
+
+        belongs_to :parent, record_type: :goods_nomenclature, &:ns_parent
       end
     end
   end

--- a/spec/serializers/api/v2/csv/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/api/v2/csv/goods_nomenclature_serializer_spec.rb
@@ -21,12 +21,13 @@ RSpec.describe Api::V2::Csv::GoodsNomenclatureSerializer do
           'Start date',
           'End date',
           'Declarable',
+          'Parent SID',
         ],
       )
     end
 
     it 'serializes row correctly' do
-      expect(rows[1].split(',')).to eq(
+      expect(rows[1].split(',', -1)).to eq(
         [
           goods_nomenclature.goods_nomenclature_sid.to_s,
           goods_nomenclature.goods_nomenclature_item_id,
@@ -38,6 +39,7 @@ RSpec.describe Api::V2::Csv::GoodsNomenclatureSerializer do
           "#{goods_nomenclature.validity_start_date.to_date} 00:00:00 UTC",
           '',
           'true',
+          '',
         ],
       )
     end
@@ -46,6 +48,15 @@ RSpec.describe Api::V2::Csv::GoodsNomenclatureSerializer do
       let(:goods_nomenclature) { create :commodity, :with_children }
 
       it { expect(rows[1]).to match "api/v2/subheadings/#{goods_nomenclature.to_param}" }
+    end
+
+    context 'with parent' do
+      let(:goods_nomenclature) { create :commodity, :with_heading }
+
+      it 'includes the parent sid' do
+        expect(rows[1].split(',')[10]).to eq \
+          goods_nomenclature.heading.goods_nomenclature_sid.to_s
+      end
     end
   end
 end

--- a/spec/serializers/api/v2/goods_nomenclatures/goods_nomenclature_extended_serializer_spec.rb
+++ b/spec/serializers/api/v2/goods_nomenclatures/goods_nomenclature_extended_serializer_spec.rb
@@ -63,5 +63,26 @@ RSpec.describe Api::V2::GoodsNomenclatures::GoodsNomenclatureExtendedSerializer 
         it { is_expected.to include declarable: false }
       end
     end
+
+    describe 'relationships' do
+      subject { serializable[:relationships] }
+
+      context 'with parent' do
+        let(:gn) { create :commodity, :with_heading }
+
+        let :parent do
+          {
+            id: gn.heading.goods_nomenclature_sid.to_s,
+            type: :goods_nomenclature,
+          }
+        end
+
+        it { is_expected.to include parent: { data: parent } }
+      end
+
+      context 'without parent' do
+        it { is_expected.to include parent: { data: nil } }
+      end
+    end
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-2945

### What?

I have added/removed/altered:

- [x] Include Parent SID in the goods nomenclature api CSV output
- [x] Include a Parent relationship in the Goods Nomenclature api JSON-API output

### Why?

I am doing this because:

- It helps our users understand the relationship between different Goods Nomenclature within the hierarchy