### PR TITLE
HOTT-3844: Split Redis

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -38,7 +38,8 @@ Terraform to deploy the service into AWS.
 | [aws_secretsmanager_secret.newrelic_license_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.oauth_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.oauth_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
-| [aws_secretsmanager_secret.redis_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
+| [aws_secretsmanager_secret.redis_uk_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
+| [aws_secretsmanager_secret.redis_xi_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.secret_key_base](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.sentry_dsn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.sync_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -38,8 +38,12 @@ data "aws_kms_key" "secretsmanager_key" {
   key_id = "alias/secretsmanager-key"
 }
 
-data "aws_secretsmanager_secret" "redis_connection_string" {
-  name = "redis-backend-connection-string"
+data "aws_secretsmanager_secret" "redis_uk_connection_string" {
+  name = "redis-backend-uk-connection-string"
+}
+
+data "aws_secretsmanager_secret" "redis_xi_connection_string" {
+  name = "redis-backend-xi-connection-string"
 }
 
 data "aws_secretsmanager_secret" "database_connection_string" {

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -11,9 +11,10 @@ data "aws_iam_policy_document" "secrets" {
       data.aws_secretsmanager_secret.database_connection_string.arn,
       data.aws_secretsmanager_secret.oauth_id.arn,
       data.aws_secretsmanager_secret.oauth_secret.arn,
-      data.aws_secretsmanager_secret.redis_connection_string.arn,
-      data.aws_secretsmanager_secret.secret_key_base.arn,
+      data.aws_secretsmanager_secret.redis_uk_connection_string.arn,
+      data.aws_secretsmanager_secret.redis_xi_connection_string.arn,
       data.aws_secretsmanager_secret.sentry_dsn.arn,
+      data.aws_secretsmanager_secret.secret_key_base.arn,
       data.aws_secretsmanager_secret.sync_password.arn,
       data.aws_secretsmanager_secret.newrelic_license_key.arn
     ]

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -128,14 +128,14 @@ locals {
   backend_uk_common_secrets = [
     {
       name      = "REDIS_URL"
-      valueFrom = data.aws_secretsmanager_secret.redis_connection_string.arn # TODO: Replace with UK-specific redis connection string
+      valueFrom = data.aws_secretsmanager_secret.redis_uk_connection_string.arn
     },
   ]
 
   backend_xi_common_secrets = [
     {
       name      = "REDIS_URL"
-      valueFrom = data.aws_secretsmanager_secret.redis_connection_string.arn # TODO: Replace with XI-specific redis connection string
+      valueFrom = data.aws_secretsmanager_secret.redis_xi_connection_string.arn
     },
   ]
 


### PR DESCRIPTION
### Jira link

[HOTT-3844](https://transformuk.atlassian.net/browse/HOTT-3844)

### What?

I have added/removed/altered:

- Replaced the Redis URL environment variables with new service-specific connection strings.

### Why?

I am doing this because:

- The backend services require the new UK and XI specific Redis connection strings, removing a TODO item, as they have changed in the core infra.