### PR TITLE
HOTT-4006: Disable Exec on API backends

### DIFF
--- a/terraform/backend_uk.tf
+++ b/terraform/backend_uk.tf
@@ -25,7 +25,6 @@ module "backend_uk" {
   memory = var.memory
 
   task_role_policy_arns = [
-    aws_iam_policy.exec.arn,
     aws_iam_policy.s3.arn,
     aws_iam_policy.task_role_kms_keys.arn
   ]
@@ -33,8 +32,6 @@ module "backend_uk" {
   execution_role_policy_arns = [
     aws_iam_policy.secrets.arn,
   ]
-
-  enable_ecs_exec = true
 
   service_environment_config = flatten([local.backend_common_vars,
     [

--- a/terraform/backend_xi.tf
+++ b/terraform/backend_xi.tf
@@ -25,17 +25,13 @@ module "backend_xi" {
   memory = var.memory
 
   task_role_policy_arns = [
-    aws_iam_policy.exec.arn,
     aws_iam_policy.s3.arn,
     aws_iam_policy.task_role_kms_keys.arn
   ]
 
-
   execution_role_policy_arns = [
     aws_iam_policy.secrets.arn
   ]
-
-  enable_ecs_exec = true
 
   init_container            = true
   init_container_entrypoint = [""]


### PR DESCRIPTION
### Jira link

[HOTT-4006](https://transformuk.atlassian.net/browse/HOTT-4006)

### What?

I have added/removed/altered:

- Disabled ECS Exec on non-worker services.

### Why?

I am doing this because:

- We only need to be able to exec into the worker services here. To prevent engineers touching the API services, I'm disabling it for them.
