### PR TITLE
HOTT-2940 Fix for incorrect subheading url in GN API

### DIFF
--- a/app/controllers/api/v2/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/goods_nomenclatures_controller.rb
@@ -72,7 +72,7 @@ module Api
           "/api/v2/subheadings/#{object.to_param}"
         else
           if check_for_subheadings && !object.ns_declarable?
-            "/api/v2/subheadings/#{object.to_param}"
+            "/api/v2/subheadings/#{gnid.first(10)}-#{object.producline_suffix}"
           else
             "/api/v2/commodities/#{gnid.first(10)}"
           end


### PR DESCRIPTION
### Jira link

HOTT-2940

### What?

I have added/removed/altered:

- [x] Fixed the subheadings URL in goods nomenclature api

### Why?

I am doing this because:

- if the object is a commodity then `#to_param` excludes the producline_suffix

### Deployment risks (optional)

- Low, fixes bug
