### PR TITLE
HOTT-3579: Updates search suggestion primary keys

### DIFF
--- a/app/services/search_suggestion_populator_service.rb
+++ b/app/services/search_suggestion_populator_service.rb
@@ -5,7 +5,6 @@ class SearchSuggestionPopulatorService
     SearchSuggestion.unrestrict_primary_key
     TimeMachine.now do
       suggestions = SuggestionsService.new.call
-      suggestions = suggestions.uniq { |suggestion| [suggestion[:id], suggestion[:type]] }
 
       suggestions.each_slice(BATCH_SIZE) do |values|
         SearchSuggestion.dataset.insert_conflict(
@@ -51,6 +50,7 @@ class SearchSuggestionPopulatorService
 
     SearchSuggestion
       .where(id: expired_goods_nomenclature_sids.map(&:to_s))
+      .goods_nomenclature_type
       .delete
   end
 end

--- a/app/services/search_suggestion_populator_service.rb
+++ b/app/services/search_suggestion_populator_service.rb
@@ -1,16 +1,17 @@
 class SearchSuggestionPopulatorService
+  BATCH_SIZE = 5000
+
   def call
     SearchSuggestion.unrestrict_primary_key
     TimeMachine.now do
       suggestions = SuggestionsService.new.call
-      suggestions = suggestions.uniq { |suggestion| [suggestion[:id], suggestion[:value]] }
+      suggestions = suggestions.uniq { |suggestion| [suggestion[:id], suggestion[:type]] }
 
-      suggestions.each_slice(5000) do |values|
+      suggestions.each_slice(BATCH_SIZE) do |values|
         SearchSuggestion.dataset.insert_conflict(
           constraint: :search_suggestions_pkey,
           update: {
             value: Sequel[:excluded][:value],
-            type: Sequel[:excluded][:type],
             goods_nomenclature_sid: Sequel[:excluded][:goods_nomenclature_sid],
             goods_nomenclature_class: Sequel[:excluded][:goods_nomenclature_class],
             priority: Sequel[:excluded][:priority],
@@ -20,7 +21,6 @@ class SearchSuggestionPopulatorService
       end
 
       clear_old_suggestions
-      clear_duplicate_goods_nomenclature_suggestions
     end
     SearchSuggestion.restrict_primary_key
   end
@@ -51,38 +51,6 @@ class SearchSuggestionPopulatorService
 
     SearchSuggestion
       .where(id: expired_goods_nomenclature_sids.map(&:to_s))
-      .delete
-  end
-
-  # A search suggestion is unique based on its input id and value
-  #
-  # Sometimes the value for a given goods nomenclature can change due to it moving about the hierarchy (e.g. a Subheading becomes a Commodity or a Commodity becomes a Subheading)
-  # and we end up with two records that are unique based on their id (sid) but different values
-  #
-  # This method handles these movements by identifying and deleting the older records
-  # whilst preserving the newer records.
-  #
-  # We only ever assume that the most recent record is the correct one since the suggestions do not support the concept
-  # of the time machine currently.
-  def clear_duplicate_goods_nomenclature_suggestions
-    rows_to_delete = SearchSuggestion.duplicates_by(:id)
-      .all
-      .map do |row|
-        { id: row[:id], value: row[:value] }
-      end
-
-    Rails.logger.info "Deleting #{rows_to_delete.count} duplicate suggestions\n#{JSON.pretty_generate(rows_to_delete)}"
-
-    return if rows_to_delete.none?
-
-    delete_condition = Sequel.|(
-      *rows_to_delete.map do |row|
-        Sequel.&({ id: row[:id] }, { value: row[:value] })
-      end,
-    )
-
-    SearchSuggestion
-      .where(delete_condition)
       .delete
   end
 end

--- a/db/migrate/20230817135045_adds_primary_key_for_id_and_type.rb
+++ b/db/migrate/20230817135045_adds_primary_key_for_id_and_type.rb
@@ -1,0 +1,15 @@
+Sequel.migration do
+  up do
+    alter_table(:search_suggestions) do
+      drop_constraint(:search_suggestions_pkey, type: :primary_key)
+      add_primary_key %i[id type]
+    end
+  end
+
+  down do
+    alter_table(:search_suggestions) do
+      drop_constraint(:search_suggestions_pkey, type: :primary_key)
+      add_primary_key %i[id value]
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7101,7 +7101,7 @@ CREATE TABLE uk.search_suggestions (
     value text NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    type text,
+    type text NOT NULL,
     priority integer,
     goods_nomenclature_sid integer,
     goods_nomenclature_class text
@@ -9283,7 +9283,7 @@ ALTER TABLE ONLY uk.search_references
 --
 
 ALTER TABLE ONLY uk.search_suggestions
-    ADD CONSTRAINT search_suggestions_pkey PRIMARY KEY (id, value);
+    ADD CONSTRAINT search_suggestions_pkey PRIMARY KEY (id, type);
 
 
 --
@@ -12032,3 +12032,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20230731095730_adds_index_
 INSERT INTO "schema_migrations" ("filename") VALUES ('20230731202727_adds_additional_code_indexes_to_measures.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20230801133145_adds_certificate_indexes.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20230808103253_adds_footnote_indexes.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20230817135045_adds_primary_key_for_id_and_type.rb');

--- a/spec/controllers/api/v2/headings_controller_spec.rb
+++ b/spec/controllers/api/v2/headings_controller_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe Api::V2::HeadingsController, type: :controller do
           :heading,
           :with_indent,
           :with_description,
+          :declarable,
           :with_chapter,
         )
       end

--- a/spec/controllers/api/v2/headings_controller_spec.rb
+++ b/spec/controllers/api/v2/headings_controller_spec.rb
@@ -131,7 +131,6 @@ RSpec.describe Api::V2::HeadingsController, type: :controller do
           :heading,
           :with_indent,
           :with_description,
-          :declarable,
           :with_chapter,
         )
       end

--- a/spec/controllers/api/v2/search_controller_search_spec.rb
+++ b/spec/controllers/api/v2/search_controller_search_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::V2::SearchController do
       before do
         goods_nomenclature = create :chapter, goods_nomenclature_item_id: '0100000000'
 
-        create(:search_suggestion, goods_nomenclature:)
+        create(:search_suggestion, :goods_nomenclature, goods_nomenclature:)
 
         post :search, params: { q: '01', as_of: Time.zone.today.iso8601 }
       end
@@ -112,7 +112,7 @@ RSpec.describe Api::V2::SearchController do
         {
           'data' => [
             {
-              'id' => 'test',
+              'id' => be_present,
               'type' => 'search_suggestion',
               'attributes' => {
                 'value' => 'same',

--- a/spec/factories/search_suggestion_factory.rb
+++ b/spec/factories/search_suggestion_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
       goods_nomenclature { nil }
     end
 
-    id { goods_nomenclature&.goods_nomenclature_sid || 'test' }
+    id { goods_nomenclature&.goods_nomenclature_sid || generate(:sid) }
     value { goods_nomenclature&.short_code || 'test' }
     goods_nomenclature_sid { goods_nomenclature&.goods_nomenclature_sid || 124_456_789 }
     goods_nomenclature_class { goods_nomenclature&.goods_nomenclature_class || 'Heading' }

--- a/spec/models/search_suggestion_spec.rb
+++ b/spec/models/search_suggestion_spec.rb
@@ -1,6 +1,12 @@
 RSpec.describe SearchSuggestion do
   describe '#goods_nomenclature' do
-    subject(:goods_nomenclature) { create(:search_suggestion, goods_nomenclature: create(:heading)).goods_nomenclature }
+    subject(:goods_nomenclature) do
+      create(
+        :search_suggestion,
+        :goods_nomenclature,
+        goods_nomenclature: create(:heading),
+      ).goods_nomenclature
+    end
 
     it { is_expected.to be_a(Heading) }
   end
@@ -20,7 +26,7 @@ RSpec.describe SearchSuggestion do
       end
 
       it 'returns search suggestions' do
-        expect(fuzzy_search.pluck(:value)).to eq(
+        expect(fuzzy_search.pluck(:value)).to match_array(
           [
             'alu',
             'aluminium wire',
@@ -110,7 +116,7 @@ RSpec.describe SearchSuggestion do
       let(:query) { '' }
 
       before do
-        create(:search_suggestion, value: '') # control
+        create(:search_suggestion, :goods_nomenclature, value: '') # control
       end
 
       it 'returns an empty array' do
@@ -167,7 +173,6 @@ RSpec.describe SearchSuggestion do
     before do
       create(:search_suggestion, :search_reference, value: 'gold ore')
       create(:search_suggestion, :full_chemical_name, value: 'ore')
-      create(:search_suggestion, value: 'null type')
     end
 
     it { is_expected.to eq(['gold ore', 'ore']) }
@@ -180,7 +185,6 @@ RSpec.describe SearchSuggestion do
       create(:search_suggestion, :goods_nomenclature, value: '1234')
       create(:search_suggestion, :full_chemical_cus, value: '0154438-3')
       create(:search_suggestion, :full_chemical_cas, value: '8028-66-8')
-      create(:search_suggestion, value: '1235')
     end
 
     it { is_expected.to eq(%w[1234 0154438-3 8028-66-8]) }

--- a/spec/serializers/api/v2/search_suggestion_serializer_spec.rb
+++ b/spec/serializers/api/v2/search_suggestion_serializer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Api::V2::SearchSuggestionSerializer do
     expect(serialized).to include_json(
       {
         data: {
-          id: 'test',
+          id: be_present,
           type: eq(:search_suggestion),
           attributes: {
             value: 'aluminium wire',

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe SearchService do
       before do
         goods_nomenclature = create :chapter, goods_nomenclature_item_id: '1100000000'
 
-        create :search_suggestion, goods_nomenclature:
+        create :search_suggestion, :goods_nomenclature, goods_nomenclature:
       end
 
       it { expect(result).to match_json_expression pattern }
@@ -83,7 +83,7 @@ RSpec.describe SearchService do
       before do
         goods_nomenclature = create :heading, goods_nomenclature_item_id: '0101000000'
 
-        create :search_suggestion, goods_nomenclature:
+        create :search_suggestion, :goods_nomenclature, goods_nomenclature:
       end
 
       it { expect(result).to match_json_expression pattern }
@@ -103,7 +103,7 @@ RSpec.describe SearchService do
       before do
         goods_nomenclature = create :subheading, goods_nomenclature_item_id: '0101210000'
 
-        create :search_suggestion, goods_nomenclature:
+        create :search_suggestion, :goods_nomenclature, goods_nomenclature:
       end
 
       context 'when subheading with suffix' do
@@ -133,7 +133,7 @@ RSpec.describe SearchService do
       before do
         goods_nomenclature = create :commodity, goods_nomenclature_item_id: '0101210000'
 
-        create :search_suggestion, goods_nomenclature:
+        create :search_suggestion, :goods_nomenclature, goods_nomenclature:
       end
 
       context 'when searching by full code' do
@@ -153,7 +153,7 @@ RSpec.describe SearchService do
       before do
         goods_nomenclature = create :commodity, goods_nomenclature_item_id: '0101210000'
 
-        create :search_suggestion, goods_nomenclature:, value: '8028-66-8'
+        create :search_suggestion, :goods_nomenclature, goods_nomenclature:, value: '8028-66-8'
       end
 
       let(:pattern) do
@@ -194,7 +194,7 @@ RSpec.describe SearchService do
       before do
         goods_nomenclature = create :commodity, goods_nomenclature_item_id: '0101210000'
 
-        create :search_suggestion, goods_nomenclature:, value: '0150000-1'
+        create :search_suggestion, :goods_nomenclature, goods_nomenclature:, value: '0150000-1'
       end
 
       it { expect(result).to match_json_expression pattern }
@@ -215,7 +215,7 @@ RSpec.describe SearchService do
       before do
         goods_nomenclature = create :commodity, goods_nomenclature_item_id: '0101210000'
 
-        create :search_suggestion, goods_nomenclature:, value: 'insulin, human'
+        create :search_suggestion, :goods_nomenclature, goods_nomenclature:, value: 'insulin, human'
       end
 
       it { expect(result).to match_json_expression pattern }
@@ -418,6 +418,7 @@ RSpec.describe SearchService do
     describe 'validity period function' do
       before do
         create :search_suggestion,
+               :search_reference,
                goods_nomenclature: heading,
                value: 'water'
       end

--- a/spec/services/search_suggestion_populator_service_spec.rb
+++ b/spec/services/search_suggestion_populator_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe SearchSuggestionPopulatorService do
 
   context 'when the search suggestion already exists' do
     before do
-      create(:search_suggestion, value: 'gold ore')
+      create(:search_suggestion, :search_reference, value: 'gold ore')
     end
 
     it { expect { call }.not_to raise_error }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3579

### What?

We've moved to using an id, type primary key constraint on the search suggestions since these are necessary to identify a unique row in the search suggestions table and to avoid duplication.

I have added/removed/altered:

- [x] Updated the primary key of search suggestions

### Why?

I am doing this because:

- This is needed to fix duplication patches
