### PR TITLE
Allow overriding database host

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,4 @@
+PGHOST=localhost
 AWS_REPORTING_BUCKET_NAME=trade-tariff-reporting
 BETA_SEARCH_DEBUG=true
 BETA_SEARCH_GUIDES_ENABLED=true

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,4 @@
+PGHOST=localhost
 AGGREGATED_SYNONYMS_FILE=spec/fixtures/beta/search/goods_nomenclatures/test_synonyms.txt
 AWS_ACCESS_KEY_ID=xxxxxxxxxxxxxxxxxxxx
 AWS_BUCKET_NAME=trade-tariff-backend

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,12 +7,10 @@ default: &default
 development:
   <<: *default
   database: tariff_development
-  host: localhost
 
 test:
   <<: *default
   database: tariff_test
-  host: localhost
 
 production:
   <<: *default


### PR DESCRIPTION
### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [x] Allow overriding the db host

### Why?

I am doing this because:

- developer nit - internal docker networks sometimes dont access via localhost

### Deployment risks (optional)

- Non - dev environment only, and the addition of `PGHOST` env vars should achieve the same goal but make it overrideable should the developer wish to
