### PR TITLE
BAU: Run Worker Commands

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -21,8 +21,8 @@ Terraform to deploy the service into AWS.
 |------|--------|---------|
 | <a name="module_backend_uk"></a> [backend\_uk](#module\_backend\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.8.0 |
 | <a name="module_backend_xi"></a> [backend\_xi](#module\_backend\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.8.0 |
-| <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | 4ff9670 |
-| <a name="module_worker_xi"></a> [worker\_xi](#module\_worker\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | 4ff9670 |
+| <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | d178ba0 |
+| <a name="module_worker_xi"></a> [worker\_xi](#module\_worker\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | d178ba0 |
 
 ## Resources
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -21,6 +21,8 @@ Terraform to deploy the service into AWS.
 |------|--------|---------|
 | <a name="module_backend_uk"></a> [backend\_uk](#module\_backend\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.8.0 |
 | <a name="module_backend_xi"></a> [backend\_xi](#module\_backend\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.8.0 |
+| <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.9.0 |
+| <a name="module_worker_xi"></a> [worker\_xi](#module\_worker\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.9.0 |
 
 ## Resources
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -21,8 +21,8 @@ Terraform to deploy the service into AWS.
 |------|--------|---------|
 | <a name="module_backend_uk"></a> [backend\_uk](#module\_backend\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.8.0 |
 | <a name="module_backend_xi"></a> [backend\_xi](#module\_backend\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.8.0 |
-| <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | d178ba0 |
-| <a name="module_worker_xi"></a> [worker\_xi](#module\_worker\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | d178ba0 |
+| <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.10.0 |
+| <a name="module_worker_xi"></a> [worker\_xi](#module\_worker\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.10.0 |
 
 ## Resources
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -21,8 +21,8 @@ Terraform to deploy the service into AWS.
 |------|--------|---------|
 | <a name="module_backend_uk"></a> [backend\_uk](#module\_backend\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.8.0 |
 | <a name="module_backend_xi"></a> [backend\_xi](#module\_backend\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.8.0 |
-| <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.9.0 |
-| <a name="module_worker_xi"></a> [worker\_xi](#module\_worker\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.9.0 |
+| <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | 4ff9670 |
+| <a name="module_worker_xi"></a> [worker\_xi](#module\_worker\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | 4ff9670 |
 
 ## Resources
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,7 +1,7 @@
 locals {
   no_reply = "no-reply@trade-tariff.service.gov.uk"
 
-  worker_command = ["/bin/sh", "bundle exec sidekiq -C", "./config/sidekiq.yml"]
+  worker_command = ["/bin/sh", "-c", "bundle exec sidekiq -C ./config/sidekiq.yml"]
 
   backend_common_vars = [
     {

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,8 +1,8 @@
 locals {
   no_reply = "no-reply@trade-tariff.service.gov.uk"
-}
 
-locals {
+  worker_command = ["/bin/sh", "bundle exec sidekiq -C", "./config/sidekiq.yml"]
+
   backend_common_vars = [
     {
       name  = "PORT"

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -1,5 +1,5 @@
 module "worker_uk" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.9.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=4ff9670"
 
   service_name  = "worker-uk"
   service_count = var.service_count
@@ -35,7 +35,8 @@ module "worker_uk" {
 
   enable_ecs_exec = true
 
-  container_command = local.worker_command
+  container_entrypoint = [""]
+  container_command    = local.worker_command
 
   service_environment_config = flatten([local.backend_common_vars,
     [

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -1,5 +1,5 @@
 module "worker_uk" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=4ff9670"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=d178ba0"
 
   service_name  = "worker-uk"
   service_count = var.service_count
@@ -9,7 +9,6 @@ module "worker_uk" {
   cluster_name              = "trade-tariff-cluster-${var.environment}"
   subnet_ids                = data.aws_subnets.private.ids
   security_groups           = [data.aws_security_group.this.id]
-  target_group_arn          = data.aws_lb_target_group.this["backend-uk-tg-${var.environment}"].arn
   cloudwatch_log_group_name = "platform-logs-${var.environment}"
 
   min_capacity = var.min_capacity

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -1,5 +1,5 @@
 module "worker_uk" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.8.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.9.0"
 
   service_name  = "worker-uk"
   service_count = var.service_count
@@ -35,6 +35,8 @@ module "worker_uk" {
 
   enable_ecs_exec = true
 
+  container_command = ["bundle exec sidekiq -C ./config/sidekiq.yml"]
+
   service_environment_config = flatten([local.backend_common_vars,
     [
       {
@@ -60,10 +62,6 @@ module "worker_uk" {
       {
         name  = "VCAP_APPLICATION"
         value = "{}"
-      },
-      {
-        name  = "command"
-        value = "[tail, -f, /dev/null]"
       }
     ]
   ])

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -1,5 +1,5 @@
 module "worker_uk" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=d178ba0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.10.0"
 
   service_name  = "worker-uk"
   service_count = var.service_count

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -35,7 +35,7 @@ module "worker_uk" {
 
   enable_ecs_exec = true
 
-  container_command = ["bundle exec sidekiq -C ./config/sidekiq.yml"]
+  container_command = ["/bin/sh", "bundle exec sidekiq -C ./config/sidekiq.yml"]
 
   service_environment_config = flatten([local.backend_common_vars,
     [

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -35,7 +35,7 @@ module "worker_uk" {
 
   enable_ecs_exec = true
 
-  container_command = ["/bin/sh", "bundle exec sidekiq -C ./config/sidekiq.yml"]
+  container_command = local.worker_command
 
   service_environment_config = flatten([local.backend_common_vars,
     [

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -35,7 +35,7 @@ module "worker_xi" {
 
   enable_ecs_exec = true
 
-  container_command = ["bundle exec sidekiq -C ./config/sidekiq.yml"]
+  container_command = ["/bin/sh", "bundle exec sidekiq -C ./config/sidekiq.yml"]
 
   service_environment_config = flatten([local.backend_common_vars,
     [

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -35,7 +35,7 @@ module "worker_xi" {
 
   enable_ecs_exec = true
 
-  container_command = ["/bin/sh", "bundle exec sidekiq -C ./config/sidekiq.yml"]
+  container_command = local.worker_command
 
   service_environment_config = flatten([local.backend_common_vars,
     [

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -1,5 +1,5 @@
 module "worker_xi" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=4ff9670"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=d178ba0"
 
   service_name  = "worker-xi"
   service_count = var.service_count
@@ -9,7 +9,6 @@ module "worker_xi" {
   cluster_name              = "trade-tariff-cluster-${var.environment}"
   subnet_ids                = data.aws_subnets.private.ids
   security_groups           = [data.aws_security_group.this.id]
-  target_group_arn          = data.aws_lb_target_group.this["backend-xi-tg-${var.environment}"].arn
   cloudwatch_log_group_name = "platform-logs-${var.environment}"
 
   min_capacity = var.min_capacity

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -1,5 +1,5 @@
 module "worker_xi" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.9.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=4ff9670"
 
   service_name  = "worker-xi"
   service_count = var.service_count
@@ -35,7 +35,8 @@ module "worker_xi" {
 
   enable_ecs_exec = true
 
-  container_command = local.worker_command
+  container_entrypoint = [""]
+  container_command    = local.worker_command
 
   service_environment_config = flatten([local.backend_common_vars,
     [

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -1,5 +1,5 @@
 module "worker_xi" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.8.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.9.0"
 
   service_name  = "worker-xi"
   service_count = var.service_count
@@ -35,6 +35,8 @@ module "worker_xi" {
 
   enable_ecs_exec = true
 
+  container_command = ["bundle exec sidekiq -C ./config/sidekiq.yml"]
+
   service_environment_config = flatten([local.backend_common_vars,
     [
       {
@@ -60,10 +62,6 @@ module "worker_xi" {
       {
         name  = "VCAP_APPLICATION"
         value = "{}"
-      },
-      {
-        name  = "command"
-        value = "[tail, -f, /dev/null]"
       }
     ]
   ])

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -1,5 +1,5 @@
 module "worker_xi" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=d178ba0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.10.0"
 
   service_name  = "worker-xi"
   service_count = var.service_count


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Added worker command
- Bumped worker module versions

### Why?

I am doing this because:

- The workers had commands passed as env vars, which is not what we want - we want to use the new module that supports overriding `entrypoint` and providing `command`.