### PR TITLE
HOTT-3372: Handle nil hits

### DIFF
--- a/app/services/bulk_search_result_answer_service.rb
+++ b/app/services/bulk_search_result_answer_service.rb
@@ -4,7 +4,7 @@ class BulkSearchResultAnswerService
 
   def initialize(search, hits, ancestor_digits: 6)
     @search = search
-    @hits = hits
+    @hits = hits || []
     @ancestor_digits = ancestor_digits
   end
 

--- a/spec/services/bulk_search_result_answer_service_spec.rb
+++ b/spec/services/bulk_search_result_answer_service_spec.rb
@@ -9,6 +9,17 @@ RSpec.describe BulkSearchResultAnswerService do
     )
   end
 
+  context 'when nil is passed as the hits' do
+    let(:hits) { nil }
+
+    it 'sets the fallback search result ancestor short code' do
+      expect { service.call }
+        .to change { search.search_result_ancestors.first&.short_code }
+        .from(nil)
+        .to('999999')
+    end
+  end
+
   context 'when there are no hits' do
     let(:hits) { [] }
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3414

### What?

I have added/removed/altered:

- [x] Added handling for a nil result coming back from opensearch client

### Why?

I am doing this because:

- This seems to be an internal quirk of opensearch that doesn't ever happen in real situations
- This is just a quick fix for making test scenarios pass
