### PR TITLE
HOTT-3447: Adds support for csv to bulk search api

### DIFF
--- a/app/controllers/api/v2/bulk_searches_controller.rb
+++ b/app/controllers/api/v2/bulk_searches_controller.rb
@@ -10,17 +10,52 @@ module Api
 
       def show
         @result = ::BulkSearch::ResultCollection.find(params[:id])
-        @serialized_result = Api::V2::BulkSearch::ResultCollectionSerializer.new(
-          @result,
-          include: ['searches.search_result_ancestors'],
-        ).serializable_hash
 
-        render json: @serialized_result, status: @result.http_code
+        respond_to do |format|
+          format.json do
+            render json: serialized_json_result, status: @result.http_code
+          end
+          format.csv do
+            filename = "#{TradeTariffBackend.service}-bulk-searches-#{params[:id]}-#{actual_date.iso8601}.csv"
+
+            if @result.completed?
+              send_data(
+                serialized_csv_result,
+                type: 'text/csv; charset=utf-8; header=present',
+                disposition: "attachment; filename=#{filename}",
+                status: @result.http_code,
+              )
+            else
+              render plain: nil, status: @result.http_code
+            end
+          end
+        end
       end
+
+      private
 
       def bulk_search_params
         params.require(:data).map do |json|
           json.permit(:type, attributes: %i[input_description ancestor_digits])
+        end
+      end
+
+      def serialized_json_result
+        Api::V2::BulkSearch::ResultCollectionSerializer.new(
+          @result,
+          include: ['searches.search_result_ancestors'],
+        ).serializable_hash
+      end
+
+      def serialized_csv_result
+        Api::V2::Csv::BulkSearchResultSerializer.new(presented_searches).serialized_csv
+      end
+
+      def presented_searches
+        if @result.completed?
+          Api::V2::BulkSearchResultPresenter.wrap(@result)
+        else
+          []
         end
       end
     end

--- a/app/models/bulk_search/result_collection.rb
+++ b/app/models/bulk_search/result_collection.rb
@@ -2,7 +2,7 @@ module BulkSearch
   class ResultCollection
     class RecordNotFound < StandardError; end
 
-    delegate :processing?, :complete?, :failed?, :queued?, to: :status
+    delegate :processing?, :completed?, :failed?, :queued?, to: :status
     delegate :to_param, to: :id
 
     attr_accessor :status

--- a/app/presenters/api/v2/bulk_search_result_presenter.rb
+++ b/app/presenters/api/v2/bulk_search_result_presenter.rb
@@ -1,0 +1,24 @@
+module Api
+  module V2
+    class BulkSearchResultPresenter < WrapDelegator
+      def self.wrap(result_collection)
+        result_collection.searches.each_with_object([]) do |search, acc|
+          search.search_result_ancestors.each do |search_result|
+            acc << new(search, search_result)
+          end
+        end
+      end
+
+      def initialize(search, search_result)
+        @search = search
+        @search_result = search_result
+
+        super(@search_result)
+      end
+
+      def input_description
+        @search.input_description
+      end
+    end
+  end
+end

--- a/app/serializers/api/v2/csv/bulk_search_result_serializer.rb
+++ b/app/serializers/api/v2/csv/bulk_search_result_serializer.rb
@@ -1,0 +1,16 @@
+module Api
+  module V2
+    module Csv
+      class BulkSearchResultSerializer
+        include Api::Shared::CsvSerializer
+
+        columns :input_description,
+                :goods_nomenclature_item_id,
+                :producline_suffix,
+                :goods_nomenclature_class,
+                :short_code,
+                :score
+      end
+    end
+  end
+end

--- a/spec/factories/bulk_search/search_ancestor_factory.rb
+++ b/spec/factories/bulk_search/search_ancestor_factory.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :bulk_search_ancestor, class: 'BulkSearch::SearchAncestor' do
+    short_code { '851821' }
+    goods_nomenclature_item_id { '8518210000' }
+    description { 'Other equipment for wireless networks' }
+    producline_suffix { '80' }
+    goods_nomenclature_class { 'C' }
+    declarable { true }
+    score { 0.5 }
+    reason { 'matching_digit_ancestor' }
+  end
+end

--- a/spec/factories/bulk_search/search_factory.rb
+++ b/spec/factories/bulk_search/search_factory.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :bulk_search, class: 'BulkSearch::Search' do
+    input_description { 'foo' }
+    ancestor_digits { 6 }
+    search_result_ancestors do
+      [
+        build(:bulk_search_ancestor),
+      ]
+    end
+  end
+end

--- a/spec/presenters/api/v2/bulk_search_result_presenter_spec.rb
+++ b/spec/presenters/api/v2/bulk_search_result_presenter_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Api::V2::BulkSearchResultPresenter do
+  describe '.wrap' do
+    subject(:result) { described_class.wrap(result_collection) }
+
+    let(:result_collection) { BulkSearch::ResultCollection.build([attributes_for(:bulk_search)]) }
+
+    it { is_expected.to all(be_a(described_class)) }
+  end
+
+  describe '#input_description' do
+    subject(:input_description) { described_class.new(search, search_result).input_description }
+
+    let(:search) { build(:bulk_search) }
+    let(:search_result) { search.search_result_ancestors.first }
+
+    it { is_expected.to eq(search.input_description) }
+  end
+end

--- a/spec/requests/api/v2/bulk_searches_controller_spec.rb
+++ b/spec/requests/api/v2/bulk_searches_controller_spec.rb
@@ -178,4 +178,29 @@ RSpec.describe Api::V2::BulkSearchesController, type: :request do
       it { expect(response.body).to match_json_expression(pattern) }
     end
   end
+
+  describe 'GET /bulk_searches/:id.csv' do
+    subject(:do_get) { make_request && response }
+
+    let(:path) { "/bulk_searches/#{uuid}" }
+    let(:status) { 'completed' }
+    let(:uuid) { SecureRandom.uuid }
+    let(:expected_filename) { "uk-bulk-searches-#{uuid}-#{Time.zone.today.iso8601}.csv" }
+
+    let(:json_blob) do
+      {
+        id: uuid,
+        status:,
+        searches: [build(:bulk_search)],
+      }.to_json
+    end
+
+    before do
+      TradeTariffBackend.redis.set(uuid, Zlib::Deflate.deflate(json_blob))
+
+      do_get
+    end
+
+    it_behaves_like 'a successful csv response'
+  end
 end

--- a/spec/serializers/api/v2/csv/bulk_search_result_serializer_spec.rb
+++ b/spec/serializers/api/v2/csv/bulk_search_result_serializer_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe Api::V2::Csv::BulkSearchResultSerializer do
+  describe '#serializable_array' do
+    subject(:serializable_array) { described_class.new([serializable]).serializable_array }
+
+    let(:serializable) do
+      Api::V2::BulkSearchResultPresenter.new(
+        search,
+        search_result_ancestor,
+      )
+    end
+
+    let(:search) { build(:bulk_search) }
+    let(:search_result_ancestor) { search.search_result_ancestors.first }
+
+    it 'serializes correctly' do
+      expect(serializable_array).to eq(
+        [
+          %i[input_description goods_nomenclature_item_id producline_suffix goods_nomenclature_class short_code score],
+          [
+            search.input_description,
+            search_result_ancestor.goods_nomenclature_item_id,
+            search_result_ancestor.producline_suffix,
+            search_result_ancestor.goods_nomenclature_class,
+            search_result_ancestor.short_code,
+            search_result_ancestor.score,
+          ],
+        ],
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3447

### What?

I have added/removed/altered:

- [x] Added CSV support to bulk search api

### Why?

I am doing this because:

- This is required for simple reporting from the results of this api
