### PR TITLE
BAU: Fix typo in api component

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -657,7 +657,7 @@ class Measure < Sequel::Model
   end
 
   def components_express_unit?
-    measure_components.any?(&:expresses_unit?) || measure_conditions.any?(&:expresses_unit?) || measure_conditions.flat_map(&:measure_condition_components).any?(&:expresses_unit) || resolved_measure_components.any?(&:expresses_unit?)
+    measure_components.any?(&:expresses_unit?) || measure_conditions.any?(&:expresses_unit?) || measure_conditions.flat_map(&:measure_condition_components).any?(&:expresses_unit?) || resolved_measure_components.any?(&:expresses_unit?)
   end
 
   def meursing_additional_code_id


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Fixes typo in unit method
