### PR TITLE
HOTT-4054: Adjust sync cutoff

### DIFF
--- a/app/workers/updates_synchronizer_worker.rb
+++ b/app/workers/updates_synchronizer_worker.rb
@@ -2,7 +2,7 @@ class UpdatesSynchronizerWorker
   include Sidekiq::Worker
 
   TRY_AGAIN_IN = 20.minutes
-  CUT_OFF_TIME = '07:30'.freeze
+  CUT_OFF_TIME = '10:00'.freeze
 
   sidekiq_options queue: :sync, retry: false
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4054

### What?

I have added/removed/altered:

- [x] Altered cutoff for the sync process

### Why?

I am doing this because:

- This is required because these files have been arriving later and later
