### PR TITLE
HOTT-3432 Fix migration for when non-merged databases

### DIFF
--- a/db/data_migrations/20230619123312_remove_duplicate_geo_area_memberships.rb
+++ b/db/data_migrations/20230619123312_remove_duplicate_geo_area_memberships.rb
@@ -10,7 +10,7 @@ Sequel.migration do
 	      filename IN ('tariff_dailyExtract_v1_20220622T235959.gzip', 'tariff_dailyExtract_v1_20220721T235959.gzip')
 	      AND oid NOT IN (
 		      SELECT max(latest.oid) AS max
-          FROM uk.geographical_area_memberships_oplog latest
+          FROM geographical_area_memberships_oplog latest
           WHERE
             gamo.geographical_area_sid = latest.geographical_area_sid AND
             gamo.geographical_area_group_sid = latest.geographical_area_group_sid AND


### PR DESCRIPTION
### Jira link

HOTT-3432

### What?

I have added/removed/altered:

- [x] Fix migration for when non merged databases

### Why?

I am doing this because:

- It wont work on prod

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical data
