### PR TITLE
BAU: Add missing sync credential

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -44,6 +44,7 @@ Terraform to deploy the service into AWS.
 | [aws_secretsmanager_secret.secret_key_base](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.sentry_dsn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.sync_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
+| [aws_secretsmanager_secret.sync_username](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
 | [aws_ssm_parameter.ecr_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.elasticsearch_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -64,6 +64,10 @@ data "aws_secretsmanager_secret" "sync_password" {
   name = "backend-sync-password"
 }
 
+data "aws_secretsmanager_secret" "sync_username" {
+  name = "backend-sync-username"
+}
+
 data "aws_secretsmanager_secret" "oauth_id" {
   name = "backend-oauth-id"
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -16,6 +16,7 @@ data "aws_iam_policy_document" "secrets" {
       data.aws_secretsmanager_secret.sentry_dsn.arn,
       data.aws_secretsmanager_secret.secret_key_base.arn,
       data.aws_secretsmanager_secret.sync_password.arn,
+      data.aws_secretsmanager_secret.sync_username.arn,
       data.aws_secretsmanager_secret.newrelic_license_key.arn
     ]
   }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -161,6 +161,10 @@ locals {
       valueFrom = data.aws_secretsmanager_secret.secret_key_base.arn
     },
     {
+      name      = "TARIFF_SYNC_USERNAME"
+      valueFrom = data.aws_secretsmanager_secret.sync_username.arn
+    },
+    {
       name      = "TARIFF_SYNC_PASSWORD"
       valueFrom = data.aws_secretsmanager_secret.sync_password.arn
     },


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Added missing `TARIFF_SYNC_USERNAME`.

### Why?

I am doing this because:

- We need this credential so that we can download the CDS/Taric files.