### PR TITLE
HOTT-3571: Handle expired nomenclature in chemical suggestions

### DIFF
--- a/app/services/suggestions_service.rb
+++ b/app/services/suggestions_service.rb
@@ -11,6 +11,7 @@ class SuggestionsService
       ].flatten.compact
     end
     SearchSuggestion.restrict_primary_key
+    Rails.logger.debug("Query count: #{::SequelRails::Railties::LogSubscriber.count}")
     suggestions
   end
 
@@ -27,9 +28,10 @@ class SuggestionsService
   def build_search_references_search_suggestions
     SearchReference
       .select(:id, :title, :goods_nomenclature_sid, :referenced_class)
-      .eager(:referenced)
+      .eager(referenced: :ns_children)
       .distinct(:title)
       .order(Sequel.desc(:title))
+      .all
       .map { |search_reference| build_search_reference_record(search_reference) }
   end
 
@@ -46,7 +48,7 @@ class SuggestionsService
   end
 
   def full_chemicals
-    @full_chemicals ||= FullChemical.eager(:goods_nomenclature).all
+    @full_chemicals ||= FullChemical.eager(goods_nomenclature: :ns_children).all
   end
 
   def build_search_reference_record(search_reference)
@@ -76,6 +78,7 @@ class SuggestionsService
   end
 
   def build_name_chemical_record(full_chemical)
+    return nil if full_chemical.goods_nomenclature.blank?
     return nil if full_chemical.name.blank?
 
     SearchSuggestion.build(
@@ -90,6 +93,8 @@ class SuggestionsService
   end
 
   def build_cus_chemical_record(full_chemical)
+    return nil if full_chemical.goods_nomenclature.blank?
+
     SearchSuggestion.build(
       id: full_chemical.cus,
       value: full_chemical.cus,
@@ -102,6 +107,7 @@ class SuggestionsService
   end
 
   def build_cas_chemical_record(full_chemical)
+    return nil if full_chemical.goods_nomenclature.blank?
     return nil if full_chemical.cas_rn.blank?
 
     SearchSuggestion.build(

--- a/spec/factories/full_chemical_factory.rb
+++ b/spec/factories/full_chemical_factory.rb
@@ -11,12 +11,18 @@ FactoryBot.define do
     un_number { nil }
     nomen { 'INCI' }
     name { 'mel powder' }
-    goods_nomenclature_item_id { goods_nomenclature&.goods_nomenclature_item_id || '0409000000' }
-    producline_suffix { goods_nomenclature&.producline_suffix || '80' }
-    goods_nomenclature_sid { goods_nomenclature&.goods_nomenclature_sid || generate(:goods_nomenclature_sid) }
+    goods_nomenclature_item_id do
+      (goods_nomenclature && goods_nomenclature.goods_nomenclature_item_id) || '0409000000'
+    end
+    producline_suffix do
+      (goods_nomenclature && goods_nomenclature&.producline_suffix) || '80'
+    end
+    goods_nomenclature_sid do
+      (goods_nomenclature && goods_nomenclature&.goods_nomenclature_sid) || generate(:goods_nomenclature_sid)
+    end
 
     before(:create) do |full_chemical, evaluator|
-      unless evaluator.goods_nomenclature
+      if evaluator.goods_nomenclature.nil?
         if full_chemical.goods_nomenclature_sid
           create(
             :goods_nomenclature,

--- a/spec/services/suggestions_service_spec.rb
+++ b/spec/services/suggestions_service_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe SuggestionsService do
     create(:search_reference, referenced: chapter, title: 'gold Ore')
     create(:full_chemical, goods_nomenclature: heading)
 
+    create(:full_chemical, goods_nomenclature: false) # We do not create chemical suggestions without goods nomenclature
+
     create(:chapter, :hidden, goods_nomenclature_item_id: '0200000000')
     create(:heading, :hidden, goods_nomenclature_item_id: '0202000000')
     create(:commodity, :hidden, goods_nomenclature_item_id: '0202090000')


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3571

### What?

I have added/removed/altered:

- [x] Added handling for chemical suggestions without current goods nomenclature

### Why?

I am doing this because:

- This is required to unlock the population of suggestions
