### PR TITLE
HOTT-3025 Grouping headings

### DIFF
--- a/app/presenters/api/v2/subheadings/subheading_presenter.rb
+++ b/app/presenters/api/v2/subheadings/subheading_presenter.rb
@@ -42,7 +42,7 @@ module Api
         end
 
         def heading
-          @heading ||= ns_ancestors.find { |a| a.is_a? Heading }
+          @heading ||= ns_ancestors.reverse.find { |a| a.is_a? Heading }
         end
       end
     end

--- a/db/data_migrations/20230421152645_fix_heading_9905_tree_node.rb
+++ b/db/data_migrations/20230421152645_fix_heading_9905_tree_node.rb
@@ -1,0 +1,25 @@
+Sequel.migration do
+  # IMPORTANT! Data migrations up block should be idempotent (reruns of up should produce the same effect)
+  # they may get re-run as part of data rollbacks but the rollback (down) function of the data migration will not get invoked
+  up do
+    attrs = {
+      goods_nomenclature_indent_sid: 93_337,
+      depth: 3,
+      created_at: '2023-04-21 16:35:00',
+    }
+
+    if GoodsNomenclatures::TreeNodeOverride.where(attrs).count.zero?
+      GoodsNomenclatures::TreeNodeOverride.create(attrs)
+    end
+  end
+
+  down do
+    attrs = {
+      goods_nomenclature_indent_sid: 93_337,
+      depth: 3,
+      created_at: '2023-04-21 16:35:00',
+    }
+
+    GoodsNomenclatures::TreeNodeOverride.where(attrs).delete
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3563,11 +3563,12 @@ CREATE MATERIALIZED VIEW uk.goods_nomenclature_tree_nodes AS
     indents.validity_start_date,
     COALESCE(indents.validity_end_date, (min(replacement_indents.validity_start_date) - '00:00:01'::interval), nomenclatures.validity_end_date) AS validity_end_date,
     indents.oid,
-    COALESCE(overrides.depth, ((indents.number_indents + 2) - ((((indents.goods_nomenclature_item_id)::text ~~ '%00000000'::text) AND (indents.number_indents = 0)))::integer)) AS depth
-   FROM (((uk.goods_nomenclature_indents indents
+    COALESCE((overrides.depth)::bigint, (((indents.number_indents + 2) - ((((indents.goods_nomenclature_item_id)::text ~~ '%00000000'::text) AND (indents.number_indents = 0)))::integer) + count(grouping_headings.goods_nomenclature_sid))) AS depth
+   FROM ((((uk.goods_nomenclature_indents indents
      JOIN uk.goods_nomenclatures nomenclatures ON ((indents.goods_nomenclature_sid = nomenclatures.goods_nomenclature_sid)))
      LEFT JOIN uk.goods_nomenclature_indents replacement_indents ON (((indents.goods_nomenclature_sid = replacement_indents.goods_nomenclature_sid) AND (indents.validity_start_date < replacement_indents.validity_start_date) AND (indents.validity_end_date IS NULL))))
      LEFT JOIN uk.goods_nomenclature_tree_node_overrides overrides ON (((indents.goods_nomenclature_indent_sid = overrides.goods_nomenclature_indent_sid) AND (indents.operation_date < COALESCE(overrides.updated_at, overrides.created_at)))))
+     LEFT JOIN uk.goods_nomenclatures grouping_headings ON ((((indents.goods_nomenclature_item_id)::text !~~ '%00000000'::text) AND ((grouping_headings.producline_suffix)::text < '80'::text) AND ((grouping_headings.goods_nomenclature_item_id)::text = concat("substring"((indents.goods_nomenclature_item_id)::text, 1, 4), '000000')) AND (grouping_headings.goods_nomenclature_sid <> indents.goods_nomenclature_sid) AND (((grouping_headings.producline_suffix)::text < (indents.productline_suffix)::text) OR ((indents.goods_nomenclature_item_id)::text !~~ '%000000'::text)) AND (grouping_headings.validity_start_date <= indents.validity_start_date) AND ((grouping_headings.validity_end_date IS NULL) OR (grouping_headings.validity_end_date >= indents.validity_start_date)))))
   GROUP BY indents.goods_nomenclature_indent_sid, indents.goods_nomenclature_sid, indents.number_indents, indents.goods_nomenclature_item_id, indents.productline_suffix, indents.validity_start_date, indents.validity_end_date, nomenclatures.validity_end_date, indents.oid, overrides.depth
   WITH NO DATA;
 

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -296,6 +296,55 @@ RSpec.describe GoodsNomenclatures::NestedSet do
 
           it { is_expected.to include number_indents: 2 }
         end
+
+        context 'with grouping subheadings' do
+          let :tree do
+            chapter = create :chapter
+            grouping1 = create :heading, producline_suffix: '10', parent: chapter
+            grouping2 = create :heading,
+                               producline_suffix: '20',
+                               goods_nomenclature_item_id: grouping1.goods_nomenclature_item_id
+            non_grouping = create :heading,
+                                  producline_suffix: '80',
+                                  goods_nomenclature_item_id: grouping1.goods_nomenclature_item_id
+            subheading = create :commodity, parent: non_grouping
+            commodity = create :commodity, parent: subheading
+
+            { chapter:, grouping1:, grouping2:, non_grouping:, subheading:, commodity: }
+          end
+
+          context 'with chapter' do
+            subject { tree[:chapter] }
+
+            it { is_expected.to have_attributes ns_children: eq_pk(tree.values_at(:grouping1)) }
+            it { is_expected.to have_attributes ns_descendants: eq_pk(tree.without(:chapter).values) }
+          end
+
+          context 'with grouping heading' do
+            subject { tree[:grouping2] }
+
+            it { is_expected.to have_attributes ns_ancestors: eq_pk(tree.values_at(:chapter, :grouping1)) }
+            it { is_expected.to have_attributes ns_parent: eq_pk(tree[:grouping1]) }
+            it { is_expected.to have_attributes ns_children: eq_pk(tree.values_at(:non_grouping)) }
+            it { is_expected.to have_attributes ns_descendants: eq_pk(tree.values_at(:non_grouping, :subheading, :commodity)) }
+          end
+
+          context 'with non_grouping' do
+            subject { tree[:non_grouping] }
+
+            it { is_expected.to have_attributes ns_ancestors: eq_pk(tree.values_at(:chapter, :grouping1, :grouping2)) }
+            it { is_expected.to have_attributes ns_parent: eq_pk(tree[:grouping2]) }
+            it { is_expected.to have_attributes ns_children: eq_pk(tree.values_at(:subheading)) }
+            it { is_expected.to have_attributes ns_descendants: eq_pk(tree.values_at(:subheading, :commodity)) }
+          end
+
+          context 'with commodity' do
+            subject { tree[:commodity] }
+
+            it { is_expected.to have_attributes ns_ancestors: eq_pk(tree.without(:commodity).values) }
+            it { is_expected.to have_attributes ns_parent: eq_pk(tree[:subheading]) }
+          end
+        end
       end
 
       describe '#ns_children' do


### PR DESCRIPTION
### Jira link

HOTT-3025

### What?

I have added/removed/altered:

- [x] Replaced the tree_nodes view with one which takes into account grouping headings

### Why?

I am doing this because:

- Whilst there is a lot of inconsistency in the code base, general conclusion is that grouping headings should be above their non-grouping equivalents rather then adjacent to them
- This is how GoodsNomenclatureMapper handles it _if_ given a full tree of nodes, which it only is for the chapters endpoint
- Tarics UI nests non-grouped headings under grouped
- It is easier to drop and replace the view now whilst it has limited usage rather then later when it has heavy usage

### Technical notes

Technically this is incorrect! 

Prior to now the position in the tree of every node could be decided from the information provided by that indent record itself - this is necessary for time machine compatibility.

That is no longer possible, every node needs to know how many grouping headings are above it in order to know its position. The approach I take is to look for available grouping headings at the goods_nomenclature_indent validity_start_date - this does mean if the number of grouping headings in the hierarchy above changes over the lifetime of that indent then the depth value becomes incorrect. 

I've concluded a SQL implementation is irreconcilable with 'correct behaviour' and since the grouping indents have _never_ changed over the lifetime of the tariff (ie 1970's onwards) I don't see this as a significant risk. If a new grouping heading is published, and new indents are published for the goods_nomenclatures below it then it would also not be a problem.

### Deployment risks

- Drops and replaces the tree nodes view - this isn't heavily used yet so shouldn't cause any issues
- This is built to modify the migration from an earlier PR because its better to do this as a single migration

![Screenshot from 2023-04-21 10-22-15](https://user-images.githubusercontent.com/10818/234520176-a352eeaa-5aa0-4023-9ac8-3cae02bb19c9.png)

