### PR TITLE
HOTT-2987 Precache headings and subheadings

### DIFF
--- a/app/controllers/api/v2/subheadings_controller.rb
+++ b/app/controllers/api/v2/subheadings_controller.rb
@@ -43,42 +43,8 @@ module Api
         params[:id].split('-', 2)[1] || '80'
       end
 
-      def ns_measures_eager_load
-        {
-          ns_overview_measures: [
-            {
-              measure_components: {
-                duty_expression: :duty_expression_description,
-                measurement_unit: %i[measurement_unit_description
-                                     measurement_unit_abbreviations],
-                monetary_unit: :monetary_unit_description,
-                measurement_unit_qualifier: [],
-              },
-              measure_type: %i[measure_type_description
-                               measure_type_series
-                               measure_type_series_description],
-            },
-            :additional_code,
-          ],
-        }
-      end
-
       def ns_eager_load
-        [
-          :goods_nomenclature_descriptions,
-          :footnotes,
-          ns_measures_eager_load,
-          {
-            ns_ancestors: [
-              :goods_nomenclature_descriptions,
-              ns_measures_eager_load,
-            ],
-            ns_descendants: [
-              :goods_nomenclature_descriptions,
-              ns_measures_eager_load,
-            ],
-          },
-        ]
+        HeadingService::Serialization::NsNondeclarableService::HEADING_EAGER_LOAD
       end
 
       def ns_subheading

--- a/app/controllers/api/v2/subheadings_controller.rb
+++ b/app/controllers/api/v2/subheadings_controller.rb
@@ -43,23 +43,13 @@ module Api
         params[:id].split('-', 2)[1] || '80'
       end
 
-      def ns_eager_load
-        HeadingService::Serialization::NsNondeclarableService::HEADING_EAGER_LOAD
-      end
-
       def ns_subheading
-        @subheading = Subheading.actual
-                                .non_hidden
-                                .by_code(subheading_code)
-                                .by_productline_suffix(productline_suffix)
-                                .eager(*ns_eager_load)
-                                .limit(1)
-                                .all
-                                .first
-
-        raise Sequel::RecordNotFound if !@subheading || @subheading.ns_leaf?
-
-        @subheading
+        Subheading.actual
+                  .non_hidden
+                  .by_code(subheading_code)
+                  .by_productline_suffix(productline_suffix)
+                  .take
+                  .tap { |sh| raise Sequel::RecordNotFound if sh.ns_leaf? }
       end
     end
   end

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -104,7 +104,8 @@ class GoodsNomenclature < Sequel::Model
                            left_primary_key: :goods_nomenclature_sid,
                            left_key: :goods_nomenclature_sid,
                            right_key: %i[footnote_type footnote_id],
-                           right_primary_key: %i[footnote_type_id footnote_id] do |ds|
+                           right_primary_key: %i[footnote_type_id footnote_id],
+                           order: %i[footnote_type_id footnote_id] do |ds|
     ds.with_actual(FootnoteAssociationGoodsNomenclature)
   end
 

--- a/app/services/cached_subheading_service.rb
+++ b/app/services/cached_subheading_service.rb
@@ -26,6 +26,10 @@ class CachedSubheadingService
     end
   end
 
+  def cache_key
+    "_subheading-#{@subheading.goods_nomenclature_sid}-#{@actual_date}#{cache_version}"
+  end
+
   private
 
   def presented_subheading
@@ -67,10 +71,6 @@ class CachedSubheadingService
 
       presented
     end
-  end
-
-  def cache_key
-    "_subheading-#{@subheading.goods_nomenclature_sid}-#{@actual_date}#{cache_version}"
   end
 
   def cache_version

--- a/app/services/cached_subheading_service.rb
+++ b/app/services/cached_subheading_service.rb
@@ -15,14 +15,17 @@ class CachedSubheadingService
     'commodities.overview_measures.additional_code',
   ].freeze
 
-  def initialize(subheading, actual_date)
+  def initialize(subheading, actual_date, eager_reload: true)
     @subheading = subheading
-    @actual_date = actual_date
+    @actual_date = actual_date.to_date.to_formatted_s(:db)
+    @eager_reload = eager_reload
   end
 
   def call
     Rails.cache.fetch(cache_key, expires_in: TTL) do
-      Api::V2::Subheadings::SubheadingSerializer.new(presented_subheading, options).serializable_hash
+      Api::V2::Subheadings::SubheadingSerializer
+        .new(presented_subheading, options)
+        .serializable_hash
     end
   end
 
@@ -34,7 +37,7 @@ class CachedSubheadingService
 
   def presented_subheading
     if TradeTariffBackend.nested_set_subheadings?
-      return Api::V2::Subheadings::SubheadingPresenter.new(@subheading)
+      return Api::V2::Subheadings::SubheadingPresenter.new(ns_eager_loaded_subheading)
     end
 
     @presented_subheading ||= begin
@@ -82,5 +85,23 @@ class CachedSubheadingService
     opts[:is_collection] = false
     opts[:include] = DEFAULT_INCLUDES
     opts
+  end
+
+  def ns_eager_loaded_subheading
+    return @subheading unless eager_reload?
+
+    @ns_eager_loaded_subheading ||=
+      Subheading
+        .actual
+        .non_hidden
+        .where(goods_nomenclature_sid: @subheading.goods_nomenclature_sid)
+        .eager(*HeadingService::Serialization::NsNondeclarableService::HEADING_EAGER_LOAD)
+        .limit(1)
+        .all
+        .first || (raise Sequel::RecordNotFound)
+  end
+
+  def eager_reload?
+    @eager_reload
   end
 end

--- a/app/services/heading_service/precache_service.rb
+++ b/app/services/heading_service/precache_service.rb
@@ -56,7 +56,8 @@ module HeadingService
     end
 
     def write_subheading(subheading)
-      CachedSubheadingService.new(subheading, actual_date).call
+      CachedSubheadingService.new(subheading, actual_date, eager_reload: false)
+                             .call
     end
   end
 end

--- a/app/services/heading_service/precache_service.rb
+++ b/app/services/heading_service/precache_service.rb
@@ -1,0 +1,50 @@
+module HeadingService
+  class PrecacheService
+    CACHE_TTL = 23.hours
+
+    attr_reader :actual_date
+
+    def initialize(date)
+      @actual_date = date
+    end
+
+    def call
+      TimeMachine.at(actual_date) do
+        each_heading do |heading|
+          write_heading(heading) if TradeTariffBackend.nested_set_headings?
+        end
+      end
+    end
+
+    private
+
+    def each_heading
+      Chapter.actual.non_hidden.all do |chapter|
+        Chapter.actual
+               .where(goods_nomenclature_sid: chapter.goods_nomenclature_sid)
+               .eager(*Serialization::NsNondeclarableService::HEADING_EAGER_LOAD)
+               .limit(1)
+               .all
+               .first
+               .ns_children
+               .each do |heading|
+          next if heading.ns_declarable?
+
+          yield heading
+        end
+      end
+    end
+
+    def heading_cache_key(heading)
+      HeadingSerializationService.cache_key(heading, actual_date, false, {})
+    end
+
+    def write_heading(heading)
+      data = HeadingService::Serialization::NsNondeclarableService
+               .new(heading, eager_reload: false)
+               .serializable_hash
+
+      Rails.cache.write(heading_cache_key(heading), data, expires_in: CACHE_TTL)
+    end
+  end
+end

--- a/app/services/heading_service/precache_service.rb
+++ b/app/services/heading_service/precache_service.rb
@@ -12,6 +12,14 @@ module HeadingService
       TimeMachine.at(actual_date) do
         each_heading do |heading|
           write_heading(heading) if TradeTariffBackend.nested_set_headings?
+
+          next unless TradeTariffBackend.nested_set_subheadings?
+
+          heading.ns_descendants.each do |subheading|
+            next if subheading.ns_declarable?
+
+            write_subheading subheading
+          end
         end
       end
     end
@@ -45,6 +53,10 @@ module HeadingService
                .serializable_hash
 
       Rails.cache.write(heading_cache_key(heading), data, expires_in: CACHE_TTL)
+    end
+
+    def write_subheading(subheading)
+      CachedSubheadingService.new(subheading, actual_date).call
     end
   end
 end

--- a/app/services/heading_service/serialization/ns_nondeclarable_service.rb
+++ b/app/services/heading_service/serialization/ns_nondeclarable_service.rb
@@ -56,11 +56,16 @@ module HeadingService
 
       delegate :serializable_hash, to: :serializer
 
-      def initialize(heading)
+      def initialize(heading, eager_reload: true)
         @heading = heading
+        @eager_reload = eager_reload
       end
 
     private
+
+      def eager_reload?
+        @eager_reload
+      end
 
       def presented_heading
         Api::V2::Headings::HeadingPresenter.new(eager_loaded_heading)
@@ -72,6 +77,8 @@ module HeadingService
       end
 
       def eager_loaded_heading
+        return @heading unless eager_reload?
+
         Heading.actual
                .non_hidden
                .where(goods_nomenclature_sid: heading.goods_nomenclature_sid)

--- a/app/workers/clear_cache_worker.rb
+++ b/app/workers/clear_cache_worker.rb
@@ -8,6 +8,7 @@ class ClearCacheWorker
     Rails.cache.clear
     logger.info 'Clearing Rails cache completed'
 
+    Sidekiq::Client.enqueue(PrecacheHeadingsWorker)
     Sidekiq::Client.enqueue(PrewarmQuotaOrderNumbersWorker)
     Sidekiq::Client.enqueue(ReindexModelsWorker)
     Sidekiq::Client.enqueue(PrewarmSubheadingsWorker)

--- a/app/workers/clear_cache_worker.rb
+++ b/app/workers/clear_cache_worker.rb
@@ -8,7 +8,7 @@ class ClearCacheWorker
     Rails.cache.clear
     logger.info 'Clearing Rails cache completed'
 
-    Sidekiq::Client.enqueue(PrecacheHeadingsWorker)
+    Sidekiq::Client.enqueue(PrecacheHeadingsWorker, Time.zone.today.to_formatted_s(:db))
     Sidekiq::Client.enqueue(PrewarmQuotaOrderNumbersWorker)
     Sidekiq::Client.enqueue(ReindexModelsWorker)
     Sidekiq::Client.enqueue(PrewarmSubheadingsWorker)

--- a/app/workers/precache_headings_worker.rb
+++ b/app/workers/precache_headings_worker.rb
@@ -1,0 +1,9 @@
+class PrecacheHeadingsWorker
+  include Sidekiq::Worker
+
+  def perform(date = nil)
+    date = date ? Time.zone.parse(date).to_date : Time.zone.today
+
+    HeadingService::PrecacheService.new(date).call
+  end
+end

--- a/app/workers/precache_headings_worker.rb
+++ b/app/workers/precache_headings_worker.rb
@@ -2,7 +2,7 @@ class PrecacheHeadingsWorker
   include Sidekiq::Worker
 
   def perform(date = nil)
-    date = date ? Time.zone.parse(date).to_date : Time.zone.today
+    date = date ? Time.zone.parse(date).to_date : Time.zone.tomorrow
 
     HeadingService::PrecacheService.new(date).call
   end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -48,3 +48,6 @@
     description: "Uploads a new snapshot of the spelling model based on the latest data."
     class: SpellingFileUploaderWorker
     status: <%= TradeTariffBackend.uk? ? 'enabled' : 'disabled' %>
+  PrecacheHeadingsWorker:
+    cron: "00 22 * * *"
+    description: Precaches all headings and subheadings ready for tomorrow

--- a/spec/services/heading_service/precache_service_spec.rb
+++ b/spec/services/heading_service/precache_service_spec.rb
@@ -1,13 +1,15 @@
 RSpec.describe HeadingService::PrecacheService do
   before do
     allow(TradeTariffBackend).to receive(:nested_set_headings?).and_return ns_heading
-    allow(Rails).to receive(:cache).and_return cache
+    allow(TradeTariffBackend).to receive(:nested_set_subheadings?).and_return ns_subheading
+    allow(Rails.cache).to receive(:write).and_call_original
+    allow(Rails.cache).to receive(:fetch).and_call_original
 
     commodity
   end
 
   let(:ns_heading) { true }
-  let(:cache) { instance_double 'Rails.cache', write: true }
+  let(:ns_subheading) { true }
   let(:commodity) { create :commodity, :with_chapter_and_heading, :with_children }
 
   let :heading_key do
@@ -15,19 +17,36 @@ RSpec.describe HeadingService::PrecacheService do
       .cache_key(commodity.heading, Time.zone.today, false, {})
   end
 
+  let :subheading_key do
+    CachedSubheadingService.new(commodity, Time.zone.today).cache_key
+  end
+
   describe '#call' do
     before { described_class.new(Time.zone.today).call }
 
     it 'caches heading' do
-      expect(cache).to have_received(:write).with(heading_key,
-                                                  hash_including(:data),
-                                                  expires_in: 23.hours)
+      expect(Rails.cache).to have_received(:write).with(heading_key,
+                                                        hash_including(:data),
+                                                        expires_in: 23.hours)
+    end
+
+    it 'caches subheading' do
+      expect(Rails.cache).to have_received(:fetch).with(subheading_key,
+                                                        expires_in: 23.hours)
     end
 
     context 'with nested set headings disabled' do
       let(:ns_heading) { false }
 
-      it { expect(cache).not_to have_received(:write).with(heading_key, any_args) }
+      it { expect(Rails.cache).not_to have_received(:write).with(heading_key, any_args) }
+      it { expect(Rails.cache).to have_received(:fetch).with(subheading_key, any_args) }
+    end
+
+    context 'with nested set subheadings disabled' do
+      let(:ns_subheading) { false }
+
+      it { expect(Rails.cache).to have_received(:write).with(heading_key, any_args) }
+      it { expect(Rails.cache).not_to have_received(:fetch).with(subheading_key, any_args) }
     end
   end
 end

--- a/spec/services/heading_service/precache_service_spec.rb
+++ b/spec/services/heading_service/precache_service_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe HeadingService::PrecacheService do
+  before do
+    allow(TradeTariffBackend).to receive(:nested_set_headings?).and_return ns_heading
+    allow(Rails).to receive(:cache).and_return cache
+
+    commodity
+  end
+
+  let(:ns_heading) { true }
+  let(:cache) { instance_double 'Rails.cache', write: true }
+  let(:commodity) { create :commodity, :with_chapter_and_heading, :with_children }
+
+  let :heading_key do
+    HeadingService::HeadingSerializationService
+      .cache_key(commodity.heading, Time.zone.today, false, {})
+  end
+
+  describe '#call' do
+    before { described_class.new(Time.zone.today).call }
+
+    it 'caches heading' do
+      expect(cache).to have_received(:write).with(heading_key,
+                                                  hash_including(:data),
+                                                  expires_in: 23.hours)
+    end
+
+    context 'with nested set headings disabled' do
+      let(:ns_heading) { false }
+
+      it { expect(cache).not_to have_received(:write).with(heading_key, any_args) }
+    end
+  end
+end

--- a/spec/workers/precache_headings_worker_spec.rb
+++ b/spec/workers/precache_headings_worker_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe PrecacheHeadingsWorker, type: :worker do
+  let(:date) { Time.zone.today }
+
+  describe '#perform' do
+    before do
+      allow(TradeTariffBackend).to receive(:nested_set_headings?).and_return(true)
+      allow(Rails.cache).to receive(:write).and_call_original
+
+      heading
+
+      described_class.new.perform date.to_formatted_s(:db)
+    end
+
+    let(:heading) { create :heading, :with_chapter, :with_children }
+
+    let(:cache_key) do
+      HeadingService::HeadingSerializationService.cache_key(heading, date, false, {})
+    end
+
+    it 'writes to cache' do
+      expect(Rails.cache).to \
+        have_received(:write).with(cache_key, hash_including(:data), any_args)
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-2987

### What?

I have added/removed/altered:

- [x] Added a service and worker to precache the jsonapi output of all non-declarable headings
- [x] Extended to also precache subheadings
- [x] Schedule worker to also cache all of tomorrows headings and subheadings at 10pm UTC
- [x] Sets default order for commodities footnotes relationship

### Why?

I am doing this because:

- It should reduce load on postgres at the start of the day
- Footnotes order ensures consistency of presentation across pages, particularly when eager loading

### Deployment risks (optional)

- Low, if nested set headings/subheadings are used it will speed them up, if not it will just iterate through the chapters without caching anything
