### PR TITLE
HOTT-2789: Run init container for all backends

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -19,10 +19,10 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_backend_uk"></a> [backend\_uk](#module\_backend\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.11.3 |
-| <a name="module_backend_xi"></a> [backend\_xi](#module\_backend\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.11.3 |
-| <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.11.3 |
-| <a name="module_worker_xi"></a> [worker\_xi](#module\_worker\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.11.3 |
+| <a name="module_backend_uk"></a> [backend\_uk](#module\_backend\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.12.0 |
+| <a name="module_backend_xi"></a> [backend\_xi](#module\_backend\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.12.0 |
+| <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.12.0 |
+| <a name="module_worker_xi"></a> [worker\_xi](#module\_worker\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.12.0 |
 
 ## Resources
 
@@ -35,6 +35,7 @@ Terraform to deploy the service into AWS.
 | [aws_iam_policy_document.exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.spelling_corrector_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_kms_key.opensearch_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_kms_key.secretsmanager_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
 | [aws_s3_bucket.persistence](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |

--- a/terraform/backend_uk.tf
+++ b/terraform/backend_uk.tf
@@ -1,5 +1,5 @@
 module "backend_uk" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.11.3"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.12.0"
 
   service_name  = "${var.service_name}-uk"
   service_count = var.service_count

--- a/terraform/backend_xi.tf
+++ b/terraform/backend_xi.tf
@@ -1,5 +1,5 @@
 module "backend_xi" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.11.3"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.12.0"
 
   service_name  = "${var.service_name}-xi"
   service_count = var.service_count
@@ -34,6 +34,10 @@ module "backend_xi" {
   ]
 
   enable_ecs_exec = true
+
+  init_container            = true
+  init_container_entrypoint = [""]
+  init_container_command    = local.init_command
 
   service_environment_config = flatten([local.backend_common_vars,
     [

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -40,6 +40,10 @@ data "aws_kms_key" "secretsmanager_key" {
   key_id = "alias/secretsmanager-key"
 }
 
+data "aws_kms_key" "opensearch_key" {
+  key_id = "alias/opensearch-key"
+}
+
 data "aws_secretsmanager_secret" "redis_uk_connection_string" {
   name = "redis-backend-uk-connection-string"
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -45,7 +45,8 @@ data "aws_iam_policy_document" "secrets" {
       "kms:GenerateDataKeyWithoutPlaintext"
     ]
     resources = [
-      data.aws_kms_key.secretsmanager_key.arn
+      data.aws_kms_key.secretsmanager_key.arn,
+      data.aws_kms_key.opensearch_key.arn
     ]
   }
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -2,6 +2,7 @@ locals {
   account_id     = data.aws_caller_identity.current.account_id
   no_reply       = "no-reply@trade-tariff.service.gov.uk"
   worker_command = ["/bin/sh", "-c", "bundle exec sidekiq -C ./config/sidekiq.yml"]
+  init_command   = ["/bin/sh", "-c", "bundle exec rails db:migrate && bundle exec rails data:migrate"]
 
   backend_common_vars = [
     {

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -1,5 +1,5 @@
 module "worker_uk" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.11.3"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.12.0"
 
   service_name  = "worker-uk"
   service_count = var.service_count
@@ -36,6 +36,10 @@ module "worker_uk" {
 
   container_entrypoint = [""]
   container_command    = local.worker_command
+
+  init_container            = true
+  init_container_entrypoint = [""]
+  init_container_command    = local.init_command
 
   service_environment_config = flatten([
     local.backend_common_vars,

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -1,5 +1,5 @@
 module "worker_xi" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.11.3"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.12.0"
 
   service_name  = "worker-xi"
   service_count = var.service_count
@@ -36,6 +36,10 @@ module "worker_xi" {
 
   container_entrypoint = [""]
   container_command    = local.worker_command
+
+  init_container            = true
+  init_container_entrypoint = [""]
+  init_container_command    = local.init_command
 
   service_environment_config = flatten([
     local.backend_common_vars,


### PR DESCRIPTION
### Jira link

[HOTT-2789](https://transformuk.atlassian.net/browse/HOTT-2789)

### What?

I have added/removed/altered:

- Upgraded the backend module versions to v1.12.0

### Why?

See https://github.com/trade-tariff/trade-tariff-platform-terraform-modules/pull/41