### PR TITLE
HOTT-3453 - Update the UK RoO schemes definition

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk.json
+++ b/db/rules_of_origin/roo_schemes_uk.json
@@ -5010,7 +5010,7 @@
             "scheme_code": "dcts-ldcs",
             "validity_start_date": "2023-06-19",
             "validity_end_date": null,
-            "title": "Developing Countries Trading Scheme (DCTS)",
+            "title": "Developing Countries Trading Scheme (DCTS) - Comprehensive Preferences",
             "proofs": [
                 {
                     "summary": "Generalised Scheme of Preferences Form A",
@@ -5095,7 +5095,6 @@
                         "TZ",
                         "UG",
                         "UZ",
-                        "VN",
                         "VU",
                         "YE",
                         "ZM"
@@ -5210,7 +5209,7 @@
             "scheme_code": "dcts-general-enhanced",
             "validity_start_date": "2023-06-19",
             "validity_end_date": null,
-            "title": "Developing Countries Trading Scheme (DCTS)",
+            "title": "Developing Countries Trading Scheme (DCTS) - Standard and Enhanced Preferences",
             "proofs": [
                 {
                     "summary": "Generalised Scheme of Preferences Form A",


### PR DESCRIPTION
### Jira link

HOTT-3452
HOTT-3453

### What?

I have added/removed/altered:

- [x] Disambiguate the two DCTS schemes
- [x] Removed Vietnam from the dcts-ldcs scheme

### Why?

I am doing this because:

- On the proofs screen on the frontend which lists proofs for all schemes, you cannot tell which scheme is which
- Vietnam was included in dcts-ldcs by mistake

### Deployment risks (optional)

- Low
