### PR TITLE
HOTT-3093 Ignore feature flag in PrewarmSubheadingsWorker

### DIFF
--- a/app/controllers/api/v2/subheadings_controller.rb
+++ b/app/controllers/api/v2/subheadings_controller.rb
@@ -8,7 +8,11 @@ module Api
       private
 
       def cached_subheading
-        CachedSubheadingService.new(subheading, actual_date.iso8601).call
+        CachedSubheadingService.new(
+          subheading,
+          actual_date.iso8601,
+          use_nested_set: TradeTariffBackend.nested_set_subheadings?,
+        ).call
       end
 
       def subheading

--- a/app/services/cached_subheading_service.rb
+++ b/app/services/cached_subheading_service.rb
@@ -15,9 +15,10 @@ class CachedSubheadingService
     'commodities.overview_measures.additional_code',
   ].freeze
 
-  def initialize(subheading, actual_date, eager_reload: true)
+  def initialize(subheading, actual_date, use_nested_set: false, eager_reload: true)
     @subheading = subheading
     @actual_date = actual_date.to_date.to_formatted_s(:db)
+    @use_nested_set = use_nested_set
     @eager_reload = eager_reload
   end
 
@@ -36,7 +37,7 @@ class CachedSubheadingService
   private
 
   def presented_subheading
-    if TradeTariffBackend.nested_set_subheadings?
+    if use_nested_set?
       return Api::V2::Subheadings::SubheadingPresenter.new(ns_eager_loaded_subheading)
     end
 
@@ -77,7 +78,7 @@ class CachedSubheadingService
   end
 
   def cache_version
-    "-v#{CACHE_VERSION}" if TradeTariffBackend.nested_set_subheadings?
+    "-v#{CACHE_VERSION}" if use_nested_set?
   end
 
   def options
@@ -99,6 +100,10 @@ class CachedSubheadingService
         .limit(1)
         .all
         .first || (raise Sequel::RecordNotFound)
+  end
+
+  def use_nested_set?
+    @use_nested_set
   end
 
   def eager_reload?

--- a/app/services/heading_service/precache_service.rb
+++ b/app/services/heading_service/precache_service.rb
@@ -56,8 +56,12 @@ module HeadingService
     end
 
     def write_subheading(subheading)
-      CachedSubheadingService.new(subheading, actual_date, eager_reload: false)
-                             .call
+      CachedSubheadingService.new(
+        subheading,
+        actual_date,
+        eager_reload: false,
+        use_nested_set: true,
+      ).call
     end
   end
 end

--- a/spec/services/cached_subheading_service_spec.rb
+++ b/spec/services/cached_subheading_service_spec.rb
@@ -73,10 +73,6 @@ RSpec.describe CachedSubheadingService do
   end
 
   context 'without nested set subheadings' do
-    before do
-      allow(TradeTariffBackend).to receive(:nested_set_subheadings?).and_return false
-    end
-
     it_behaves_like 'subheading service'
 
     it 'caches with the correct key' do
@@ -87,9 +83,7 @@ RSpec.describe CachedSubheadingService do
   end
 
   context 'with nested set subheadings' do
-    before do
-      allow(TradeTariffBackend).to receive(:nested_set_subheadings?).and_return true
-    end
+    subject(:service) { described_class.new(subheading, actual_date, use_nested_set: true) }
 
     it_behaves_like 'subheading service'
 

--- a/spec/services/heading_service/precache_service_spec.rb
+++ b/spec/services/heading_service/precache_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe HeadingService::PrecacheService do
   end
 
   let :subheading_key do
-    CachedSubheadingService.new(commodity, Time.zone.today).cache_key
+    CachedSubheadingService.new(commodity, Time.zone.today, use_nested_set: true).cache_key
   end
 
   describe '#call' do


### PR DESCRIPTION
### Jira link

HOTT-3093

### What?

I have added/removed/altered:

- [x] Ensure PrewarmSubheadingsWorker generates non-nested set  derived cache entries

### Why?

I am doing this because:

- The PrewarmSubheadingsWorker should continue to operate 'as-is' even when the feature flag is turned on

### Deployment risks (optional)

- Low - fixes bug when feature flag is on, but flag is off at present
