### PR TITLE
HOTT-3975: Add rake tasks `import_agv_ex_rates` to import average exchange rates

### DIFF
--- a/app/models/exchange_rate_currency_rate.rb
+++ b/app/models/exchange_rate_currency_rate.rb
@@ -1,6 +1,8 @@
 require 'csv'
 
 class ExchangeRateCurrencyRate < Sequel::Model
+  plugin :validation_helpers
+
   SCHEDULED_RATE_TYPE = 'scheduled'.freeze
   SPOT_RATE_TYPE = 'spot'.freeze
 
@@ -19,6 +21,12 @@ class ExchangeRateCurrencyRate < Sequel::Model
   include ContentAddressableId
 
   content_addressable_fields :currency_code, :validity_start_date, :validity_end_date, :country, :country_code
+
+  def validate
+    super
+
+    validates_unique(%i[currency_code validity_start_date validity_end_date rate_type])
+  end
 
   def presented_rate
     sprintf('%.4f', rate)

--- a/lib/tasks/exchange_rate_importer.rake
+++ b/lib/tasks/exchange_rate_importer.rake
@@ -1,0 +1,76 @@
+# Import TARIC or CDS file manually. Usually for initial seed files.
+namespace :importer do
+  namespace :rates do
+    desc 'Import Average Exchange Rates'
+
+    task import_agv_ex_rates: %i[environment] do
+      average_type = 'average'
+
+      url = 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1154375/Average_for_the_year_to_31_March_2023.csv'
+
+      client = Faraday.new
+      response = client.get(url)
+
+      csv = csv_without_title(response.body)
+
+      data = CSV.parse(csv, headers: true)
+
+      validity_end_date = Date.new(2023, 3, 31)
+      validity_start_date = validity_end_date - 1.year # TODO: assuming that average period is one year - To be confirmed!
+
+      invalid_rows = []
+      invalid_records = []
+      new_records_count = 0
+
+      puts 'Importing Exchange rates ...'
+
+      data.each do |row|
+        if invalid?(row)
+          invalid_rows << row
+
+          puts 'Invalid row'
+          next
+        end
+
+        currency_unit_per_pound = row[4].to_f # Currency Units per £1
+
+        new_rate = ExchangeRateCurrencyRate.new(currency_code: row['Currency Code'],
+                                                validity_start_date:,
+                                                validity_end_date:,
+                                                rate_type: average_type,
+                                                rate: currency_unit_per_pound)
+
+        if new_rate.valid?
+          new_rate.save
+          new_records_count += 1
+        else
+          invalid_records << new_rate
+
+          puts 'Invalid record'
+          next
+        end
+      end
+
+      puts '- - - Outcome - - -'
+      puts "New exchage rates imported: #{new_records_count}"
+      puts "Invalid CSV rows: #{invalid_rows.count}"
+      puts "Invalid records: #{invalid_records.count}"
+    end
+
+    # rubocop:disable Rake/MethodDefinitionInTask
+    def invalid?(row)
+      row.to_hash.values.any?(&:empty?)
+    end
+
+    def csv_without_title(text)
+      start_valid_data = 0
+
+      if text.include?('Average for the year')
+        start_valid_data = text.index("\r\n") + 2 # skip the first row with the Title
+      end
+
+      text[start_valid_data..]
+    end
+    # rubocop:enable Rake/MethodDefinitionInTask
+  end
+end

--- a/lib/tasks/exchange_rates_averages/Average for the year to 31 December 2020.csv
+++ b/lib/tasks/exchange_rates_averages/Average for the year to 31 December 2020.csv
@@ -1,0 +1,168 @@
+Country,Unit of Currency,Sterling value of Currency Unit,Currency Units per pound
+Abu Dhabi,Dirham ,0.2133,4.689050
+Albania,Lek ,0.0072,139.310833
+Algeria,Dinar ,0.0062,160.590833
+Angola,Readj Kwanza ,0.0014,719.303333
+Antigua,E Caribbean Dollar ,0.2901,3.447167
+Argentina,Peso ,0.0113,88.141750
+Armenia,Dram ,0.0016,619.242500
+Aruba,Florin,0.4376,2.285333
+Australia,Dollar ,0.5339,1.873142
+Azerbaijan,New Manat ,0.4614,2.167325
+Bahamas,Dollar,0.7832,1.276733
+Bahrain,Dinar ,2.0802,0.480725
+Bangladesh,Taka ,0.0092,108.395833
+Barbados,Dollar ,0.3916,2.553458
+Belarus,Rouble ,0.3273,3.055558
+Belize,Dollar ,0.3916,2.553458
+Benin,CFA Franc ,0.0014,740.530833
+Bermuda,Dollar (US) ,0.7832,1.276733
+Bhutan,Ngultrum ,0.0106,94.385833
+Bolivia,Boliviano ,0.1134,8.822192
+Bosnia- Herzegovinia,Marka ,0.4544,2.200517
+Botswana,Pula ,0.0685,14.591667
+Brazil,Real ,0.1540,6.491583
+Brunei,Dollar ,0.5669,1.764075
+Bulgaria,Lev ,0.4529,2.208083
+Burkina Faso,CFA Franc ,0.0014,740.530833
+Burundi,Franc ,0.0004,2440.217500
+Cambodia,Riel ,0.0002,5207.861667
+Cameroon,CFA Franc ,0.0014,740.530833
+Canada,Dollar,0.5819,1.718633
+Cape Verde Islands,Escudo ,0.0071,140.077500
+Cayman Islands,Dollar ,0.9552,1.046908
+Central African Republic,CFA Franc ,0.0014,740.530833
+Chad,CFA Franc ,0.0014,740.530833
+Chile,Peso ,0.0010,1011.877500
+China,Yuan,0.1132,8.836050
+Colombia,Peso ,0.0002,4728.159167
+Comoros,Franc ,0.0018,555.396667
+Congo (Brazaville),CFA Franc ,0.0014,740.530833
+Congo (DemRep),Congo Fr ,0.0004,2337.635000
+Costa Rica,Colon ,0.0013,741.578333
+Cote d'Ivoire,CFA Franc,0.0014,740.530833
+Croatia,Kuna ,0.1177,8.498333
+Cuba,Peso ,0.7832,1.276733
+Czech Republic,Koruna ,0.0335,29.850000
+Denmark,Krone ,0.1188,8.418783
+Djibouti,Franc ,0.0044,226.896667
+Dominica,E Caribbean Dollar ,0.2901,3.447167
+Dominican Republic,Peso ,0.0139,71.733333
+Dubai,Dirham ,0.2133,4.689050
+Ecuador,Dollar ,0.7832,1.276733
+Egypt,Pound ,0.0495,20.204167
+El Salvador,Colon ,0.0895,11.170000
+Equatorial Guinea,CFA Franc ,0.0014,740.530833
+Eritrea,Nakfa ,0.0522,19.146667
+Ethiopia,Birr ,0.0227,44.015833
+Eurozone,Euro ,0.8858,1.128925
+Fiji Islands,Dollar ,0.3596,2.780583
+Fr. Polynesia,CFP Franc,0.0074,134.714167
+Gabon,CFA Franc ,0.0014,740.530833
+Gambia,Dalasi ,0.0152,66.004817
+Georgia,Lari ,0.2541,3.935558
+Ghana,Cedi ,0.1368,7.308000
+Grenada,E Caribbean Dollar ,0.2901,3.447167
+Guatemala,Quetzal ,0.1016,9.838883
+Guinea Bissau,CFA Franc,0.0014,740.530833
+Guinea Republic,Franc ,0.0001,12279.964167
+Guyana,Dollar ,0.0037,266.823333
+Haiti,Gourde ,0.0083,120.159167
+Honduras,Lempira ,0.0318,31.422500
+Hong Kong,Dollar ,0.1010,9.904692
+Hungary,Forint ,0.0025,394.454167
+Iceland,Krona ,0.0058,172.778333
+India,Rupee ,0.0106,94.385833
+Indonesia,Rupiah ,0.0001,18468.680833
+Iraq,Dinar ,0.0007,1520.055000
+Israel,Shekel ,0.2259,4.426167
+Jamaica,Dollar ,0.0055,181.420000
+Japan,Yen ,0.0073,136.966667
+Jordan,Dinar ,1.1047,0.905200
+Kazakhstan,Tenge ,0.0019,526.415000
+Kenya,Schilling ,0.0074,135.229167
+Kuwait,Dinar ,2.5534,0.391633
+Kyrgyz Republic,Som ,0.0103,97.189167
+Lao People's Dem Rep,Kip ,0.0001,11536.412500
+Lebanon,Pound ,0.0005,1930.905000
+Lesotho,Loti ,0.0478,20.923333
+Liberia,Dollar (US) ,0.7832,1.276733
+Libya,Dinar ,0.5633,1.775383
+Macao,Pataca ,0.0980,10.201058
+Macedonia,Denar ,0.0144,69.519167
+Madagascar,Malagasy Ariary,0.0002,4863.433333
+Malawi,Kwacha ,0.0011,947.640000
+Malaysia,Ringgit ,0.1861,5.374058
+Maldive Islands,Rufiyaa ,0.0508,19.687500
+Mali Republic,CFA Franc,0.0014,740.530833
+Mauritania,Ouguiya ,0.0212,47.225000
+Mauritius,Rupee ,0.0200,49.938333
+Mexico,Mexican Peso ,0.0365,27.360000
+Moldova,Leu ,0.0452,22.127500
+Mongolia,Tugrik ,0.0003,3580.108333
+Montserrat,E Caribbean Dollar ,0.2901,3.447167
+Morocco,Dirham ,0.0823,12.150833
+Mozambique, Metical ,0.0114,87.615000
+Myanmar,Kyat ,0.0006,1782.799167
+Nepal,Rupee ,0.0066,151.020833
+New Caledonia,CFP Franc ,0.0074,134.714167
+New Zealand,Dollar ,0.5044,1.982358
+Nicaragua,Gold Cordoba ,0.0229,43.752500
+Niger Republic,CFA Franc ,0.0014,740.530833
+Nigeria,Naira ,0.0021,483.495000
+Norway,Norwegian Krone ,0.0825,12.116667
+Oman,Rial ,2.0342,0.491600
+Pakistan,Rupee ,0.0049,205.564167
+Panama,Balboa ,0.7832,1.276733
+Papua New Guinea,Kina ,0.2267,4.410667
+Paraguay,Guarani ,0.0001,8614.231667
+Peru,New Sol ,0.2257,4.430742
+Philippines,Peso ,0.0157,63.585833
+Poland,Zloty ,0.1998,5.003908
+Qatar,Riyal ,0.2151,4.648642
+Romania,New Leu ,0.1833,5.455892
+Russia,Rouble ,0.0110,91.295000
+Rwanda,Franc ,0.0008,1213.141667
+Saotome & Principe,Dobra ,0.0000,27989.925000
+Saudi Arabia,Riyal ,0.2088,4.789858
+Senegal,CFA Franc ,0.0014,740.530833
+Serbia,Dinar ,0.0075,132.730000
+Seychelles,Rupee ,0.0461,21.707500
+Sierra Leone,Leone ,0.0001,12664.014167
+Singapore,Dollar ,0.5669,1.764075
+Soloman Islands,Dollar ,0.0953,10.488000
+Somali Republic,Schilling ,0.0013,743.965833
+South Africa,Rand ,0.0478,20.925417
+South Korea,Won ,0.0007,1511.498333
+Sri Lanka,Rupee ,0.0042,236.467500
+St Christopher & Anguilla,E Caribbean Dollar ,0.2901,3.447167
+St Lucia,E Caribbean Dollar ,0.2901,3.447167
+St Vincent,E Caribbean Dollar ,0.2901,3.447167
+Sudan Republic,Pound ,0.0147,68.125000
+Surinam,Dollar ,0.0854,11.709608
+Swaziland,Lilangeni ,0.0478,20.923333
+Sweden,Krona ,0.0842,11.870833
+Switzerland,Franc ,0.8270,1.209258
+Taiwan,Dollar ,0.0265,37.768333
+Tanzania,Schilling,0.0003,2953.545000
+Thailand,Baht ,0.0250,39.922500
+Togo Republic,CFA Franc ,0.0014,740.530833
+Tonga Islands,Pa'anga (AUS) ,0.5339,1.873142
+Trinidad/Tobago,Dollar ,0.1160,8.620492
+Tunisia,Dinar ,0.2778,3.599142
+Turkey,Turkish  Lira ,0.1141,8.765433
+Turkmenistan,New Manat ,0.2234,4.476125
+UAE,Dirham ,0.2133,4.689050
+Uganda,Schilling ,0.0002,4744.462500
+Ukraine,Hryvnia ,0.0294,34.065000
+Uruguay,Peso ,0.0188,53.310000
+USA,Dollar ,0.7832,1.276733
+Uzbekistan,Sum ,0.0001,12779.250833
+Vanuatu,Vatu ,0.0067,149.078333
+Venezuela,Bolivar Fuerte ,0.0000,312878.370833
+Vietnam,Dong ,0.0000,29649.391667
+Wallis & Futuna Islands,CFP Franc ,0.0074,134.714167
+Western Samoa,Tala ,0.2943,3.397967
+Yemen (Rep of),Rial ,0.0031,319.280833
+Zambia,Kwacha ,0.0440,22.721667
+Zimbabwe,Dollar ,0.0022,462.043333

--- a/lib/tasks/exchange_rates_averages/Average for the year to 31 December 2021.csv
+++ b/lib/tasks/exchange_rates_averages/Average for the year to 31 December 2021.csv
@@ -1,0 +1,168 @@
+﻿Country,Unit of Currency,Sterling value of Currency Unit,Currency Units per pound
+Abu Dhabi,Dirham ,0.1976,5.059783
+Albania,Lek ,0.007,142.095833
+Algeria,Dinar ,0.0054,185.1375
+Angola,Readj Kwanza ,0.0011,880.195
+Antigua,E Caribbean Dollar ,0.2689,3.719283
+Argentina,Peso ,0.0077,129.08
+Armenia,Dram ,0.0014,696.846667
+Aruba,Florin,0.4056,2.46575
+Australia,Dollar ,0.5474,1.826717
+Azerbaijan,New Manat ,0.4273,2.34055
+Bahamas,Dollar,0.7259,1.377525
+Bahrain,Dinar ,1.9255,0.519342
+Bangladesh,Taka ,0.0085,117.01
+Barbados,Dollar ,0.363,2.755017
+Belarus,Rouble ,0.2865,3.489917
+Belize,Dollar ,0.363,2.755017
+Benin,CFA Franc ,0.0013,760.395833
+Bermuda,Dollar (US) ,0.7259,1.377525
+Bhutan,Ngultrum ,0.0098,101.6892
+Bolivia,Boliviano ,0.1051,9.5186
+Bosnia- Herzegovinia,Marka ,0.4411,2.267242
+Botswana,Pula ,0.0659,15.165833
+Brazil,Real ,0.1357,7.369158
+Brunei,Dollar ,0.5409,1.848725
+Bulgaria,Lev ,0.441,2.267458
+Burkina Faso,CFA Franc ,0.0013,760.395833
+Burundi,Franc ,0.0004,2715.426667
+Cambodia,Riel ,0.0002,5605.188333
+Cameroon,CFA Franc ,0.0013,760.395833
+Canada,Dollar,0.5796,1.725308
+Cape Verde Islands,Escudo ,0.0078,128.2375
+Cayman Islands,Dollar ,0.8853,1.12955
+Central African Republic,CFA Franc ,0.0013,760.395833
+Chad,CFA Franc ,0.0013,760.395833
+Chile,Peso ,0.001,1033.0825
+China,Yuan,0.1123,8.908242
+Colombia,Peso ,0.0002,5105.273333
+Comoros,Franc ,0.0018,570.295
+Congo (Brazaville),CFA Franc ,0.0013,760.395833
+Congo (DemRep),Congo Fr ,0.0004,2729.225833
+Costa Rica,Colon ,0.0012,850.896667
+Cote d'Ivoire,CFA Franc,0.0013,760.395833
+Croatia,Kuna ,0.1146,8.729233
+Cuba,Peso ,0.7259,1.377517
+Czech Republic,Koruna ,0.0336,29.786375
+Denmark,Krone ,0.116,8.621517
+Djibouti,Franc ,0.0041,244.806667
+Dominica,E Caribbean Dollar ,0.2689,3.719283
+Dominican Republic,Peso ,0.0127,78.701667
+Dubai,Dirham ,0.1976,5.059783
+Ecuador,Dollar ,0.7259,1.377525
+Egypt,Pound ,0.0462,21.621667
+El Salvador,Colon ,0.083,12.050833
+Equatorial Guinea,CFA Franc ,0.0013,760.395833
+Eritrea,Nakfa ,0.0484,20.6575
+Ethiopia,Birr ,0.0169,59.2825
+Eurozone,Euro ,0.8626,1.159233
+Fiji Islands,Dollar ,0.352,2.841058
+Fr. Polynesia,CFP Franc,0.0072,138.3275
+Gabon,CFA Franc ,0.0013,760.395833
+Gambia,Dalasi ,0.0141,70.8975
+Georgia,Lari ,0.2244,4.455608
+Ghana,Cedi ,0.1232,8.115208
+Grenada,E Caribbean Dollar ,0.2689,3.719283
+Guatemala,Quetzal ,0.0938,10.658333
+Guinea Bissau,CFA Franc,0.0013,760.395833
+Guinea Republic,Franc ,0.0001,13592.07
+Guyana,Dollar ,0.0035,288.2525
+Haiti,Gourde ,0.0084,119.556667
+Honduras,Lempira ,0.0302,33.073333
+Hong Kong,Dollar ,0.0935,10.698183
+Hungary,Forint ,0.0024,414.65
+Iceland,Krona ,0.0057,174.98
+India,Rupee ,0.0098,101.688367
+Indonesia,Rupiah ,0.0001,19678.37667
+Iraq,Dinar ,0.0005,1981.900833
+Israel,Shekel ,0.2241,4.463075
+Jamaica,Dollar ,0.0048,206.474167
+Japan,Yen ,0.0067,150.054167
+Jordan,Dinar ,1.0239,0.97665
+Kazakhstan,Tenge ,0.0017,585.908333
+Kenya,Schilling ,0.0066,151.085833
+Kuwait,Dinar ,2.4048,0.415833
+Kyrgyz Republic,Som ,0.0086,116.456667
+Lao People's Dem Rep,Kip ,0.0001,13250.84083
+Lebanon,Pound ,0.0005,2088.468333
+Lesotho,Loti ,0.0495,20.205
+Liberia,Dollar (US) ,0.7259,1.377525
+Libya,Dinar ,0.171,5.846542
+Macao,Pataca ,0.0908,11.018333
+Macedonia,Denar ,0.014,71.3725
+Madagascar,Malagasy Ariary,0.0002,5286.916667
+Malawi,Kwacha ,0.0009,1097.516667
+Malaysia,Ringgit ,0.1753,5.7043
+Maldive Islands,Rufiyaa ,0.047,21.259167
+Mali Republic,CFA Franc,0.0013,760.395833
+Mauritania,Ouguiya ,0.02,50.075
+Mauritius,Rupee ,0.0176,56.763333
+Mexico,Mexican Peso ,0.036,27.799167
+Moldova,Leu ,0.0411,24.3325
+Mongolia,Tugrik ,0.0003,3924.9125
+Montserrat,E Caribbean Dollar ,0.2689,3.719283
+Morocco,Dirham ,0.0809,12.355
+Mozambique, Metical ,0.011,91.033333
+Myanmar,Kyat ,0.0005,2180.525
+Nepal,Rupee ,0.0061,162.703333
+New Caledonia,CFP Franc ,0.0072,138.3275
+New Zealand,Dollar ,0.5144,1.943825
+Nicaragua,Gold Cordoba ,0.0207,48.303333
+Niger Republic,CFA Franc ,0.0013,760.395833
+Nigeria,Naira ,0.0018,562.569167
+Norway,Norwegian Krone ,0.0847,11.81
+Oman,Rial ,1.8857,0.530308
+Pakistan,Rupee ,0.0045,222.594167
+Panama,Balboa ,0.7259,1.377517
+Papua New Guinea,Kina ,0.2066,4.839467
+Paraguay,Guarani ,0.0001,9333.338333
+Peru,New Sol ,0.189,5.291608
+Philippines,Peso ,0.0147,67.805542
+Poland,Zloty ,0.1892,5.286592
+Qatar,Riyal ,0.1994,5.015858
+Romania,New Leu ,0.1755,5.698425
+Russia,Rouble ,0.0098,102.370833
+Rwanda,Franc ,0.0007,1369.264167
+Saotome & Principe,Dobra ,0,28749.33333
+Saudi Arabia,Riyal ,0.1935,5.166683
+Senegal,CFA Franc ,0.0013,760.395833
+Serbia,Dinar ,0.0073,136.270833
+Seychelles,Rupee ,0.0421,23.761667
+Sierra Leone,Leone ,0.0001,14245.12833
+Singapore,Dollar ,0.5409,1.848725
+Soloman Islands,Dollar ,0.0905,11.051667
+Somali Republic,Schilling ,0.0012,805.554167
+South Africa,Rand ,0.0495,20.205
+South Korea,Won ,0.0006,1570.145833
+Sri Lanka,Rupee ,0.0037,271.3975
+St Christopher & Anguilla,E Caribbean Dollar ,0.2689,3.719283
+St Lucia,E Caribbean Dollar ,0.2689,3.719283
+St Vincent,E Caribbean Dollar ,0.2689,3.719283
+Sudan Republic,Pound ,0.0024,420.705
+Surinam,Dollar ,0.0411,24.3425
+Swaziland,Lilangeni ,0.0495,20.205
+Sweden,Krona ,0.0852,11.7425
+Switzerland,Franc ,0.7954,1.257175
+Taiwan,Dollar ,0.0259,38.569167
+Tanzania,Schilling,0.0003,3191.265833
+Thailand,Baht ,0.0228,43.768017
+Togo Republic,CFA Franc ,0.0013,760.395833
+Tonga Islands,Pa'anga (AUS) ,0.5599,1.786033
+Trinidad/Tobago,Dollar ,0.1074,9.310583
+Tunisia,Dinar ,0.2622,3.814233
+Turkey,Turkish  Lira ,0.0864,11.579225
+Turkmenistan,New Manat ,0.2071,4.828742
+UAE,Dirham ,0.1976,5.059783
+Uganda,Schilling ,0.0002,4955.909167
+Ukraine,Hryvnia ,0.0266,37.650833
+Uruguay,Peso ,0.0167,59.855833
+USA,Dollar ,0.7259,1.377525
+Uzbekistan,Sum ,0.0001,14588.7475
+Vanuatu,Vatu ,0.0066,152.045
+Venezuela,Bolivar Fuerte ,0,333147.7217
+Vietnam,Dong ,0,31620.9925
+Wallis & Futuna Islands,CFP Franc ,0.0072,138.3275
+Western Samoa,Tala ,0.2851,3.507625
+Yemen (Rep of),Rial ,0.0029,346.2125
+Zambia,Kwacha ,0.0355,28.196667
+Zimbabwe,Dollar ,0.002,498.515

--- a/lib/tasks/exchange_rates_averages/Average for the year to 31 December 2022.csv
+++ b/lib/tasks/exchange_rates_averages/Average for the year to 31 December 2022.csv
@@ -1,0 +1,168 @@
+Country,Unit of Currency,Sterling value of Currency Unit,Currency Units per pound
+Abu Dhabi,Dirham ,0.2180,4.587583
+Albania,Lek ,0.0071,140.518158
+Algeria,Dinar ,0.0056,177.218483
+Angola,Readj Kwanza ,0.0017,584.521292
+Antigua,E Caribbean Dollar ,0.2965,3.372242
+Argentina,Peso ,0.0064,155.678025
+Armenia,Dram ,0.0018,554.851658
+Aruba,Florin,0.4473,2.235675
+Australia,Dollar ,0.5598,1.786317
+Azerbaijan,New Manat ,0.4711,2.122550
+Bahamas,Dollar,0.8003,1.249458
+Bahrain,Dinar ,2.1237,0.470883
+Bangladesh,Taka ,0.0087,114.828175
+Barbados,Dollar ,0.4003,2.497967
+Belarus,Rouble ,0.2782,3.595008
+Belize,Dollar ,0.4003,2.497967
+Benin,CFA Franc ,0.0013,772.533083
+Bermuda,Dollar (US) ,0.8003,1.249458
+Bhutan,Ngultrum ,0.0103,97.560208
+Bolivia,Boliviano ,0.1159,8.630467
+Bosnia- Herzegovinia,Marka ,0.4341,2.303408
+Botswana,Pula ,0.0654,15.296442
+Brazil,Real ,0.1541,6.488892
+Brunei,Dollar ,0.5809,1.721442
+Bulgaria,Lev ,0.4341,2.303508
+Burkina Faso,CFA Franc ,0.0013,772.533083
+Burundi,Franc ,0.0004,2532.150683
+Cambodia,Riel ,0.0002,4887.786717
+Cameroon,CFA Franc ,0.0013,772.533083
+Canada,Dollar,0.6192,1.615100
+Cape Verde Islands,Escudo ,0.0077,129.823058
+Cayman Islands,Dollar ,0.9764,1.024167
+Central African Republic,CFA Franc ,0.0013,772.533083
+Chad,CFA Franc ,0.0013,772.533083
+Chile,Peso ,0.0009,1086.696008
+China,Yuan,0.1199,8.342033
+Colombia,Peso ,0.0002,5215.888425
+Comoros,Franc ,0.0017,579.399825
+Congo (Brazaville),CFA Franc ,0.0013,772.533083
+Congo (DemRep),Congo Fr ,0.0004,2513.077133
+Costa Rica,Colon ,0.0012,808.035925
+Cote d'Ivoire,CFA Franc,0.0013,772.533083
+Croatia,Kuna ,0.1127,8.870908
+Cuba,Peso ,0.1245,8.029975
+Czech Republic,Koruna ,0.0345,28.948308
+Denmark,Krone ,0.1141,8.763033
+Djibouti,Franc ,0.0045,222.443008
+Dominica,E Caribbean Dollar ,0.2965,3.372242
+Dominican Republic,Peso ,0.0145,68.807925
+Dubai,Dirham ,0.2180,4.587583
+Ecuador,Dollar ,0.8003,1.249458
+Egypt,Pound ,0.0433,23.079258
+El Salvador,Colon ,0.0915,10.928442
+Equatorial Guinea,CFA Franc ,0.0013,772.533083
+Eritrea,Nakfa ,0.0534,18.734733
+Ethiopia,Birr ,0.0155,64.426317
+Eurozone,Euro ,0.8489,1.177958
+Fiji Islands,Dollar ,0.3666,2.727417
+Fr. Polynesia,CFP Franc,0.0071,140.539225
+Gabon,CFA Franc ,0.0013,772.533083
+Gambia,Dalasi ,0.0145,68.751142
+Georgia,Lari ,0.2719,3.677642
+Ghana,Cedi ,0.0929,10.768683
+Grenada,E Caribbean Dollar ,0.2965,3.372242
+Guatemala,Quetzal ,0.1035,9.658108
+Guinea Bissau,CFA Franc,0.0013,772.533083
+Guinea Republic,Franc ,0.0001,11062.409800
+Guyana,Dollar ,0.0038,261.310525
+Haiti,Gourde ,0.0072,139.630000
+Honduras,Lempira ,0.0326,30.702658
+Hong Kong,Dollar ,0.1022,9.783883
+Hungary,Forint ,0.0022,455.204617
+Iceland,Krona ,0.0060,166.914933
+India,Rupee ,0.0103,97.560208
+Indonesia,Rupiah ,0.0001,18416.008242
+Iraq,Dinar ,0.0005,1823.344258
+Israel,Shekel ,0.2417,4.137783
+Jamaica,Dollar ,0.0052,191.686408
+Japan,Yen ,0.0062,162.148108
+Jordan,Dinar ,1.1288,0.885917
+Kazakhstan,Tenge ,0.0017,571.997592
+Kenya,Schilling ,0.0068,146.142083
+Kuwait,Dinar ,2.6168,0.382142
+Kyrgyz Republic,Som ,0.0096,104.682758
+Lao People's Dem Rep,Kip ,0.0001,17129.935425
+Lebanon,Pound ,0.0005,1889.545975
+Lesotho,Loti ,0.0494,20.249583
+Liberia,Dollar (US) ,0.8003,1.249458
+Libya,Dinar ,0.1678,5.960717
+Macao,Pataca ,0.0993,10.073417
+Macedonia,Denar ,0.0138,72.511692
+Madagascar,Malagasy Ariary,0.0002,5100.389675
+Malawi,Kwacha ,0.0009,1143.846642
+Malaysia,Ringgit ,0.1827,5.474008
+Maldive Islands,Rufiyaa ,0.0519,19.265767
+Mali Republic,CFA Franc,0.0013,772.533083
+Mauritania,Ouguiya ,0.0224,44.626108
+Mauritius,Rupee ,0.0182,54.860475
+Mexico,Mexican Peso ,0.0397,25.216475
+Moldova,Leu ,0.0427,23.428475
+Mongolia,Tugrik ,0.0003,3866.233808
+Montserrat,E Caribbean Dollar ,0.2965,3.372242
+Morocco,Dirham ,0.0799,12.516267
+Mozambique, Metical ,0.0126,79.501925
+Myanmar,Kyat ,0.0004,2376.123875
+Nepal,Rupee ,0.0064,156.039000
+New Caledonia,CFP Franc ,0.0071,140.539225
+New Zealand,Dollar ,0.5126,1.950917
+Nicaragua,Gold Cordoba ,0.0224,44.677892
+Niger Republic,CFA Franc ,0.0013,772.533083
+Nigeria,Naira ,0.0019,528.036800
+Norway,Norwegian Krone ,0.0843,11.857917
+Oman,Rial ,2.0777,0.481300
+Pakistan,Rupee ,0.0040,251.475625
+Panama,Balboa ,0.8007,1.248967
+Papua New Guinea,Kina ,0.2276,4.394100
+Paraguay,Guarani ,0.0001,8667.174108
+Peru,New Sol ,0.2079,4.808908
+Philippines,Peso ,0.0148,67.568508
+Poland,Zloty ,0.1816,5.506658
+Qatar,Riyal ,0.2199,4.548225
+Romania,New Leu ,0.1720,5.813208
+Russia,Rouble ,0.0108,92.189042
+Rwanda,Franc ,0.0008,1287.687250
+Saotome & Principe,Dobra ,0.0000,28910.383333
+Saudi Arabia,Riyal ,0.2132,4.691083
+Senegal,CFA Franc ,0.0013,772.533083
+Serbia,Dinar ,0.0072,138.351933
+Seychelles,Rupee ,0.0556,17.970425
+Sierra Leone,Leone ,0.0001,15889.594467
+Singapore,Dollar ,0.5807,1.722058
+Soloman Islands,Dollar ,0.0984,10.160000
+Somali Republic,Schilling ,0.0014,723.207908
+South Africa,Rand ,0.0494,20.254450
+South Korea,Won ,0.0006,1599.895175
+Sri Lanka,Rupee ,0.0026,386.788617
+St Christopher & Anguilla,E Caribbean Dollar ,0.2965,3.372242
+St Lucia,E Caribbean Dollar ,0.2965,3.372242
+St Vincent,E Caribbean Dollar ,0.2965,3.372242
+Sudan Republic,Pound ,0.0016,606.466408
+Surinam,Dollar ,0.0343,29.162683
+Swaziland,Lilangeni ,0.0494,20.249583
+Sweden,Krona ,0.0804,12.430433
+Switzerland,Franc ,0.8405,1.189767
+Taiwan,Dollar ,0.0271,36.907833
+Tanzania,Schilling,0.0003,2901.870233
+Thailand,Baht ,0.0229,43.640367
+Togo Republic,CFA Franc ,0.0013,772.533083
+Tonga Islands,Pa'anga (AUS) ,0.5598,1.786317
+Trinidad/Tobago,Dollar ,0.1185,8.435533
+Tunisia,Dinar ,0.2606,3.837967
+Turkey,Turkish  Lira ,0.0494,20.249233
+Turkmenistan,New Manat ,0.2285,4.376475
+UAE,Dirham ,0.2180,4.587583
+Uganda,Schilling ,0.0002,4585.370842
+Ukraine,Hryvnia ,0.0255,39.140292
+Uruguay,Peso ,0.0192,52.078017
+USA,Dollar ,0.8003,1.249458
+Uzbekistan,Sum ,0.0001,13782.084425
+Vanuatu,Vatu ,0.0069,145.966742
+Venezuela,Bolivar Fuerte ,0.0000,310194.693333
+Vietnam,Dong ,0.0000,29168.755583
+Wallis & Futuna Islands,CFP Franc ,0.0071,140.539225
+Western Samoa,Tala ,0.2989,3.345750
+Yemen (Rep of),Rial ,0.0032,312.466317
+Zambia,Kwacha ,0.0476,21.029708
+Zimbabwe,Dollar ,0.0022,452.006683

--- a/lib/tasks/exchange_rates_averages/Average for the year to 31 March 2020.csv
+++ b/lib/tasks/exchange_rates_averages/Average for the year to 31 March 2020.csv
@@ -1,0 +1,168 @@
+Country,Unit of Currency,Sterling value of Currency Unit,Currency Units per pound
+Abu Dhabi,Dirham ,0.2128,4.6984
+Albania,Lek ,0.0071,140.6141667
+Algeria,Dinar ,0.0065,152.9641667
+Angola,Readj Kwanza ,0.0020,504.7191667
+Antigua,E Caribbean Dollar ,0.2895,3.454033333
+Argentina,Peso ,0.0152,65.96833333
+Armenia,Dram ,0.0016,612.795
+Aruba,Florin,0.4367,2.2899
+Australia,Dollar ,0.5403,1.850933333
+Azerbaijan,New Manat ,0.4608,2.170275
+Bahamas,Dollar,0.7817,1.279266667
+Bahrain,Dinar ,2.0735,0.482275
+Bangladesh,Taka ,0.0092,108.225
+Barbados,Dollar ,0.3908,2.55855
+Belarus,Rouble ,0.3744,2.670708333
+Belize,Dollar ,0.3909,2.558416667
+Benin,CFA Franc ,0.0013,754.9858333
+Bermuda,Dollar (US) ,0.7817,1.279266667
+Bhutan,Ngultrum ,0.0111,90.24666667
+Bolivia,Boliviano ,0.1131,8.839783333
+Bosnia- Herzegovinia,Marka ,0.4472,2.23615
+Botswana,Pula ,0.0725,13.785
+Brazil,Real ,0.1944,5.143041667
+Brunei,Dollar ,0.5727,1.746025
+Bulgaria,Lev ,0.4457,2.243708333
+Burkina Faso,CFA Franc ,0.0013,754.9858333
+Burundi,Franc ,0.0004,2372.325
+Cambodia,Riel ,0.0002,5191.7775
+Cameroon,CFA Franc ,0.0013,754.9858333
+Canada,Dollar,0.5903,1.693958333
+Cape Verde Islands,Escudo ,0.0079,126.7458333
+Cayman Islands,Dollar ,0.9533,1.049
+Central African Republic,CFA Franc ,0.0013,754.9858333
+Chad,CFA Franc ,0.0013,754.9858333
+Chile,Peso ,0.0011,923.7366667
+China,Yuan,0.1127,8.87015
+Colombia,Peso ,0.0002,4219.970833
+Comoros,Franc ,0.0018,564.3633333
+Congo (Brazaville),CFA Franc ,0.0013,754.9858333
+Congo (DemRep),Congo Fr ,0.0001,7956.9025
+Costa Rica,Colon ,0.0013,740.8725
+Cote d'Ivoire,CFA Franc,0.0013,754.9858333
+Croatia,Kuna ,0.1174,8.515383333
+Cuba,Peso ,0.7817,1.279266667
+Czech Republic,Koruna ,0.0341,29.315
+Denmark,Krone ,0.1167,8.5666
+Djibouti,Franc ,0.0044,227.3475
+Dominica,E Caribbean Dollar ,0.2895,3.454033333
+Dominican Republic,Peso ,0.0151,66.345
+Dubai,Dirham ,0.2128,4.6984
+Ecuador,Dollar ,0.7817,1.279266667
+Egypt,Pound ,0.0473,21.15166667
+El Salvador,Colon ,0.0894,11.18833333
+Equatorial Guinea,CFA Franc ,0.0013,754.9858333
+Eritrea,Nakfa ,0.0521,19.18416667
+Ethiopia,Birr ,0.0263,38.07
+Eurozone,Euro ,0.8717,1.147166667
+Fiji Islands,Dollar ,0.3616,2.765566667
+Fr. Polynesia,CFP Franc,0.0073,136.88
+Gabon,CFA Franc ,0.0013,754.9858333
+Gambia,Dalasi ,0.0155,64.65
+Georgia,Lari ,0.2748,3.6389
+Ghana,Cedi ,0.1447,6.912391667
+Grenada,E Caribbean Dollar ,0.2895,3.454033333
+Guatemala,Quetzal ,0.1017,9.837058333
+Guinea Bissau,CFA Franc,0.0013,754.9858333
+Guinea Republic,Franc ,0.0001,11896.815
+Guyana,Dollar ,0.0037,267.1966667
+Haiti,Gourde ,0.0087,114.7375
+Honduras,Lempira ,0.0318,31.405
+Hong Kong,Dollar ,0.1000,10.00035833
+Hungary,Forint ,0.0027,375.9525
+Iceland,Krona ,0.0063,157.9741667
+India,Rupee ,0.0111,90.24666667
+Indonesia,Rupiah ,0.0001,17981.0175
+Iraq,Dinar ,0.0007,1522.913333
+Israel,Shekel ,0.2206,4.532491667
+Jamaica,Dollar ,0.0058,171.3341667
+Japan,Yen ,0.0071,140.1766667
+Jordan,Dinar ,1.1024,0.907083333
+Kazakhstan,Tenge ,0.0020,488.3433333
+Kenya,Schilling ,0.0077,130.45
+Kuwait,Dinar ,2.5706,0.389016667
+Kyrgyz Republic,Som ,0.0112,89.25
+Lao People's Dem Rep,Kip ,0.0001,11192.2025
+Lebanon,Pound ,0.0005,1931.2
+Lesotho,Loti ,0.0540,18.52666667
+Liberia,Dollar (US) ,0.7817,1.279266667
+Libya,Dinar ,0.5577,1.793108333
+Macao,Pataca ,0.0971,10.297525
+Macedonia,Denar ,0.0142,70.59
+Madagascar,Malagasy Ariary,0.0002,4680.174167
+Malawi,Kwacha ,0.0011,947.33
+Malaysia,Ringgit ,0.1886,5.302833333
+Maldive Islands,Rufiyaa ,0.0506,19.75166667
+Mali Republic,CFA Franc,0.0013,754.9858333
+Mauritania,Ouguiya ,0.0028,352.52
+Mauritius,Rupee ,0.0217,46.05416667
+Mexico,Mexican Peso ,0.0408,24.49083333
+Moldova,Leu ,0.0445,22.465
+Mongolia,Tugrik ,0.0003,3433.8275
+Montserrat,E Caribbean Dollar ,0.2895,3.454033333
+Morocco,Dirham ,0.0813,12.29583333
+Mozambique, Metical ,0.0125,80.17666667
+Myanmar,Kyat ,0.0005,1940.684167
+Nepal,Rupee ,0.0069,144.3975
+New Caledonia,CFP Franc ,0.0073,136.88
+New Zealand,Dollar ,0.5131,1.949025
+Nicaragua,Gold Cordoba ,0.0235,42.62666667
+Niger Republic,CFA Franc ,0.0013,754.9858333
+Nigeria,Naira ,0.0022,463.2416667
+Norway,Norwegian Krone ,0.0881,11.34583333
+Oman,Rial ,2.0303,0.492541667
+Pakistan,Rupee ,0.0051,194.5241667
+Panama,Balboa ,0.7817,1.279266667
+Papua New Guinea,Kina ,0.2303,4.341941667
+Paraguay,Guarani ,0.0001,8049.758333
+Peru,New Sol ,0.2343,4.268375
+Philippines,Peso ,0.0152,65.9925
+Poland,Zloty ,0.2034,4.915541667
+Qatar,Riyal ,0.2147,4.657791667
+Romania,New Leu ,0.1836,5.447533333
+Russia,Rouble ,0.0122,81.9125
+Rwanda,Franc ,0.0009,1176.019167
+Saotome & Principe,Dobra ,0.0000,28188.20833
+Saudi Arabia,Riyal ,0.2084,4.798216667
+Senegal,CFA Franc ,0.0013,754.9858333
+Serbia,Dinar ,0.0074,135.0566667
+Seychelles,Rupee ,0.0561,17.81083333
+Sierra Leone,Leone ,0.0001,11925.09167
+Singapore,Dollar ,0.5727,1.746025
+Soloman Islands,Dollar ,0.0967,10.33748333
+Somali Republic,Schilling ,0.0013,743.9033333
+South Africa,Rand ,0.0540,18.52666667
+South Korea,Won ,0.0007,1492.601667
+Sri Lanka,Rupee ,0.0044,229.2983333
+St Christopher & Anguilla,E Caribbean Dollar ,0.2895,3.454033333
+St Lucia,E Caribbean Dollar ,0.2895,3.454033333
+St Vincent,E Caribbean Dollar ,0.2895,3.454033333
+Sudan Republic,Pound ,0.0168,59.365
+Surinam,Dollar ,0.1048,9.540825
+Swaziland,Lilangeni ,0.0540,18.52666667
+Sweden,Krona ,0.0825,12.11666667
+Switzerland,Franc ,0.7898,1.26615
+Taiwan,Dollar ,0.0255,39.2825
+Tanzania,Schilling,0.0003,2950.009167
+Thailand,Baht ,0.0252,39.64416667
+Togo Republic,CFA Franc ,0.0013,754.9858333
+Tonga Islands,Pa'anga (AUS) ,0.5514,1.813441667
+Trinidad/Tobago,Dollar ,0.1158,8.637966667
+Tunisia,Dinar ,0.2698,3.706508333
+Turkey,Turkish  Lira ,0.1363,7.334416667
+Turkmenistan,New Manat ,0.2230,4.484966667
+UAE,Dirham ,0.2128,4.6984
+Uganda,Schilling ,0.0002,4722.220833
+Ukraine,Hryvnia ,0.0307,32.53
+Uruguay,Peso ,0.0217,46.00083333
+USA,Dollar ,0.7817,1.279266667
+Uzbekistan,Sum ,0.0001,11547.23667
+Vanuatu,Vatu ,0.0067,148.8058333
+Venezuela,Bolivar Fuerte ,0.0000,317237.2425
+Vietnam,Dong ,0.0000,29699.93667
+Wallis & Futuna Islands,CFP Franc ,0.0073,136.88
+Western Samoa,Tala ,0.2962,3.3766
+Yemen (Rep of),Rial ,0.0031,319.9191667
+Zambia,Kwacha ,0.0590,16.96333333
+Zimbabwe,Dollar ,0.0022,462.9641667

--- a/lib/tasks/exchange_rates_averages/Average for the year to 31 March 2021.csv
+++ b/lib/tasks/exchange_rates_averages/Average for the year to 31 March 2021.csv
@@ -1,0 +1,168 @@
+﻿Country,Unit of Currency,Currency Code,Sterling value of Currency Unit,Currency Units per pound
+Abu Dhabi,Dirham ,AED,0.2105,4.751333
+Albania,Lek ,ALL,0.0072,137.970833
+Algeria,Dinar ,DZD,0.0060,166.886667
+Angola,Readj Kwanza ,AOA,0.0013,785.983333
+Antigua,E Caribbean Dollar ,XCD,0.2863,3.492542
+Argentina,Peso ,ARS,0.0102,97.953417
+Armenia,Dram ,AMD,0.0016,642.707500
+Aruba,Florin,AWG,0.4319,2.315417
+Australia,Dollar ,AUD,0.5446,1.836092
+Azerbaijan,New Manat ,AZN,0.4552,2.196692
+Bahamas,Dollar,BSD,0.7731,1.293542
+Bahrain,Dinar ,BHD,2.0531,0.487058
+Bangladesh,Taka ,BDT,0.0091,109.718333
+Barbados,Dollar ,BBD,0.3865,2.587067
+Belarus,Rouble ,BYN,0.3093,3.232717
+Belize,Dollar ,BZD,0.3865,2.587067
+Benin,CFA Franc ,XOF,0.0014,731.237500
+Bermuda,Dollar (US) ,BMD,0.7731,1.293542
+Bhutan,Ngultrum ,BTN,0.0104,96.196700
+Bolivia,Boliviano ,BOB,0.1119,8.938317
+Bosnia- Herzegovinia,Marka ,BAM,0.4587,2.180308
+Botswana,Pula ,BWP,0.0676,14.796667
+Brazil,Real ,BRL,0.1440,6.942050
+Brunei,Dollar ,BND,0.5640,1.773183
+Bulgaria,Lev ,BGN,0.4586,2.180367
+Burkina Faso,CFA Franc ,XOF,0.0014,731.237500
+Burundi,Franc ,BIF,0.0004,2495.950000
+Cambodia,Riel ,KHR,0.0002,5272.730000
+Cameroon,CFA Franc ,XAF,0.0014,731.237500
+Canada,Dollar,CAD,0.5801,1.723967
+Cape Verde Islands,Escudo ,CVE,0.0072,138.523333
+Cayman Islands,Dollar ,KYD,0.9428,1.060692
+Central African Republic,CFA Franc ,XAF,0.0014,731.237500
+Chad,CFA Franc ,XAF,0.0014,731.237500
+Chile,Peso ,CLP,0.0010,1007.135000
+China,Yuan,CNY,0.1138,8.789867
+Colombia,Peso ,COP,0.0002,4833.270000
+Comoros,Franc ,KMF,0.0018,548.425833
+Congo (Brazaville),CFA Franc ,XAF,0.0014,731.237500
+Congo (DemRep),Congo Fr ,CDF,0.0004,2463.205000
+Costa Rica,Colon ,CRC,0.0013,765.158333
+Cote d'Ivoire,CFA Franc,XOF,0.0014,731.237500
+Croatia,Kuna ,HRK,0.1187,8.423958
+Cuba,Peso ,CUP,0.7731,1.293542
+Czech Republic,Koruna ,CZK,0.0336,29.739167
+Denmark,Krone ,DKK,0.1204,8.303700
+Djibouti,Franc ,DJF,0.0044,229.883333
+Dominica,E Caribbean Dollar ,XCD,0.2863,3.492542
+Dominican Republic,Peso ,DOP,0.0135,74.263333
+Dubai,Dirham ,AED,0.2105,4.751333
+Ecuador,Dollar ,ECS,0.7731,1.293542
+Egypt,Pound ,EGP,0.0489,20.430833
+El Salvador,Colon ,SVC,0.0884,11.317500
+Equatorial Guinea,CFA Franc ,XAF,0.0014,731.237500
+Eritrea,Nakfa ,ERN,0.0516,19.398333
+Ethiopia,Birr ,ETB,0.0212,47.111667
+Eurozone,Euro ,EUR,0.8970,1.114767
+Fiji Islands,Dollar ,FJD,0.3614,2.767367
+Fr. Polynesia,CFP Franc,XPF,0.0075,133.023333
+Gabon,CFA Franc ,XAF,0.0014,731.237500
+Gambia,Dalasi ,GMD,0.0149,66.932317
+Georgia,Lari ,GEL,0.2423,4.127825
+Ghana,Cedi ,GHS,0.1336,7.486900
+Grenada,E Caribbean Dollar ,XCD,0.2863,3.492542
+Guatemala,Quetzal ,GTQ,0.1000,10.001933
+Guinea Bissau,CFA Franc,XOF,0.0014,731.237500
+Guinea Republic,Franc ,GNF,0.0001,12628.364167
+Guyana,Dollar ,GYD,0.0037,270.505833
+Haiti,Gourde ,HTG,0.0087,114.690000
+Honduras,Lempira ,HNL,0.0316,31.647500
+Hong Kong,Dollar ,HKD,0.0997,10.026542
+Hungary,Forint ,HUF,0.0025,396.121667
+Iceland,Krona ,ISK,0.0057,175.959167
+India,Rupee ,INR,0.0104,96.196700
+Indonesia,Rupiah ,IDR,0.0001,18809.988333
+Iraq,Dinar ,IQD,0.0006,1602.635833
+Israel,Shekel ,ILS,0.2265,4.415492
+Jamaica,Dollar ,JMD,0.0054,186.800000
+Japan,Yen ,JPY,0.0073,136.731667
+Jordan,Dinar ,JOD,1.0904,0.917108
+Kazakhstan,Tenge ,KZT,0.0018,546.324167
+Kenya,Schilling ,KES,0.0071,140.160000
+Kuwait,Dinar ,KWD,2.5222,0.396475
+Kyrgyz Republic,Som ,KGS,0.0097,103.279167
+Lao People's Dem Rep,Kip ,LAK,0.0001,11834.261667
+Lebanon,Pound ,LBP,0.0005,1958.484167
+Lesotho,Loti ,LSL,0.0470,21.266667
+Liberia,Dollar (US) ,LRD,0.7731,1.293542
+Libya,Dinar ,LYD,0.4004,2.497567
+Macao,Pataca ,MOP,0.0968,10.327725
+Macedonia,Denar ,MKD,0.0146,68.645833
+Madagascar,Malagasy Ariary,MGA,0.0002,4948.669167
+Malawi,Kwacha ,MWK,0.0010,972.155000
+Malaysia,Ringgit ,MYR,0.1846,5.417408
+Maldive Islands,Rufiyaa ,MVR,0.0502,19.932500
+Mali Republic,CFA Franc,XOF,0.0014,731.237500
+Mauritania,Ouguiya ,MRU,0.0211,47.439167
+Mauritius,Rupee ,MUR,0.0194,51.450000
+Mexico,Mexican Peso ,MXN,0.0355,28.140833
+Moldova,Leu ,MDL,0.0447,22.356667
+Mongolia,Tugrik ,MNT,0.0003,3663.994167
+Montserrat,E Caribbean Dollar ,XCD,0.2863,3.492542
+Morocco,Dirham ,MAD,0.0829,12.065000
+Mozambique, Metical ,MZN,0.0108,92.478333
+Myanmar,Kyat ,MMK,0.0006,1771.008333
+Nepal,Rupee ,NPR,0.0065,153.920000
+New Caledonia,CFP Franc ,XPF,0.0075,133.023333
+New Zealand,Dollar ,NZD,0.5104,1.959167
+Nicaragua,Gold Cordoba ,NIO,0.0224,44.655000
+Niger Republic,CFA Franc ,XOF,0.0014,731.237500
+Nigeria,Naira ,NGN,0.0020,501.564167
+Norway,Norwegian Krone ,NOK,0.0827,12.086667
+Oman,Rial ,OMR,2.0078,0.498067
+Pakistan,Rupee ,PKR,0.0048,209.940833
+Panama,Balboa ,PAB,0.7731,1.293542
+Papua New Guinea,Kina ,PGK,0.2219,4.505708
+Paraguay,Guarani ,PYG,0.0001,8832.770833
+Peru,New Sol ,PEN,0.2183,4.581367
+Philippines,Peso ,PHP,0.0157,63.600833
+Poland,Zloty ,PLN,0.1997,5.007900
+Qatar,Riyal ,QAR,0.2123,4.709917
+Romania,New Leu ,RON,0.1847,5.415200
+Russia,Rouble ,RUB,0.0103,96.965000
+Rwanda,Franc ,RWF,0.0008,1244.740000
+Saotome & Principe,Dobra ,STD,0.0000,27681.016667
+Saudi Arabia,Riyal ,SAR,0.2061,4.852992
+Senegal,CFA Franc ,XOF,0.0014,731.237500
+Serbia,Dinar ,RSD,0.0076,131.072500
+Seychelles,Rupee ,SCR,0.0409,24.449167
+Sierra Leone,Leone ,SLL,0.0001,12957.001667
+Singapore,Dollar ,SGD,0.5640,1.773183
+Soloman Islands,Dollar ,SBD,0.0948,10.553000
+Somali Republic,Schilling ,SOS,0.0013,754.263333
+South Africa,Rand ,ZAR,0.0470,21.268750
+South Korea,Won ,KRW,0.0007,1506.367500
+Sri Lanka,Rupee ,LKR,0.0041,243.107500
+St Christopher & Anguilla,E Caribbean Dollar ,XCD,0.2863,3.492542
+St Lucia,E Caribbean Dollar ,XCD,0.2863,3.492542
+St Vincent,E Caribbean Dollar ,XCD,0.2863,3.492542
+Sudan Republic,Pound ,SDG,0.0140,71.515000
+Surinam,Dollar ,SRD,0.0708,14.131467
+Swaziland,Lilangeni ,SZL,0.0470,21.266667
+Sweden,Krona ,SEK,0.0862,11.605000
+Switzerland,Franc ,CHF,0.8363,1.195758
+Taiwan,Dollar ,TWD,0.0266,37.559167
+Tanzania,Schilling,TZS,0.0003,2997.416667
+Thailand,Baht ,THB,0.0249,40.240000
+Togo Republic,CFA Franc ,XOF,0.0014,731.237500
+Tonga Islands,Pa'anga (AUS) ,TOP,0.5446,1.836092
+Trinidad/Tobago,Dollar ,TTD,0.1145,8.735967
+Tunisia,Dinar ,TND,0.2780,3.597400
+Turkey,Turkish  Lira ,TRY,0.1068,9.361358
+Turkmenistan,New Manat ,TMT,0.2206,4.533900
+UAE,Dirham ,AED,0.2105,4.751333
+Uganda,Schilling ,UGX,0.0002,4806.030000
+Ukraine,Hryvnia ,UAH,0.0279,35.803333
+Uruguay,Peso ,UYU,0.0180,55.613333
+USA,Dollar ,USD,0.7731,1.293542
+Uzbekistan,Sum ,UZS,0.0001,13272.061667
+Vanuatu,Vatu ,VUV,0.0067,148.303333
+Venezuela,Bolivar Fuerte ,VEF,0.0000,310877.333333
+Vietnam,Dong ,VND,0.0000,29998.280833
+Wallis & Futuna Islands,CFP Franc ,XPF,0.0075,133.023333
+Western Samoa,Tala ,WST,0.2945,3.395500
+Yemen (Rep of),Rial ,YER,0.0031,323.984167
+Zambia,Kwacha ,ZMW,0.0395,25.295833
+Zimbabwe,Dollar ,ZWL,0.0021,468.124167

--- a/lib/tasks/exchange_rates_averages/Average for the year to 31 March 2022.csv
+++ b/lib/tasks/exchange_rates_averages/Average for the year to 31 March 2022.csv
@@ -1,0 +1,168 @@
+Country,Unit of Currency,Currency Code,Sterling value of Currency Unit,Currency Units per pound
+Abu Dhabi,Dirham ,AED,0.1985,5.036608
+Albania,Lek ,ALL,0.007,143.280958
+Algeria,Dinar ,DZD,0.0054,186.727808
+Angola,Readj Kwanza ,AOA,0.0012,840.224358
+Antigua,E Caribbean Dollar ,XCD,0.2701,3.702267
+Argentina,Peso ,ARS,0.0074,134.622542
+Armenia,Dram ,AMD,0.0015,679.396625
+Aruba,Florin,AWG,0.4074,2.454475
+Australia,Dollar ,AUD,0.5397,1.8529
+Azerbaijan,New Manat ,AZN,0.4292,2.32985
+Bahamas,Dollar,BSD,0.7293,1.371217
+Bahrain,Dinar ,BHD,1.9344,0.51695
+Bangladesh,Taka ,BDT,0.0086,116.877292
+Barbados,Dollar ,BBD,0.3646,2.742417
+Belarus,Rouble ,BYN,0.2878,3.474067
+Belize,Dollar ,BZD,0.3646,2.742417
+Benin,CFA Franc ,XOF,0.0013,770.204875
+Bermuda,Dollar (US) ,BMD,0.7293,1.371217
+Bhutan,Ngultrum ,BTN,0.0098,101.97445
+Bolivia,Boliviano ,BOB,0.1055,9.475058
+Bosnia- Herzegovinia,Marka ,BAM,0.4354,2.296483
+Botswana,Pula ,BWP,0.0652,15.346392
+Brazil,Real ,BRL,0.1354,7.383258
+Brunei,Dollar ,BND,0.5406,1.849633
+Bulgaria,Lev ,BGN,0.4354,2.296692
+Burkina Faso,CFA Franc ,XOF,0.0013,770.204875
+Burundi,Franc ,BIF,0.0004,2720.572308
+Cambodia,Riel ,KHR,0.0002,5377.713067
+Cameroon,CFA Franc ,XAF,0.0013,770.204875
+Canada,Dollar,CAD,0.5819,1.718633
+Cape Verde Islands,Escudo ,CVE,0.0077,129.912975
+Cayman Islands,Dollar ,KYD,0.8894,1.124392
+Central African Republic,CFA Franc ,XAF,0.0013,770.204875
+Chad,CFA Franc ,XAF,0.0013,770.204875
+Chile,Peso ,CLP,0.0009,1061.542942
+China,Yuan,CNY,0.1134,8.822225
+Colombia,Peso ,COP,0.0002,5246.333825
+Comoros,Franc ,KMF,0.0017,577.653042
+Congo (Brazaville),CFA Franc ,XAF,0.0013,770.204875
+Congo (DemRep),Congo Fr ,CDF,0.0004,2724.914992
+Costa Rica,Colon ,CRC,0.0012,856.750483
+Cote d'Ivoire,CFA Franc,XOF,0.0013,770.204875
+Croatia,Kuna ,HRK,0.1132,8.832933
+Cuba,Peso ,CUP,0.7293,1.371208
+Czech Republic,Koruna ,CZK,0.0336,29.749125
+Denmark,Krone ,DKK,0.1145,8.733058
+Djibouti,Franc ,DJF,0.0041,243.687983
+Dominica,E Caribbean Dollar ,XCD,0.2701,3.702267
+Dominican Republic,Peso ,DOP,0.0128,77.971208
+Dubai,Dirham ,AED,0.1985,5.036608
+Ecuador,Dollar ,ECS,0.7293,1.371217
+Egypt,Pound ,EGP,0.0465,21.528508
+El Salvador,Colon ,SVC,0.0834,11.997025
+Equatorial Guinea,CFA Franc ,XAF,0.0013,770.204875
+Eritrea,Nakfa ,ERN,0.0486,20.5646
+Ethiopia,Birr ,ETB,0.016,62.526067
+Eurozone,Euro ,EUR,0.8517,1.174183
+Fiji Islands,Dollar ,FJD,0.3493,2.862567
+Fr. Polynesia,CFP Franc,XPF,0.0071,140.11265
+Gabon,CFA Franc ,XAF,0.0013,770.204875
+Gambia,Dalasi ,GMD,0.0141,71.145883
+Georgia,Lari ,GEL,0.2295,4.356567
+Ghana,Cedi ,GHS,0.1213,8.246033
+Grenada,E Caribbean Dollar ,XCD,0.2701,3.702267
+Guatemala,Quetzal ,GTQ,0.0944,10.588517
+Guinea Bissau,CFA Franc,XOF,0.0013,770.204875
+Guinea Republic,Franc ,GNF,0.0001,13226.28354
+Guyana,Dollar ,GYD,0.0035,286.946792
+Haiti,Gourde ,HTG,0.0078,128.812592
+Honduras,Lempira ,HNL,0.0302,33.058825
+Hong Kong,Dollar ,HKD,0.0938,10.665842
+Hungary,Forint ,HUF,0.0024,420.910308
+Iceland,Krona ,ISK,0.0057,173.975733
+India,Rupee ,INR,0.0098,101.973617
+Indonesia,Rupiah ,IDR,0.0001,19666.16168
+Iraq,Dinar ,IQD,0.0005,2002.72125
+Israel,Shekel ,ILS,0.2269,4.40695
+Jamaica,Dollar ,JMD,0.0048,208.703925
+Japan,Yen ,JPY,0.0065,152.927892
+Jordan,Dinar ,JOD,1.0286,0.972192
+Kazakhstan,Tenge ,KZT,0.0017,588.500883
+Kenya,Schilling ,KES,0.0066,151.35675
+Kuwait,Dinar ,KWD,2.4179,0.413583
+Kyrgyz Republic,Som ,KGS,0.0086,116.155558
+Lao People's Dem Rep,Kip ,LAK,0.0001,13844.41001
+Lebanon,Pound ,LBP,0.0005,2077.124725
+Lesotho,Loti ,LSL,0.0491,20.347292
+Liberia,Dollar (US) ,LRD,0.7293,1.371217
+Libya,Dinar ,LYD,0.161,6.211958
+Macao,Pataca ,MOP,0.091,10.984792
+Macedonia,Denar ,MKD,0.0138,72.294242
+Madagascar,Malagasy Ariary,MGA,0.0002,5335.710233
+Malawi,Kwacha ,MWK,0.0009,1107.938783
+Malaysia,Ringgit ,MYR,0.1745,5.731425
+Maldive Islands,Rufiyaa ,MVR,0.0472,21.182592
+Mali Republic,CFA Franc,XOF,0.0013,770.204875
+Mauritania,Ouguiya ,MRU,0.0201,49.851075
+Mauritius,Rupee ,MUR,0.0173,57.922183
+Mexico,Mexican Peso ,MXN,0.0359,27.867567
+Moldova,Leu ,MDL,0.041,24.403783
+Mongolia,Tugrik ,MNT,0.0003,3910.600783
+Montserrat,E Caribbean Dollar ,XCD,0.2701,3.702267
+Morocco,Dirham ,MAD,0.0805,12.425783
+Mozambique, Metical ,MZN,0.0115,86.85835
+Myanmar,Kyat ,MMK,0.0004,2310.2158
+Nepal,Rupee ,NPR,0.0061,163.158283
+New Caledonia,CFP Franc ,XPF,0.0071,140.11265
+New Zealand,Dollar ,NZD,0.5083,1.967325
+Nicaragua,Gold Cordoba ,NIO,0.0207,48.278775
+Niger Republic,CFA Franc ,XOF,0.0013,770.204875
+Nigeria,Naira ,NGN,0.0018,565.677667
+Norway,Norwegian Krone ,NOK,0.0842,11.878892
+Oman,Rial ,OMR,1.8929,0.528292
+Pakistan,Rupee ,PKR,0.0044,227.258283
+Panama,Balboa ,PAB,0.7293,1.371208
+Papua New Guinea,Kina ,PGK,0.2077,4.814617
+Paraguay,Guarani ,PYG,0.0001,9317.166592
+Peru,New Sol ,PEN,0.1862,5.371342
+Philippines,Peso ,PHP,0.0146,68.433592
+Poland,Zloty ,PLN,0.1862,5.370367
+Qatar,Riyal ,QAR,0.2003,4.992908
+Romania,New Leu ,RON,0.1726,5.792775
+Russia,Rouble ,RUB,0.0093,107.382983
+Rwanda,Franc ,RWF,0.0007,1375.6681
+Saotome & Principe,Dobra ,STD,0,29136.46667
+Saudi Arabia,Riyal ,SAR,0.1944,5.143233
+Senegal,CFA Franc ,XOF,0.0013,770.204875
+Serbia,Dinar ,RSD,0.0072,138.033525
+Seychelles,Rupee ,SCR,0.0467,21.394775
+Sierra Leone,Leone ,SLL,0.0001,14576.45433
+Singapore,Dollar ,SGD,0.5406,1.849633
+Soloman Islands,Dollar ,SBD,0.0907,11.026867
+Somali Republic,Schilling ,SOS,0.0012,802.327075
+South Africa,Rand ,ZAR,0.0491,20.347292
+South Korea,Won ,KRW,0.0006,1593.502258
+Sri Lanka,Rupee ,LKR,0.0037,273.656017
+St Christopher & Anguilla,E Caribbean Dollar ,XCD,0.2701,3.702267
+St Lucia,E Caribbean Dollar ,XCD,0.2701,3.702267
+St Vincent,E Caribbean Dollar ,XCD,0.2701,3.702267
+Sudan Republic,Pound ,SDG,0.0018,549.858583
+Surinam,Dollar ,SRD,0.0376,26.606775
+Swaziland,Lilangeni ,SZL,0.0491,20.347292
+Sweden,Krona ,SEK,0.0835,11.977483
+Switzerland,Franc ,CHF,0.7924,1.261917
+Taiwan,Dollar ,TWD,0.0261,38.315242
+Tanzania,Schilling,TZS,0.0003,3173.298867
+Thailand,Baht ,THB,0.0224,44.561967
+Togo Republic,CFA Franc ,XOF,0.0013,770.204875
+Tonga Islands,Pa'anga (AUS) ,TOP,0.5518,1.812217
+Trinidad/Tobago,Dollar ,TTD,0.108,9.26325
+Tunisia,Dinar ,TND,0.2593,3.85635
+Turkey,Turkish  Lira ,TRY,0.0728,13.726917
+Turkmenistan,New Manat ,TMT,0.2081,4.80555
+UAE,Dirham ,AED,0.1985,5.036608
+Uganda,Schilling ,UGX,0.0002,4887.814
+Ukraine,Hryvnia ,UAH,0.0267,37.438425
+Uruguay,Peso ,UYU,0.0167,60.047917
+USA,Dollar ,USD,0.7293,1.371217
+Uzbekistan,Sum ,UZS,0.0001,14632.27089
+Vanuatu,Vatu ,VUV,0.0065,153.041225
+Venezuela,Bolivar Fuerte ,VEF,0,337689.5808
+Vietnam,Dong ,VND,0,31393.55474
+Wallis & Futuna Islands,CFP Franc ,XPF,0.0071,140.11265
+Western Samoa,Tala ,WST,0.2835,3.527625
+Yemen (Rep of),Rial ,YER,0.0029,344.221367
+Zambia,Kwacha ,ZMW,0.0375,26.643017
+Zimbabwe,Dollar ,ZWL,0.002,496.236267

--- a/lib/tasks/exchange_rates_averages/Average for the year to 31 March 2023.csv
+++ b/lib/tasks/exchange_rates_averages/Average for the year to 31 March 2023.csv
@@ -1,0 +1,168 @@
+Country,Unit of Currency,Currency Code,Sterling value of Currency Unit,Currency Units per pound
+Abu Dhabi,Dirham ,AED,0.2234,4.476675
+Albania,Lek ,ALL,0.0073,137.496725
+Algeria,Dinar ,DZD,0.0058,172.102683
+Angola,Readj Kwanza ,AOA,0.0018,556.979375
+Antigua,E Caribbean Dollar ,XCD,0.3039,3.290717
+Argentina,Peso ,ARS,0.0057,176.4786
+Armenia,Dram ,AMD,0.0019,513.773608
+Aruba,Florin,AWG,0.4584,2.181633
+Australia,Dollar ,AUD,0.5682,1.759892
+Azerbaijan,New Manat ,AZN,0.4827,2.071808
+Bahamas,Dollar,BSD,0.8202,1.219267
+Bahrain,Dinar ,BHD,2.1763,0.459492
+Bangladesh,Taka ,BDT,0.0085,118.187492
+Barbados,Dollar ,BBD,0.4102,2.437575
+Belarus,Rouble ,BYN,0.2855,3.502592
+Belize,Dollar ,BZD,0.4102,2.437575
+Benin,CFA Franc ,XOF,0.0013,765.028242
+Bermuda,Dollar (US) ,BMD,0.8202,1.219267
+Bhutan,Ngultrum ,BTN,0.0103,97.412425
+Bolivia,Boliviano ,BOB,0.1187,8.421825
+Bosnia- Herzegovinia,Marka ,BAM,0.4383,2.281792
+Botswana,Pula ,BWP,0.0652,15.332908
+Brazil,Real ,BRL,0.1599,6.252975
+Brunei,Dollar ,BND,0.5972,1.674575
+Bulgaria,Lev ,BGN,0.4384,2.281125
+Burkina Faso,CFA Franc ,XOF,0.0013,765.028242
+Burundi,Franc ,BIF,0.0004,2489.052558
+Cambodia,Riel ,KHR,0.0002,4982.176633
+Cameroon,CFA Franc ,XAF,0.0013,765.028242
+Canada,Dollar,CAD,0.625,1.599892
+Cape Verde Islands,Escudo ,CVE,0.0078,128.549225
+Cayman Islands,Dollar ,KYD,1.0006,0.9994
+Central African Republic,CFA Franc ,XAF,0.0013,765.028242
+Chad,CFA Franc ,XAF,0.0013,765.028242
+Chile,Peso ,CLP,0.0009,1064.248783
+China,Yuan,CNY,0.1205,8.301708
+Colombia,Peso ,COP,0.0002,5344.492408
+Comoros,Franc ,KMF,0.0017,573.771192
+Congo (Brazaville),CFA Franc ,XAF,0.0013,765.028242
+Congo (DemRep),Congo Fr ,CDF,0.0004,2464.980317
+Costa Rica,Colon ,CRC,0.0013,771.006017
+Cote d'Ivoire,CFA Franc,XOF,0.0013,765.028242
+Croatia,Kuna ,HRK,0.1324,7.552633
+Cuba,Peso ,CUP,0.0665,15.04745
+Czech Republic,Koruna ,CZK,0.0351,28.474025
+Denmark,Krone ,DKK,0.1152,8.678967
+Djibouti,Franc ,DJF,0.0046,217.152
+Dominica,E Caribbean Dollar ,XCD,0.3039,3.290717
+Dominican Republic,Peso ,DOP,0.015,66.773917
+Dubai,Dirham ,AED,0.2234,4.476675
+Ecuador,Dollar ,ECS,0.8202,1.219267
+Egypt,Pound ,EGP,0.0378,26.458733
+El Salvador,Colon ,SVC,0.0938,10.664025
+Equatorial Guinea,CFA Franc ,XAF,0.0013,765.028242
+Eritrea,Nakfa ,ERN,0.0547,18.281817
+Ethiopia,Birr ,ETB,0.0156,64.12205
+Eurozone,Euro ,EUR,0.8572,1.166525
+Fiji Islands,Dollar ,FJD,0.3727,2.683442
+Fr. Polynesia,CFP Franc,XPF,0.0072,139.173942
+Gabon,CFA Franc ,XAF,0.0013,765.028242
+Gambia,Dalasi ,GMD,0.0143,69.758625
+Georgia,Lari ,GEL,0.2888,3.462192
+Ghana,Cedi ,GHS,0.0822,12.170933
+Grenada,E Caribbean Dollar ,XCD,0.3039,3.290717
+Guatemala,Quetzal ,GTQ,0.1056,9.470175
+Guinea Bissau,CFA Franc,XOF,0.0013,765.028242
+Guinea Republic,Franc ,GNF,0.0001,10609.16913
+Guyana,Dollar ,GYD,0.0039,255.152633
+Haiti,Gourde ,HTG,0.0066,150.5696
+Honduras,Lempira ,HNL,0.0333,30.011417
+Hong Kong,Dollar ,HKD,0.1047,9.553342
+Hungary,Forint ,HUF,0.0022,460.408958
+Iceland,Krona ,ISK,0.006,167.687967
+India,Rupee ,INR,0.0103,97.412425
+Indonesia,Rupiah ,IDR,0.0001,18283.72129
+Iraq,Dinar ,IQD,0.0006,1778.995433
+Israel,Shekel ,ILS,0.2423,4.127867
+Jamaica,Dollar ,JMD,0.0054,186.367783
+Japan,Yen ,JPY,0.0061,164.193992
+Jordan,Dinar ,JOD,1.1565,0.864692
+Kazakhstan,Tenge ,KZT,0.0018,566.955258
+Kenya,Schilling ,KES,0.0068,146.031758
+Kuwait,Dinar ,KWD,2.6735,0.374042
+Kyrgyz Republic,Som ,KGS,0.0098,102.446883
+Lao People's Dem Rep,Kip ,LAK,0.0001,18554.28488
+Lebanon,Pound ,LBP,0.0003,3196.5929
+Lesotho,Loti ,LSL,0.0491,20.356708
+Liberia,Dollar (US) ,LRD,0.8202,1.219267
+Libya,Dinar ,LYD,0.1699,5.886467
+Macao,Pataca ,MOP,0.1017,9.835958
+Macedonia,Denar ,MKD,0.0139,71.799833
+Madagascar,Malagasy Ariary,MGA,0.0002,5095.812367
+Malawi,Kwacha ,MWK,0.0008,1183.304642
+Malaysia,Ringgit ,MYR,0.1853,5.397125
+Maldive Islands,Rufiyaa ,MVR,0.0533,18.776692
+Mali Republic,CFA Franc,XOF,0.0013,765.028242
+Mauritania,Ouguiya ,MRU,0.023,43.547258
+Mauritius,Rupee ,MUR,0.0186,53.768217
+Mexico,Mexican Peso ,MXN,0.0415,24.0871
+Moldova,Leu ,MDL,0.0431,23.227242
+Mongolia,Tugrik ,MNT,0.0003,3962.776383
+Montserrat,E Caribbean Dollar ,XCD,0.3039,3.290717
+Morocco,Dirham ,MAD,0.0797,12.544617
+Mozambique, Metical ,MZN,0.0129,77.588642
+Myanmar,Kyat ,MMK,0.0004,2420.796592
+Nepal,Rupee ,NPR,0.0064,155.802558
+New Caledonia,CFP Franc ,XPF,0.0072,139.173942
+New Zealand,Dollar ,NZD,0.5183,1.929425
+Nicaragua,Gold Cordoba ,NIO,0.0228,43.912992
+Niger Republic,CFA Franc ,XOF,0.0013,765.028242
+Nigeria,Naira ,NGN,0.0019,527.848025
+Norway,Norwegian Krone ,NOK,0.084,11.899383
+Oman,Rial ,OMR,2.131,0.469258
+Pakistan,Rupee ,PKR,0.0038,265.421767
+Panama,Balboa ,PAB,0.8205,1.218775
+Papua New Guinea,Kina ,PGK,0.233,4.291908
+Paraguay,Guarani ,PYG,0.0001,8583.659417
+Peru,New Sol ,PEN,0.2143,4.666042
+Philippines,Peso ,PHP,0.0149,67.30305
+Poland,Zloty ,PLN,0.1817,5.503558
+Qatar,Riyal ,QAR,0.2253,4.438533
+Romania,New Leu ,RON,0.1739,5.749633
+Russia,Rouble ,RUB,0.0121,82.310275
+Rwanda,Franc ,RWF,0.0008,1274.076858
+Saotome & Principe,Dobra ,STD,0,28515.875
+Saudi Arabia,Riyal ,SAR,0.2184,4.579042
+Senegal,CFA Franc ,XOF,0.0013,765.028242
+Serbia,Dinar ,RSD,0.0073,136.944642
+Seychelles,Rupee ,SCR,0.0575,17.397875
+Sierra Leone,Leone ,SLL,0.0001,13503.47706
+Singapore,Dollar ,SGD,0.5969,1.675192
+Soloman Islands,Dollar ,SBD,0.1004,9.959233
+Somali Republic,Schilling ,SOS,0.0014,700.579375
+South Africa,Rand ,ZAR,0.0491,20.363467
+South Korea,Won ,KRW,0.0006,1588.517933
+Sri Lanka,Rupee ,LKR,0.0023,430.760917
+St Christopher & Anguilla,E Caribbean Dollar ,XCD,0.3039,3.290717
+St Lucia,E Caribbean Dollar ,XCD,0.3039,3.290717
+St Vincent,E Caribbean Dollar ,XCD,0.3039,3.290717
+Sudan Republic,Pound ,SDG,0.0016,635.535233
+Surinam,Dollar ,SRD,0.0314,31.848058
+Swaziland,Lilangeni ,SZL,0.0491,20.3586
+Sweden,Krona ,SEK,0.08,12.495058
+Switzerland,Franc ,CHF,0.8609,1.161625
+Taiwan,Dollar ,TWD,0.0271,36.874942
+Tanzania,Schilling,TZS,0.0004,2840.202058
+Thailand,Baht ,THB,0.0233,42.943117
+Togo Republic,CFA Franc ,XOF,0.0013,765.028242
+Tonga Islands,Pa'anga (AUS) ,TOP,0.5682,1.759892
+Trinidad/Tobago,Dollar ,TTD,0.1215,8.231233
+Tunisia,Dinar ,TND,0.2619,3.817725
+Turkey,Turkish  Lira ,TRY,0.0469,21.3076
+Turkmenistan,New Manat ,TMT,0.2343,4.268208
+UAE,Dirham ,AED,0.2234,4.476675
+Uganda,Schilling ,UGX,0.0002,4523.575567
+Ukraine,Hryvnia ,UAH,0.0244,41.035483
+Uruguay,Peso ,UYU,0.0203,49.221867
+USA,Dollar ,USD,0.8202,1.219267
+Uzbekistan,Sum ,UZS,0.0001,13600.38266
+Vanuatu,Vatu ,VUV,0.007,143.530358
+Venezuela,Bolivar Fuerte ,VEF,0,304876.5683
+Vietnam,Dong ,VND,0,28696.12768
+Wallis & Futuna Islands,CFP Franc ,XPF,0.0072,139.173942
+Western Samoa,Tala ,WST,0.3043,3.286142
+Yemen (Rep of),Rial ,YER,0.0033,304.943708
+Zambia,Kwacha ,ZMW,0.0478,20.912858
+Zimbabwe,Dollar ,ZWL,0.0023,441.079283


### PR DESCRIPTION
### What?
This PR imports data from the  CSV https://www.gov.uk/government/publications/exchange-rates-for-customs-and-vat-yearly
into ExchangeRateCurrencyRate table

### Jira link
https://transformuk.atlassian.net/browse/HOTT-3975
