### PR TITLE
HOTT-3040 Include negative measure conditions

### DIFF
--- a/app/models/measure_condition_permutations/calculator.rb
+++ b/app/models/measure_condition_permutations/calculator.rb
@@ -45,6 +45,7 @@ module MeasureConditionPermutations
     def excluded_condition?(condition)
       condition.negative_class? &&
         condition.measure_action.present? &&
+        condition.document_code.blank? &&
         INCLUDED_NEGATIVE_ACTIONS.exclude?(condition.measure_action.action_code)
     end
   end

--- a/spec/models/measure_condition_permutations/calculator_spec.rb
+++ b/spec/models/measure_condition_permutations/calculator_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe MeasureConditionPermutations::Calculator do
 
       it { is_expected.to include negative_condition }
     end
+
+    context 'with negative condition with document code' do
+      let :negative_condition do
+        create :measure_condition, :negative, :document, measure_sid: measure.measure_sid
+      end
+
+      it { is_expected.to include negative_condition }
+    end
   end
 
   describe '#permutation_groups' do


### PR DESCRIPTION
### Jira link

HOTT-3040

### What?

I have added/removed/altered:

- [x] Stop filtering negative measure conditions from permutation groups if they have a document code

### Why?

I am doing this because:

- Whilst the data is invalid DBT would prefer that we expose it to our users

### Deployment risks (optional)

- Low, exposes addition measure conditions in permutation groups which is an internal api extension

### Before

![image](https://user-images.githubusercontent.com/10818/232794984-c6f12124-2e0d-4825-96a7-48a6e099843d.png)


### After

![image](https://user-images.githubusercontent.com/10818/232794898-e03aa9b2-c368-42bf-b00e-1552114ae37c.png)

