### PR TITLE
HOTT-3372: Fixes eager loading in build index worker

### DIFF
--- a/app/workers/build_index_page_worker.rb
+++ b/app/workers/build_index_page_worker.rb
@@ -13,9 +13,11 @@ class BuildIndexPageWorker
       body: serialize_for(
         :index,
         index,
-        index.dataset.eager(index.eager_load_graph).paginate(page_number, page_size),
+        index.dataset.eager(index.eager_load_graph).paginate(page_number, page_size).all,
       ),
     )
+
+    Rails.logger.info("Query count: #{::SequelRails::Railties::LogSubscriber.count}")
   end
 
   private


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3372

### What?

I have added/removed/altered:

- [x] Fixed eager loading not working when building opensearch indexes in batches

### Why?

I am doing this because:

- This is essential for optimising these index jobs
