### PR TITLE
HOTT-3388: Quota 051534 origins data fix

### DIFF
--- a/db/data_migrations/20230614094504_remove_montenegro_from_quota_order_number_origins.rb
+++ b/db/data_migrations/20230614094504_remove_montenegro_from_quota_order_number_origins.rb
@@ -1,0 +1,14 @@
+Sequel.migration do
+  # IMPORTANT! Data migrations up block should be idempotent (reruns of up should produce the same effect)
+  # they may get re-run as part of data rollbacks but the rollback (down) function of the data migration will not get invoked
+
+  up do
+    if TradeTariffBackend.uk?
+      Sequel::Model.db[:quota_order_number_origins_oplog].where(quota_order_number_sid: 20919, quota_order_number_origin_sid: 20988, geographical_area_id: "ME", operation_date: nil, oid: 8674, operation: "C", geographical_area_sid: 348).delete
+    end
+  end
+
+  down do
+    # deletion, cannot be reversed
+  end
+end

--- a/db/data_migrations/20230614094504_remove_montenegro_from_quota_order_number_origins.rb
+++ b/db/data_migrations/20230614094504_remove_montenegro_from_quota_order_number_origins.rb
@@ -4,7 +4,7 @@ Sequel.migration do
 
   up do
     if TradeTariffBackend.uk?
-      Sequel::Model.db[:quota_order_number_origins_oplog].where(quota_order_number_sid: 20919, quota_order_number_origin_sid: 20988, geographical_area_id: "ME", operation_date: nil, oid: 8674, operation: "C", geographical_area_sid: 348).delete
+      Sequel::Model.db[:quota_order_number_origins_oplog].where(quota_order_number_sid: 20_919, quota_order_number_origin_sid: 20_988, geographical_area_id: 'ME', operation_date: nil, oid: 8674, operation: 'C', geographical_area_sid: 348).delete
     end
   end
 

--- a/db/data_migrations/20230614094504_remove_montenegro_from_quota_order_number_origins.rb
+++ b/db/data_migrations/20230614094504_remove_montenegro_from_quota_order_number_origins.rb
@@ -4,11 +4,34 @@ Sequel.migration do
 
   up do
     if TradeTariffBackend.uk?
-      Sequel::Model.db[:quota_order_number_origins_oplog].where(quota_order_number_sid: 20_919, quota_order_number_origin_sid: 20_988, geographical_area_id: 'ME', operation_date: nil, oid: 8674, operation: 'C', geographical_area_sid: 348).delete
+      QuotaOrderNumberOrigin::Operation.where(
+        quota_order_number_sid: 20_919,
+        quota_order_number_origin_sid: 20_988,
+        geographical_area_id: 'ME',
+        operation_date: nil,
+        operation: 'C',
+        geographical_area_sid: 348,
+        filename: nil,
+      ).delete
     end
   end
 
   down do
-    # deletion, cannot be reversed
+    if TradeTariffBackend.uk?
+      QuotaOrderNumberOrigin.unrestrict_primary_key
+
+      QuotaOrderNumberOrigin.create(
+        quota_order_number_sid: 20_919,
+        quota_order_number_origin_sid: 20_988,
+        geographical_area_id: 'ME',
+        operation_date: nil,
+        operation: 'C',
+        geographical_area_sid: 348,
+        filename: nil,
+        validity_start_date: Date.parse('2021-01-01T00:00:00.000Z'),
+      )
+
+      QuotaOrderNumberOrigin.restrict_primary_key
+    end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3388

### What?

I have added/removed/altered:

- Removed Quota 051534 ME origins

### Why?

I am doing this because:

- The data was incorrect

<img width="1073" alt="Screenshot 2023-06-19 at 15 43 22" src="https://github.com/trade-tariff/trade-tariff-backend/assets/12201130/b6ef19df-ec48-49a3-b159-2d7dee253a47">
<img width="1143" alt="Screenshot 2023-06-19 at 15 41 57" src="https://github.com/trade-tariff/trade-tariff-backend/assets/12201130/e6fd4e9f-757c-4c52-9f5f-2946f47ab51f">
