### PR TITLE
HOTT-3547: Adds by headings index builder worker

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -18,3 +18,4 @@ STEMMING_EXCLUSION_REFERENCE_ANALYZER=/usr/share/opensearch/config/stemming_excl
 SYNONYM_REFERENCE_ANALYZER=/usr/share/opensearch/config/synonyms_all.txt
 TARIFF_IGNORE_PRESENCE_ERRORS=1
 TARIFF_QUERY_SEARCH_PARSER_URL=http://127.0.0.1:5000/api/search/
+SERVICE=xi

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -117,8 +117,8 @@ class GoodsNomenclature < Sequel::Model
       exclude(chapter_short_code: '98')
     end
 
-    def indexable
-      where(Sequel.~(goods_nomenclature_item_id: HiddenGoodsNomenclature.codes))
+    def non_grouping
+      where(producline_suffix: '80')
     end
   end
 

--- a/app/workers/build_index_by_heading_worker.rb
+++ b/app/workers/build_index_by_heading_worker.rb
@@ -1,0 +1,13 @@
+class BuildIndexByHeadingWorker
+  class IndexingError < StandardError; end
+
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :default, retry: false
+
+  delegate :opensearch_client, to: TradeTariffBackend
+
+  def perform(index_namespace, index_name, heading_sid)
+    # TOOD: Implement me
+  end
+end

--- a/app/workers/build_index_by_headings_worker.rb
+++ b/app/workers/build_index_by_headings_worker.rb
@@ -1,0 +1,19 @@
+class BuildIndexByHeadingsWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :default, retry: false
+
+  def perform(index_name)
+    TimeMachine.now do
+      Heading
+        .actual
+        .non_grouping
+        .non_hidden
+        .non_classifieds
+        .select_map(:heading_short_code)
+        .each do |heading_short_code|
+          BuildIndexByHeadingWorker.perform_async(index_name, heading_short_code)
+        end
+    end
+  end
+end

--- a/spec/factories/heading_factory.rb
+++ b/spec/factories/heading_factory.rb
@@ -20,6 +20,10 @@ FactoryBot.define do
       end
     end
 
+    trait :classified do
+      goods_nomenclature_item_id { '9801000000' }
+    end
+
     trait :with_chapter do
       before(:create) do |heading, _evaluator|
         create(:chapter,

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -594,6 +594,17 @@ RSpec.describe GoodsNomenclature do
     it { is_expected.to eq(%w[0111110000]) }
   end
 
+  describe '.non_grouping' do
+    subject(:non_grouping) { described_class.non_grouping.pluck(:goods_nomenclature_item_id) }
+
+    before do
+      create(:goods_nomenclature, :non_grouping, goods_nomenclature_item_id: '0111110000')
+      create(:goods_nomenclature, :grouping)
+    end
+
+    it { is_expected.to eq(%w[0111110000]) }
+  end
+
   describe '#cast_to' do
     subject(:casted) { commodity.cast_to Subheading }
 

--- a/spec/workers/build_index_by_heading_worker_spec.rb
+++ b/spec/workers/build_index_by_heading_worker_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe BuildIndexByHeadingWorker, type: :worker do
+  describe '#perform' do
+    let!(:commodity) { create(:commodity, goods_nomenclature_item_id: '0101000001') }
+    let(:index_name) { 'Search::BulkSearchIndex' }
+    let(:heading_short_code) { '0101' }
+    let(:opensearch_client) { instance_double(OpenSearch::Client) }
+
+    before do
+      allow(TradeTariffBackend).to receive(:opensearch_client).and_return(opensearch_client)
+      allow(opensearch_client).to receive(:bulk)
+    end
+
+    it 'serializes and indexes the entries' do
+      described_class.new.perform(index_name, heading_short_code)
+
+      expect(opensearch_client)
+        .to have_received(:bulk)
+        .with(
+          body: [
+            {
+              index: {
+                _index: 'tariff-test-bulk_searches-uk',
+                _id: commodity.id,
+                data: 'serialized_entry',
+              },
+            },
+          ],
+        )
+    end
+  end
+end

--- a/spec/workers/build_index_by_headings_worker_spec.rb
+++ b/spec/workers/build_index_by_headings_worker_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe BuildIndexByHeadingsWorker, type: :worker do
+  describe '#perform' do
+    let!(:heading) { create(:heading, :non_grouping) }
+
+    let(:index_name) { 'Search::BulkSearchIndex' }
+
+    before do
+      create(:heading, :grouping)   # not queued
+      create(:heading, :classified) # not queued
+      create(:heading, :hidden)     # not queued
+      create(:commodity)            # not queued
+
+      allow(BuildIndexByHeadingWorker).to receive(:perform_async)
+    end
+
+    it 'enqueues a BuildIndexByHeadingWorker for each heading' do
+      described_class.new.perform(index_name)
+
+      expect(BuildIndexByHeadingWorker).to have_received(:perform_async).with(index_name, heading.heading_short_code)
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3532

### What?

I have added/removed/altered:

- [x] Added worker to populate an index for a given heading
- [x] Removes redundant `indexable` method

### Why?

I am doing this because:

- This is required to enable bulk-search index population
