### PR TITLE
BAU: Fixes basic auth api

### DIFF
--- a/app/lib/tariff_synchronizer/tariff_updates_requester.rb
+++ b/app/lib/tariff_synchronizer/tariff_updates_requester.rb
@@ -56,7 +56,7 @@ module TariffSynchronizer
 
       client = Faraday.new(uri.host) do |conn|
         if TradeTariffBackend.xi?
-          conn.request :basic_auth, TariffSynchronizer.username, TariffSynchronizer.password
+          conn.set_basic_auth(TariffSynchronizer.username, TariffSynchronizer.password)
         end
       end
 


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Fixes basic_auth api

### Why?

I am doing this because:

- This is required since the api for setting basic auth on the faraday connection changed. We were being warned but ignored the warnings
