### PR TITLE
HOTT-3649: Only surface requirement units after start date

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -627,12 +627,20 @@ class Measure < Sequel::Model
   end
 
   def all_components
-    all_condition_components + measure_components + resolved_measure_components
+    default_components = measure_components + resolved_measure_components
+
+    return default_components if Time.zone.today < TradeTariffBackend.excise_alcohol_coercian_starts_from
+    return default_components if point_in_time.present? && point_in_time < TradeTariffBackend.excise_alcohol_coercian_starts_from
+
+    all_condition_components + default_components
   end
 
   private
 
   def all_unit_components
+    return all_components if Time.zone.today < TradeTariffBackend.excise_alcohol_coercian_starts_from
+    return all_components if point_in_time.present? && point_in_time < TradeTariffBackend.excise_alcohol_coercian_starts_from
+
     all_components + measure_conditions
   end
 


### PR DESCRIPTION
### Jira link

HOTT-3649

### What?

I have added/removed/altered:

- [x] Stop surfacing old excise requirement units

### Why?

I am doing this because:

- This is causing regression suite failures and is wrong
