### PR TITLE
HOTT-3368 Fix unpublished stories not invalidating cache

### DIFF
--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -111,7 +111,7 @@ module News
       end
 
       def latest_change
-        for_today.order(Sequel.desc(:updated_at)).first
+        order(Sequel.desc(:updated_at)).first
       end
     end
 

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -411,13 +411,17 @@ RSpec.describe News::Item do
 
     context 'with unpublished' do
       before do
-        create :news_item, start_date: 3.days.from_now,
-                           created_at: 1.minute.ago
+        unpublished
 
         described_class.dataset.update(updated_at: :created_at)
       end
 
-      it { is_expected.to eq_pk newer }
+      let :unpublished do
+        create :news_item, start_date: 3.days.from_now,
+                           created_at: 1.minute.ago
+      end
+
+      it { is_expected.to eq_pk unpublished }
     end
   end
 


### PR DESCRIPTION
### Jira link

HOTT-3368

### What?

I have added/removed/altered:

- [x] Fixed unpublished news stories not invalidating cache

### Why?

I am doing this because:

- If you updated the expiry date to unpublish a story which was not the latest, then the story would be no longer published and so wouldn't become the last changed story, so the cache would not invalidiate. 

### Deployment risks (optional)

- Low, fixes minor bug with news stories not invalidating
