### PR TITLE
HOTT-3087: Drop borked balance events

### DIFF
--- a/db/data_migrations/20230502102427_kill_broken_balance_events.rb
+++ b/db/data_migrations/20230502102427_kill_broken_balance_events.rb
@@ -1,0 +1,46 @@
+Sequel.migration do
+  BALANCE_EVENTS = [
+    {
+      quota_definition_sid: 22_046,
+      occurrence_timestamp: '2023-01-06T16:01:00.000Z',
+      last_import_date_in_allocation: nil,
+      old_balance: 0.998e6,
+      new_balance: 0.1471e7,
+      imported_amount: 0.0,
+      operation: 'C',
+      operation_date: Date.parse('2023-01-09'),
+      filename: 'tariff_dailyExtract_v1_20230109T235959.gzip',
+    },
+    {
+      quota_definition_sid: 22_052,
+      occurrence_timestamp: '2023-01-06T16:01:00.000Z',
+      last_import_date_in_allocation: nil,
+      old_balance: 0.998e6,
+      new_balance: 0.1471e7,
+      imported_amount: 0.0,
+      operation: 'C',
+      operation_date: Date.parse('2023-01-09'),
+      filename: 'tariff_dailyExtract_v1_20230109T235959.gzip',
+    },
+  ].freeze
+
+  # IMPORTANT! Data migrations up block should be idempotent (reruns of up should produce the same effect)
+  # they may get re-run as part of data rollbacks but the rollback (down) function of the data migration will not get invoked
+  up do
+    if TradeTariffBackend.uk?
+      BALANCE_EVENTS.each do |event_data|
+        QuotaBalanceEvent.where(event_data).destroy
+      end
+    end
+  end
+
+  down do
+    if TradeTariffBackend.uk?
+      BALANCE_EVENTS.each do |event_data|
+        QuotaBalanceEvent.unrestrict_primary_key
+        QuotaBalanceEvent.new(event_data).save
+        QuotaBalanceEvent.restrict_primary_key
+      end
+    end
+  end
+end

--- a/db/data_migrations/20230502102427_kill_broken_balance_events.rb
+++ b/db/data_migrations/20230502102427_kill_broken_balance_events.rb
@@ -1,11 +1,11 @@
 Sequel.migration do
-  BALANCE_EVENTS = [
+  balance_events = [
     {
       quota_definition_sid: 22_046,
       occurrence_timestamp: '2023-01-06T16:01:00.000Z',
       last_import_date_in_allocation: nil,
-      old_balance: 0.998e6,
-      new_balance: 0.1471e7,
+      old_balance: 998_000.0,
+      new_balance: 1_471_000.0,
       imported_amount: 0.0,
       operation: 'C',
       operation_date: Date.parse('2023-01-09'),
@@ -15,8 +15,8 @@ Sequel.migration do
       quota_definition_sid: 22_052,
       occurrence_timestamp: '2023-01-06T16:01:00.000Z',
       last_import_date_in_allocation: nil,
-      old_balance: 0.998e6,
-      new_balance: 0.1471e7,
+      old_balance: 998_000.0,
+      new_balance: 1_471_000.0,
       imported_amount: 0.0,
       operation: 'C',
       operation_date: Date.parse('2023-01-09'),
@@ -28,7 +28,7 @@ Sequel.migration do
   # they may get re-run as part of data rollbacks but the rollback (down) function of the data migration will not get invoked
   up do
     if TradeTariffBackend.uk?
-      BALANCE_EVENTS.each do |event_data|
+      balance_events.each do |event_data|
         QuotaBalanceEvent.where(event_data).destroy
       end
     end
@@ -36,7 +36,7 @@ Sequel.migration do
 
   down do
     if TradeTariffBackend.uk?
-      BALANCE_EVENTS.each do |event_data|
+      balance_events.each do |event_data|
         QuotaBalanceEvent.unrestrict_primary_key
         QuotaBalanceEvent.new(event_data).save
         QuotaBalanceEvent.restrict_primary_key


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3088

Before

![image](https://user-images.githubusercontent.com/8156884/235644622-20abbe66-1a85-460d-8c31-91e764bd65e0.png)

After

![image](https://user-images.githubusercontent.com/8156884/235644729-979ca20a-95fd-4068-af28-dc9674c46e49.png)

### What?

I have added/removed/altered:

- [x] Added data migration to drop broken balance events

### Why?

I am doing this because:

- These shouldn't exist and show an increasing volume
