### PR TITLE
BAU: Renames all ns_<method_name> methods to just <method_name>

### DIFF
--- a/app/controllers/api/admin/commodities/search_references_controller.rb
+++ b/app/controllers/api/admin/commodities/search_references_controller.rb
@@ -17,7 +17,7 @@ module Api
         end
 
         def commodity_or_subheading
-          subheading.ns_declarable? ? commodity : subheading
+          subheading.declarable? ? commodity : subheading
         end
 
         def commodity

--- a/app/controllers/api/admin/headings_controller.rb
+++ b/app/controllers/api/admin/headings_controller.rb
@@ -19,7 +19,7 @@ module Api
                             .non_grouping
                             .non_hidden
                             .by_code(params[:id])
-                            .eager(ns_descendants: %i[goods_nomenclature_descriptions search_references])
+                            .eager(descendants: %i[goods_nomenclature_descriptions search_references])
                             .take
       end
 
@@ -32,7 +32,7 @@ module Api
       end
 
       def applicable_goods_nomenclature_sids
-        heading.ns_descendants.pluck(:goods_nomenclature_sid) +
+        heading.descendants.pluck(:goods_nomenclature_sid) +
           [heading.goods_nomenclature_sid]
       end
     end

--- a/app/controllers/api/v1/chapters_controller.rb
+++ b/app/controllers/api/v1/chapters_controller.rb
@@ -63,7 +63,7 @@ module Api
         groups = []
         group = { group_lead: nil, group_members: [] }
 
-        chapter.ns_children.each do |heading|
+        chapter.children.each do |heading|
           if heading.producline_suffix == GoodsNomenclatureIndent::NON_GROUPING_PRODUCTLINE_SUFFIX
             if group[:group_lead].present?
               group[:group_members] << heading
@@ -105,7 +105,7 @@ module Api
       end
 
       def declarable
-        ns_declarable?
+        declarable?
       end
     end
   end

--- a/app/controllers/api/v1/commodities_controller.rb
+++ b/app/controllers/api/v1/commodities_controller.rb
@@ -5,7 +5,7 @@ module Api
 
       def show
         @measures = MeasureCollection.new(
-          @commodity.ns_measures_dataset.eager(
+          @commodity.measures_dataset.eager(
             { footnotes: :footnote_descriptions },
             { measure_type: :measure_type_description },
             { measure_components: [{ duty_expression: :duty_expression_description },
@@ -54,7 +54,7 @@ module Api
       def find_commodity
         @commodity = Commodity.actual
                               .non_hidden
-                              .ns_declarable
+                              .declarable
                               .by_code(params[:id])
                               .take
       end

--- a/app/controllers/api/v1/headings_controller.rb
+++ b/app/controllers/api/v1/headings_controller.rb
@@ -52,8 +52,8 @@ module Api
             :chapter_note,
             { sections: :section_note },
           ],
-          ns_measures: MEASURE_EAGER,
-          ns_ancestors: [{ ns_measures: MEASURE_EAGER }],
+          measures: MEASURE_EAGER,
+          ancestors: [{ measures: MEASURE_EAGER }],
         },
       ].freeze
 
@@ -66,8 +66,8 @@ module Api
             :chapter_note,
             { sections: :section_note },
           ],
-          ns_descendants: %i[
-            ns_parent
+          descendants: %i[
+            parent
             goods_nomenclature_descriptions
           ],
         },
@@ -75,7 +75,7 @@ module Api
 
       def show
         @heading = heading
-        @heading_cache_key = "heading-#{@heading.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}-#{@heading.ns_declarable?}"
+        @heading_cache_key = "heading-#{@heading.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}-#{@heading.declarable?}"
         respond_with @heading
       end
 
@@ -125,7 +125,7 @@ module Api
       def declarable?
         shared_heading_scope
           .take
-          .ns_declarable?
+          .declarable?
       end
     end
   end

--- a/app/controllers/api/v2/chapters_controller.rb
+++ b/app/controllers/api/v2/chapters_controller.rb
@@ -93,7 +93,7 @@ module Api
       def chapter_headings
         chapter
           .headings_dataset
-          .eager(:goods_nomenclature_descriptions, :ns_children)
+          .eager(:goods_nomenclature_descriptions, :children)
           .all
       end
     end

--- a/app/controllers/api/v2/commodities_controller.rb
+++ b/app/controllers/api/v2/commodities_controller.rb
@@ -23,7 +23,7 @@ module Api
       def find_commodity
         @commodity = Commodity.actual
                               .non_hidden
-                              .ns_declarable
+                              .declarable
                               .by_code(params[:id])
                               .take
       end

--- a/app/controllers/api/v2/headings_controller.rb
+++ b/app/controllers/api/v2/headings_controller.rb
@@ -48,11 +48,11 @@ module Api
 
       def heading_commodities
         heading_scope
-          .eager(ns_descendants: :goods_nomenclature_descriptions)
+          .eager(descendants: :goods_nomenclature_descriptions)
           .all
           .first
           .tap { |heading| heading || (raise Sequel::RecordNotFound) }
-          .ns_descendants
+          .descendants
       end
 
       def filter_params

--- a/app/controllers/api/v2/subheadings_controller.rb
+++ b/app/controllers/api/v2/subheadings_controller.rb
@@ -28,7 +28,7 @@ module Api
                   .by_code(subheading_code)
                   .by_productline_suffix(productline_suffix)
                   .take
-                  .tap { |sh| raise Sequel::RecordNotFound if sh.ns_leaf? }
+                  .tap { |sh| raise Sequel::RecordNotFound if sh.leaf? }
       end
     end
   end

--- a/app/elastic_search_indexes/cache/cache_index.rb
+++ b/app/elastic_search_indexes/cache/cache_index.rb
@@ -27,7 +27,7 @@ module Cache
           :modification_regulation,
           {
             goods_nomenclature: %i[goods_nomenclature_descriptions
-                                   ns_children
+                                   children
                                    goods_nomenclature_indents],
             geographical_area: %i[geographical_area_descriptions],
           },

--- a/app/elastic_search_indexes/cache/footnote_index.rb
+++ b/app/elastic_search_indexes/cache/footnote_index.rb
@@ -19,7 +19,7 @@ module Cache
       eager_load_measures.merge(
         footnote_descriptions: {},
         goods_nomenclatures: %i[goods_nomenclature_descriptions
-                                ns_children
+                                children
                                 goods_nomenclature_indents],
       )
     end

--- a/app/elastic_search_indexes/search/bulk_search_index.rb
+++ b/app/elastic_search_indexes/search/bulk_search_index.rb
@@ -6,7 +6,7 @@ module Search
       declarables = GoodsNomenclature
         .actual
         .where(heading_short_code:)
-        .ns_declarable
+        .declarable
         .eager(*eager_load)
         .all
 
@@ -21,8 +21,8 @@ module Search
         :goods_nomenclature_descriptions,
         :search_references,
         :tradeset_descriptions,
-        :ns_children,
-        { ns_ancestors: %i[search_references goods_nomenclature_descriptions] },
+        :children,
+        { ancestors: %i[search_references goods_nomenclature_descriptions] },
       ]
     end
 

--- a/app/elastic_search_indexes/search/goods_nomenclature_index.rb
+++ b/app/elastic_search_indexes/search/goods_nomenclature_index.rb
@@ -6,7 +6,7 @@ module Search
       TimeMachine.now do
         Commodity
           .actual
-          .ns_declarable
+          .declarable
           .non_hidden
       end
     end
@@ -17,7 +17,7 @@ module Search
         :search_references,
         :chapter,
         { heading: :guides },
-        { ns_ancestors: %i[search_references goods_nomenclature_descriptions] },
+        { ancestors: %i[search_references goods_nomenclature_descriptions] },
       ]
     end
 

--- a/app/lib/changes_table_populator/descendant_populator.rb
+++ b/app/lib/changes_table_populator/descendant_populator.rb
@@ -10,7 +10,7 @@ module ChangesTablePopulator
 
     def build_descendant_change_records(row:, day: Time.zone.today)
       find_source_and_descendants(row:, day:).map do |descendant|
-        build_change_record(row: descendant, day:, is_end_line: descendant.ns_declarable?)
+        build_change_record(row: descendant, day:, is_end_line: descendant.declarable?)
       end
     end
   end

--- a/app/lib/changes_table_populator/importer.rb
+++ b/app/lib/changes_table_populator/importer.rb
@@ -95,7 +95,7 @@ module ChangesTablePopulator
              .first
 
       TimeMachine.at(descendants_date(gn, day)) do
-        gn.ns_declarable?
+        gn.declarable?
       end
     end
 
@@ -105,7 +105,7 @@ module ChangesTablePopulator
              .first
 
       TimeMachine.at(descendants_date(gn, day)) do
-        [gn] + gn.ns_descendants
+        [gn] + gn.descendants
       end
     end
   end

--- a/app/lib/reporting/basic.rb
+++ b/app/lib/reporting/basic.rb
@@ -16,9 +16,9 @@ module Reporting
     ].freeze
 
     GOODS_NOMENCLATURE_EAGER = [
-      { ns_ancestors: [{ ns_overview_measures: MEASURE_EAGER }] },
-      { ns_overview_measures: MEASURE_EAGER },
-      :ns_children,
+      { ancestors: [{ overview_measures: MEASURE_EAGER }] },
+      { overview_measures: MEASURE_EAGER },
+      :children,
       :goods_nomenclature_descriptions,
     ].freeze
 
@@ -102,7 +102,7 @@ module Reporting
       def goods_nomenclatures
         GoodsNomenclature
           .actual
-          .ns_declarable
+          .declarable
           .eager(GOODS_NOMENCLATURE_EAGER)
           .non_hidden
           .non_classifieds

--- a/app/lib/reporting/declarable_duties.rb
+++ b/app/lib/reporting/declarable_duties.rb
@@ -24,9 +24,9 @@ module Reporting
 
     GOODS_NOMENCLATURE_EAGER = [
       {
-        ns_ancestors: [{ ns_measures: MEASURE_EAGER }],
-        ns_descendants: [{ ns_measures: MEASURE_EAGER }, :goods_nomenclature_descriptions],
-        ns_measures: MEASURE_EAGER,
+        ancestors: [{ measures: MEASURE_EAGER }],
+        descendants: [{ measures: MEASURE_EAGER }, :goods_nomenclature_descriptions],
+        measures: MEASURE_EAGER,
       },
       :goods_nomenclature_descriptions,
     ].freeze
@@ -184,8 +184,8 @@ module Reporting
 
       def each_declarable
         each_chapter do |eager_chapter|
-          eager_chapter.ns_descendants.each do |chapter_descendant|
-            next unless chapter_descendant.ns_declarable?
+          eager_chapter.descendants.each do |chapter_descendant|
+            next unless chapter_descendant.declarable?
 
             yield PresentedDeclarable.new(chapter_descendant)
           end

--- a/app/lib/reporting/differences.rb
+++ b/app/lib/reporting/differences.rb
@@ -12,29 +12,29 @@ module Reporting
     ].freeze
 
     GOODS_NOMENCLATURE_MEASURE_EAGER = [
-      :ns_measures,
+      :measures,
       {
-        ns_ancestors: :ns_measures,
-        ns_descendants: :ns_measures,
+        ancestors: :measures,
+        descendants: :measures,
       },
     ].freeze
 
     GOODS_NOMENCLATURE_OVERVIEW_MEASURE_EAGER = [
-      :ns_overview_measures,
+      :overview_measures,
       :goods_nomenclature_descriptions,
       {
-        ns_ancestors: :ns_overview_measures,
-        ns_descendants: %i[ns_overview_measures goods_nomenclature_descriptions],
+        ancestors: :overview_measures,
+        descendants: %i[overview_measures goods_nomenclature_descriptions],
       },
     ].freeze
 
     GOODS_NOMENCLATURE_OVERVIEW_MEASURE_WITH_COMPONENTS_EAGER = [
-      :ns_overview_measures,
+      :overview_measures,
       :goods_nomenclature_descriptions,
       {
-        ns_ancestors: [{ ns_overview_measures: MEASURE_EAGER }],
-        ns_descendants: [
-          { ns_overview_measures: MEASURE_EAGER },
+        ancestors: [{ overview_measures: MEASURE_EAGER }],
+        descendants: [
+          { overview_measures: MEASURE_EAGER },
           :goods_nomenclature_descriptions,
         ],
       },

--- a/app/lib/reporting/differences/me32.rb
+++ b/app/lib/reporting/differences/me32.rb
@@ -100,8 +100,8 @@ module Reporting
 
       def each_declarable
         each_chapter(eager: Differences::GOODS_NOMENCLATURE_MEASURE_EAGER) do |eager_chapter|
-          eager_chapter.ns_descendants.each do |chapter_descendant|
-            next unless chapter_descendant.ns_declarable?
+          eager_chapter.descendants.each do |chapter_descendant|
+            next unless chapter_descendant.declarable?
 
             yield chapter_descendant
           end

--- a/app/lib/reporting/differences/mfn_duplicated.rb
+++ b/app/lib/reporting/differences/mfn_duplicated.rb
@@ -84,8 +84,8 @@ module Reporting
 
       def each_declarable
         each_chapter(eager: Differences::GOODS_NOMENCLATURE_OVERVIEW_MEASURE_WITH_COMPONENTS_EAGER) do |eager_chapter|
-          eager_chapter.ns_descendants.each do |chapter_descendant|
-            next unless chapter_descendant.ns_declarable?
+          eager_chapter.descendants.each do |chapter_descendant|
+            next unless chapter_descendant.declarable?
 
             mfns = chapter_descendant.applicable_overview_measures.select do |measure|
               measure.measure_type_id.in?(MeasureType::THIRD_COUNTRY)

--- a/app/lib/reporting/differences/mfn_missing.rb
+++ b/app/lib/reporting/differences/mfn_missing.rb
@@ -68,8 +68,8 @@ module Reporting
 
       def each_declarable
         each_chapter(eager: Differences::GOODS_NOMENCLATURE_OVERVIEW_MEASURE_EAGER) do |eager_chapter|
-          eager_chapter.ns_descendants.each do |chapter_descendant|
-            next unless chapter_descendant.ns_declarable?
+          eager_chapter.descendants.each do |chapter_descendant|
+            next unless chapter_descendant.declarable?
 
             next if chapter_descendant.applicable_overview_measures.any? do |measure|
               measure.measure_type_id.in?(MeasureType::THIRD_COUNTRY)

--- a/app/lib/reporting/differences/missing_vat_measure.rb
+++ b/app/lib/reporting/differences/missing_vat_measure.rb
@@ -67,8 +67,8 @@ module Reporting
 
       def each_declarable
         each_chapter(eager: Differences::GOODS_NOMENCLATURE_OVERVIEW_MEASURE_EAGER) do |eager_chapter|
-          eager_chapter.ns_descendants.each do |chapter_descendant|
-            next unless chapter_descendant.ns_declarable?
+          eager_chapter.descendants.each do |chapter_descendant|
+            next unless chapter_descendant.declarable?
 
             next if chapter_descendant.applicable_overview_measures.find { |measure|
               measure.measure_type_id.in?(FILTERED_MEASURE_TYPES) &&

--- a/app/lib/reporting/differences/omitted_duty_measures.rb
+++ b/app/lib/reporting/differences/omitted_duty_measures.rb
@@ -156,8 +156,8 @@ module Reporting
       def each_declarable(as_of)
         start_time = Time.zone.now
         each_chapter(eager: Differences::GOODS_NOMENCLATURE_MEASURE_EAGER, as_of:) do |eager_chapter|
-          eager_chapter.ns_descendants.each do |chapter_descendant|
-            next unless chapter_descendant.ns_declarable?
+          eager_chapter.descendants.each do |chapter_descendant|
+            next unless chapter_descendant.declarable?
 
             yield PresentedDeclarable.new(chapter_descendant)
           end

--- a/app/lib/reporting/prohibitions.rb
+++ b/app/lib/reporting/prohibitions.rb
@@ -24,9 +24,9 @@ module Reporting
 
     GOODS_NOMENCLATURE_EAGER = [
       {
-        ns_ancestors: [{ ns_measures: MEASURE_EAGER }],
-        ns_descendants: [{ ns_measures: MEASURE_EAGER }, :goods_nomenclature_descriptions],
-        ns_measures: MEASURE_EAGER,
+        ancestors: [{ measures: MEASURE_EAGER }],
+        descendants: [{ measures: MEASURE_EAGER }, :goods_nomenclature_descriptions],
+        measures: MEASURE_EAGER,
       },
       :goods_nomenclature_descriptions,
     ].freeze
@@ -165,8 +165,8 @@ module Reporting
 
       def each_declarable
         each_chapter do |eager_chapter|
-          eager_chapter.ns_descendants.each do |chapter_descendant|
-            next unless chapter_descendant.ns_declarable?
+          eager_chapter.descendants.each do |chapter_descendant|
+            next unless chapter_descendant.declarable?
 
             yield DeclarableDuties::PresentedDeclarable.new(chapter_descendant)
           end

--- a/app/models/concerns/ten_digit_goods_nomenclature.rb
+++ b/app/models/concerns/ten_digit_goods_nomenclature.rb
@@ -45,7 +45,7 @@ module TenDigitGoodsNomenclature
     end
 
     def short_code
-      if ns_declarable?
+      if declarable?
         goods_nomenclature_item_id
       else
         specific_system_short_code
@@ -99,7 +99,7 @@ module TenDigitGoodsNomenclature
     end
 
     def goods_nomenclature_class
-      ns_declarable? ? 'Commodity' : 'Subheading'
+      declarable? ? 'Commodity' : 'Subheading'
     end
 
     def to_admin_param

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -224,7 +224,7 @@ class GoodsNomenclature < Sequel::Model
   end
 
   def classifiable_goods_nomenclatures
-    ns_ancestors.dup.push(self).reverse
+    ancestors.dup.push(self).reverse
   end
 
   def has_chemicals

--- a/app/presenters/api/admin/headings/heading_presenter.rb
+++ b/app/presenters/api/admin/headings/heading_presenter.rb
@@ -13,7 +13,7 @@ module Api
         end
 
         def commodities
-          @commodities ||= CommodityPresenter.wrap(ns_descendants, @search_reference_counts)
+          @commodities ||= CommodityPresenter.wrap(descendants, @search_reference_counts)
         end
 
         def commodity_ids

--- a/app/presenters/api/v2/commodities/commodity_presenter.rb
+++ b/app/presenters/api/v2/commodities/commodity_presenter.rb
@@ -49,7 +49,7 @@ module Api
         end
 
         def ancestors
-          @ancestors ||= ns_ancestors.select { |ancestor| ancestor.is_a? TenDigitGoodsNomenclature }
+          @ancestors ||= super.select { |ancestor| ancestor.is_a? TenDigitGoodsNomenclature }
         end
 
         def ancestor_ids

--- a/app/presenters/api/v2/headings/commodity_presenter.rb
+++ b/app/presenters/api/v2/headings/commodity_presenter.rb
@@ -3,8 +3,8 @@ module Api
     module Headings
       class CommodityPresenter < WrapDelegator
         def parent_sid
-          if ns_parent.is_a?(TenDigitGoodsNomenclature)
-            ns_parent.goods_nomenclature_sid
+          if parent.is_a?(TenDigitGoodsNomenclature)
+            parent.goods_nomenclature_sid
           end
         end
 
@@ -19,11 +19,11 @@ module Api
         end
 
         def leaf
-          ns_leaf?
+          leaf?
         end
 
         def declarable
-          ns_declarable?
+          declarable?
         end
       end
     end

--- a/app/presenters/api/v2/headings/heading_presenter.rb
+++ b/app/presenters/api/v2/headings/heading_presenter.rb
@@ -18,11 +18,11 @@ module Api
 
         def chapter
           @chapter ||= \
-            ChapterPresenter.new(ns_ancestors.find { |a| a.is_a? Chapter })
+            ChapterPresenter.new(ancestors.find { |a| a.is_a? Chapter })
         end
 
         def commodities
-          @commodities ||= CommodityPresenter.wrap(ns_descendants)
+          @commodities ||= CommodityPresenter.wrap(descendants)
         end
 
         def commodity_ids

--- a/app/presenters/api/v2/subheadings/subheading_presenter.rb
+++ b/app/presenters/api/v2/subheadings/subheading_presenter.rb
@@ -17,19 +17,19 @@ module Api
         end
 
         def commodities
-          @commodities ||= Headings::CommodityPresenter.wrap(ancestors + [self] + ns_descendants)
+          @commodities ||= Headings::CommodityPresenter.wrap(ten_digit_ancestors + [self] + descendants)
         end
 
         def commodity_ids
           commodities.map(&:goods_nomenclature_sid)
         end
 
-        def ancestors
-          @ancestors ||= ns_ancestors.select { |ancestor| ancestor.is_a? TenDigitGoodsNomenclature }
+        def ten_digit_ancestors
+          @ten_digit_ancestors ||= ancestors.select { |ancestor| ancestor.is_a? TenDigitGoodsNomenclature }
         end
 
-        def ancestor_ids
-          ancestors.map(&:goods_nomenclature_sid)
+        def ten_digit_ancestor_ids
+          ten_digit_ancestors.map(&:goods_nomenclature_sid)
         end
 
         def section
@@ -38,11 +38,11 @@ module Api
 
         def chapter
           @chapter ||= \
-            Headings::ChapterPresenter.new(ns_ancestors.find { |a| a.is_a? Chapter })
+            Headings::ChapterPresenter.new(ancestors.find { |a| a.is_a? Chapter })
         end
 
         def heading
-          @heading ||= ns_ancestors.find { |a| a.is_a? Heading }
+          @heading ||= ancestors.find { |a| a.is_a? Heading }
         end
       end
     end

--- a/app/serializers/api/admin/chapters/heading_serializer.rb
+++ b/app/serializers/api/admin/chapters/heading_serializer.rb
@@ -10,7 +10,7 @@ module Api
 
         attributes :goods_nomenclature_sid, :goods_nomenclature_item_id, :description
 
-        attribute :declarable, &:ns_declarable?
+        attribute :declarable, &:declarable?
 
         attribute :search_references_count do |heading|
           heading.search_references.count

--- a/app/serializers/api/admin/csv/goods_nomenclature_serializer.rb
+++ b/app/serializers/api/admin/csv/goods_nomenclature_serializer.rb
@@ -11,7 +11,7 @@ module Api
         column :validity_start_date, column_name: 'Start date'
         column :validity_end_date, column_name: 'End date'
         column :number_indents, column_name: 'Indentation'
-        column :end_line, column_name: 'End line', &:ns_declarable?
+        column :end_line, column_name: 'End line', &:declarable?
         column :goods_nomenclature_class, column_name: 'Class'
 
         column :item_id_plus_pls, column_name: 'ItemIDPlusPLS' do |goods_nomenclature|
@@ -19,7 +19,7 @@ module Api
         end
 
         column :ancestors, column_name: 'Hierarchy' do |goods_nomenclature|
-          ancestor_ids = goods_nomenclature.ns_ancestors.map do |ancestor|
+          ancestor_ids = goods_nomenclature.ancestors.map do |ancestor|
             "#{ancestor.goods_nomenclature_item_id}_#{ancestor.producline_suffix}"
           end
 

--- a/app/serializers/api/admin/headings/commodity_serializer.rb
+++ b/app/serializers/api/admin/headings/commodity_serializer.rb
@@ -13,7 +13,7 @@ module Api
                    :goods_nomenclature_item_id,
                    :producline_suffix
 
-        attribute :declarable, &:ns_declarable?
+        attribute :declarable, &:declarable?
       end
     end
   end

--- a/app/serializers/api/v2/chapters/heading_leaf_serializer.rb
+++ b/app/serializers/api/v2/chapters/heading_leaf_serializer.rb
@@ -7,7 +7,7 @@ class Api::V2::Chapters::HeadingLeafSerializer
 
   attribute :goods_nomenclature_sid, :goods_nomenclature_item_id
 
-  attribute :declarable, &:ns_declarable?
+  attribute :declarable, &:declarable?
 
   attributes :description, :producline_suffix, :leaf
   attributes :description_plain, :formatted_description

--- a/app/serializers/api/v2/chapters/heading_serializer.rb
+++ b/app/serializers/api/v2/chapters/heading_serializer.rb
@@ -9,7 +9,7 @@ module Api
         set_id :goods_nomenclature_sid
 
         attributes :goods_nomenclature_sid, :goods_nomenclature_item_id
-        attribute :declarable, &:ns_declarable?
+        attribute :declarable, &:declarable?
 
         attributes :description, :producline_suffix, :leaf
         attributes :description_plain, :formatted_description,

--- a/app/serializers/api/v2/commodities/commodity_serializer.rb
+++ b/app/serializers/api/v2/commodities/commodity_serializer.rb
@@ -23,7 +23,7 @@ module Api
                    :validity_end_date,
                    :has_chemicals
 
-        attribute :declarable, &:ns_declarable?
+        attribute :declarable, &:declarable?
 
         has_many :footnotes, serializer: Api::V2::Headings::FootnoteSerializer
         has_one :section, serializer: Api::V2::Commodities::SectionSerializer

--- a/app/serializers/api/v2/csv/commodity_serializer.rb
+++ b/app/serializers/api/v2/csv/commodity_serializer.rb
@@ -8,8 +8,8 @@ module Api
                 :number_indents,
                 :goods_nomenclature_item_id
 
-        column :declarable, &:ns_declarable?
-        column :leaf, &:ns_leaf?
+        column :declarable, &:declarable?
+        column :leaf, &:leaf?
 
         columns :goods_nomenclature_sid,
                 :formatted_description,
@@ -17,8 +17,8 @@ module Api
                 :producline_suffix
 
         column :parent_sid do |commodity|
-          if commodity.ns_parent.is_a?(TenDigitGoodsNomenclature)
-            commodity.ns_parent.goods_nomenclature_sid
+          if commodity.parent.is_a?(TenDigitGoodsNomenclature)
+            commodity.parent.goods_nomenclature_sid
           end
         end
       end

--- a/app/serializers/api/v2/csv/goods_nomenclature_serializer.rb
+++ b/app/serializers/api/v2/csv/goods_nomenclature_serializer.rb
@@ -18,10 +18,10 @@ module Api
         column :formatted_description, column_name: 'Formatted description'
         column :validity_start_date, column_name: 'Start date'
         column :validity_end_date, column_name: 'End date'
-        column :declarable, column_name: 'Declarable', &:ns_declarable?
+        column :declarable, column_name: 'Declarable', &:declarable?
 
         column :parent_sid, column_name: 'Parent SID' do |goods_nomenclature|
-          goods_nomenclature.ns_parent&.goods_nomenclature_sid
+          goods_nomenclature.parent&.goods_nomenclature_sid
         end
       end
     end

--- a/app/serializers/api/v2/csv/heading_serializer.rb
+++ b/app/serializers/api/v2/csv/heading_serializer.rb
@@ -7,14 +7,14 @@ module Api
         columns :goods_nomenclature_item_id,
                 :goods_nomenclature_sid
 
-        column  :declarable, &:ns_declarable?
+        column  :declarable, &:declarable?
 
         columns :description,
                 :description_plain,
                 :formatted_description,
                 :producline_suffix
 
-        column  :leaf, &:ns_leaf?
+        column  :leaf, &:leaf?
       end
     end
   end

--- a/app/serializers/api/v2/goods_nomenclatures/goods_nomenclature_extended_serializer.rb
+++ b/app/serializers/api/v2/goods_nomenclatures/goods_nomenclature_extended_serializer.rb
@@ -13,9 +13,9 @@ module Api
         end
 
         attributes :formatted_description, :validity_start_date, :validity_end_date
-        attribute :declarable, &:ns_declarable?
+        attribute :declarable, &:declarable?
 
-        belongs_to :parent, record_type: :goods_nomenclature, &:ns_parent
+        belongs_to :parent, record_type: :goods_nomenclature, &:parent
       end
     end
   end

--- a/app/serializers/api/v2/subheadings/subheading_serializer.rb
+++ b/app/serializers/api/v2/subheadings/subheading_serializer.rb
@@ -25,9 +25,13 @@ module Api
         has_one :section, serializer: Api::V2::Subheadings::SectionSerializer
         has_one :chapter, serializer: Api::V2::Subheadings::ChapterSerializer
         has_one :heading, serializer: Api::V2::Subheadings::HeadingSerializer
-        has_many :ancestors, serializer: Api::V2::Commodities::CommoditySerializer
         has_many :commodities, serializer: Api::V2::Subheadings::CommoditySerializer
         has_many :footnotes, serializer: Api::V2::Subheadings::FootnoteSerializer
+
+        has_many :ancestors,
+                 serializer: Api::V2::Commodities::CommoditySerializer,
+                 object_method_name: :ten_digit_ancestors,
+                 id_method_name: :ten_digit_ancestor_ids
       end
     end
   end

--- a/app/serializers/search/goods_nomenclature_serializer.rb
+++ b/app/serializers/search/goods_nomenclature_serializer.rb
@@ -51,7 +51,7 @@ module Search
     end
 
     def ancestors
-      @ancestors ||= ns_ancestors.map do |ancestor|
+      @ancestors ||= super.map do |ancestor|
         {
           id: ancestor.goods_nomenclature_sid,
           goods_nomenclature_item_id: ancestor.goods_nomenclature_item_id,
@@ -112,7 +112,7 @@ module Search
     end
 
     def facet_classification
-      @facet_classification ||= if ns_declarable?
+      @facet_classification ||= if declarable?
                                   Beta::Search::FacetClassification::Declarable.build(self)
                                 else
                                   Beta::Search::FacetClassification::NonDeclarable.build(self)

--- a/app/services/bulk_search_document_builder_service.rb
+++ b/app/services/bulk_search_document_builder_service.rb
@@ -34,7 +34,7 @@ class BulkSearchDocumentBuilderService
         intercept_terms: Set.new,
       )
 
-      [goods_nomenclature].concat(goods_nomenclature.ns_ancestors).each do |applicable_goods_nomenclature|
+      [goods_nomenclature].concat(goods_nomenclature.ancestors).each do |applicable_goods_nomenclature|
         next if acc[short_code][:observed].include?(applicable_goods_nomenclature.goods_nomenclature_sid)
 
         search_references = applicable_goods_nomenclature.search_references.pluck(:title).flatten

--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -95,9 +95,9 @@ class CachedCommodityService
     @commodity ||= Commodity
       .actual
       .where(goods_nomenclature_sid: @commodity_sid)
-      .eager(ns_ancestors: { ns_measures: MEASURES_EAGER_LOAD_GRAPH,
-                             goods_nomenclature_descriptions: {} },
-             ns_measures: MEASURES_EAGER_LOAD_GRAPH)
+      .eager(ancestors: { measures: MEASURES_EAGER_LOAD_GRAPH,
+                          goods_nomenclature_descriptions: {} },
+             measures: MEASURES_EAGER_LOAD_GRAPH)
       .take
   end
 

--- a/app/services/find_ancestors_service.rb
+++ b/app/services/find_ancestors_service.rb
@@ -6,7 +6,7 @@ class FindAncestorsService
   def call
     return [] if goods_nomenclature_item_id.blank?
 
-    goods_nomenclature.ns_ancestors.dup.push(goods_nomenclature).map(&:goods_nomenclature_item_id)
+    goods_nomenclature.ancestors.dup.push(goods_nomenclature).map(&:goods_nomenclature_item_id)
   end
 
   private

--- a/app/services/heading_service/heading_serialization_service.rb
+++ b/app/services/heading_service/heading_serialization_service.rb
@@ -45,7 +45,7 @@ module HeadingService
     attr_reader :heading, :actual_date, :filters
 
     def serialization_service
-      if heading.ns_declarable?
+      if heading.declarable?
         HeadingService::Serialization::DeclarableService
           .new(heading, filters)
       else
@@ -55,7 +55,7 @@ module HeadingService
     end
 
     def heading_cache_key
-      self.class.cache_key(heading, actual_date, heading.ns_declarable?, filters)
+      self.class.cache_key(heading, actual_date, heading.declarable?, filters)
     end
   end
 end

--- a/app/services/heading_service/precache_service.rb
+++ b/app/services/heading_service/precache_service.rb
@@ -13,8 +13,8 @@ module HeadingService
         each_heading do |heading|
           write_heading(heading)
 
-          heading.ns_descendants.each do |subheading|
-            next if subheading.ns_declarable?
+          heading.descendants.each do |subheading|
+            next if subheading.declarable?
 
             write_subheading subheading
           end
@@ -30,9 +30,9 @@ module HeadingService
                .where(goods_nomenclature_sid: chapter.goods_nomenclature_sid)
                .eager(*Serialization::NsNondeclarableService::HEADING_EAGER_LOAD)
                .take
-               .ns_children
+               .children
                .each do |heading|
-          next if heading.ns_declarable?
+          next if heading.declarable?
 
           yield heading
         end

--- a/app/services/heading_service/serialization/declarable_service.rb
+++ b/app/services/heading_service/serialization/declarable_service.rb
@@ -34,7 +34,7 @@ module HeadingService
       end
 
       def measures
-        heading.ns_measures_dataset.eager(
+        heading.measures_dataset.eager(
           {
             geographical_area: [
               :geographical_area_descriptions,

--- a/app/services/heading_service/serialization/ns_nondeclarable_service.rb
+++ b/app/services/heading_service/serialization/ns_nondeclarable_service.rb
@@ -34,18 +34,18 @@ module HeadingService
         :goods_nomenclature_descriptions,
         {
           footnotes: :footnote_descriptions,
-          ns_overview_measures: MEASURES_EAGER_LOAD,
-          ns_ancestors: [
+          overview_measures: MEASURES_EAGER_LOAD,
+          ancestors: [
             :goods_nomenclature_descriptions,
             {
-              ns_overview_measures: MEASURES_EAGER_LOAD,
+              overview_measures: MEASURES_EAGER_LOAD,
               footnotes: :footnote_descriptions,
             },
           ],
-          ns_descendants: [
+          descendants: [
             :goods_nomenclature_descriptions,
             {
-              ns_overview_measures: MEASURES_EAGER_LOAD,
+              overview_measures: MEASURES_EAGER_LOAD,
               footnotes: :footnote_descriptions,
             },
           ],

--- a/app/services/suggestions_service.rb
+++ b/app/services/suggestions_service.rb
@@ -28,7 +28,7 @@ class SuggestionsService
   def build_search_references_search_suggestions
     SearchReference
       .select(:id, :title, :goods_nomenclature_sid, :referenced_class)
-      .eager(referenced: :ns_children)
+      .eager(referenced: :children)
       .distinct(:title)
       .order(Sequel.desc(:title))
       .all
@@ -48,7 +48,7 @@ class SuggestionsService
   end
 
   def full_chemicals
-    @full_chemicals ||= FullChemical.eager(goods_nomenclature: :ns_children).all
+    @full_chemicals ||= FullChemical.eager(goods_nomenclature: :children).all
   end
 
   def build_search_reference_record(search_reference)

--- a/app/services/tree_integrity_checking_service.rb
+++ b/app/services/tree_integrity_checking_service.rb
@@ -18,9 +18,9 @@ class TreeIntegrityCheckingService
   private
 
   def check_for_tree_break!(chapter)
-    chapter.ns_descendants.each do |descendant|
-      if (descendant.ns_children.empty? && descendant.ns_descendants.any?) ||
-          descendant.ns_parent.nil?
+    chapter.descendants.each do |descendant|
+      if (descendant.children.empty? && descendant.descendants.any?) ||
+          descendant.parent.nil?
         @failures << descendant.goods_nomenclature_sid
       end
     end

--- a/app/views/api/v1/commodities/_commodity.json.rabl
+++ b/app/views/api/v1/commodities/_commodity.json.rabl
@@ -1,7 +1,7 @@
 extends 'api/v1/commodities/commodity_base'
 
 node(:children) do |commodity|
-  commodity.ns_children.map do |child_commodity|
+  commodity.children.map do |child_commodity|
     partial('api/v1/commodities/commodity', object: child_commodity)
   end
 end

--- a/app/views/api/v1/commodities/show.json.rabl
+++ b/app/views/api/v1/commodities/show.json.rabl
@@ -32,7 +32,7 @@ child @commodity.chapter do |chapter|
   end
 end
 
-child(@commodity.ns_ancestors => :ancestors) {
+child(@commodity.ancestors => :ancestors) {
   attributes :producline_suffix,
              :description,
              :number_indents,

--- a/app/views/api/v1/headings/show.json.rabl
+++ b/app/views/api/v1/headings/show.json.rabl
@@ -11,7 +11,7 @@ if footnotes.any?
   end
 end
 
-if @heading.ns_declarable?
+if @heading.declarable?
   attributes :basic_duty_rate
 
   extends 'api/v1/declarables/declarable', object: @heading, locals: { measures: @heading.applicable_measures }
@@ -33,7 +33,7 @@ else
     end
   end
 
-  child(@heading.ns_descendants) do
+  child(@heading.descendants) do
     attributes :description,
                :number_indents,
                :goods_nomenclature_item_id,
@@ -42,9 +42,9 @@ else
                :description_plain,
                :producline_suffix
 
-    attribute :leaf?, &:ns_leaf
+    attribute :leaf?, &:leaf
 
-    node(:parent_sid) { |commodity| commodity.ns_parent.try(:goods_nomenclature_sid) }
+    node(:parent_sid) { |commodity| commodity.parent.try(:goods_nomenclature_sid) }
     node(:search_references_count) { |commodity| commodity.search_references.count }
   end
 end

--- a/app/views/api/v1/headings/tree.json.rabl
+++ b/app/views/api/v1/headings/tree.json.rabl
@@ -1,6 +1,6 @@
 object @heading
 attributes :id, :declarable
 
-child(@heading.ns_descendants) do
+child(@heading.descendants) do
   attributes :id
 end

--- a/app/workers/generate_goods_nomenclatures_csv_report_worker.rb
+++ b/app/workers/generate_goods_nomenclatures_csv_report_worker.rb
@@ -24,13 +24,13 @@ class GenerateGoodsNomenclaturesCsvReportWorker
       .non_hidden
       .eager(
         :goods_nomenclature_descriptions,
-        ns_ancestors: :goods_nomenclature_descriptions,
-        ns_descendants: :goods_nomenclature_descriptions,
+        ancestors: :goods_nomenclature_descriptions,
+        descendants: :goods_nomenclature_descriptions,
       )
       .all
       .each_with_object([]) do |chapter, acc|
         acc << chapter
-        acc.concat chapter.ns_descendants
+        acc.concat chapter.descendants
       end
   end
 end

--- a/spec/controllers/api/v2/certificates_controller_search_spec.rb
+++ b/spec/controllers/api/v2/certificates_controller_search_spec.rb
@@ -58,20 +58,14 @@ RSpec.describe Api::V2::CertificatesController, type: :controller do
       )
     end
 
-    context 'when searching by code' do
-      let(:params) { { code: certificate.certificate_code } }
+    context 'when searching by code and type' do
+      let(:params) { { code: certificate.certificate_code, type: certificate.certificate_type_code } }
 
       it { expect(do_response.body).to match_json_expression pattern }
     end
 
     context 'when searching by description' do
       let(:params) { { description: certificate.description } }
-
-      it { expect(do_response.body).to match_json_expression pattern }
-    end
-
-    context 'when searching by type' do
-      let(:params) { { type: certificate.certificate_type_code } }
 
       it { expect(do_response.body).to match_json_expression pattern }
     end

--- a/spec/controllers/api/v2/chapters_controller_spec.rb
+++ b/spec/controllers/api/v2/chapters_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Api::V2::ChaptersController do
             attributes: {
               goods_nomenclature_sid: heading.goods_nomenclature_sid,
               goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
-              declarable: heading.ns_declarable?,
+              declarable: heading.declarable?,
               description: heading.description,
               producline_suffix: heading.producline_suffix,
               leaf: true,

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe GoodsNomenclatures::NestedSet do
 
       shared_examples 'it has ancestors' do |context_name, node, ancestors|
         context "with #{context_name}" do
-          subject { tree[node].ns_ancestors }
+          subject { tree[node].ancestors }
 
           it { is_expected.to eq_pk tree.values_at(*ancestors) }
         end
@@ -76,7 +76,7 @@ RSpec.describe GoodsNomenclatures::NestedSet do
 
       shared_examples 'it has parent' do |context_name, node, parent_node|
         context "with #{context_name}" do
-          subject { tree[node].ns_parent }
+          subject { tree[node].parent }
 
           it { is_expected.to eq_pk tree[parent_node] }
         end
@@ -84,7 +84,7 @@ RSpec.describe GoodsNomenclatures::NestedSet do
 
       shared_examples 'it has descendants' do |context_name, node, descendants|
         context "with #{context_name}" do
-          subject { tree[node].ns_descendants }
+          subject { tree[node].descendants }
 
           it { is_expected.to eq_pk tree.values_at(*descendants) }
         end
@@ -92,7 +92,7 @@ RSpec.describe GoodsNomenclatures::NestedSet do
 
       shared_examples 'it has children' do |context_name, node, children|
         context "with #{context_name}" do
-          subject { tree[node].ns_children }
+          subject { tree[node].children }
 
           it { is_expected.to eq_pk tree.values_at(*children) }
         end
@@ -110,7 +110,7 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         it { is_expected.not_to be_nil }
       end
 
-      describe '#ns_ancestors' do
+      describe '#ancestors' do
         let(:third_tier_ancestors) { tree.values_at(:chapter, :heading, :subheading) }
 
         it_behaves_like 'it has ancestors', 'chapter', :chapter, []
@@ -120,10 +120,10 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         it_behaves_like 'it has ancestors', 'leaf commodity', :commodity1, %i[chapter heading subheading subsubheading]
         it_behaves_like 'it has ancestors', 'second leaf commodity', :commodity3, %i[chapter heading subheading]
 
-        it_behaves_like 'it supports eager loading', :ns_ancestors
+        it_behaves_like 'it supports eager loading', :ancestors
 
         context 'for second tree' do
-          subject { tree[:second_tree].ns_ancestors.map(&:goods_nomenclature_item_id) }
+          subject { tree[:second_tree].ancestors.map(&:goods_nomenclature_item_id) }
 
           let(:commodity) { tree[:second_tree] }
 
@@ -138,40 +138,40 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         end
 
         context 'when eager loading' do
-          let(:eager_loaded) { commodities.eager(:ns_ancestors).all.first }
+          let(:eager_loaded) { commodities.eager(:ancestors).all.first }
 
           let :commodities do
             GoodsNomenclature.where(goods_nomenclature_sid: tree[:subsubheading].goods_nomenclature_sid)
           end
 
           context 'for eager loaded goods nomenclature' do
-            subject { eager_loaded.associations[:ns_parent] }
+            subject { eager_loaded.associations[:parent] }
 
             it { is_expected.to eq_pk tree[:subheading] }
           end
 
           context 'for eager loaded goods nomenclatures parents parent' do
-            subject { eager_loaded.associations[:ns_parent].associations[:ns_parent] }
+            subject { eager_loaded.associations[:parent].associations[:parent] }
 
             it { is_expected.to eq_pk tree[:heading] }
           end
 
           context 'for eager loaded goods nomenclatures parents ancestors' do
-            subject { eager_loaded.associations[:ns_parent].associations[:ns_ancestors] }
+            subject { eager_loaded.associations[:parent].associations[:ancestors] }
 
             it { is_expected.to eq_pk tree.values_at(:chapter, :heading) }
           end
         end
 
         describe 'values from db query' do
-          subject { tree[:subheading].ns_ancestors.map(&:values) }
+          subject { tree[:subheading].ancestors.map(&:values) }
 
           it { is_expected.to all include leaf: false }
           it { is_expected.to all include :number_indents }
         end
       end
 
-      describe '#ns_parent' do
+      describe '#parent' do
         it_behaves_like 'it has parent', 'chapter', :chapter, nil
         it_behaves_like 'it has parent', 'heading', :heading, :chapter
         it_behaves_like 'it has parent', 'subheading', :subheading, :heading
@@ -179,10 +179,10 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         it_behaves_like 'it has parent', 'leaf commodity', :commodity1, :subsubheading
         it_behaves_like 'it has parent', 'second leaf commodity', :commodity3, :subheading
 
-        it_behaves_like 'it supports eager loading', :ns_parent
+        it_behaves_like 'it supports eager loading', :parent
 
         context 'for second tree' do
-          subject { tree[:second_tree].ns_parent.goods_nomenclature_item_id }
+          subject { tree[:second_tree].parent.goods_nomenclature_item_id }
 
           let(:item_id) { "#{tree[:second_tree].goods_nomenclature_item_id.first(4)}000000" }
 
@@ -190,14 +190,14 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         end
 
         describe 'values from db query' do
-          subject { tree[:subheading].ns_parent.values }
+          subject { tree[:subheading].parent.values }
 
           it { is_expected.to include leaf: false }
           it { is_expected.to include number_indents: 0 }
         end
       end
 
-      describe '#ns_descendants' do
+      describe '#descendants' do
         it_behaves_like 'it has descendants', 'chapter', :chapter, %i[heading subheading subsubheading commodity1 commodity2 commodity3]
         it_behaves_like 'it has descendants', 'heading', :heading, %i[subheading subsubheading commodity1 commodity2 commodity3]
         it_behaves_like 'it has descendants', 'subheading', :subheading, %i[subsubheading commodity1 commodity2 commodity3]
@@ -205,10 +205,10 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         it_behaves_like 'it has descendants', 'leaf commodity', :commodity1, %i[]
         it_behaves_like 'it has descendants', 'second leaf commodity', :commodity3, %i[]
 
-        it_behaves_like 'it supports eager loading', :ns_descendants
+        it_behaves_like 'it supports eager loading', :descendants
 
         context 'for second tree' do
-          subject { tree[:second_tree].ns_descendants.map(&:goods_nomenclature_item_id) }
+          subject { tree[:second_tree].descendants.map(&:goods_nomenclature_item_id) }
 
           it { is_expected.to have_attributes length: 3 }
         end
@@ -223,43 +223,43 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         end
 
         context 'when eager loading' do
-          let(:eager_loaded) { commodities.eager(:ns_descendants).all.first }
+          let(:eager_loaded) { commodities.eager(:descendants).all.first }
 
           let :commodities do
             GoodsNomenclature.where(goods_nomenclature_sid: tree[:subheading].goods_nomenclature_sid)
           end
 
           context 'for eager loaded goods nomenclatures children' do
-            subject { eager_loaded.associations[:ns_children] }
+            subject { eager_loaded.associations[:children] }
 
             it { is_expected.to eq_pk [tree[:subsubheading], tree[:commodity3]] }
           end
 
           context 'for eager loaded goods_nomenclatures childs descendants' do
-            subject { eager_loaded.associations[:ns_children].first.associations[:ns_descendants] }
+            subject { eager_loaded.associations[:children].first.associations[:descendants] }
 
             it { is_expected.to eq_pk tree.values_at(:commodity1, :commodity2) }
           end
 
           context 'for eager loaded goods nomenclatures childs children' do
-            subject { eager_loaded.associations[:ns_children].first.associations[:ns_children] }
+            subject { eager_loaded.associations[:children].first.associations[:children] }
 
             it { is_expected.to eq_pk [tree[:commodity1], tree[:commodity2]] }
           end
 
           context 'for eager loaded goods nomenclatures childs parent' do
-            subject { eager_loaded.associations[:ns_children].first.associations[:ns_parent] }
+            subject { eager_loaded.associations[:children].first.associations[:parent] }
 
             it { is_expected.to eq_pk tree[:subheading] }
           end
 
           context 'for eager loaded goods nomenclatures childs childrens parent' do
             subject do
-              eager_loaded.associations[:ns_children]
+              eager_loaded.associations[:children]
                           .first
-                          .associations[:ns_children]
+                          .associations[:children]
                           .first
-                          .associations[:ns_parent]
+                          .associations[:parent]
             end
 
             it { is_expected.to eq_pk tree[:subsubheading] }
@@ -267,16 +267,16 @@ RSpec.describe GoodsNomenclatures::NestedSet do
 
           context 'when including ancestors' do
             let(:eager_loaded) do
-              commodities.eager(:ns_ancestors, :ns_descendants).all.first
+              commodities.eager(:ancestors, :descendants).all.first
             end
 
             context 'for eager loaded goods nomenclatures childs childrens parent' do
               subject(:leaf) do
-                eager_loaded.associations[:ns_children]
+                eager_loaded.associations[:children]
                             .first
-                            .associations[:ns_children]
+                            .associations[:children]
                             .first
-                            .associations[:ns_ancestors]
+                            .associations[:ancestors]
               end
 
               it 'populates descendant ancestors automatically' do
@@ -290,13 +290,13 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         end
 
         describe 'values from db query' do
-          subject { tree[:subheading].ns_descendants[0].values }
+          subject { tree[:subheading].descendants[0].values }
 
           it { is_expected.to include number_indents: 2 }
         end
       end
 
-      describe '#ns_children' do
+      describe '#children' do
         it_behaves_like 'it has children', 'chapter', :chapter, %i[heading]
         it_behaves_like 'it has children', 'heading', :heading, %i[subheading]
         it_behaves_like 'it has children', 'subheading', :subheading, %i[subsubheading commodity3]
@@ -304,10 +304,10 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         it_behaves_like 'it has children', 'leaf commodity', :commodity1, %i[]
         it_behaves_like 'it has children', 'second leaf commodity', :commodity3, %i[]
 
-        it_behaves_like 'it supports eager loading', :ns_children
+        it_behaves_like 'it supports eager loading', :children
 
         context 'for second tree' do
-          subject { tree[:second_tree].ns_children.map(&:goods_nomenclature_item_id) }
+          subject { tree[:second_tree].children.map(&:goods_nomenclature_item_id) }
 
           it { is_expected.to have_attributes length: 1 }
         end
@@ -322,7 +322,7 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         end
 
         describe 'values from db query' do
-          subject { tree[:subheading].ns_children[0].values }
+          subject { tree[:subheading].children[0].values }
 
           it { is_expected.to include number_indents: 2 }
         end
@@ -346,25 +346,25 @@ RSpec.describe GoodsNomenclatures::NestedSet do
                  number_indents: 2
         end
 
-        describe '#ns_ancestors' do
+        describe '#ancestors' do
           it_behaves_like 'it has ancestors', 'subsubheading', :subsubheading, %i[chapter heading]
           it_behaves_like 'it has ancestors', 'commodity under subsubheading', :commodity1, %i[chapter heading subsubheading]
           it_behaves_like 'it has ancestors', 'commodity under subheading', :commodity3, %i[chapter heading subsubheading]
         end
 
-        describe '#ns_parent' do
+        describe '#parent' do
           it_behaves_like 'it has parent', 'subsubheading', :subsubheading, :heading
           it_behaves_like 'it has parent', 'commodity under subsubheading', :commodity1, :subsubheading
           it_behaves_like 'it has parent', 'commodity under subheading', :commodity3, :subsubheading
         end
 
-        describe '#ns_descendants' do
+        describe '#descendants' do
           it_behaves_like 'it has descendants', 'heading', :heading, %i[subheading subsubheading commodity1 commodity2 commodity3]
           it_behaves_like 'it has descendants', 'subheading', :subheading, %i[]
           it_behaves_like 'it has descendants', 'nested subheading', :subsubheading, %i[commodity1 commodity2 commodity3]
         end
 
-        describe '#ns_children' do
+        describe '#children' do
           it_behaves_like 'it has children', 'heading', :heading, %i[subheading subsubheading]
           it_behaves_like 'it has children', 'subheading', :subheading, %i[]
           it_behaves_like 'it has children', 'nested subheading', :subsubheading, %i[commodity1 commodity2 commodity3]
@@ -373,25 +373,25 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         context 'when accessing historical data via TimeMachine' do
           around { |example| TimeMachine.at(2.weeks.ago) { example.run } }
 
-          describe '#ns_ancestors' do
+          describe '#ancestors' do
             it_behaves_like 'it has ancestors', 'nested subheading', :subsubheading, %i[chapter heading subheading]
             it_behaves_like 'it has ancestors', 'leaf commodity', :commodity1, %i[chapter heading subheading subsubheading]
             it_behaves_like 'it has ancestors', 'second leaf commodity', :commodity3, %i[chapter heading subheading]
           end
 
-          describe '#ns_parent' do
+          describe '#parent' do
             it_behaves_like 'it has parent', 'nested subheading', :subsubheading, :subheading
             it_behaves_like 'it has parent', 'leaf commodity', :commodity1, :subsubheading
             it_behaves_like 'it has parent', 'second leaf commodity', :commodity3, :subheading
           end
 
-          describe '#ns_descendants' do
+          describe '#descendants' do
             it_behaves_like 'it has descendants', 'heading', :heading, %i[subheading subsubheading commodity1 commodity2 commodity3]
             it_behaves_like 'it has descendants', 'subheading', :subheading, %i[subsubheading commodity1 commodity2 commodity3]
             it_behaves_like 'it has descendants', 'nested subheading', :subsubheading, %i[commodity1 commodity2]
           end
 
-          describe '#ns_children' do
+          describe '#children' do
             it_behaves_like 'it has children', 'heading', :heading, %i[subheading]
             it_behaves_like 'it has children', 'subheading', :subheading, %i[subsubheading commodity3]
             it_behaves_like 'it has children', 'nested subheading', :subsubheading, %i[commodity1 commodity2]
@@ -403,27 +403,27 @@ RSpec.describe GoodsNomenclatures::NestedSet do
 
           let(:commodity) { create :commodity }
 
-          describe '#ns_ancestors' do
-            it { expect { commodity.ns_ancestors }.to raise_exception described_class::DateNotSet }
+          describe '#ancestors' do
+            it { expect { commodity.ancestors }.to raise_exception described_class::DateNotSet }
           end
 
-          describe '#ns_parent' do
-            it { expect { commodity.ns_parent }.to raise_exception described_class::DateNotSet }
+          describe '#parent' do
+            it { expect { commodity.parent }.to raise_exception described_class::DateNotSet }
           end
 
-          describe '#ns_children' do
-            it { expect { commodity.ns_children }.to raise_exception described_class::DateNotSet }
+          describe '#children' do
+            it { expect { commodity.children }.to raise_exception described_class::DateNotSet }
           end
 
-          describe '#ns_descendants' do
-            it { expect { commodity.ns_descendants }.to raise_exception described_class::DateNotSet }
+          describe '#descendants' do
+            it { expect { commodity.descendants }.to raise_exception described_class::DateNotSet }
           end
         end
       end
     end
 
-    describe '#ns_measures' do
-      subject { measure.goods_nomenclature.ns_measures.map(&:measure_sid) }
+    describe '#measures' do
+      subject { measure.goods_nomenclature.measures.map(&:measure_sid) }
 
       let :measure do
         create :measure, :with_base_regulation, :with_goods_nomenclature, measure_type_id:
@@ -444,10 +444,10 @@ RSpec.describe GoodsNomenclatures::NestedSet do
           GoodsNomenclature
             .actual
             .where(goods_nomenclature_sid: measure.goods_nomenclature_sid)
-            .eager(:ns_measures)
+            .eager(:measures)
             .all
             .first
-            .associations[:ns_measures]
+            .associations[:measures]
             .map(&:measure_sid)
         end
 
@@ -455,8 +455,8 @@ RSpec.describe GoodsNomenclatures::NestedSet do
       end
     end
 
-    describe '#ns_overview_measures' do
-      subject { measure.goods_nomenclature.ns_overview_measures.map(&:measure_sid) }
+    describe '#overview_measures' do
+      subject { measure.goods_nomenclature.overview_measures.map(&:measure_sid) }
 
       let :measure do
         create :measure, :with_base_regulation, :with_goods_nomenclature, measure_type_id:
@@ -483,10 +483,10 @@ RSpec.describe GoodsNomenclatures::NestedSet do
           GoodsNomenclature
             .actual
             .where(goods_nomenclature_sid: measure.goods_nomenclature_sid)
-            .eager(:ns_overview_measures)
+            .eager(:overview_measures)
             .all
             .first
-            .associations[:ns_overview_measures]
+            .associations[:overview_measures]
             .map(&:measure_sid)
         end
 
@@ -513,34 +513,34 @@ RSpec.describe GoodsNomenclatures::NestedSet do
     it { is_expected.to include commodity.pk => true }
   end
 
-  describe '.ns_declarable' do
-    subject { GoodsNomenclature.actual.ns_declarable.all }
+  describe '.declarable' do
+    subject { GoodsNomenclature.actual.declarable.all }
 
     before { commodity }
 
     let(:commodity) { create :commodity, :non_grouping, :with_children }
 
     it { is_expected.not_to include commodity }
-    it { is_expected.to include commodity.ns_children.first.ns_children.first }
+    it { is_expected.to include commodity.children.first.children.first }
   end
 
-  describe '#ns_declarable?' do
+  describe '#declarable?' do
     context 'with descendants' do
       subject { create :commodity, :non_grouping, :with_children }
 
-      it { is_expected.not_to be_ns_declarable }
+      it { is_expected.not_to be_declarable }
     end
 
     context 'without descendants' do
       subject { create :commodity, :non_grouping, :without_children }
 
-      it { is_expected.to be_ns_declarable }
+      it { is_expected.to be_declarable }
     end
 
     context 'with grouping productline suffix' do
       subject { create :commodity, :grouping, :without_children }
 
-      it { is_expected.not_to be_ns_declarable }
+      it { is_expected.not_to be_declarable }
     end
   end
 
@@ -561,19 +561,19 @@ RSpec.describe GoodsNomenclatures::NestedSet do
       end
 
       context 'with chapter' do
-        let(:gn) { commodity.ns_ancestors[0] }
+        let(:gn) { commodity.ancestors[0] }
 
         it { is_expected.to be 0 }
       end
 
       context 'with heading' do
-        let(:gn) { commodity.ns_ancestors[1] }
+        let(:gn) { commodity.ancestors[1] }
 
         it { is_expected.to be 0 }
       end
 
       context 'with commodity' do
-        let(:gn) { commodity.ns_parent.ns_descendants[0] }
+        let(:gn) { commodity.parent.descendants[0] }
 
         it { is_expected.to be 1 }
       end
@@ -590,7 +590,7 @@ RSpec.describe GoodsNomenclatures::NestedSet do
              :with_base_regulation,
              geographical_area_id: 'ES',
              measure_type_id: 2,
-             goods_nomenclature: subheading.ns_children.first
+             goods_nomenclature: subheading.children.first
     end
 
     it { is_expected.to eq_pk [measure] }
@@ -602,7 +602,7 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         create :measure,
                :with_base_regulation,
                geographical_area_id: 'FR',
-               goods_nomenclature: subheading.ns_parent
+               goods_nomenclature: subheading.parent
       end
 
       let :parent_measure do
@@ -629,7 +629,7 @@ RSpec.describe GoodsNomenclatures::NestedSet do
              :supplementary,
              :with_base_regulation,
              :erga_omnes,
-             goods_nomenclature: subheading.ns_children.first
+             goods_nomenclature: subheading.children.first
     end
 
     it { is_expected.to eq_pk [measure] }
@@ -642,7 +642,7 @@ RSpec.describe GoodsNomenclatures::NestedSet do
                :vat,
                :with_base_regulation,
                :erga_omnes,
-               goods_nomenclature: subheading.ns_parent
+               goods_nomenclature: subheading.parent
       end
 
       let :parent_measure do

--- a/spec/models/goods_nomenclatures/tree_node_spec.rb
+++ b/spec/models/goods_nomenclatures/tree_node_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe GoodsNomenclatures::TreeNode do
     let(:subheading) { create :subheading, :with_chapter_and_heading }
     let(:commodities) { create_list :commodity, 2, parent: subheading }
 
-    it { is_expected.to include subheading.chapter.pk => [subheading.ns_parent.pk] }
+    it { is_expected.to include subheading.chapter.pk => [subheading.parent.pk] }
     it { is_expected.to include subheading.pk => commodities.map(&:pk) }
     it { is_expected.to include commodities.first.pk => [nil] }
   end

--- a/spec/presenters/api/admin/headings/heading_presenter_spec.rb
+++ b/spec/presenters/api/admin/headings/heading_presenter_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Api::Admin::Headings::HeadingPresenter do
   let(:counts) do
     {
       heading.goods_nomenclature_sid => 1,
-      heading.ns_descendants.first.goods_nomenclature_sid => 3,
-      heading.ns_descendants.last.goods_nomenclature_sid => 3,
+      heading.descendants.first.goods_nomenclature_sid => 3,
+      heading.descendants.last.goods_nomenclature_sid => 3,
     }
   end
 
@@ -27,7 +27,7 @@ RSpec.describe Api::Admin::Headings::HeadingPresenter do
     it { is_expected.to have_attributes values: heading.values }
     it { is_expected.to have_attributes search_references_count: 1 }
     it { expect(presented.commodities).to have_attributes length: 2 }
-    it { expect(presented.commodities.first).to have_attributes pk: heading.ns_descendants.first.pk }
+    it { expect(presented.commodities.first).to have_attributes pk: heading.descendants.first.pk }
     it { expect(presented.commodities.first).to have_attributes search_references_count: 3 }
   end
 end

--- a/spec/presenters/api/v2/commodities/commodity_presenter_spec.rb
+++ b/spec/presenters/api/v2/commodities/commodity_presenter_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Api::V2::Commodities::CommodityPresenter do
   describe '#ancestors' do
     subject { described_class.new(commodity, MeasureCollection.new([])).ancestors }
 
-    let(:commodity) { subheading.ns_children.first }
+    let(:commodity) { subheading.children.first }
     let(:subheading) { create :subheading, :with_chapter_and_heading, :with_children }
 
     it { is_expected.to eq_pk [subheading] }

--- a/spec/presenters/api/v2/headings/commodity_presenter_spec.rb
+++ b/spec/presenters/api/v2/headings/commodity_presenter_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Api::V2::Headings::CommodityPresenter do
     end
 
     context 'for non_declarable' do
-      subject { described_class.new child.ns_parent }
+      subject { described_class.new child.parent }
 
       it { is_expected.to have_attributes declarable: false }
       it { is_expected.to have_attributes leaf: false }
@@ -54,7 +54,7 @@ RSpec.describe Api::V2::Headings::CommodityPresenter do
 
     let(:measures) do
       [
-        Api::V2::Measures::MeasurePresenter.new(heading_measure, commodity.ns_parent),
+        Api::V2::Measures::MeasurePresenter.new(heading_measure, commodity.parent),
         Api::V2::Measures::MeasurePresenter.new(measure, commodity),
       ]
     end
@@ -64,7 +64,7 @@ RSpec.describe Api::V2::Headings::CommodityPresenter do
     end
 
     let :heading_measure do
-      create :measure, :with_base_regulation, :supplementary, goods_nomenclature: commodity.ns_parent
+      create :measure, :with_base_regulation, :supplementary, goods_nomenclature: commodity.parent
     end
 
     it 'has expected measures' do

--- a/spec/presenters/api/v2/subheadings/subheading_presenter_spec.rb
+++ b/spec/presenters/api/v2/subheadings/subheading_presenter_spec.rb
@@ -9,27 +9,25 @@ RSpec.describe Api::V2::Subheadings::SubheadingPresenter do
   it { is_expected.to have_attributes chapter_id: subheading.chapter.goods_nomenclature_sid }
   it { is_expected.to have_attributes section: instance_of(Api::V2::Headings::SectionPresenter) }
   it { is_expected.to have_attributes chapter: instance_of(Api::V2::Headings::ChapterPresenter) }
-  it { is_expected.to have_attributes ancestors: [] }
+  it { is_expected.to have_attributes ten_digit_ancestors: [] }
 
   it 'includes ancestors and self in commodities' do
-    commodities = subheading.ns_ancestors.select { |anc| anc.number_indents.positive? }
+    commodities = subheading.ancestors.select { |anc| anc.number_indents.positive? }
     commodities << subheading
-    commodities += subheading.ns_descendants
+    commodities += subheading.descendants
 
     expect(presenter.commodity_ids).to eq commodities.map(&:goods_nomenclature_sid)
   end
 
-  it 'maps commodities to their presenter' do
-    expect(presenter.commodities).to all be_instance_of Api::V2::Headings::CommodityPresenter
-  end
+  it { expect(presenter.commodities).to all(be_instance_of(Api::V2::Headings::CommodityPresenter)) }
 
   context 'for subsubheading' do
     subject(:presenter) { described_class.new leaf }
 
-    let(:leaf) { subheading.ns_children.first }
-    let(:leaf_commodities) { [leaf.ns_parent, leaf] + leaf.ns_descendants }
+    let(:leaf) { subheading.children.first }
+    let(:leaf_commodities) { [leaf.parent, leaf] + leaf.descendants }
 
-    it { is_expected.to have_attributes ancestors: [leaf.ns_parent] }
+    it { is_expected.to have_attributes ten_digit_ancestors: [leaf.parent] }
     it { is_expected.to have_attributes commodity_ids: leaf_commodities.map(&:pk) }
   end
 

--- a/spec/serializers/api/admin/chapters/heading_serializer_spec.rb
+++ b/spec/serializers/api/admin/chapters/heading_serializer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Api::Admin::Chapters::HeadingSerializer do
           goods_nomenclature_sid: serializable.goods_nomenclature_sid,
           goods_nomenclature_item_id: serializable.goods_nomenclature_item_id,
           description: serializable.description,
-          declarable: serializable.ns_declarable?,
+          declarable: serializable.declarable?,
           search_references_count: 0,
         },
       },

--- a/spec/serializers/api/v2/headings/heading_serializer_spec.rb
+++ b/spec/serializers/api/v2/headings/heading_serializer_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Api::V2::Headings::HeadingSerializer do
           footnotes: { data: [] },
           section: { data: { id: chapter.section.id.to_s, type: 'section' } },
           chapter: { data: { id: chapter.goods_nomenclature_sid.to_s, type: 'chapter' } },
-          commodities: { data: [{ id: heading.ns_descendants.first.goods_nomenclature_sid.to_s, type: 'commodity' }] },
+          commodities: { data: [{ id: heading.descendants.first.goods_nomenclature_sid.to_s, type: 'commodity' }] },
         },
       },
     }

--- a/spec/services/find_ancestors_service_spec.rb
+++ b/spec/services/find_ancestors_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe FindAncestorsService do
     let(:goods_nomenclature_item_id) { commodity.goods_nomenclature_item_id }
 
     it 'returns the correct ancestors' do
-      expected_result = commodity.ns_ancestors.pluck(:goods_nomenclature_item_id).push(goods_nomenclature_item_id)
+      expected_result = commodity.ancestors.pluck(:goods_nomenclature_item_id).push(goods_nomenclature_item_id)
 
       expect(service).to eq(expected_result)
     end
@@ -25,7 +25,7 @@ RSpec.describe FindAncestorsService do
     let(:goods_nomenclature_item_id) { chapter.goods_nomenclature_item_id }
 
     it 'returns the correct ancestors' do
-      expected_result = chapter.ns_ancestors.pluck(:goods_nomenclature_item_id).push(goods_nomenclature_item_id)
+      expected_result = chapter.ancestors.pluck(:goods_nomenclature_item_id).push(goods_nomenclature_item_id)
 
       expect(service).to eq(expected_result)
     end
@@ -36,7 +36,7 @@ RSpec.describe FindAncestorsService do
     let(:goods_nomenclature_item_id) { heading.goods_nomenclature_item_id }
 
     it 'returns the correct ancestors' do
-      expected_result = heading.ns_ancestors.pluck(:goods_nomenclature_item_id).push(goods_nomenclature_item_id)
+      expected_result = heading.ancestors.pluck(:goods_nomenclature_item_id).push(goods_nomenclature_item_id)
 
       expect(service).to eq(expected_result)
     end


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [ ] Rename all occurances of `ns_<method_name>` to just `<method_name>`

### Why?

I am doing this because:

- We do not need api users to know about nested set internals
