### PR TITLE
HOTT-2267 Switch to API only app

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -4,8 +4,6 @@ module Api
 
     respond_to :json
 
-    skip_forgery_protection
-
     rescue_from Sequel::NoMatchingRow, Sequel::RecordNotFound do |_exception|
       serializer = TradeTariffBackend.error_serializer(request)
       render json: serializer.serialized_errors({ error: 'not found', url: request.url }), status: :not_found

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,10 @@
-class ApplicationController < ActionController::Base
-  respond_to :json, :html
+class ApplicationController < ActionController::API
+  include ::ActionController::MimeResponds
+  # SequelRails incorrectly includes this into ActionController::Base but our
+  # ApplicationController derives from ActionController::API
+  include ::SequelRails::Railties::ControllerRuntime
+
+  respond_to :json
 
   before_action :maintenance_mode_if_active
   around_action :configure_time_machine

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,9 @@ Bundler.require(*Rails.groups)
 
 module TradeTariffBackend
   class Application < Rails::Application
+    config.api_only = true
+    config.debug_exception_response_format = :default
+
     config.load_defaults 6.1
 
     config.generators do |g|


### PR DESCRIPTION
### Jira link

HOTT-3367

### What?

I have added/removed/altered:

- [x] Switch to using Rails' API only stack

### Why?

I am doing this because:

- Prevents the writing of cookies 
- Lightens the middleware stack a bit
- Removes functionality we are not using and probably shouldn't be using

### Deployment risks (optional)

- Low level change
