### PR TITLE
HOTT-3547: Enable population of a bulk search index by heading

### DIFF
--- a/app/elastic_search_indexes/search/bulk_search_index.rb
+++ b/app/elastic_search_indexes/search/bulk_search_index.rb
@@ -3,12 +3,17 @@ module Search
     include PointInTimeIndex
 
     def dataset_heading(heading_short_code)
-      GoodsNomenclature
+      declarables = GoodsNomenclature
         .actual
         .where(heading_short_code:)
         .ns_declarable
         .eager(*eager_load)
         .all
+
+      [
+        BulkSearchDocumentBuilderService.new(declarables, 6).call,
+        BulkSearchDocumentBuilderService.new(declarables, 8).call,
+      ].flatten.compact
     end
 
     def eager_load
@@ -20,12 +25,97 @@ module Search
       ]
     end
 
-    # TODO: Implement me
-    def definition; end
+    def definition
+      if TradeTariffBackend.stemming_exclusion_reference_analyzer.present?
+        # Stemming exclusions _must_ come before other filters
+        base_definition[:settings][:index][:analysis][:analyzer][:english][:filter].unshift('english_stem_exclusions')
+        base_definition[:settings][:index][:analysis][:filter][:english_stem_exclusions] = {
+          type: 'stemmer_override',
+          rules_path: TradeTariffBackend.stemming_exclusion_reference_analyzer,
+        }
+      end
 
-    # TODO: Implement me
-    def serialize_record(_record)
-      'serialized_entry'
+      if TradeTariffBackend.synonym_reference_analyzer.present?
+        # Synonyms _must_ come before the stemming exclusion filter otherwise
+        # they will have a mixture of stemmed/unstemmed expanded terms
+        base_definition[:settings][:index][:analysis][:analyzer][:english][:filter].unshift('synonym')
+        base_definition[:settings][:index][:analysis][:filter][:synonym] = {
+          type: 'synonym',
+          synonyms_path: TradeTariffBackend.synonym_reference_analyzer,
+        }
+      end
+
+      base_definition
+    end
+
+    def base_definition
+      @base_definition ||= {
+        settings: {
+          index: {
+            analysis: {
+              analyzer: {
+                english: {
+                  tokenizer: 'standard',
+                  filter: %w[
+                    english_possessive_stemmer
+                    lowercase
+                    english_stop
+                    english_stemmer
+                  ],
+                },
+              },
+              filter: {
+                english_stop: {
+                  type: 'stop',
+                  stopwords: '_english_',
+                },
+                english_stemmer: {
+                  type: 'stemmer',
+                  language: 'english',
+                },
+                english_possessive_stemmer: {
+                  type: 'stemmer',
+                  language: 'possessive_english',
+                },
+              },
+              char_filter: {
+                standardise_quotes: {
+                  type: 'mapping',
+                  mappings: [
+                    '\\u0091=>\\u0027',
+                    '\\u0092=>\\u0027',
+                    '\\u2018=>\\u0027',
+                    '\\u2019=>\\u0027',
+                    '\\u201B=>\\u0027',
+                  ],
+                },
+              },
+            },
+          },
+        },
+        mappings: {
+          properties: {
+            number_of_digits: {
+              type: 'keyword',
+            },
+            indexed_descriptions: {
+              type: 'text',
+              analyzer: 'english',
+            },
+            intercept_terms: {
+              type: 'text',
+              analyzer: 'english',
+            },
+            search_references: {
+              type: 'text',
+              analyzer: 'english',
+            },
+            short_code: {
+              enabled: false,
+            },
+          },
+        },
+      }
     end
   end
 end

--- a/app/elastic_search_indexes/search_index.rb
+++ b/app/elastic_search_indexes/search_index.rb
@@ -13,6 +13,10 @@ class SearchIndex
     self.class.name.split('::').last
   end
 
+  def name_with_namespace
+    self.class.name
+  end
+
   def type
     model_class.to_s.underscore
   end

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -125,6 +125,14 @@ module TradeTariffBackend
       )
     end
 
+    def by_heading_search_client
+      @by_heading_search_client ||= SearchClient.new(
+        opensearch_client,
+        indexes: by_heading_search_indexes,
+        by_heading: true,
+      )
+    end
+
     def cache_client
       @cache_client ||= SearchClient.new(
         opensearch_client,
@@ -146,6 +154,12 @@ module TradeTariffBackend
     def v2_search_indexes
       [
         Search::GoodsNomenclatureIndex,
+      ].map(&:new)
+    end
+
+    def by_heading_search_indexes
+      [
+        Search::BulkSearchIndex,
       ].map(&:new)
     end
 

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -96,6 +96,12 @@ module TradeTariffBackend
       Mailer.reindex_exception(e).deliver_now
     end
 
+    def by_heading_reindex(indexer = by_heading_search_client)
+      indexer.update_all
+    rescue StandardError => e
+      Mailer.reindex_exception(e).deliver_now
+    end
+
     def recache(indexer = cache_client)
       indexer.update_all
     rescue StandardError => e

--- a/app/lib/trade_tariff_backend/search_client.rb
+++ b/app/lib/trade_tariff_backend/search_client.rb
@@ -12,12 +12,14 @@ module TradeTariffBackend
 
     attr_reader :indexes,
                 :search_operation_options,
-                :namespace
+                :namespace,
+                :by_heading
 
     def initialize(search_client, options = {})
       @indexes = options.fetch(:indexes, [])
       @search_operation_options = options.fetch(:search_operation_options,
                                                 self.class.search_operation_options)
+      @by_heading = options.fetch(:by_heading, false)
       @namespace = options.fetch(:namespace, 'search')
 
       super(search_client)
@@ -59,6 +61,8 @@ module TradeTariffBackend
     end
 
     def build_index(index)
+      return BuildIndexByHeadingsWorker.perform_async(index.name_with_namespace) if by_heading
+
       (1..index.total_pages).each do |page_number|
         BuildIndexPageWorker.perform_async(namespace, index.name_without_namespace, page_number)
       end

--- a/app/models/bulk_search/result_collection.rb
+++ b/app/models/bulk_search/result_collection.rb
@@ -75,7 +75,7 @@ module BulkSearch
       @searches = (data.delete(:searches) || []).map do |search|
         attributes = search.to_h.try(:deep_symbolize_keys!) || search.to_h
         attributes[:search_result_ancestors] = attributes[:search_result_ancestors].presence || []
-        attributes[:ancestor_digits] = attributes[:ancestor_digits].presence || 8
+        attributes[:number_of_digits] = attributes[:number_of_digits].presence || 8
 
         BulkSearch::Search.build(attributes)
       end

--- a/app/models/bulk_search/search.rb
+++ b/app/models/bulk_search/search.rb
@@ -5,16 +5,16 @@ module BulkSearch
     content_addressable_fields :input_description
 
     attr_accessor :input_description,
-                  :ancestor_digits,
+                  :number_of_digits,
                   :search_result_ancestors
 
     def self.build(attributes)
       search = new
 
       search.input_description = attributes[:input_description]
-      search.ancestor_digits = attributes[:ancestor_digits]
-      search.search_result_ancestors = attributes[:search_result_ancestors].map do |ancestor_attributes|
-        SearchAncestor.build(ancestor_attributes.symbolize_keys!)
+      search.number_of_digits = attributes[:number_of_digits]
+      search.search_result_ancestors = attributes[:search_result_ancestors].map do |result|
+        SearchAncestor.build(result.symbolize_keys!)
       end
 
       search

--- a/app/serializers/api/v2/bulk_search/search_serializer.rb
+++ b/app/serializers/api/v2/bulk_search/search_serializer.rb
@@ -6,7 +6,7 @@ module Api
 
         set_type :search
 
-        attributes :input_description, :ancestor_digits
+        attributes :input_description, :number_of_digits
 
         has_many :search_result_ancestors, serializer: Api::V2::BulkSearch::SearchAncestorSerializer
       end

--- a/app/serializers/search/bulk_search_serializer.rb
+++ b/app/serializers/search/bulk_search_serializer.rb
@@ -1,0 +1,13 @@
+module Search
+  class BulkSearchSerializer < ::Serializer
+    def serializable_hash(_opts = {})
+      {
+        number_of_digits: record.number_of_digits,
+        short_code: record.short_code,
+        indexed_descriptions: record.indexed_descriptions.join('|'),
+        search_references: record.search_references.join('|'),
+        intercept_terms: record.intercept_terms.join('|'),
+      }
+    end
+  end
+end

--- a/app/serializers/serializer.rb
+++ b/app/serializers/serializer.rb
@@ -3,6 +3,13 @@ class Serializer < SimpleDelegator
 
   self.include_root_in_json = false
 
+  attr_reader :record
+
+  def initialize(record)
+    @record = record
+    super(@record)
+  end
+
   def to_json(opts = {})
     as_json(opts).to_json
   end

--- a/app/services/bulk_search/hit_ancestor_finder_service.rb
+++ b/app/services/bulk_search/hit_ancestor_finder_service.rb
@@ -2,9 +2,9 @@ module BulkSearch
   class HitAncestorFinderService
     HEADING_DIGITS = 4
 
-    def initialize(hit, ancestor_digits)
+    def initialize(hit, number_of_digits)
       @hit = hit
-      @ancestor_digits = ancestor_digits
+      @number_of_digits = number_of_digits
     end
 
     def call
@@ -23,11 +23,11 @@ module BulkSearch
 
     private
 
-    attr_reader :hit, :ancestor_digits
+    attr_reader :hit, :number_of_digits
 
     def find_result_in_ancestor
       result = hit._source.ancestors.find do |ancestor|
-        ancestor.short_code.length == ancestor_digits
+        ancestor.short_code.length == number_of_digits
       end
 
       reason = :matching_digit_ancestor if result
@@ -38,7 +38,7 @@ module BulkSearch
     def find_result_in_hit
       hit_digits = hit._source.short_code.length
 
-      result = [ancestor_digits, HEADING_DIGITS].include?(hit_digits) ? hit._source : nil
+      result = [number_of_digits, HEADING_DIGITS].include?(hit_digits) ? hit._source : nil
 
       reason = if result.present?
                  result.goods_nomenclature_class == 'Heading' ? :matching_declarable_heading : :matching_digit_commodity

--- a/app/services/bulk_search/result_answer_service.rb
+++ b/app/services/bulk_search/result_answer_service.rb
@@ -2,15 +2,15 @@ module BulkSearch
   class ResultAnswerService
     MAX_ANCESTORS = 5
 
-    def initialize(search, hits, ancestor_digits: 6)
+    def initialize(search, hits, number_of_digits: 6)
       @search = search
       @hits = hits || []
-      @ancestor_digits = ancestor_digits
+      @number_of_digits = number_of_digits
     end
 
     def call
       search_result_ancestors = hits.each_with_object({}) do |hit, acc|
-        candidate_ancestor, reason = HitAncestorFinderService.new(hit, ancestor_digits).call
+        candidate_ancestor, reason = HitAncestorFinderService.new(hit, number_of_digits).call
 
         next if candidate_ancestor.blank?
 
@@ -27,7 +27,7 @@ module BulkSearch
 
     private
 
-    attr_reader :search, :hits, :ancestor_digits
+    attr_reader :search, :hits, :number_of_digits
 
     def sort_and_accumulate_search_result_ancestors(search_result_ancestors)
       return search.search_result_ancestors.concat(fallback_ancestors) if search_result_ancestors.blank?

--- a/app/services/bulk_search_document_builder_service.rb
+++ b/app/services/bulk_search_document_builder_service.rb
@@ -1,0 +1,57 @@
+# This service is responsible for accumulating negated descriptions,
+# search references and intercept messages for every declarable goods nomenclature
+# under a specified number of digits as the key (6 or 8, typically).
+#
+# The result is a presented list of document objects that can be indexed by
+# Opensearch.
+#
+# We index declarable headings with padded 0s which seems to reflect the documented
+# behaviour of the Harmonised System implementation https://www.wcoomd.org/en/topics/nomenclature/overview/what-is-the-harmonized-system.aspx.
+#
+# Each key may correspond to an existing goods nomenclature or a heading but
+# this is not guaranteed.
+#
+# Instead this is an agreed-upon abstraction as part of the Windsor Framework to support bulk
+# classification of searched-for goods.
+class BulkSearchDocumentBuilderService
+  def initialize(goods_nomenclatures, number_of_digits)
+    @goods_nomenclatures = goods_nomenclatures
+    @number_of_digits = number_of_digits
+  end
+
+  def call
+    result = goods_nomenclatures.each_with_object({}) do |goods_nomenclature, acc|
+      short_code = goods_nomenclature.goods_nomenclature_item_id.first(number_of_digits)
+      acc[short_code] ||= Hashie::TariffMash.new(
+        id: short_code,
+        observed: Set.new,
+        number_of_digits:,
+        short_code:,
+        indexed_descriptions: Set.new,
+        search_references: Set.new,
+        intercept_terms: Set.new,
+      )
+
+      [goods_nomenclature].concat(goods_nomenclature.ns_ancestors).each do |applicable_goods_nomenclature|
+        next if acc[short_code][:observed].include?(applicable_goods_nomenclature.goods_nomenclature_sid)
+
+        search_references = applicable_goods_nomenclature.search_references.pluck(:title).flatten
+
+        acc[short_code][:observed] << applicable_goods_nomenclature.goods_nomenclature_sid
+        acc[short_code][:indexed_descriptions] << applicable_goods_nomenclature.description_indexed
+        acc[short_code][:search_references].merge(search_references) if search_references.present?
+        acc[short_code][:intercept_terms] << applicable_goods_nomenclature.intercept_terms if applicable_goods_nomenclature.intercept_terms.present?
+      end
+    end
+
+    result.values.map do |document_presenter|
+      document_presenter.search_references.flatten!
+
+      document_presenter
+    end
+  end
+
+  private
+
+  attr_reader :goods_nomenclatures, :number_of_digits
+end

--- a/app/workers/build_index_by_heading_worker.rb
+++ b/app/workers/build_index_by_heading_worker.rb
@@ -18,8 +18,8 @@ class BuildIndexByHeadingWorker
         body: serialize_for(:index, index, entries),
       )
     end
-  rescue StandardError
-    raise IndexingError, "Failed building index: #{index_name} - heading #{heading_short_code}"
+  rescue StandardError => e
+    raise IndexingError "Failed building index: #{index_name} - heading #{heading_short_code}\n#{e.class}\n#{e.message}\n#{e.backtrace}"
   end
 
   private

--- a/app/workers/clear_cache_worker.rb
+++ b/app/workers/clear_cache_worker.rb
@@ -11,7 +11,6 @@ class ClearCacheWorker
     Sidekiq::Client.enqueue(PrecacheHeadingsWorker, Time.zone.today.to_formatted_s(:db))
     Sidekiq::Client.enqueue(PrewarmQuotaOrderNumbersWorker)
     Sidekiq::Client.enqueue(ReindexModelsWorker)
-    # TODO: Recaching takes ages (c 5 hours) and shouldn't really take more than 20 minutes
     Sidekiq::Client.enqueue(RecacheModelsWorker)
   end
 end

--- a/app/workers/reindex_models_worker.rb
+++ b/app/workers/reindex_models_worker.rb
@@ -7,6 +7,7 @@ class ReindexModelsWorker
     logger.info 'Reindexing models in Elastic Search...'
     TradeTariffBackend.reindex
     TradeTariffBackend.v2_reindex
+    TradeTariffBackend.by_heading_reindex
     logger.info 'Reindexing of models completed'
   end
 end

--- a/spec/elastic_search_indexes/search/bulk_search_index_spec.rb
+++ b/spec/elastic_search_indexes/search/bulk_search_index_spec.rb
@@ -1,0 +1,111 @@
+RSpec.describe Search::BulkSearchIndex do
+  subject(:index) { described_class.new('testnamespace') }
+
+  it { is_expected.to have_attributes type: 'bulk_search' }
+  it { is_expected.to have_attributes name: 'testnamespace-bulk_searches-uk' }
+  it { is_expected.to have_attributes serializer: Search::BulkSearchSerializer }
+
+  describe '#serialize_record' do
+    subject(:result) { index.serialize_record(record) }
+
+    let(:record) do
+      Hashie::TariffMash.new(
+        number_of_digits: 8,
+        short_code: '03028910',
+        indexed_descriptions: ['FISH AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES', 'Fish, fresh or chilled', 'Other fish', 'Other'],
+        search_references: ['fish', 'fish - fresh or chilled', 'fish - livers', 'fish - roes'],
+        intercept_terms: ['red mullet'],
+      )
+    end
+
+    it 'returns a serialized record' do
+      expect(result).to include(
+        'number_of_digits' => 8,
+        'short_code' => '03028910',
+        'indexed_descriptions' => 'FISH AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES|Fish, fresh or chilled|Other fish|Other',
+        'search_references' => 'fish|fish - fresh or chilled|fish - livers|fish - roes',
+        'intercept_terms' => 'red mullet',
+      )
+    end
+  end
+
+  describe '#dataset_heading' do
+    subject(:dataset_heading) do
+      described_class
+        .new('testnamespace')
+        .dataset_heading(heading.heading_short_code)
+    end
+
+    let!(:heading) { create :heading, :with_description, goods_nomenclature_item_id: '0101000000' }
+
+    it { is_expected.to all(be_a(Hashie::TariffMash)) }
+  end
+
+  describe '#definition' do
+    context 'when the stemming exclusion and synonym references are specified in the environment' do
+      before do
+        allow(TradeTariffBackend).to receive(:stemming_exclusion_reference_analyzer).and_return(stemming_exclusion_reference_analyzer)
+        allow(TradeTariffBackend).to receive(:synonym_reference_analyzer).and_return(synonym_reference_analyzer)
+      end
+
+      let(:stemming_exclusion_reference_analyzer) { 'analyzers/F135140295' }
+      let(:synonym_reference_analyzer) { 'analyzers/F135140296' }
+
+      it 'generates the correct stemmer_override filter setting' do
+        expected_filter_setting = {
+          type: 'stemmer_override',
+          rules_path: 'analyzers/F135140295',
+        }
+
+        actual_filter_setting = index.definition.dig(
+          :settings,
+          :index,
+          :analysis,
+          :filter,
+          :english_stem_exclusions,
+        )
+
+        expect(actual_filter_setting).to eq(expected_filter_setting)
+      end
+
+      it 'generates the correct synonym filter setting' do
+        expected_filter_setting = {
+          type: 'synonym',
+          synonyms_path: 'analyzers/F135140296',
+        }
+
+        actual_filter_setting = index.definition.dig(
+          :settings,
+          :index,
+          :analysis,
+          :filter,
+          :synonym,
+        )
+
+        expect(actual_filter_setting).to eq(expected_filter_setting)
+      end
+
+      it 'uses the correct filter order' do
+        expected_filter_order = %w[
+          synonym
+          english_stem_exclusions
+          english_possessive_stemmer
+          lowercase
+          english_stop
+          english_stemmer
+        ]
+
+        actual_filter_order = index.definition.dig(
+          :settings,
+          :index,
+          :analysis,
+          :analyzer,
+          :english,
+          :filter,
+        )
+
+        expect(actual_filter_order).to eq(expected_filter_order)
+      end
+    end
+  end
+end

--- a/spec/factories/bulk_search/search_factory.rb
+++ b/spec/factories/bulk_search/search_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :bulk_search, class: 'BulkSearch::Search' do
     input_description { 'foo' }
-    ancestor_digits { 6 }
+    number_of_digits { 6 }
     search_result_ancestors do
       [
         build(:bulk_search_ancestor),

--- a/spec/models/bulk_search/result_collection_spec.rb
+++ b/spec/models/bulk_search/result_collection_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe BulkSearch::ResultCollection do
     let(:searches) do
       [
         {
-          ancestor_digits: 8,
+          number_of_digits: 8,
           input_description: 'red herring',
           search_result_ancestors: [
             {
@@ -32,7 +32,7 @@ RSpec.describe BulkSearch::ResultCollection do
           ],
         },
         {
-          ancestor_digits: 8,
+          number_of_digits: 8,
           input_description: 'white bait',
           search_result_ancestors: [
             {

--- a/spec/models/bulk_search/search_spec.rb
+++ b/spec/models/bulk_search/search_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe BulkSearch::Search do
   subject(:search) do
     described_class.build(
       input_description:,
-      ancestor_digits:,
+      number_of_digits:,
       search_result_ancestors:,
     )
   end
@@ -25,7 +25,7 @@ RSpec.describe BulkSearch::Search do
   end
 
   let(:input_description) { 'red herring' }
-  let(:ancestor_digits) { 8 }
+  let(:number_of_digits) { 8 }
 
   describe '#search_result_ancestors' do
     it { expect(search.search_result_ancestors).to all(be_a(BulkSearch::SearchAncestor)) }

--- a/spec/serializers/api/v2/bulk_search/result_collection_serializer_spec.rb
+++ b/spec/serializers/api/v2/bulk_search/result_collection_serializer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::V2::BulkSearch::ResultCollectionSerializer do
       status: 'complete',
       searches: [
         {
-          ancestor_digits: 8,
+          number_of_digits: 8,
           input_description: 'red herring',
           search_result_ancestors: [
             {
@@ -23,7 +23,7 @@ RSpec.describe Api::V2::BulkSearch::ResultCollectionSerializer do
           ],
         },
         {
-          ancestor_digits: 8,
+          number_of_digits: 8,
           input_description: 'white bait',
           search_result_ancestors: [
             {

--- a/spec/serializers/api/v2/bulk_search/search_serializer_spec.rb
+++ b/spec/serializers/api/v2/bulk_search/search_serializer_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Api::V2::BulkSearch::SearchSerializer do
 
   let(:search) do
     BulkSearch::Search.build(
-      ancestor_digits: 8,
+      number_of_digits: 8,
       input_description: 'red herring',
       search_result_ancestors: [
         {
@@ -29,7 +29,7 @@ RSpec.describe Api::V2::BulkSearch::SearchSerializer do
           id: '28092073ed1b2c9697e79ac868175964',
           type: eq(:search),
           attributes: {
-            ancestor_digits: 8,
+            number_of_digits: 8,
             input_description: 'red herring',
           },
           relationships: {

--- a/spec/serializers/search/bulk_search_serializer_spec.rb
+++ b/spec/serializers/search/bulk_search_serializer_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe Search::BulkSearchSerializer do
+  describe '#serializable_hash' do
+    subject(:result) { described_class.new(record).serializable_hash }
+
+    let(:record) do
+      Hashie::TariffMash.new(
+        number_of_digits: 8,
+        short_code: '03028910',
+        indexed_descriptions: ['FISH AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES', 'Fish, fresh or chilled', 'Other fish', 'Other'],
+        search_references: ['fish', 'fish - fresh or chilled', 'fish - livers', 'fish - roes'],
+        intercept_terms: ['red mullet'],
+      )
+    end
+
+    it 'returns a serialized record' do
+      expect(result).to eq(
+        number_of_digits: 8,
+        short_code: '03028910',
+        indexed_descriptions: 'FISH AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES|Fish, fresh or chilled|Other fish|Other',
+        search_references: 'fish|fish - fresh or chilled|fish - livers|fish - roes',
+        intercept_terms: 'red mullet',
+      )
+    end
+  end
+end

--- a/spec/services/bulk_search/result_answer_service_spec.rb
+++ b/spec/services/bulk_search/result_answer_service_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe BulkSearch::ResultAnswerService do
   let(:search) do
     BulkSearch::Search.build(
       input_description: 'red herring',
-      ancestor_digits: 8,
+      number_of_digits: 8,
       search_result_ancestors: [],
     )
   end

--- a/spec/services/bulk_search_document_builder_service_spec.rb
+++ b/spec/services/bulk_search_document_builder_service_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe BulkSearchDocumentBuilderService do
+  describe '#call' do
+    subject(:service) { described_class.new([goods_nomenclature], number_of_digits) }
+
+    let(:goods_nomenclature) do
+      create(
+        :commodity,
+        :with_description,
+        :with_ancestors,
+        goods_nomenclature_item_id: '0101210001',
+        include_search_references: true,
+        description: 'Horses',
+      )
+    end
+
+    context 'when passing 6 digits' do
+      let(:number_of_digits) { 6 }
+
+      it 'returns a list of document objects that can be indexed by Opensearch' do
+        expect(service.call).to include_json(
+          [
+            {
+              'id' => '010121',
+              'observed' => be_present,
+              'number_of_digits' => 6,
+              'short_code' => '010121',
+              'indexed_descriptions' => match(['Horses', 'Live horses, asses, mules and hinnies', 'Live animals']),
+              'search_references' => match(['chapter search reference', 'heading search reference']),
+              'intercept_terms' => be_empty,
+            },
+          ],
+        )
+      end
+    end
+
+    context 'when passing 8 digits' do
+      let(:number_of_digits) { 8 }
+
+      it 'returns a list of document objects that can be indexed by Opensearch' do
+        expect(service.call).to include_json(
+          [
+            {
+              'id' => '01012100',
+              'observed' => be_present,
+              'number_of_digits' => 8,
+              'short_code' => '01012100',
+              'indexed_descriptions' => match(['Horses', 'Live horses, asses, mules and hinnies', 'Live animals']),
+              'search_references' => match(['chapter search reference', 'heading search reference']),
+              'intercept_terms' => be_empty,
+            },
+          ],
+        )
+      end
+    end
+  end
+end

--- a/spec/workers/build_index_by_heading_worker_spec.rb
+++ b/spec/workers/build_index_by_heading_worker_spec.rb
@@ -1,11 +1,11 @@
 RSpec.describe BuildIndexByHeadingWorker, type: :worker do
   describe '#perform' do
-    let!(:commodity) { create(:commodity, goods_nomenclature_item_id: '0101000001') }
     let(:index_name) { 'Search::BulkSearchIndex' }
     let(:heading_short_code) { '0101' }
     let(:opensearch_client) { instance_double(OpenSearch::Client) }
 
     before do
+      create(:commodity, goods_nomenclature_item_id: '0101000001')
       allow(TradeTariffBackend).to receive(:opensearch_client).and_return(opensearch_client)
       allow(opensearch_client).to receive(:bulk)
     end
@@ -20,8 +20,27 @@ RSpec.describe BuildIndexByHeadingWorker, type: :worker do
             {
               index: {
                 _index: 'tariff-test-bulk_searches-uk',
-                _id: commodity.id,
-                data: 'serialized_entry',
+                _id: '010100',
+                data: {
+                  'number_of_digits' => 6,
+                  'short_code' => '010100',
+                  'indexed_descriptions' => '',
+                  'search_references' => '',
+                  'intercept_terms' => '',
+                },
+              },
+            },
+            {
+              index: {
+                _index: 'tariff-test-bulk_searches-uk',
+                _id: '01010000',
+                data: {
+                  'number_of_digits' => 8,
+                  'short_code' => '01010000',
+                  'indexed_descriptions' => '',
+                  'search_references' => '',
+                  'intercept_terms' => '',
+                },
               },
             },
           ],

--- a/spec/workers/reindex_models_worker_spec.rb
+++ b/spec/workers/reindex_models_worker_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ReindexModelsWorker, type: :worker do
       allow(BuildIndexPageWorker).to receive(:perform_async).and_call_original
       allow(TradeTariffBackend).to receive(:reindex).and_call_original
       allow(TradeTariffBackend).to receive(:v2_reindex).and_call_original
+      allow(TradeTariffBackend).to receive(:by_heading_reindex).and_call_original
 
       perform
     end
@@ -20,6 +21,10 @@ RSpec.describe ReindexModelsWorker, type: :worker do
 
     it 'calls v2_reindex' do
       expect(TradeTariffBackend).to have_received(:v2_reindex)
+    end
+
+    it 'calls by_heading_reindex' do
+      expect(TradeTariffBackend).to have_received(:by_heading_reindex)
     end
 
     it 'queues workers to build the index' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3532

### What?

I have added/removed/altered:

- [x] Added a new index to populate with bulk search data
- [x] Added a service to present documents for the new index
- [x] Added test coverage for the newly generated index and surrounding modules

### Why?

I am doing this because:

- This is required and reflects a consistent approach to the index creation between Keith, Matt and myself after recent discussions
