### PR TITLE
HOTT-3216: Shorter comm code suggestion support

### DIFF
--- a/app/services/api/beta/search_service.rb
+++ b/app/services/api/beta/search_service.rb
@@ -83,7 +83,15 @@ module Api
       end
 
       def search_suggestion_match
-        SearchSuggestion.by_value(search_query.downcase, resource_id)
+        exact_search_suggestion_match.presence || padded_search_suggestion_match
+      end
+
+      def exact_search_suggestion_match
+        @exact_search_suggestion_match ||= SearchSuggestion.by_value(search_query.downcase, resource_id)
+      end
+
+      def padded_search_suggestion_match
+        @padded_search_suggestion_match ||= SearchSuggestion.by_value(search_query.downcase.ljust(10, '0'), resource_id)
       end
 
       def resource_id

--- a/app/services/search_service/exact_search.rb
+++ b/app/services/search_service/exact_search.rb
@@ -8,7 +8,9 @@ class SearchService
                    q = matchdata ? matchdata[2] : query_string.gsub(/\Acas\s+/i, '')
                    find_search_suggestion(q)
                  else
-                   find_search_suggestion(query_string) || find_historic_goods_nomenclature(query_string)
+                   find_search_suggestion(query_string) ||
+                     find_search_suggestion(query_string.ljust(10, '0')) ||
+                     find_historic_goods_nomenclature(query_string)
                  end
 
       self

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -120,8 +120,6 @@ RSpec.describe SearchService do
     end
 
     context 'when commodities' do
-      let(:query) { '0101210000' }
-
       let(:pattern) do
         {
           type: 'exact_match',
@@ -138,7 +136,17 @@ RSpec.describe SearchService do
         create :search_suggestion, goods_nomenclature:
       end
 
-      it { expect(result).to match_json_expression pattern }
+      context 'when searching by full code' do
+        let(:query) { '0101210000' }
+
+        it { expect(result).to match_json_expression pattern }
+      end
+
+      context 'when searching by a shorter version of the code' do
+        let(:query) { '0101210' }
+
+        it { expect(result).to match_json_expression pattern }
+      end
     end
 
     context 'when chemicals by cas rn' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3216

### What?

I have added/removed/altered:

- [x] Support short commodity form in legacy search results
- [x] Support short commodity form in beta search results

### Why?

I am doing this because:

- This is required so that suggestions with matches to commodities can be submitted in their short form, too

### Have you? (optional)

- [ ] Added documentation for new apis
- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks (optional)

- Low, it updates/augments existing behaviour which has good test coverage
