### PR TITLE
HOTT-3995: Removed extended cumulation method from Canada

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk.json
+++ b/db/rules_of_origin/roo_schemes_uk.json
@@ -465,30 +465,6 @@
                         "GB",
                         "CA"
                     ]
-                },
-                "extended": {
-                    "countries": [
-                        "EU",
-                        "AD",
-                        "SM",
-                        "XX",
-                        "JP",
-                        "MX",
-                        "SG",
-                        "VN",
-                        "CL",
-                        "CO",
-                        "CR",
-                        "IS",
-                        "LI",
-                        "NO",
-                        "CH",
-                        "HO",
-                        "IL",
-                        "KR",
-                        "PE",
-                        "UA"
-                    ]
                 }
             },
             "ord": {


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3995

### What?

I have added/removed/altered:

- [ ] Removed extended cumulation method from Canada

### Why?

I am doing this because:

- it is no longer required

