### PR TITLE
HOTT-3156 Add missing FTA intro docs for AU and NZ

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk/fta_intro/australia.md
+++ b/db/rules_of_origin/roo_schemes_uk/fta_intro/australia.md
@@ -1,0 +1,11 @@
+###  UK-Australia Free Trade Agreement
+
+The UK has signed a free trade agreement with Australia, which came into effect on 31 May 2023.
+
+### What the agreement covers
+
+The agreement contains 32 chapters covering a wide range of issues.
+
+It removes most tariffs on trade between the UK and Australia. The UK market for some agricultural goods will be opened to Australia more gradually.
+
+Other provisions cover trade in services, digital trade, public procurement and intellectual property. UK citizens aged under 35 will be able to travel and work in Australia more easily. There are provisions covering technical barriers to trade, and sanitary & phytosanitary (SPS) measures relating to food safety and animal and plant health. There are chapters on small business, the environment, and animal welfare and antimicrobial resistance.

--- a/db/rules_of_origin/roo_schemes_uk/fta_intro/new-zealand.md
+++ b/db/rules_of_origin/roo_schemes_uk/fta_intro/new-zealand.md
@@ -1,0 +1,11 @@
+###  UK-Australia Free Trade Agreement
+
+The UK has signed a free trade agreement with Australia, which came into effect on 31 May 2023.
+
+### What the agreement covers
+
+The agreement aims to reduce barriers to trade between the UK and New Zealand. It removes tariffs on UK-New Zealand trade.
+
+UK tariffs on some sensitive agricultural products are reduced over a transitional period.
+
+It also removes barriers to trade in services and in a number of other areas. This briefing looks at some of the main issues but does not cover all of the agreement's 33 chapters.

--- a/db/rules_of_origin/roo_schemes_uk/introductory_notes/australia_intro.md
+++ b/db/rules_of_origin/roo_schemes_uk/introductory_notes/australia_intro.md
@@ -1,0 +1,152 @@
+# Headnotes to the Annex
+
+1. For the purposes of this Annex:
+
+    (a) “chapter” means the first two digits of the tariff classification number under the Harmonized System 2017;
+
+    (b) “heading” means the first four digits of the tariff classification number under the Harmonized System 2017;
+
+    (c) “section" means a section of the Harmonized System 2017; and
+
+    (d) “sub-heading” means the first six digits of the tariff classification number under the Harmonized System 2017.
+
+2. The product specific rule, or set of product specific rules, that applies to a particular sub-heading is set out immediately adjacent to the sub-heading.
+
+3. Section, chapter or heading notes, where applicable, are found at the beginning of each section, chapter or heading, and are read in conjunction with the product specific rules of origin and may impose further conditions or provide an alternative product specific rule of origin.
+
+    For the avoidance of doubt, if a product or material is classified differently under HS 2017 and the Goods Classification Table made pursuant to the Taxation (Cross-border Trade) Act 2018 and the Customs Tariff (Establishment) (EU Exit) Regulations 2020, contained in Annex 1 to the Tariff of the United Kingdom and interpreted in accordance with Part Two of the Tariff of the United Kingdom, HS 2017 shall be used to classify the product for the purposes of determining which product specific rule, or set of rules of origin, applies to the product and to classify the material for the purposes of determining the application of a product specific rule.
+
+4. A requirement of a change in tariff classification applies only to non-originating materials.
+
+5. If a chapter, heading or sub-heading is excluded as part of a change in tariff classification rule, it means that non-originating materials of that chapter, heading or sub-heading may not be used to meet the change in tariff classification rule. All materials that are excluded must be originating goods.  
+
+6. Where a heading or sub-heading is subject to alternative product specific rules, the requirements of this Annex will be considered to be satisfied if a good satisfies one of the alternative rules.
+
+7. If a good is subject to a product specific rule that includes multiple requirements, the requirements of this Annex will be considered to be satisfied for that good only if the good satisfies all applicable requirements.
+
+8. For the purposes of Section B of this Annex:
+
+    (a) “CC” means that all non-originating materials used in the production of the good have undergone a change in tariff classification at the two-digit level;
+
+    (b) “CTH” means that all non-originating materials used in the production of the good have undergone a change in tariff classification at the four-digit level; 
+
+    (c) “CTSH” means that all non-originating materials used in the production of the good have undergone a change in tariff classification at the six-digit level;  
+
+    (d) “FF” means that the good must undergo a change from fabric that is constructed but not further prepared or finished provided that it is dyed or printed and undergoes at least one preparatory or finishing processes in the territory of one or both of the Parties to render it directly usable; and
+
+    (e) “RVC(X)” means that the good must have a regional value content as calculated under Article 4 (Regional Value Content) of this Origin Reference Document of not less than (X) per cent whether using the build-up method or build-down method.
+
+## Section notes
+
+### SECTION II VEGETABLE PRODUCTS
+
+An agricultural or horticultural good grown in the territory of a Party is originating even if grown from seed, bulbs, rhizomes, rootstock, cuttings, slips, grafts, shoots, buds or other live parts of plants that are imported from a non-
+Party.
+
+
+### SECTION VI PRODUCTS OF THE CHEMICAL OR ALLIED INDUSTRIES
+
+#### Section Note 1: Chemical Reaction Rule
+Notwithstanding the applicable product specific rules of origin, a good of chapter 28 through chapter 38 that is the product of a chemical reaction satisfies the requirements of this Annex, if the chemical reaction occurs in the territory of one or both of the Parties. 
+
+For the purposes of this rule:
+
+“chemical reaction” means a process (including a biochemical process) which results in a molecule with a new structure by breaking intramolecular bonds and by forming new intramolecular bonds, or by altering the spatial arrangement of atoms in a molecule. The following are not chemical reactions: 
+
+  (a) dissolving in water or other solvents; 
+
+  (b) the elimination of solvents including solvent water; or
+
+  (c) the addition or elimination of water of crystallisation.
+
+The Chemical Reaction Rule also applies to goods of chapters 27, 39 and 40.
+
+
+#### Section Note 2: Purification Rule
+Notwithstanding the applicable product specific rules of origin, a good of chapter 28 through chapter 35, or chapter 38, that is the product of purification satisfies the requirements of this Annex, if the purification occurred in the territory of one or both of the Parties.
+
+For the purposes of this rule:
+
+“purification” means purification which results in one of the following criteria being satisfied:
+
+- (a) purification of a good resulting in the elimination of 80 per cent of the content of existing impurities; or
+
+- (b) the reduction or elimination of impurities resulting in a good suitable for one or more of the following applications:
+
+    - (i) pharmaceutical, medicinal, cosmetic, veterinary, or food grade substances;
+
+    - (ii) chemical products and reagents for analytical, diagnostic or laboratory uses;
+
+    - (iii) elements and components for use in micro-elements;
+
+    - (iv) specialised optical uses;
+
+    - (v) non-toxic uses for health and safety;
+
+    - (vi) biotechnical use (e.g. in cell culturing, in genetic technology, or as a catalyst);
+
+    - (vii) carriers used in a separation process; or
+
+    - (viii) nuclear grade uses.
+
+The Purification Rule also applies to goods of chapters 39.
+
+#### Section Note 3: Mixing and Blending Rule
+
+Notwithstanding the applicable product specific rules of origin, a good of chapter 30, 31 and heading of 3302, 3304, 3506, 3507, 3707 or sub-heading 3502.20, satisfies the requirements of this Annex if mixing and blending occurred in the territory of one or both of the Parties. 
+
+For the purposes of this rule:
+
+“mixing and blending” means the deliberate and proportionally controlled mixing or blending (including dispersing) of materials other than the addition of diluents, to conform to predetermined specifications which results in the production of a good having physical or chemical characteristics which are relevant to the purposes or uses of the good and are different from the input materials.
+
+#### Section Note 4: Change in Particle Size Rule
+
+Notwithstanding the applicable product specific rules of origin, a good of chapter 30, 31 or 33 satisfies the requirements of this Annex if it undergoes a change in particle size in the territory of one or both of the Parties. 
+
+For the purposes of this rule:
+
+“change in particle size” means the deliberate and controlled modification in particle size of a good, including micronising by dissolving a polymer and subsequent precipitation, other than by merely crushing or pressing, resulting in a good with different physical or chemical characteristics from the input materials and that has: 
+
+- (a) a defined particle size;
+
+- (b) defined particle size distribution; or
+
+- (c) defined surface area,
+
+that is relevant to the purposes of the resulting good.
+
+The Change in Particle Size Rule also applies to goods of chapters 39.
+
+#### Section Note 5: Standard Materials Rule
+
+Notwithstanding the applicable product specific rules of origin, a standard material of chapter 28 through chapter 38, satisfies the requirements of this Annex if the production of such good occurs in the territory of one or both of the Parties. 
+
+For the purposes of this rule: 
+
+“standard material” means a preparation (including a solution) suitable for analytical, calibrating or referencing uses having precise degrees of purity or proportions which are certified by the manufacturer.
+
+The Standard Materials Rule also applies to goods of chapters 39.
+
+#### Section Note 6: Isomer Separation Rule
+
+Notwithstanding the applicable product specific rules of origin, a good of chapter 28 through chapter 38, satisfies the requirements of this Annex if the isolation or separation of isomers from a mixture of isomers occurs in the territory of one or both of the Parties.
+
+The Isomer Separation Rule also applies to goods of chapters 39.
+
+#### Section Note 7: Biotechnological Processing Rule
+
+Notwithstanding the applicable product specific rules of origin, a good of chapter 28 through chapter 30, chapter 33 or chapter 38 satisfies the requirements of this Annex  if biotechnological processing was used in the production of such good in the territory of one or both of the Parties.
+
+For the purposes of this rule: 
+
+“biotechnological processing” means one or more of the following biotechnological processes:
+
+- (a) biological or biotechnological culturing, hybridisation or genetic modification of:
+
+  - (i) micro-organisms (including bacteria and viruses (including phages)); or
+
+  - (ii) human, animal or plant cells; 
+
+- (b) the production, isolation or purification of cellular or intercellular structures (such as isolated genes, gene fragments and plasmids); or
+
+- (c) fermentation.

--- a/db/rules_of_origin/roo_schemes_uk/introductory_notes/new-zealand_intro.md
+++ b/db/rules_of_origin/roo_schemes_uk/introductory_notes/new-zealand_intro.md
@@ -1,0 +1,35 @@
+# Headnotes to the Annex
+
+1. The Product Specific Rule, or product specific set of rules, that applies to a particular subheading is set out immediately adjacent to the subheading, heading, or chapter, as applicable.
+
+2. The Product Specific Rules in this Annex are structured on the basis of the nomenclature of the Harmonized System in January 2017, including its General Interpretative Rules, Section Notes, and Chapter Notes.
+
+3. Where a tariff heading or subheading is subject to alternative product specific rules, it shall be sufficient to comply with one of the rules.
+
+4. A requirement of a change in tariff classification applies only to non-originating materials.
+
+5. Where the change in tariff classification rule expressly excludes a change from other tariff classifications, the exclusion applies only to non-originating materials.
+
+6. Section, chapter, or heading notes, where applicable, are found at the beginning of each section, chapter, or heading, and are read in conjunction with the product specific rules of origin and may impose further conditions, or provide an alternative product specific rule of origin.
+
+7. For the purposes of this Annex:
+
+- (a) “section” means a section of the Harmonized System 2017;
+
+- (b) “chapter” means the first two digits in the tariff classification number under the Harmonized System 2017;
+
+- (c) “heading” means the first four digits in the tariff classification number under the Harmonized System 2017; and
+
+- (d) “subheading” means the first six digits in the tariff classification number under the Harmonized System 2017.
+
+For the avoidance of doubt, if a product or material is classified differently under HS 2017 and the Goods Classification Table made pursuant to the Taxation (Cross-border Trade) Act 2018 and the Customs Tariff (Establishment) (EU Exit) Regulations 2020, contained in Annex 1 to the Tariff of the United Kingdom and interpreted in accordance with Part Two of the Tariff of the United Kingdom, HS 2017 shall be used to classify the product for the purposes of determining which product specific rule, or set of rules of origin, applies to the product and to classify the material for the purposes of determining the application of a product specific rule.
+
+1. For the purposes of column 4 titled ‘Product Specific Rule’ in section B of this Annex:
+
+- (a) “CC” means that all non-originating materials used in the production of the good have undergone a change in tariff classification at the two-digit level;
+
+- (b) “CTH” means that all non-originating materials used in the production of the good have undergone a change in tariff classification at the four-digit level;
+
+- (c) “CTSH” means that all non-originating materials used in the production of the good have undergone a change in tariff classification at the six-digit level; and
+
+- (d) “RVC (25)” or “RVC (40)” means that the good must have a regional value content of either not less than 25 or 40 per cent using the build-up method or build-down method, as calculated under Article 4 (Regional Value Content).


### PR DESCRIPTION
### Jira link

HOTT-3156
HOTT-3157

### What?

I have added/removed/altered:

- [ ] Added missing fta intro doc for Australia rules of origin scheme
- [ ] Added missing fta intro doc for New Zealand rules of origin scheme
- [ ] Added missing intro notes doc for Australia rules of origin scheme
- [ ] Added missing intro notes doc for New Zealand rules of origin scheme

### Why?

I am doing this because:

- It increases the available information to help our users

