### PR TITLE
HOTT-2638 Drop legacy declarable scope

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -146,10 +146,6 @@ class GoodsNomenclature < Sequel::Model
                           order: Sequel.desc(:created_at)
 
   dataset_module do
-    def declarable
-      filter(producline_suffix: '80')
-    end
-
     def non_hidden
       filter(Sequel.~(goods_nomenclatures__goods_nomenclature_item_id: HiddenGoodsNomenclature.codes))
     end

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -332,17 +332,6 @@ RSpec.describe GoodsNomenclature do
     end
   end
 
-  describe '.declarable' do
-    subject(:declarable) { described_class.declarable }
-
-    before do
-      create(:goods_nomenclature, producline_suffix: '80')
-      create(:goods_nomenclature, producline_suffix: '10')
-    end
-
-    it { is_expected.to all(have_attributes(producline_suffix: '80')) }
-  end
-
   describe '#code' do
     let(:gono) { create(:goods_nomenclature, goods_nomenclature_item_id: '8056116321') }
 


### PR DESCRIPTION
### Jira link

HOTT-2638

### What?

I have added/removed/altered:

- [x] Dropped the old `GoodsNomenclature#declarable` scope

### Why?

I am doing this because:

- it is no longer in use, and ns_declarable is quick enough to act as a replacement

### Deployment risks (optional)

- Drops code which is believed to be orphaned
