### PR TITLE
Fix specs requiring scheme which ends on June 19th

### DIFF
--- a/spec/models/rules_of_origin/scheme_set_spec.rb
+++ b/spec/models/rules_of_origin/scheme_set_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe RulesOfOrigin::SchemeSet do
       let(:country_code) { 'VN' }
 
       it { is_expected.to include have_attributes(scheme_code: 'vietnam') }
-      it { is_expected.to include have_attributes(scheme_code: 'gsp') }
+      it { is_expected.to include have_attributes(scheme_code: /gsp|dcts/) }
     end
   end
 


### PR DESCRIPTION
### Jira link

HOTT-3289

### What?

I have added/removed/altered:

- [x] Fix schemes hard coding gsp scheme

### Why?

I am doing this because:

- The gsp scheme gets replaced with dcts on 19 June at which point the test suite will start failing

### Deployment risks (optional)

- None
