### PR TITLE
HOTT-3372: Make opensearch version consistent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -419,7 +419,7 @@ jobs:
       - image: cimg/redis:6.2
         environment:
           REDIS_URL: "redis://localhost:6379/"
-      - image: opensearchproject/opensearch:1.2.4
+      - image: opensearchproject/opensearch:2
         environment:
           cluster.name: elasticsearch
           transport.host: localhost


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3414

### What?

I have added/removed/altered:

- [x] Updated circle ci version of opensearch

### Why?

I am doing this because:

- This is consistent with all live environments
