### PR TITLE
BAU: BCC support address on exchange rate email

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -42,4 +42,4 @@ XE_API_PASSWORD=pass
 XE_API_URL=https://example.com
 XE_API_USERNAME=user
 TARIFF_SUPPORT_EMAIL=user@example.com
-TARIFF_MANAGEMENT_EMAIL=user@example.com
+TARIFF_MANAGEMENT_EMAIL=manager@example.com

--- a/app/mailers/exchange_rates_mailer.rb
+++ b/app/mailers/exchange_rates_mailer.rb
@@ -1,5 +1,5 @@
 class ExchangeRatesMailer < ApplicationMailer
-  default to: TradeTariffBackend.management_email
+  default to: TradeTariffBackend.management_email, bcc: TradeTariffBackend.support_email
 
   attr_reader :date
 

--- a/spec/mailers/exchange_rates_mailer_spec.rb
+++ b/spec/mailers/exchange_rates_mailer_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe ExchangeRatesMailer, type: :mailer do
 
     it { expect(mail.subject).to eq("#{date.strftime('%B %Y')} Exchange Rate Files (monthly)") }
     it { expect(mail.from).to eq(['no-reply@example.com']) }
-    it { expect(mail.to).to eq(['user@example.com']) }
+    it { expect(mail.to).to eq(['manager@example.com']) }
+    it { expect(mail.bcc).to eq(['user@example.com']) }
   end
 end


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added BCC to exchange rate emails

### Why?

I am doing this because:

- This gives us visibility on whether the mail was successfully sent
