### PR TITLE
HOTT-3520: Fixes n+1 in search references

### DIFF
--- a/app/controllers/api/v2/search_references_controller.rb
+++ b/app/controllers/api/v2/search_references_controller.rb
@@ -4,12 +4,21 @@ module Api
       include SimpleCaching
 
       def index
-        search_references = SearchReference.for_letter(letter).all
-
-        render json: Api::V2::SearchReferenceSerializer.new(search_references).serializable_hash
+        render json: serialized_search_references
       end
 
       private
+
+      def serialized_search_references
+        Api::V2::SearchReferenceSerializer.new(search_references).serializable_hash
+      end
+
+      def search_references
+        @search_references ||= SearchReference
+          .for_letter(letter)
+          .eager(:referenced)
+          .all
+      end
 
       def letter
         params.dig(:query, :letter) || ''

--- a/app/models/concerns/ten_digit_goods_nomenclature.rb
+++ b/app/models/concerns/ten_digit_goods_nomenclature.rb
@@ -103,7 +103,7 @@ module TenDigitGoodsNomenclature
     end
 
     def to_admin_param
-      "#{goods_nomenclature_item_id}-#{producline_suffix}"
+      goods_nomenclature_item_id
     end
 
     private

--- a/app/models/search_reference.rb
+++ b/app/models/search_reference.rb
@@ -49,7 +49,7 @@ class SearchReference < Sequel::Model
   end
 
   def referenced_id
-    referenced.to_admin_param
+    referenced.to_param
   end
 
   def title_indexed


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3520

### What?

I have added/removed/altered:

- [x] Eager load the goods nomenclatures when pulling out search references
- [x] Fixes broken to_admin_param

### Why?

I am doing this because:

- The /search_references endpoint was taking 9000 queries to finish (it now takes 2)
- The admin id was just wrong
