### PR TITLE
HOTT-1658 speed up cache jobs

### DIFF
--- a/app/elastic_search_indexes/cache/additional_code_index.rb
+++ b/app/elastic_search_indexes/cache/additional_code_index.rb
@@ -33,19 +33,7 @@ module Cache
     end
 
     def eager_load
-      {
-        additional_code_descriptions: {},
-        measures: [
-          :base_regulation,
-          :modification_regulation,
-          {
-            goods_nomenclature: %i[goods_nomenclature_descriptions
-                                   ns_children
-                                   goods_nomenclature_indents],
-            geographical_area: %i[geographical_area_descriptions],
-          },
-        ],
-      }
+      eager_load_measures.merge(additional_code_descriptions: {})
     end
   end
 end

--- a/app/elastic_search_indexes/cache/additional_code_index.rb
+++ b/app/elastic_search_indexes/cache/additional_code_index.rb
@@ -3,22 +3,18 @@ module Cache
     EXCLUDED_TYPES = %w[6 7 9 D F P].freeze
 
     def dataset
-      TimeMachine.now do
-        current_sids = Measure
-          .actual
-          .with_generating_regulation
-          .distinct(:additional_code_id, :additional_code_type_id)
-          .select(:additional_code_sid, :additional_code_id, :additional_code_type_id)
-          .exclude(additional_code_sid: nil)
-          .exclude(additional_code_type_id: EXCLUDED_TYPES)
-          .exclude(goods_nomenclature_sid: nil)
-          .exclude(goods_nomenclature_item_id: nil)
-          .pluck(:additional_code_sid)
+      current_sids = Measure
+        .actual
+        .with_generating_regulation
+        .distinct(:additional_code_id, :additional_code_type_id)
+        .select(:additional_code_sid, :additional_code_id, :additional_code_type_id)
+        .exclude(additional_code_sid: nil)
+        .exclude(additional_code_type_id: EXCLUDED_TYPES)
+        .exclude(goods_nomenclature_sid: nil)
+        .exclude(goods_nomenclature_item_id: nil)
+        .pluck(:additional_code_sid)
 
-        AdditionalCode
-          .actual
-          .where(additional_code_sid: current_sids)
-      end
+      super.where(additional_code_sid: current_sids)
     end
 
     def definition
@@ -33,6 +29,22 @@ module Cache
             validity_end_date: { type: 'date', format: 'date_optional_time' },
           },
         },
+      }
+    end
+
+    def eager_load
+      {
+        additional_code_descriptions: {},
+        measures: [
+          :base_regulation,
+          :modification_regulation,
+          {
+            goods_nomenclature: %i[goods_nomenclature_descriptions
+                                   ns_children
+                                   goods_nomenclature_indents],
+            geographical_area: %i[geographical_area_descriptions],
+          },
+        ],
       }
     end
   end

--- a/app/elastic_search_indexes/cache/cache_index.rb
+++ b/app/elastic_search_indexes/cache/cache_index.rb
@@ -4,6 +4,14 @@ module Cache
       "#{super}-cache"
     end
 
+    def dataset
+      TimeMachine.now { super.actual }
+    end
+
+    def dataset_page(...)
+      TimeMachine.now { super }
+    end
+
     def page_size
       5
     end

--- a/app/elastic_search_indexes/cache/cache_index.rb
+++ b/app/elastic_search_indexes/cache/cache_index.rb
@@ -13,7 +13,7 @@ module Cache
     end
 
     def page_size
-      5
+      50
     end
 
     def hidden_codes

--- a/app/elastic_search_indexes/cache/cache_index.rb
+++ b/app/elastic_search_indexes/cache/cache_index.rb
@@ -15,5 +15,13 @@ module Cache
     def page_size
       5
     end
+
+    def hidden_codes
+      @hidden_codes ||= HiddenGoodsNomenclature.codes
+    end
+
+    def serialize_record(record)
+      serializer.new(record, hidden_codes).as_json
+    end
   end
 end

--- a/app/elastic_search_indexes/cache/cache_index.rb
+++ b/app/elastic_search_indexes/cache/cache_index.rb
@@ -3,5 +3,9 @@ module Cache
     def name
       "#{super}-cache"
     end
+
+    def page_size
+      5
+    end
   end
 end

--- a/app/elastic_search_indexes/cache/cache_index.rb
+++ b/app/elastic_search_indexes/cache/cache_index.rb
@@ -23,5 +23,22 @@ module Cache
     def serialize_record(record)
       serializer.new(record, hidden_codes).as_json
     end
+
+  private
+
+    def eager_load_measures
+      {
+        measures: [
+          :base_regulation,
+          :modification_regulation,
+          {
+            goods_nomenclature: %i[goods_nomenclature_descriptions
+                                   ns_children
+                                   goods_nomenclature_indents],
+            geographical_area: %i[geographical_area_descriptions],
+          },
+        ],
+      }
+    end
   end
 end

--- a/app/elastic_search_indexes/cache/certificate_index.rb
+++ b/app/elastic_search_indexes/cache/certificate_index.rb
@@ -18,20 +18,7 @@ module Cache
     end
 
     def eager_load
-      {
-        certificate_descriptions: {},
-        appendix_5a: {},
-        measures: [
-          :base_regulation,
-          :modification_regulation,
-          {
-            goods_nomenclature: %i[goods_nomenclature_descriptions
-                                   ns_children
-                                   goods_nomenclature_indents],
-            geographical_area: %i[geographical_area_descriptions],
-          },
-        ],
-      }
+      eager_load_measures.merge(certificate_descriptions: {})
     end
   end
 end

--- a/app/elastic_search_indexes/cache/certificate_index.rb
+++ b/app/elastic_search_indexes/cache/certificate_index.rb
@@ -16,5 +16,22 @@ module Cache
         },
       }
     end
+
+    def eager_load
+      {
+        certificate_descriptions: {},
+        appendix_5a: {},
+        measures: [
+          :base_regulation,
+          :modification_regulation,
+          {
+            goods_nomenclature: %i[goods_nomenclature_descriptions
+                                   ns_children
+                                   goods_nomenclature_indents],
+            geographical_area: %i[geographical_area_descriptions],
+          },
+        ],
+      }
+    end
   end
 end

--- a/app/elastic_search_indexes/cache/footnote_index.rb
+++ b/app/elastic_search_indexes/cache/footnote_index.rb
@@ -16,22 +16,12 @@ module Cache
     end
 
     def eager_load
-      {
+      eager_load_measures.merge(
         footnote_descriptions: {},
         goods_nomenclatures: %i[goods_nomenclature_descriptions
                                 ns_children
                                 goods_nomenclature_indents],
-        measures: [
-          :base_regulation,
-          :modification_regulation,
-          {
-            goods_nomenclature: %i[goods_nomenclature_descriptions
-                                   ns_children
-                                   goods_nomenclature_indents],
-            geographical_area: %i[geographical_area_descriptions],
-          },
-        ],
-      }
+      )
     end
   end
 end

--- a/app/elastic_search_indexes/cache/footnote_index.rb
+++ b/app/elastic_search_indexes/cache/footnote_index.rb
@@ -10,8 +10,27 @@ module Cache
             description: { type: 'text', analyzer: 'snowball' },
             validity_start_date: { type: 'date', format: 'date_optional_time' },
             validity_end_date: { type: 'date', format: 'date_optional_time' },
-          }
-        }
+          },
+        },
+      }
+    end
+
+    def eager_load
+      {
+        footnote_descriptions: {},
+        goods_nomenclatures: %i[goods_nomenclature_descriptions
+                                ns_children
+                                goods_nomenclature_indents],
+        measures: [
+          :base_regulation,
+          :modification_regulation,
+          {
+            goods_nomenclature: %i[goods_nomenclature_descriptions
+                                   ns_children
+                                   goods_nomenclature_indents],
+            geographical_area: %i[geographical_area_descriptions],
+          },
+        ],
       }
     end
   end

--- a/app/elastic_search_indexes/search/goods_nomenclature_index.rb
+++ b/app/elastic_search_indexes/search/goods_nomenclature_index.rb
@@ -8,7 +8,7 @@ module Search
       end
     end
 
-    def eager_load_graph
+    def eager_load
       [
         :goods_nomenclature_descriptions,
         :search_references,

--- a/app/elastic_search_indexes/search/goods_nomenclature_index.rb
+++ b/app/elastic_search_indexes/search/goods_nomenclature_index.rb
@@ -19,6 +19,10 @@ module Search
       ]
     end
 
+    def page_size
+      2000
+    end
+
     def definition
       if TradeTariffBackend.stemming_exclusion_reference_analyzer.present?
         # Stemming exclusions _must_ come before other filters

--- a/app/elastic_search_indexes/search_index.rb
+++ b/app/elastic_search_indexes/search_index.rb
@@ -33,7 +33,7 @@ class SearchIndex
     false
   end
 
-  def eager_load_graph
+  def eager_load
     []
   end
 
@@ -42,7 +42,7 @@ class SearchIndex
   end
 
   def dataset_page(page_number)
-    dataset.eager(eager_load_graph).paginate(page_number, page_size).all
+    dataset.eager(eager_load).paginate(page_number, page_size).all
   end
 
   def total_pages

--- a/app/elastic_search_indexes/search_index.rb
+++ b/app/elastic_search_indexes/search_index.rb
@@ -40,4 +40,16 @@ class SearchIndex
   def exclude_from_search_results?
     !goods_nomenclature?
   end
+
+  def dataset_page(page_number)
+    dataset.eager(eager_load_graph).paginate(page_number, page_size).all
+  end
+
+  def total_pages
+    (dataset.count / page_size.to_f).ceil
+  end
+
+  def page_size
+    500
+  end
 end

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -114,7 +114,6 @@ module TradeTariffBackend
       @search_client ||= SearchClient.new(
         opensearch_client,
         indexes: search_indexes,
-        index_page_size: 500,
       )
     end
 
@@ -122,7 +121,6 @@ module TradeTariffBackend
       @v2_search_client ||= SearchClient.new(
         opensearch_client,
         indexes: v2_search_indexes,
-        index_page_size: 2000,
       )
     end
 
@@ -131,7 +129,6 @@ module TradeTariffBackend
         opensearch_client,
         namespace: 'cache',
         indexes: cache_indexes,
-        index_page_size: 5,
       )
     end
 

--- a/app/lib/trade_tariff_backend/search_client.rb
+++ b/app/lib/trade_tariff_backend/search_client.rb
@@ -11,13 +11,11 @@ module TradeTariffBackend
     cattr_accessor :search_operation_options, default: {}
 
     attr_reader :indexes,
-                :index_page_size,
                 :search_operation_options,
                 :namespace
 
     def initialize(search_client, options = {})
       @indexes = options.fetch(:indexes, [])
-      @index_page_size = options.fetch(:index_page_size, 1000)
       @search_operation_options = options.fetch(:search_operation_options,
                                                 self.class.search_operation_options)
       @namespace = options.fetch(:namespace, 'search')
@@ -61,9 +59,8 @@ module TradeTariffBackend
     end
 
     def build_index(index)
-      total_pages = (index.dataset.count / index_page_size.to_f).ceil
-      (1..total_pages).each do |page_number|
-        BuildIndexPageWorker.perform_async(namespace, index.name_without_namespace, page_number, index_page_size)
+      (1..index.total_pages).each do |page_number|
+        BuildIndexPageWorker.perform_async(namespace, index.name_without_namespace, page_number)
       end
     end
 

--- a/app/serializers/cache/additional_code_serializer.rb
+++ b/app/serializers/cache/additional_code_serializer.rb
@@ -44,10 +44,7 @@ module Cache
     end
 
     def measures
-      @measures ||= additional_code.measures.select do |measure|
-        measure.generating_regulation && measure.goods_nomenclature &&
-          @hidden_codes.exclude?(measure.goods_nomenclature_item_id)
-      end
+      @measures ||= valid_measures(additional_code)
     end
   end
 end

--- a/app/serializers/cache/additional_code_serializer.rb
+++ b/app/serializers/cache/additional_code_serializer.rb
@@ -4,7 +4,7 @@ module Cache
 
     attr_reader :additional_code, :as_of
 
-    def initialize(additional_code)
+    def initialize(additional_code, _hidden_codes)
       @additional_code = additional_code
       @as_of = Time.zone.today.midnight
     end

--- a/app/serializers/cache/certificate_serializer.rb
+++ b/app/serializers/cache/certificate_serializer.rb
@@ -2,8 +2,9 @@ module Cache
   class CertificateSerializer
     include ::Cache::SearchCacheMethods
 
-    def initialize(certificate)
+    def initialize(certificate, hidden_codes)
       @certificate = certificate
+      @hidden_codes = hidden_codes
     end
 
     def as_json
@@ -42,7 +43,7 @@ module Cache
     def measures
       @measures ||= certificate.measures.select do |measure|
         measure.generating_regulation && measure.goods_nomenclature &&
-          !HiddenGoodsNomenclature.codes.include?(measure.goods_nomenclature_item_id)
+          !@hidden_codes.include?(measure.goods_nomenclature_item_id)
       end
     end
   end

--- a/app/serializers/cache/certificate_serializer.rb
+++ b/app/serializers/cache/certificate_serializer.rb
@@ -4,7 +4,6 @@ module Cache
 
     def initialize(certificate)
       @certificate = certificate
-      @as_of = Time.zone.today.midnight
     end
 
     def as_json
@@ -38,7 +37,7 @@ module Cache
 
     private
 
-    attr_reader :certificate, :as_of
+    attr_reader :certificate
 
     def measures
       @measures ||= certificate
@@ -48,8 +47,7 @@ module Cache
         .exclude(goods_nomenclature_item_id: nil)
         .all
         .select do |measure|
-          has_valid_dates(measure) &&
-            measure.goods_nomenclature.present? &&
+          measure.goods_nomenclature.present? &&
             HiddenGoodsNomenclature.codes.exclude?(measure.goods_nomenclature_item_id)
         end
     end

--- a/app/serializers/cache/certificate_serializer.rb
+++ b/app/serializers/cache/certificate_serializer.rb
@@ -40,16 +40,10 @@ module Cache
     attr_reader :certificate
 
     def measures
-      @measures ||= certificate
-        .measures_dataset
-        .with_generating_regulation
-        .eager(:goods_nomenclature)
-        .exclude(goods_nomenclature_item_id: nil)
-        .all
-        .select do |measure|
-          measure.goods_nomenclature.present? &&
-            HiddenGoodsNomenclature.codes.exclude?(measure.goods_nomenclature_item_id)
-        end
+      @measures ||= certificate.measures.select do |measure|
+        measure.generating_regulation && measure.goods_nomenclature &&
+          !HiddenGoodsNomenclature.codes.include?(measure.goods_nomenclature_item_id)
+      end
     end
   end
 end

--- a/app/serializers/cache/certificate_serializer.rb
+++ b/app/serializers/cache/certificate_serializer.rb
@@ -41,10 +41,7 @@ module Cache
     attr_reader :certificate
 
     def measures
-      @measures ||= certificate.measures.select do |measure|
-        measure.generating_regulation && measure.goods_nomenclature &&
-          @hidden_codes.exclude?(measure.goods_nomenclature_item_id)
-      end
+      @measures ||= valid_measures(certificate)
     end
   end
 end

--- a/app/serializers/cache/certificate_serializer.rb
+++ b/app/serializers/cache/certificate_serializer.rb
@@ -43,7 +43,7 @@ module Cache
     def measures
       @measures ||= certificate.measures.select do |measure|
         measure.generating_regulation && measure.goods_nomenclature &&
-          !@hidden_codes.include?(measure.goods_nomenclature_item_id)
+          @hidden_codes.exclude?(measure.goods_nomenclature_item_id)
       end
     end
   end

--- a/app/serializers/cache/footnote_serializer.rb
+++ b/app/serializers/cache/footnote_serializer.rb
@@ -4,11 +4,10 @@ module Cache
 
     MAX_MEASURE_THRESHOLD = 1000
 
-    attr_reader :footnote, :as_of
+    attr_reader :footnote
 
     def initialize(footnote)
       @footnote = footnote
-      @as_of = Time.zone.today.midnight
     end
 
     def as_json
@@ -51,8 +50,7 @@ module Cache
 
     def goods_nomenclatures
       @goods_nomenclatures ||= footnote.goods_nomenclatures.compact.select do |goods_nomenclature|
-        has_valid_dates(goods_nomenclature) &&
-          HiddenGoodsNomenclature.codes.exclude?(goods_nomenclature.goods_nomenclature_item_id)
+        HiddenGoodsNomenclature.codes.exclude?(goods_nomenclature.goods_nomenclature_item_id)
       end
     end
 
@@ -64,8 +62,7 @@ module Cache
         .exclude(goods_nomenclature_item_id: nil)
         .all
         .select do |measure|
-          has_valid_dates(measure) &&
-            measure.goods_nomenclature.present? &&
+          measure.goods_nomenclature.present? &&
             HiddenGoodsNomenclature.codes.exclude?(measure.goods_nomenclature_item_id)
         end
     end

--- a/app/serializers/cache/footnote_serializer.rb
+++ b/app/serializers/cache/footnote_serializer.rb
@@ -56,16 +56,10 @@ module Cache
     end
 
     def measures
-      @measures ||= footnote
-        .measures_dataset
-        .with_generating_regulation
-        .eager(:goods_nomenclature)
-        .exclude(goods_nomenclature_item_id: nil)
-        .all
-        .select do |measure|
-          measure.goods_nomenclature.present? &&
-            @hidden_codes.exclude?(measure.goods_nomenclature_item_id)
-        end
+      @measures ||= footnote.measures.select do |measure|
+        measure.generating_regulation && measure.goods_nomenclature &&
+          @hidden_codes.exclude?(measure.goods_nomenclature_item_id)
+      end
     end
 
     def extra_large_measures?

--- a/app/serializers/cache/footnote_serializer.rb
+++ b/app/serializers/cache/footnote_serializer.rb
@@ -56,10 +56,7 @@ module Cache
     end
 
     def measures
-      @measures ||= footnote.measures.select do |measure|
-        measure.generating_regulation && measure.goods_nomenclature &&
-          @hidden_codes.exclude?(measure.goods_nomenclature_item_id)
-      end
+      @measures ||= valid_measures(footnote)
     end
 
     def extra_large_measures?

--- a/app/serializers/cache/footnote_serializer.rb
+++ b/app/serializers/cache/footnote_serializer.rb
@@ -6,8 +6,9 @@ module Cache
 
     attr_reader :footnote
 
-    def initialize(footnote)
+    def initialize(footnote, hidden_codes)
       @footnote = footnote
+      @hidden_codes = hidden_codes
     end
 
     def as_json
@@ -50,7 +51,7 @@ module Cache
 
     def goods_nomenclatures
       @goods_nomenclatures ||= footnote.goods_nomenclatures.compact.select do |goods_nomenclature|
-        HiddenGoodsNomenclature.codes.exclude?(goods_nomenclature.goods_nomenclature_item_id)
+        @hidden_codes.exclude?(goods_nomenclature.goods_nomenclature_item_id)
       end
     end
 
@@ -63,7 +64,7 @@ module Cache
         .all
         .select do |measure|
           measure.goods_nomenclature.present? &&
-            HiddenGoodsNomenclature.codes.exclude?(measure.goods_nomenclature_item_id)
+            @hidden_codes.exclude?(measure.goods_nomenclature_item_id)
         end
     end
 

--- a/app/serializers/cache/search_cache_methods.rb
+++ b/app/serializers/cache/search_cache_methods.rb
@@ -1,10 +1,5 @@
 module Cache
   module SearchCacheMethods
-    def has_valid_dates(hash)
-      hash[:validity_start_date].to_date <= as_of &&
-        (hash[:validity_end_date].nil? || hash[:validity_end_date].to_date >= as_of)
-    end
-
     def goods_nomenclature_attributes(goods_nomenclature)
       return nil if goods_nomenclature.blank?
 

--- a/app/serializers/cache/search_cache_methods.rb
+++ b/app/serializers/cache/search_cache_methods.rb
@@ -26,5 +26,12 @@ module Cache
         description: geographical_area.description,
       }
     end
+
+    def valid_measures(source)
+      source.measures.select do |measure|
+        measure.generating_regulation && measure.goods_nomenclature &&
+          @hidden_codes.exclude?(measure.goods_nomenclature_item_id)
+      end
+    end
   end
 end

--- a/app/workers/build_index_page_worker.rb
+++ b/app/workers/build_index_page_worker.rb
@@ -5,7 +5,7 @@ class BuildIndexPageWorker
 
   delegate :opensearch_client, to: TradeTariffBackend
 
-  def perform(index_namespace, index_name, page_number, page_size)
+  def perform(index_namespace, index_name, page_number, _page_size = nil)
     index_name = "#{index_name}Index" unless index_name.ends_with?('Index')
     index = "#{index_namespace.camelize}::#{index_name}".constantize.new
 
@@ -13,7 +13,7 @@ class BuildIndexPageWorker
       body: serialize_for(
         :index,
         index,
-        index.dataset.eager(index.eager_load_graph).paginate(page_number, page_size).all,
+        index.dataset_page(page_number),
       ),
     )
 

--- a/spec/elastic_search_indexes/cache/additional_code_index_spec.rb
+++ b/spec/elastic_search_indexes/cache/additional_code_index_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Cache::AdditionalCodeIndex do
   describe '#dataset' do
     subject(:dataset) { instance.dataset }
 
+    around { |example| TimeMachine.now { example.run } }
+
     let(:additional_code) { create(:additional_code) }
 
     before do

--- a/spec/elastic_search_indexes/search/section_index_spec.rb
+++ b/spec/elastic_search_indexes/search/section_index_spec.rb
@@ -16,4 +16,20 @@ RSpec.describe Search::SectionIndex do
 
     it { is_expected.to include 'id' => record.id }
   end
+
+  describe 'dataset_page' do
+    subject { instance.dataset_page(page).map(&:position) }
+
+    before { create_list :section, 5 }
+
+    let(:page) { 1 }
+
+    it { is_expected.to eql (1..5).to_a }
+
+    context 'with higher page number' do
+      let(:page) { 2 }
+
+      it { is_expected.to be_empty }
+    end
+  end
 end

--- a/spec/serializers/api/v2/certificates/certificates_serializer_spec.rb
+++ b/spec/serializers/api/v2/certificates/certificates_serializer_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Api::V2::Certificates::CertificatesSerializer do
 
   let(:serializable) do
     Hashie::TariffMash.new(
-      Cache::CertificateSerializer.new(certificate).as_json,
+      Cache::CertificateSerializer.new(certificate, []).as_json,
     )
   end
 

--- a/spec/serializers/api/v2/footnotes/footnote_serializer_spec.rb
+++ b/spec/serializers/api/v2/footnotes/footnote_serializer_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Api::V2::Footnotes::FootnoteSerializer do
   subject(:serializer) { described_class.new(serializable).serializable_hash.as_json }
 
   let(:serializable) do
-    cache_serialized_footnote = Cache::FootnoteSerializer.new(footnote).as_json
+    cache_serialized_footnote = Cache::FootnoteSerializer.new(footnote, []).as_json
 
     Hashie::TariffMash.new(cache_serialized_footnote)
   end

--- a/spec/serializers/cache/additional_code_serializer_spec.rb
+++ b/spec/serializers/cache/additional_code_serializer_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Cache::AdditionalCodeSerializer do
-  subject(:serialized) { described_class.new(additional_code.reload).as_json }
+  subject(:serialized) { described_class.new(additional_code.reload, []).as_json }
 
   let(:additional_code) do
     code = create(:additional_code)

--- a/spec/serializers/cache/certificate_serializer_spec.rb
+++ b/spec/serializers/cache/certificate_serializer_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Cache::CertificateSerializer do
-  subject(:serialized) { described_class.new(certificate).as_json }
+  subject(:serialized) { described_class.new(certificate, []).as_json }
 
   let(:certificate) do
     create(

--- a/spec/serializers/cache/footnote_serializer_spec.rb
+++ b/spec/serializers/cache/footnote_serializer_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Cache::FootnoteSerializer do
-  subject(:serialized) { described_class.new(footnote).as_json }
+  subject(:serialized) { described_class.new(footnote, []).as_json }
 
   let(:footnote) { create(:footnote, :with_description) }
   let(:measure_with_goods_nomenclature) do

--- a/spec/serializers/cache/search_cache_methods_spec.rb
+++ b/spec/serializers/cache/search_cache_methods_spec.rb
@@ -1,51 +1,11 @@
-class TestSearchCacheSerializer
-  include Cache::SearchCacheMethods
-
-  attr_reader :as_of
-
-  def initialize(as_of)
-    @as_of = as_of
-  end
-end
-
 RSpec.describe Cache::SearchCacheMethods do
-  let(:serializer) { TestSearchCacheSerializer.new(Date.parse(as_of)) }
-  let(:as_of) { '2021-01-01' }
-
-  describe '#has_valid_dates' do
-    subject(:has_valid_dates) { serializer.has_valid_dates(record_hash) }
-
-    let(:record_hash) do
-      {
-        validity_start_date: '2021-01-01',
-        validity_end_date: '2021-01-03',
-      }
-    end
-
-    context 'when the as of date is before the range' do
-      let(:as_of) { '2020-12-31' }
-
-      it { is_expected.to be(false) }
-    end
-
-    context 'when the as of date is on the start of the range' do
-      let(:as_of) { '2021-01-01' }
-
-      it { is_expected.to be(true) }
-    end
-
-    context 'when the as of date is on the end of the range' do
-      let(:as_of) { '2021-01-03' }
-
-      it { is_expected.to be(true) }
-    end
-
-    context 'when the as of date is after the range' do
-      let(:as_of) { '2021-01-04' }
-
-      it { is_expected.to be(false) }
+  let :serializer_class do
+    Class.new do
+      include Cache::SearchCacheMethods
     end
   end
+
+  let(:serializer) { serializer_class.new }
 
   describe '#goods_nomenclature_attributes' do
     subject(:goods_nomenclature_attributes) { serializer.goods_nomenclature_attributes(goods_nomenclature) }

--- a/spec/workers/build_index_page_worker_spec.rb
+++ b/spec/workers/build_index_page_worker_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe BuildIndexPageWorker, type: :worker do
         TradeTariffBackend.search_client.create_index(search_index)
         commodities # trigger creation of commodity
 
-        described_class.new.perform 'search', search_index.name_without_namespace, 1, 10
+        described_class.new.perform 'search', search_index.name_without_namespace, 1
       end
 
       let(:commodities) do
@@ -39,7 +39,7 @@ RSpec.describe BuildIndexPageWorker, type: :worker do
         TradeTariffBackend.search_client.drop_index(search_index)
         TradeTariffBackend.search_client.create_index(search_index)
 
-        described_class.new.perform 'search', commodity.class.name, 1, 10
+        described_class.new.perform 'search', commodity.class.name, 1
       end
 
       let(:commodity) do


### PR DESCRIPTION
### Jira link

HOTT-1658

### What?

I have added/removed/altered:

- [ ] Moved data fetching to the index
- [ ] Changed the cache indexes to wrap data fetches in TimeMachine.now
- [ ] Renamed `#eager_load_graph` to `#eager_load`
- [ ] Added eager loading when regenerating the CertificateIndex
- [ ] Added eager loading when regenerating the FootnoteIndex
- [ ] Added eager loading when regenerating the AdditionalCodeIndex
- [ ] Fixed the logging of query counts to reset for each job
- [ ] Fixed the BuildIndexPageWorker erroring when the filtering of measures meant there were no records to submit
- [ ] Changed the page size when rebuilding the cache indexes from 5 to 50

### Why?

I am doing this because:

- It will greatly speed up the reindexing of the search caches
- The method name change is for clarity

### Deployment risks (optional)

- Low
