### PR TITLE
HOTT-3133 Eager loadable Sequel#take

### DIFF
--- a/app/controllers/api/admin/headings_controller.rb
+++ b/app/controllers/api/admin/headings_controller.rb
@@ -22,9 +22,7 @@ module Api
                             .non_hidden
                             .by_code(params[:id])
                             .eager(ns_descendants: %i[goods_nomenclature_descriptions])
-                            .limit(1)
-                            .all
-                            .first || (raise Sequel::RecordNotFound)
+                            .take
       end
 
       def search_reference_counts

--- a/app/controllers/api/v2/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/goods_nomenclatures_controller.rb
@@ -36,10 +36,7 @@ module Api
                          .by_code(params[:chapter_id])
                          .eager(:ns_ancestors,
                                 ns_descendants: :goods_nomenclature_descriptions)
-                         .limit(1)
-                         .all
-                         .first
-                         .presence || (raise Sequel::RecordNotFound)
+                         .take
 
         @goods_nomenclatures = [chapter] + chapter.ns_descendants
 

--- a/app/lib/sequel/plugins/take.rb
+++ b/app/lib/sequel/plugins/take.rb
@@ -5,7 +5,7 @@ module Sequel
     module Take
       module DatasetMethods
         def take
-          first.presence || (raise Sequel::RecordNotFound)
+          limit(1).all.first.presence || (raise Sequel::RecordNotFound)
         end
       end
     end

--- a/app/services/cached_subheading_service.rb
+++ b/app/services/cached_subheading_service.rb
@@ -97,9 +97,7 @@ class CachedSubheadingService
         .non_hidden
         .where(goods_nomenclature_sid: @subheading.goods_nomenclature_sid)
         .eager(*HeadingService::Serialization::NsNondeclarableService::HEADING_EAGER_LOAD)
-        .limit(1)
-        .all
-        .first || (raise Sequel::RecordNotFound)
+        .take
   end
 
   def use_nested_set?

--- a/app/services/heading_service/precache_service.rb
+++ b/app/services/heading_service/precache_service.rb
@@ -31,9 +31,7 @@ module HeadingService
         Chapter.actual
                .where(goods_nomenclature_sid: chapter.goods_nomenclature_sid)
                .eager(*Serialization::NsNondeclarableService::HEADING_EAGER_LOAD)
-               .limit(1)
-               .all
-               .first
+               .take
                .ns_children
                .each do |heading|
           next if heading.ns_declarable?

--- a/app/services/heading_service/serialization/ns_nondeclarable_service.rb
+++ b/app/services/heading_service/serialization/ns_nondeclarable_service.rb
@@ -83,9 +83,7 @@ module HeadingService
                .non_hidden
                .where(goods_nomenclature_sid: heading.goods_nomenclature_sid)
                .eager(*HEADING_EAGER_LOAD)
-               .limit(1)
-               .all
-               .first
+               .take
       end
     end
   end


### PR DESCRIPTION
### Jira link

HOTT-3133

### What?

I have added/removed/altered:

- [x] Changed the `Sequel#take` plugin to be compatible with eager loading
- [x] Used #take for various pieces of code which were previously working around #take not being eager load compatible

### Why?

I am doing this because:

- We have quite a few locations in the code base which are using `.eager`  together with `.take` without the authors realising this has no effect. Its best to make it work with `.eager`

### Deployment risks (optional)

- change to a sequel plugin used in lots of places but should be a safe change
