### PR TITLE
HOTT-3360: Adds an overview worksheet

### DIFF
--- a/app/lib/reporting/differences.rb
+++ b/app/lib/reporting/differences.rb
@@ -73,7 +73,9 @@ module Reporting
                 :regular_style,
                 :bold_style,
                 :centered_style,
-                :as_of
+                :print_style,
+                :as_of,
+                :overview_counts
 
     def initialize
       @package = Axlsx::Package.new
@@ -101,7 +103,17 @@ module Reporting
         font_name: 'Calibri',
         sz: 11,
       )
+      @print_style = workbook.styles.add_style(
+        alignment: {
+          wrap_text: true,
+          horizontal: :left,
+          vertical: :top,
+        },
+        font_name: 'Courier New',
+        sz: 11,
+      )
       @as_of = Time.zone.today.iso8601
+      @overview_counts = Hash.new(0)
     end
 
     def generate(only: [])
@@ -130,15 +142,14 @@ module Reporting
         add_missing_supplementary_units_from_xi_worksheet
         add_candidate_supplementary_units
         add_me16_worksheet
+        add_overview_worksheet
       ]
 
       methods = (methods & only) if only.any?
 
       methods.each do |method|
         start = Time.zone.now
-
         public_send(method)
-
         finish = Time.zone.now
         Rails.logger.info("Finished method '#{method}' (Duration: #{finish - start} seconds)")
       end
@@ -149,166 +160,96 @@ module Reporting
       package
     end
 
+    def add_overview_worksheet
+      Reporting::Differences::Overview.new(self).add_worksheet
+    end
+
     def add_missing_from_uk_worksheet
-      Reporting::Differences::GoodsNomenclature.new(
-        'xi',
-        'uk',
-        'Commodities in EU, not in UK',
-        self,
-      ).add_worksheet
+      Reporting::Differences::GoodsNomenclature.new('xi', 'uk', self).add_worksheet
     end
 
     def add_missing_from_xi_worksheet
-      Reporting::Differences::GoodsNomenclature.new(
-        'uk',
-        'xi',
-        'Commodities in UK, not in EU',
-        self,
-      ).add_worksheet
+      Reporting::Differences::GoodsNomenclature.new('uk', 'xi', self).add_worksheet
     end
 
     def add_indentation_worksheet
-      Reporting::Differences::Indentation.new(
-        'Indentation differences',
-        self,
-      ).add_worksheet
+      Reporting::Differences::Indentation.new(self).add_worksheet
     end
 
     def add_hierarchy_worksheet
-      Reporting::Differences::Hierarchy.new(
-        'Hierarchy differences',
-        self,
-      ).add_worksheet
+      Reporting::Differences::Hierarchy.new(self).add_worksheet
     end
 
     def add_endline_worksheet
-      Reporting::Differences::Endline.new(
-        'End line differences',
-        self,
-      ).add_worksheet
+      Reporting::Differences::Endline.new(self).add_worksheet
     end
 
     def add_start_date_worksheet
-      Reporting::Differences::GoodsNomenclatureStartDate.new(
-        'Start date differences',
-        self,
-      ).add_worksheet
+      Reporting::Differences::GoodsNomenclatureStartDate.new(self).add_worksheet
     end
 
     def add_end_date_worksheet
-      Reporting::Differences::GoodsNomenclatureEndDate.new(
-        'End date differences',
-        self,
-      ).add_worksheet
+      Reporting::Differences::GoodsNomenclatureEndDate.new(self).add_worksheet
     end
 
     def add_mfn_missing_worksheet
-      Reporting::Differences::MfnMissing.new(
-        'MFN missing',
-        self,
-      ).add_worksheet
+      Reporting::Differences::MfnMissing.new(self).add_worksheet
     end
 
     def add_mfn_duplicated_worksheet
-      Reporting::Differences::MfnDuplicated.new(
-        'Duplicate MFNs',
-        self,
-      ).add_worksheet
+      Reporting::Differences::MfnDuplicated.new(self).add_worksheet
     end
 
     def add_misapplied_action_code_worksheet
-      Reporting::Differences::MisappliedActionCode.new(
-        'Misapplied action codes',
-        self,
-      ).add_worksheet
+      Reporting::Differences::MisappliedActionCode.new(self).add_worksheet
     end
 
     def add_incomplete_measure_condition_worksheet
-      Reporting::Differences::IncompleteMeasureCondition.new(
-        'Incomplete conditions',
-        self,
-      ).add_worksheet
+      Reporting::Differences::IncompleteMeasureCondition.new(self).add_worksheet
     end
 
     def add_me32_worksheet
-      Reporting::Differences::Me32.new(
-        'ME32 candidates',
-        self,
-      ).add_worksheet
+      Reporting::Differences::Me32.new(self).add_worksheet
     end
 
     def add_omitted_duty_measures_worksheet
-      Reporting::Differences::OmittedDutyMeasures.new(
-        'Omitted duties',
-        self,
-      ).add_worksheet
+      Reporting::Differences::OmittedDutyMeasures.new(self).add_worksheet
     end
 
     def add_missing_vat_measure_worksheet
-      Reporting::Differences::MissingVatMeasure.new(
-        'VAT missing',
-        self,
-      ).add_worksheet
+      Reporting::Differences::MissingVatMeasure.new(self).add_worksheet
     end
 
     def add_missing_quota_origins_worksheet
-      Reporting::Differences::QuotaMissingOrigin.new(
-        'Quota with no origins',
-        self,
-      ).add_worksheet
+      Reporting::Differences::QuotaMissingOrigin.new(self).add_worksheet
     end
 
     def add_bad_quota_association_worksheet
-      Reporting::Differences::BadQuotaAssociation.new(
-        'Self-referential associations',
-        self,
-      ).add_worksheet
+      Reporting::Differences::BadQuotaAssociation.new(self).add_worksheet
     end
 
     def add_quota_exclusion_misalignment_worksheet
-      Reporting::Differences::QuotaExclusionMisalignment.new(
-        'Exclusion misalignment',
-        self,
-      ).add_worksheet
+      Reporting::Differences::QuotaExclusionMisalignment.new(self).add_worksheet
     end
 
     def add_measure_quota_coverage_worksheet
-      Reporting::Differences::MeasureQuotaCoverage.new(
-        'Measure quot def coverage',
-        self,
-      ).add_worksheet
+      Reporting::Differences::MeasureQuotaCoverage.new(self).add_worksheet
     end
 
     def add_missing_supplementary_units_from_uk_worksheet
-      Reporting::Differences::SupplementaryUnit.new(
-        'xi',
-        'uk',
-        'Supp units on EU not UK',
-        self,
-      ).add_worksheet
+      Reporting::Differences::SupplementaryUnit.new('xi', 'uk', self).add_worksheet
     end
 
     def add_missing_supplementary_units_from_xi_worksheet
-      Reporting::Differences::SupplementaryUnit.new(
-        'uk',
-        'xi',
-        'Supp units on UK not EU',
-        self,
-      ).add_worksheet
+      Reporting::Differences::SupplementaryUnit.new('uk', 'xi', self).add_worksheet
     end
 
     def add_candidate_supplementary_units
-      Reporting::Differences::CandidateSupplementaryUnit.new(
-        'Supp unit candidates',
-        self,
-      ).add_worksheet
+      Reporting::Differences::CandidateSupplementaryUnit.new(self).add_worksheet
     end
 
     def add_me16_worksheet
-      Reporting::Differences::Me16.new(
-        'Supp unit candidates',
-        self,
-      ).add_worksheet
+      Reporting::Differences::Me16.new(self).add_worksheet
     end
 
     def uk_goods_nomenclatures
@@ -346,6 +287,10 @@ module Reporting
 
     def handle_csv(csv)
       CSV.parse(csv, headers: true).map(&:to_h)
+    end
+
+    def increment_count(worksheet_name)
+      overview_counts[worksheet_name] += 1
     end
 
     class << self

--- a/app/lib/reporting/differences/bad_quota_association.rb
+++ b/app/lib/reporting/differences/bad_quota_association.rb
@@ -7,6 +7,8 @@ module Reporting
                :centered_style,
                to: :report
 
+      WORKSHEET_NAME = 'Self-referential associations'.freeze
+
       HEADER_ROW = [
         'Order number (main)',
         'Def. start date (main)',
@@ -29,8 +31,7 @@ module Reporting
       AUTOFILTER_CELL_RANGE = 'A1:J1'.freeze
       FROZEN_VIEW_STARTING_CELL = 'A2'.freeze
 
-      def initialize(name, report)
-        @name = name
+      def initialize(report)
         @report = report
       end
 
@@ -46,6 +47,7 @@ module Reporting
           end
 
           each_row do |row|
+            report.increment_count(name)
             sheet.add_row(row, types: CELL_TYPES, style: regular_style)
           end
 
@@ -53,9 +55,13 @@ module Reporting
         end
       end
 
+      def name
+        WORKSHEET_NAME
+      end
+
       private
 
-      attr_reader :name, :report
+      attr_reader :report
 
       def each_row
         ::BadQuotaAssociation.actual.each do |bad_quota_association|

--- a/app/lib/reporting/differences/candidate_supplementary_unit.rb
+++ b/app/lib/reporting/differences/candidate_supplementary_unit.rb
@@ -8,6 +8,8 @@ module Reporting
                :each_chapter,
                to: :report
 
+      WORKSHEET_NAME = 'Supp unit candidates'.freeze
+
       HEADER_ROW = [
         'Commodity code',
         'Unit(s)',
@@ -28,8 +30,7 @@ module Reporting
       METRIC = 'Supplementary units that should be present'.freeze
       SUBTEXT = 'Excise etc. may require a supp unit that is not provided'.freeze
 
-      def initialize(name, report)
-        @name = name
+      def initialize(report)
         @report = report
       end
 
@@ -50,6 +51,7 @@ module Reporting
           end
 
           each_row do |row|
+            report.increment_count(name)
             sheet.add_row(row, types: CELL_TYPES, style: regular_style)
           end
 
@@ -57,9 +59,13 @@ module Reporting
         end
       end
 
+      def name
+        WORKSHEET_NAME
+      end
+
       private
 
-      attr_reader :name, :report
+      attr_reader :report
 
       def each_row
         each_chapter(eager: Differences::GOODS_NOMENCLATURE_MEASURE_WITH_UNIT_EAGER) do |eager_chapter|

--- a/app/lib/reporting/differences/endline.rb
+++ b/app/lib/reporting/differences/endline.rb
@@ -9,6 +9,8 @@ module Reporting
                :xi_goods_nomenclatures,
                to: :report
 
+      WORKSHEET_NAME = 'End line differences'.freeze
+
       HEADER_ROW = [
         'Commodity code (PLS)',
         'UK endline status',
@@ -28,8 +30,7 @@ module Reporting
       AUTOFILTER_CELL_RANGE = 'A1:C1'.freeze
       FROZEN_VIEW_STARTING_CELL = 'A2'.freeze
 
-      def initialize(name, report)
-        @name = name
+      def initialize(report)
         @report = report
       end
 
@@ -45,6 +46,7 @@ module Reporting
           end
 
           rows.compact.each do |row|
+            report.increment_count(name)
             sheet.add_row(row, types: CELL_TYPES, style: regular_style)
             sheet.rows.last.tap do |last_row|
               last_row.cells[1].style = centered_style # UK endline status
@@ -56,9 +58,13 @@ module Reporting
         end
       end
 
+      def name
+        WORKSHEET_NAME
+      end
+
       private
 
-      attr_reader :name, :report
+      attr_reader :report
 
       def rows
         matching_goods_nomenclature = uk_goods_nomenclature_ids.keys & xi_goods_nomenclature_ids.keys

--- a/app/lib/reporting/differences/goods_nomenclature.rb
+++ b/app/lib/reporting/differences/goods_nomenclature.rb
@@ -9,6 +9,9 @@ module Reporting
                :xi_goods_nomenclatures,
                to: :report
 
+      WORKSHEET_NAME_EU = 'Commodities in EU, not in UK'.freeze
+      WORKSHEET_NAME_UK = 'Commodities in UK, not in EU'.freeze
+
       HEADER_ROW = [
         'SID',
         'Commodity',
@@ -38,7 +41,7 @@ module Reporting
       AUTOFILTER_CELL_RANGE = 'A1:H1'.freeze
       FROZEN_VIEW_STARTING_CELL = 'A2'.freeze
 
-      def initialize(source, target, name, report)
+      def initialize(source, target, report)
         @source = source
         @target = target
         @name = name
@@ -57,6 +60,7 @@ module Reporting
           end
 
           rows.each do |row|
+            report.increment_count(name)
             sheet.add_row(row, types: CELL_TYPES, style: regular_style)
             sheet.rows.last.tap do |last_row|
               last_row.cells[5].style = centered_style # Indentation
@@ -68,9 +72,13 @@ module Reporting
         end
       end
 
+      def name
+        source == 'uk' ? WORKSHEET_NAME_UK : WORKSHEET_NAME_EU
+      end
+
       private
 
-      attr_reader :source, :target, :name, :report
+      attr_reader :source, :target, :report
 
       def rows
         all_missing = source_goods_nomenclatures.keys - target_goods_nomenclatures.keys

--- a/app/lib/reporting/differences/goods_nomenclature_end_date.rb
+++ b/app/lib/reporting/differences/goods_nomenclature_end_date.rb
@@ -9,6 +9,8 @@ module Reporting
                :xi_goods_nomenclatures,
                to: :report
 
+      WORKSHEET_NAME = 'End date differences'.freeze
+
       HEADER_ROW = [
         'Commodity code (PLS)',
         'UK end date',
@@ -28,8 +30,7 @@ module Reporting
       AUTOFILTER_CELL_RANGE = 'A1:C1'.freeze
       FROZEN_VIEW_STARTING_CELL = 'A2'.freeze
 
-      def initialize(name, report)
-        @name = name
+      def initialize(report)
         @report = report
       end
 
@@ -45,6 +46,7 @@ module Reporting
           end
 
           rows.compact.each do |row|
+            report.increment_count(name)
             sheet.add_row(row, types: CELL_TYPES, style: regular_style)
           end
 
@@ -52,9 +54,13 @@ module Reporting
         end
       end
 
+      def name
+        WORKSHEET_NAME
+      end
+
       private
 
-      attr_reader :name, :report
+      attr_reader :report
 
       def rows
         matching_goods_nomenclature = uk_goods_nomenclature_ids.keys & xi_goods_nomenclature_ids.keys

--- a/app/lib/reporting/differences/goods_nomenclature_start_date.rb
+++ b/app/lib/reporting/differences/goods_nomenclature_start_date.rb
@@ -9,6 +9,8 @@ module Reporting
                :xi_goods_nomenclatures,
                to: :report
 
+      WORKSHEET_NAME = 'Start date differences'.freeze
+
       HEADER_ROW = [
         'Commodity code (PLS)',
         'UK start date',
@@ -28,8 +30,7 @@ module Reporting
       AUTOFILTER_CELL_RANGE = 'A1:C1'.freeze
       FROZEN_VIEW_STARTING_CELL = 'A2'.freeze
 
-      def initialize(name, report)
-        @name = name
+      def initialize(report)
         @report = report
       end
 
@@ -45,6 +46,7 @@ module Reporting
           end
 
           rows.compact.each do |row|
+            report.increment_count(name)
             sheet.add_row(row, types: CELL_TYPES, style: regular_style)
           end
 
@@ -52,9 +54,13 @@ module Reporting
         end
       end
 
+      def name
+        WORKSHEET_NAME
+      end
+
       private
 
-      attr_reader :name, :report
+      attr_reader :report
 
       def rows
         matching_goods_nomenclature = uk_goods_nomenclature_ids.keys & xi_goods_nomenclature_ids.keys

--- a/app/lib/reporting/differences/hierarchy.rb
+++ b/app/lib/reporting/differences/hierarchy.rb
@@ -9,6 +9,8 @@ module Reporting
                :xi_goods_nomenclatures,
                to: :report
 
+      WORKSHEET_NAME = 'Hierarchy differences'.freeze
+
       HEADER_ROW = [
         'Commodity code (PLS)',
         'UK hiearchy',
@@ -28,8 +30,7 @@ module Reporting
       AUTOFILTER_CELL_RANGE = 'A1:C1'.freeze
       FROZEN_VIEW_STARTING_CELL = 'A2'.freeze
 
-      def initialize(name, report)
-        @name = name
+      def initialize(report)
         @report = report
       end
 
@@ -45,6 +46,7 @@ module Reporting
           end
 
           rows.compact.each do |row|
+            report.increment_count(name)
             sheet.add_row(row, types: CELL_TYPES, style: regular_style)
             sheet.rows.last.tap do |last_row|
               last_row.cells[1].style = centered_style # UK endline status
@@ -56,9 +58,13 @@ module Reporting
         end
       end
 
+      def name
+        WORKSHEET_NAME
+      end
+
       private
 
-      attr_reader :name, :report
+      attr_reader :report
 
       def rows
         matching_goods_nomenclature = uk_goods_nomenclature_ids.keys & xi_goods_nomenclature_ids.keys

--- a/app/lib/reporting/differences/incomplete_measure_condition.rb
+++ b/app/lib/reporting/differences/incomplete_measure_condition.rb
@@ -6,6 +6,10 @@ module Reporting
                :bold_style,
                to: :report
 
+      WORKSHEET_NAME = 'Incomplete conditions'.freeze
+
+      DASHBOARD_SECTION = 'Duty and measure-related anomalies'.freeze
+
       HEADER_ROW = [
         'Measure SID',
         'Measure type ID',
@@ -25,8 +29,7 @@ module Reporting
       AUTOFILTER_CELL_RANGE = 'A1:H1'.freeze
       FROZEN_VIEW_STARTING_CELL = 'A2'.freeze
 
-      def initialize(name, report)
-        @name = name
+      def initialize(report)
         @report = report
       end
 
@@ -42,6 +45,7 @@ module Reporting
           end
 
           rows.compact.each do |row|
+            report.increment_count(name)
             sheet.add_row(row, types: CELL_TYPES, style: regular_style)
           end
 
@@ -51,9 +55,13 @@ module Reporting
         Rails.logger.debug("Query count: #{::SequelRails::Railties::LogSubscriber.count}")
       end
 
+      def name
+        WORKSHEET_NAME
+      end
+
       private
 
-      attr_reader :name, :report
+      attr_reader :report
 
       def rows
         acc = []

--- a/app/lib/reporting/differences/indentation.rb
+++ b/app/lib/reporting/differences/indentation.rb
@@ -9,6 +9,8 @@ module Reporting
                :xi_goods_nomenclatures,
                to: :report
 
+      WORKSHEET_NAME = 'Indentation differences'.freeze
+
       HEADER_ROW = [
         'Commodity code (PLS)',
         'UK indentation',
@@ -28,8 +30,7 @@ module Reporting
       AUTOFILTER_CELL_RANGE = 'A1:C1'.freeze
       FROZEN_VIEW_STARTING_CELL = 'A2'.freeze
 
-      def initialize(name, report)
-        @name = name
+      def initialize(report)
         @report = report
       end
 
@@ -45,6 +46,7 @@ module Reporting
           end
 
           rows.compact.each do |row|
+            report.increment_count(name)
             sheet.add_row(row, types: CELL_TYPES, style: regular_style)
             sheet.rows.last.tap do |last_row|
               last_row.cells[1].style = centered_style # UK indentation
@@ -56,9 +58,13 @@ module Reporting
         end
       end
 
+      def name
+        WORKSHEET_NAME
+      end
+
       private
 
-      attr_reader :name, :report
+      attr_reader :report
 
       def rows
         matching_goods_nomenclature = uk_goods_nomenclature_ids.keys & xi_goods_nomenclature_ids.keys

--- a/app/lib/reporting/differences/me16.rb
+++ b/app/lib/reporting/differences/me16.rb
@@ -7,12 +7,14 @@ module Reporting
                :each_chapter,
                to: :report
 
+      WORKSHEET_NAME = 'ME16 candidates'.freeze
+
       HEADER_ROW = [
         'Commodity code',
         'Measure type',
       ].freeze
 
-      TAB_COLOR = '00ff00'.freeze
+      TAB_COLOR = '000000'.freeze
 
       CELL_TYPES = Array.new(HEADER_ROW.size, :string).freeze
 
@@ -27,8 +29,7 @@ module Reporting
       METRIC = 'ME16 candidates'.freeze
       SUBTEXT = 'This indicates that there are comm codes where a duty exists both with and without additional codes, which breaks ME16'.freeze
 
-      def initialize(name, report)
-        @name = name
+      def initialize(report)
         @report = report
       end
 
@@ -51,6 +52,7 @@ module Reporting
           end
 
           rows.compact.each do |row|
+            report.increment_count(name)
             sheet.add_row(row, types: CELL_TYPES, style: regular_style)
           end
 
@@ -60,9 +62,13 @@ module Reporting
         Rails.logger.debug("Query count: #{::SequelRails::Railties::LogSubscriber.count}")
       end
 
+      def name
+        WORKSHEET_NAME
+      end
+
       private
 
-      attr_reader :name, :report
+      attr_reader :report
 
       def rows
         acc = []

--- a/app/lib/reporting/differences/me32.rb
+++ b/app/lib/reporting/differences/me32.rb
@@ -7,6 +7,8 @@ module Reporting
                :each_chapter,
                to: :report
 
+      WORKSHEET_NAME = 'ME32 candidates'.freeze
+
       HEADER_ROW = [
         'Commodity code',
         'Measure type',
@@ -33,8 +35,7 @@ module Reporting
       METRIC = 'ME32 candidates'.freeze
       SUBTEXT = 'There may be no overlap in time with other measure occurrences with a goods code in the same nomenclature hierarchy which references the same measure type, geo area, order number and additional code.'.freeze
 
-      def initialize(name, report)
-        @name = name
+      def initialize(report)
         @report = report
       end
 
@@ -57,6 +58,7 @@ module Reporting
           end
 
           rows.compact.each do |row|
+            report.increment_count(name)
             sheet.add_row(row, types: CELL_TYPES, style: regular_style)
           end
 
@@ -66,9 +68,13 @@ module Reporting
         Rails.logger.debug("Query count: #{::SequelRails::Railties::LogSubscriber.count}")
       end
 
+      def name
+        WORKSHEET_NAME
+      end
+
       private
 
-      attr_reader :name, :report
+      attr_reader :report
 
       def rows
         acc = []

--- a/app/lib/reporting/differences/measure_quota_coverage.rb
+++ b/app/lib/reporting/differences/measure_quota_coverage.rb
@@ -6,6 +6,8 @@ module Reporting
     class MeasureQuotaCoverage
       delegate :workbook, :bold_style, :regular_style, to: :report
 
+      WORKSHEET_NAME = 'Measure quot def coverage'.freeze
+
       HEADER_ROW = [
         'Measure SID',
         'Commodity code',
@@ -20,8 +22,7 @@ module Reporting
       COLUMN_WIDTHS = [20] * HEADER_ROW.size
       FROZEN_VIEW_STARTING_CELL = 'A2'.freeze
 
-      def initialize(name, report)
-        @name = name
+      def initialize(report)
         @report = report
         @end_of_year = Time.zone.today.end_of_year
       end
@@ -37,6 +38,7 @@ module Reporting
           end
 
           rows.each do |row|
+            report.increment_count(name)
             sheet.add_row(
               row,
               types: CELL_TYPES,
@@ -48,9 +50,13 @@ module Reporting
         end
       end
 
+      def name
+        WORKSHEET_NAME
+      end
+
       private
 
-      attr_reader :name, :report
+      attr_reader :report
 
       def rows
         rs = measures_with_quota_definitions.each_with_object([]) do |measure_with_quota_definitions, acc|

--- a/app/lib/reporting/differences/mfn_duplicated.rb
+++ b/app/lib/reporting/differences/mfn_duplicated.rb
@@ -7,6 +7,8 @@ module Reporting
                :each_chapter,
                to: :report
 
+      WORKSHEET_NAME = 'Duplicate MFNs'.freeze
+
       HEADER_ROW = [
         'Commodity code',
         'Headline',
@@ -40,8 +42,7 @@ module Reporting
       AUTOFILTER_CELL_RANGE = 'A1:J1'.freeze
       FROZEN_VIEW_STARTING_CELL = 'A2'.freeze
 
-      def initialize(name, report)
-        @name = name
+      def initialize(report)
         @report = report
       end
 
@@ -57,6 +58,7 @@ module Reporting
           end
 
           rows.compact.each do |row|
+            report.increment_count(name)
             sheet.add_row(row, types: CELL_TYPES, style: regular_style)
           end
 
@@ -66,9 +68,13 @@ module Reporting
         Rails.logger.debug("Query count: #{::SequelRails::Railties::LogSubscriber.count}")
       end
 
+      def name
+        WORKSHEET_NAME
+      end
+
       private
 
-      attr_reader :name, :report
+      attr_reader :report
 
       def rows
         acc = []

--- a/app/lib/reporting/differences/mfn_missing.rb
+++ b/app/lib/reporting/differences/mfn_missing.rb
@@ -7,6 +7,8 @@ module Reporting
                :each_chapter,
                to: :report
 
+      WORKSHEET_NAME = 'MFN missing'.freeze
+
       HEADER_ROW = [
         'Commodity code',
         'Description',
@@ -24,8 +26,7 @@ module Reporting
       AUTOFILTER_CELL_RANGE = 'A1:B1'.freeze
       FROZEN_VIEW_STARTING_CELL = 'A2'.freeze
 
-      def initialize(name, report)
-        @name = name
+      def initialize(report)
         @report = report
       end
 
@@ -41,6 +42,7 @@ module Reporting
           end
 
           rows.compact.each do |row|
+            report.increment_count(name)
             sheet.add_row(row, types: CELL_TYPES, style: regular_style)
           end
 
@@ -50,9 +52,13 @@ module Reporting
         Rails.logger.debug("Query count: #{::SequelRails::Railties::LogSubscriber.count}")
       end
 
+      def name
+        WORKSHEET_NAME
+      end
+
       private
 
-      attr_reader :name, :report
+      attr_reader :report
 
       def rows
         acc = []

--- a/app/lib/reporting/differences/misapplied_action_code.rb
+++ b/app/lib/reporting/differences/misapplied_action_code.rb
@@ -6,6 +6,8 @@ module Reporting
                :bold_style,
                to: :report
 
+      WORKSHEET_NAME = 'Misapplied action codes'.freeze
+
       HEADER_ROW = [
         'Measure sid',
         'Commodity code',
@@ -27,8 +29,7 @@ module Reporting
       AUTOFILTER_CELL_RANGE = 'A1:J1'.freeze
       FROZEN_VIEW_STARTING_CELL = 'A2'.freeze
 
-      def initialize(name, report)
-        @name = name
+      def initialize(report)
         @report = report
       end
 
@@ -44,6 +45,7 @@ module Reporting
           end
 
           rows.compact.each do |row|
+            report.increment_count(name)
             sheet.add_row(row, types: CELL_TYPES, style: regular_style)
           end
 
@@ -53,9 +55,13 @@ module Reporting
         Rails.logger.debug("Query count: #{::SequelRails::Railties::LogSubscriber.count}")
       end
 
+      def name
+        WORKSHEET_NAME
+      end
+
       private
 
-      attr_reader :name, :report
+      attr_reader :report
 
       def rows
         acc = []

--- a/app/lib/reporting/differences/missing_vat_measure.rb
+++ b/app/lib/reporting/differences/missing_vat_measure.rb
@@ -7,6 +7,8 @@ module Reporting
                :each_chapter,
                to: :report
 
+      WORKSHEET_NAME = 'VAT-related anomalies'.freeze
+
       FILTERED_MEASURE_TYPES = Set.new(%w[305]).freeze
       FILTERED_GEOGRAPHICAL_AREA_IDS = Set.new(%w[1011]).freeze
 
@@ -27,8 +29,7 @@ module Reporting
       AUTOFILTER_CELL_RANGE = 'A1:B1'.freeze
       FROZEN_VIEW_STARTING_CELL = 'A2'.freeze
 
-      def initialize(name, report)
-        @name = name
+      def initialize(report)
         @report = report
       end
 
@@ -44,6 +45,7 @@ module Reporting
           end
 
           each_row do |row|
+            report.increment_count(name)
             sheet.add_row(row, types: CELL_TYPES, style: regular_style)
           end
 
@@ -53,9 +55,13 @@ module Reporting
         Rails.logger.debug("Query count: #{::SequelRails::Railties::LogSubscriber.count}")
       end
 
+      def name
+        WORKSHEET_NAME
+      end
+
       private
 
-      attr_reader :name, :report
+      attr_reader :report
 
       def each_row
         each_declarable do |declarable|

--- a/app/lib/reporting/differences/omitted_duty_measures.rb
+++ b/app/lib/reporting/differences/omitted_duty_measures.rb
@@ -7,6 +7,8 @@ module Reporting
                :each_chapter,
                to: :report
 
+      WORKSHEET_NAME = 'Omitted duties'.freeze
+
       FILTERED_MEASURE_TYPES = Set.new(
         %w[
           141
@@ -50,8 +52,7 @@ module Reporting
       AUTOFILTER_CELL_RANGE = 'A1:F1'.freeze
       FROZEN_VIEW_STARTING_CELL = 'A2'.freeze
 
-      def initialize(name, report)
-        @name = name
+      def initialize(report)
         @report = report
       end
 
@@ -67,6 +68,7 @@ module Reporting
           end
 
           each_row do |row|
+            report.increment_count(name)
             sheet.add_row(row, types: CELL_TYPES, style: regular_style)
           end
 
@@ -76,9 +78,13 @@ module Reporting
         Rails.logger.debug("Query count: #{::SequelRails::Railties::LogSubscriber.count}")
       end
 
+      def name
+        WORKSHEET_NAME
+      end
+
       private
 
-      attr_reader :name, :report
+      attr_reader :report
 
       def each_row
         start_time = Time.zone.now

--- a/app/lib/reporting/differences/overview.rb
+++ b/app/lib/reporting/differences/overview.rb
@@ -1,0 +1,264 @@
+module Reporting
+  class Differences
+    class Overview
+      delegate :workbook,
+               :regular_style,
+               :bold_style,
+               :centered_style,
+               to: :report
+
+      WORKSHEET_NAME = 'Overview'.freeze
+
+      OVERVIEW_SECTION_CONFIG = {
+        'Commodity code-related anomalies' => {
+          section_colour: 'C02814',
+          worksheets: {
+            'Commodities in EU tariff, but missing from UK tariff' => {
+              description: 'As of as_of, these commodity codes are in the EU tariff but not in the UK tariff.',
+              worksheet_name: 'Commodities in EU, not in UK',
+            },
+            'Commodities in UK tariff, but missing from EU tariff' => {
+              description: 'As of as_of, these commodity codes are in the UK tariff but not in the EU tariff.',
+              worksheet_name: 'Commodities in UK, not in EU',
+            },
+            'Commodities where indentation is different between the UK and EU tariffs' => {
+              description: 'Indentation is crucial to get right to avoid measures being unexpectedly assigned or omitted.',
+              worksheet_name: 'Indentation differences',
+            },
+            'Commodities where the hierarchy is different between the UK and EU tariffs' => {
+              description: 'This tends to be linked to or caused by missing or unwanted codes or indentation issues.',
+              worksheet_name: 'Hierarchy differences',
+            },
+            'Commodities where the end line (declarable) status is different between the UK and EU tariffs' => {
+              description: 'End lines (or declarable) codes need to align between the two tariffs, or there will be issues on the XI dual tariff',
+              worksheet_name: 'End line differences',
+            },
+            'Commodities where the start date is different between the UK and EU tariffs' => {
+              description: 'Not crucial, but worth checking in case there are wild differences: the EU has made mistakes in this area',
+              worksheet_name: 'Start date differences',
+            },
+            'Commodities where the end date is different between the UK and EU tariffs' => {
+              description: '',
+              worksheet_name: 'End date differences',
+            },
+          },
+        },
+        'Duty and measure-related anomalies' => {
+          section_colour: '48C83F',
+          worksheets: {
+            'Missing MFN (third-country) duties' => {
+              description: 'Commodities, as of as_of, where there is no third-country duty.',
+              worksheet_name: 'MFN missing',
+            },
+            'Duplicated UK MFN duties' => {
+              description: 'More than one MFN is on a single commodity code',
+              worksheet_name: 'Duplicate MFNs',
+            },
+            'Misapplied action codes' => {
+              description: 'An action code that should be negative is positive, or vice versa.',
+              worksheet_name: 'Misapplied action codes',
+            },
+            'ME32 candidates' => {
+              description: 'There may be no overlap in time with other measure occurrences with a goods code in the same nomenclature hierarchy which references the same measure type, geo area, order number and additional code.',
+              worksheet_name: 'ME32 candidates',
+            },
+            'Incomplete conditions' => {
+              description: 'These are conditions where the measurement unit is missing, rendering the measure invalid.',
+              worksheet_name: 'Incomplete conditions',
+            },
+            'Omitted duties' => {
+              description: 'Comparing preferential and suspension measures that are present now (16 October 2023) versus those that were present a year before. Ukraine-related measures are omitted, as these changed by design. Not all items listed here will be issues.',
+              worksheet_name: 'Omitted duties',
+            },
+            # 'Seasonal duties' => 'Seasonal duties that should be in place (according to the reference documents) but cannot be found',
+          },
+        },
+        'VAT-related anomalies' => {
+          section_colour: '666666',
+          worksheets: {
+            'Missing VAT rates' => {
+              description: 'Commodities, as of as_of, where there is no VAT rate.',
+              worksheet_name: 'VAT-related anomalies',
+            },
+          },
+        },
+        'Commodity code description-related anomalies' => {
+          section_colour: '311493',
+          worksheets: {
+            # 'Total number of differences in commodity code descriptions' => 'Covers all difference types - does not imply there is an issue',
+            # 'Descriptions - UK description is missing' => 'Indentation is crucial to get right to avoid measures being unexpectedly assigned or omitted.',
+            # 'Descriptions - Typo or small difference' => 'This tends to be linked to or caused by missing or unwanted codes or indentation issues.',
+          },
+        },
+        'Quota-related anomalies' => {
+          section_colour: 'CACC43',
+          worksheets: {
+            'Quotas missing origins' => {
+              description: 'This tends to be linked to or caused by missing or unwanted codes or indentation issues.',
+              worksheet_name: 'Quota with no origins',
+            },
+            'Quota measures - insufficient definition coverage' => {
+              description: 'These are measures where, at some point, they will start to become non-operational or illusory as there is no equivalent quota definition associated with it for its full extent',
+              worksheet_name: 'Measure quot def coverage',
+            },
+            'Self-referential quota associations' => {
+              description: 'These are quotas where a parent (main) definition refers to itself as well as to its child (sub) definitions. These are very problematic for EQ type associations, and will result in improper quota balance decrementation, but less so for NM type associations. Past definitions are now omitted',
+              worksheet_name: 'Self-referential associations',
+            },
+            'Quota exclusion misalignment' => {
+              description: 'A FCFS quota is made up of both measures and quota order numbers. Each point to origins, and each of these origins may have exclusions. They need to match to provide a reliable experience for traders.',
+              worksheet_name: 'Exclusion misalignment',
+            },
+          },
+        },
+        'Supplementary unit-related anomalies' => {
+          section_colour: '611062',
+          worksheets: {
+            'Supplementary units present on the EU tariff, but not on the UK tariff' => {
+              description: 'May cause issues for Northern Ireland trade',
+              worksheet_name: 'Supp units on EU not UK',
+            },
+            'Supplementary units present on the UK tariff, but not on the EU tariff' => {
+              description: 'May cause issues for Northern Ireland trade',
+              worksheet_name: 'Supp units on UK not EU',
+            },
+            'Supplementary units that should be present' => {
+              description: 'Excise etc. may require a supp unit that is not provided',
+              worksheet_name: 'Supp unit candidates',
+            },
+          },
+        },
+        'Suspension-related anomalies' => {
+          section_colour: '000000',
+          worksheets: {
+            # 'Unpaired additional codes' => 'This indicates that there is a single additional code, not an MFN plus a suspension additional code on a commodity. It's not certain if this will cause an issue, but it creates additional trader effort for no reason.',
+            'ME16 candidates' => {
+              description: 'This indicates that there are comm codes where a duty exists both with and without additional codes, which breaks ME16',
+              worksheet_name: 'ME16 candidates',
+            },
+          },
+        },
+      }.freeze
+
+      CELL_TYPES = Array.new(4, :string).freeze
+
+      COLUMN_WIDTHS = [
+        4,  # Section square
+        90, # Dashboard section/worksheet
+        10, # Count
+        90, # About this metric
+        10, # View issues
+      ].freeze
+
+      def initialize(report)
+        @report = report
+      end
+
+      def add_worksheet
+        dashboard_styles = {
+          'C02814' => workbook.styles.add_style(bg_color: 'C02814', fg_color: 'FFFFFF'),
+          '48C83F' => workbook.styles.add_style(bg_color: '48C83F', fg_color: 'FFFFFF'),
+          '666666' => workbook.styles.add_style(bg_color: '666666', fg_color: 'FFFFFF'),
+          '311493' => workbook.styles.add_style(bg_color: '311493', fg_color: 'FFFFFF'),
+          'CACC43' => workbook.styles.add_style(bg_color: 'CACC43', fg_color: 'FFFFFF'),
+          '611062' => workbook.styles.add_style(bg_color: '611062', fg_color: 'FFFFFF'),
+          '000000' => workbook.styles.add_style(bg_color: '000000', fg_color: 'FFFFFF'),
+          'header_section' => workbook.styles.add_style(
+            b: true,
+            alignment: {
+              horizontal: :left,
+              vertical: :top,
+              wrap_text: true,
+            },
+            sz: 14,
+            font_name: 'Calibri',
+          ),
+          'header_count' => workbook.styles.add_style(
+            b: true,
+            alignment: {
+              horizontal: :center,
+              vertical: :top,
+            },
+            sz: 14,
+            font_name: 'Calibri',
+          ),
+          'header_about' => workbook.styles.add_style(
+            b: true,
+            alignment: {
+              horizontal: :left,
+              vertical: :top,
+              wrap_text: true,
+            },
+            sz: 14,
+            font_name: 'Calibri',
+          ),
+          'header_view' => workbook.styles.add_style(
+            b: true,
+            alignment: {
+              horizontal: :center,
+              vertical: :top,
+            },
+            sz: 11,
+            font_name: 'Calibri',
+          ),
+        }
+
+        workbook.add_worksheet(name:) do |sheet|
+          OVERVIEW_SECTION_CONFIG.each do |section, config|
+            sheet.add_row([nil, section, 'Count', 'About this metric', nil])
+            colour = config[:section_colour]
+
+            section_header_row = sheet.rows.last
+            section_header_row[0].style = dashboard_styles[colour]
+            section_header_row[1].style = dashboard_styles['header_section']
+            section_header_row[2].style = dashboard_styles['header_count']
+            section_header_row[3].style = dashboard_styles['header_about']
+            section_header_row[4].style = dashboard_styles['header_view']
+
+            config[:worksheets].each do |worksheet, worksheet_config|
+              worksheet_description = worksheet_config[:description].sub('as_of', report.as_of)
+              worksheet_name = worksheet_config[:worksheet_name]
+
+              sheet.add_row(
+                [
+                  nil,
+                  worksheet,
+                  report.overview_counts[worksheet_name],
+                  worksheet_description,
+                  'View issues',
+                  nil,
+                ],
+                types: CELL_TYPES,
+              )
+              worksheet_row = sheet.rows.last
+
+              worksheet_row[1].style = regular_style
+              worksheet_row[2].style = centered_style
+              worksheet_row[3].style = regular_style
+
+              sheet.add_hyperlink(
+                location: "'#{worksheet_name}'!A1",
+                target: :sheet,
+                ref: worksheet_row[4].r,
+              )
+            end
+
+            sheet.add_row([])
+          end
+
+          sheet.column_widths(*COLUMN_WIDTHS)
+        end
+
+        workbook.worksheets.rotate!(-1)
+      end
+
+      private
+
+      attr_reader :report
+
+      def name
+        WORKSHEET_NAME
+      end
+    end
+  end
+end

--- a/app/lib/reporting/differences/quota_missing_origin.rb
+++ b/app/lib/reporting/differences/quota_missing_origin.rb
@@ -7,6 +7,8 @@ module Reporting
                :each_chapter,
                to: :report
 
+      WORKSHEET_NAME = 'Quota with no origins'.freeze
+
       HEADER_ROW = [
         'Quota order number ID',
         'Quota order number SID',
@@ -20,8 +22,7 @@ module Reporting
       AUTOFILTER_CELL_RANGE = 'A1:B1'.freeze
       FROZEN_VIEW_STARTING_CELL = 'A2'.freeze
 
-      def initialize(name, report)
-        @name = name
+      def initialize(report)
         @report = report
       end
 
@@ -37,6 +38,7 @@ module Reporting
           end
 
           each_row do |row|
+            report.increment_count(name)
             sheet.add_row(row, types: CELL_TYPES, style: regular_style)
           end
 
@@ -46,9 +48,13 @@ module Reporting
         Rails.logger.debug("Query count: #{::SequelRails::Railties::LogSubscriber.count}")
       end
 
+      def name
+        WORKSHEET_NAME
+      end
+
       private
 
-      attr_reader :name, :report
+      attr_reader :report
 
       def each_row
         TimeMachine.at(report.as_of) do

--- a/app/lib/reporting/differences/supplementary_unit.rb
+++ b/app/lib/reporting/differences/supplementary_unit.rb
@@ -8,6 +8,9 @@ module Reporting
                :uk_supplementary_unit_measures,
                :xi_supplementary_unit_measures, to: :report
 
+      WORKSHEET_NAME_EU = 'Supp units on EU not UK'.freeze
+      WORKSHEET_NAME_UK = 'Supp units on UK not EU'.freeze
+
       HEADER_ROW = [
         'Commodity code',
         'Geographical area ID',
@@ -34,7 +37,7 @@ module Reporting
       METRIC = ERB.new('Supplementary units present on the <%= source_name %> tariff, but not on the <%= target_name %> tariff')
       SUBTEXT = 'May cause issues for Northern Ireland trade'.freeze
 
-      def initialize(source, target, name, report)
+      def initialize(source, target, report)
         @source = source
         @target = target
         @name = name
@@ -58,6 +61,7 @@ module Reporting
           end
 
           rows.each do |row|
+            report.increment_count(name)
             sheet.add_row(row, types: CELL_TYPES, style: centered_style)
             sheet.rows.last.tap do |last_row|
               last_row.cells[0].style = regular_style # Commodity code
@@ -68,9 +72,13 @@ module Reporting
         end
       end
 
+      def name
+        source == 'uk' ? WORKSHEET_NAME_UK : WORKSHEET_NAME_EU
+      end
+
       private
 
-      attr_reader :source, :target, :name, :report
+      attr_reader :source, :target, :report
 
       def rows
         all_missing = source_measures - target_measures

--- a/app/models/quota_order_number.rb
+++ b/app/models/quota_order_number.rb
@@ -12,12 +12,10 @@ class QuotaOrderNumber < Sequel::Model
     ds.order(Sequel.desc(:validity_start_date))
   end
 
-  one_to_one :measure, primary_key: :quota_order_number_id,
-                       key: :ordernumber do |ds|
-    ds
-      .with_actual(Measure)
-      .with_regulation_dates_query
-  end
+  one_to_one :measure,
+             primary_key: :quota_order_number_id,
+             key: :ordernumber,
+             &:with_regulation_dates_query
 
   one_to_many :quota_order_number_origins,
               primary_key: :quota_order_number_sid,


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3360

![2023-10-23-085747_1732x934_scrot](https://github.com/trade-tariff/trade-tariff-backend/assets/8156884/9174aec7-64f5-4af3-ad51-034eb785d614)

### What?

I have added/removed/altered:

- [x] Fixes some issues with the quota_exclusion_misalignment worksheet
- [x] Adds support for accumulating differences report counts in all worksheets
- [x] Adds an overview worksheet

### Why?

I am doing this because:

- This is required to get us to a feature complete differences report
