### PR TITLE
HOTT-3284 Raise if using NestedSet outside TimeMachine

### DIFF
--- a/app/lib/time_machine.rb
+++ b/app/lib/time_machine.rb
@@ -48,6 +48,10 @@ module TimeMachine
   end
 
   def self.date_is_set?
-    !Thread.current[THREAD_DATETIME_KEY].nil?
+    !point_in_time.nil?
+  end
+
+  def self.point_in_time
+    Thread.current[THREAD_DATETIME_KEY]
   end
 end

--- a/app/lib/time_machine.rb
+++ b/app/lib/time_machine.rb
@@ -46,4 +46,8 @@ module TimeMachine
   ensure
     Thread.current[THREAD_RELEVANT_KEY] = nil
   end
+
+  def self.date_is_set?
+    !Thread.current[THREAD_DATETIME_KEY].nil?
+  end
 end

--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -5,6 +5,12 @@ module GoodsNomenclatures
   module NestedSet
     extend ActiveSupport::Concern
 
+    class DateNotSet < RuntimeError
+      def initialize
+        super 'TimeMachine date is not set, code should be inside TimeMachine.now {}'
+      end
+    end
+
     included do
       one_to_one :tree_node, key: :goods_nomenclature_sid,
                              class_name: 'GoodsNomenclatures::TreeNode',
@@ -23,6 +29,8 @@ module GoodsNomenclatures
                    join_table: Sequel.as(:goods_nomenclature_tree_nodes, :ancestor_nodes),
                    after_load: :recursive_ancestor_populator,
                    read_only: true do |ds|
+        raise DateNotSet unless TimeMachine.date_is_set?
+
         ds.order(:ancestor_nodes__position)
           .with_validity_dates(:ancestor_nodes)
           .select_append(:ancestor_nodes__depth)
@@ -45,6 +53,8 @@ module GoodsNomenclatures
                       class_name: '::GoodsNomenclature',
                       join_table: Sequel.as(:goods_nomenclature_tree_nodes, :parent_nodes),
                       read_only: true do |ds|
+        raise DateNotSet unless TimeMachine.date_is_set?
+
         ds.order(:parent_nodes__position)
           .with_validity_dates(:parent_nodes)
           .select_append(:parent_nodes__depth)
@@ -68,6 +78,8 @@ module GoodsNomenclatures
                    join_table: Sequel.as(:goods_nomenclature_tree_nodes, :descendant_nodes),
                    after_load: :recursive_descendant_populator,
                    read_only: true do |ds|
+        raise DateNotSet unless TimeMachine.date_is_set?
+
         ds.non_hidden
           .order(:descendant_nodes__position)
           .with_validity_dates(:descendant_nodes)
@@ -90,6 +102,8 @@ module GoodsNomenclatures
                    class_name: '::GoodsNomenclature',
                    join_table: Sequel.as(:goods_nomenclature_tree_nodes, :child_nodes),
                    read_only: true do |ds|
+        raise DateNotSet unless TimeMachine.date_is_set?
+
         ds.non_hidden
           .order(:child_nodes__position)
           .with_validity_dates(:child_nodes)

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -693,7 +693,7 @@ RSpec.describe Commodity do
       it 'caches the result' do
         commodity.declarable?
 
-        expect(Rails.cache).to have_received(:fetch).with("commodity-#{commodity.goods_nomenclature_sid}--is-declarable?")
+        expect(Rails.cache).to have_received(:fetch).with("commodity-#{commodity.goods_nomenclature_sid}-#{TimeMachine.point_in_time.to_date}-is-declarable?")
       end
     end
 
@@ -703,7 +703,7 @@ RSpec.describe Commodity do
       it 'caches the result' do
         commodity.declarable?
 
-        expect(Rails.cache).to have_received(:fetch).with("commodity-#{commodity.goods_nomenclature_sid}--is-declarable?")
+        expect(Rails.cache).to have_received(:fetch).with("commodity-#{commodity.goods_nomenclature_sid}-#{TimeMachine.point_in_time.to_date}-is-declarable?")
       end
     end
 

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe GoodsNomenclatures::NestedSet do
-  around { |example| TimeMachine.now { example.run } }
-
   describe 'relationships' do
     describe '#tree_node' do
       subject(:tree_node) { commodity.reload.tree_node }

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -399,6 +399,28 @@ RSpec.describe GoodsNomenclatures::NestedSet do
             it_behaves_like 'it has children', 'nested subheading', :subsubheading, %i[commodity1 commodity2]
           end
         end
+
+        context 'when outside of TimeMachine' do
+          around { |example| TimeMachine.no_time_machine { example.run } }
+
+          let(:commodity) { create :commodity }
+
+          describe '#ns_ancestors' do
+            it { expect { commodity.ns_ancestors }.to raise_exception described_class::DateNotSet }
+          end
+
+          describe '#ns_parent' do
+            it { expect { commodity.ns_parent }.to raise_exception described_class::DateNotSet }
+          end
+
+          describe '#ns_children' do
+            it { expect { commodity.ns_children }.to raise_exception described_class::DateNotSet }
+          end
+
+          describe '#ns_descendants' do
+            it { expect { commodity.ns_descendants }.to raise_exception described_class::DateNotSet }
+          end
+        end
       end
     end
 

--- a/spec/models/goods_nomenclatures/tree_node_spec.rb
+++ b/spec/models/goods_nomenclatures/tree_node_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe GoodsNomenclatures::TreeNode do
-  around { |example| TimeMachine.now { example.run } }
-
   describe 'Sequel::Model config' do
     subject { described_class }
 

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -328,8 +328,8 @@ RSpec.describe Measure do
                              })
       end
 
-      it { expect(described_class.with_modification_regulations.all.count).to eq 3 }
-      it { expect(Commodity.by_code('0805201000').first.measures.count).to eq 3 }
+      it { expect(TimeMachine.no_time_machine { described_class.with_modification_regulations.all.count }).to eq 3 }
+      it { expect(TimeMachine.no_time_machine { Commodity.by_code('0805201000').first.measures.count }).to eq 3 }
       it { expect(TimeMachine.at(Time.zone.parse('2016-07-21')) { described_class.with_modification_regulations.with_actual(ModificationRegulation).all.first.measure_sid }).to eq 3_445_396 }
       it { expect(TimeMachine.at(Time.zone.parse('2016-07-21')) { Commodity.by_code('0805201005').first.measures.count }).to eq 1 }
       it { expect(TimeMachine.at(Time.zone.parse('2016-07-21')) { Commodity.by_code('0805201005').first.measures.first.measure_sid }).to eq 3_445_396 }

--- a/spec/models/meursing_measure_spec.rb
+++ b/spec/models/meursing_measure_spec.rb
@@ -46,8 +46,6 @@ RSpec.describe MeursingMeasure do
       )
     end
 
-    around { |example| TimeMachine.now { example.run } }
-
     context 'when the validity end date is null' do
       let(:validity_end_date) { nil }
 

--- a/spec/models/quota_definition_spec.rb
+++ b/spec/models/quota_definition_spec.rb
@@ -1,7 +1,5 @@
 RSpec.describe QuotaDefinition do
   describe '#status' do
-    around { |example| TimeMachine.now { example.run } }
-
     context 'when not in a critical state with no events' do
       subject(:status) { build(:quota_definition, critical_state: 'N').status }
 
@@ -180,8 +178,6 @@ RSpec.describe QuotaDefinition do
   end
 
   describe '#quota_critical_event_ids' do
-    around { |example| TimeMachine.now { example.run } }
-
     context 'when there are quota critical events' do
       let(:quota_definition) { create(:quota_definition, :with_quota_critical_events) }
 
@@ -269,6 +265,8 @@ RSpec.describe QuotaDefinition do
     end
 
     context 'when the time machine is not set' do
+      around { |example| TimeMachine.no_time_machine { example.run } }
+
       it { is_expected.to be_present }
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,6 +40,16 @@ RSpec.configure do |config|
 
   config.include_context 'with fake global rules of origin data'
 
+  config.around do |example|
+    # Workers are known to operate outside of TimeMachine so make them
+    # responsible for setting the date
+    if example.metadata[:type].in? %i[worker]
+      TimeMachine.no_time_machine { example.run }
+    else
+      TimeMachine.now { example.run }
+    end
+  end
+
   config.before(:all) do
     FileUtils.rm_rf('tmp/data/cds')
     FileUtils.mkpath('tmp/data/cds')

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -310,18 +310,20 @@ RSpec.describe SearchService do
           }.ignore_extra_keys!
         end
 
-        it 'returns goods code if search date falls within validity period' do
-          result = described_class.new(data_serializer, q: 'water',
-                                                        as_of: '2005-01-01').to_json
+        context 'with search date within goods code validity period' do
+          subject { described_class.new(data_serializer, q: 'water', as_of: '2005-01-01').to_json }
 
-          expect(result).to match_json_expression heading_pattern
+          around { |example| TimeMachine.at('2005-01-01') { example.run } }
+
+          it { is_expected.to match_json_expression heading_pattern }
         end
 
-        it 'does not return goods code if search date does not fall within validity period' do
-          result = described_class.new(data_serializer, q: 'water',
-                                                        as_of: '2007-01-01').to_json
+        context 'with search date outside goods code validity period' do
+          subject { described_class.new(data_serializer, q: 'water', as_of: '2007-01-01').to_json }
 
-          expect(result).not_to match_json_expression heading_pattern
+          around { |example| TimeMachine.at('2007-01-01') { example.run } }
+
+          it { is_expected.not_to match_json_expression heading_pattern }
         end
       end
 

--- a/spec/unit/time_machine_spec.rb
+++ b/spec/unit/time_machine_spec.rb
@@ -43,4 +43,20 @@ RSpec.describe TimeMachine do
   describe '.no_time_machine' do
     it { described_class.no_time_machine { expect(Commodity.point_in_time).to be_nil } }
   end
+
+  describe '.date_is_set?' do
+    subject { described_class.date_is_set? }
+
+    context 'when date is set' do
+      around { |example| described_class.now { example.run } }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when date is not set' do
+      around { |example| described_class.no_time_machine { example.run } }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/unit/time_machine_spec.rb
+++ b/spec/unit/time_machine_spec.rb
@@ -59,4 +59,20 @@ RSpec.describe TimeMachine do
       it { is_expected.to be false }
     end
   end
+
+  describe '.point_in_time' do
+    subject { described_class.point_in_time }
+
+    context 'when date is set' do
+      around { |example| described_class.now { example.run } }
+
+      it { is_expected.not_to be_nil }
+    end
+
+    context 'when date is not set' do
+      around { |example| described_class.no_time_machine { example.run } }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

HOTT-3284

### What?

I have added/removed/altered:

- [x] Added method to check if Time Machine date is set
- [x] Raise exception in nested set hierarchy methods if Time Machine date is not set
- [x] Setup TimeMachine in `spec/rails_helper`

### Why?

I am doing this because:

- There is not currently a known use case for querying the hiearchy outside of TimeMachine
- Doing so will return confusing results requiring additional filtering in Ruby
- The most likely scenario for the developer doing this is by mistake running outside of TimeMachine, so remove this source of confusion
- Almost all specs are written with an expectation they are running inside of TimeMachine, even though they are not. Change that behaviour globally and the user can disable TimeMachine on the specific specs thats required for

### Deployment risks (optional)

- Low
