### PR TITLE
HOTT-2883 Fix race when loading footnotes

### DIFF
--- a/app/models/rules_of_origin/v2/rule_set.rb
+++ b/app/models/rules_of_origin/v2/rule_set.rb
@@ -23,7 +23,7 @@ module RulesOfOrigin
 
       class << self
         def build_for_scheme(scheme, rule_sets_data)
-          footnote_definitions = rule_sets_data['footnote_definitions'] || {}
+          footnote_definitions = rule_sets_data['footnotes'] || {}
 
           rule_sets_data['rule_sets']
             .map { |rs| new rs.merge(scheme:, footnote_definitions:) }
@@ -33,7 +33,7 @@ module RulesOfOrigin
 
       def initialize(attributes = {})
         attributes = attributes.stringify_keys
-        self.footnote_definitions = attributes.delete(:footnote_definitions) || {}
+        self.footnote_definitions = attributes.delete('footnote_definitions') || {}
 
         attributes.each do |attribute_name, attribute_value|
           if respond_to?("#{attribute_name}=")

--- a/spec/models/rules_of_origin/v2/rule_set_spec.rb
+++ b/spec/models/rules_of_origin/v2/rule_set_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe RulesOfOrigin::V2::RuleSet do
 
     it { is_expected.to have_attributes length: 2 }
     it { is_expected.to all be_instance_of described_class }
+
+    context 'with footnote_definitions' do
+      let :rule_set_data do
+        {
+          'rule_sets' => attributes_for_list(:rules_of_origin_v2_rule_set, 2),
+          'footnotes' => { 'first footnote' => 'This is a footnote' },
+        }
+      end
+
+      it { is_expected.to all have_attributes footnote_definitions: include('first footnote') }
+    end
   end
 
   describe '#id' do


### PR DESCRIPTION
### Jira link

HOTT-2883

### What?

I have added/removed/altered:

- [x] Fixed key to load footnote definitions from
- [x] Fixed race condition loading footnote definitions

### Why?

I am doing this because:

- Footnotes weren't showing up in the API

### Deployment risks (optional)

- Low
