### PR TITLE
HOTT-3667: Show threshold conditions that are negative

### DIFF
--- a/app/models/measure_condition_permutations/calculator.rb
+++ b/app/models/measure_condition_permutations/calculator.rb
@@ -1,16 +1,13 @@
 module MeasureConditionPermutations
+  # There are 2 rules for calculating permutations
+  #
+  # When there are conditions with matching permutation_keys, then a single
+  # permutation group is provided with all permutations
+  #
+  # If there are no conditions with matching permutation key, then generate
+  # one group per condition code, with a separate permutation per condition
+  # within it
   class Calculator
-    # There are 2 rules for calculating permutations
-    #
-    # When there are conditions with matching permutation_keys, then a single
-    # permutation group is provided with all permutations
-    #
-    # If there are no conditions with matching permutation key, then generate
-    # one group per condition code, with a separate permutation per condition
-    # within it
-
-    INCLUDED_NEGATIVE_ACTIONS = %w[08].freeze
-
     delegate :measure_sid, to: :@measure
 
     def initialize(measure)
@@ -27,12 +24,10 @@ module MeasureConditionPermutations
       end
     end
 
-  private
+    private
 
     def measure_conditions
-      @measure_conditions ||= @measure.measure_conditions
-                                      .reject(&:universal_waiver_applies?)
-                                      .reject(&method(:excluded_condition?))
+      @measure_conditions ||= @measure.measure_conditions.reject(&:is_excluded_condition?)
     end
 
     def matched_measure_conditions?
@@ -40,13 +35,6 @@ module MeasureConditionPermutations
         .group_by(&:permutation_key)
         .values
         .any?(&:many?) # multiple conditions with same key
-    end
-
-    def excluded_condition?(condition)
-      condition.negative_class? &&
-        condition.measure_action.present? &&
-        condition.document_code.blank? &&
-        INCLUDED_NEGATIVE_ACTIONS.exclude?(condition.measure_action.action_code)
     end
   end
 end

--- a/spec/models/measure_condition_spec.rb
+++ b/spec/models/measure_condition_spec.rb
@@ -198,6 +198,38 @@ RSpec.describe MeasureCondition do
     end
   end
 
+  describe '#is_excluded_condition?' do
+    context 'when the measure condition has a cds waiver document_code' do
+      subject(:measure_condition) { create(:measure_condition, certificate_type_code: '9', certificate_code: '99L') }
+
+      it { is_expected.to be_is_excluded_condition }
+    end
+
+    context 'when the measure condition has a negative action' do
+      subject(:measure_condition) { create(:measure_condition, :negative) }
+
+      it { is_expected.to be_is_excluded_condition }
+    end
+
+    context 'when the measure condition has a negative action and is an included explicitly negative action' do
+      subject(:measure_condition) { create(:measure_condition, :negative, action_code: '08') }
+
+      it { is_expected.not_to be_is_excluded_condition }
+    end
+
+    context 'when the measure condition has a negative action and has a document_code' do
+      subject(:measure_condition) { create(:measure_condition, :negative, certificate_code: '999') }
+
+      it { is_expected.not_to be_is_excluded_condition }
+    end
+
+    context 'when the measure condition has a negative action and is a threshold' do
+      subject(:measure_condition) { create(:measure_condition, :negative, :threshold) }
+
+      it { is_expected.not_to be_is_excluded_condition }
+    end
+  end
+
   describe '#universal_waiver_applies?' do
     context 'when the measure condition has a cds waiver document_code' do
       subject(:measure_condition) { create(:measure_condition, certificate_type_code: '9', certificate_code: '99L') }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3667

![image](https://github.com/trade-tariff/trade-tariff-backend/assets/8156884/abb5284a-b7d2-4f33-b0f8-42cd18027310)

### What?

I have added/removed/altered:

- [x] Show measure conditions that are negative in the permutations UI
- [x] Refactor permutations logic to reflect the real world examples

### Why?

I am doing this because:

- This is required as part of the alcohol work to make sure users can see when excise does not apply to them
