### PR TITLE
HOTT-3268: This PR allows to generate the quota exclusion misalignment report

### DIFF
--- a/app/models/quota_order_number.rb
+++ b/app/models/quota_order_number.rb
@@ -12,6 +12,21 @@ class QuotaOrderNumber < Sequel::Model
     ds.order(Sequel.desc(:validity_start_date))
   end
 
+  one_to_one :measure, primary_key: :quota_order_number_id,
+                       key: :ordernumber do |ds|
+    ds
+      .with_actual(Measure)
+      .with_regulation_dates_query
+  end
+
+  one_to_many :quota_order_number_origins,
+              primary_key: :quota_order_number_sid,
+              key: :quota_order_number_sid do |ds|
+                ds.with_actual(QuotaOrderNumberOrigin)
+              end
+
+  one_to_many :quota_order_number_origin_exclusions, key: :quota_order_number_id, primary_key: :quota_order_number_id
+
   dataset_module do
     def by_order_number(order_number)
       where(quota_order_number_id: order_number)

--- a/app/models/quota_order_number_origin_exclusion.rb
+++ b/app/models/quota_order_number_origin_exclusion.rb
@@ -9,5 +9,5 @@ class QuotaOrderNumberOriginExclusion < Sequel::Model
     ds.with_actual(GeographicalArea)
   end
 
-  delegate :geographical_area_id, to: :geographical_area
+  delegate :geographical_area_id, to: :geographical_area, allow_nil: true
 end

--- a/spec/models/quota_order_number_spec.rb
+++ b/spec/models/quota_order_number_spec.rb
@@ -84,4 +84,7 @@ RSpec.describe QuotaOrderNumber do
 
     it { is_expected.to include(quota_order_number) }
   end
+
+  it { is_expected.to respond_to :measure }
+  it { is_expected.to respond_to :quota_order_number_origins }
 end


### PR DESCRIPTION
### What?
This PR adds the report generator for the quota exclusion misalignment.

### Jira link

https://transformuk.atlassian.net/browse/HOTT-3268

### Why?

the UK data of measure geographical area exclusions and quota origin exclusions should have the same data.
In case of misalignment, we must report it to HMRC
