### PR TITLE
HOTT-3589: Extend XI measure type exclusions

### DIFF
--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -1,18 +1,110 @@
-# National Measure Type ID mapping
-# A B C D E F G H I J
-# 1 2 3 4 5 6 7 8 9 0
-
 class MeasureType < Sequel::Model
   IMPORT_MOVEMENT_CODES = [0, 2].freeze
   EXPORT_MOVEMENT_CODES = [1, 2].freeze
-  THIRD_COUNTRY = %w[103 105].freeze # 105 measure types are for end use Third Country duties. 103 are for everything else
+  THIRD_COUNTRY = %w[103 105].freeze
   VAT_TYPES = %w[305].freeze
   SUPPLEMENTARY_TYPES = %w[109 110 111].freeze
-  QUOTA_TYPES = %w[046 122 123 143 146 147 653 654].freeze
-  NATIONAL_PR_TYPES = %w[AHC AIL ATT CEX CHM COE COI CVD DPO ECM EHC EQC EWP HOP HSE IWP PHC PRE PRT QRC SFS].freeze
-  DEFAULT_EXCLUDED_TYPES = %w[442 447 SPL].freeze
-  XI_EXCLUDED_TYPES = DEFAULT_EXCLUDED_TYPES + NATIONAL_PR_TYPES + QUOTA_TYPES
-  UK_EXCLUDED_TYPES = DEFAULT_EXCLUDED_TYPES
+
+  XI_EXCLUDED_TYPES = %w[
+    046
+    122
+    123
+    143
+    146
+    147
+    305
+    306
+    442
+    447
+    653
+    654
+    AHC
+    AIL
+    ATT
+    CEX
+    CHM
+    COE
+    COI
+    CVD
+    DAA
+    DAB
+    DAC
+    DAE
+    DAI
+    DBA
+    DBB
+    DBC
+    DBE
+    DBI
+    DCA
+    DCC
+    DCE
+    DCH
+    DDA
+    DDB
+    DDC
+    DDD
+    DDE
+    DDF
+    DDG
+    DDJ
+    DEA
+    DFA
+    DFB
+    DFC
+    DGC
+    DHA
+    DHC
+    DHE
+    DHG
+    DPO
+    EBA
+    EBB
+    EBJ
+    ECM
+    EDA
+    EDB
+    EDJ
+    EEA
+    EEF
+    EFA
+    EGA
+    EGB
+    EGJ
+    EHC
+    EHI
+    EQC
+    EWP
+    EXA
+    EXB
+    EXC
+    EXD
+    FAA
+    FAE
+    FAI
+    FBC
+    FBG
+    FCC
+    HOP
+    HSE
+    IWP
+    LBJ
+    LDA
+    LEA
+    LEF
+    LFA
+    PHC
+    PRE
+    PRT
+    QRC
+    SFS
+    SPL
+    VTA
+    VTE
+    VTS
+    VTZ
+  ].freeze
+  UK_EXCLUDED_TYPES = %w[442 447 SPL].freeze
 
   AUTHORISED_USE_PROVISIONS_SUBMISSION = '464'.freeze
   TARIFF_PREFERENCE = %w[142 145].freeze

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -429,12 +429,12 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         create :measure, :with_base_regulation, :with_goods_nomenclature, measure_type_id:
       end
 
-      let(:measure_type_id) { MeasureType::QUOTA_TYPES.first }
+      let(:measure_type_id) { '306' }
 
       it { is_expected.to include measure.measure_sid }
 
       context 'with measures that are excluded' do
-        let(:measure_type_id) { MeasureType::DEFAULT_EXCLUDED_TYPES.first }
+        let(:measure_type_id) { MeasureType::UK_EXCLUDED_TYPES.first }
 
         it { is_expected.not_to include measure.measure_sid }
       end
@@ -467,13 +467,13 @@ RSpec.describe GoodsNomenclatures::NestedSet do
       it { is_expected.to include measure.measure_sid }
 
       context 'with non overview measure types' do
-        let(:measure_type_id) { MeasureType::QUOTA_TYPES.first }
+        let(:measure_type_id) { '306' }
 
         it { is_expected.not_to include measure.measure_sid }
       end
 
       context 'with measures that are excluded' do
-        let(:measure_type_id) { MeasureType::DEFAULT_EXCLUDED_TYPES.first }
+        let(:measure_type_id) { MeasureType::UK_EXCLUDED_TYPES.first }
 
         it { is_expected.not_to include measure.measure_sid }
       end

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -81,17 +81,13 @@ RSpec.describe Measure do
     context 'for UK service' do
       let(:service) { 'uk' }
 
-      it_behaves_like 'excludes measure type', 'DEFAULT_EXCLUDED_TYPES'
-      it_behaves_like 'includes measure type', 'QUOTA_TYPES'
-      it_behaves_like 'includes measure type', 'NATIONAL_PR_TYPES'
+      it_behaves_like 'excludes measure type', 'UK_EXCLUDED_TYPES'
     end
 
     context 'for XI service' do
       let(:service) { 'xi' }
 
-      it_behaves_like 'excludes measure type', 'DEFAULT_EXCLUDED_TYPES'
-      it_behaves_like 'excludes measure type', 'QUOTA_TYPES'
-      it_behaves_like 'excludes measure type', 'NATIONAL_PR_TYPES'
+      it_behaves_like 'excludes measure type', 'XI_EXCLUDED_TYPES'
     end
   end
 

--- a/spec/models/measure_type_spec.rb
+++ b/spec/models/measure_type_spec.rb
@@ -18,9 +18,18 @@ RSpec.describe MeasureType do
 
       let(:excluded_types) do
         %w[
+          046
+          122
+          123
+          143
+          146
+          147
+          305
+          306
           442
           447
-          SPL
+          653
+          654
           AHC
           AIL
           ATT
@@ -29,27 +38,83 @@ RSpec.describe MeasureType do
           COE
           COI
           CVD
+          DAA
+          DAB
+          DAC
+          DAE
+          DAI
+          DBA
+          DBB
+          DBC
+          DBE
+          DBI
+          DCA
+          DCC
+          DCE
+          DCH
+          DDA
+          DDB
+          DDC
+          DDD
+          DDE
+          DDF
+          DDG
+          DDJ
+          DEA
+          DFA
+          DFB
+          DFC
+          DGC
+          DHA
+          DHC
+          DHE
+          DHG
           DPO
+          EBA
+          EBB
+          EBJ
           ECM
+          EDA
+          EDB
+          EDJ
+          EEA
+          EEF
+          EFA
+          EGA
+          EGB
+          EGJ
           EHC
+          EHI
           EQC
           EWP
+          EXA
+          EXB
+          EXC
+          EXD
+          FAA
+          FAE
+          FAI
+          FBC
+          FBG
+          FCC
           HOP
           HSE
           IWP
+          LBJ
+          LDA
+          LEA
+          LEF
+          LFA
           PHC
           PRE
           PRT
           QRC
           SFS
-          046
-          122
-          123
-          143
-          146
-          147
-          653
-          654
+          SPL
+          VTA
+          VTE
+          VTS
+          VTZ
         ]
       end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3589

### What?

I have added/removed/altered:

- [x] Altered the list of measure type exclusions on XI
- [x] Altered specs to reflect this change

### Why?

I am doing this because:

- These measure types are not meant to show in the api and are confusing people
