### PR TITLE
HOTT-3892: Retry job later if XE connection fails

### DIFF
--- a/app/workers/monthly_exchange_rates_worker.rb
+++ b/app/workers/monthly_exchange_rates_worker.rb
@@ -1,7 +1,7 @@
 class MonthlyExchangeRatesWorker
   include Sidekiq::Worker
 
-  sidekiq_options retry: false
+  sidekiq_options retry: 1, retry_in: 1.hour
 
   def perform
     ExchangeRates::MonthlyExchangeRatesService.call


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3892

### What?

I have added/removed/altered:

- [ ] Retry job later if XE connection fails

### Why?

I am doing this because:

- We want to retry the background job if XE API is down

