### PR TITLE
HOTT-3976: Fix the support for type average 

### DIFF
--- a/app/controllers/api/v2/exchange_rates/period_lists_controller.rb
+++ b/app/controllers/api/v2/exchange_rates/period_lists_controller.rb
@@ -24,7 +24,7 @@ module Api
         end
 
         def year
-          params[:year]
+          params[:year].to_i if params[:year]
         end
       end
     end

--- a/app/controllers/api/v2/exchange_rates/period_lists_controller.rb
+++ b/app/controllers/api/v2/exchange_rates/period_lists_controller.rb
@@ -20,15 +20,11 @@ module Api
         end
 
         def period_list
-          @period_list ||= ::ExchangeRates::PeriodList.build(year, type)
+          @period_list ||= ::ExchangeRates::PeriodList.build(type, year)
         end
 
         def year
-          (params[:year].presence || default_year).to_i
-        end
-
-        def default_year
-          ExchangeRateCurrencyRate.max_year(type)
+          params[:year]
         end
       end
     end

--- a/app/models/exchange_rate_file.rb
+++ b/app/models/exchange_rate_file.rb
@@ -13,7 +13,7 @@ class ExchangeRateFile < Sequel::Model
   content_addressable_fields :format, :type, :publication_date, :period_year, :period_month
 
   def file_path
-    "/api/v2/exchange_rates/files/#{type}_#{period_year}-#{period_month}.#{format}"
+    "/api/v2/exchange_rates/files/#{filename}"
   end
 
   def object_key
@@ -55,11 +55,10 @@ class ExchangeRateFile < Sequel::Model
       end
     end
 
-    def applicable_files_for(month, year, type)
-      file_types = TYPE_TO_FILE_MAP[type]
+    def applicable_files_for(month, year, rate_type)
+      file_types = TYPE_TO_FILE_MAP[rate_type]
 
-      applicable_types
-        .where(period_year: year, period_month: month, type: file_types)
+      where(period_year: year, period_month: month, type: file_types)
         .all
     end
   end

--- a/app/models/exchange_rates/period.rb
+++ b/app/models/exchange_rates/period.rb
@@ -2,12 +2,7 @@ module ExchangeRates
   class Period
     attr_accessor :month, :year, :files, :has_exchange_rates
 
-    def initialize(month:, year:, has_exchange_rates:, files:)
-      @month = month
-      @year = year
-      @has_exchange_rates = has_exchange_rates
-      @file = files
-    end
+    include ActiveModel::Model
 
     def id
       "#{year}-#{month}-exchange_rate_period"

--- a/app/models/exchange_rates/period.rb
+++ b/app/models/exchange_rates/period.rb
@@ -11,25 +11,19 @@ module ExchangeRates
     end
 
     class << self
-      def wrap(months_and_years, type)
-        months_and_years.map do |month_and_year|
-          build(
-            month_and_year[:month_and_year],
-            month_and_year[:has_exchange_rates],
-            type,
-          )
-        end
+      def wrap(months_years_rates, type)
+        months_years_rates.map { |m_y_r| build(m_y_r, type) }
       end
 
-      def build(month_and_year, has_exchange_rates, type)
-        month = month_and_year&.first
-        year = month_and_year&.last
+      def build(month_year_rate, type)
+        month = month_year_rate.month
+        year = month_year_rate.year
 
         period = new
         period.month = month
         period.year = year
         period.files = ::ExchangeRateFile.applicable_files_for(month, year, type)
-        period.has_exchange_rates = has_exchange_rates
+        period.has_exchange_rates = month_year_rate.has_exchange_rates
         period
       end
     end

--- a/app/models/exchange_rates/period.rb
+++ b/app/models/exchange_rates/period.rb
@@ -11,13 +11,20 @@ module ExchangeRates
     end
 
     class << self
-      def wrap(months_and_years, type, has_exchange_rates)
-        months_and_years.map do |month, year|
-          build(month, year, type, has_exchange_rates)
+      def wrap(months_and_years, type)
+        months_and_years.map do |month_and_year|
+          build(
+            month_and_year[:month_and_year],
+            month_and_year[:has_exchange_rates],
+            type,
+          )
         end
       end
 
-      def build(month, year, type, has_exchange_rates)
+      def build(month_and_year, has_exchange_rates, type)
+        month = month_and_year&.first
+        year = month_and_year&.last
+
         period = new
         period.month = month
         period.year = year

--- a/app/models/exchange_rates/period.rb
+++ b/app/models/exchange_rates/period.rb
@@ -2,6 +2,13 @@ module ExchangeRates
   class Period
     attr_accessor :month, :year, :files, :has_exchange_rates
 
+    def initialize(month:, year:, has_exchange_rates:, files:)
+      @month = month
+      @year = year
+      @has_exchange_rates = has_exchange_rates
+      @file = files
+    end
+
     def id
       "#{year}-#{month}-exchange_rate_period"
     end
@@ -16,15 +23,13 @@ module ExchangeRates
       end
 
       def build(month_year_rate, type)
-        month = month_year_rate.month
-        year = month_year_rate.year
+        month = month_year_rate[:month]
+        year = month_year_rate[:year]
 
-        period = new
-        period.month = month
-        period.year = year
-        period.files = ::ExchangeRateFile.applicable_files_for(month, year, type)
-        period.has_exchange_rates = month_year_rate.has_exchange_rates
-        period
+        new(month:,
+            year:,
+            has_exchange_rates: month_year_rate[:has_exchange_rates],
+            files: ::ExchangeRateFile.applicable_files_for(month, year, type))
       end
     end
   end

--- a/app/models/exchange_rates/period.rb
+++ b/app/models/exchange_rates/period.rb
@@ -1,6 +1,6 @@
 module ExchangeRates
   class Period
-    attr_accessor :month, :year, :files
+    attr_accessor :month, :year, :files, :has_exchange_rates
 
     def id
       "#{year}-#{month}-exchange_rate_period"
@@ -11,17 +11,18 @@ module ExchangeRates
     end
 
     class << self
-      def wrap(months, year, type)
-        months.map do |month|
-          build(month, year, type)
+      def wrap(months_and_years, type, has_exchange_rates)
+        months_and_years.map do |month, year|
+          build(month, year, type, has_exchange_rates)
         end
       end
 
-      def build(month, year, type)
+      def build(month, year, type, has_exchange_rates)
         period = new
         period.month = month
         period.year = year
         period.files = ::ExchangeRateFile.applicable_files_for(month, year, type)
+        period.has_exchange_rates = has_exchange_rates
         period
       end
     end

--- a/app/models/exchange_rates/period_list.rb
+++ b/app/models/exchange_rates/period_list.rb
@@ -28,8 +28,11 @@ module ExchangeRates
       end
 
       def exchange_rate_periods_for(year, type)
-        months = ExchangeRateCurrencyRate.months_for_year(year, type)
-
+        months = if type == 'average'
+                   [3, 12]
+                 else
+                   ExchangeRateCurrencyRate.months_for_year(year, type)
+                 end
         ExchangeRates::Period.wrap(months, year, type)
       end
 

--- a/app/models/exchange_rates/period_list.rb
+++ b/app/models/exchange_rates/period_list.rb
@@ -32,12 +32,17 @@ module ExchangeRates
       def periods_for(type, year)
         year = default_year(year, type)
 
-        months_and_years = ExchangeRateCurrencyRate.months_for(type, year)
-        has_exchange_rates = months_and_years.present?
-        months_and_years += ExchangeRateFile.months_for(type, year)
-        months_and_years = months_and_years.uniq.sort_by { |m, y| [y, m] }.reverse
+        rate_months_and_years = ExchangeRateCurrencyRate.months_for(type, year).to_set
+        file_months_and_years = ExchangeRateFile.months_for(type, year).to_set
 
-        ExchangeRates::Period.wrap(months_and_years, type, has_exchange_rates)
+        months_and_years = (rate_months_and_years + file_months_and_years).uniq.sort_by { |m, y| [y, m] }.reverse.map do |month_and_year|
+          {
+            month_and_year:,
+            has_exchange_rates: rate_months_and_years.include?(month_and_year),
+          }
+        end
+
+        ExchangeRates::Period.wrap(months_and_years, type)
       end
 
       def exchange_rate_years(type)

--- a/app/models/exchange_rates/period_list.rb
+++ b/app/models/exchange_rates/period_list.rb
@@ -9,8 +9,6 @@ module ExchangeRates
 
     content_addressable_fields :year, :type
 
-    MonthYearRates = Struct.new(:month, :year, :has_exchange_rates)
-
     def exchange_rate_year_ids
       exchange_rate_years.map(&:id)
     end
@@ -40,11 +38,11 @@ module ExchangeRates
         months_years_rates = (rate_months_and_years + file_months_and_years).uniq.sort_by { |m, y| [y, m] }
           .reverse
           .map do |month_and_year|
-            MonthYearRates.new(
+            {
               month: month_and_year[0],
               year: month_and_year[1],
               has_exchange_rates: rate_months_and_years.include?(month_and_year),
-            )
+            }
           end
 
         ExchangeRates::Period.wrap(months_years_rates, type)

--- a/app/models/exchange_rates/period_list.rb
+++ b/app/models/exchange_rates/period_list.rb
@@ -9,6 +9,8 @@ module ExchangeRates
 
     content_addressable_fields :year, :type
 
+    MonthYearRates = Struct.new(:month, :year, :has_exchange_rates)
+
     def exchange_rate_year_ids
       exchange_rate_years.map(&:id)
     end
@@ -35,14 +37,17 @@ module ExchangeRates
         rate_months_and_years = ExchangeRateCurrencyRate.months_for(type, year).to_set
         file_months_and_years = ExchangeRateFile.months_for(type, year).to_set
 
-        months_and_years = (rate_months_and_years + file_months_and_years).uniq.sort_by { |m, y| [y, m] }.reverse.map do |month_and_year|
-          {
-            month_and_year:,
-            has_exchange_rates: rate_months_and_years.include?(month_and_year),
-          }
-        end
+        months_years_rates = (rate_months_and_years + file_months_and_years).uniq.sort_by { |m, y| [y, m] }
+          .reverse
+          .map do |month_and_year|
+            MonthYearRates.new(
+              month: month_and_year[0],
+              year: month_and_year[1],
+              has_exchange_rates: rate_months_and_years.include?(month_and_year),
+            )
+          end
 
-        ExchangeRates::Period.wrap(months_and_years, type)
+        ExchangeRates::Period.wrap(months_years_rates, type)
       end
 
       def exchange_rate_years(type)

--- a/app/serializers/api/v2/exchange_rates/exchange_rate_period_serializer.rb
+++ b/app/serializers/api/v2/exchange_rates/exchange_rate_period_serializer.rb
@@ -6,7 +6,7 @@ module Api
 
         set_type :exchange_rate_period
 
-        attributes :month, :year
+        attributes :month, :year, :has_exchange_rates
 
         has_many :files, serializer: Api::V2::ExchangeRates::ExchangeRateFileSerializer
       end

--- a/spec/models/exchange_rate_currency_rate_spec.rb
+++ b/spec/models/exchange_rate_currency_rate_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ExchangeRateCurrencyRate do
   end
 
   describe '.months_for_year' do
-    subject(:result) { described_class.months_for_year(2020, ExchangeRateCurrencyRate::SCHEDULED_RATE_TYPE) }
+    subject(:result) { described_class.months_for(ExchangeRateCurrencyRate::SCHEDULED_RATE_TYPE, 2020) }
 
     before do
       create(
@@ -37,7 +37,7 @@ RSpec.describe ExchangeRateCurrencyRate do
       )
     end
 
-    it { expect(result).to eq([7, 1]) }
+    it { expect(result).to eq([[7, 2020], [1, 2020]]) }
   end
 
   describe '.for_month' do
@@ -151,8 +151,8 @@ RSpec.describe ExchangeRateCurrencyRate do
     subject(:dataset) { described_class.by_type('scheduled') }
 
     before do
-      create(:exchange_rate_currency_rate, rate_type: 'scheduled')
-      create(:exchange_rate_currency_rate, rate_type: 'foo')
+      create(:exchange_rate_currency_rate, :scheduled_rate, currency_code: 'XXX')
+      create(:exchange_rate_currency_rate, :spot_rate, currency_code: 'YYY')
     end
 
     it { expect(dataset.pluck(:rate_type)).to eq(%w[scheduled]) }

--- a/spec/models/exchange_rates/period_list_spec.rb
+++ b/spec/models/exchange_rates/period_list_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ExchangeRates::PeriodList do
   end
 
   describe '.build' do
-    subject(:period_list) { described_class.build(year, ExchangeRateCurrencyRate::SCHEDULED_RATE_TYPE) }
+    subject(:period_list) { described_class.build(ExchangeRateCurrencyRate::SCHEDULED_RATE_TYPE, year) }
 
     it 'builds a period list with exchange rate periods and years' do
       expect(period_list).to be_an_instance_of(described_class)
@@ -46,43 +46,12 @@ RSpec.describe ExchangeRates::PeriodList do
     end
   end
 
-  describe '.exchange_rate_periods_for' do
-    subject(:exchange_rate_periods) { described_class.exchange_rate_periods_for(year, ExchangeRateCurrencyRate::SCHEDULED_RATE_TYPE) }
-
-    before do
-      allow(ExchangeRateCurrencyRate).to receive(:months_for_year).with(year, ExchangeRateCurrencyRate::SCHEDULED_RATE_TYPE).and_return(months)
-    end
-
-    it 'calls ExchangeRates::Period.build with the correct arguments' do
-      allow(ExchangeRates::Period).to receive(:wrap).with(months, year, ExchangeRateCurrencyRate::SCHEDULED_RATE_TYPE).and_return([])
-      exchange_rate_periods
-    end
-
-    it 'returns an array' do
-      expect(exchange_rate_periods).to be_an(Array)
-    end
-
-    it 'returns an array of ExchangeRates::Period instances' do
-      expect(exchange_rate_periods).to all(be_an_instance_of(ExchangeRates::Period))
-    end
-
-    context 'when the year contains no periods' do
-      let(:year) { 1970 }
-
-      before do
-        allow(ExchangeRateCurrencyRate).to receive(:months_for_year).with(year, ExchangeRateCurrencyRate::SCHEDULED_RATE_TYPE).and_return([])
-      end
-
-      it 'returns an empty array' do
-        expect(exchange_rate_periods).to eq([])
-      end
-    end
-  end
-
   describe '.exchange_rate_years' do
-    subject(:exchange_rate_years) { described_class.exchange_rate_years(ExchangeRateCurrencyRate::SCHEDULED_RATE_TYPE) }
+    subject(:exchange_rate_years) do
+      described_class.exchange_rate_years(ExchangeRateCurrencyRate::SCHEDULED_RATE_TYPE)
+    end
 
-    let(:years) { [2020, 2021, 2022] }
+    let(:years) { [2022, 2021, 2020] }
 
     before do
       allow(ExchangeRateCurrencyRate).to receive(:all_years).and_return(years)

--- a/spec/models/exchange_rates/period_list_spec.rb
+++ b/spec/models/exchange_rates/period_list_spec.rb
@@ -44,30 +44,17 @@ RSpec.describe ExchangeRates::PeriodList do
     it 'initializes exchange rate years to an empty array' do
       expect(period_list.exchange_rate_years).to be_empty
     end
-  end
 
-  describe '.exchange_rate_years' do
-    subject(:exchange_rate_years) do
-      described_class.exchange_rate_years(ExchangeRateCurrencyRate::SCHEDULED_RATE_TYPE)
-    end
+    context 'when year is nil' do
+      let(:year) { nil }
 
-    let(:years) { [2022, 2021, 2020] }
+      it 'calls max_year' do
+        allow(ExchangeRateCurrencyRate).to receive(:max_year)
 
-    before do
-      allow(ExchangeRateCurrencyRate).to receive(:all_years).and_return(years)
-    end
+        period_list.exchange_rate_periods
 
-    it 'calls ExchangeRates::PeriodYear.build with the correct arguments' do
-      allow(ExchangeRates::PeriodYear).to receive(:wrap).with(years).and_return([])
-      exchange_rate_years
-    end
-
-    it 'returns an array' do
-      expect(exchange_rate_years).to be_an(Array)
-    end
-
-    it 'returns an array of ExchangeRates::PeriodYear instances' do
-      expect(exchange_rate_years).to all(be_an_instance_of(ExchangeRates::PeriodYear))
+        expect(ExchangeRateCurrencyRate).to have_received(:max_year).with('scheduled')
+      end
     end
   end
 end

--- a/spec/models/exchange_rates/period_list_spec.rb
+++ b/spec/models/exchange_rates/period_list_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe ExchangeRates::PeriodList do
   let(:year) { 2020 }
-  let(:months) { [1, 2, 3] }
 
   describe '#id' do
     subject(:period_list) { build(:period_list) }

--- a/spec/models/exchange_rates/period_spec.rb
+++ b/spec/models/exchange_rates/period_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe ExchangeRates::Period do
   let(:year) { 2022 }
   let(:month) { 3 }
-  let(:period) { described_class.build(month, year, ExchangeRateCurrencyRate::SCHEDULED_RATE_TYPE) }
+  let(:period) { described_class.build([month, year], true, ExchangeRateCurrencyRate::SCHEDULED_RATE_TYPE) }
 
   describe '#id' do
     it 'returns the formatted period ID' do
@@ -60,20 +60,28 @@ RSpec.describe ExchangeRates::Period do
 
   describe '.wrap' do
     let(:year) { 2022 }
-    let(:months) { [1, 2, 3] }
-    let(:periods) { described_class.wrap(months, year, ExchangeRateCurrencyRate::SCHEDULED_RATE_TYPE) }
+    let(:month) { 1 }
+    let(:periods) do
+      described_class.wrap(
+        [{
+          month_and_year: [month, year],
+          has_exchange_rates: true,
+        }],
+        ExchangeRateCurrencyRate::SCHEDULED_RATE_TYPE,
+      )
+    end
 
     it 'builds an array of periods' do
       expect(periods).to be_an(Array)
     end
 
-    it 'builds an array of 3 periods' do
-      expect(periods.size).to eq(3)
+    it 'builds an array of one period' do
+      expect(periods.size).to eq(1)
     end
 
     it 'builds periods with correct month' do
       periods.each do |period|
-        expect(period.month).to be_in(months)
+        expect(period.month).to be(month)
       end
     end
 

--- a/spec/models/exchange_rates/period_spec.rb
+++ b/spec/models/exchange_rates/period_spec.rb
@@ -1,60 +1,34 @@
 RSpec.describe ExchangeRates::Period do
-  let(:year) { 2022 }
-  let(:month) { 3 }
-  let(:period) { described_class.build([month, year], true, ExchangeRateCurrencyRate::SCHEDULED_RATE_TYPE) }
-
   describe '#id' do
-    it 'returns the formatted period ID' do
-      expect(period.id).to eq('2022-3-exchange_rate_period')
-    end
-  end
+    subject(:id) { build(:exchange_rates_period, year: '2022', month: '3').id }
 
-  describe '#file_ids' do
-    context 'without files' do
-      it 'returns empty array' do
-        expect(period.file_ids).to be_empty
-      end
-    end
-
-    context 'with files' do
-      before do
-        create(:exchange_rate_file, period_year: year, period_month: month)
-      end
-
-      it 'returns the ids of associated exchange rate files' do
-        expect(period.file_ids).to eq([period.files.first.id])
-      end
-    end
+    it { is_expected.to eq('2022-3-exchange_rate_period') }
   end
 
   describe '.build' do
+    let(:period) do
+      described_class.build(
+        {
+          month: '3',
+          year: '2022',
+          has_exchange_rates: true,
+        },
+        ExchangeRateCurrencyRate::SCHEDULED_RATE_TYPE,
+      )
+    end
+
     context 'without files' do
-      it 'does not load any associated files' do
-        expect(period.files.count).to eq(0)
-      end
+      it { expect(period.files).to be_empty }
     end
 
     context 'with files' do
       before do
-        create(:exchange_rate_file, period_year: year, period_month: month, type: 'monthly_csv')
-        create(:exchange_rate_file, period_year: year, period_month: month, type: 'monthly_xml')
+        create(:exchange_rate_file, period_year: '2022', period_month: '3', type: 'monthly_csv')
       end
 
-      it 'builds a period' do
-        expect(period).to be_a(described_class)
-      end
-
-      it 'builds a period with correct month' do
-        expect(period.month).to eq(month)
-      end
-
-      it 'builds a period with correct year' do
-        expect(period.year).to eq(year)
-      end
-
-      it 'loads associated files' do
-        expect(period.files.count).to eq(2)
-      end
+      it { expect(period).to be_a(described_class) }
+      it { expect(period).to have_attributes(month: '3', year: '2022') }
+      it { expect(period.files.pluck(:type)).to eq(%w[monthly_csv]) }
     end
   end
 
@@ -64,7 +38,8 @@ RSpec.describe ExchangeRates::Period do
     let(:periods) do
       described_class.wrap(
         [{
-          month_and_year: [month, year],
+          month:,
+          year:,
           has_exchange_rates: true,
         }],
         ExchangeRateCurrencyRate::SCHEDULED_RATE_TYPE,

--- a/spec/serializers/api/v2/exchange_rates/exchange_rate_period_serializer_spec.rb
+++ b/spec/serializers/api/v2/exchange_rates/exchange_rate_period_serializer_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Api::V2::ExchangeRates::ExchangeRatePeriodSerializer do
         attributes: {
           month: 1,
           year: 2022,
+          has_exchange_rates: nil,
         },
         relationships: {
           files: {


### PR DESCRIPTION
### What?
Fix the support for for type `average` on the endpoint 'exchange_rates/period_lists'.

### Jira link
https://transformuk.atlassian.net/browse/HOTT-3976


### Why?
To simplify/unify FE exchange rate pages.