### PR TITLE
HOTT-3611: Add show_proofs_for_geographical_areas to roo_scheme_uk.

### DIFF
--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -10,7 +10,7 @@ module RulesOfOrigin
 
     attr_reader :cumulation_methods, :validity_start_date, :validity_end_date
 
-    attr_writer :rule_sets, :proof_codes
+    attr_writer :rule_sets, :proof_codes, :show_proofs_for_geographical_areas
 
     delegate :read_referenced_file, to: :scheme_set
 
@@ -23,6 +23,10 @@ module RulesOfOrigin
 
     def links
       @links || []
+    end
+
+    def show_proofs_for_geographical_areas
+      @show_proofs_for_geographical_areas || []
     end
 
     def cumulation_methods=(cumulation_methods_data)

--- a/app/models/rules_of_origin/scheme_set.rb
+++ b/app/models/rules_of_origin/scheme_set.rb
@@ -2,6 +2,7 @@
 
 module RulesOfOrigin
   class SchemeSet
+    # Scheme in this context is the Trading Scheme and not a scheme that provide a validation
     DEFAULT_SOURCE_PATH = Rails.root.join('db/rules_of_origin').freeze
 
     attr_reader :base_path, :links, :proof_urls

--- a/app/serializers/api/v2/rules_of_origin/full_scheme_serializer.rb
+++ b/app/serializers/api/v2/rules_of_origin/full_scheme_serializer.rb
@@ -8,9 +8,17 @@ module Api
 
         set_id :scheme_code
 
-        attributes :scheme_code, :title, :countries, :footnote, :unilateral,
-                   :fta_intro, :introductory_notes, :cumulation_methods,
-                   :proof_intro, :proof_codes
+        attributes :scheme_code,
+                   :title,
+                   :countries,
+                   :footnote,
+                   :unilateral,
+                   :fta_intro,
+                   :introductory_notes,
+                   :cumulation_methods,
+                   :proof_intro,
+                   :proof_codes,
+                   :show_proofs_for_geographical_areas
 
         has_many :rules, serializer: Api::V2::RulesOfOrigin::RuleSerializer
         has_many :links, serializer: Api::V2::RulesOfOrigin::LinkSerializer

--- a/app/serializers/api/v2/rules_of_origin/scheme_serializer.rb
+++ b/app/serializers/api/v2/rules_of_origin/scheme_serializer.rb
@@ -8,8 +8,13 @@ module Api
 
         set_id :scheme_code
 
-        attributes :scheme_code, :title, :countries, :unilateral,
-                   :proof_intro, :proof_codes
+        attributes :scheme_code,
+                   :title,
+                   :countries,
+                   :unilateral,
+                   :proof_intro,
+                   :proof_codes,
+                   :show_proofs_for_geographical_areas
 
         has_many :links, serializer: Api::V2::RulesOfOrigin::LinkSerializer
         has_many :proofs, serializer: Api::V2::RulesOfOrigin::ProofSerializer

--- a/db/rules_of_origin/roo_schemes_uk.json
+++ b/db/rules_of_origin/roo_schemes_uk.json
@@ -441,6 +441,9 @@
             ],
             "countries": [
                 "AU"
+            ],
+            "show_proofs_for_geographical_areas": [
+                "AU"
             ]
         },
         {
@@ -3157,6 +3160,9 @@
             ],
             "countries": [
                 "NZ"
+            ],
+            "show_proofs_for_geographical_areas": [
+                "NZ"
             ]
         },
         {
@@ -5204,6 +5210,9 @@
                 "TZ",
                 "YE",
                 "ZM"
+            ],
+            "show_proofs_for_geographical_areas": [
+                "1062"
             ]
         },
         {
@@ -5376,6 +5385,10 @@
                 "PH",
                 "LK",
                 "UZ"
+            ],
+            "show_proofs_for_geographical_areas": [
+                "1060",
+                "1061"
             ]
         }
     ],

--- a/spec/serializers/api/v2/rules_of_origin/full_scheme_serializer_spec.rb
+++ b/spec/serializers/api/v2/rules_of_origin/full_scheme_serializer_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Api::V2::RulesOfOrigin::FullSchemeSerializer do
           :with_proofs,
           :with_origin_reference_document,
           scheme_set:,
-          unilateral: true
+          unilateral: true,
+          show_proofs_for_geographical_areas: %w[AU]
   end
 
   let :rules do
@@ -38,6 +39,7 @@ RSpec.describe Api::V2::RulesOfOrigin::FullSchemeSerializer do
           introductory_notes: scheme.introductory_notes,
           proof_intro: nil,
           proof_codes: {},
+          show_proofs_for_geographical_areas: %w[AU],
         },
         relationships: {
           links: {

--- a/spec/serializers/api/v2/rules_of_origin/scheme_serializer_spec.rb
+++ b/spec/serializers/api/v2/rules_of_origin/scheme_serializer_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemeSerializer do
           :with_links,
           :with_origin_reference_document,
           scheme_set:,
-          unilateral: true
+          unilateral: true,
+          show_proofs_for_geographical_areas: %w[AU]
   end
 
   let :serializer do
@@ -29,6 +30,7 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemeSerializer do
           unilateral: true,
           proof_intro: nil,
           proof_codes: {},
+          show_proofs_for_geographical_areas: %w[AU],
         },
         relationships: {
           links: {


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-3611

### What?
To fix where the DCTS instructions are also showing, the attribute `show_proofs_for_geographical_areas` has been added to the roo scheme uk.

### Why?
To fix this:

![image](https://github.com/trade-tariff/trade-tariff-backend/assets/58971/4c9c919e-a2e0-4c84-b9f7-9c7cb516820c)

### Have you? (optional)

- [ ] Added documentation for new apis
