### PR TITLE
HOTT-3065 Fixed N+1s in admin headings api

### DIFF
--- a/app/controllers/api/admin/headings_controller.rb
+++ b/app/controllers/api/admin/headings_controller.rb
@@ -18,12 +18,13 @@ module Api
 
       def heading
         @heading ||= Heading.actual
-                          .non_grouping
-                          .non_hidden
-                          .by_code(params[:id])
-                          .eager(path_descendants: %i[goods_nomenclature_descriptions path_descendants])
-                          .limit(1)
-                          .take
+                            .non_grouping
+                            .non_hidden
+                            .by_code(params[:id])
+                            .eager(ns_descendants: %i[goods_nomenclature_descriptions])
+                            .limit(1)
+                            .all
+                            .first || (raise Sequel::RecordNotFound)
       end
 
       def search_reference_counts
@@ -35,7 +36,8 @@ module Api
       end
 
       def applicable_goods_nomenclature_sids
-        heading.path_descendants.pluck(:goods_nomenclature_sid).tap { |sids| sids << heading.goods_nomenclature_sid }
+        heading.ns_descendants.pluck(:goods_nomenclature_sid) +
+          [heading.goods_nomenclature_sid]
       end
     end
   end

--- a/app/presenters/api/admin/headings/heading_presenter.rb
+++ b/app/presenters/api/admin/headings/heading_presenter.rb
@@ -21,7 +21,7 @@ module Api
         end
 
         def commodities
-          @commodities ||= CommodityPresenter.wrap(path_descendants, @search_reference_counts)
+          @commodities ||= CommodityPresenter.wrap(ns_descendants, @search_reference_counts)
         end
 
         def commodity_ids

--- a/app/serializers/api/admin/headings/commodity_serializer.rb
+++ b/app/serializers/api/admin/headings/commodity_serializer.rb
@@ -13,7 +13,7 @@ module Api
                    :goods_nomenclature_item_id,
                    :producline_suffix
 
-        attribute :declarable, &:path_declarable?
+        attribute :declarable, &:ns_declarable?
       end
     end
   end

--- a/spec/presenters/api/admin/headings/heading_presenter_spec.rb
+++ b/spec/presenters/api/admin/headings/heading_presenter_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Api::Admin::Headings::HeadingPresenter do
     it { is_expected.to have_attributes values: heading.values }
     it { is_expected.to have_attributes search_references_count: 1 }
     it { expect(presented.commodities).to have_attributes length: 2 }
-    it { expect(presented.commodities.first).to have_attributes values: heading.path_descendants.first.values }
+    it { expect(presented.commodities.first).to have_attributes pk: heading.path_descendants.first.pk }
     it { expect(presented.commodities.first).to have_attributes search_references_count: 3 }
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-3065

### What?

I have added/removed/altered:

- [x] Changed the admin headings api to use Nested Sets

### Why?

I am doing this because:

- To reduce N+1s in the admin api
- To replace existing materialized path code with nested set which available for more scenarios

### Deployment risks (optional)

- Low

### Before

Running locally so no real network latency impact

![Screenshot from 2023-05-02 12-30-42](https://user-images.githubusercontent.com/10818/235654905-60286252-9ca9-422e-ace7-2ff111a437ce.png)

### After

![Screenshot from 2023-05-02 12-29-36](https://user-images.githubusercontent.com/10818/235654946-bbccc242-7ae1-41cf-9f7b-94a4e969990a.png)

