### PR TITLE
HOTT-3922: Fix backend S3 access in AWS

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -37,6 +37,7 @@ Terraform to deploy the service into AWS.
 | [aws_iam_policy_document.spelling_corrector_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_kms_key.secretsmanager_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
+| [aws_s3_bucket.persistence](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 | [aws_s3_bucket.spelling_corrector](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 | [aws_secretsmanager_secret.database_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.newrelic_license_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -79,3 +79,7 @@ data "aws_secretsmanager_secret" "oauth_secret" {
 data "aws_s3_bucket" "spelling_corrector" {
   bucket = "trade-tariff-search-configuration-${local.account_id}"
 }
+
+data "aws_s3_bucket" "persistence" {
+  bucket = "trade-tariff-persistence-${local.account_id}"
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -79,16 +79,25 @@ resource "aws_iam_policy" "exec" {
 
 data "aws_iam_policy_document" "spelling_corrector_bucket" {
   statement {
-    effect    = "Allow"
-    actions   = ["s3:ListBucket"]
-    resources = [data.aws_s3_bucket.spelling_corrector.arn]
+    effect  = "Allow"
+    actions = ["s3:ListBucket"]
+    resources = [
+      data.aws_s3_bucket.spelling_corrector.arn,
+      data.aws_s3_bucket.persistence.arn
+    ]
   }
 
   statement {
-    effect  = "Allow"
-    actions = ["s3:PutObject"]
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject"
+    ]
     # tfsec:ignore:aws-iam-no-policy-wildcards
-    resources = ["${data.aws_s3_bucket.spelling_corrector.arn}/*"]
+    resources = [
+      "${data.aws_s3_bucket.spelling_corrector.arn}/*",
+      "${data.aws_s3_bucket.persistence.arn}/*"
+    ]
   }
 }
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -18,7 +18,7 @@ locals {
     },
     {
       name  = "AWS_BUCKET_NAME"
-      value = "trade-tariff-persistence-${var.environment}-${local.account_id}"
+      value = data.aws_s3_bucket.persistence.bucket
     },
     {
       name  = "BETA_SEARCH_MAX_HITS"
@@ -74,7 +74,7 @@ locals {
     },
     {
       name  = "SENTRY_ENVIRONMENT"
-      value = var.environment
+      value = "aws-${var.environment}"
     },
     {
       name  = "SENTRY_PROJECT"
@@ -82,15 +82,15 @@ locals {
     },
     {
       name  = "SPELLING_CORRECTOR_BUCKET_NAME"
-      value = "trade-tariff-search-configuration-${local.account_id}"
+      value = data.aws_s3_bucket.spelling_corrector.bucket
     },
     {
       name  = "STEMMING_EXCLUSION_REFERENCE_ANALYZER"
-      value = "analyzers/F159568045"
+      value = "analyzers/F159568045" # TODO: fetch from each env
     },
     {
       name  = "SYNONYM_REFERENCE_ANALYZER"
-      value = "analyzers/F202143497"
+      value = "analyzers/F202143497" # TODO: fetch from each env
     },
     {
       name  = "TARIFF_SYNC_EMAIL"


### PR DESCRIPTION
### Jira link

[HOTT-3922](https://transformuk.atlassian.net/browse/HOTT-3922)

### What?

I have added/removed/altered:

- Amended the S3 policy for the backend task role.
- Fixed the persistence bucket name, and added it to the S3 policy.

### Why?

I am doing this because:

- We are getting an `Aws::S3::Errors::AccessDenied` error when the backend attempts to run the spelling model updater.