### PR TITLE
HOTT-3302: Enhance report generation performance

### DIFF
--- a/app/lib/reporting/differences.rb
+++ b/app/lib/reporting/differences.rb
@@ -2,6 +2,8 @@ module Reporting
   class Differences
     extend Reporting::Reportable
 
+    delegate :get, to: TariffSynchronizer::FileService
+
     attr_reader :package, :workbook, :bold_style, :centered_style
 
     def initialize
@@ -42,6 +44,18 @@ module Reporting
         'Indentation differences',
         self,
       ).add_worksheet
+    end
+
+    def uk_goods_nomenclatures
+      @uk_goods_nomenclatures ||= handle_csv(get("uk/goods_nomenclatures/#{Time.zone.today.iso8601}.csv"))
+    end
+
+    def xi_goods_nomenclatures
+      @xi_goods_nomenclatures ||= handle_csv(get("xi/goods_nomenclatures/#{Time.zone.today.iso8601}.csv"))
+    end
+
+    def handle_csv(csv)
+      CSV.parse(csv, headers: true).map(&:to_h)
     end
 
     class << self

--- a/app/lib/reporting/differences/goods_nomenclature.rb
+++ b/app/lib/reporting/differences/goods_nomenclature.rb
@@ -56,8 +56,12 @@ module Reporting
     end
 
     class GoodsNomenclature
-      delegate :get, to: TariffSynchronizer::FileService
-      delegate :workbook, :bold_style, :centered_style, to: :report
+      delegate :workbook,
+               :bold_style,
+               :centered_style,
+               :uk_goods_nomenclatures,
+               :xi_goods_nomenclatures,
+               to: :report
 
       HEADER_ROW = [
         'SID',
@@ -123,34 +127,36 @@ module Reporting
       attr_reader :source, :target, :name, :report
 
       def rows
-        all_missing = source_goods_nomenclatures - target_goods_nomenclatures
+        all_missing = source_goods_nomenclatures.keys - target_goods_nomenclatures.keys
         all_missing.map do |missing|
           build_row_for(missing)
         end
       end
 
       def build_row_for(missing)
-        missing_goods_nomenclature = read_source.find do |source_goods_nomenclature|
-          source_goods_nomenclature['ItemIDPlusPLS'] == missing
-        end
+        missing_goods_nomenclature = source_goods_nomenclatures[missing]
 
         PresentedGoodsNomenclature.new(missing_goods_nomenclature).to_row
       end
 
       def target_goods_nomenclatures
-        read_target.pluck('ItemIDPlusPLS')
+        @target_goods_nomenclatures ||= read_target.each_with_object({}) do |goods_nomenclature, acc|
+          acc[goods_nomenclature['ItemIDPlusPLS']] = goods_nomenclature
+        end
       end
 
       def source_goods_nomenclatures
-        read_source.pluck('ItemIDPlusPLS')
+        @source_goods_nomenclatures ||= read_source.each_with_object({}) do |goods_nomenclature, acc|
+          acc[goods_nomenclature['ItemIDPlusPLS']] = goods_nomenclature
+        end
       end
 
       def read_source
-        @read_source ||= handle_csv(get("#{source}/goods_nomenclatures/#{Time.zone.today.iso8601}.csv"))
+        public_send("#{source}_goods_nomenclatures")
       end
 
       def read_target
-        @read_target ||= handle_csv(get("#{target}/goods_nomenclatures/#{Time.zone.today.iso8601}.csv"))
+        public_send("#{target}_goods_nomenclatures")
       end
 
       def handle_csv(csv)

--- a/app/lib/reporting/differences/goods_nomenclature.rb
+++ b/app/lib/reporting/differences/goods_nomenclature.rb
@@ -140,14 +140,14 @@ module Reporting
       end
 
       def target_goods_nomenclatures
-        @target_goods_nomenclatures ||= read_target.each_with_object({}) do |goods_nomenclature, acc|
-          acc[goods_nomenclature['ItemIDPlusPLS']] = goods_nomenclature
+        @target_goods_nomenclatures ||= read_target.index_by do |goods_nomenclature|
+          goods_nomenclature['ItemIDPlusPLS']
         end
       end
 
       def source_goods_nomenclatures
-        @source_goods_nomenclatures ||= read_source.each_with_object({}) do |goods_nomenclature, acc|
-          acc[goods_nomenclature['ItemIDPlusPLS']] = goods_nomenclature
+        @source_goods_nomenclatures ||= read_source.index_by do |goods_nomenclature|
+          goods_nomenclature['ItemIDPlusPLS']
         end
       end
 

--- a/app/lib/reporting/differences/indentation.rb
+++ b/app/lib/reporting/differences/indentation.rb
@@ -82,14 +82,14 @@ module Reporting
       end
 
       def uk_goods_nomenclature_ids
-        @uk_goods_nomenclature_ids ||= uk_goods_nomenclatures.each_with_object({}) do |goods_nomenclature, acc|
-          acc[goods_nomenclature['ItemIDPlusPLS']] = goods_nomenclature
+        @uk_goods_nomenclature_ids ||= uk_goods_nomenclatures.index_by do |goods_nomenclature|
+          goods_nomenclature['ItemIDPlusPLS']
         end
       end
 
       def xi_goods_nomenclature_ids
-        @xi_goods_nomenclature_ids ||= xi_goods_nomenclatures.each_with_object({}) do |goods_nomenclature, acc|
-          acc[goods_nomenclature['ItemIDPlusPLS']] = goods_nomenclature
+        @xi_goods_nomenclature_ids ||= xi_goods_nomenclatures.index_by do |goods_nomenclature|
+          goods_nomenclature['ItemIDPlusPLS']
         end
       end
     end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3302

### What?

I have added/removed/altered:

- [x] Moved to 0(1) for pulling out matched/missing goods nomenclature from csv
- [x] Reuse downloaded goods nomenclature report

### Why?

I am doing this because:

- This dramatically speeds up the reporting implementation
