### PR TITLE
HOTT-3587: Adds validations to search model

### DIFF
--- a/app/controllers/api/v2/bulk_searches_controller.rb
+++ b/app/controllers/api/v2/bulk_searches_controller.rb
@@ -5,9 +5,15 @@ module Api
 
       def create
         @result = ::BulkSearch::ResultCollection.enqueue(bulk_search_params)
-        @serialized_result = Api::V2::BulkSearch::ResultCollectionSerializer.new(@result).serializable_hash
 
-        render json: @serialized_result, status: :accepted, location: api_bulk_search_path(@result)
+        if @result.valid?
+          @serialized_result = Api::V2::BulkSearch::ResultCollectionSerializer.new(@result).serializable_hash
+          render json: @serialized_result, status: :accepted, location: api_bulk_search_path(@result)
+        else
+          @serialized_result = ::BulkSearch::ErrorSerializationService.new(@result.searches).call
+
+          render json: @serialized_result, status: :unprocessable_entity
+        end
       end
 
       def show

--- a/app/models/bulk_search/search.rb
+++ b/app/models/bulk_search/search.rb
@@ -1,12 +1,13 @@
 module BulkSearch
   class Search
+    include ActiveModel::Model
     include ContentAddressableId
 
     content_addressable_fields :input_description
 
-    attr_accessor :input_description,
-                  :number_of_digits,
-                  :search_results
+    attr_accessor :input_description, :search_results, :number_of_digits
+
+    validates :number_of_digits, inclusion: { in: [6, 8], message: '%{value} is not a valid number of digits' }
 
     def self.build(attributes)
       search = new
@@ -23,8 +24,8 @@ module BulkSearch
     def no_results!
       self.search_results = [
         SearchResult.build(
-          number_of_digits:,
-          short_code: '9' * number_of_digits,
+          number_of_digits: @number_of_digits,
+          short_code: '9' * @number_of_digits.to_i,
           score: 0,
         ),
       ]

--- a/app/models/bulk_search/search.rb
+++ b/app/models/bulk_search/search.rb
@@ -8,6 +8,7 @@ module BulkSearch
     attr_accessor :input_description, :search_results, :number_of_digits
 
     validates :number_of_digits, inclusion: { in: [6, 8], message: '%{value} is not a valid number of digits' }
+    validates :input_description, presence: true
 
     def self.build(attributes)
       search = new
@@ -24,8 +25,8 @@ module BulkSearch
     def no_results!
       self.search_results = [
         SearchResult.build(
-          number_of_digits: @number_of_digits,
-          short_code: '9' * @number_of_digits.to_i,
+          number_of_digits:,
+          short_code: '9' * number_of_digits,
           score: 0,
         ),
       ]

--- a/app/services/bulk_search/error_serialization_service.rb
+++ b/app/services/bulk_search/error_serialization_service.rb
@@ -1,0 +1,36 @@
+module BulkSearch
+  class ErrorSerializationService
+    DEFAULT_ERROR_STATUS_CODE = 422 # Unprocessable_entity
+
+    def initialize(searches)
+      @searches = searches
+    end
+
+    def call
+      { errors: }
+    end
+
+    private
+
+    def errors
+      @searches.each_with_object([]) do |search, acc|
+        search.errors.messages.each do |attribute, errors|
+          errors.each do |error|
+            acc << attribute_error(attribute, error)
+          end
+        end
+      end
+    end
+
+    def attribute_error(attribute, message)
+      {
+        status: DEFAULT_ERROR_STATUS_CODE,
+        title: message,
+        detail: "#{attribute.to_s.humanize} #{message}",
+        source: {
+          pointer: "/data/attributes/#{attribute}",
+        },
+      }
+    end
+  end
+end

--- a/spec/models/bulk_search/search_spec.rb
+++ b/spec/models/bulk_search/search_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe BulkSearch::Search do
 
       it { expect(search).to be_valid }
     end
+
+    context 'when input_description is blank' do
+      let(:input_description) { '' }
+
+      it { expect(search).not_to be_valid }
+    end
   end
 
   describe '#search_results' do

--- a/spec/models/bulk_search/search_spec.rb
+++ b/spec/models/bulk_search/search_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe BulkSearch::Search do
   subject(:search) do
     described_class.build(
@@ -27,8 +25,36 @@ RSpec.describe BulkSearch::Search do
   let(:input_description) { 'red herring' }
   let(:number_of_digits) { 8 }
 
+  describe 'validations' do
+    context 'when number_of_digits is not 6 or 8' do
+      let(:number_of_digits) { 7 }
+
+      it { expect(search).not_to be_valid }
+    end
+
+    context 'when number_of_digits is 6' do
+      let(:number_of_digits) { 6 }
+
+      it { expect(search).to be_valid }
+    end
+
+    context 'when number_of_digits is 8' do
+      let(:number_of_digits) { 8 }
+
+      it { expect(search).to be_valid }
+    end
+  end
+
   describe '#search_results' do
     it { expect(search.search_results).to all(be_a(BulkSearch::SearchResult)) }
+  end
+
+  describe '#no_results!' do
+    before { search.no_results! }
+
+    it { expect(search.search_results).to all(be_a(BulkSearch::SearchResult)) }
+    it { expect(search.search_results.first.short_code).to eq('99999999') }
+    it { expect(search.search_results.first.score).to eq(0) }
   end
 
   describe '#search_result_ids' do

--- a/spec/services/bulk_search/error_serialization_service_spec.rb
+++ b/spec/services/bulk_search/error_serialization_service_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe BulkSearch::ErrorSerializationService do
+  describe '#call' do
+    subject(:result) { described_class.new(searches).call }
+
+    let(:searches) { [BulkSearch::Search.new.tap(&:valid?)] }
+
+    context 'with errors' do
+      let(:error_response) do
+        {
+          errors: [
+            {
+              status: 422,
+              title: ' is not a valid number of digits',
+              detail: 'Number of digits  is not a valid number of digits',
+              source: { pointer: '/data/attributes/number_of_digits' },
+            },
+          ],
+        }
+      end
+
+      it { is_expected.to eq(error_response) }
+    end
+
+    context 'without errors' do
+      let(:searches) { [BulkSearch::Search.new] }
+
+      it { is_expected.to eq(errors: []) }
+    end
+  end
+end

--- a/spec/services/bulk_search/error_serialization_service_spec.rb
+++ b/spec/services/bulk_search/error_serialization_service_spec.rb
@@ -2,9 +2,9 @@ RSpec.describe BulkSearch::ErrorSerializationService do
   describe '#call' do
     subject(:result) { described_class.new(searches).call }
 
-    let(:searches) { [BulkSearch::Search.new.tap(&:valid?)] }
-
     context 'with errors' do
+      let(:searches) { [BulkSearch::Search.new.tap(&:valid?)] }
+
       let(:error_response) do
         {
           errors: [
@@ -13,6 +13,12 @@ RSpec.describe BulkSearch::ErrorSerializationService do
               title: ' is not a valid number of digits',
               detail: 'Number of digits  is not a valid number of digits',
               source: { pointer: '/data/attributes/number_of_digits' },
+            },
+            {
+              status: 422,
+              title: "can't be blank",
+              detail: "Input description can't be blank",
+              source: { pointer: '/data/attributes/input_description' },
             },
           ],
         }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3587

### What?

I have added/removed/altered:

- [x] Added digit and presence validations to search model
- [x] Propagate validation errors to the api caller

### Why?

I am doing this because:

- This is to avoid odd behaviour/people doing searches on digits we do not support
