### PR TITLE
HOTT-3265: Filter origins by order number

### DIFF
--- a/app/lib/reporting/differences/quota_missing_origin.rb
+++ b/app/lib/reporting/differences/quota_missing_origin.rb
@@ -55,6 +55,7 @@ module Reporting
           QuotaOrderNumber
             .actual
             .association_left_join(:quota_order_number_origins)
+            .where(quota_order_numbers__quota_order_number_id: /^05/)
             .where(quota_order_number_origins__quota_order_number_origin_sid: nil)
             .select_map(
               %i[


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3265

### What?

I have added/removed/altered:

- [x] Added filter to missing origins

### Why?

I am doing this because:

- This now matches Matt's implementation and outputs
