### PR TITLE
HOTT-3432 Remove duplicate oplogs for geo area memberships

### DIFF
--- a/db/data_migrations/20230619123312_remove_duplicate_geo_area_memberships.rb
+++ b/db/data_migrations/20230619123312_remove_duplicate_geo_area_memberships.rb
@@ -1,0 +1,26 @@
+Sequel.migration do
+  # IMPORTANT! Data migrations up block should be idempotent (reruns of up should produce the same effect)
+  # they may get re-run as part of data rollbacks but the rollback (down) function of the data migration will not get invoked
+  up do
+    next unless TradeTariffBackend.uk?
+
+    Sequel::Model.db.run <<~SQL
+      DELETE FROM geographical_area_memberships_oplog gamo
+      WHERE
+	      filename IN ('tariff_dailyExtract_v1_20220622T235959.gzip', 'tariff_dailyExtract_v1_20220721T235959.gzip')
+	      AND oid NOT IN (
+		      SELECT max(latest.oid) AS max
+          FROM uk.geographical_area_memberships_oplog latest
+          WHERE
+            gamo.geographical_area_sid = latest.geographical_area_sid AND
+            gamo.geographical_area_group_sid = latest.geographical_area_group_sid AND
+            gamo.validity_start_date = latest.validity_start_date AND
+            gamo.filename = latest.filename
+	      )
+    SQL
+  end
+
+  down do
+    # Not reversible
+  end
+end


### PR DESCRIPTION
These were cause by bad data files from CDS

### Jira link

HOTT-3432

### What?

I have added/removed/altered:

- [x] A data migration to remove the duplicate geographica_area_memberships entries from the oplog

### Why?

I am doing this because:

- There is a bug in CDS which particularly badly impacted two files and created hundreds of oplog updates for certain membership records. Because of the implementation of the oplog system this results in poor performance when querying affected memberships in the view above the table.
- We only require the last oplog entries from a given sync

### Deployment risks (optional)

- Removes oplog data
