### PR TITLE
Change the default log level in development environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   config.cache_store = [:null_store]
 
   # enable sequel transaction logs by setting RAILS_LOG_LEVEL=debug
-  config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info').to_sym
+  config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'debug').to_sym
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [x] Changed the default log level in `Rails.env.development?` to `debug`

### Why?

I am doing this because:

- It will help highlight when changes introduce N+1s
- It sets the 'default' developer experience to have increased visibility
- The developer can still easily control it via the env var using `.env.development.local`

### Deployment risks (optional)

- None
