### PR TITLE
BAU: Handle referenced class getting updated in search references

### DIFF
--- a/app/models/search_reference.rb
+++ b/app/models/search_reference.rb
@@ -30,6 +30,7 @@ class SearchReference < Sequel::Model
               reciprocal_type: :many_to_one,
               setter: referenced_setter do |ds|
     ds.with_actual(GoodsNomenclature)
+      .with_leaf_column
   end
 
   self.raise_on_save_failure = false
@@ -50,6 +51,10 @@ class SearchReference < Sequel::Model
 
   def referenced_id
     referenced.to_param
+  end
+
+  def referenced_class
+    referenced&.goods_nomenclature_class || super
   end
 
   def title_indexed


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added handling for dynamic changes to the referenced class

### Why?

I am doing this because:

- This is helpful because goods nomenclature can move whilst retaining the same sid value. We already have handling for goods nomenclature references that get end-dated https://github.com/trade-tariff/trade-tariff-backend/blob/main/app/workers/clear_invalid_search_references.rb
