### PR TITLE
HOTT-2871 Only refresh view if applicable data migrations

### DIFF
--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -14,8 +14,6 @@ namespace :data do
         Rake::Task['data:rollback'].invoke
         Rake::Task['data:migrate'].invoke
       end
-
-      GoodsNomenclatures::TreeNode.refresh!
     end
 
     desc 'Runs the "up" for a given data migration VERSION.'
@@ -41,9 +39,11 @@ namespace :data do
 
   desc 'Migrate data to the latest version - IMPORTANT ensure migrations are idempotent'
   task migrate: 'migrate:load' do
+    refresh_tree_nodes = ::DataMigrator.pending_migrations? || ENV['VERSION'].present?
+
     ::DataMigrator.migrate_up!(ENV['VERSION'] ? ENV['VERSION'].to_i : nil)
 
-    GoodsNomenclatures::TreeNode.refresh!
+    GoodsNomenclatures::TreeNode.refresh! if refresh_tree_nodes
   end
 
   desc 'Rollback the latest data migration file or down to specified VERSION=x'


### PR DESCRIPTION
### Jira link

HOTT-2871

### What?

I have added/removed/altered:

- [x] Only refresh the view if data migrations were applied
- [x] Don't manually apply after a `rake data:migrate:redo`

### Why?

I am doing this because:

- It is a 'pause the app for 2 seconds' event, so can take a few seconds to acquire a lock
- It is unneeded on deploy unless we've actually changed the data via a data migration
- The view was already being refreshed as part of the `rake data:migrate` so no need to do it again straight afterward

### Deployment risks (optional)

- Low, just avoids an unneeded step on deploy
