### PR TITLE
HOTT-3639: Add presenter to override duty amount on alcohol excise units

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,5 @@
 PGHOST=localhost
+ALCOHOL_COERCIAN_STARTS_FROM=2022-01-01
 AWS_BUCKET_NAME=trade-tariff-persistence-development
 AWS_REPORTING_BUCKET_NAME=trade-tariff-reporting
 BETA_SEARCH_DEBUG=true

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,6 @@
 PGHOST=localhost
 AGGREGATED_SYNONYMS_FILE=spec/fixtures/beta/search/goods_nomenclatures/test_synonyms.txt
+ALCOHOL_COERCIAN_STARTS_FROM=2022-01-01
 AWS_ACCESS_KEY_ID=xxxxxxxxxxxxxxxxxxxx
 AWS_BUCKET_NAME=trade-tariff-backend
 AWS_REPORTING_BUCKET_NAME=trade-tariff-reporting

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -269,7 +269,12 @@ module TradeTariffBackend
     end
 
     def excise_alcohol_coercian_starts_from
-      Date.parse(ENV.fetch('ALCOHOL_COERCIAN_STARTS_FROM', '2023-08-01'))
+      @excise_alcohol_coercian_starts_from ||= Date.parse(
+        ENV.fetch(
+          'ALCOHOL_COERCIAN_STARTS_FROM',
+          '2023-08-01',
+        ),
+      )
     end
 
     def revision

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -268,6 +268,10 @@ module TradeTariffBackend
       ENV.fetch('OPENSEARCH_DEBUG', 'false') == 'true'
     end
 
+    def excise_alcohol_coercian_starts_from
+      Date.parse(ENV.fetch('ALCOHOL_COERCIAN_STARTS_FROM', '2023-08-01'))
+    end
+
     def revision
       @revision ||= begin
         File.read(REVISION_FILE).chomp if File.file?(REVISION_FILE)

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -629,6 +629,10 @@ class Measure < Sequel::Model
     all_condition_components + measure_components + resolved_measure_components
   end
 
+  def has_alcohol_measurement_units?
+    all_components.any?(&:percentage_alcohol_and_volume_per_hl?)
+  end
+
   private
 
   def excluded_country?(country_id)

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -50,7 +50,8 @@ class MeasureCondition < Sequel::Model
   end
 
   one_to_many :measure_condition_components, key: :measure_condition_sid,
-                                             primary_key: :measure_condition_sid
+                                             primary_key: :measure_condition_sid,
+                                             order: Sequel.asc(:duty_expression_id)
 
   delegate :abbreviation, to: :monetary_unit, prefix: true, allow_nil: true
   delegate :description, to: :measurement_unit, prefix: true, allow_nil: true

--- a/app/presenters/api/v2/measures/measure_condition_component_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_condition_component_presenter.rb
@@ -13,7 +13,7 @@ module Api
         #
         # The coercian only happened for excise duties, on the first measure component
         # of alcohol measures.
-        COERCED_DUTY_AMOUNT_CONVERSION_FACTOR = 0.01
+        COERCED_ASVX_DUTY_AMOUNT_CONVERSION_FACTOR = 0.01
 
         def initialize(measure, measure_condition_component, index)
           super(measure_condition_component)
@@ -27,7 +27,7 @@ module Api
           return super unless apply_coerced_duty_amount_conversion_factor?
           return super if super.blank?
 
-          super * COERCED_DUTY_AMOUNT_CONVERSION_FACTOR
+          super * COERCED_ASVX_DUTY_AMOUNT_CONVERSION_FACTOR
         end
 
         def formatted_duty_expression

--- a/app/presenters/api/v2/measures/measure_condition_component_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_condition_component_presenter.rb
@@ -2,6 +2,8 @@ module Api
   module V2
     module Measures
       class MeasureConditionComponentPresenter < WrapDelegator
+        delegate :excise_alcohol_coercian_starts_from, to: TradeTariffBackend
+
         # Sadly, rather than just creating a new measurement unit,
         # CDS have opted to multiply the duty amount by 100 to balance
         # the difference between the measurement units of hectoliters and liters.
@@ -53,6 +55,9 @@ module Api
         attr_reader :measure, :measure_condition_component, :index
 
         def apply_coerced_duty_amount_conversion_factor?
+          return false if Time.zone.today < excise_alcohol_coercian_starts_from
+          return false if MeasureCondition.point_in_time.present? && MeasureCondition.point_in_time < excise_alcohol_coercian_starts_from
+
           index.zero? && measure.excise? && measure.has_alcohol_measurement_units?
         end
 

--- a/app/presenters/api/v2/measures/measure_condition_component_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_condition_component_presenter.rb
@@ -1,0 +1,74 @@
+module Api
+  module V2
+    module Measures
+      class MeasureConditionComponentPresenter < WrapDelegator
+        # Sadly, rather than just creating a new measurement unit,
+        # CDS have opted to multiply the duty amount by 100 to balance
+        # the difference between the measurement units of hectoliters and liters.
+        #
+        # We already have a conversion factor for hectoliters to liters as part of the
+        # duty calculator so CDS showing the converted duty amount is very confusing.
+        #
+        # This saves us from treating hectoliters as liters in some special snowflake way.
+        #
+        # The coercian only happened for excise duties, on the first measure component
+        # of alcohol measures.
+        COERCED_DUTY_AMOUNT_CONVERSION_FACTOR = 0.01
+
+        def initialize(measure, measure_condition_component, index)
+          super(measure_condition_component)
+
+          @measure = measure
+          @measure_condition_component = measure_condition_component
+          @index = index
+        end
+
+        def duty_amount
+          return super unless apply_coerced_duty_amount_conversion_factor?
+          return super if super.blank?
+
+          super * COERCED_DUTY_AMOUNT_CONVERSION_FACTOR
+        end
+
+        def formatted_duty_expression
+          DutyExpressionFormatter.format(duty_expression_formatter_options.merge(formatted: true))
+        end
+
+        def verbose_duty_expression
+          DutyExpressionFormatter.format(duty_expression_formatter_options.merge(verbose: true))
+        end
+
+        def duty_expression_str
+          DutyExpressionFormatter.format(duty_expression_formatter_options)
+        end
+
+        def self.wrap(measure, measure_condition_components)
+          measure_condition_components.each_with_index.map do |measure_condition_component, index|
+            new(measure, measure_condition_component, index)
+          end
+        end
+
+        private
+
+        attr_reader :measure, :measure_condition_component, :index
+
+        def apply_coerced_duty_amount_conversion_factor?
+          index.zero? && measure.excise? && measure.has_alcohol_measurement_units?
+        end
+
+        def duty_expression_formatter_options
+          {
+            duty_expression_id:,
+            duty_expression_description:,
+            duty_expression_abbreviation:,
+            duty_amount:,
+            monetary_unit: monetary_unit_code,
+            monetary_unit_abbreviation:,
+            measurement_unit:,
+            measurement_unit_qualifier:,
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/api/v2/measures/measure_condition_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_condition_presenter.rb
@@ -2,6 +2,11 @@ module Api
   module V2
     module Measures
       class MeasureConditionPresenter < WrapDelegator
+        ALCOHOL_PERCENTAGE_MEASUREMENT_UNIT_CODE = 'ASV'.freeze
+        # ASV condition duty amounts on excise measures are presented as
+        # 0.01 rather than 1% and need adjusting to be presented as 1%.
+        COERCED_ASV_REQUIREMENT_CONVERSION_FACTOR = 100
+
         def initialize(measure, measure_condition)
           super(measure_condition)
 
@@ -13,6 +18,24 @@ module Api
           @measure_condition_components ||= MeasureConditionComponentPresenter.wrap(measure, super)
         end
 
+        def condition_duty_amount
+          return super unless apply_coerced_condition_duty_amount_conversion_factor?
+          return super if super.blank?
+
+          super * COERCED_ASV_REQUIREMENT_CONVERSION_FACTOR
+        end
+
+        def requirement_duty_expression
+          RequirementDutyExpressionFormatter.format(
+            duty_amount: condition_duty_amount,
+            monetary_unit: condition_monetary_unit_code,
+            monetary_unit_abbreviation:,
+            measurement_unit:,
+            formatted_measurement_unit_qualifier:,
+            formatted: true,
+          )
+        end
+
         def self.wrap(measure, measure_conditions)
           measure_conditions.map do |measure_condition|
             new(measure, measure_condition)
@@ -22,6 +45,23 @@ module Api
         private
 
         attr_reader :measure, :measure_condition
+
+        def requirement
+          case requirement_type
+          when :document
+            "#{certificate_type_description}: #{certificate_description}"
+          when :duty_expression
+            requirement_duty_expression
+          end
+        end
+
+        def apply_coerced_condition_duty_amount_conversion_factor?
+          measure.excise? && asv_requirement?
+        end
+
+        def asv_requirement?
+          condition_measurement_unit_code == ALCOHOL_PERCENTAGE_MEASUREMENT_UNIT_CODE
+        end
       end
     end
   end

--- a/app/presenters/api/v2/measures/measure_condition_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_condition_presenter.rb
@@ -2,6 +2,8 @@ module Api
   module V2
     module Measures
       class MeasureConditionPresenter < WrapDelegator
+        delegate :excise_alcohol_coercian_starts_from, to: TradeTariffBackend
+
         ALCOHOL_PERCENTAGE_MEASUREMENT_UNIT_CODE = 'ASV'.freeze
         # ASV condition duty amounts on excise measures are presented as
         # 0.01 rather than 1% and need adjusting to be presented as 1%.
@@ -56,6 +58,9 @@ module Api
         end
 
         def apply_coerced_condition_duty_amount_conversion_factor?
+          return false if Time.zone.today < excise_alcohol_coercian_starts_from
+          return false if MeasureCondition.point_in_time.present? && MeasureCondition.point_in_time < excise_alcohol_coercian_starts_from
+
           measure.excise? && asv_requirement?
         end
 

--- a/app/presenters/api/v2/measures/measure_condition_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_condition_presenter.rb
@@ -1,0 +1,28 @@
+module Api
+  module V2
+    module Measures
+      class MeasureConditionPresenter < WrapDelegator
+        def initialize(measure, measure_condition)
+          super(measure_condition)
+
+          @measure = measure
+          @measure_condition = measure_condition
+        end
+
+        def measure_condition_components
+          @measure_condition_components ||= MeasureConditionComponentPresenter.wrap(measure, super)
+        end
+
+        def self.wrap(measure, measure_conditions)
+          measure_conditions.map do |measure_condition|
+            new(measure, measure_condition)
+          end
+        end
+
+        private
+
+        attr_reader :measure, :measure_condition
+      end
+    end
+  end
+end

--- a/app/presenters/api/v2/measures/measure_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_presenter.rb
@@ -41,7 +41,7 @@ module Api
             def verbose_duty
               verbose_duty_expression
             end
-          }.new(@measure)
+          }.new(measure)
         end
 
         def national_measurement_units
@@ -58,6 +58,10 @@ module Api
 
         def additional_code_id
           export_refund_nomenclature_sid || additional_code_sid
+        end
+
+        def measure_conditions
+          MeasureConditionPresenter.wrap(measure, super)
         end
 
         def measure_condition_ids
@@ -110,7 +114,7 @@ module Api
 
         def measure_condition_permutation_groups
           @measure_condition_permutation_groups = \
-            MeasureConditionPermutations::Calculator.new(@measure)
+            MeasureConditionPermutations::Calculator.new(measure)
                                                     .permutation_groups
         end
 
@@ -159,6 +163,8 @@ module Api
         end
 
       private
+
+        attr_reader :measure, :declarable
 
         def measure_type_exclusions
           @measure_type_exclusions ||= MeasureTypeExclusion.find_geographical_areas(

--- a/app/presenters/api/v2/measures/measure_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_presenter.rb
@@ -61,7 +61,7 @@ module Api
         end
 
         def measure_conditions
-          MeasureConditionPresenter.wrap(measure, super)
+          MeasureConditionPresenter.wrap(super, measure)
         end
 
         def measure_condition_ids

--- a/app/serializers/api/v2/measure_serializer.rb
+++ b/app/serializers/api/v2/measure_serializer.rb
@@ -1,6 +1,5 @@
 module Api
   module V2
-    # Serializer used in MeasuresController#show
     class MeasureSerializer < Api::V2::BaseMeasureSerializer
       attribute :excise, &:excise?
       attribute :vat, &:vat?

--- a/spec/factories/measure_component_factory.rb
+++ b/spec/factories/measure_component_factory.rb
@@ -1,6 +1,10 @@
 FactoryBot.define do
   factory :measure_component do
-    measure_sid { generate(:measure_sid) }
+    transient do
+      measure {}
+    end
+
+    measure_sid { measure.try(:measure_sid) || generate(:measure_sid) }
     duty_expression_id { Forgery(:basic).text(exactly: 2) }
     duty_amount { Forgery(:basic).number }
     monetary_unit_code { 'EUR' }
@@ -8,9 +12,19 @@ FactoryBot.define do
     measurement_unit_qualifier_code { generate(:measurement_unit_qualifier_code) }
   end
 
+  trait :small_producers_quotient do
+    measurement_unit_code { 'SPQ' }
+    measurement_unit_qualifier_code {}
+  end
+
   trait :ad_valorem do
     monetary_unit_code { nil }
     measurement_unit_code { nil }
+  end
+
+  trait :asvx do
+    measurement_unit_code { 'ASV' }
+    measurement_unit_qualifier_code { 'X' }
   end
 
   trait :with_measure_unit do

--- a/spec/factories/measure_condition_component_factory.rb
+++ b/spec/factories/measure_condition_component_factory.rb
@@ -1,17 +1,16 @@
 FactoryBot.define do
   sequence(:measure_condition_component) { |n| n }
 
-  trait :small_producers_quotient do
-    measurement_unit_code { 'SPQ' }
-    measurement_unit_qualifier_code {}
-  end
-
   factory :measure_condition_component do
-    measure_condition_sid           { generate(:measure_condition_component) }
-    duty_expression_id              { Forgery(:basic).text(exactly: 2) }
-    duty_amount                     { Forgery(:basic).number }
-    monetary_unit_code              { Forgery(:basic).text(exactly: 3) }
-    measurement_unit_code           { Forgery(:basic).text(exactly: 3) }
+    transient do
+      measure_condition {}
+    end
+
+    measure_condition_sid { measure_condition.try(:measure_condition_sid) || generate(:measure_condition_component) }
+    duty_expression_id    { Forgery(:basic).text(exactly: 2) }
+    duty_amount           { Forgery(:basic).number }
+    monetary_unit_code    { Forgery(:basic).text(exactly: 3) }
+    measurement_unit_code { Forgery(:basic).text(exactly: 3) }
     measurement_unit_qualifier_code { generate(:measurement_unit_qualifier_code) }
 
     trait :with_duty_expression do

--- a/spec/factories/measure_condition_factory.rb
+++ b/spec/factories/measure_condition_factory.rb
@@ -3,13 +3,14 @@ FactoryBot.define do
 
   factory :measure_condition do
     transient do
+      measure {}
       measurement_unit_code {}
       measurement_unit_qualifier_code {}
       measure_condition_code { Forgery(:basic).text(exactly: 2) }
     end
 
     measure_condition_sid { generate(:measure_condition_sid) }
-    measure_sid { generate(:measure_sid) }
+    measure_sid { measure.try(:measure_sid) || generate(:measure_sid) }
     condition_code { create(:measure_condition_code, :with_description, condition_code: measure_condition_code).condition_code }
     component_sequence_number { Forgery(:basic).number }
     condition_duty_amount { Forgery(:basic).number }

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -296,6 +296,7 @@ FactoryBot.define do
 
     trait :excise do
       measure_type { create(:measure_type, measure_type_series_id: 'Q', measure_type_id: '306') }
+      measure_type_id { '306' }
     end
 
     trait :mfn do

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -1638,4 +1638,24 @@ RSpec.describe Measure do
 
     it { is_expected.to match(/\.* \(.*\)/) }
   end
+
+  describe '#has_alcohol_measurement_units?' do
+    subject(:measure) { create(:measure) }
+
+    context 'when measure has no components' do
+      it { is_expected.not_to be_has_alcohol_measurement_units }
+    end
+
+    context 'when measure has components but no alcohol measurement units' do
+      before { create(:measure_component, measure:) }
+
+      it { is_expected.not_to be_has_alcohol_measurement_units }
+    end
+
+    context 'when measure has components with alcohol measurement units' do
+      before { create(:measure_component, :asvx, measure:) }
+
+      it { is_expected.to be_has_alcohol_measurement_units }
+    end
+  end
 end

--- a/spec/presenters/api/v2/measures/measure_condition_component_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_condition_component_presenter_spec.rb
@@ -1,117 +1,131 @@
 RSpec.describe Api::V2::Measures::MeasureConditionComponentPresenter do
-  describe '#duty_amount' do
-    subject(:duty_amount) { described_class.new(measure, measure_condition_component, index).duty_amount }
+  subject(:presenter) { described_class.new(measure_condition_component, measure) }
 
+  describe '#duty_amount' do
     shared_examples 'a measure condition presented duty amount' do |expected_duty_amount|
-      it { is_expected.to eq(expected_duty_amount) }
+      it { expect(presenter.duty_amount).to eq(expected_duty_amount) }
     end
 
     it_behaves_like 'a measure condition presented duty amount', 1.0 do
-      before do
-        create(:measure_condition_component, :asvx, measure_condition:)
-      end
-
       let(:measure) { create(:measure, :excise) }
       let(:measure_condition) { create(:measure_condition, measure:) }
-      let(:measure_condition_component) { create(:measure_condition_component, measure_condition:, duty_amount: 100.0) }
-      let(:index) { 0 }
+      let(:measure_condition_component) { create(:measure_condition_component, :asvx, measure_condition:, duty_amount: 100.0) }
     end
 
     it_behaves_like 'a measure condition presented duty amount', 100.0 do
       let(:measure) { create(:measure) }
       let(:measure_condition) { create(:measure_condition, measure:) }
       let(:measure_condition_component) { create(:measure_condition_component, measure_condition:, duty_amount: 100.0) }
-      let(:index) { 1 }
     end
 
     it_behaves_like 'a measure condition presented duty amount', nil do
       let(:measure) { create(:measure) }
       let(:measure_condition) { create(:measure_condition, measure:) }
       let(:measure_condition_component) { create(:measure_condition_component, measure_condition:, duty_amount: nil) }
-      let(:index) { 1 }
     end
   end
 
   describe '#formatted_duty_expression' do
-    subject(:formatted_duty_expression) { described_class.new(measure, measure_condition_component, index).formatted_duty_expression }
-
     shared_examples 'a presented formatted duty expression' do |expected_duty_amount|
-      it { is_expected.to match(expected_duty_amount) }
+      it { expect(presenter.formatted_duty_expression).to match(expected_duty_amount) }
     end
 
     it_behaves_like 'a presented formatted duty expression', /^<span>1.00<\/span>.*$/ do
-      before do
-        create(:measure_condition_component, :asvx, measure_condition:)
-      end
-
       let(:measure) { create(:measure, :excise) }
       let(:measure_condition) { create(:measure_condition, measure:) }
-      let(:measure_condition_component) { create(:measure_condition_component, :with_duty_expression, measure_condition:, duty_amount: 100.0) }
-      let(:index) { 0 }
+      let(:measure_condition_component) do
+        create(
+          :measure_condition_component,
+          :asvx,
+          :with_duty_expression,
+          measure_condition:,
+          duty_amount: 100.0,
+        )
+      end
     end
 
     it_behaves_like 'a presented formatted duty expression', /^<span>100.00<\/span>.*$/ do
       let(:measure) { create(:measure) }
       let(:measure_condition) { create(:measure_condition, measure:) }
-      let(:measure_condition_component) { create(:measure_condition_component, :with_duty_expression, measure_condition:, duty_amount: 100.0) }
-      let(:index) { 1 }
+      let(:measure_condition_component) do
+        create(
+          :measure_condition_component,
+          :with_duty_expression,
+          measure_condition:,
+          duty_amount: 100.0,
+        )
+      end
     end
   end
 
   describe '#verbose_duty_expression' do
-    subject(:verbose_duty_expression) { described_class.new(measure, measure_condition_component, index).verbose_duty_expression }
-
     shared_examples 'a presented verbose duty expression' do |expected_duty_amount|
-      it { is_expected.to match(expected_duty_amount) }
+      it { expect(presenter.verbose_duty_expression).to match(expected_duty_amount) }
     end
 
     it_behaves_like 'a presented verbose duty expression', /^1\.00.*$/ do
-      before do
-        create(:measure_condition_component, :asvx, measure_condition:)
-      end
-
       let(:measure) { create(:measure, :excise) }
       let(:measure_condition) { create(:measure_condition, measure:) }
-      let(:measure_condition_component) { create(:measure_condition_component, :with_duty_expression, measure_condition:, duty_amount: 100.0) }
-      let(:index) { 0 }
+      let(:measure_condition_component) do
+        create(
+          :measure_condition_component,
+          :asvx,
+          :with_duty_expression,
+          measure_condition:,
+          duty_amount: 100.0,
+        )
+      end
     end
 
     it_behaves_like 'a presented verbose duty expression', /^100\.00.*$/ do
       let(:measure) { create(:measure) }
       let(:measure_condition) { create(:measure_condition, measure:) }
-      let(:measure_condition_component) { create(:measure_condition_component, :with_duty_expression, measure_condition:, duty_amount: 100.0) }
-      let(:index) { 1 }
+      let(:measure_condition_component) do
+        create(
+          :measure_condition_component,
+          :with_duty_expression,
+          measure_condition:,
+          duty_amount: 100.0,
+        )
+      end
     end
   end
 
   describe '#duty_expression_str' do
-    subject(:duty_expression_str) { described_class.new(measure, measure_condition_component, index).duty_expression_str }
-
     shared_examples 'a presented duty expression string' do |expected_duty_amount|
-      it { is_expected.to match(expected_duty_amount) }
+      it { expect(presenter.duty_expression_str).to match(expected_duty_amount) }
     end
 
     it_behaves_like 'a presented duty expression string', /^1\.00.*$/ do
-      before do
-        create(:measure_condition_component, :asvx, measure_condition:)
-      end
-
       let(:measure) { create(:measure, :excise) }
       let(:measure_condition) { create(:measure_condition, measure:) }
-      let(:measure_condition_component) { create(:measure_condition_component, :with_duty_expression, measure_condition:, duty_amount: 100.0) }
-      let(:index) { 0 }
+      let(:measure_condition_component) do
+        create(
+          :measure_condition_component,
+          :asvx,
+          :with_duty_expression,
+          measure_condition:,
+          duty_amount: 100.0,
+        )
+      end
     end
 
     it_behaves_like 'a presented duty expression string', /^100\.00.*$/ do
       let(:measure) { create(:measure) }
       let(:measure_condition) { create(:measure_condition, measure:) }
-      let(:measure_condition_component) { create(:measure_condition_component, :with_duty_expression, measure_condition:, duty_amount: 100.0) }
-      let(:index) { 1 }
+      let(:measure_condition_component) do
+        create(
+          :measure_condition_component,
+          :with_duty_expression,
+          measure_condition:,
+          duty_amount: 100.0,
+        )
+      end
     end
   end
 
   describe '.wrap' do
-    subject(:wrapped) { described_class.wrap(measure, measure_condition_components) }
+    subject(:wrapped) { described_class.wrap(measure_condition_components, measure) }
 
     let(:measure) { create(:measure) }
     let(:measure_condition) { create(:measure_condition, measure:) }

--- a/spec/presenters/api/v2/measures/measure_condition_component_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_condition_component_presenter_spec.rb
@@ -1,0 +1,124 @@
+RSpec.describe Api::V2::Measures::MeasureConditionComponentPresenter do
+  describe '#duty_amount' do
+    subject(:duty_amount) { described_class.new(measure, measure_condition_component, index).duty_amount }
+
+    shared_examples 'a measure condition presented duty amount' do |expected_duty_amount|
+      it { is_expected.to eq(expected_duty_amount) }
+    end
+
+    it_behaves_like 'a measure condition presented duty amount', 1.0 do
+      before do
+        create(:measure_condition_component, :asvx, measure_condition:)
+      end
+
+      let(:measure) { create(:measure, :excise) }
+      let(:measure_condition) { create(:measure_condition, measure:) }
+      let(:measure_condition_component) { create(:measure_condition_component, measure_condition:, duty_amount: 100.0) }
+      let(:index) { 0 }
+    end
+
+    it_behaves_like 'a measure condition presented duty amount', 100.0 do
+      let(:measure) { create(:measure) }
+      let(:measure_condition) { create(:measure_condition, measure:) }
+      let(:measure_condition_component) { create(:measure_condition_component, measure_condition:, duty_amount: 100.0) }
+      let(:index) { 1 }
+    end
+
+    it_behaves_like 'a measure condition presented duty amount', nil do
+      let(:measure) { create(:measure) }
+      let(:measure_condition) { create(:measure_condition, measure:) }
+      let(:measure_condition_component) { create(:measure_condition_component, measure_condition:, duty_amount: nil) }
+      let(:index) { 1 }
+    end
+  end
+
+  describe '#formatted_duty_expression' do
+    subject(:formatted_duty_expression) { described_class.new(measure, measure_condition_component, index).formatted_duty_expression }
+
+    shared_examples 'a presented formatted duty expression' do |expected_duty_amount|
+      it { is_expected.to match(expected_duty_amount) }
+    end
+
+    it_behaves_like 'a presented formatted duty expression', /^<span>1.00<\/span>.*$/ do
+      before do
+        create(:measure_condition_component, :asvx, measure_condition:)
+      end
+
+      let(:measure) { create(:measure, :excise) }
+      let(:measure_condition) { create(:measure_condition, measure:) }
+      let(:measure_condition_component) { create(:measure_condition_component, :with_duty_expression, measure_condition:, duty_amount: 100.0) }
+      let(:index) { 0 }
+    end
+
+    it_behaves_like 'a presented formatted duty expression', /^<span>100.00<\/span>.*$/ do
+      let(:measure) { create(:measure) }
+      let(:measure_condition) { create(:measure_condition, measure:) }
+      let(:measure_condition_component) { create(:measure_condition_component, :with_duty_expression, measure_condition:, duty_amount: 100.0) }
+      let(:index) { 1 }
+    end
+  end
+
+  describe '#verbose_duty_expression' do
+    subject(:verbose_duty_expression) { described_class.new(measure, measure_condition_component, index).verbose_duty_expression }
+
+    shared_examples 'a presented verbose duty expression' do |expected_duty_amount|
+      it { is_expected.to match(expected_duty_amount) }
+    end
+
+    it_behaves_like 'a presented verbose duty expression', /^1\.00.*$/ do
+      before do
+        create(:measure_condition_component, :asvx, measure_condition:)
+      end
+
+      let(:measure) { create(:measure, :excise) }
+      let(:measure_condition) { create(:measure_condition, measure:) }
+      let(:measure_condition_component) { create(:measure_condition_component, :with_duty_expression, measure_condition:, duty_amount: 100.0) }
+      let(:index) { 0 }
+    end
+
+    it_behaves_like 'a presented verbose duty expression', /^100\.00.*$/ do
+      let(:measure) { create(:measure) }
+      let(:measure_condition) { create(:measure_condition, measure:) }
+      let(:measure_condition_component) { create(:measure_condition_component, :with_duty_expression, measure_condition:, duty_amount: 100.0) }
+      let(:index) { 1 }
+    end
+  end
+
+  describe '#duty_expression_str' do
+    subject(:duty_expression_str) { described_class.new(measure, measure_condition_component, index).duty_expression_str }
+
+    shared_examples 'a presented duty expression string' do |expected_duty_amount|
+      it { is_expected.to match(expected_duty_amount) }
+    end
+
+    it_behaves_like 'a presented duty expression string', /^1\.00.*$/ do
+      before do
+        create(:measure_condition_component, :asvx, measure_condition:)
+      end
+
+      let(:measure) { create(:measure, :excise) }
+      let(:measure_condition) { create(:measure_condition, measure:) }
+      let(:measure_condition_component) { create(:measure_condition_component, :with_duty_expression, measure_condition:, duty_amount: 100.0) }
+      let(:index) { 0 }
+    end
+
+    it_behaves_like 'a presented duty expression string', /^100\.00.*$/ do
+      let(:measure) { create(:measure) }
+      let(:measure_condition) { create(:measure_condition, measure:) }
+      let(:measure_condition_component) { create(:measure_condition_component, :with_duty_expression, measure_condition:, duty_amount: 100.0) }
+      let(:index) { 1 }
+    end
+  end
+
+  describe '.wrap' do
+    subject(:wrapped) { described_class.wrap(measure, measure_condition_components) }
+
+    let(:measure) { create(:measure) }
+    let(:measure_condition) { create(:measure_condition, measure:) }
+    let(:measure_condition_components) { create_list(:measure_condition_component, 2, measure_condition:) }
+
+    it 'returns an array of wrapped measure condition components' do
+      expect(wrapped).to all(be_a(described_class))
+    end
+  end
+end

--- a/spec/presenters/api/v2/measures/measure_condition_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_condition_presenter_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Api::V2::Measures::MeasureConditionPresenter do
+  describe '#measure_condition_components' do
+    subject(:measure_condition_components) { described_class.new(measure, measure_condition).measure_condition_components }
+
+    let(:measure) { create(:measure, :with_measure_conditions) }
+    let(:measure_condition) { measure.measure_conditions.first }
+
+    it { is_expected.to all(be_a(Api::V2::Measures::MeasureConditionComponentPresenter)) }
+  end
+
+  describe '.wrap' do
+    subject(:wrapped_measure_conditions) { described_class.wrap(measure, measure_conditions) }
+
+    let(:measure) { create(:measure, :with_measure_conditions) }
+    let(:measure_conditions) { measure.measure_conditions }
+
+    it { is_expected.to all(be_a(described_class)) }
+  end
+end

--- a/spec/presenters/api/v2/measures/measure_condition_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_condition_presenter_spec.rb
@@ -16,4 +16,66 @@ RSpec.describe Api::V2::Measures::MeasureConditionPresenter do
 
     it { is_expected.to all(be_a(described_class)) }
   end
+
+  describe '#condition_duty_amount' do
+    subject(:condition_duty_amount) { described_class.new(measure, measure_condition).condition_duty_amount }
+
+    shared_examples 'a measure condition presented condition duty amount' do |expected_condition_duty_amount|
+      it { is_expected.to eq(expected_condition_duty_amount) }
+    end
+
+    it_behaves_like 'a measure condition presented condition duty amount', 1.0 do
+      let(:measure) { create(:measure, :excise) }
+      let(:measure_condition) { create(:measure_condition, measure:, condition_measurement_unit_code: 'ASV', condition_duty_amount: 0.01) }
+    end
+
+    it_behaves_like 'a measure condition presented condition duty amount', 0.01 do
+      let(:measure) { create(:measure) }
+      let(:measure_condition) { create(:measure_condition, measure:, condition_duty_amount: 0.01) }
+    end
+
+    it_behaves_like 'a measure condition presented condition duty amount', nil do
+      let(:measure) { create(:measure) }
+      let(:measure_condition) do
+        create(
+          :measure_condition,
+          measure:,
+          condition_duty_amount: nil,
+        )
+      end
+    end
+  end
+
+  describe '#requirement_duty_expression' do
+    subject(:requirement_duty_expression) do
+      described_class.new(measure, measure_condition).requirement_duty_expression
+    end
+
+    shared_examples 'a presented requirement duty expression' do |expected_duty_amount|
+      it { is_expected.to match(expected_duty_amount) }
+    end
+
+    it_behaves_like 'a presented requirement duty expression', /^<span>1.00<\/span>.*$/ do
+      let(:measure) { create(:measure, :excise) }
+      let(:measure_condition) do
+        create(
+          :measure_condition,
+          measure:,
+          condition_measurement_unit_code: 'ASV',
+          condition_duty_amount: 0.01,
+        )
+      end
+    end
+
+    it_behaves_like 'a presented requirement duty expression', /^<span>0.01<\/span>.*$/ do
+      let(:measure) { create(:measure) }
+      let(:measure_condition) do
+        create(
+          :measure_condition,
+          measure:,
+          condition_duty_amount: 0.01,
+        )
+      end
+    end
+  end
 end

--- a/spec/presenters/api/v2/measures/measure_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_presenter_spec.rb
@@ -3,6 +3,10 @@ RSpec.describe Api::V2::Measures::MeasurePresenter do
 
   let(:measure) { create(:measure, :with_base_regulation, :with_measure_conditions) }
 
+  describe '#measure_conditions' do
+    it { expect(presenter.measure_conditions).to all(be_a(Api::V2::Measures::MeasureConditionPresenter)) }
+  end
+
   describe '#legal_acts' do
     it 'will be mapped through the MeasureLegalActPresenter' do
       expect(presenter.legal_acts.first).to \


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3639

https://dev.trade-tariff.service.gov.uk/commodities/2203000100?day=21&month=8&year=2023#vat_excise

UK

![image](https://github.com/trade-tariff/trade-tariff-backend/assets/8156884/13c38ce6-6323-4129-b0b7-678ed050dac2)

XI

![image](https://github.com/trade-tariff/trade-tariff-backend/assets/8156884/9cbfc2ef-0281-4247-b14b-2502fd089af7)

### What?

For ASVX condition components on excise alcohol measures we need to coerce the
first duty amount to be balanced so its no longer making adjustments to handle
liters/hectoliter conversion.

For ASV condition components on excise alcohol measures the ASV part is presenting too small `0.01` instead of `1.00%` and this is incorrect.

I have added/removed/altered:

- [x] Added presentation adjustments to alcohol duty amounts for ASVX
- [x] Added presentation adjustments to alcohol condition duty amounts for ASV

### Why?

I am doing this because:

- This is required so that the presentation of the duty amount reflects the legislation/intended duty amounts
