### PR TITLE
HOTT-2638 add NestedSet#ns_declarable scope

### DIFF
--- a/app/controllers/api/v1/commodities_controller.rb
+++ b/app/controllers/api/v1/commodities_controller.rb
@@ -31,7 +31,7 @@ module Api
             :additional_code,
             :full_temporary_stop_regulations,
             :measure_partial_temporary_stops,
-          ).all
+          ).all,
         ).filter
 
         @commodity_cache_key = "commodity-#{@commodity.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}"
@@ -53,12 +53,10 @@ module Api
 
       def find_commodity
         @commodity = Commodity.actual
-                              .declarable
+                              .non_hidden
+                              .ns_declarable
                               .by_code(params[:id])
                               .take
-
-        raise Sequel::RecordNotFound if @commodity.children.any?
-        raise Sequel::RecordNotFound if @commodity.goods_nomenclature_item_id.in? HiddenGoodsNomenclature.codes
       end
     end
   end

--- a/app/controllers/api/v2/commodities_controller.rb
+++ b/app/controllers/api/v2/commodities_controller.rb
@@ -22,13 +22,11 @@ module Api
 
       def find_commodity
         @commodity = Commodity.actual
-                              .declarable
+                              .non_hidden
+                              .ns_declarable
                               .by_code(params[:id])
                               .eager(:goods_nomenclature_indents, :goods_nomenclature_descriptions, :footnotes)
                               .take
-
-        raise Sequel::RecordNotFound if commodity_has_children?
-        raise Sequel::RecordNotFound if @commodity.goods_nomenclature_item_id.in? HiddenGoodsNomenclature.codes
       end
 
       def cached_commodity

--- a/app/elastic_search_indexes/search/goods_nomenclature_index.rb
+++ b/app/elastic_search_indexes/search/goods_nomenclature_index.rb
@@ -4,7 +4,7 @@ module Search
       TimeMachine.now do
         Commodity # Filter out headings and chapters
           .actual
-          .declarable # Avoid the majority of subheadings
+          .ns_declarable # Avoid all subheadings
           .non_hidden
       end
     end

--- a/app/lib/reporting/basic.rb
+++ b/app/lib/reporting/basic.rb
@@ -55,8 +55,6 @@ module Reporting
 
         TimeMachine.now do
           goods_nomenclatures.each do |goods_nomenclature|
-            next unless goods_nomenclature.ns_declarable?
-
             rows << build_row_for(goods_nomenclature)
           end
 
@@ -104,7 +102,7 @@ module Reporting
       def goods_nomenclatures
         GoodsNomenclature
           .actual
-          .declarable
+          .ns_declarable
           .eager(GOODS_NOMENCLATURE_EAGER)
           .non_hidden
           .non_classifieds

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -42,7 +42,7 @@ class Chapter < GoodsNomenclature
 
   dataset_module do
     def by_code(code = '')
-      filter('goods_nomenclatures.goods_nomenclature_item_id LIKE ?', "#{code.to_s.first(2)}00000000")
+      filter(goods_nomenclatures__goods_nomenclature_item_id: "#{code.to_s.first(2)}00000000")
     end
   end
 

--- a/app/models/concerns/ten_digit_goods_nomenclature.rb
+++ b/app/models/concerns/ten_digit_goods_nomenclature.rb
@@ -30,7 +30,7 @@ module TenDigitGoodsNomenclature
 
     dataset_module do
       def by_code(code = '')
-        filter(goods_nomenclature_item_id: code.to_s.first(10))
+        filter(goods_nomenclatures__goods_nomenclature_item_id: code.to_s.first(10))
       end
 
       def by_productline_suffix(productline_suffix)

--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -138,6 +138,17 @@ module GoodsNomenclatures
             .group(qualified_columns + %i[tree_node__number_indents tree_node__depth])
         end
 
+        def ns_declarable
+          association_join(tree_node: proc { |ds| ds.join_child_sids })
+            .select_all(:goods_nomenclatures)
+            .select_append(:tree_node__number_indents, :tree_node__depth)
+            .select_append(Sequel.as(true, :leaf))
+            .where(
+              tree_node__child_sid: nil,
+              goods_nomenclatures__producline_suffix: GoodsNomenclatureIndent::NON_GROUPING_PRODUCTLINE_SUFFIX,
+            )
+        end
+
       private
 
         def qualified_columns(qualifier = model.table_name)

--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -39,7 +39,7 @@ class Heading < GoodsNomenclature
 
   dataset_module do
     def by_code(code = '')
-      filter('goods_nomenclatures.goods_nomenclature_item_id LIKE ?', "#{code.to_s.first(4)}000000")
+      filter(goods_nomenclatures__goods_nomenclature_item_id: "#{code.to_s.first(4)}000000")
     end
 
     def by_declarable_code(code = '')

--- a/app/services/heading_service/heading_serialization_service.rb
+++ b/app/services/heading_service/heading_serialization_service.rb
@@ -55,7 +55,7 @@ module HeadingService
     end
 
     def heading_cache_key
-      self.class.cache_key(heading, actual_date, heading.declarable?, filters)
+      self.class.cache_key(heading, actual_date, heading.ns_declarable?, filters)
     end
   end
 end

--- a/docs/goods-nomenclature-nested-set.md
+++ b/docs/goods-nomenclature-nested-set.md
@@ -160,6 +160,7 @@ chapter.ns_children.first.ns_children.first.ns_children.map(&ns_ancestors)
 * `#number_indents` - if data is loaded via the nested set relationships then this is populated automatically without needing to eager load `goods_nomenclature_indents`
 * `#depth` - internal reference for the depth of a goods nomenclature, normally `number_indents` + 2 except for chapters which are `number_indents` + 1
 * `#goods_nomenclature_class` - this now utilises ns_leaf? internally so benefits from eager loading `#ns_children` or `#ns_descendants` the same
+* `.ns_declarable` - Dataset method to filter by only declarable goods nomenclatures - this does do a left join to check for child_nodes _but_ it skips any rows which have children so shouldn't impact results
 
 ### Measures
 

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -493,6 +493,17 @@ RSpec.describe GoodsNomenclatures::NestedSet do
     it { is_expected.to include commodity.pk => true }
   end
 
+  describe '.ns_declarable' do
+    subject { GoodsNomenclature.actual.ns_declarable.all }
+
+    before { commodity }
+
+    let(:commodity) { create :commodity, :non_grouping, :with_children }
+
+    it { is_expected.not_to include commodity }
+    it { is_expected.to include commodity.ns_children.first.ns_children.first }
+  end
+
   describe '#ns_declarable?' do
     context 'with descendants' do
       subject { create :commodity, :non_grouping, :with_children }


### PR DESCRIPTION
### Jira link

HOTT-2638

### What?

I have added/removed/altered:

- [x] Added a NestedSet#ns_declarable scope to filter goods nomenclature queries by only declarable GNs
- [x] Changed the `#by_code` methods on Chapter and Heading to use `=` instead of `LIKE`
- [x] Changed the `#by_code` methods on Subheading and Commodity to include the table in the where clause
- [x] Change the existing codebase to use `#ns_declarable` scope instead of `#declarable`

### Why?

I am doing this because:

- It is able to return only declarable GNs, the old method only filtered on PLS - so subsequent filtering in Ruby was required to find if a GN was really declarable - this often involved other expensive db queries and was not eager loadable
- Drive by fix but this should potentially speed up `#by_code` for Chapter and Heading - it certainly shouldn't be slower then using `LIKE`
- This is necessary if we are joining on tree nodes because they also have a `goods_nomenclature_item_id` column
- Replace use of the old scope with the new one because it is faster

### Deployment risks (optional)

- Replaces existing code with nested set variants with differing behaviour
