### PR TITLE
HOTT-3858: Ensure files are created in S3 for the Search Query Parser

### DIFF
--- a/config/initializers/spelling_corrector_bucket.rb
+++ b/config/initializers/spelling_corrector_bucket.rb
@@ -1,10 +1,15 @@
 s3_bucket_name = ENV['SPELLING_CORRECTOR_BUCKET_NAME']
+running_in_aws = ENV['ECS_AGENT_URI'].present?
 credentials_loaded = ENV['AWS_PROFILE'].present? || (ENV['AWS_SECRET_ACCESS_KEY'].present? && ENV['AWS_ACCESS_KEY_ID'])
 
-s3_bucket = if Rails.env.test?
-              Aws::S3::Resource.new(stub_responses: true).bucket(s3_bucket_name)
-            elsif s3_bucket_name && credentials_loaded
-              Aws::S3::Resource.new.bucket(s3_bucket_name)
-            end
+if Rails.env.test?
+  s3_bucket = Aws::S3::Resource.new(stub_responses: true).bucket(s3_bucket_name)
+elsif s3_bucket_name
+  if running_in_aws || credentials_loaded
+    s3_bucket = Aws::S3::Resource.new.bucket(s3_bucket_name)
+  else
+    Rails.logger.warn 'AWS credentials missing, or not running on AWS.'
+  end
+end
 
 Rails.application.config.spelling_corrector_s3_bucket = s3_bucket

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -29,12 +29,15 @@ Terraform to deploy the service into AWS.
 | Name | Type |
 |------|------|
 | [aws_iam_policy.exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.spelling_corrector_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_kms_key.secretsmanager_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
+| [aws_s3_bucket.spelling_corrector](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 | [aws_secretsmanager_secret.database_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.newrelic_license_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.oauth_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |

--- a/terraform/backend_uk.tf
+++ b/terraform/backend_uk.tf
@@ -26,7 +26,8 @@ module "backend_uk" {
   memory = var.memory
 
   task_role_policy_arns = [
-    aws_iam_policy.exec.arn
+    aws_iam_policy.exec.arn,
+    aws_iam_policy.s3.arn
   ]
 
   execution_role_policy_arns = [

--- a/terraform/backend_xi.tf
+++ b/terraform/backend_xi.tf
@@ -26,7 +26,8 @@ module "backend_xi" {
   memory = var.memory
 
   task_role_policy_arns = [
-    aws_iam_policy.exec.arn
+    aws_iam_policy.exec.arn,
+    aws_iam_policy.s3.arn
   ]
 
   execution_role_policy_arns = [

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -77,5 +77,5 @@ data "aws_secretsmanager_secret" "oauth_secret" {
 }
 
 data "aws_s3_bucket" "spelling_corrector" {
-  bucket = "trade-tariff-search-configuration-${var.environment}-${local.account_id}"
+  bucket = "trade-tariff-search-configuration-${local.account_id}"
 }

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -75,3 +75,7 @@ data "aws_secretsmanager_secret" "oauth_id" {
 data "aws_secretsmanager_secret" "oauth_secret" {
   name = "backend-oauth-secret"
 }
+
+data "aws_s3_bucket" "spelling_corrector" {
+  bucket = "trade-tariff-search-configuration-${var.environment}-${local.account_id}"
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -50,6 +50,11 @@ data "aws_iam_policy_document" "secrets" {
   }
 }
 
+resource "aws_iam_policy" "secrets" {
+  name   = "backend-execution-role-secrets-policy"
+  policy = data.aws_iam_policy_document.secrets.json
+}
+
 data "aws_iam_policy_document" "exec" {
   statement {
     effect = "Allow"
@@ -67,12 +72,26 @@ data "aws_iam_policy_document" "exec" {
   }
 }
 
-resource "aws_iam_policy" "secrets" {
-  name   = "backend-execution-role-secrets-policy"
-  policy = data.aws_iam_policy_document.secrets.json
-}
-
 resource "aws_iam_policy" "exec" {
   name   = "backend-task-role-exec-policy"
   policy = data.aws_iam_policy_document.exec.json
+}
+
+data "aws_iam_policy_document" "spelling_corrector_bucket" {
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [data.aws_s3_bucket.spelling_corrector.arn]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["${data.aws_s3_bucket.spelling_corrector.arn}/*"]
+  }
+}
+
+resource "aws_iam_policy" "s3" {
+  name   = "backend-task-role-s3-policy"
+  policy = data.aws_iam_policy_document.spelling_corrector_bucket.json
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -82,7 +82,7 @@ locals {
     },
     {
       name  = "SPELLING_CORRECTOR_BUCKET_NAME"
-      value = "trade-tariff-search-configuration-${var.environment}-${local.account_id}"
+      value = "trade-tariff-search-configuration-${local.account_id}"
     },
     {
       name  = "STEMMING_EXCLUSION_REFERENCE_ANALYZER"

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -25,7 +25,8 @@ module "worker_uk" {
   memory = 5120
 
   task_role_policy_arns = [
-    aws_iam_policy.exec.arn
+    aws_iam_policy.exec.arn,
+    aws_iam_policy.s3.arn
   ]
 
   execution_role_policy_arns = [

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -25,7 +25,8 @@ module "worker_xi" {
   memory = 5120
 
   task_role_policy_arns = [
-    aws_iam_policy.exec.arn
+    aws_iam_policy.exec.arn,
+    aws_iam_policy.s3.arn
   ]
 
   execution_role_policy_arns = [


### PR DESCRIPTION
### Jira link

[HOTT-3858](https://transformuk.atlassian.net/browse/HOTT-3858)

### What?

I have:

- Added a check for `ECS_AGENT_URI` to allow the application to know if its running in ECS.
- Updated the initialiser for the spelling corrector bucket to allow it to work in AWS without explicit credential environment variables.
- Added a new IAM policy for access to Spelling Corrector bucket for the backend ECS task role.

### Why?

I am doing this because:

- The AWS SDK will automatically search for credentials from the ECS metadata agent and use the generated credentials linked to the ECS task role, so we do not need to supply environment variables for access.
- We need the backend to be able to upload the spelling corrector files for the Search Query Parser to the S3 bucket.
