### PR TITLE
HOTT-3603: Add show_proofs_for_geographical_areas to roo_scheme_uk.

### DIFF
--- a/app/models/rules_of_origin/data_set.rb
+++ b/app/models/rules_of_origin/data_set.rb
@@ -15,7 +15,7 @@ module RulesOfOrigin
     private
 
       def default_scheme_set
-        RulesOfOrigin::SchemeSet.from_default_file(TradeTariffBackend.service)
+        RulesOfOrigin::TradingScheme.from_default_file(TradeTariffBackend.service)
       end
 
       def default_rule_set

--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -10,7 +10,7 @@ module RulesOfOrigin
 
     attr_reader :cumulation_methods, :validity_start_date, :validity_end_date
 
-    attr_writer :rule_sets, :proof_codes
+    attr_writer :rule_sets, :proof_codes, :show_proofs_for_geographical_areas
 
     delegate :read_referenced_file, to: :scheme_set
 
@@ -23,6 +23,10 @@ module RulesOfOrigin
 
     def links
       @links || []
+    end
+
+    def show_proofs_for_geographical_areas
+      @show_proofs_for_geographical_areas || []
     end
 
     def cumulation_methods=(cumulation_methods_data)

--- a/app/models/rules_of_origin/scheme_set.rb
+++ b/app/models/rules_of_origin/scheme_set.rb
@@ -2,6 +2,7 @@
 
 module RulesOfOrigin
   class SchemeSet
+    # Scheme in this context is the Trading Scheme and not a scheme that provide a validation
     DEFAULT_SOURCE_PATH = Rails.root.join('db/rules_of_origin').freeze
 
     attr_reader :base_path, :links, :proof_urls

--- a/app/models/rules_of_origin/trading_scheme.rb
+++ b/app/models/rules_of_origin/trading_scheme.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 module RulesOfOrigin
-  class SchemeSet
-    # Scheme in this context is the Trading Scheme and not a scheme that provide a validation
+  class TradingScheme
     DEFAULT_SOURCE_PATH = Rails.root.join('db/rules_of_origin').freeze
 
     attr_reader :base_path, :links, :proof_urls

--- a/app/serializers/api/v2/rules_of_origin/full_scheme_serializer.rb
+++ b/app/serializers/api/v2/rules_of_origin/full_scheme_serializer.rb
@@ -8,9 +8,17 @@ module Api
 
         set_id :scheme_code
 
-        attributes :scheme_code, :title, :countries, :footnote, :unilateral,
-                   :fta_intro, :introductory_notes, :cumulation_methods,
-                   :proof_intro, :proof_codes
+        attributes :scheme_code,
+                   :title,
+                   :countries,
+                   :footnote,
+                   :unilateral,
+                   :fta_intro,
+                   :introductory_notes,
+                   :cumulation_methods,
+                   :proof_intro,
+                   :proof_codes,
+                   :show_proofs_for_geographical_areas
 
         has_many :rules, serializer: Api::V2::RulesOfOrigin::RuleSerializer
         has_many :links, serializer: Api::V2::RulesOfOrigin::LinkSerializer

--- a/app/serializers/api/v2/rules_of_origin/scheme_serializer.rb
+++ b/app/serializers/api/v2/rules_of_origin/scheme_serializer.rb
@@ -8,8 +8,13 @@ module Api
 
         set_id :scheme_code
 
-        attributes :scheme_code, :title, :countries, :unilateral,
-                   :proof_intro, :proof_codes
+        attributes :scheme_code,
+                   :title,
+                   :countries,
+                   :unilateral,
+                   :proof_intro,
+                   :proof_codes,
+                   :show_proofs_for_geographical_areas
 
         has_many :links, serializer: Api::V2::RulesOfOrigin::LinkSerializer
         has_many :proofs, serializer: Api::V2::RulesOfOrigin::ProofSerializer

--- a/db/rules_of_origin/roo_schemes_uk.json
+++ b/db/rules_of_origin/roo_schemes_uk.json
@@ -441,6 +441,9 @@
             ],
             "countries": [
                 "AU"
+            ],
+            "show_proofs_for_geographical_areas": [
+                "AU"
             ]
         },
         {
@@ -3157,6 +3160,9 @@
             ],
             "countries": [
                 "NZ"
+            ],
+            "show_proofs_for_geographical_areas": [
+                "NZ"
             ]
         },
         {
@@ -5204,6 +5210,9 @@
                 "TZ",
                 "YE",
                 "ZM"
+            ],
+            "show_proofs_for_geographical_areas": [
+                "1062"
             ]
         },
         {
@@ -5376,6 +5385,10 @@
                 "PH",
                 "LK",
                 "UZ"
+            ],
+            "show_proofs_for_geographical_areas": [
+                "1060",
+                "1061"
             ]
         }
     ],

--- a/spec/factories/rules_of_origin/trading_scheme_factory.rb
+++ b/spec/factories/rules_of_origin/trading_scheme_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :rules_of_origin_scheme_set, class: 'RulesOfOrigin::SchemeSet' do
+  factory :rules_of_origin_scheme_set, class: 'RulesOfOrigin::TradingScheme' do
     initialize_with { new base_path, scheme_data.to_json }
 
     transient do

--- a/spec/features/rules_of_origin_data_spec.rb
+++ b/spec/features/rules_of_origin_data_spec.rb
@@ -4,7 +4,7 @@ unless RSpec.configuration.filter.opposite.rules[:roo_data]
   RSpec.describe 'Rules of Origin Data', :roo_data do
     describe 'v2 rulesets' do
       %w[uk xi].each do |service|
-        RulesOfOrigin::SchemeSet::DEFAULT_SOURCE_PATH
+        RulesOfOrigin::TradingScheme::DEFAULT_SOURCE_PATH
           .join("roo_schemes_#{service}", 'rule_sets')
           .children
           .each do |data_set_json|
@@ -24,7 +24,7 @@ unless RSpec.configuration.filter.opposite.rules[:roo_data]
     end
 
     describe 'UK articles' do
-      RulesOfOrigin::SchemeSet::DEFAULT_SOURCE_PATH
+      RulesOfOrigin::TradingScheme::DEFAULT_SOURCE_PATH
         .join('roo_schemes_uk', 'articles')
         .children
         .select(&:directory?)

--- a/spec/models/rules_of_origin/proof_spec.rb
+++ b/spec/models/rules_of_origin/proof_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe RulesOfOrigin::Proof do
     let(:scheme) { build :rules_of_origin_scheme, scheme_set: }
     let(:proof_urls) { { 'origin-declaration' => 'https://www.gov.uk/' } }
     let(:proof_class) { 'origin-declaration' }
-    let(:scheme_set) { instance_double RulesOfOrigin::SchemeSet, proof_urls: }
+    let(:scheme_set) { instance_double RulesOfOrigin::TradingScheme, proof_urls: }
 
     context 'without proof_class' do
       let(:proof_class) { nil }
@@ -104,7 +104,7 @@ RSpec.describe RulesOfOrigin::Proof do
 
     let(:scheme) { build :rules_of_origin_scheme, scheme_set: }
     let(:proof_class) { 'origin-declaration' }
-    let(:scheme_set) { instance_double RulesOfOrigin::SchemeSet, read_referenced_file: 'foobar' }
+    let(:scheme_set) { instance_double RulesOfOrigin::TradingScheme, read_referenced_file: 'foobar' }
 
     context 'when assigned directly' do
       let(:proof) { build :rules_of_origin_proof, proof_class:, scheme: }

--- a/spec/models/rules_of_origin/scheme_spec.rb
+++ b/spec/models/rules_of_origin/scheme_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe RulesOfOrigin::Scheme do
     end
 
     let(:intro_file) { 'intro.md' }
-    let(:scheme_set) { instance_double RulesOfOrigin::SchemeSet }
+    let(:scheme_set) { instance_double RulesOfOrigin::TradingScheme }
 
     it 'will read the referenced file' do
       expect(scheme).to have_attributes fta_intro: 'fta intro content'
@@ -239,7 +239,7 @@ RSpec.describe RulesOfOrigin::Scheme do
     end
 
     let(:notes_file) { 'notes.md' }
-    let(:scheme_set) { instance_double RulesOfOrigin::SchemeSet }
+    let(:scheme_set) { instance_double RulesOfOrigin::TradingScheme }
 
     it 'will read the referenced file' do
       expect(scheme).to \

--- a/spec/models/rules_of_origin/trading_scheme_spec.rb
+++ b/spec/models/rules_of_origin/trading_scheme_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe RulesOfOrigin::SchemeSet do
+RSpec.describe RulesOfOrigin::TradingScheme do
   subject(:scheme_set) { described_class.from_file test_file }
 
   let(:test_file) { Rails.root.join('db/rules_of_origin/roo_schemes_uk.json') }

--- a/spec/serializers/api/v2/rules_of_origin/full_scheme_serializer_spec.rb
+++ b/spec/serializers/api/v2/rules_of_origin/full_scheme_serializer_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Api::V2::RulesOfOrigin::FullSchemeSerializer do
           :with_proofs,
           :with_origin_reference_document,
           scheme_set:,
-          unilateral: true
+          unilateral: true,
+          show_proofs_for_geographical_areas: %w[AU]
   end
 
   let :rules do
@@ -38,6 +39,7 @@ RSpec.describe Api::V2::RulesOfOrigin::FullSchemeSerializer do
           introductory_notes: scheme.introductory_notes,
           proof_intro: nil,
           proof_codes: {},
+          show_proofs_for_geographical_areas: %w[AU],
         },
         relationships: {
           links: {

--- a/spec/serializers/api/v2/rules_of_origin/proof_serializer_spec.rb
+++ b/spec/serializers/api/v2/rules_of_origin/proof_serializer_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Api::V2::RulesOfOrigin::ProofSerializer do
   subject(:serializable) { described_class.new(proof).serializable_hash }
 
-  let(:scheme_set) { instance_double RulesOfOrigin::SchemeSet, proof_urls: urls }
+  let(:scheme_set) { instance_double RulesOfOrigin::TradingScheme, proof_urls: urls }
   let(:scheme) { build :rules_of_origin_scheme, scheme_set: }
   let(:proof) { build :rules_of_origin_proof, scheme: }
   let(:urls) { { 'origin-declaration' => 'https://www.gov.uk/' } }

--- a/spec/serializers/api/v2/rules_of_origin/scheme_serializer_spec.rb
+++ b/spec/serializers/api/v2/rules_of_origin/scheme_serializer_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemeSerializer do
           :with_links,
           :with_origin_reference_document,
           scheme_set:,
-          unilateral: true
+          unilateral: true,
+          show_proofs_for_geographical_areas: ['AU']
   end
 
   let :serializer do
@@ -29,6 +30,7 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemeSerializer do
           unilateral: true,
           proof_intro: nil,
           proof_codes: {},
+          show_proofs_for_geographical_areas: ['AU']
         },
         relationships: {
           links: {

--- a/spec/serializers/api/v2/rules_of_origin/scheme_serializer_spec.rb
+++ b/spec/serializers/api/v2/rules_of_origin/scheme_serializer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemeSerializer do
           :with_origin_reference_document,
           scheme_set:,
           unilateral: true,
-          show_proofs_for_geographical_areas: ['AU']
+          show_proofs_for_geographical_areas: %w[AU]
   end
 
   let :serializer do
@@ -30,7 +30,7 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemeSerializer do
           unilateral: true,
           proof_intro: nil,
           proof_codes: {},
-          show_proofs_for_geographical_areas: ['AU']
+          show_proofs_for_geographical_areas: %w[AU],
         },
         relationships: {
           links: {


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-3611

### What?
To fix where the DCTS instructions are also showing, the attribute `show_proofs_for_geographical_areas` has been added to the roo scheme uk.

### Why?
To fix this:

![image](https://github.com/trade-tariff/trade-tariff-backend/assets/58971/4c9c919e-a2e0-4c84-b9f7-9c7cb516820c)

### Have you? (optional)

- [ ] Added documentation for new apis
