### PR TITLE
BAU: Don't log healthchecks in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,10 @@ Rails.application.configure do
     }.merge(JSON.parse(ENV['VCAP_APPLICATION']))
   end
 
-  config.lograge.ignore_actions = ['HealthcheckController#index']
+  config.lograge.ignore_actions = [
+    'HealthcheckController#index',
+    'HealthcheckController#checkz'
+  ]
 
   # Rails cache store
   # PaasConfig returns url and db


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Ignored `checkz` action of the healthcheck controller in lograge options.

### Why?

I am doing this because:

- We don't need this to be logged in production mode, it's just noise.