### PR TITLE
HOTT-3119 Use leaf where available for Single Table Inheritance

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -19,7 +19,11 @@ class GoodsNomenclature < Sequel::Model
     elsif gono_id.ends_with?('000000') && gono_id.slice(2, 2) != '00'
       'Heading'
     elsif !gono_id.ends_with?('000000')
-      'Commodity'
+      # checking its a False class because if :leaf is not assigned, we should
+      # continue to assume Commodity as previously done
+      #
+      # :leaf can be included by the use of `GoodsNomenclature.with_leaf_column`
+      record[:producline_suffix] != '80' || record[:leaf].is_a?(FalseClass) ? 'Subheading' : 'Commodity'
     else
       'GoodsNomenclature'
     end

--- a/app/presenters/api/v2/commodities/commodity_presenter.rb
+++ b/app/presenters/api/v2/commodities/commodity_presenter.rb
@@ -49,7 +49,7 @@ module Api
         end
 
         def ancestors
-          @ancestors ||= ns_ancestors.select { |ancestor| ancestor.is_a?(Commodity) }
+          @ancestors ||= ns_ancestors.select { |ancestor| ancestor.is_a? TenDigitGoodsNomenclature }
         end
 
         def ancestor_ids

--- a/app/presenters/api/v2/headings/commodity_presenter.rb
+++ b/app/presenters/api/v2/headings/commodity_presenter.rb
@@ -3,7 +3,7 @@ module Api
     module Headings
       class CommodityPresenter < WrapDelegator
         def parent_sid
-          if ns_parent.is_a?(Commodity) || ns_parent.is_a?(Subheading)
+          if ns_parent.is_a?(TenDigitGoodsNomenclature)
             ns_parent.goods_nomenclature_sid
           end
         end

--- a/app/presenters/api/v2/subheadings/subheading_presenter.rb
+++ b/app/presenters/api/v2/subheadings/subheading_presenter.rb
@@ -25,7 +25,7 @@ module Api
         end
 
         def ancestors
-          @ancestors ||= ns_ancestors.select { |ancestor| ancestor.is_a?(Commodity) }
+          @ancestors ||= ns_ancestors.select { |ancestor| ancestor.is_a? TenDigitGoodsNomenclature }
         end
 
         def ancestor_ids

--- a/app/serializers/api/v2/csv/commodity_serializer.rb
+++ b/app/serializers/api/v2/csv/commodity_serializer.rb
@@ -17,7 +17,7 @@ module Api
                 :producline_suffix
 
         column :parent_sid do |commodity|
-          if commodity.ns_parent.is_a?(Commodity)
+          if commodity.ns_parent.is_a?(TenDigitGoodsNomenclature)
             commodity.ns_parent.goods_nomenclature_sid
           end
         end

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -47,12 +47,12 @@ RSpec.describe GoodsNomenclatures::NestedSet do
       let :tree do
         chapter = create(:chapter)
         heading = create(:heading, parent: chapter)
-        subheading = create(:commodity, parent: heading)
-        subsubheading = create(:commodity, parent: subheading)
+        subheading = create(:subheading, parent: heading)
+        subsubheading = create(:subheading, parent: subheading)
         commodity1 = create(:commodity, parent: subsubheading)
         commodity2 = create(:commodity, parent: subsubheading)
         commodity3 = create(:commodity, parent: subheading)
-        second_tree = create(:commodity, :with_chapter_and_heading, :with_children)
+        second_tree = create(:subheading, :with_chapter_and_heading, :with_children)
 
         {
           chapter:,

--- a/spec/models/search_reference_spec.rb
+++ b/spec/models/search_reference_spec.rb
@@ -46,12 +46,10 @@ RSpec.describe SearchReference do
 
     context 'when getting a Subheading reference' do
       let(:referenced) do
-        create(:commodity, goods_nomenclature_item_id: '0101110000', producline_suffix: '30')
-
-        Subheading.find(goods_nomenclature_item_id: '0101110000', producline_suffix: '30')
+        create(:subheading, goods_nomenclature_item_id: '0101110000', producline_suffix: '30')
       end
 
-      it { expect(search_reference.referenced).to be_a(Commodity) }
+      it { expect(search_reference.referenced).to be_a(Subheading) }
     end
   end
 

--- a/spec/presenters/api/v2/commodities/commodity_presenter_spec.rb
+++ b/spec/presenters/api/v2/commodities/commodity_presenter_spec.rb
@@ -91,14 +91,12 @@ RSpec.describe Api::V2::Commodities::CommodityPresenter do
   describe '#special_nature?' do
     context 'when commodity has at least one measure condition containing special nature certificate' do
       let(:measures) do
-        [
-          create(
-            :measure,
-            :with_measure_conditions,
-            :with_special_nature,
-            goods_nomenclature_sid: commodity.goods_nomenclature_sid,
-          ),
-        ]
+        create_list(
+          :measure, 1,
+          :with_measure_conditions,
+          :with_special_nature,
+          goods_nomenclature_sid: commodity.goods_nomenclature_sid
+        )
       end
 
       it { is_expected.to be_special_nature }
@@ -106,9 +104,7 @@ RSpec.describe Api::V2::Commodities::CommodityPresenter do
 
     context 'when commodity does not have any measure conditions containing special nature certificate' do
       let(:measures) do
-        [
-          create(:measure, goods_nomenclature_sid: commodity.goods_nomenclature_sid),
-        ]
+        create_list(:measure, 1, goods_nomenclature_sid: commodity.goods_nomenclature_sid)
       end
 
       it { is_expected.not_to be_special_nature }
@@ -122,13 +118,13 @@ RSpec.describe Api::V2::Commodities::CommodityPresenter do
       let(:measure_collection) { MeasureCollection.new measures, geographical_area_id: 'CN' }
 
       context 'when commodity has at least one measure with authorised use submissions measure type id' do
-        let(:measures) { [create(:measure, :with_authorised_use_provisions_submission)] }
+        let(:measures) { create_list(:measure, 1, :with_authorised_use_provisions_submission) }
 
         it { is_expected.to be_authorised_use_provisions_submission }
       end
 
       context 'when commodity does not have any measures with authorised use submissions measure type id' do
-        let(:measures) { [create(:measure)] }
+        let(:measures) { create_list(:measure, 1) }
 
         it { is_expected.not_to be_authorised_use_provisions_submission }
       end
@@ -136,13 +132,13 @@ RSpec.describe Api::V2::Commodities::CommodityPresenter do
 
     context 'when not filtering by country' do
       context 'when commodity has at least one measure with authorised use submissions measure type id' do
-        let(:measures) { [create(:measure, :with_authorised_use_provisions_submission)] }
+        let(:measures) { create_list(:measure, 1, :with_authorised_use_provisions_submission) }
 
         it { is_expected.not_to be_authorised_use_provisions_submission }
       end
 
       context 'when commodity does not have any measures with authorised use submissions measure type id' do
-        let(:measures) { [create(:measure)] }
+        let(:measures) { create_list(:measure, 1) }
 
         it { is_expected.not_to be_authorised_use_provisions_submission }
       end
@@ -165,5 +161,14 @@ RSpec.describe Api::V2::Commodities::CommodityPresenter do
 
       it { is_expected.not_to be_filtering_by_country }
     end
+  end
+
+  describe '#ancestors' do
+    subject { described_class.new(commodity, MeasureCollection.new([])).ancestors }
+
+    let(:commodity) { subheading.ns_children.first }
+    let(:subheading) { create :subheading, :with_chapter_and_heading, :with_children }
+
+    it { is_expected.to eq_pk [subheading] }
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-3119

### What?

I have added/removed/altered:

- [x] Reintroduce the Single Table Inheritance change
- [x] Fixed a bug discovered where a check for Commodity was introduced in a separate branch concurrently with this change

### Why?

I am doing this because:

- The functionality is desirable but was reverted in a hotfix after discover of the bug

### Deployment risks (optional)

- Medium - its been deployed once already, and we know it doesn't trigger any outright problems. The origin of how the bug crept in has been established - multiple concurrent branches, and a new check for instances of `is_a?(Commodity)` has been done. Specs have also been introduced checking the ancestors behaviour from the problematic presenter.
