### PR TITLE
HOTT-3509 Check for missing tree nodes

### DIFF
--- a/app/services/tree_integrity_checking_service.rb
+++ b/app/services/tree_integrity_checking_service.rb
@@ -2,19 +2,37 @@ class TreeIntegrityCheckingService
   attr_reader :failures
 
   def initialize
-    @failures = []
+    @failures = Set.new
   end
 
   def check!
     Chapter.actual.all.each do |chapter|
-      chapter.ns_descendants.each do |descendant|
-        if (descendant.ns_children.empty? && descendant.ns_descendants.any?) ||
-            descendant.ns_parent.nil?
-          @failures << descendant.goods_nomenclature_sid
-        end
-      end
+      check_for_tree_break!(chapter)
     end
 
+    check_for_missing_indent!
+
     @failures.empty?
+  end
+
+  private
+
+  def check_for_tree_break!(chapter)
+    chapter.ns_descendants.each do |descendant|
+      if (descendant.ns_children.empty? && descendant.ns_descendants.any?) ||
+          descendant.ns_parent.nil?
+        @failures << descendant.goods_nomenclature_sid
+      end
+    end
+  end
+
+  def check_for_missing_indent!
+    @failures += GoodsNomenclature
+      .actual
+      .select(:goods_nomenclatures__goods_nomenclature_sid)
+      .association_left_join(:tree_node)
+      .where(tree_node__goods_nomenclature_sid: nil)
+      .all
+      .map(&:goods_nomenclature_sid)
   end
 end

--- a/app/workers/updates_synchronizer_worker.rb
+++ b/app/workers/updates_synchronizer_worker.rb
@@ -31,6 +31,7 @@ class UpdatesSynchronizerWorker
     refresh_materialized_view
 
     Sidekiq::Client.enqueue(ClearInvalidSearchReferences)
+    Sidekiq::Client.enqueue(TreeIntegrityCheckWorker)
     # Repopulation of the goods nomenclature index depends on the materialised paths being present
     Sidekiq::Client.enqueue(ClearCacheWorker)
     Sidekiq::Client.enqueue(GenerateGoodsNomenclaturesCsvReportWorker)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -51,9 +51,6 @@
     PrecacheHeadingsWorker:
       cron: "00 22 * * *"
       description: Precaches all headings and subheadings ready for tomorrow
-    TreeIntegrityCheckWorker:
-      cron: '0 8 * * 1'
-      description: Check current integrity of Goods Nomenclature hierarchy
     OneWeekTreeIntegrityCheck:
       cron: '05 8 * * 1'
       class: TreeIntegrityCheckWorker

--- a/spec/services/tree_integrity_checking_service_spec.rb
+++ b/spec/services/tree_integrity_checking_service_spec.rb
@@ -22,7 +22,22 @@ RSpec.describe TreeIntegrityCheckingService do
         instance.check!
 
         expect(instance.failures).to eq \
-          [commodity.heading, commodity].map(&:goods_nomenclature_sid)
+          Set.new([commodity.heading, commodity].map(&:goods_nomenclature_sid))
+      end
+    end
+
+    context 'with missing indents' do
+      before do
+        commodity.goods_nomenclature_indent.destroy
+        GoodsNomenclatures::TreeNode.refresh!
+      end
+
+      it { is_expected.to be false }
+
+      it 'tracks sid with missing indent' do
+        instance.check!
+
+        expect(instance.failures).to eq Set.new([commodity.goods_nomenclature_sid])
       end
     end
   end


### PR DESCRIPTION
### Jira link

HOTT-3509 

### What?

I have added/removed/altered:

- [x] Check for missing tree nodes during integrity check
- [x] Run integrity check after syncing in case there's anything bad in todays CDS/Taric data

### Why?

I am doing this because:

- Last week we didn't pick up when a sync was sent through removing the indents for several commodities - an alert  would have aided debugging
- We should alert immediately if we find something amiss rather then waiting for users to notice something

### Have you? (optional)

- [ ] Added documentation for new apis
- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks (optional)

- Low, schedules a job during syncs
