### PR TITLE
Revert "Removes dead frozen string literal instruction"

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,10 +65,6 @@ Rails/UniqueValidationWithoutIndex:
 Style/Documentation:
   Enabled: false
 
-Style/FrozenStringLiteralComment:
-  Enabled: true
-  EnforcedStyle: never
-
 Style/GuardClause:
   MinBodyLength: 2
 

--- a/app/models/rules_of_origin/article.rb
+++ b/app/models/rules_of_origin/article.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RulesOfOrigin
   class Article
     include ActiveModel::Model

--- a/app/models/rules_of_origin/explainer.rb
+++ b/app/models/rules_of_origin/explainer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RulesOfOrigin
   class Explainer
     include ActiveModel::Model

--- a/app/models/rules_of_origin/heading_mappings.rb
+++ b/app/models/rules_of_origin/heading_mappings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'csv'
 
 module RulesOfOrigin

--- a/app/models/rules_of_origin/link.rb
+++ b/app/models/rules_of_origin/link.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RulesOfOrigin
   class Link
     include ActiveModel::Model

--- a/app/models/rules_of_origin/query.rb
+++ b/app/models/rules_of_origin/query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RulesOfOrigin
   class Query
     HEADING_CHECKER = /\A\d{6}\z/

--- a/app/models/rules_of_origin/rule.rb
+++ b/app/models/rules_of_origin/rule.rb
@@ -5,8 +5,8 @@ module RulesOfOrigin
     include ActiveModel::Model
     include ActiveModel::Attributes
 
-    ID_RULE_FORMAT = %r{\A\d+\z}.freeze
-    SCHEME_CODE_FORMAT = %r{\A[a-zA-Z\-]+\z}.freeze
+    ID_RULE_FORMAT = %r{\A\d+\z}
+    SCHEME_CODE_FORMAT = %r{\A[a-zA-Z-]+\z}
 
     attribute :id_rule
     attribute :scheme_code

--- a/app/models/rules_of_origin/rule.rb
+++ b/app/models/rules_of_origin/rule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RulesOfOrigin
   class Rule
     include ActiveModel::Model

--- a/app/models/rules_of_origin/rule_set.rb
+++ b/app/models/rules_of_origin/rule_set.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'csv'
 
 module RulesOfOrigin

--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RulesOfOrigin
   class Scheme
     include ActiveModel::Model

--- a/app/models/rules_of_origin/scheme_set.rb
+++ b/app/models/rules_of_origin/scheme_set.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RulesOfOrigin
   class SchemeSet
     DEFAULT_SOURCE_PATH = Rails.root.join('db/rules_of_origin').freeze

--- a/app/models/rules_of_origin/v2/rule.rb
+++ b/app/models/rules_of_origin/v2/rule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RulesOfOrigin
   module V2
     class Rule

--- a/app/models/rules_of_origin/v2/rule_set.rb
+++ b/app/models/rules_of_origin/v2/rule_set.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RulesOfOrigin
   module V2
     class RuleSet


### PR DESCRIPTION
### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [x] Add frozen string literals back in

### Why?

I am doing this because:

- it drops mem usage by 20%

### Before

![Screenshot from 2023-05-12 15-51-35](https://github.com/trade-tariff/trade-tariff-backend/assets/10818/adf647ab-77dc-4cc1-b5cb-1e5dce8bd059)

### After

![Screenshot from 2023-05-12 15-57-01](https://github.com/trade-tariff/trade-tariff-backend/assets/10818/933b60e6-09a1-4f03-9bf5-548c42a4d182)

