### PR TITLE
HOTT-3566 Add solomon islands to pacific RoO scheme

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk.json
+++ b/db/rules_of_origin/roo_schemes_uk.json
@@ -3446,6 +3446,7 @@
             "countries": [
                 "FJ",
                 "PG",
+                "SB",
                 "WS"
             ]
         },


### PR DESCRIPTION
### Jira link

HOTT-3566

### What?

I have added/removed/altered:

- [x] Added Solomon Islands to Pacific rules of origin scheme

### Why?

I am doing this because:

- This was missing from the original data

### Have you? (optional)

- [ ] Added documentation for new apis
- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks (optional)

- Low, changes the schemes which apply to Solomon Islands
