### PR TITLE
HOTT-3271: Adds candidate supplementary unit worksheet

### DIFF
--- a/app/lib/reporting/differences.rb
+++ b/app/lib/reporting/differences.rb
@@ -11,6 +11,24 @@ module Reporting
       },
     ].freeze
 
+    MEASURE_UNIT_EAGER = [
+      :measure_type,
+      {
+        measure_components: %i[
+          measurement_unit
+          measurement_unit_qualifier
+        ],
+        measure_conditions: [
+          {
+            measure_condition_components: %i[
+              measurement_unit
+              measurement_unit_qualifier
+            ],
+          },
+        ],
+      },
+    ].freeze
+
     GOODS_NOMENCLATURE_MEASURE_EAGER = [
       :measures,
       {
@@ -37,6 +55,14 @@ module Reporting
           { overview_measures: MEASURE_EAGER },
           :goods_nomenclature_descriptions,
         ],
+      },
+    ].freeze
+
+    GOODS_NOMENCLATURE_MEASURE_WITH_UNIT_EAGER = [
+      { measures: MEASURE_UNIT_EAGER },
+      {
+        ancestors: [{ measures: MEASURE_UNIT_EAGER }],
+        descendants: [{ measures: MEASURE_UNIT_EAGER }],
       },
     ].freeze
 
@@ -102,6 +128,7 @@ module Reporting
         add_measure_quota_coverage_worksheet
         add_missing_supplementary_units_from_uk_worksheet
         add_missing_supplementary_units_from_xi_worksheet
+        add_candidate_supplementary_units
       ]
 
       methods = (methods & only) if only.any?
@@ -265,6 +292,13 @@ module Reporting
         'uk',
         'xi',
         'Supp units on UK not EU',
+        self,
+      ).add_worksheet
+    end
+
+    def add_candidate_supplementary_units
+      Reporting::Differences::CandidateSupplementaryUnit.new(
+        'Supp unit candidates',
         self,
       ).add_worksheet
     end

--- a/app/lib/reporting/differences/candidate_supplementary_unit.rb
+++ b/app/lib/reporting/differences/candidate_supplementary_unit.rb
@@ -1,0 +1,84 @@
+module Reporting
+  class Differences
+    class CandidateSupplementaryUnit
+      delegate :workbook,
+               :regular_style,
+               :bold_style,
+               :centered_style,
+               :each_chapter,
+               to: :report
+
+      HEADER_ROW = [
+        'Commodity code',
+        'Unit(s)',
+      ].freeze
+
+      TAB_COLOR = '660066'.freeze
+
+      CELL_TYPES = Array.new(HEADER_ROW.size, :string).freeze
+
+      COLUMN_WIDTHS = [
+        20, # Commodity code
+        20, # Unit(s)
+      ].freeze
+
+      AUTOFILTER_CELL_RANGE = 'A5:B5'.freeze
+      FROZEN_VIEW_STARTING_CELL = 'A2'.freeze
+
+      METRIC = 'Supplementary units that should be present'.freeze
+      SUBTEXT = 'Excise etc. may require a supp unit that is not provided'.freeze
+
+      def initialize(name, report)
+        @name = name
+        @report = report
+      end
+
+      def add_worksheet
+        workbook.add_worksheet(name:) do |sheet|
+          sheet.sheet_pr.tab_color = TAB_COLOR
+          sheet.add_row([METRIC], style: bold_style)
+          sheet.merge_cells('A2:E2')
+          sheet.add_row([SUBTEXT], style: regular_style)
+          sheet.add_row(['Back to overview', nil, nil, nil, nil], style: nil, hyperlink: { location: 'Overview!A1', target: :sheet })
+          sheet.add_row([])
+          sheet.add_row(HEADER_ROW, style: bold_style)
+          sheet.auto_filter = AUTOFILTER_CELL_RANGE
+          sheet.sheet_view.pane do |pane|
+            pane.top_left_cell = FROZEN_VIEW_STARTING_CELL
+            pane.state = :frozen
+            pane.y_split = 1
+          end
+
+          each_row do |row|
+            sheet.add_row(row, types: CELL_TYPES, style: regular_style)
+          end
+
+          sheet.column_widths(*COLUMN_WIDTHS)
+        end
+      end
+
+      private
+
+      attr_reader :name, :report
+
+      def each_row
+        each_chapter(eager: Differences::GOODS_NOMENCLATURE_MEASURE_WITH_UNIT_EAGER) do |eager_chapter|
+          eager_chapter.descendants.each do |chapter_descendant|
+            next unless chapter_descendant.declarable?
+
+            supplementary_unit = chapter_descendant.applicable_measures.find(&:supplementary?)
+            next if supplementary_unit.present?
+
+            units = chapter_descendant.applicable_measures.flat_map(&:units).uniq
+
+            next if units.blank?
+
+            units = units.map { |unit| "#{unit[:measurement_unit_code]}#{unit[:measurement_unit_qualifier]}" }.join(', ')
+
+            yield [chapter_descendant.goods_nomenclature_item_id, units]
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3271

### What?

I have added/removed/altered:

- [x] Added candidate supplementary unit worksheet

### Why?

I am doing this because:

- This worksheet is used to work out whether there are candidate
supplementary units that could do with being created to highlight the
relevant units for trade.
