### PR TITLE
HOTT-3572: Handle hierarchy movements in search suggestions

### DIFF
--- a/app/services/search_suggestion_populator_service.rb
+++ b/app/services/search_suggestion_populator_service.rb
@@ -20,12 +20,19 @@ class SearchSuggestionPopulatorService
       end
 
       clear_old_suggestions
+      clear_duplicate_goods_nomenclature_suggestions
     end
     SearchSuggestion.restrict_primary_key
   end
 
   private
 
+  # A search suggestion always points to an associated goods nomenclature
+  #
+  # This goods nomenclature may expire or be replaced by a new goods nomenclature
+  # and the suggestions point to now-expired goods nomenclatures
+  #
+  # This method clears out these expired suggestions
   def clear_old_suggestions
     candidate_goods_nomenclature_sids = SearchSuggestion.goods_nomenclature_type.select_map(:id)
 
@@ -40,8 +47,42 @@ class SearchSuggestionPopulatorService
 
     expired_goods_nomenclature_sids = all_goods_nomenclature_sids - current_goods_nomenclature_sids
 
+    Rails.logger.info "Deleting #{expired_goods_nomenclature_sids.count} expired suggestions"
+
     SearchSuggestion
       .where(id: expired_goods_nomenclature_sids.map(&:to_s))
+      .delete
+  end
+
+  # A search suggestion is unique based on its input id and value
+  #
+  # Sometimes the value for a given goods nomenclature can change due to it moving about the hierarchy (e.g. a Subheading becomes a Commodity or a Commodity becomes a Subheading)
+  # and we end up with two records that are unique based on their id (sid) but different values
+  #
+  # This method handles these movements by identifying and deleting the older records
+  # whilst preserving the newer records.
+  #
+  # We only ever assume that the most recent record is the correct one since the suggestions do not support the concept
+  # of the time machine currently.
+  def clear_duplicate_goods_nomenclature_suggestions
+    rows_to_delete = SearchSuggestion.duplicates_by(:id)
+      .all
+      .map do |row|
+        { id: row[:id], value: row[:value] }
+      end
+
+    Rails.logger.info "Deleting #{rows_to_delete.count} duplicate suggestions\n#{JSON.pretty_generate(rows_to_delete)}"
+
+    return if rows_to_delete.none?
+
+    delete_condition = Sequel.|(
+      *rows_to_delete.map do |row|
+        Sequel.&({ id: row[:id] }, { value: row[:value] })
+      end,
+    )
+
+    SearchSuggestion
+      .where(delete_condition)
       .delete
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3571

### What?

I have added/removed/altered:

- [x] Handle hierarchy movements in search suggestions

### Why?

I am doing this because:

- This is required because the search suggestions use values which change as the hierarchy reorganises but these changes were not being reflected by clearing out the no-longer-current values.
