### PR TITLE
HOTT-2904 Convert v2 chapters to use nested sets

### DIFF
--- a/app/presenters/api/admin/headings/heading_presenter.rb
+++ b/app/presenters/api/admin/headings/heading_presenter.rb
@@ -1,15 +1,7 @@
 module Api
   module Admin
     module Headings
-      class HeadingPresenter < SimpleDelegator
-        class << self
-          def wrap(headings, search_reference_counts)
-            headings.map do |heading|
-              new(heading, search_reference_counts)
-            end
-          end
-        end
-
+      class HeadingPresenter < WrapDelegator
         def initialize(heading, search_reference_counts)
           @search_reference_counts = search_reference_counts
 

--- a/app/presenters/api/v2/chapters/chapter_presenter.rb
+++ b/app/presenters/api/v2/chapters/chapter_presenter.rb
@@ -1,22 +1,13 @@
 module Api
   module V2
     module Chapters
-      class ChapterPresenter
-        attr_reader :chapter, :root_headings
-        alias headings root_headings
-
-        delegate :goods_nomenclature_sid, :goods_nomenclature_item_id,
-                 :description, :formatted_description, :chapter_note, :section,
-                 :guides, :section_id, :guide_ids, :forum_link, :validity_start_date,
-                 :validity_end_date, to: :chapter
-
-        def initialize(chapter, root_headings)
-          @chapter = chapter
-          @root_headings = root_headings
+      class ChapterPresenter < SimpleDelegator
+        def heading_ids
+          headings.map(&:goods_nomenclature_sid)
         end
 
-        def heading_ids
-          root_headings.map(&:goods_nomenclature_sid)
+        def headings
+          @headings ||= HeadingPresenter.wrap(ns_children)
         end
       end
     end

--- a/app/presenters/api/v2/chapters/heading_presenter.rb
+++ b/app/presenters/api/v2/chapters/heading_presenter.rb
@@ -1,0 +1,50 @@
+module Api
+  module V2
+    module Chapters
+      class HeadingPresenter < SimpleDelegator
+        class << self
+          def nest(headings)
+            tree = {}
+
+            headings.inject(nil) do |previous, heading|
+              if previous.nil? # First iteration
+                tree[heading] = nil
+              elsif heading.producline_suffix > previous.producline_suffix
+                tree[tree.keys.last] = [heading]
+              elsif heading.producline_suffix < previous.producline_suffix
+                tree[heading] = nil
+              elsif tree[tree.keys.last].nil? # same PLS, and previous was at upper level
+                tree[heading] = nil
+              else # same PLS, and previous was at lower level
+                tree[tree.keys.last] << heading
+              end
+
+              heading
+            end
+
+            tree
+          end
+
+          def wrap(headings)
+            nest(headings).map { |heading, children| new(heading, children) }
+          end
+        end
+
+        attr_reader :children
+
+        def initialize(heading, children = nil)
+          @children = (children || []).map(&self.class.method(:new))
+          super(heading)
+        end
+
+        def child_ids
+          children.map(&:goods_nomenclature_sid)
+        end
+
+        def leaf
+          children.none?
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/api/v2/headings/commodity_presenter.rb
+++ b/app/presenters/api/v2/headings/commodity_presenter.rb
@@ -1,13 +1,7 @@
 module Api
   module V2
     module Headings
-      class CommodityPresenter < SimpleDelegator
-        class << self
-          def wrap(commodities)
-            commodities.map(&method(:new))
-          end
-        end
-
+      class CommodityPresenter < WrapDelegator
         def parent_sid
           if ns_parent.is_a?(Commodity) || ns_parent.is_a?(Subheading)
             ns_parent.goods_nomenclature_sid

--- a/app/presenters/api/v2/news/item_presenter.rb
+++ b/app/presenters/api/v2/news/item_presenter.rb
@@ -1,13 +1,7 @@
 module Api
   module V2
     module News
-      class ItemPresenter < SimpleDelegator
-        class << self
-          def wrap(items)
-            items.map(&method(:new))
-          end
-        end
-
+      class ItemPresenter < WrapDelegator
         def collections
           published_collections
         end

--- a/app/presenters/wrap_delegator.rb
+++ b/app/presenters/wrap_delegator.rb
@@ -1,0 +1,9 @@
+class WrapDelegator < SimpleDelegator
+  class << self
+    def wrap(records, ...)
+      records.map do |record|
+        new(record, ...)
+      end
+    end
+  end
+end

--- a/app/serializers/api/v2/chapters/chapter_serializer.rb
+++ b/app/serializers/api/v2/chapters/chapter_serializer.rb
@@ -15,7 +15,7 @@ module Api
                    :validity_start_date,
                    :validity_end_date
 
-        attribute :chapter_note, if: Proc.new { |chapter| chapter.chapter_note.present? } do |chapter|
+        attribute :chapter_note, if: proc { |chapter| chapter.chapter_note.present? } do |chapter|
           chapter.chapter_note.content
         end
 

--- a/app/serializers/api/v2/chapters/heading_leaf_serializer.rb
+++ b/app/serializers/api/v2/chapters/heading_leaf_serializer.rb
@@ -5,7 +5,10 @@ class Api::V2::Chapters::HeadingLeafSerializer
 
   set_id :goods_nomenclature_sid
 
-  attributes :goods_nomenclature_sid, :goods_nomenclature_item_id,
-             :declarable, :description, :producline_suffix, :leaf,
-             :description_plain, :formatted_description
+  attribute :goods_nomenclature_sid, :goods_nomenclature_item_id
+
+  attribute :declarable, &:ns_declarable?
+
+  attributes :description, :producline_suffix, :leaf
+  attributes :description_plain, :formatted_description
 end

--- a/app/serializers/api/v2/chapters/heading_serializer.rb
+++ b/app/serializers/api/v2/chapters/heading_serializer.rb
@@ -8,12 +8,15 @@ module Api
 
         set_id :goods_nomenclature_sid
 
-        attributes :goods_nomenclature_sid, :goods_nomenclature_item_id,
-                   :declarable, :description, :producline_suffix, :leaf,
-                   :description_plain, :formatted_description, :validity_start_date,
-                   :validity_end_date
+        attributes :goods_nomenclature_sid, :goods_nomenclature_item_id
+        attribute :declarable, &:ns_declarable?
 
-        has_many :children, record_type: 'heading', serializer: Api::V2::Chapters::HeadingLeafSerializer
+        attributes :description, :producline_suffix, :leaf
+        attributes :description_plain, :formatted_description,
+                   :validity_start_date, :validity_end_date
+
+        has_many :children, record_type: 'heading',
+                            serializer: Api::V2::Chapters::HeadingLeafSerializer
       end
     end
   end

--- a/app/serializers/api/v2/chapters/section_serializer.rb
+++ b/app/serializers/api/v2/chapters/section_serializer.rb
@@ -9,7 +9,7 @@ module Api
         set_id :id
 
         attributes :id, :numeral, :title, :position
-        attribute :section_note, if: Proc.new { |section| section.section_note.present? } do |section|
+        attribute :section_note, if: proc { |section| section.section_note.present? } do |section|
           section.section_note.content
         end
       end

--- a/app/serializers/api/v2/csv/heading_serializer.rb
+++ b/app/serializers/api/v2/csv/heading_serializer.rb
@@ -5,14 +5,16 @@ module Api
         include Api::Shared::CsvSerializer
 
         columns :goods_nomenclature_item_id,
-                :goods_nomenclature_sid,
-                :declarable,
-                :description,
+                :goods_nomenclature_sid
+
+        column  :declarable, &:ns_declarable?
+
+        columns :description,
                 :description_plain,
                 :formatted_description,
                 :producline_suffix
 
-        column(:leaf) { |heading| heading.commodities_dataset.empty? }
+        column  :leaf, &:ns_leaf?
       end
     end
   end

--- a/spec/presenters/api/v2/chapters/headings_presenter_spec.rb
+++ b/spec/presenters/api/v2/chapters/headings_presenter_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe Api::V2::Chapters::HeadingPresenter do
+  let(:nongrouping) { build_list :heading, 3, :non_grouping }
+  let(:grouping) { build :heading, :grouping }
+
+  describe '.nest' do
+    subject { described_class.nest headings }
+
+    context 'with flat set of headings' do
+      let(:headings) { nongrouping }
+
+      it { is_expected.to eq(headings[0] => nil, headings[1] => nil, headings[2] => nil) }
+    end
+
+    context 'when all nested' do
+      let(:headings) { [grouping] + nongrouping }
+
+      it { is_expected.to eq(grouping => nongrouping) }
+    end
+
+    context 'when some are nested' do
+      let(:headings) { [nongrouping1, grouping] + nongrouping }
+      let(:nongrouping1) { build :heading, :non_grouping }
+
+      it { is_expected.to eq(nongrouping1 => nil, grouping => nongrouping) }
+    end
+
+    context 'when pls decreases again' do
+      let(:grouping2) { build :heading, :grouping }
+      let(:grouping3) { build :heading, :grouping }
+      let(:headings) { [grouping] + nongrouping + [grouping2, grouping3] }
+
+      it { is_expected.to eq grouping => nongrouping, grouping2 => nil, grouping3 => nil }
+    end
+
+    context 'with multiple trees in set' do
+      let(:grouping2) { build :heading, :grouping }
+      let(:nongrouping2) { build_list :heading, 2, :non_grouping }
+      let(:headings) { [grouping] + nongrouping + [grouping2] + nongrouping2 }
+
+      it { is_expected.to eq grouping => nongrouping, grouping2 => nongrouping2 }
+    end
+  end
+
+  describe '.wrap' do
+    subject(:wrapped) { described_class.wrap headings }
+
+    let(:headings) { [grouping] + nongrouping }
+
+    it { expect(wrapped.map(&:pk)).to eq [grouping.pk] }
+    it { expect(wrapped.first.children.map(&:pk)).to eq nongrouping.map(&:pk) }
+    it { expect(wrapped.first.children).to all be_instance_of described_class }
+  end
+end

--- a/spec/requests/api/v2/chapters_controller_spec.rb
+++ b/spec/requests/api/v2/chapters_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::V2::ChaptersController, type: :request do
       expect(Rails.cache)
         .to have_received(:fetch)
         .with(
-          "_chapters-#{now.iso8601}/v1",
+          "_chapters-#{now.iso8601}/v2",
           expires_at:,
         )
     end
@@ -37,7 +37,7 @@ RSpec.describe Api::V2::ChaptersController, type: :request do
       expect(Rails.cache)
         .to have_received(:fetch)
         .with(
-          "_chapter-#{chapter.short_code}-#{now.iso8601}/v1",
+          "_chapter-#{chapter.short_code}-#{now.iso8601}/v2",
           expires_at:,
         )
     end
@@ -52,7 +52,7 @@ RSpec.describe Api::V2::ChaptersController, type: :request do
       expect(Rails.cache)
         .to have_received(:fetch)
         .with(
-          "_chapter-#{chapter.short_code}-#{now.iso8601}/changes-v1",
+          "_chapter-#{chapter.short_code}-#{now.iso8601}/changes-v2",
           expires_at:,
         )
     end


### PR DESCRIPTION
### Jira link

HOTT-2904

### What?

I have added/removed/altered:

- [x] Changed v2 chapters controller to use nested set
- [x] Abstracted out `SimpleDelegator#wrap` method

### Why?

I am doing this because:

- This is a good test bed for comparing nested set output
- We can further optimise the endpoint with nested set
- I keep adding `SomePresenter#wrap` everywhere, this standardises it

### Deployment risks (optional)

- Low, behaviour is the same

### Screenshots

Old (prod) on the left and new (dev) on the right

![Screenshot from 2023-05-04 14-51-11](https://user-images.githubusercontent.com/10818/236227988-b41c8596-9f06-4572-ba46-dcbeb2fe00e2.png)
![Screenshot from 2023-05-04 14-50-31](https://user-images.githubusercontent.com/10818/236228000-55266596-c80f-4be1-988e-3f865227c9b5.png)

