### PR TITLE
HOTT-3641: Surface SPQ measure units

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -566,7 +566,7 @@ class Measure < Sequel::Model
     all_components.each_with_object([]) do |component, acc|
       next unless component.expresses_unit?
 
-      acc << component.unit
+      acc << component.unit_for(self)
     end
   end
 
@@ -625,6 +625,10 @@ class Measure < Sequel::Model
     0
   end
 
+  def all_components
+    all_condition_components + measure_components + resolved_measure_components
+  end
+
   private
 
   def excluded_country?(country_id)
@@ -655,8 +659,8 @@ class Measure < Sequel::Model
     Thread.current[:meursing_additional_code_id]
   end
 
-  def all_components
-    measure_conditions.flat_map(&:measure_condition_components) + measure_components + resolved_measure_components
+  def all_condition_components
+    measure_conditions.flat_map(&:measure_condition_components)
   end
 
   def ad_valorem_resource?(resource)

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -152,10 +152,6 @@ class MeasureCondition < Sequel::Model
     document_code.present? && document_code == CDS_WAIVER_DOCUMENT_CODE
   end
 
-  def units
-    measure_condition_components.map(&:unit)
-  end
-
   def permutation_key
     if certificate_type_code || certificate_code || condition_duty_amount
       "#{certificate_type_code}-#{certificate_code}-#{condition_duty_amount}"

--- a/app/models/measurement_unit.rb
+++ b/app/models/measurement_unit.rb
@@ -1,4 +1,5 @@
 class MeasurementUnit < Sequel::Model
+  STANDARD_MEASUREMENT_UNIT_CODE_LENGTH = 3
   MEASUREMENT_UNIT_OVERLAY_FILE = 'db/measurement_units_20220825.json'.freeze
 
   plugin :oplog, primary_key: :measurement_unit_code
@@ -50,7 +51,11 @@ class MeasurementUnit < Sequel::Model
     def build_missing_measurement_unit(unit_code, unit_key)
       unit = find(measurement_unit_code: unit_code)
 
-      qualifier_code = unit_key.length == 4 ? unit_key[3..] : ''
+      qualifier_code = if unit_key.length > STANDARD_MEASUREMENT_UNIT_CODE_LENGTH
+                         unit_key[STANDARD_MEASUREMENT_UNIT_CODE_LENGTH..]
+                       else
+                         ''
+                       end
 
       if unit.present?
         Sentry.capture_message("Missing measurement unit in database for measurement unit key: #{unit_key}")

--- a/db/measurement_units_20220825.json
+++ b/db/measurement_units_20220825.json
@@ -22,7 +22,10 @@
     "multiplier": null,
     "coerced_measurement_unit_code": null,
     "original_unit": null,
-    "compound_units": ["ASV", "HLT"]
+    "compound_units": [
+      "ASV",
+      "HLT"
+    ]
   },
   "BRX": {
     "measurement_unit_code": "BRX",
@@ -199,7 +202,10 @@
     "unit_question": "What is the weight per 1% by weight of sucrose in the goods you will be importing?",
     "unit_hint": "Enter the value in decitonnes (100kg)",
     "unit": "x 100 kg",
-    "compound_units": ["DTN", "BRX"]
+    "compound_units": [
+      "DTN",
+      "BRX"
+    ]
   },
   "EUR": {
     "measurement_unit_code": "EUR",
@@ -704,6 +710,52 @@
     "coerced_measurement_unit_code": null,
     "original_unit": null,
     "measurement_unit_type": "weight"
+  },
+  "SPQLPA": {
+    "measurement_unit_code": "SPQ",
+    "measurement_unit_qualifier_code": "LPA",
+    "abbreviation": "for each litre of pure alcohol, multiplied by the SPR discount",
+    "expansion": "for each litre of pure alcohol, multiplied by the SPR discount",
+    "unit_question": "",
+    "unit_hint": "",
+    "unit": "SPQ",
+    "multiplier": null,
+    "coerced_measurement_unit_code": null,
+    "original_unit": null,
+    "compound_units": [
+      "SPR",
+      "LPA"
+    ]
+  },
+  "SPQLTR": {
+    "measurement_unit_code": "SPQ",
+    "measurement_unit_qualifier_code": "LTR",
+    "abbreviation": "for each litre of pure alcohol, multiplied by the SPR discount",
+    "expansion": "for each litre of pure alcohol, multiplied by the SPR discount",
+    "unit_question": "",
+    "unit_hint": "",
+    "unit": "SPQ",
+    "multiplier": null,
+    "coerced_measurement_unit_code": null,
+    "original_unit": null,
+    "compound_units": [
+      "SPR",
+      "ASV",
+      "HLT"
+    ]
+  },
+  "SPR": {
+    "measurement_unit_code": "SPR",
+    "measurement_unit_qualifier_code": null,
+    "abbreviation": "SPR discount",
+    "expansion": "SPR discount (£)",
+    "unit_question": "What discount are you entitled to as a result of Small Producer Relief?",
+    "unit_hint": "Enter the SPR discount against the full rate, not the chargeable SPR rate. For example, if the full rate, before application of SPR is £10.00 / litre of pure alcohol, and you are entitled to pay £7.00, enter 3.00 as your SPR discount.",
+    "unit": "SPR discount (£)",
+    "multiplier": null,
+    "coerced_measurement_unit_code": null,
+    "original_unit": null,
+    "measurement_unit_type": "other"
   },
   "TJO": {
     "measurement_unit_code": "TJO",

--- a/spec/factories/measure_condition_component_factory.rb
+++ b/spec/factories/measure_condition_component_factory.rb
@@ -1,6 +1,11 @@
 FactoryBot.define do
   sequence(:measure_condition_component) { |n| n }
 
+  trait :small_producers_quotient do
+    measurement_unit_code { 'SPQ' }
+    measurement_unit_qualifier_code {}
+  end
+
   factory :measure_condition_component do
     measure_condition_sid           { generate(:measure_condition_component) }
     duty_expression_id              { Forgery(:basic).text(exactly: 2) }

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -238,6 +238,24 @@ FactoryBot.define do
       end
     end
 
+    trait :with_liters_of_pure_alcohol_measure_component do
+      with_measure_components
+
+      transient do
+        measurement_unit_code { 'LPA' }
+        measurement_unit_qualifier_code {}
+      end
+    end
+
+    trait :with_percentage_alcohol_and_volume_per_hl_component do
+      with_measure_components
+
+      transient do
+        measurement_unit_code { 'ASV' }
+        measurement_unit_qualifier_code { 'X' }
+      end
+    end
+
     trait :third_country_overview do
       erga_omnes
       third_country

--- a/spec/models/measure_condition_spec.rb
+++ b/spec/models/measure_condition_spec.rb
@@ -173,36 +173,6 @@ RSpec.describe MeasureCondition do
     end
   end
 
-  describe '#units' do
-    context 'when the measure condition has measure condition components' do
-      subject(:measure_condition) do
-        create(
-          :measure_condition,
-          :with_measure_condition_components,
-          measurement_unit_code: 'TNE',
-          measurement_unit_qualifier_code: 'R',
-        )
-      end
-
-      it 'returns the properly formatted unit' do
-        expect(measure_condition.units).to eq(
-          [
-            {
-              measurement_unit_code: 'TNE',
-              measurement_unit_qualifier_code: 'R',
-            },
-          ],
-        )
-      end
-    end
-
-    context 'when the measure condition has no components' do
-      subject(:measure_condition) { create(:measure_condition) }
-
-      it { expect(measure_condition.units).to eq([]) }
-    end
-  end
-
   describe '#universal_waiver_applies?' do
     context 'when the measure condition has a cds waiver document_code' do
       subject(:measure_condition) { create(:measure_condition, certificate_type_code: '9', certificate_code: '99L') }

--- a/spec/support/shared_examples/a_component.rb
+++ b/spec/support/shared_examples/a_component.rb
@@ -31,20 +31,31 @@ RSpec.shared_examples_for 'a component' do |type|
     end
   end
 
-  describe '#unit' do
-    subject(:component) do
-      build(
-        type,
-        measurement_unit_code: 'TNE',
-        measurement_unit_qualifier_code: 'I',
-      )
+  describe '#unit_for' do
+    subject(:unit_for) { component.unit_for(measure) }
+
+    shared_examples_for 'a component with a measurement unit' do |measurement_unit_code, measurement_unit_qualifier_code|
+      it { is_expected.to include(measurement_unit_code:, measurement_unit_qualifier_code:) }
     end
 
-    it 'returns the properly formatted unit' do
-      expect(component.unit).to eq(
-        measurement_unit_code: 'TNE',
-        measurement_unit_qualifier_code: 'I',
-      )
+    it_behaves_like 'a component with a measurement unit', 'TNE', 'I' do
+      let(:component) { build(type, measurement_unit_code: 'TNE', measurement_unit_qualifier_code: 'I') }
+      let(:measure) { build(:measure) }
+    end
+
+    it_behaves_like 'a component with a measurement unit', 'SPQ', 'LTR' do
+      let(:component) { create(type, :small_producers_quotient) }
+      let(:measure) { build(:measure, :excise, :with_percentage_alcohol_and_volume_per_hl_component) }
+    end
+
+    it_behaves_like 'a component with a measurement unit', 'SPQ', 'LPA' do
+      let(:component) { create(type, :small_producers_quotient) }
+      let(:measure) { build(:measure, :excise, :with_liters_of_pure_alcohol_measure_component) }
+    end
+
+    it_behaves_like 'a component with a measurement unit', 'SPQ', nil do
+      let(:component) { create(type, :small_producers_quotient) }
+      let(:measure) { build(:measure) } # not an excise measure
     end
   end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3641

![image](https://github.com/trade-tariff/trade-tariff-backend/assets/8156884/a639b8ed-4ee3-493c-aaf8-5e60c7423de3)
![image](https://github.com/trade-tariff/trade-tariff-backend/assets/8156884/7e92cba4-151f-43f4-a0ea-fb6ccd6fb357)
![image](https://github.com/trade-tariff/trade-tariff-backend/assets/8156884/3538afd5-bccd-4ff1-a975-87fc848615ac)
![image](https://github.com/trade-tariff/trade-tariff-backend/assets/8156884/241e0ad7-a2e5-4e4a-8c77-2f5e405256b9)

### What?

I have added/removed/altered:

- [x] Support new compound SPQ and SPR measurement unit
- [x] Reflect qualifier length change
- [x] Intercept units for SPQ and surface SPQLTR or SPQLPA

### Why?

I am doing this because:

- This is required to enable asking for different units in the duty calculator
- Depending on the available units, we'll require different inputs from the user
