### PR TITLE
HOTT-3642: Adjust SPQ presentation

### DIFF
--- a/app/models/concerns/componentable.rb
+++ b/app/models/concerns/componentable.rb
@@ -114,7 +114,6 @@ module Componentable
         monetary_unit_abbreviation:,
         measurement_unit:,
         measurement_unit_qualifier:,
-        currency: TradeTariffBackend.currency,
       }
     end
 

--- a/app/presenters/api/v2/measures/measure_condition_component_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_condition_component_presenter.rb
@@ -30,6 +30,14 @@ module Api
           end
         end
 
+        def presented_duty_expression
+          if small_producers_quotient?
+            verbose_duty_expression
+          else
+            formatted_duty_expression
+          end
+        end
+
         def formatted_duty_expression
           DutyExpressionFormatter.format(duty_expression_formatter_options.merge(formatted: true))
         end

--- a/app/presenters/api/v2/measures/measure_condition_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_condition_presenter.rb
@@ -31,15 +31,7 @@ module Api
         end
 
         def duty_expression
-          formatted_components = measure_condition_components.map do |measure_condition_component|
-            if measure_condition_component.small_producers_quotient?
-              measure_condition_component.verbose_duty_expression
-            else
-              measure_condition_component.formatted_duty_expression
-            end
-          end
-
-          formatted_components.join(' ')
+          measure_condition_components.map(&:presented_duty_expression).join(' ')
         end
 
         def requirement_duty_expression

--- a/app/presenters/api/v2/measures/measure_condition_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_condition_presenter.rb
@@ -31,7 +31,15 @@ module Api
         end
 
         def duty_expression
-          measure_condition_components.map(&:formatted_duty_expression).join(' ')
+          formatted_components = measure_condition_components.map do |measure_condition_component|
+            if measure_condition_component.small_producers_quotient?
+              measure_condition_component.verbose_duty_expression
+            else
+              measure_condition_component.formatted_duty_expression
+            end
+          end
+
+          formatted_components.join(' ')
         end
 
         def requirement_duty_expression

--- a/spec/factories/measure_condition_component_factory.rb
+++ b/spec/factories/measure_condition_component_factory.rb
@@ -18,5 +18,15 @@ FactoryBot.define do
         create(:duty_expression, :with_description, duty_expression_id: measure_condition_component.duty_expression_id)
       end
     end
+
+    trait :with_measurement_unit do
+      after(:create) do |measure_condition_component, _evaluator|
+        create(
+          :measurement_unit,
+          :with_description,
+          measurement_unit_code: measure_condition_component.measurement_unit_code,
+        )
+      end
+    end
   end
 end

--- a/spec/presenters/api/v2/measures/measure_condition_component_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_condition_component_presenter_spec.rb
@@ -124,6 +124,45 @@ RSpec.describe Api::V2::Measures::MeasureConditionComponentPresenter do
     end
   end
 
+  describe '#presented_duty_expression' do
+    context 'when the component is an Small Producers Quotient component' do
+      let(:measure) { create(:measure) }
+      let(:measure_condition) { create(:measure_condition, measure:) }
+      let(:measure_condition_component) do
+        create(
+          :measure_condition_component,
+          :with_duty_expression,
+          :with_measurement_unit,
+          duty_expression_id: '02',
+          measure_condition:,
+          measurement_unit_code: 'SPQ',
+          monetary_unit_code: 'GBP',
+          duty_amount: 1.0,
+        )
+      end
+
+      it { expect(presenter.presented_duty_expression).to eq('- £1.00  / for each litre of pure alcohol, multiplied by the SPR discount') }
+    end
+
+    context 'when the component is not an Small Producers Quotient component' do
+      let(:measure) { create(:measure) }
+      let(:measure_condition) { create(:measure_condition, measure:) }
+      let(:measure_condition_component) do
+        create(
+          :measure_condition_component,
+          :asvx,
+          :with_duty_expression,
+          measure_condition:,
+          duty_expression_id: '01',
+          monetary_unit_code: 'GBP',
+          duty_amount: 500.0,
+        )
+      end
+
+      it { expect(presenter.presented_duty_expression).to eq('<span>500.00</span> GBP') }
+    end
+  end
+
   describe '.wrap' do
     subject(:wrapped) { described_class.wrap(measure_condition_components, measure) }
 

--- a/spec/presenters/api/v2/measures/measure_condition_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_condition_presenter_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Api::V2::Measures::MeasureConditionPresenter do
       it { expect(presenter.duty_expression).to match(expected_duty_expression) }
     end
 
-    it_behaves_like 'a measure condition presented duty expression', /^<span>5.00<\/span>.*<span>100.00<\/span>.*$/ do
+    it_behaves_like 'a measure condition presented duty expression', /<span>5.00<\/span> GBP - £1.00  \/ for each litre of pure alcohol, multiplied by the SPR discount/ do
       before do
         create(
           :measure_condition_component,
@@ -48,14 +48,18 @@ RSpec.describe Api::V2::Measures::MeasureConditionPresenter do
           :with_duty_expression,
           measure_condition:,
           duty_expression_id: '01',
+          monetary_unit_code: 'GBP',
           duty_amount: 500.0,
         )
         create(
           :measure_condition_component,
           :with_duty_expression,
-          duty_expression_id: '04',
+          :with_measurement_unit,
+          duty_expression_id: '02',
           measure_condition:,
-          duty_amount: 100.0,
+          measurement_unit_code: 'SPQ',
+          monetary_unit_code: 'GBP',
+          duty_amount: 1.0,
         )
       end
 

--- a/spec/presenters/api/v2/measures/meursing_measure_component_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/meursing_measure_component_presenter_spec.rb
@@ -1,23 +1,23 @@
 RSpec.describe Api::V2::Measures::MeursingMeasureComponentPresenter do
   subject(:presenter) { described_class.new(measure_component) }
 
-  let(:measure_component) do
-    create(
-      :measure_component,
-      :agricultural_meursing,
-      :with_duty_expression,
-      duty_amount: 100,
-      measurement_unit_code: 'DTN',
-      monetary_unit_code: 'EUR',
-      measure_sid: create(:meursing_measure).measure_sid,
-    )
-  end
-
-  before do
-    allow(DutyExpressionFormatter).to receive(:format).and_call_original
-  end
-
   describe '#formatted_duty_expression' do
+    let(:measure_component) do
+      create(
+        :measure_component,
+        :agricultural_meursing,
+        :with_duty_expression,
+        duty_amount: 100,
+        measurement_unit_code: 'DTN',
+        monetary_unit_code: 'EUR',
+        measure_sid: create(:meursing_measure).measure_sid,
+      )
+    end
+
+    before do
+      allow(DutyExpressionFormatter).to receive(:format).and_call_original
+    end
+
     it { expect(presenter.formatted_duty_expression).to eq('<strong>+ <span>100.00</span> EUR</strong>') }
 
     it 'calls the DutyExpressionFormatter with the correct options' do
@@ -28,7 +28,6 @@ RSpec.describe Api::V2::Measures::MeursingMeasureComponentPresenter do
         duty_expression_abbreviation: '+', # Fixes incorrect abbreviation that would have been inherited from the root measure
         resolved_meursing: true, # Marks the component to be formatted as a resolved component
         formatted: true, # Adds html tags to the component
-        currency: 'GBP',
         duty_amount: 100.0,
         duty_expression_description: measure_component.duty_expression_description,
         measurement_unit: nil,


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3642

![image](https://github.com/trade-tariff/trade-tariff-backend/assets/8156884/de56c3fe-a035-430c-8dc7-6a3f2c4ae86e)

### What?

I have added/removed/altered:

- [x] Added expanded presentation of SPQ units on condition duty expression components
- [x] Added test coverage for the conditional expansion of SPQ unit components

### Why?

I am doing this because:

- This is required because the default `SPQ  (SPR * Rate)` is just incorrect
