### PR TITLE
Handle connection failures to search query parser

### DIFF
--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -39,6 +39,8 @@ private
       .new('test')
       .call
       .is_a?(::Beta::Search::SearchQueryParserResult)
+  rescue Faraday::Error
+    false
   end
 
   def opensearch_healthy?


### PR DESCRIPTION
### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [x] Rescue errors trying to connect to the search query parser in the Healthcheck

### Why?

I am doing this because:

- Previously we were just triggering the default 500 response

### Deployment risks (optional)

- Low, should improve our robustness in the face of problems
