### PR TITLE
HOTT-3199 Use eager loading to speed up /quota_order_numbers

### DIFF
--- a/app/models/quota_definition.rb
+++ b/app/models/quota_definition.rb
@@ -64,8 +64,8 @@ class QuotaDefinition < Sequel::Model
     ds.with_actual(MeasurementUnit)
   end
 
-  one_to_many :measures, key: [:ordernumber],
-                         primary_key: [:quota_order_number_id] do |ds|
+  one_to_many :measures, key: :ordernumber,
+                         primary_key: :quota_order_number_id do |ds|
     ds.where('validity_end_date IS NULL OR validity_end_date >= ?', Measure.point_in_time)
   end
 

--- a/app/models/quota_order_number.rb
+++ b/app/models/quota_order_number.rb
@@ -22,7 +22,6 @@ class QuotaOrderNumber < Sequel::Model
       inner_join(:quota_definitions, quota_order_numbers__quota_order_number_sid: :quota_definitions__quota_order_number_sid)
         .actual
         .with_actual(QuotaDefinition)
-        .eager(quota_definition: :measures)
     end
   end
 

--- a/app/services/cached_quota_order_number_service.rb
+++ b/app/services/cached_quota_order_number_service.rb
@@ -1,5 +1,12 @@
 class CachedQuotaOrderNumberService
-  DEFAULT_INCLUDES = [:quota_definition, 'quota_definition.measures'].freeze
+  DEFAULT_INCLUDES = %w[quota_definition quota_definition.measures].freeze
+  EAGER_LOAD = {
+    quota_definition: {
+      measurement_unit: %i[measurement_unit_description
+                           measurement_unit_abbreviations],
+      measures: [],
+    },
+  }.freeze
 
   TTL = 1.day
 
@@ -15,7 +22,7 @@ class CachedQuotaOrderNumberService
   private
 
   def quota_order_numbers
-    QuotaOrderNumber.with_quota_definitions
+    QuotaOrderNumber.with_quota_definitions.eager(EAGER_LOAD).all
   end
 
   def cache_key


### PR DESCRIPTION
### Jira link

HOTT-3199

### What?

I have added/removed/altered:

- [x] Reduce query count for `/quota_order_numbers`

### Why?

I am doing this because:

- Currently it generates 6000 queries on XI

### Deployment risks (optional)

- Low, changes sort order of returned data - content is identical

### Before

![Screenshot from 2023-05-15 17-17-11](https://github.com/trade-tariff/trade-tariff-backend/assets/10818/3929cce6-667c-44d5-bf7b-558318e92042)

### After

![Screenshot from 2023-05-15 17-18-21](https://github.com/trade-tariff/trade-tariff-backend/assets/10818/83b3fdfd-6510-4e5b-bb97-54f6e3eafd1b)

