### PR TITLE
HOTT-3075: Adds handling for non-zip content when downloading CDS files

### DIFF
--- a/spec/factories/response_factory.rb
+++ b/spec/factories/response_factory.rb
@@ -7,6 +7,16 @@ FactoryBot.define do
       response_code { 200 }
     end
 
+    trait :success_cds do
+      success
+      content do
+        File.read(
+          'spec/fixtures/cds_samples/tariff_dailyExtract_v1_20201004T235959.gzip',
+          encoding: 'binary'
+        )
+      end
+    end
+
     trait :not_found do
       response_code { 404 }
       content { nil }

--- a/spec/factories/response_factory.rb
+++ b/spec/factories/response_factory.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
       content do
         File.read(
           'spec/fixtures/cds_samples/tariff_dailyExtract_v1_20201004T235959.gzip',
-          encoding: 'binary'
+          encoding: 'binary',
         )
       end
     end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3075

![image](https://user-images.githubusercontent.com/8156884/233979114-e247beae-b090-4cc8-b45b-14a616329a9c.png)

![image](https://user-images.githubusercontent.com/8156884/233979179-2d8abaf1-bacb-469b-ae0b-d2cbd080eb3a.png)


### What?

I have added/removed/altered:

- [x] Prevent non-zip files in the CDS download process from being persisted to S3

### Why?

I am doing this because:

- We have a repeating issue with CDS files which are not actually zip files. This reduces to burden to rollback/rollforward which can now just be done in the admin UI
