### PR TITLE
HOTT-3895 - Rollout blue-green deployment

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -19,10 +19,10 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_backend_uk"></a> [backend\_uk](#module\_backend\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.8.0 |
-| <a name="module_backend_xi"></a> [backend\_xi](#module\_backend\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.8.0 |
-| <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.10.0 |
-| <a name="module_worker_xi"></a> [worker\_xi](#module\_worker\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.10.0 |
+| <a name="module_backend_uk"></a> [backend\_uk](#module\_backend\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.11.3 |
+| <a name="module_backend_xi"></a> [backend\_xi](#module\_backend\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.11.3 |
+| <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.11.3 |
+| <a name="module_worker_xi"></a> [worker\_xi](#module\_worker\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.11.3 |
 
 ## Resources
 

--- a/terraform/backend_uk.tf
+++ b/terraform/backend_uk.tf
@@ -1,9 +1,8 @@
 module "backend_uk" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.8.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.11.3"
 
   service_name  = "${var.service_name}-uk"
   service_count = var.service_count
-  environment   = var.environment
   region        = var.region
 
   cluster_name              = "trade-tariff-cluster-${var.environment}"

--- a/terraform/backend_xi.tf
+++ b/terraform/backend_xi.tf
@@ -1,9 +1,8 @@
 module "backend_xi" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.8.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.11.3"
 
   service_name  = "${var.service_name}-xi"
   service_count = var.service_count
-  environment   = var.environment
   region        = var.region
 
   cluster_name              = "trade-tariff-cluster-${var.environment}"

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -1,9 +1,8 @@
 module "worker_uk" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.10.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.11.3"
 
   service_name  = "worker-uk"
   service_count = var.service_count
-  environment   = var.environment
   region        = var.region
 
   cluster_name              = "trade-tariff-cluster-${var.environment}"

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -1,9 +1,8 @@
 module "worker_xi" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.10.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.11.3"
 
   service_name  = "worker-xi"
   service_count = var.service_count
-  environment   = var.environment
   region        = var.region
 
   cluster_name              = "trade-tariff-cluster-${var.environment}"


### PR DESCRIPTION
### Jira link

HOTT-3895

### What?

- Updated ECS service module to v1.11.3

### Why?

I am doing this because:

- To rollout blue-green deployment
