### PR TITLE
HOTT-3414: Clear out redis between tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,6 +53,10 @@ RSpec.configure do |config|
     FileUtils.cp_r('spec/fixtures/cds_samples/.', 'tmp/data/cds')
   end
 
+  config.after do
+    TradeTariffBackend.redis.flushdb
+  end
+
   config.before(:suite) do
     # Materialized Views need populating after a schema load before concurrent
     # refresh can be used. Doing a blocking refresh to ensure the View is in a


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3414

### What?

I have added/removed/altered:

- [x] Clear out redis after we're finished with any test

### Why?

I am doing this because:

- This should stop us from needing a specific order for the tests to run in and makes our tests less brittle
