### PR TITLE
HOTT-2642 Use distinct for `with_leaf_column`

### DIFF
--- a/docs/goods-nomenclature-nested-set.md
+++ b/docs/goods-nomenclature-nested-set.md
@@ -161,6 +161,7 @@ chapter.ns_children.first.ns_children.first.ns_children.map(&ns_ancestors)
 * `#depth` - internal reference for the depth of a goods nomenclature, normally `number_indents` + 2 except for chapters which are `number_indents` + 1
 * `#goods_nomenclature_class` - this now utilises ns_leaf? internally so benefits from eager loading `#ns_children` or `#ns_descendants` the same
 * `.ns_declarable` - Dataset method to filter by only declarable goods nomenclatures - this does do a left join to check for child_nodes _but_ it skips any rows which have children so shouldn't impact results
+* `.with_leaf_column` - Dataset method which includes a virtual `leaf` column showing whether an record has any children. This can be utilised by `ns_declarable?` to determining declarability without requiring additional queries. Carries a performance cost but can provide `leaf` for 24k commodities in ~0.5 seconds
 
 ### Measures
 
@@ -214,19 +215,6 @@ Chapter.actual
               ns_descendants: MEASURE_EAGER)
        .take
 ```
-
-### Virtual leaf column
-
-This not the easiest method to consume but solves a specific scenario, and is relatively quick - ~0.5 seconds for all goods nomenclatures. If you need to find the 'leaf' status of a goods nomenclature at the SQL level, eg you want to fetch all non declarable commodities without needing to load every commodity back to Ruby.
-
-```
-GoodsNomenclature.with_leaf_column
-                 .where(leaf: false)
-                 .exclude(producline_suffix: '80')
-                 .all
-```
-
-Because this uses a join and group you may need `Sequel.dataset.from_self` to nest the query depending upon what your using it for.
 
 ### Some examples
 


### PR DESCRIPTION
### Jira link

HOTT-2642

### What?

I have added/removed/altered:

- [x] Use `DISTINCT` to select each goods_nomenclatures instead of `GROUP BY`

### Why?

I am doing this because:

- It greatly simplifies using this dataset method - previously if you were joining anything else, you would need to override the grouping rules

### Have you? (optional)

- [x] Added documentation for new apis

### Deployment risks (optional)

- Low

### Notes

There is a 5-10% performance cost to this approach vs GROUPing but its still very quick and way quicker for alternatives when you want the leaf status for large numbers of goods nomenclatures.

```
~460ms = All GNs
 ~32ms = 1000 GNs by sid
  ~6ms = 100 GNs by sid
~1.8ms = 10 GNs by sid
```