### PR TITLE
HOTT-2913 Add rake task to recreate all changes data

### DIFF
--- a/lib/tasks/tariff.rake
+++ b/lib/tasks/tariff.rake
@@ -110,4 +110,12 @@ namespace :tariff do
       end
     end
   end
+
+  desc 'Recreate changes'
+  task recreate_changes_data: %w[environment] do
+    Change.db.transaction do
+      Change.dataset.delete
+      ChangesTablePopulator.populate_backlog
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

HOTT-2913

### What?

I have added/removed/altered:

- [x] Added rake task to recreate all changes data

### Why?

I am doing this because:

- When this feature is deployed we will want to recreate all data

### Deployment risks (optional)

- Low, just a rake task
