### PR TITLE
HOTT-3507 Let indexer control reindexing environment

### DIFF
--- a/app/elastic_search_indexes/concerns/point_in_time_index.rb
+++ b/app/elastic_search_indexes/concerns/point_in_time_index.rb
@@ -3,10 +3,14 @@
 
 module PointInTimeIndex
   def dataset
-    TimeMachine.now { super.actual }
+    apply_constraints { super.actual }
   end
 
   def dataset_page(...)
-    TimeMachine.now { super }
+    apply_constraints { super }
+  end
+
+  def apply_constraints(&block)
+    TimeMachine.now(&block)
   end
 end

--- a/app/elastic_search_indexes/search_index.rb
+++ b/app/elastic_search_indexes/search_index.rb
@@ -52,4 +52,9 @@ class SearchIndex
   def page_size
     500
   end
+
+  # Allows descendants to override and apply timemachine if applicable
+  def apply_constraints(&_block)
+    yield
+  end
 end


### PR DESCRIPTION
### Jira link

HOTT-3507

### What?

I have added/removed/altered:

- [x] Ensure index applies relevant contraints when reindexing

### Why?

I am doing this because:

- Previously if data was excluded from an eager load (eg because of bad references, or because of a missing eager load) then the subsequent attempt to fetch the data at serialization time would either do a non-timemachine query or in the case of nested sets would actually raise an error because it was outside of time machine

### Deployment risks (optional)

- Changes reindexing but should improve consistency so lower risk of different behaviour under differing circumstances
