### PR TITLE
BAU: Handle no-measure certificates

### DIFF
--- a/app/services/certificate_finder_service.rb
+++ b/app/services/certificate_finder_service.rb
@@ -6,7 +6,7 @@ class CertificateFinderService
   end
 
   def call
-    return [] if description_types_and_codes.empty? && type.blank? && code.blank?
+    return [] if description_types_and_codes.empty? && (type.blank? && code.blank?)
 
     Api::V2::CertificateSearch::CertificatePresenter.wrap(
       certificates,
@@ -19,6 +19,8 @@ class CertificateFinderService
   attr_reader :type, :code, :description
 
   def certificates
+    return [] if grouped_measures.none?
+
     all_certificate_codes = grouped_measures.keys.map do |certificate_full_code|
       [certificate_full_code[0], certificate_full_code[1...]]
     end

--- a/spec/services/certificate_finder_service_spec.rb
+++ b/spec/services/certificate_finder_service_spec.rb
@@ -42,5 +42,12 @@ RSpec.describe CertificateFinderService do
       it { is_expected.to all(be_a(Api::V2::CertificateSearch::CertificatePresenter)) }
       it { expect(call.first.certificate_code).to eq certificate.certificate_code }
     end
+
+    context 'when no measures are associated with the certificate' do
+      let(:code) { certificate.certificate_code }
+      let(:type) { 'Y' }
+
+      it { is_expected.to be_empty }
+    end
   end
 end


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added handling for certificates that have no measures

### Why?

I am doing this because:

- This is causing us to return a list of certificates despite having no measures attached
