### PR TITLE
BAU: Supply account ID to correct bucket names

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -30,6 +30,7 @@ Terraform to deploy the service into AWS.
 |------|------|
 | [aws_iam_policy.exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_kms_key.secretsmanager_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 data "aws_vpc" "vpc" {
   tags = { Name = "trade_tariff_${var.environment}_vpc" }
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  no_reply = "no-reply@trade-tariff.service.gov.uk"
-
+  account_id     = data.aws_caller_identity.current.account_id
+  no_reply       = "no-reply@trade-tariff.service.gov.uk"
   worker_command = ["/bin/sh", "-c", "bundle exec sidekiq -C ./config/sidekiq.yml"]
 
   backend_common_vars = [
@@ -18,7 +18,7 @@ locals {
     },
     {
       name  = "AWS_BUCKET_NAME"
-      value = "trade-tariff-persistence-${var.environment}"
+      value = "trade-tariff-persistence-${var.environment}-${local.account_id}"
     },
     {
       name  = "BETA_SEARCH_MAX_HITS"
@@ -82,7 +82,7 @@ locals {
     },
     {
       name  = "SPELLING_CORRECTOR_BUCKET_NAME"
-      value = "trade-tariff-search-configuration-${var.environment}"
+      value = "trade-tariff-search-configuration-${var.environment}-${local.account_id}"
     },
     {
       name  = "STEMMING_EXCLUSION_REFERENCE_ANALYZER"
@@ -110,20 +110,20 @@ locals {
     }
   ]
 
-  # backend_common_worker_vars = [
-  #   {
-  #     name  = "TARIFF_SYNC_EMAIL"
-  #     value = "trade-tariff-support@enginegroup.com"
-  #   },
-  #   {
-  #     name  = "TARIFF_SYNC_HOST"
-  #     value = "https://webservices.hmrc.gov.uk"
-  #   },
-  #   {
-  #     name  = "SLACK_CHANNEL"
-  #     value = "#tariffs-etl"
-  #   },
-  # ]
+  backend_common_worker_vars = [
+    {
+      name  = "TARIFF_SYNC_EMAIL"
+      value = "trade-tariff-support@enginegroup.com"
+    },
+    {
+      name  = "TARIFF_SYNC_HOST"
+      value = "https://webservices.hmrc.gov.uk"
+    },
+    {
+      name  = "SLACK_CHANNEL"
+      value = "#tariffs-etl"
+    },
+  ]
 
   backend_uk_common_secrets = [
     {

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -37,7 +37,9 @@ module "worker_uk" {
   container_entrypoint = [""]
   container_command    = local.worker_command
 
-  service_environment_config = flatten([local.backend_common_vars,
+  service_environment_config = flatten([
+    local.backend_common_vars,
+    local.backend_common_worker_vars,
     [
       {
         name  = "CDS"

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -37,7 +37,9 @@ module "worker_xi" {
   container_entrypoint = [""]
   container_command    = local.worker_command
 
-  service_environment_config = flatten([local.backend_common_vars,
+  service_environment_config = flatten([
+    local.backend_common_vars,
+    local.backend_common_worker_vars,
     [
       {
         name  = "CDS"


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Corrected the bucket names by using the account ID.
- Uncommented worker common vars.

### Why?

I am doing this because:

- I noticed that the S3 bucket names were missing the account ID suffix, so I've added a data source to fetch the current account ID.
- There were a couple of vars that were commented out but the worker could use having these.