### PR TITLE
HOTT-3553: Update OpenSearch Sync Script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -671,13 +671,15 @@ jobs:
     parameters:
       space:
         type: string
+      bucket:
+        type: string
     steps:
       - aws-cli/install
       - checkout
       - run:
           name: "Synchronise opensearch packages"
           command: |
-            bin/sync_opensearch_packages << parameters.space >>
+            bin/sync_opensearch_packages << parameters.space >> << parameters.bucket >>
 
   notify_production_deployment:
     docker:
@@ -836,6 +838,7 @@ workflows:
       - sync_opensearch_packages:
           name: sync_packages_dev
           space: development
+          bucket: trade-tariff-opensearch-packages-development
           context: trade-tariff
           filters:
             branches:
@@ -858,6 +861,7 @@ workflows:
       - sync_opensearch_packages:
           name: sync_packages_staging
           space: staging
+          bucket: trade-tariff-opensearch-packages-staging
           context: trade-tariff
           filters:
             branches:
@@ -956,6 +960,7 @@ workflows:
       - sync_opensearch_packages:
           name: sync_packages_production
           space: production
+          bucket: trade-tariff-opensearch-packages-production
           context: trade-tariff
           filters:
             tags:

--- a/bin/sync_opensearch_packages
+++ b/bin/sync_opensearch_packages
@@ -3,9 +3,10 @@
 set -e
 
 SPACE=$1
+BUCKET=$2
 
 function check_changed_packages {
-  aws s3 sync --exclude ".*" --dryrun --size-only config/opensearch s3://trade-tariff-opensearch-packages-$SPACE/config/opensearch/
+  aws s3 sync --exclude ".*" --dryrun --size-only config/opensearch "s3://${BUCKET}/config/opensearch/"
 }
 
 function package_id_for {
@@ -15,7 +16,7 @@ function package_id_for {
 }
 
 function sync_package_files_with_s3 {
-  aws s3 sync --exclude ".*" config/opensearch s3://trade-tariff-opensearch-packages-$SPACE/config/opensearch/
+  aws s3 sync --exclude ".*" config/opensearch "s3://${BUCKET}/config/opensearch/"
 }
 
 function package_status {
@@ -59,7 +60,7 @@ function update_and_associate_package {
   domain_name=tariff-search-$SPACE
 
   aws opensearch update-package --package-id $package_id \
-    --package-source "S3BucketName=trade-tariff-opensearch-packages-$SPACE,S3Key=config/opensearch/$s3_key_suffix" \
+    --package-source "S3BucketName=${BUCKET},S3Key=config/opensearch/$s3_key_suffix" \
     --package-description "$package_description_prefix for the $SPACE environment search" \
     --commit-message "Commit: $(git rev-parse --short HEAD), branch: $CIRCLE_BRANCH"
 


### PR DESCRIPTION
### Jira link

[HOTT-3553](https://transformuk.atlassian.net/browse/HOTT-3553)

### What?

I have added/removed/altered:

- Updated the `sync_opensearch_packages` script to take a `bucket` parameter.

### Why?

I am doing this because:

- As S3 bucket names are globally unique across AWS, when we come to do this on the new accounts, we'll have to specify different bucket names.

