### PR TITLE
HOTT-3426 Added proofs documents for NZ/AU schemes

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk/proofs/australia/importers-knowledge.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/australia/importers-knowledge.md
@@ -1,0 +1,15 @@
+1. If a producer declares the origin of a good, the declaration of origin must be completed on the basis of the producer having information that the good is originating.
+
+2. If the exporter is not the producer of the good, a declaration of origin may be completed by the exporter of the good on the basis of:
+
+    (a) the exporter having information that the good is originating; *or* 
+
+    (b) the exporter placing reasonable reliance on the producer’s information that the good is originating.
+
+3. If an importer of the good makes a claim for preferential tariff treatment on the basis of the importer’s knowledge the good is originating, the claim is made on the basis of: 
+
+    (a) the importer having documentation that the good is originating; *or*
+
+    (b) the importer placing reasonable reliance on supporting documentation provided by the exporter or producer that the good is originating. 
+
+4. For greater certainty, nothing in paragraph 1 or paragraph 2 shall be construed to allow a Party to require an exporter or producer to complete a declaration of origin or provide a declaration of origin to another person.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/australia/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/australia/origin-declaration.md
@@ -1,0 +1,83 @@
+A declaration of origin: 
+
+(a) need not follow a prescribed format; 
+
+(b) must be in writing, including electronic format;
+
+(c) must specify that the good is both originating and meets the requirements of this Origin Reference Document;
+
+(d) must be attached to, or provided on, an invoice or any other commercial document that describes the goods concerned in sufficient detail to enable them to be identified; and
+ 
+(e) must fulfil the data requirements as set out in Annex I (Data Requirements) - see below.
+
+A declaration of origin may apply to:
+
+(a) a single shipment of a good into the territory of a Party; or
+
+(b) multiple shipments of identical goods within any period specified in the declaration of origin, but not exceeding 12 months.
+
+A declaration of origin is valid for one year after the date that it was completed or for such longer period specified by the laws and regulations of the importing Party. 
+ 
+If unassembled or disassembled products within the meaning of rule 2(a) of the General Rules for the Interpretation of the Harmonized System falling within Sections XV to XXI of the Harmonized System 2017 are imported by more than one shipment, a single declaration of origin for such products may be used on request of the importer and in accordance with the requirements laid down by the customs authority of the importing Party.
+
+If a producer declares the origin of a good, the declaration of origin must be completed on the basis of the producer having information that the good is originating.
+
+If the exporter is not the producer of the good, a declaration of origin may be completed by the exporter of the good on the basis of:
+
+(a) the exporter having information that the good is originating; or 
+
+(b) the exporter placing reasonable reliance on the producer’s information that the good is originating.
+
+If an importer of the good makes a claim for preferential tariff treatment on the basis of the importer’s knowledge the good is originating, the claim is made on the basis of: 
+
+(a) the importer having documentation that the good is originating; or
+
+(b) the importer placing reasonable reliance on supporting documentation provided by the exporter or producer that the good is originating. 
+
+### Annex I (Data Requirements)
+
+A declaration of origin that is the basis for a claim for preferential tariff treatment under the United Kingdom-Australia Agreement must include the following elements:
+
+1. Exporter, Producer, or Authorised Representative of the Exporter or Producer 
+
+    Indicate whether the signatory is the exporter, or producer in accordance with Article 18 (Claims for Preferential Tariff Treatment). In the case of an authorised representative, indicate whether the declaration of origin has been completed on behalf of the exporter, producer, or both. 
+
+2. Signatory
+
+    Provide the signatory’s name, company name (if applicable), address (including country), telephone number, and e-mail address.
+
+3. Exporter
+
+    Provide the exporter’s name, address (including country), e-mail address, and telephone number if different from the signatory. For UK exporters, provide the UK exporter reference number where one has been assigned. The address of the exporter must be in the exporting Party. This information is not required if the producer is completing the declaration of origin and does not know the identity of the exporter. 
+
+4. Producer
+
+    Provide the producer’s name, address (including country), e-mail address, and telephone number, if different from the certifier or exporter or, if there are multiple producers, state “Various” or provide a list of producers. A person that wishes for this information to remain confidential may state “Available upon request by the importing authorities”. The address of a producer must be the place of production of the good in a Party.
+
+5. Importer
+
+    Provide, if known, the importer’s name, address, e-mail address, and telephone number. The address of the importer must be in a Party.
+
+6. Description and HS Tariff Classification of the Good
+
+    (a) Provide a description of the good and the Harmonized System tariff classification of the good to the six-digit level. The description should be sufficient to relate it to the good covered by the declaration of origin; and 
+
+    (b) If the declaration of origin covers a single shipment of a good, indicate, if known, the invoice number related to the exportation.
+
+7. Origin Criterion
+
+    Specify the rule of origin under which the good qualifies.
+
+8. Period for multiple shipments
+
+    If the declaration of origin covers multiple shipments of identical goods for a specified period of up to 12 months as set out in paragraph 3 of Article 18 (Claims for Preferential Tariff Treatment), state the period during which such shipments will be made.
+
+9. Authorised Signature and Date
+
+    If the exporter or producer is the signatory, the declaration of origin must be signed and dated by the signatory, and accompanied by the following statement:
+
+    I (the exporter/the producer) declare that the goods described in this document qualify as originating and the information contained in this document is true and accurate. I (the exporter/the producer) assume responsibility for proving such representations and agree to maintain and present upon request or to make available during a verification visit, documentation necessary to support this declaration of origin.
+
+    If an authorised representative of the exporter or producer is the signatory, the declaration of origin must be signed, dated and accompanied by the following statement:
+
+    I (the authorised representative of the exporter/producer) declare that the goods described in this document qualify as originating and the information contained in this document is true and accurate. The exporter or the producer, as the case may be, assumes responsibility for providing such representations and agrees to maintain and present upon request or to make available during a verification visit, documentation necessary to support this declaration of origin.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/new-zealand/importers-knowledge.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/new-zealand/importers-knowledge.md
@@ -1,0 +1,7 @@
+An importer may make a claim for preferential tariff treatment based on the importer's knowledge that a product is originating. Such claims shall be made by the importer of the good on the basis of:
+
+(a)	the importer having documentation demonstrating that the good is originating; or
+
+(b)	reasonable reliance on supporting documentation provided by the exporter or producer that the good is originating.
+
+If a claim is based on importer's knowledge, an importer that becomes aware or has reason to believe that the importer's knowledge and supporting documentation for a good which it has imported, and to which preferential treatment has been granted, contains incorrect information shall immediately notify the customs authority of the importing Party in writing of any change affecting the originating status of that good and pay any duties owing.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/new-zealand/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/new-zealand/origin-declaration.md
@@ -1,0 +1,21 @@
+1. An origin declaration does not need to follow a prescribed format, provided it contains all minimum data elements identified in Annex I (Origin Declarations – Guidance).
+
+2. An origin declaration may be provided on, or attached to, an invoice or other commercial document issued in the exporting Party that contains some of the required minimum data elements, provided all the minimum data elements are included on or with the origin declaration.
+
+3. An origin declaration shall be valid for at least 12 months from the date it was completed or for a longer period as provided by the importing Party. 
+
+4. An origin declaration will be applicable to a single importation of one or more goods or multiple importations of identical goods that occur within a specified period not exceeding 12 months after the date of original declaration.
+
+5. For any originating good imported into the territory of a Party on or after the date of entry into force of the United Kingdom-New Zealand Agreement, the customs authority of the importing Party shall accept an origin declaration that has been completed and signed prior to the date of entry into force by the exporter or producer of that good.
+
+6. If unassembled or disassembled products within the meaning of General Rule 2(a) of the Harmonized System falling within Sections XV to XXI of the Harmonized System 2017 are imported in instalments, a single origin declaration for those products may be used on request of the importer and in accordance with the requirements laid down by the customs authority of the importing Party.
+
+### Waiver of Origin Documentation
+
+1. An importer, exporter or producer shall not be required to present an origin declaration as specified in Article 18 (Origin Declaration) in respect of:
+
+    (a) an importation of a good whose customs value does not exceed 2,000 New Zealand dollars for goods imported in New Zealand, or 1,000 United Kingdom pounds for goods imported into the United Kingdom, or such higher amount as the importing Party may establish; *or*
+
+    (b) an importation of a good into the territory of the importing Party for which the importing Party has waived the requirement for an origin declaration.
+
+2. Paragraph 1 does not apply to an importation when the customs authority of the importing Party reasonably considers that the importation is part of a series of importations that have been undertaken or arranged for the purpose of avoiding the requirements of this Origin Reference Document related to origin declarations.


### PR DESCRIPTION
### Jira link

HOTT-3426

### What?

I have added/removed/altered:

- [x] Added proof documents for New Zealand and Australia schemes

### Why?

I am doing this because:

- So that we can show the additional proofs information to users at the end of the wizard

### Deployment risks (optional)

- Low