### PR TITLE
HOTT-3334 Fix bad indents

### DIFF
--- a/db/data_migrations/20230607095600_fix_bad_indents_on_uk.rb
+++ b/db/data_migrations/20230607095600_fix_bad_indents_on_uk.rb
@@ -1,0 +1,21 @@
+Sequel.migration do
+  # IMPORTANT! Data migrations up block should be idempotent (reruns of up should produce the same effect)
+  # they may get re-run as part of data rollbacks but the rollback (down) function of the data migration will not get invoked
+  up do
+    if TradeTariffBackend.uk?
+      Sequel::Model.db[:goods_nomenclatures_oplog]
+        .where(goods_nomenclature_sid: [106_651, 107_908],
+               validity_end_date: nil)
+        .update(validity_end_date: '2022-12-31 23:59:59')
+    end
+  end
+
+  down do
+    if TradeTariffBackend.uk?
+      Sequel::Model.db[:goods_nomenclatures_oplog]
+        .where(goods_nomenclature_sid: [106_651, 107_908],
+               validity_end_date: '2022-12-31 23:59:59')
+        .update(validity_end_date: nil)
+    end
+  end
+end


### PR DESCRIPTION
Caused by goods nomenclatures that should have been end dated and were not

### Jira link

HOTT-3334

### What?

I have added/removed/altered:

- [x] Added data migration to end date two goods nomenclatures

### Why?

I am doing this because:

- The EU end dated these at the end of 2022
- DBT has stated an intention to correct this discrepancy but has not done so yet
- This causes a broken hiearchy warning on the integrity checker

### Deployment risks (optional)

- Low, does change production data
