### PR TITLE
HOTT-3372: Surface short code in beta search

### DIFF
--- a/app/elastic_search_indexes/search/goods_nomenclature_index.rb
+++ b/app/elastic_search_indexes/search/goods_nomenclature_index.rb
@@ -13,7 +13,6 @@ module Search
       [
         :goods_nomenclature_descriptions,
         :search_references,
-        :ns_children,
         :chapter,
         { heading: :guides },
         { ns_ancestors: %i[search_references goods_nomenclature_descriptions] },

--- a/app/elastic_search_indexes/search/goods_nomenclature_index.rb
+++ b/app/elastic_search_indexes/search/goods_nomenclature_index.rb
@@ -4,6 +4,7 @@ module Search
       TimeMachine.now do
         Commodity
           .actual
+          .ns_declarable
           .non_hidden
       end
     end

--- a/app/serializers/search/goods_nomenclature_serializer.rb
+++ b/app/serializers/search/goods_nomenclature_serializer.rb
@@ -55,6 +55,7 @@ module Search
           id: ancestor.goods_nomenclature_sid,
           goods_nomenclature_item_id: ancestor.goods_nomenclature_item_id,
           producline_suffix: ancestor.producline_suffix,
+          short_code: ancestor.short_code,
           goods_nomenclature_class: ancestor.goods_nomenclature_class,
           description: ancestor.description,
           description_indexed: ancestor.description_indexed,

--- a/app/serializers/search/goods_nomenclature_serializer.rb
+++ b/app/serializers/search/goods_nomenclature_serializer.rb
@@ -22,7 +22,7 @@ module Search
           validity_end_date:,
           guides:,
           guide_ids:,
-          declarable: ns_declarable?,
+          declarable: true,
         }
 
         1.upto(MAX_ANCESTORS) do |i|

--- a/spec/elastic_search_indexes/search/goods_nomenclature_index_spec.rb
+++ b/spec/elastic_search_indexes/search/goods_nomenclature_index_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Search::GoodsNomenclatureIndex do
 
     let(:expected_goods_nomenclatures) do
       [
-        %w[0101210000 10], # subheading
         %w[0101210000 80], # commodity
       ]
     end

--- a/spec/serializers/search/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/search/goods_nomenclature_serializer_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Search::GoodsNomenclatureSerializer, flaky: true do
             {
               id: be_a(Integer),
               goods_nomenclature_item_id: '0100000000',
+              short_code: '01',
               producline_suffix: '80',
               goods_nomenclature_class: 'Chapter',
               description: 'Live horses, asses, mules and hinnies',
@@ -42,6 +43,7 @@ RSpec.describe Search::GoodsNomenclatureSerializer, flaky: true do
             {
               id: be_a(Integer),
               goods_nomenclature_item_id: '0101000000',
+              short_code: '0101',
               producline_suffix: '80',
               goods_nomenclature_class: 'Heading',
               description: 'Live animals',


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3372

### What?

I have added/removed/altered:

- [x] Surface short code in beta search index
- [x] Remove subheadings from beta search index

### Why?

I am doing this because:

- Short codes come in 2, 4, 6, 8 and 10 digit forms for ancestors. The form is interesting to the bulk-search api as a point to accumulate scores across search results for.
