### PR TITLE
HOTT-2210 Sidekiq 7 upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,7 +416,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_DB: tariff_test
           POSTGRES_PASSWORD: postgres
-      - image: circleci/redis:4.0.9
+      - image: cimg/redis:6.2
         environment:
           REDIS_URL: "redis://localhost:6379/"
       - image: opensearchproject/opensearch:1.2.4
@@ -467,7 +467,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_DB: tariff_test
           POSTGRES_PASSWORD: postgres
-      - image: circleci/redis:4.0.9
+      - image: cimg/redis:6.2
         environment:
           - REDIS_URL: "redis://localhost:6379/"
       - image: opensearchproject/opensearch:1.2.4

--- a/Gemfile
+++ b/Gemfile
@@ -20,9 +20,10 @@ gem 'rubyzip'
 
 # Background jobs
 gem 'connection_pool'
-gem 'redis-elasticache'
+gem 'redis', '>= 5.0.6'
+gem 'redis-client', '>= 0.11.2'
 gem 'redlock'
-gem 'sidekiq'
+gem 'sidekiq', '< 8'
 gem 'sidekiq-scheduler'
 
 # Elasticsearch

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,7 +175,7 @@ GEM
     faraday-retry (1.0.3)
     foreman (0.87.2)
     forgery (0.8.1)
-    fugit (1.7.1)
+    fugit (1.8.1)
       et-orbi (~> 1, >= 1.2.7)
       raabro (~> 1.4)
     gds-sso (17.1.1)
@@ -320,11 +320,12 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
-    redis (4.8.0)
-    redis-elasticache (0.2.0)
-      redis (>= 3.0.0)
-    redlock (1.3.2)
-      redis (>= 3.0.0, < 6.0)
+    redis (5.0.6)
+      redis-client (>= 0.9.0)
+    redis-client (0.14.1)
+      connection_pool
+    redlock (2.0.1)
+      redis-client
     regexp_parser (2.6.2)
     request_store (1.5.1)
       rack (>= 1.4)
@@ -400,14 +401,14 @@ GEM
       activemodel (>= 4.0.0)
       railties (>= 4.0.0)
       sequel (>= 3.28, < 6.0)
-    sidekiq (6.5.8)
-      connection_pool (>= 2.2.5, < 3)
-      rack (~> 2.0)
-      redis (>= 4.5.0, < 5)
-    sidekiq-scheduler (4.0.3)
-      redis (>= 4.2.0)
+    sidekiq (7.0.9)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.11.0)
+    sidekiq-scheduler (5.0.2)
       rufus-scheduler (~> 3.2)
-      sidekiq (>= 4, < 7)
+      sidekiq (>= 6, < 8)
       tilt (>= 1.4.0)
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -476,7 +477,8 @@ DEPENDENCIES
   rabl
   rack-timeout
   rails (~> 7.0)
-  redis-elasticache
+  redis (>= 5.0.6)
+  redis-client (>= 0.11.2)
   redlock
   responders
   routing-filter!
@@ -489,7 +491,7 @@ DEPENDENCIES
   sentry-sidekiq
   sequel
   sequel-rails
-  sidekiq
+  sidekiq (< 8)
   sidekiq-scheduler
   simplecov
   slack-notifier

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,47 +7,48 @@
   - rollbacks
   - sync
   - default
-:schedule:
-  #
-  # Syntax:
-  #
-  # mm hh dd mt wd  command
-  #
-  # mm minute 0-59
-  # hh hour 0-23
-  # dd day of month 1-31
-  # mt month 1-12
-  # wd day of week 0-7 (Sunday = 0 or 7)
-  #
-  # Online converter: https://crontab.guru/#0_22_*_*_*
-  #
-  RefreshAppendix5aGuidanceWorker:
-    cron: "00 22 * * *"
-    description: "Hot refreshes Chief CDS Guidance"
-  PopulateChangesTableWorker:
-    cron: "30 4 * * *"
-    description: "Populates the changes table"
-  PopulateSearchSuggestionsWorker:
-    cron: "0 18 * * *"
-    description: "Populates search suggestions which are used in the frontend"
-  UKUpdatesSynchronizerWorker:
-    cron: "0 5 * * *"
-    description: "Runs ETL of CDS files and populates indexes"
-    class: UpdatesSynchronizerWorker
-    status: <%= TradeTariffBackend.uk? ? 'enabled' : 'disabled' %>
-  XIUpdatesSynchronizerWorker:
-    cron: "0 0 * * *"
-    description: "Runs ETL of Taric files and populates indexes"
-    class: UpdatesSynchronizerWorker
-    status: <%= TradeTariffBackend.xi? ? 'enabled' : 'disabled' %>
-  HealthcheckWorker:
-    every: 30.minutes
-    description: Trigger the health check
-  UKSpellingFileUploaderWorker:
-    cron: "0 14 * * *"
-    description: "Uploads a new snapshot of the spelling model based on the latest data."
-    class: SpellingFileUploaderWorker
-    status: <%= TradeTariffBackend.uk? ? 'enabled' : 'disabled' %>
-  PrecacheHeadingsWorker:
-    cron: "00 22 * * *"
-    description: Precaches all headings and subheadings ready for tomorrow
+:scheduler:
+  :schedule:
+    #
+    # Syntax:
+    #
+    # mm hh dd mt wd  command
+    #
+    # mm minute 0-59
+    # hh hour 0-23
+    # dd day of month 1-31
+    # mt month 1-12
+    # wd day of week 0-7 (Sunday = 0 or 7)
+    #
+    # Online converter: https://crontab.guru/#0_22_*_*_*
+    #
+    RefreshAppendix5aGuidanceWorker:
+      cron: "00 22 * * *"
+      description: "Hot refreshes Chief CDS Guidance"
+    PopulateChangesTableWorker:
+      cron: "30 4 * * *"
+      description: "Populates the changes table"
+    PopulateSearchSuggestionsWorker:
+      cron: "0 18 * * *"
+      description: "Populates search suggestions which are used in the frontend"
+    UKUpdatesSynchronizerWorker:
+      cron: "0 5 * * *"
+      description: "Runs ETL of CDS files and populates indexes"
+      class: UpdatesSynchronizerWorker
+      status: <%= TradeTariffBackend.uk? ? 'enabled' : 'disabled' %>
+    XIUpdatesSynchronizerWorker:
+      cron: "0 0 * * *"
+      description: "Runs ETL of Taric files and populates indexes"
+      class: UpdatesSynchronizerWorker
+      status: <%= TradeTariffBackend.xi? ? 'enabled' : 'disabled' %>
+    HealthcheckWorker:
+      every: 30.minutes
+      description: Trigger the health check
+    UKSpellingFileUploaderWorker:
+      cron: "0 14 * * *"
+      description: "Uploads a new snapshot of the spelling model based on the latest data."
+      class: SpellingFileUploaderWorker
+      status: <%= TradeTariffBackend.uk? ? 'enabled' : 'disabled' %>
+    PrecacheHeadingsWorker:
+      cron: "00 22 * * *"
+      description: Precaches all headings and subheadings ready for tomorrow


### PR DESCRIPTION
### Jira link

HOTT-2210

### What?

I have added/removed/altered:

- [x] Upgrade to Redis 5 and Redis-client
- [x] Lock versions to redis >= 5.0.6 and and redis-client >= 0.11.2
- [x] Drop redis-elasticache
- [x] Upgraded sidekiq-scheduler
- [x] Upgraded sidekiq to v7
- [x] Upgraded redlock
- [x] Updated sidekiq.yml for new scheduler config key

### Why?

I am doing this because:

- Redis-Elasticache is incompatible with the Redis 5 rubygem
- Its purpose is to reconnect on READONLY errors caused by a failover in the elasticache cluster
- That functionality is now provided by the redis-client (>= 0.11.2) and redis (>= 5.0.6) gems
- Upgraded sidekiq-scheduler to be compatible with Sidekiq 7 and Redis 5 gem
- Upgraded redlock to be compatible with Redis 5 gem

### Deployment risks (optional)

- Replaces a key component
- Removes the `redis-elasticache` gem which had solved our errors from the frequent failures from redis at weekends - my reading of the docs implies this should be a 'solved issue' now even without that gem
