### PR TITLE
HOTT-3119 Make STI Subheading aware

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -19,7 +19,11 @@ class GoodsNomenclature < Sequel::Model
     elsif gono_id.ends_with?('000000') && gono_id.slice(2, 2) != '00'
       'Heading'
     elsif !gono_id.ends_with?('000000')
-      'Commodity'
+      # checking its a False class because if :leaf is not assigned, we should
+      # continue to assume Commodity as previously done
+      #
+      # :leaf can be included by the use of `GoodsNomenclature.with_leaf_column`
+      record[:producline_suffix] != '80' || record[:leaf].is_a?(FalseClass) ? 'Subheading' : 'Commodity'
     else
       'GoodsNomenclature'
     end

--- a/app/presenters/api/v2/subheadings/subheading_presenter.rb
+++ b/app/presenters/api/v2/subheadings/subheading_presenter.rb
@@ -25,7 +25,7 @@ module Api
         end
 
         def ancestors
-          @ancestors ||= ns_ancestors.select { |ancestor| ancestor.is_a?(Commodity) }
+          @ancestors ||= ns_ancestors.select { |ancestor| ancestor.is_a? TenDigitGoodsNomenclature }
         end
 
         def ancestor_ids

--- a/app/serializers/api/v2/csv/commodity_serializer.rb
+++ b/app/serializers/api/v2/csv/commodity_serializer.rb
@@ -17,7 +17,7 @@ module Api
                 :producline_suffix
 
         column :parent_sid do |commodity|
-          if commodity.ns_parent.is_a?(Commodity)
+          if commodity.ns_parent.is_a?(TenDigitGoodsNomenclature)
             commodity.ns_parent.goods_nomenclature_sid
           end
         end

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -47,12 +47,12 @@ RSpec.describe GoodsNomenclatures::NestedSet do
       let :tree do
         chapter = create(:chapter)
         heading = create(:heading, parent: chapter)
-        subheading = create(:commodity, parent: heading)
-        subsubheading = create(:commodity, parent: subheading)
+        subheading = create(:subheading, parent: heading)
+        subsubheading = create(:subheading, parent: subheading)
         commodity1 = create(:commodity, parent: subsubheading)
         commodity2 = create(:commodity, parent: subsubheading)
         commodity3 = create(:commodity, parent: subheading)
-        second_tree = create(:commodity, :with_chapter_and_heading, :with_children)
+        second_tree = create(:subheading, :with_chapter_and_heading, :with_children)
 
         {
           chapter:,

--- a/spec/models/search_reference_spec.rb
+++ b/spec/models/search_reference_spec.rb
@@ -46,12 +46,10 @@ RSpec.describe SearchReference do
 
     context 'when getting a Subheading reference' do
       let(:referenced) do
-        create(:commodity, goods_nomenclature_item_id: '0101110000', producline_suffix: '30')
-
-        Subheading.find(goods_nomenclature_item_id: '0101110000', producline_suffix: '30')
+        create(:subheading, goods_nomenclature_item_id: '0101110000', producline_suffix: '30')
       end
 
-      it { expect(search_reference.referenced).to be_a(Commodity) }
+      it { expect(search_reference.referenced).to be_a(Subheading) }
     end
   end
 


### PR DESCRIPTION
This will not always work, if nothing is pulling in the tree nodes join then we cannot know leaf. And pulling it in is non-optimal if we are pulling a vertical slice of the tree

### Jira link

HOTT-3119

### What?

I have added/removed/altered:

- [x] Extended Single Table Inheritance for goods nomenclatures to take account of whether a GN is a subheading

### Why?

I am doing this because:

- It has been requested by other developers

### Have you? (optional)

- [ ] Added documentation for new apis
- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks (optional)

- Changes how we load goods nomenclatures - GNs that were previously loaded as Commodities (but were actually Subheadings) will now be loaded as Subheadings

### Notes

I've dithered on adding this because I am very aware it only works if something is setting the the `leaf` attribute for GNs with PLS=80. This is a potential source of confusion for future developers but can be resolved if needed by utilising the `with_leaf_column` scope. When looking up the tree this is set automatically.

In general I think it makes more sense to utilise `#goods_nomenclature_class` and remove the Subheading data type but that would be a larger undertaking
