### PR TITLE
HOTT-2642 Drop custom STI logic

### DIFF
--- a/app/models/concerns/ten_digit_goods_nomenclature.rb
+++ b/app/models/concerns/ten_digit_goods_nomenclature.rb
@@ -173,24 +173,6 @@ module TenDigitGoodsNomenclature
       ns_declarable? ? 'Commodity' : 'Subheading'
     end
 
-    def cast_to(klass)
-      return self if is_a?(klass)
-
-      klass.call(values).tap do |casted|
-        associations.each do |association, cached_values|
-          casted.associations[association] = cached_values
-        end
-      end
-    end
-
-    def cast_according_to_declarable
-      case goods_nomenclature_class
-      when 'Subheading' then cast_to(Subheading)
-      when 'Commodity' then cast_to(Commodity)
-      else self
-      end
-    end
-
     def to_admin_param
       "#{goods_nomenclature_item_id}-#{producline_suffix}"
     end

--- a/app/models/full_chemical.rb
+++ b/app/models/full_chemical.rb
@@ -8,14 +8,6 @@ class FullChemical < Sequel::Model
                                      ds.with_actual(GoodsNomenclature)
                                    end
 
-  def custom_sti_goods_nomenclature
-    if goods_nomenclature.path_goods_nomenclature_class == 'Subheading' && goods_nomenclature.instance_of?(::Commodity)
-      goods_nomenclature.cast_to(Subheading)
-    else
-      goods_nomenclature
-    end
-  end
-
   def validate
     super
 

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -167,6 +167,24 @@ class GoodsNomenclature < Sequel::Model
     self.class.name
   end
 
+  def cast_to(klass)
+    return self if is_a?(klass)
+
+    klass.call(values).tap do |casted|
+      associations.each do |association, cached_values|
+        casted.associations[association] = cached_values
+      end
+    end
+  end
+
+  def sti_cast
+    case goods_nomenclature_class
+    when 'Subheading' then cast_to(Subheading)
+    when 'Commodity' then cast_to(Commodity)
+    else self
+    end
+  end
+
   def goods_nomenclature_indent
     goods_nomenclature_indents.first
   end

--- a/app/models/search_reference.rb
+++ b/app/models/search_reference.rb
@@ -15,7 +15,7 @@ class SearchReference < Sequel::Model
   referenced_setter = proc do |referenced|
     if referenced.present?
       set(
-        referenced_class: referenced.class.name,
+        referenced_class: referenced.goods_nomenclature_class,
         productline_suffix: referenced.producline_suffix,
         goods_nomenclature_item_id: referenced.goods_nomenclature_item_id,
         goods_nomenclature_sid: referenced.goods_nomenclature_sid,
@@ -30,14 +30,6 @@ class SearchReference < Sequel::Model
               reciprocal_type: :many_to_one,
               setter: referenced_setter do |ds|
     ds.with_actual(GoodsNomenclature)
-  end
-
-  def custom_sti_goods_nomenclature
-    if referenced_class == 'Subheading' && referenced.instance_of?(::Commodity)
-      referenced.cast_to(Subheading)
-    else
-      referenced
-    end
   end
 
   self.raise_on_save_failure = false

--- a/app/models/search_suggestion.rb
+++ b/app/models/search_suggestion.rb
@@ -16,14 +16,6 @@ class SearchSuggestion < Sequel::Model
                                      ds.with_actual(GoodsNomenclature)
                                    end
 
-  def custom_sti_goods_nomenclature
-    if goods_nomenclature_class == 'Subheading' && goods_nomenclature.instance_of?(::Commodity)
-      goods_nomenclature.cast_to(Subheading)
-    else
-      goods_nomenclature
-    end
-  end
-
   dataset_module do
     def fuzzy_search(query)
       case query

--- a/app/services/api/beta/search_service.rb
+++ b/app/services/api/beta/search_service.rb
@@ -75,7 +75,7 @@ module Api
       end
 
       def goods_nomenclature
-        search_suggestion&.custom_sti_goods_nomenclature
+        @goods_nomenclature ||= search_suggestion&.goods_nomenclature&.sti_cast
       end
 
       def search_suggestion

--- a/app/services/search_service/exact_search.rb
+++ b/app/services/search_service/exact_search.rb
@@ -40,7 +40,7 @@ class SearchService
 
       suggestion = SearchSuggestion.find(filter)
 
-      suggestion&.custom_sti_goods_nomenclature
+      suggestion&.goods_nomenclature&.sti_cast
     end
 
     def find_historic_goods_nomenclature(query)

--- a/app/services/suggestions_service.rb
+++ b/app/services/suggestions_service.rb
@@ -55,7 +55,7 @@ class SuggestionsService
       value: search_reference.title.downcase,
       type: SearchSuggestion::TYPE_SEARCH_REFERENCE,
       goods_nomenclature_sid: search_reference.goods_nomenclature_sid,
-      goods_nomenclature_class: search_reference.custom_sti_goods_nomenclature.class.name,
+      goods_nomenclature_class: search_reference.referenced.goods_nomenclature_class,
       created_at: now,
       updated_at: now,
     )
@@ -83,7 +83,7 @@ class SuggestionsService
       value: full_chemical.name.downcase,
       type: SearchSuggestion::TYPE_FULL_CHEMICAL_NAME,
       goods_nomenclature_sid: full_chemical.goods_nomenclature_sid,
-      goods_nomenclature_class: full_chemical.custom_sti_goods_nomenclature.class.name,
+      goods_nomenclature_class: full_chemical.goods_nomenclature.goods_nomenclature_class,
       created_at: now,
       updated_at: now,
     )
@@ -95,7 +95,7 @@ class SuggestionsService
       value: full_chemical.cus,
       type: SearchSuggestion::TYPE_FULL_CHEMICAL_CUS,
       goods_nomenclature_sid: full_chemical.goods_nomenclature_sid,
-      goods_nomenclature_class: full_chemical.custom_sti_goods_nomenclature.class.name,
+      goods_nomenclature_class: full_chemical.goods_nomenclature.goods_nomenclature_class,
       created_at: now,
       updated_at: now,
     )
@@ -109,7 +109,7 @@ class SuggestionsService
       value: full_chemical.cas_rn,
       type: SearchSuggestion::TYPE_FULL_CHEMICAL_CAS,
       goods_nomenclature_sid: full_chemical.goods_nomenclature_sid,
-      goods_nomenclature_class: full_chemical.custom_sti_goods_nomenclature.class.name,
+      goods_nomenclature_class: full_chemical.goods_nomenclature.goods_nomenclature_class,
       created_at: now,
       updated_at: now,
     )

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -770,48 +770,6 @@ RSpec.describe Commodity do
     end
   end
 
-  describe '#cast_to' do
-    subject(:casted) { commodity.cast_to Subheading }
-
-    let(:commodity) { create(:commodity) }
-
-    it { is_expected.to be_instance_of Subheading }
-    it { is_expected.to have_attributes values: commodity.values }
-    it { is_expected.not_to have_attributes object_id: commodity.object_id }
-
-    context 'with loaded relationships' do
-      subject { casted.associations }
-
-      before { commodity.tree_node }
-
-      it { is_expected.to include tree_node: be_present }
-    end
-
-    context 'when already matching type' do
-      subject { commodity.cast_to described_class }
-
-      it { is_expected.to have_attributes object_id: commodity.object_id }
-    end
-  end
-
-  describe '#cast_according_to_declarable' do
-    subject { commodity.cast_according_to_declarable }
-
-    let(:commodity) { create(:commodity) }
-
-    context 'with declarable' do
-      it { is_expected.to be_instance_of described_class }
-      it { is_expected.to have_attributes values: commodity.values }
-    end
-
-    context 'with non declarable' do
-      before { create :commodity, parent: commodity }
-
-      it { is_expected.to be_instance_of Subheading }
-      it { is_expected.to have_attributes values: commodity.values }
-    end
-  end
-
   describe '#consigned_from' do
     subject(:commodity) { create(:commodity, :with_description, description: 'Consigned from Türkiye') }
 
@@ -822,11 +780,5 @@ RSpec.describe Commodity do
     subject(:short_code) { build(:commodity, goods_nomenclature_item_id: '0101210000').short_code }
 
     it { is_expected.to eq('0101210000') }
-  end
-
-  describe '#goods_nomenclature_class' do
-    subject { create(:commodity).goods_nomenclature_class }
-
-    it { is_expected.to eq('Commodity') }
   end
 end

--- a/spec/models/full_chemical_spec.rb
+++ b/spec/models/full_chemical_spec.rb
@@ -5,34 +5,6 @@ RSpec.describe FullChemical do
     it { is_expected.to be_a(GoodsNomenclature) }
   end
 
-  describe '#custom_sti_goods_nomenclature' do
-    subject(:custom_sti_goods_nomenclature) { build(:full_chemical, goods_nomenclature:).custom_sti_goods_nomenclature }
-
-    context 'when the goods_nomenclature is a Chapter' do
-      let(:goods_nomenclature) { create(:chapter, goods_nomenclature_item_id: '0100000000') }
-
-      it { is_expected.to be_a(Chapter) }
-    end
-
-    context 'when the goods_nomenclature is a Heading' do
-      let(:goods_nomenclature) { create(:heading, goods_nomenclature_item_id: '0101000000') }
-
-      it { is_expected.to be_a(Heading) }
-    end
-
-    context 'when the goods_nomenclature is a Subheading' do
-      let(:goods_nomenclature) { create(:subheading, goods_nomenclature_item_id: '0101110000') }
-
-      it { is_expected.to be_a(Subheading) }
-    end
-
-    context 'when the goods_nomenclature is a Commodity' do
-      let(:goods_nomenclature) { create(:commodity, goods_nomenclature_item_id: '0101110000', producline_suffix: '80') }
-
-      it { is_expected.to be_a(Commodity) }
-    end
-  end
-
   describe 'validations' do
     subject(:errors) { described_class.new.tap(&:valid?).errors }
 

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -722,4 +722,58 @@ RSpec.describe GoodsNomenclature do
 
     it { is_expected.to eq(%w[0111110000]) }
   end
+
+  describe '#cast_to' do
+    subject(:casted) { commodity.cast_to Subheading }
+
+    let(:commodity) { create(:commodity) }
+
+    it { is_expected.to be_instance_of Subheading }
+    it { is_expected.to have_attributes values: commodity.values }
+    it { is_expected.not_to have_attributes object_id: commodity.object_id }
+
+    context 'with loaded relationships' do
+      subject { casted.associations }
+
+      before { commodity.tree_node }
+
+      it { is_expected.to include tree_node: be_present }
+    end
+
+    context 'when already matching type' do
+      subject { commodity.cast_to described_class }
+
+      it { is_expected.to have_attributes object_id: commodity.object_id }
+    end
+  end
+
+  describe '#sti_cast' do
+    subject { goods_nomenclature.sti_cast }
+
+    let(:goods_nomenclature) { create(:commodity) }
+
+    context 'with declarable' do
+      it { is_expected.to be_instance_of Commodity }
+      it { is_expected.to have_attributes values: goods_nomenclature.values }
+    end
+
+    context 'with non declarable' do
+      before { create :commodity, parent: goods_nomenclature }
+
+      it { is_expected.to be_instance_of Subheading }
+      it { is_expected.to have_attributes values: goods_nomenclature.values }
+    end
+
+    context 'with heading' do
+      let(:goods_nomenclature) { create :heading }
+
+      it { is_expected.to have_attributes object_id: goods_nomenclature.object_id }
+    end
+
+    context 'with chapter' do
+      let(:goods_nomenclature) { create :chapter }
+
+      it { is_expected.to have_attributes object_id: goods_nomenclature.object_id }
+    end
+  end
 end

--- a/spec/models/search_reference_spec.rb
+++ b/spec/models/search_reference_spec.rb
@@ -55,34 +55,6 @@ RSpec.describe SearchReference do
     end
   end
 
-  describe '#custom_sti_goods_nomenclature' do
-    subject(:custom_sti_goods_nomenclature) { described_class.new(referenced:).custom_sti_goods_nomenclature }
-
-    context 'when the referenced is a Chapter' do
-      let(:referenced) { create(:chapter, goods_nomenclature_item_id: '0100000000') }
-
-      it { is_expected.to be_a(Chapter) }
-    end
-
-    context 'when the referenced is a Heading' do
-      let(:referenced) { create(:heading, goods_nomenclature_item_id: '0101000000') }
-
-      it { is_expected.to be_a(Heading) }
-    end
-
-    context 'when the referenced is a Subheading' do
-      let(:referenced) { create(:subheading, goods_nomenclature_item_id: '0101110000', producline_suffix: '10') }
-
-      it { is_expected.to be_a(Subheading) }
-    end
-
-    context 'when the referenced is a Commodity' do
-      let(:referenced) { create(:commodity, goods_nomenclature_item_id: '0101110000', producline_suffix: '80') }
-
-      it { is_expected.to be_a(Commodity) }
-    end
-  end
-
   describe 'validations' do
     before { search_reference.validate }
 

--- a/spec/models/search_suggestion_spec.rb
+++ b/spec/models/search_suggestion_spec.rb
@@ -5,47 +5,6 @@ RSpec.describe SearchSuggestion do
     it { is_expected.to be_a(Heading) }
   end
 
-  describe '#custom_sti_goods_nomenclature' do
-    subject(:custom_sti_goods_nomenclature) do
-      create(:search_suggestion, goods_nomenclature:).custom_sti_goods_nomenclature
-    end
-
-    context 'when the search suggestion points to a chapter' do
-      let(:goods_nomenclature) { create(:chapter) }
-
-      it { is_expected.to be_a(Chapter) }
-    end
-
-    context 'when the search suggestion points to a heading' do
-      let(:goods_nomenclature) { create(:heading) }
-
-      it { is_expected.to be_a(Heading) }
-    end
-
-    context 'when the search suggestion points to a subheading' do
-      let(:goods_nomenclature) { create(:subheading) }
-
-      it { is_expected.to be_a(Subheading) }
-    end
-
-    context 'when the search suggestion points to a subheading but the goods_nomenclature_class is nil' do
-      subject(:custom_sti_goods_nomenclature) do
-        search_suggestion.goods_nomenclature_class = nil
-        search_suggestion.custom_sti_goods_nomenclature
-      end
-
-      let(:search_suggestion) { create(:search_suggestion, goods_nomenclature: create(:subheading)) }
-
-      it { is_expected.to be_a(Commodity) }
-    end
-
-    context 'when the search suggestion points to a commodity' do
-      let(:goods_nomenclature) { create(:commodity) }
-
-      it { is_expected.to be_a(Commodity) }
-    end
-  end
-
   describe '.fuzzy_search' do
     subject(:fuzzy_search) { described_class.fuzzy_search(query) }
 

--- a/spec/workers/clear_invalid_search_references_spec.rb
+++ b/spec/workers/clear_invalid_search_references_spec.rb
@@ -3,8 +3,10 @@ RSpec.describe ClearInvalidSearchReferences, type: :worker do
 
   context 'when the are search references to clear' do
     before do
-      create(:search_reference, :with_non_current_commodity, title: 'foo')
-      create(:search_reference, :with_current_commodity, title: 'bar')
+      TimeMachine.now do
+        create(:search_reference, :with_non_current_commodity, title: 'foo')
+        create(:search_reference, :with_current_commodity, title: 'bar')
+      end
     end
 
     it { expect { do_perform }.to change(SearchReference, :count).by(-1) }
@@ -24,8 +26,10 @@ RSpec.describe ClearInvalidSearchReferences, type: :worker do
 
   context 'when there are no search references to clear' do
     before do
-      create(:search_reference, :with_current_commodity, title: 'foo')
-      create(:search_reference, :with_current_commodity, title: 'bar')
+      TimeMachine.now do
+        create(:search_reference, :with_current_commodity, title: 'foo')
+        create(:search_reference, :with_current_commodity, title: 'bar')
+      end
     end
 
     it { expect { do_perform }.not_to change(SearchReference, :count) }


### PR DESCRIPTION
### Jira link

HOTT-2642

### What?

I have added/removed/altered:

- [x] Moved the generic casting logic up to GoodsNomenclature
- [x] Renamed it the `#cast_according_to_declarable` to `#sti_cast`
- [x] Dropped the `custom_sti_goods_nomenclature` code from `SearchReference`
- [x] Dropped the `custom_sti_goods_nomenclature` code from `SearchSuggestion`

### Why?

I am doing this because:

- DRYing out code is good

### Deployment risks (optional)

- Low