### PR TITLE
Fix flaky additional code specs

### DIFF
--- a/spec/controllers/api/v2/additional_codes_controller_spec.rb
+++ b/spec/controllers/api/v2/additional_codes_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Api::V2::AdditionalCodesController, type: :controller, flaky: true do
+RSpec.describe Api::V2::AdditionalCodesController, type: :controller do
   describe 'GET #search' do
     let!(:additional_code) { create(:additional_code, :with_description) }
 
@@ -33,7 +33,7 @@ RSpec.describe Api::V2::AdditionalCodesController, type: :controller, flaky: tru
             type: 'measure',
             attributes: {
               validity_start_date: String,
-              validity_end_date: String,
+              validity_end_date: nil,
               goods_nomenclature_item_id: String,
             },
             relationships: {

--- a/spec/elastic_search_indexes/cache/additional_code_index_spec.rb
+++ b/spec/elastic_search_indexes/cache/additional_code_index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Cache::AdditionalCodeIndex, flaky: true do
+RSpec.describe Cache::AdditionalCodeIndex do
   subject(:instance) { described_class.new 'testnamespace' }
 
   describe '#dataset' do

--- a/spec/factories/additional_code_factory.rb
+++ b/spec/factories/additional_code_factory.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
 
   factory :additional_code do
     additional_code_sid     { generate(:additional_code_sid) }
-    additional_code_type_id { generate(:additional_code_type_id) }
+    additional_code_type_id { '1' }
     additional_code         { Forgery(:basic).text(exactly: 3) }
     validity_start_date     { 2.years.ago.beginning_of_day }
     validity_end_date       { nil }

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -20,6 +20,7 @@ FactoryBot.define do
       base_regulation_effective_end_date { nil }
       generating_regulation { nil }
       default_start_date { 3.years.ago.beginning_of_day }
+      additional_code { nil }
     end
 
     filename { build(:cds_update, issue_date: operation_date || validity_start_date).filename }
@@ -28,7 +29,9 @@ FactoryBot.define do
     measure_type_id { generate(:measure_type_id) }
     measure_generating_regulation_id { generating_regulation&.regulation_id || generate(:base_regulation_sid) }
     measure_generating_regulation_role { generating_regulation&.role || Measure::BASE_REGULATION_ROLE }
-    additional_code_type_id { generate(:additional_code_type_id) }
+    additional_code_id { additional_code&.additional_code }
+    additional_code_sid { additional_code&.additional_code_sid }
+    additional_code_type_id { additional_code&.additional_code_type_id || '1' }
     goods_nomenclature_sid { goods_nomenclature&.goods_nomenclature_sid || generate(:goods_nomenclature_sid) }
     goods_nomenclature_item_id { goods_nomenclature&.goods_nomenclature_item_id || 10.times.map { Random.rand(9) }.join }
     geographical_area_sid { generate(:geographical_area_sid) }
@@ -424,7 +427,6 @@ FactoryBot.define do
 
     trait :with_additional_code do
       transient do
-        additional_code { Forgery(:basic).text(exactly: 3) }
         additional_code_description { Forgery(:basic).text }
       end
 
@@ -433,18 +435,17 @@ FactoryBot.define do
           :additional_code,
           :with_description,
           additional_code_type_id: measure.additional_code_type_id,
-          additional_code: evaluator.additional_code,
+          additional_code: evaluator.additional_code_id,
           additional_code_description: evaluator.additional_code_description,
         )
         measure.additional_code_sid = adco.additional_code_sid
-        measure.additional_code_id = adco.additional_code
         measure.additional_code_type_id = adco.additional_code_type_id
         measure.save
       end
     end
 
     trait :with_additional_code_type do
-      after(:build) do |measure, _evaluator|
+      before(:build) do |measure, _evaluator|
         create(:additional_code_type, additional_code_type_id: measure.additional_code_type_id)
       end
     end

--- a/spec/services/additional_code_search_service_spec.rb
+++ b/spec/services/additional_code_search_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe AdditionalCodeSearchService, flaky: true do
+RSpec.describe AdditionalCodeSearchService do
   describe '#call' do
     subject(:result) { described_class.new(search_attributes, current_page, per_page).call }
 

--- a/spec/services/additional_code_search_service_spec.rb
+++ b/spec/services/additional_code_search_service_spec.rb
@@ -13,9 +13,8 @@ RSpec.describe AdditionalCodeSearchService do
       create(
         :measure,
         :with_base_regulation,
-        additional_code_sid: additional_code.additional_code_sid,
-        goods_nomenclature_sid: current_goods_nomenclature.goods_nomenclature_sid,
-        goods_nomenclature_item_id: current_goods_nomenclature.goods_nomenclature_item_id,
+        additional_code:,
+        goods_nomenclature: current_goods_nomenclature,
       )
       create(
         :goods_nomenclature_description,

--- a/spec/services/applicable_additional_code_service_spec.rb
+++ b/spec/services/applicable_additional_code_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ApplicableAdditionalCodeService do
           :with_measure_type,
           measure_type_id: '105',
           additional_code_type_id: '2',
-          additional_code: '550',
+          additional_code_id: '550',
         )
         duplicate_measure = create(
           :measure,
@@ -18,7 +18,7 @@ RSpec.describe ApplicableAdditionalCodeService do
           :with_measure_type,
           measure_type_id: '105',
           additional_code_type_id: '2',
-          additional_code: '550',
+          additional_code_id: '550',
           measure_sid: measure.measure_sid,
         )
         measure_with_same_measure_and_code_type = create(
@@ -27,7 +27,7 @@ RSpec.describe ApplicableAdditionalCodeService do
           :with_measure_type,
           measure_type_id: '105',
           additional_code_type_id: '2',
-          additional_code: '551',
+          additional_code_id: '551',
         )
         measure_with_different_measure_and_code_type = create(
           :measure,

--- a/spec/services/applicable_vat_options_service_spec.rb
+++ b/spec/services/applicable_vat_options_service_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ApplicableVatOptionsService do
           measure_type_id: '305',
           additional_code_description: 'VAT zero rate',
           additional_code_type_id: 'V',
-          additional_code: 'ATZ',
+          additional_code_id: 'ATZ',
           duty_amount: 0,
         )
       end


### PR DESCRIPTION
### Jira link

HOTT-???

### What?

I have added/removed/altered:

- [x] Fixed the AdditionalCode factory output to not choose an `additional_code_type_id` excluded by the Cache::AdditionalCodeIndex
- [x] Changed Measure factory to not set `additional_code_type_id` to a value potentially excluded by Cache::AdditionalCodeIndex
- [x] Reenabled specs marked as flaky

### Why?

I am doing this because:

- It makes any spec using the AdditionalCode factory and relying on the behaviour of CacheAdditionalCodeIndex#dataset flaky

### Deployment risks (optional)

- None, spec only changes

### Notes

Addresses these failures on CI Job 23062
