### PR TITLE
HOTT-1658 List query counts for all Sidekiq jobs

### DIFF
--- a/app/lib/query_count_job_logger.rb
+++ b/app/lib/query_count_job_logger.rb
@@ -1,0 +1,23 @@
+require 'sidekiq/job_logger'
+
+class QueryCountJobLogger < ::Sidekiq::JobLogger
+  def call(item, queue)
+    super do
+      reset_query_count
+
+      yield
+
+      Sidekiq::Context.add(:queries, query_count)
+    end
+  end
+
+  private
+
+  def query_count
+    ::SequelRails::Railties::LogSubscriber.count
+  end
+
+  def reset_query_count
+    ::SequelRails::Railties::LogSubscriber.reset_count
+  end
+end

--- a/app/workers/build_index_page_worker.rb
+++ b/app/workers/build_index_page_worker.rb
@@ -6,8 +6,6 @@ class BuildIndexPageWorker
   delegate :opensearch_client, to: TradeTariffBackend
 
   def perform(index_namespace, index_name, page_number, _page_size = nil)
-    ::SequelRails::Railties::LogSubscriber.reset_count
-
     index_name = "#{index_name}Index" unless index_name.ends_with?('Index')
     index = "#{index_namespace.camelize}::#{index_name}".constantize.new
     entries = index.dataset_page(page_number)
@@ -17,8 +15,6 @@ class BuildIndexPageWorker
     opensearch_client.bulk(
       body: serialize_for(:index, index, entries),
     )
-
-    Rails.logger.info("Query count: #{::SequelRails::Railties::LogSubscriber.count}")
   end
 
   private

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,4 +1,5 @@
 require 'sidekiq'
+require 'query_count_job_logger'
 
 redis_config = PaasConfig.redis
 
@@ -6,6 +7,7 @@ Sidekiq.strict_args!
 
 Sidekiq.configure_server do |config|
   config.redis = redis_config
+  config[:job_logger] = ::QueryCountJobLogger
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
### Jira link

HOTT-1658

### What?

I have added/removed/altered:

- [x] List the queries used to execute a job in its log output

### Why?

I am doing this because:

- It will help identify jobs which can benefit from eager loading

### Deployment risks (optional)

- Limited, extends Sidekiq - works for me, if it breaks our background jobs wont run
