### PR TITLE
HOTT-2642 Use nested set for SearchSuggestions

### DIFF
--- a/app/services/suggestions_service.rb
+++ b/app/services/suggestions_service.rb
@@ -20,6 +20,7 @@ class SuggestionsService
     GoodsNomenclature
       .actual
       .non_hidden
+      .with_leaf_column
       .map { |goods_nomenclature| build_goods_nomenclature_record(goods_nomenclature) }
   end
 
@@ -68,7 +69,7 @@ class SuggestionsService
       value: goods_nomenclature.short_code,
       type: SearchSuggestion::TYPE_GOODS_NOMENCLATURE,
       goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
-      goods_nomenclature_class: goods_nomenclature.path_goods_nomenclature_class,
+      goods_nomenclature_class: goods_nomenclature.goods_nomenclature_class,
       created_at: now,
       updated_at: now,
     )


### PR DESCRIPTION
### Jira link

HOTT-2642

### What?

I have added/removed/altered:

- [x] Use nested set for search suggestions service

### Why?

I am doing this because:

- It can fetch the goods_nomenclature_class as part of the query
- It takes 2 minutes out the run time on my machine
- It removes a materialized path dependency

### Deployment risks (optional)

- Low
