### PR TITLE
HOTT-3975: Add support for average rates in files controller.

### DIFF
--- a/app/controllers/api/v2/exchange_rates/files_controller.rb
+++ b/app/controllers/api/v2/exchange_rates/files_controller.rb
@@ -15,7 +15,7 @@ module Api
         private
 
         def type
-          match_data = id.match(/^(monthly_csv_hmrc|monthly_csv|monthly_xml)_/)
+          match_data = id.match(/^(monthly_csv_hmrc|monthly_csv|monthly_xml|average_csv)_/)
           match_data[1] if match_data
         end
 

--- a/app/models/exchange_rate_currency_rate.rb
+++ b/app/models/exchange_rate_currency_rate.rb
@@ -3,6 +3,7 @@ require 'csv'
 class ExchangeRateCurrencyRate < Sequel::Model
   SCHEDULED_RATE_TYPE = 'scheduled'.freeze
   SPOT_RATE_TYPE = 'spot'.freeze
+  AVERAGE_RATE_TYPE = 'average'.freeze
 
   RATES_FILE = 'data/exchange_rates/all_rates.csv'.freeze
   SPOT_RATES_FILE = 'data/exchange_rates/all_spot_rates.csv'.freeze

--- a/app/models/exchange_rate_file.rb
+++ b/app/models/exchange_rate_file.rb
@@ -1,5 +1,5 @@
 class ExchangeRateFile < Sequel::Model
-  APPLICABLE_TYPES = %w[monthly_csv monthly_xml].freeze
+  APPLICABLE_TYPES = %w[monthly_csv monthly_xml spot_csv average_csv].freeze
   OBJECT_KEY_PREFIX = 'data/exchange_rates'.freeze
 
   include ContentAddressableId
@@ -42,14 +42,25 @@ class ExchangeRateFile < Sequel::Model
       case type
       when 'monthly_csv_hmrc'
         "#{year}#{month_with_zero}MonthlyRates.#{format}"
+      when 'average_csv'
+        "#{year}#{month_with_zero}AverageRates.#{format}"
       else
         "exrates-monthly-#{month_with_zero}#{year[2..3]}.#{format}"
       end
     end
 
-    def applicable_files_for(month, year)
+    def applicable_files_for(month, year, type)
+      file_types = case type
+                   when ExchangeRateCurrencyRate::SCHEDULED_RATE_TYPE
+                     %w[monthly_csv monthly_xml]
+                   when ExchangeRateCurrencyRate::SPOT_RATE_TYPE
+                     %w[spot_csv]
+                   when ExchangeRateCurrencyRate::AVERAGE_RATE_TYPE
+                     %w[average_csv]
+                   end
+
       applicable_types
-        .where(period_year: year, period_month: month)
+        .where(period_year: year, period_month: month, type: file_types)
         .all
     end
   end

--- a/spec/models/exchange_rate_file_spec.rb
+++ b/spec/models/exchange_rate_file_spec.rb
@@ -68,6 +68,6 @@ RSpec.describe ExchangeRateFile, type: :model do
       )
     end
 
-    it { expect(described_class.applicable_files_for(month, year)).to match_array(expected_files) }
+    it { expect(described_class.applicable_files_for(month, year, 'scheduled')).to match_array(expected_files) }
   end
 end


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-3975

### What?
This PR allows to download average_rate files.

### Why?
Because the FE page Exchange Average Rate contains links to the average rate files.