### PR TITLE
Better handling when no periods exist for exchange rates

### DIFF
--- a/app/controllers/api/v2/exchange_rates/period_lists_controller.rb
+++ b/app/controllers/api/v2/exchange_rates/period_lists_controller.rb
@@ -3,7 +3,11 @@ module Api
     module ExchangeRates
       class PeriodListsController < ApiController
         def show
-          render json: serialized_period_list
+          if serialized_period_list[:data].empty?
+            render json: { data: {} }, status: :not_found
+          else
+            render json: serialized_period_list
+          end
         end
 
         private

--- a/spec/models/exchange_rates/period_list_spec.rb
+++ b/spec/models/exchange_rates/period_list_spec.rb
@@ -65,6 +65,18 @@ RSpec.describe ExchangeRates::PeriodList do
     it 'returns an array of ExchangeRates::Period instances' do
       expect(exchange_rate_periods).to all(be_an_instance_of(ExchangeRates::Period))
     end
+
+    context 'when the year contains no periods' do
+      let(:year) { 1970 }
+
+      before do
+        allow(ExchangeRateCurrencyRate).to receive(:months_for_year).with(year).and_return([])
+      end
+
+      it 'returns an empty array' do
+        expect(exchange_rate_periods).to eq([])
+      end
+    end
   end
 
   describe '.exchange_rate_years' do

--- a/spec/requests/api/v2/exchange_rates/period_lists_controller_spec.rb
+++ b/spec/requests/api/v2/exchange_rates/period_lists_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Api::V2::ExchangeRates::PeriodListsController, type: :request do
 
     before do
       allow(ExchangeRates::PeriodList).to receive(:build).with(2023).and_return(period_list)
+      allow(ExchangeRates::PeriodList).to receive(:build).with(1970).and_return([])
       allow(ExchangeRateCurrencyRate).to receive(:max_year).and_return(2023)
 
       make_request
@@ -59,6 +60,13 @@ RSpec.describe Api::V2::ExchangeRates::PeriodListsController, type: :request do
       it { is_expected.to have_http_status(:ok) }
       it { expect(response.body).to match_json_expression(pattern) }
       it { expect(ExchangeRateCurrencyRate).to have_received(:max_year) }
+    end
+
+    context 'when the year parameter has no available data' do
+      let(:make_request) { get api_exchange_rates_period_list_path(year: '1970', format: :json) }
+
+      it { is_expected.to have_http_status(:not_found) }
+      it { expect(response.body).to match_json_expression({ data: {} }) }
     end
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-3910

### What?

I have added/removed/altered:

- [ ] Added tests for handling no periods returned in the period list controller and the period list builder
- [ ] Added code to pass the tests

### Why?

This should not happen in a real world situation but handles if the user requests a year that has no periods in the exchange rate api
