### PR TITLE
HOTT-3204: Filter out redundant logs in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,13 @@
+class SchemaQueryFilterLogger < SimpleDelegator
+  SCHEMA_QUERY_PATTERN = /pg_attribute|current_setting/
+
+  def debug(progname = nil, &block)
+    return if progname =~ SCHEMA_QUERY_PATTERN
+
+    super(progname, &block)
+  end
+end
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -48,6 +58,5 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-
-  config.logger = ActiveSupport::Logger.new($stdout)
+  config.logger = SchemaQueryFilterLogger.new(ActiveSupport::Logger.new($stdout))
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3204

**Before**

![2023-05-18-152342_3427x1025_scrot](https://github.com/trade-tariff/trade-tariff-backend/assets/8156884/28091fd9-70d9-4cfc-a631-6fc23ddd669c)

**After**

![2023-05-18-152413_3440x383_scrot](https://github.com/trade-tariff/trade-tariff-backend/assets/8156884/659dcff5-a7db-4f88-9835-e9abedaab4fd)

### What?

I have added/removed/altered:

- [x] Removed casting and current setting logs in development

### Why?

I am doing this because:

- These relate to Sequel working out the casting rules for table columns
-> model attributes but are never helpful when debugging n+1s and often
create many lines of additional output.
