### PR TITLE
BAU: Enable sample date override for monthly rates

### DIFF
--- a/app/services/exchange_rates/monthly_exchange_rates_service.rb
+++ b/app/services/exchange_rates/monthly_exchange_rates_service.rb
@@ -2,13 +2,14 @@ module ExchangeRates
   class DataNotFoundError < StandardError; end
 
   class MonthlyExchangeRatesService
-    def initialize(date, download:)
+    def initialize(date, sample_date, download:)
       @date = date
+      @sample_date = sample_date
       @download = download
     end
 
     def call
-      ExchangeRates::UpdateCurrencyRatesService.new(date).call if download
+      ExchangeRates::UpdateCurrencyRatesService.new(date, sample_date).call if download
 
       if rates.empty?
         raise DataNotFoundError, "No exchange rate data found for month #{date.month} and year #{date.year}."
@@ -41,6 +42,6 @@ module ExchangeRates
 
     private
 
-    attr_reader :date, :download
+    attr_reader :date, :sample_date, :download
   end
 end

--- a/app/services/exchange_rates/update_currency_rates_service.rb
+++ b/app/services/exchange_rates/update_currency_rates_service.rb
@@ -1,8 +1,9 @@
 module ExchangeRates
   class UpdateCurrencyRatesService
-    def initialize(date)
+    def initialize(date, sample_date)
       @date = date
-      @xe_api = ::ExchangeRates::XeApi.new(date:)
+      @sample_date = sample_date
+      @xe_api = ::ExchangeRates::XeApi.new(date: sample_date)
     end
 
     def call

--- a/spec/services/exchange_rates/monthly_exchange_rates_service_spec.rb
+++ b/spec/services/exchange_rates/monthly_exchange_rates_service_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 RSpec.describe ExchangeRates::MonthlyExchangeRatesService do
   describe '.call' do
-    subject(:call) { described_class.new(date, download:).call }
+    subject(:call) { described_class.new(date, sample_date, download:).call }
 
-    let(:date) { Time.zone.today }
+    let(:date) { sample_date.next_month }
+    let(:sample_date) { Time.zone.today }
 
     let(:update_service) { instance_double(ExchangeRates::UpdateCurrencyRatesService, call: true) }
 
@@ -15,7 +16,7 @@ RSpec.describe ExchangeRates::MonthlyExchangeRatesService do
         :with_usa,
         validity_start_date: date,
       )
-      allow(ExchangeRates::UpdateCurrencyRatesService).to receive(:new).with(date).and_return(update_service)
+      allow(ExchangeRates::UpdateCurrencyRatesService).to receive(:new).with(date, sample_date).and_return(update_service)
       allow(ExchangeRates::UploadMonthlyFileService).to receive(:new).and_call_original
 
       call

--- a/spec/services/exchange_rates/update_currency_rates_service_spec.rb
+++ b/spec/services/exchange_rates/update_currency_rates_service_spec.rb
@@ -2,10 +2,30 @@ require 'rails_helper'
 
 RSpec.describe ExchangeRates::UpdateCurrencyRatesService do
   describe '#call' do
-    let(:xe_api) { instance_double(ExchangeRates::XeApi) }
-    let(:service) do
-      described_class.new(Time.zone.today)
+    subject(:service) { described_class.new(date, sample_date) }
+
+    let(:date) { Time.zone.today.next_month }
+    let(:expected_rates) do
+      [
+        {
+          currency_code: 'AED',
+          validity_start_date: date.beginning_of_month,
+          validity_end_date: date.end_of_month,
+          rate: 4.662353708,
+          rate_type: ExchangeRateCurrencyRate::MONTHLY_RATE_TYPE,
+        },
+        {
+          currency_code: 'EUR',
+          validity_start_date: date.beginning_of_month,
+          validity_end_date: date.end_of_month,
+          rate: 6.662353708,
+          rate_type: ExchangeRateCurrencyRate::MONTHLY_RATE_TYPE,
+        },
+      ].as_json
     end
+    let(:sample_date) { Time.zone.today }
+
+    let(:xe_api) { instance_double(ExchangeRates::XeApi) }
     let(:response) do
       {
         'to' => [
@@ -17,36 +37,15 @@ RSpec.describe ExchangeRates::UpdateCurrencyRatesService do
       }
     end
 
-    let(:expected_rates) do
-      [
-        {
-          currency_code: 'AED',
-          validity_start_date: Time.zone.today.beginning_of_month,
-          validity_end_date: Time.zone.today.end_of_month,
-          rate: 4.662353708,
-          rate_type: ExchangeRateCurrencyRate::MONTHLY_RATE_TYPE,
-        },
-        {
-          currency_code: 'EUR',
-          validity_start_date: Time.zone.today.beginning_of_month,
-          validity_end_date: Time.zone.today.end_of_month,
-          rate: 6.662353708,
-          rate_type: ExchangeRateCurrencyRate::MONTHLY_RATE_TYPE,
-        },
-      ].as_json
-    end
-
     before do
-      allow(ExchangeRates::XeApi).to receive(:new).with(date: Time.zone.today).and_return(xe_api)
+      allow(ExchangeRates::XeApi).to receive(:new).with(date: sample_date).and_return(xe_api)
       allow(xe_api).to receive(:get_all_historic_rates).and_return(response)
       create(:exchange_rate_country_currency, currency_code: 'AED')
       create(:exchange_rate_country_currency, currency_code: 'EUR')
     end
 
     it 'only inserts rates that exist as currencies' do
-      expect {
-        service.call
-      }.to change(ExchangeRateCurrencyRate, :count).by(2)
+      expect { service.call }.to change(ExchangeRateCurrencyRate, :count).by(2)
     end
 
     it 'creates the rates specified in the api' do


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added sample date concept to monthly exchange rates worker
- [x] Added ability to pass the sample date to the monthly exchange rates worker

### Why?

I am doing this because:

- We have an issue with the delineation between sample date and the validity period date when populating exchange rates The sample date is the date that we sample the api and the validity date is the applicable window that the rates apply for users of the service We need to reflect this difference as currently we're sampling dates from next month (which breaks the XeApi and returns a 400 status)
