### PR TITLE
HOTT-3118 Add leaf virtual column

### DIFF
--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -124,6 +124,15 @@ module GoodsNomenclatures
           .without_excluded_types
           .overview
       end
+
+      def_column_accessor :leaf
+
+      dataset_module do
+        def with_leaf_column
+          association_join(tree_node: proc { |ds| ds.with_leaf_column })
+            .select_append(:number_indents, :depth, :leaf)
+        end
+      end
     end
 
     def recursive_ancestor_populator(ancestors)

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -475,6 +475,24 @@ RSpec.describe GoodsNomenclatures::NestedSet do
     end
   end
 
+  describe '.with_leaf_column' do
+    subject do
+      GoodsNomenclature.with_leaf_column
+                       .all
+                       .index_by(&:goods_nomenclature_sid)
+                       .transform_values(&:leaf)
+    end
+
+    before { commodity }
+
+    let(:subheading) { create :subheading, :with_chapter_and_heading }
+    let(:commodity) { create :commodity, parent: subheading }
+
+    it { is_expected.to include subheading.chapter.pk => false }
+    it { is_expected.to include subheading.pk => false }
+    it { is_expected.to include commodity.pk => true }
+  end
+
   describe '#ns_declarable?' do
     context 'with descendants' do
       subject { create :commodity, :non_grouping, :with_children }

--- a/spec/models/goods_nomenclatures/tree_node_spec.rb
+++ b/spec/models/goods_nomenclatures/tree_node_spec.rb
@@ -57,78 +57,84 @@ RSpec.describe GoodsNomenclatures::TreeNode do
   end
 
   describe '.previous_sibling' do
+    subject do
+      described_class.previous_sibling(origin.tree_node.position, origin.tree_node.depth)
+                     .first
+                     .values[:previous_sibling]
+    end
+
     let(:subheading) { create :commodity, :with_chapter_and_heading }
     let(:siblings) { create_list :commodity, 3, parent: subheading }
 
     context 'with first sibling' do
-      subject do
-        described_class.previous_sibling(siblings.first.tree_node.position,
-                                         siblings.first.tree_node.depth)
-                       .first
-                       .values[:previous_sibling]
-      end
+      let(:origin) { siblings.first }
 
       it { is_expected.to be_nil }
     end
 
     context 'with second sibling' do
-      subject do
-        described_class.previous_sibling(siblings.second.tree_node.position,
-                                         siblings.second.tree_node.depth)
-                       .first
-                       .values[:previous_sibling]
-      end
+      let(:origin) { siblings.second }
 
       it { is_expected.to eq siblings.first.tree_node.position }
     end
 
     context 'with third sibling' do
-      subject do
-        described_class.previous_sibling(siblings.third.tree_node.position,
-                                         siblings.third.tree_node.depth)
-                       .first
-                       .values[:previous_sibling]
-      end
+      let(:origin) { siblings.third }
 
       it { is_expected.to eq siblings.second.tree_node.position }
     end
   end
 
   describe '.next_sibling' do
+    subject do
+      described_class.next_sibling(origin.tree_node.position, origin.tree_node.depth)
+                     .first
+                     .values[:next_sibling]
+    end
+
     let(:subheading) { create :commodity, :with_chapter_and_heading }
     let(:siblings) { create_list :commodity, 3, parent: subheading }
 
     context 'with first sibling' do
-      subject do
-        described_class.next_sibling(siblings.first.tree_node.position,
-                                     siblings.first.tree_node.depth)
-                       .first
-                       .values[:next_sibling]
-      end
+      let(:origin) { siblings.first }
 
       it { is_expected.to eq siblings.second.tree_node.position }
     end
 
     context 'with second sibling' do
-      subject do
-        described_class.next_sibling(siblings.second.tree_node.position,
-                                     siblings.second.tree_node.depth)
-                       .first
-                       .values[:next_sibling]
-      end
+      let(:origin) { siblings.second }
 
       it { is_expected.to eq siblings.third.tree_node.position }
     end
 
     context 'with third sibling' do
-      subject do
-        described_class.next_sibling(siblings.third.tree_node.position,
-                                     siblings.third.tree_node.depth)
-                       .first
-                       .values[:next_sibling]
-      end
+      let(:origin) { siblings.third }
 
       it { is_expected.to be_nil }
+    end
+  end
+
+  describe '.next_sibling_or_end' do
+    subject do
+      described_class.db.select(
+        described_class.next_sibling_or_end(origin.tree_node.position,
+                                            origin.tree_node.depth),
+      ).first[:coalesce]
+    end
+
+    let(:subheading) { create :commodity, :with_chapter_and_heading }
+    let(:siblings) { create_list :commodity, 3, parent: subheading }
+
+    context 'with first sibling' do
+      let(:origin) { siblings.first }
+
+      it { is_expected.to eq siblings.second.tree_node.position }
+    end
+
+    context 'with third sibling' do
+      let(:origin) { siblings.third }
+
+      it { is_expected.to eq described_class::END_OF_TREE }
     end
   end
 
@@ -148,6 +154,24 @@ RSpec.describe GoodsNomenclatures::TreeNode do
     let(:table2) { GoodsNomenclatures::TreeNodeAlias.new(:table2) }
 
     it { is_expected.to be_instance_of Sequel::SQL::BooleanExpression }
+  end
+
+  describe '.with_leaf_column' do
+    subject do
+      described_class.with_leaf_column
+                     .all
+                     .index_by(&:goods_nomenclature_sid)
+                     .transform_values(&:leaf)
+    end
+
+    before { commodity }
+
+    let(:subheading) { create :subheading, :with_chapter_and_heading }
+    let(:commodity) { create :commodity, parent: subheading }
+
+    it { is_expected.to include subheading.chapter.pk => false }
+    it { is_expected.to include subheading.pk => false }
+    it { is_expected.to include commodity.pk => true }
   end
 
   describe '#goods_nomenclature relationship' do


### PR DESCRIPTION
### Jira link

HOTT-3118

### What?

I have added/removed/altered:

- [x] Added a dataset scope to add a virtual `leaf` column to GoodsNomenclature

### Why?

I am doing this because:

- It allows `ns_declarable?` to determine whether a commodity is declarable without requiring a database lookup or retrieving all its children

### Deployment risks (optional)

- Low, not currently in use - will be used in following PRs

### Performance benefit

This is checking `ns_declarable?` for every GoodsNomenclature in our database

![Screenshot from 2023-05-04 11-08-09](https://user-images.githubusercontent.com/10818/236176449-c9716470-2486-42b0-8869-d0af34a3ed26.png)

