### PR TITLE
HOTT-3962: Changed file names on download endpoint and updated emails

### DIFF
--- a/app/controllers/api/v2/exchange_rates/files_controller.rb
+++ b/app/controllers/api/v2/exchange_rates/files_controller.rb
@@ -3,7 +3,7 @@ module Api
     module ExchangeRates
       class FilesController < ApiController
         def show
-          filename = ExchangeRateFile.filename_for(type, format, year, month)
+          filename = ExchangeRateFile.filename_for_download(type, format, year, month)
 
           send_data(
             file_data,
@@ -29,10 +29,6 @@ module Api
 
         def id
           params[:id].to_s
-        end
-
-        def filename_for(type, format)
-          "#{type}_#{year}-#{month}.#{format}"
         end
 
         def format

--- a/app/mailers/exchange_rates_mailer.rb
+++ b/app/mailers/exchange_rates_mailer.rb
@@ -9,7 +9,6 @@ class ExchangeRatesMailer < ApplicationMailer
     @date = date
     @month_and_year = date.next_month.strftime('%B %Y')
     @csv_hmrc = ExchangeRateFile.where(type: 'monthly_csv_hmrc', period_month: month, period_year: year).take
-    @xml = ExchangeRateFile.where(type: 'monthly_xml', period_month: month, period_year: year).take
 
     mail subject: "#{@month_and_year} Exchange Rate Files (monthly)"
   end

--- a/app/models/exchange_rate_file.rb
+++ b/app/models/exchange_rate_file.rb
@@ -36,6 +36,17 @@ class ExchangeRateFile < Sequel::Model
       "#{type}_#{year}-#{month}.#{format}"
     end
 
+    def filename_for_download(type, format, year, month)
+      month_with_zero = format('%02i', month)
+      
+      case type
+      when "monthly_csv_hmrc"
+        "#{year}#{month_with_zero}MonthlyRates.#{format}"
+      else
+        "exrates-monthly-#{month_with_zero}#{year[2..3]}.#{format}"
+      end
+    end
+
     def applicable_files_for(month, year)
       applicable_types
         .where(period_year: year, period_month: month)

--- a/app/models/exchange_rate_file.rb
+++ b/app/models/exchange_rate_file.rb
@@ -37,10 +37,10 @@ class ExchangeRateFile < Sequel::Model
     end
 
     def filename_for_download(type, format, year, month)
-      month_with_zero = format('%02i', month)
-      
+      month_with_zero = sprintf('%02i', month)
+
       case type
-      when "monthly_csv_hmrc"
+      when 'monthly_csv_hmrc'
         "#{year}#{month_with_zero}MonthlyRates.#{format}"
       else
         "exrates-monthly-#{month_with_zero}#{year[2..3]}.#{format}"

--- a/app/views/exchange_rates_mailer/monthly_files.html.erb
+++ b/app/views/exchange_rates_mailer/monthly_files.html.erb
@@ -1,9 +1,9 @@
 <p>
-  Please use the following links to download the exchange rate files for <%= @month_and_year %>.<br>
-  Links: <a href="<%= File.join(TradeTariffBackend.frontend_host, @csv_hmrc.file_path) %>">CSV HMRC link</a> and <a href="<%= File.join(TradeTariffBackend.frontend_host, @xml.file_path) %>">XML link</a>
+  Please use the following link to download the exchange rate file for <%= @month_and_year %>.<br><br>
+  Link: <a href="<%= File.join(TradeTariffBackend.frontend_host, @csv_hmrc.file_path) %>">CSV HMRC link</a><br><br>
 </p>
 
 <p>
-  Please direct any queries to <a href="mailto:<%= TradeTariffBackend.support_email %>"><%= TradeTariffBackend.support_email %></a>.<br>
+  Please direct any queries to <a href="mailto:<%= TradeTariffBackend.support_email %>"><%= TradeTariffBackend.support_email %></a>.<br><br>
   Online Trade Tariff Team
 </p>

--- a/app/views/exchange_rates_mailer/monthly_files.html.erb
+++ b/app/views/exchange_rates_mailer/monthly_files.html.erb
@@ -1,6 +1,6 @@
 <p>
   Please use the following link to download the exchange rate file for <%= @month_and_year %>.<br><br>
-  Link: <a href="<%= File.join(TradeTariffBackend.frontend_host, @csv_hmrc.file_path) %>">CSV HMRC link</a><br><br>
+  Link: <a href="<%= File.join(TradeTariffBackend.frontend_host, @csv_hmrc.file_path) %>">CSV HMRC link</a><br>
 </p>
 
 <p>

--- a/spec/mailers/exchange_rates_mailer_spec.rb
+++ b/spec/mailers/exchange_rates_mailer_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe ExchangeRatesMailer, type: :mailer do
     before do
       travel_to Time.zone.local(2023, 7, 19)
       create(:exchange_rate_file, type: 'monthly_csv_hmrc', period_month: date.next_month.month, period_year: date.year)
-      create(:exchange_rate_file, type: 'monthly_xml', period_month: date.next_month.month, period_year: date.year)
     end
 
     context 'when email is sent it has correct attributes' do

--- a/spec/requests/api/v2/exchange_rates/files_controller_spec.rb
+++ b/spec/requests/api/v2/exchange_rates/files_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Api::V2::ExchangeRates::FilesController, type: :request do
       end
 
       it 'returns the correct Content-Disposition header' do
-        expect(response.headers['Content-Disposition']).to eq("attachment; filename=monthly_csv_#{year}-#{month}.csv")
+        expect(response.headers['Content-Disposition']).to eq("attachment; filename=exrates-monthly-0723.csv")
       end
 
       it 'returns the CSV data as the response body' do
@@ -48,7 +48,7 @@ RSpec.describe Api::V2::ExchangeRates::FilesController, type: :request do
       end
 
       it 'returns the correct Content-Disposition header' do
-        expect(response.headers['Content-Disposition']).to eq("attachment; filename=monthly_xml_#{year}-#{month}.xml")
+        expect(response.headers['Content-Disposition']).to eq("attachment; filename=exrates-monthly-0723.xml")
       end
 
       it 'returns the XML data as the response body' do
@@ -71,7 +71,7 @@ RSpec.describe Api::V2::ExchangeRates::FilesController, type: :request do
       end
 
       it 'returns the correct Content-Disposition header' do
-        expect(response.headers['Content-Disposition']).to eq("attachment; filename=monthly_csv_hmrc_#{year}-#{month}.csv")
+        expect(response.headers['Content-Disposition']).to eq("attachment; filename=202307MonthlyRates.csv")
       end
 
       it 'returns the CSV data as the response body' do

--- a/spec/requests/api/v2/exchange_rates/files_controller_spec.rb
+++ b/spec/requests/api/v2/exchange_rates/files_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Api::V2::ExchangeRates::FilesController, type: :request do
       end
 
       it 'returns the correct Content-Disposition header' do
-        expect(response.headers['Content-Disposition']).to eq("attachment; filename=exrates-monthly-0723.csv")
+        expect(response.headers['Content-Disposition']).to eq('attachment; filename=exrates-monthly-0723.csv')
       end
 
       it 'returns the CSV data as the response body' do
@@ -48,7 +48,7 @@ RSpec.describe Api::V2::ExchangeRates::FilesController, type: :request do
       end
 
       it 'returns the correct Content-Disposition header' do
-        expect(response.headers['Content-Disposition']).to eq("attachment; filename=exrates-monthly-0723.xml")
+        expect(response.headers['Content-Disposition']).to eq('attachment; filename=exrates-monthly-0723.xml')
       end
 
       it 'returns the XML data as the response body' do
@@ -71,7 +71,7 @@ RSpec.describe Api::V2::ExchangeRates::FilesController, type: :request do
       end
 
       it 'returns the correct Content-Disposition header' do
-        expect(response.headers['Content-Disposition']).to eq("attachment; filename=202307MonthlyRates.csv")
+        expect(response.headers['Content-Disposition']).to eq('attachment; filename=202307MonthlyRates.csv')
       end
 
       it 'returns the CSV data as the response body' do

--- a/spec/views/exchange_rates_mailer/monthly_files.html.erb_spec.rb
+++ b/spec/views/exchange_rates_mailer/monthly_files.html.erb_spec.rb
@@ -3,18 +3,15 @@ require 'rails_helper'
 RSpec.describe 'exchange_rates_mailer/monthly_files', type: :view do
   let(:date) { Date.new(2023, 7, 15) }
   let!(:exchange_rate_file_csv_hmrc) { create(:exchange_rate_file, type: 'monthly_csv_hmrc', period_month: date.month, period_year: date.year) }
-  let!(:exchange_rate_file_xml) { create(:exchange_rate_file, type: 'monthly_xml', period_month: date.month, period_year: date.year) }
 
   before do
     assign(:month_and_year, date.next_month.strftime('%B %Y'))
     assign(:csv_hmrc, exchange_rate_file_csv_hmrc)
-    assign(:xml, exchange_rate_file_xml)
     render
   end
 
   context 'with correct email body content' do
-    it { expect(rendered).to include("Please use the following links to download the exchange rate files for #{date.next_month.strftime('%B %Y')}.") }
+    it { expect(rendered).to include("Please use the following link to download the exchange rate file for #{date.next_month.strftime('%B %Y')}.") }
     it { expect(rendered).to include("<a href=\"#{TradeTariffBackend.frontend_host + exchange_rate_file_csv_hmrc.file_path}\">CSV HMRC link</a>") }
-    it { expect(rendered).to include("<a href=\"#{TradeTariffBackend.frontend_host + exchange_rate_file_xml.file_path}\">XML link</a>") }
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3962

### What?

I have added/removed/altered:

- [ ] Changed file names on download endpoint and updated emails

### Why?

I am doing this because:

- Filenames needed to match HMRC requirements
- Email should only send HMRC_CSV type

