### PR TITLE
HOTT-3368 Set cache headers

### DIFF
--- a/app/controllers/api/admin/admin_controller.rb
+++ b/app/controllers/api/admin/admin_controller.rb
@@ -1,0 +1,9 @@
+module Api
+  module Admin
+    class AdminController < ApiController
+      def set_cache_headers
+        no_store
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/admin_controller.rb
+++ b/app/controllers/api/admin/admin_controller.rb
@@ -1,9 +1,7 @@
 module Api
   module Admin
     class AdminController < ApiController
-      def set_cache_headers
-        no_store
-      end
+      include NoCaching
     end
   end
 end

--- a/app/controllers/api/admin/chapters/chapter_notes_controller.rb
+++ b/app/controllers/api/admin/chapters/chapter_notes_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module Admin
     module Chapters
-      class ChapterNotesController < ApiController
+      class ChapterNotesController < AdminController
         before_action :authenticate_user!
         skip_before_action :authenticate_user!, only: [:show]
 

--- a/app/controllers/api/admin/chapters_controller.rb
+++ b/app/controllers/api/admin/chapters_controller.rb
@@ -2,7 +2,7 @@ require 'goods_nomenclature_mapper'
 
 module Api
   module Admin
-    class ChaptersController < ApiController
+    class ChaptersController < AdminController
       before_action :find_chapter, only: [:show]
 
       def index
@@ -13,7 +13,7 @@ module Api
 
       def show
         options = { is_collection: false }
-        options[:include] = [:chapter_note, :headings, :section]
+        options[:include] = %i[chapter_note headings section]
 
         render json: Api::Admin::Chapters::ChapterSerializer.new(@chapter, options).serializable_hash
       end

--- a/app/controllers/api/admin/commodities_controller.rb
+++ b/app/controllers/api/admin/commodities_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module Admin
-    class CommoditiesController < ApiController
+    class CommoditiesController < AdminController
       before_action :find_commodity, only: [:show]
       before_action :authenticate_user!
 

--- a/app/controllers/api/admin/footnotes_controller.rb
+++ b/app/controllers/api/admin/footnotes_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module Admin
-    class FootnotesController < ApiController
+    class FootnotesController < AdminController
       before_action :authenticate_user!
 
       def index

--- a/app/controllers/api/admin/headings_controller.rb
+++ b/app/controllers/api/admin/headings_controller.rb
@@ -2,7 +2,7 @@ require 'goods_nomenclature_mapper'
 
 module Api
   module Admin
-    class HeadingsController < ApiController
+    class HeadingsController < AdminController
       def show
         options = { is_collection: false }
         options[:include] = %i[commodities chapter]

--- a/app/controllers/api/admin/news/collections_controller.rb
+++ b/app/controllers/api/admin/news/collections_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module Admin
     module News
-      class CollectionsController < ApiController
+      class CollectionsController < AdminController
         before_action :authenticate_user!
 
         def index

--- a/app/controllers/api/admin/news/items_controller.rb
+++ b/app/controllers/api/admin/news/items_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module Admin
     module News
-      class ItemsController < ApiController
+      class ItemsController < AdminController
         before_action :authenticate_user!
 
         def index

--- a/app/controllers/api/admin/quota_order_numbers/quota_definitions_controller.rb
+++ b/app/controllers/api/admin/quota_order_numbers/quota_definitions_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module Admin
     module QuotaOrderNumbers
-      class QuotaDefinitionsController < ApiController
+      class QuotaDefinitionsController < AdminController
         before_action :authenticate_user!
         around_action :skip_time_machine
 

--- a/app/controllers/api/admin/rollbacks_controller.rb
+++ b/app/controllers/api/admin/rollbacks_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module Admin
-    class RollbacksController < ApiController
+    class RollbacksController < AdminController
       before_action :authenticate_user!
       before_action :collection, only: :index
 

--- a/app/controllers/api/admin/search_references_base_controller.rb
+++ b/app/controllers/api/admin/search_references_base_controller.rb
@@ -7,7 +7,7 @@
 
 module Api
   module Admin
-    class SearchReferencesBaseController < ApiController
+    class SearchReferencesBaseController < AdminController
       before_action :authenticate_user!
 
       after_action :set_pagination_headers, only: [:index]

--- a/app/controllers/api/admin/search_references_controller.rb
+++ b/app/controllers/api/admin/search_references_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module Admin
-    class SearchReferencesController < ApiController
+    class SearchReferencesController < AdminController
       def index
         search_references = SearchReference.for_letter(letter).all
 

--- a/app/controllers/api/admin/sections/section_notes_controller.rb
+++ b/app/controllers/api/admin/sections/section_notes_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module Admin
     module Sections
-      class SectionNotesController < ApiController
+      class SectionNotesController < AdminController
         before_action :authenticate_user!
         # TODO: Why on earth would we do this for an admin endpoint?
         skip_before_action :authenticate_user!, only: [:show]

--- a/app/controllers/api/admin/sections_controller.rb
+++ b/app/controllers/api/admin/sections_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module Admin
-    class SectionsController < ApiController
+    class SectionsController < AdminController
       def index
         @sections = Section.eager({ chapters: [:chapter_note] }, :section_note).all
 
@@ -12,7 +12,7 @@ module Api
         @section = Section.where(position: params[:id]).take
 
         options = { is_collection: false }
-        options[:include] = [:chapters, :section_note]
+        options[:include] = %i[chapters section_note]
         render json: Api::Admin::Sections::SectionSerializer.new(@section, options).serializable_hash
       end
     end

--- a/app/controllers/api/admin/updates_controller.rb
+++ b/app/controllers/api/admin/updates_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module Admin
-    class UpdatesController < ApiController
+    class UpdatesController < AdminController
       before_action :collection, only: :index
 
       def index

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -2,6 +2,14 @@ module Api
   class ApiController < ApplicationController
     include GDS::SSO::ControllerMethods
 
+    # We use ETags so this can be low, if the data hasn't changed and we've not
+    # deployed then CloudFront will just receive a empty 304 response and there
+    # will only be a single fast db query to check tariff_updates table
+    CDN_CACHE_LIFETIME = 30.seconds
+
+    etag { TradeTariffBackend.revision || Rails.env }
+    before_action :set_cache_headers, if: :http_caching_enabled?
+
     respond_to :json
 
     rescue_from Sequel::NoMatchingRow, Sequel::RecordNotFound do |_exception|
@@ -43,6 +51,24 @@ module Api
       return [] if params[:include].blank?
 
       params[:include].split(',')
+    end
+
+    def set_cache_headers
+      set_cache_lifetime
+      set_cache_etag
+    end
+
+    def set_cache_lifetime
+      expires_in CDN_CACHE_LIFETIME, public: true
+    end
+
+    def set_cache_etag
+      update = TariffSynchronizer::BaseUpdate.most_recent_applied
+      fresh_when last_modified: update.applied_at, etag: update
+    end
+
+    def http_caching_enabled?
+      Rails.configuration.action_controller.perform_caching
     end
   end
 end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -54,10 +54,12 @@ module Api
     end
 
     def set_cache_headers
-      return unless request.get? || request.head?
-
-      set_cache_lifetime
-      set_cache_etag
+      if request.get? || request.head?
+        set_cache_lifetime
+        set_cache_etag
+      else
+        no_store
+      end
     end
 
     def set_cache_lifetime

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -54,6 +54,8 @@ module Api
     end
 
     def set_cache_headers
+      return unless request.get? || request.head?
+
       set_cache_lifetime
       set_cache_etag
     end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -5,7 +5,7 @@ module Api
     # We use ETags so this can be low, if the data hasn't changed and we've not
     # deployed then CloudFront will just receive a empty 304 response and there
     # will only be a single fast db query to check tariff_updates table
-    CDN_CACHE_LIFETIME = 30.seconds
+    CDN_CACHE_LIFETIME = 2.minutes
 
     etag { TradeTariffBackend.revision || Rails.env }
     before_action :set_cache_headers, if: :http_caching_enabled?

--- a/app/controllers/api/beta/search_controller.rb
+++ b/app/controllers/api/beta/search_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module Beta
     class SearchController < ApiController
+      include NoCaching
+
       DEFAULT_INCLUDES = [
         'hits.ancestors',
         :search_query_parser_result,

--- a/app/controllers/api/v2/bulk_searches_controller.rb
+++ b/app/controllers/api/v2/bulk_searches_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V2
     class BulkSearchesController < ApiController
+      include NoCaching
+
       def create
         @result = ::BulkSearch::ResultCollection.enqueue(bulk_search_params)
         @serialized_result = Api::V2::BulkSearch::ResultCollectionSerializer.new(@result).serializable_hash

--- a/app/controllers/api/v2/news/collections_controller.rb
+++ b/app/controllers/api/v2/news/collections_controller.rb
@@ -8,6 +8,12 @@ module Api
 
           render json: serializer.serializable_hash
         end
+
+      protected
+
+        def set_cache_etag
+          fresh_when ::News::Item.latest_change
+        end
       end
     end
   end

--- a/app/controllers/api/v2/news/items_controller.rb
+++ b/app/controllers/api/v2/news/items_controller.rb
@@ -6,6 +6,8 @@ module Api
         DEFAULT_PAGE_SIZE = 20
 
         def index
+          return unless stale? ::News::Item.latest_change
+
           news_items_page = ::News::Item.for_service(params[:service])
                                    .for_target(params[:target])
                                    .for_year(params[:year])
@@ -42,6 +44,8 @@ module Api
                         scope.with_pk!(slug_or_id)
                       end
 
+          return unless stale?(news_item)
+
           presented_news_item = Api::V2::News::ItemPresenter.new(news_item)
 
           serializer = Api::V2::News::ItemSerializer.new(presented_news_item, include: %i[collections])
@@ -70,6 +74,8 @@ module Api
             },
           }
         end
+
+        def set_cache_etag; end
       end
     end
   end

--- a/app/controllers/api/v2/news/years_controller.rb
+++ b/app/controllers/api/v2/news/years_controller.rb
@@ -12,6 +12,12 @@ module Api
 
           render json: serializer.serializable_hash
         end
+
+      private
+
+        def set_cache_etag
+          fresh_when ::News::Item.latest_change
+        end
       end
     end
   end

--- a/app/controllers/api/v2/search_controller.rb
+++ b/app/controllers/api/v2/search_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V2
     class SearchController < ApiController
+      include NoCaching
+
       def search
         render json: SearchService.new(Api::V2::SearchSerializationService.new, params).to_json
       end

--- a/app/controllers/api/v2/search_references_controller.rb
+++ b/app/controllers/api/v2/search_references_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V2
     class SearchReferencesController < ApiController
+      include SimpleCaching
+
       def index
         search_references = SearchReference.for_letter(letter).all
 

--- a/app/controllers/concerns/no_caching.rb
+++ b/app/controllers/concerns/no_caching.rb
@@ -1,0 +1,7 @@
+module NoCaching
+  protected
+
+  def set_cache_headers
+    no_store
+  end
+end

--- a/app/controllers/concerns/simple_caching.rb
+++ b/app/controllers/concerns/simple_caching.rb
@@ -1,0 +1,11 @@
+# Use this when you are happy for the endpoint to be cached
+# but once the cache lifetime expires (expected to be 5 minutes) you always want
+# the data to be reloaded
+#
+# Useful to ease high request counts
+
+module SimpleCaching
+  protected
+
+  def set_cache_etag; end
+end

--- a/app/lib/tariff_synchronizer/base_update.rb
+++ b/app/lib/tariff_synchronizer/base_update.rb
@@ -155,6 +155,16 @@ module TariffSynchronizer
       raise NotImplementedError
     end
 
+    def cache_key_with_version
+      [
+        'tariff-update',
+        filename,
+        update_type,
+        state,
+        applied_at.iso8601,
+      ].map(&:to_s).join('-')
+    end
+
     class << self
       delegate :instrument, to: ActiveSupport::Notifications
 

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -1,5 +1,6 @@
 module TradeTariffBackend
   MAX_LOCK_LIFETIME = 600_000
+  REVISION_FILE = Rails.root.join('REVISION').to_s.freeze
 
   class << self
     SERVICE_CURRENCIES = {
@@ -245,6 +246,14 @@ module TradeTariffBackend
 
     def opensearch_debug
       ENV.fetch('OPENSEARCH_DEBUG', 'false') == 'true'
+    end
+
+    def revision
+      @revision ||= begin
+        File.read(REVISION_FILE).chomp if File.file?(REVISION_FILE)
+      rescue Errno::EACCES
+        nil
+      end
     end
   end
 end

--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -1,13 +1,14 @@
 class Healthcheck
   include Singleton
 
-  REVISION_FILE = Rails.root.join('REVISION').to_s.freeze
   SIDEKIQ_KEY = 'sidekiq-healthcheck'.freeze
   SIDEKIQ_THRESHOLD = 90.minutes
 
   class << self
     delegate :check, to: :instance
   end
+
+  delegate :revision, to: TradeTariffBackend
 
   def check
     checks = {
@@ -23,15 +24,7 @@ class Healthcheck
   end
 
   def current_revision
-    @current_revision ||= read_revision_file || Rails.env.to_s
-  end
-
-private
-
-  def read_revision_file
-    File.read(REVISION_FILE).chomp if File.file?(REVISION_FILE)
-  rescue Errno::EACCES
-    nil
+    revision || Rails.env.to_s
   end
 
   def search_query_parser_healthy?

--- a/app/models/news/collection.rb
+++ b/app/models/news/collection.rb
@@ -1,6 +1,6 @@
 module News
   class Collection < Sequel::Model(:news_collections)
-    plugin :timestamps
+    plugin :timestamps, update_on_create: true
     plugin :auto_validations, not_null: :presence
 
     many_to_many :items, join_table: :news_collections_news_items,

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -1,6 +1,6 @@
 module News
   class Item < Sequel::Model(:news_items)
-    plugin :timestamps
+    plugin :timestamps, update_on_create: true
     plugin :auto_validations, not_null: :presence
 
     DISPLAY_REGULAR = 0
@@ -49,6 +49,10 @@ module News
       validates_presence :slug
       validates_presence :precis if show_on_updates_page
       validates_presence :collection_ids, message: 'must include at least one collection'
+    end
+
+    def cache_key_with_version
+      "News::Item/#{id}-#{updated_at}"
     end
 
     dataset_module do
@@ -104,6 +108,10 @@ module News
         distinct.select { date_part('year', :start_date).cast(:integer).as(:year) }
                 .order(Sequel.desc(:year))
                 .pluck(:year)
+      end
+
+      def latest_change
+        for_today.order(Sequel.desc(:updated_at)).first
       end
     end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,11 +23,21 @@ Rails.application.configure do
   config.whiny_nils = true
 
   # Show full error reports and disable caching
-  config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  config.consider_all_requests_local = true
 
-  # config.cache_store = :memory_store, { size: 20.megabytes }
-  config.cache_store = [:null_store]
+  if Rails.root.join('tmp/caching-dev.txt').exist?
+    config.action_controller.perform_caching = true
+    config.action_controller.enable_fragment_cache_logging = true
+
+    config.cache_store = :memory_store
+    config.public_file_server.headers = {
+      'Cache-Control' => "public, max-age=#{2.days.to_i}",
+    }
+  else
+    config.action_controller.perform_caching = false
+
+    config.cache_store = :null_store
+  end
 
   # enable sequel transaction logs by setting RAILS_LOG_LEVEL=debug
   config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'debug').to_sym

--- a/db/data_migrations/20230627135808_set_updated_at_on_news_items.rb
+++ b/db/data_migrations/20230627135808_set_updated_at_on_news_items.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  # IMPORTANT! Data migrations up block should be idempotent (reruns of up should produce the same effect)
+  # they may get re-run as part of data rollbacks but the rollback (down) function of the data migration will not get invoked
+  up do
+    News::Collection.where(updated_at: nil).update(updated_at: :created_at)
+    News::Item.where(updated_at: nil).update(updated_at: :created_at)
+  end
+
+  down do
+    News::Item.where(updated_at: :created_at).update(updated_at: nil)
+    News::Collection.where(updated_at: :created_at).update(updated_at: nil)
+  end
+end

--- a/db/migrate/20230627083227_add_indexes_for_cache_lookups.rb
+++ b/db/migrate/20230627083227_add_indexes_for_cache_lookups.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    add_index :tariff_updates, :issue_date
+  end
+
+  down do
+    drop_index :tariff_updates, :issue_date
+  end
+end

--- a/db/migrate/20230627083227_add_indexes_for_cache_lookups.rb
+++ b/db/migrate/20230627083227_add_indexes_for_cache_lookups.rb
@@ -3,9 +3,11 @@
 Sequel.migration do
   up do
     add_index :tariff_updates, :issue_date
+    add_index :news_items, %i[updated_at start_date end_date]
   end
 
   down do
+    drop_index :news_items, %i[updated_at start_date_end_date]
     drop_index :tariff_updates, :issue_date
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -11505,6 +11505,13 @@ CREATE INDEX tariff_update_presence_errors_tariff_update_filename_index ON uk.ta
 
 
 --
+-- Name: tariff_updates_issue_date_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX tariff_updates_issue_date_index ON uk.tariff_updates USING btree (issue_date);
+
+
+--
 -- Name: tbl_code_index; Type: INDEX; Schema: uk; Owner: -
 --
 
@@ -11761,3 +11768,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20230419084212_add_tree_no
 INSERT INTO "schema_migrations" ("filename") VALUES ('20230425151153_adds_goods_nomenclature_class_to_search_suggestions.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20230519133544_adds_simplfied_procedural_codes.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20230619124026_create_exchange_rates.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20230627083227_add_indexes_for_cache_lookups.rb');

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -11127,6 +11127,13 @@ CREATE INDEX news_items_slug_index ON uk.news_items USING btree (slug);
 
 
 --
+-- Name: news_items_updated_at_start_date_end_date_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX news_items_updated_at_start_date_end_date_index ON uk.news_items USING btree (updated_at, start_date, end_date);
+
+
+--
 -- Name: ngmo_nomgromemopl_ureoupipslog_operation_date; Type: INDEX; Schema: uk; Owner: -
 --
 

--- a/docs/adr/2023-06-28_add_cache_headers.md
+++ b/docs/adr/2023-06-28_add_cache_headers.md
@@ -1,0 +1,43 @@
+# Adding cache headers
+
+Date: 28 June 2023
+
+## Context
+
+We currently have a CDN which has its cache support disabled and always just passes requests straight through to first the frontend end and then onward to the backend.
+
+Our frontend requires various changes to support cacheability from the CDN but would benefit from that work occurring at some point.
+
+Our backend has no state so its responses to GET and HEAD requests are easily cacheable.
+
+## Decision
+
+Caching of backend responses will be enabled in two phases - first internally only, then for broader downstream use.
+
+## Consequences
+
+### Phase 1
+
+The backend will start setting headers to control caching. These will have a very short TTL to allow for quick updating will utilise ETags to allow for very quick (~2ms) HEAD 304 responses from the backend for the majority of requests which have already been seen by the caching client. 
+
+Any non-GET or HEAD requests will not set cache headers
+
+Some endpoints (eg News) will require custom ETags based on the the relevant data lifecycle. 
+
+The backends Cache-Control header is overwritten by the frontend, then ignored
+by the CDN anyway so this should not have any downstream impact.
+
+The Frontend will have a http cache added to its api client, which means it will
+in turn cache the api responses it is receiving from the backend (where the 
+backends response headers direct it to).
+
+### Phase 2
+
+The frontend will be changed to pass the cache headers through from the backend rather then overwriting them - placing the backend in control of the cachability of its responses
+
+The frontend will mark its own responses as no-store to prevent caching
+
+After the above has been deployed the CDN will be updated to follow the caching headers from its upstream -;
+
+* In the case of web access this should always be 'no-store'
+* In the case of proxied API access from the backend, this should be the ETagged behaviour dictated by the backend 

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -386,6 +386,41 @@ RSpec.describe News::Item do
     end
   end
 
+  describe '.latest_change' do
+    subject { described_class.latest_change }
+
+    before do
+      older
+      newer
+      described_class.dataset.update(updated_at: :created_at)
+    end
+
+    let(:older) { create :news_item, created_at: 5.minutes.ago }
+    let(:newer) { create :news_item, created_at: 3.minutes.ago }
+
+    it { is_expected.to eq_pk newer }
+
+    context 'when updating' do
+      before do
+        older.title = 'changed'
+        older.save
+      end
+
+      it { is_expected.to eq_pk older }
+    end
+
+    context 'with unpublished' do
+      before do
+        create :news_item, start_date: 3.days.from_now,
+                           created_at: 1.minute.ago
+
+        described_class.dataset.update(updated_at: :created_at)
+      end
+
+      it { is_expected.to eq_pk newer }
+    end
+  end
+
   describe '#slug' do
     subject { instance.save.reload.slug }
 

--- a/spec/unit/trade_tariff_backend_spec.rb
+++ b/spec/unit/trade_tariff_backend_spec.rb
@@ -52,4 +52,49 @@ RSpec.describe TradeTariffBackend do
       end
     end
   end
+
+  describe '#revision' do
+    subject { described_class.revision }
+
+    before do
+      described_class.instance_variable_set(:@revision, nil)
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:file?).and_call_original
+    end
+
+    after { described_class.instance_variable_set(:@revision, nil) }
+
+    context 'with revision file' do
+      before do
+        allow(File).to receive(:file?).with(described_class::REVISION_FILE)
+                                      .and_return true
+
+        allow(File).to receive(:read).with(described_class::REVISION_FILE)
+                                     .and_return "ABCDEF01\n"
+      end
+
+      it { is_expected.to eql 'ABCDEF01' }
+    end
+
+    context 'with unreadable revision file' do
+      before do
+        allow(File).to receive(:file?).with(described_class::REVISION_FILE)
+                                      .and_return true
+
+        allow(File).to receive(:read).with(described_class::REVISION_FILE)
+                                     .and_raise Errno::EACCES
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'without revision file' do
+      before do
+        allow(File).to receive(:file?).with(described_class::REVISION_FILE)
+                                      .and_return false
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

HOTT-3368

### What?

I have added/removed/altered:

- [x] Set default cache headers across entire API - derived from latest REVISION file and last changed to TariffUpdates
- [x] Enforce no caching on Admin endpoints
- [x] Enforce no caching on various other endpoints
- [x] Add SimpleCaching module for just caching for a fixed length of time without using ETags
- [x] Use the `updated_at` date for the news items to determine whether they are current
- [x] Add db indexes where necessary

### Why?

I am doing this because:

- These headers can be used by both our frontends and our CDN to reduce load on the backend and speed up the site

### Deployment risks (optional)

- Limited, the `Cache-Control` headers are currently hidden by the api proxying in the frontend

### Notes

- There's is a corresponding frontend PR which will start using this content to enable caching on the frontend
- There will be a future frontend PR to expose these headers in the caching proxy, and disable caching in the rest of the frontend
- There will be a future PR to turn on caching in the CDN

### Screenshots

![Screenshot from 2023-06-27 16-24-48](https://github.com/trade-tariff/trade-tariff-backend/assets/10818/186bb1df-18f1-4aff-bb11-015c8be59253)
![Screenshot from 2023-06-27 16-19-34](https://github.com/trade-tariff/trade-tariff-backend/assets/10818/38849fe5-7737-4caf-9716-bdf788ac01a8)

