### PR TITLE
Create twice-yearly exchange rate AVERAGE rate data: required in CSV and 'view online'

### DIFF
--- a/app/models/exchange_rate_country_currency.rb
+++ b/app/models/exchange_rate_country_currency.rb
@@ -16,8 +16,7 @@ class ExchangeRateCountryCurrency < Sequel::Model(:exchange_rate_countries_curre
 
   def self.live_currency_codes
     # Criteria:
-    # End date within the current month
-    # Start date less than or equal to the end of the current month
+    # Countries that are live in the current month
 
     where(
       (Sequel[:validity_end_date] =~ (Time.zone.today.beginning_of_month..Time.zone.today.end_of_month)) |
@@ -28,8 +27,8 @@ class ExchangeRateCountryCurrency < Sequel::Model(:exchange_rate_countries_curre
 
   def self.live_last_twelve_months(date)
     # Criteria:
-    # Start date less than then end of the current month and end date nil or more than
-    # End date more than then beginning of the current month 12 months ago
+    # Countries that have had a live rate in the last 12 months whole months
+    # So end of the current month minus 12 months
 
     where(
       (Sequel[:validity_start_date] <= date.end_of_month) &

--- a/app/models/exchange_rate_country_currency.rb
+++ b/app/models/exchange_rate_country_currency.rb
@@ -13,4 +13,8 @@ class ExchangeRateCountryCurrency < Sequel::Model(:exchange_rate_countries_curre
     validates_presence :currency_code
     validates_presence :validity_start_date
   end
+
+  def self.live_currency_codes
+    distinct(:currency_code).select_map(:currency_code)
+  end
 end

--- a/app/models/exchange_rate_country_currency.rb
+++ b/app/models/exchange_rate_country_currency.rb
@@ -26,16 +26,16 @@ class ExchangeRateCountryCurrency < Sequel::Model(:exchange_rate_countries_curre
     ).distinct(:currency_code).select_map(:currency_code)
   end
 
-  def self.live_last_twelve_months
+  def self.live_last_twelve_months(date)
     # Criteria:
     # Start date less than then end of the current month and end date nil or more than
     # End date more than then beginning of the current month 12 months ago
 
     where(
-      (Sequel[:validity_start_date] <= Time.zone.today.end_of_month) &
+      (Sequel[:validity_start_date] <= date.end_of_month) &
       (Sequel[:validity_end_date] =~ nil) |
-      (Sequel[:validity_start_date] <= Time.zone.today.end_of_month) &
-      (Sequel[:validity_end_date] >= Time.zone.today.beginning_of_month - 11.months),
+      (Sequel[:validity_start_date] <= date.end_of_month) &
+      (Sequel[:validity_end_date] >= date.beginning_of_month - 11.months),
     ).order_by(:country_description)
   end
 end

--- a/app/models/exchange_rate_currency_rate.rb
+++ b/app/models/exchange_rate_currency_rate.rb
@@ -87,6 +87,15 @@ class ExchangeRateCurrencyRate < Sequel::Model
       where(rate_type: type)
     end
 
+    def by_currency(currency_code)
+      where(currency_code: currency_code)
+    end
+
+    def by_currency_and_last_year(currency_code)
+      # Warning if this is called when an average rate is not meant to be called
+      by_type(MONTHLY_RATE_TYPE).by_currency(currency_code).last(12)
+    end
+
     def by_year(year)
       where(Sequel.cast(Sequel.function(:date_part, 'year', :applicable_date), Integer) => year)
     end

--- a/app/models/exchange_rate_currency_rate.rb
+++ b/app/models/exchange_rate_currency_rate.rb
@@ -88,12 +88,16 @@ class ExchangeRateCurrencyRate < Sequel::Model
     end
 
     def by_currency(currency_code)
-      where(currency_code: currency_code)
+      where(currency_code: currency_code.upcase)
     end
 
-    def by_currency_and_last_year(currency_code)
-      # Warning if this is called when an average rate is not meant to be called
-      by_type(MONTHLY_RATE_TYPE).by_currency(currency_code).last(12)
+    def monthly_by_currency_last_year(currency_code)
+      by_type(MONTHLY_RATE_TYPE)
+        .by_currency(currency_code.upcase)
+        .where('validity_start_date <= ?', Time.zone.today.end_of_month)
+        .where('validity_end_date <= ?', Time.zone.today.end_of_month)
+        .where('validity_start_date > ?', Time.zone.today.end_of_month - 12.months)
+        .order_by(:validity_start_date)
     end
 
     def by_year(year)

--- a/app/models/exchange_rate_currency_rate.rb
+++ b/app/models/exchange_rate_currency_rate.rb
@@ -91,12 +91,12 @@ class ExchangeRateCurrencyRate < Sequel::Model
       where(currency_code: currency_code.upcase)
     end
 
-    def monthly_by_currency_last_year(currency_code)
+    def monthly_by_currency_last_year(currency_code, date)
       by_type(MONTHLY_RATE_TYPE)
         .by_currency(currency_code.upcase)
-        .where('validity_start_date <= ?', Time.zone.today.end_of_month)
-        .where('validity_end_date <= ?', Time.zone.today.end_of_month)
-        .where('validity_start_date > ?', Time.zone.today.end_of_month - 12.months)
+        .where('validity_start_date <= ?', date.end_of_month)
+        .where('validity_end_date <= ?', date.end_of_month)
+        .where('validity_start_date > ?', date.end_of_month - 12.months)
         .order_by(:validity_start_date)
     end
 

--- a/app/services/exchange_rates/average_exchange_rates_service.rb
+++ b/app/services/exchange_rates/average_exchange_rates_service.rb
@@ -1,0 +1,67 @@
+module ExchangeRates
+  class AverageExchangeRatesService
+    VALID_MONTHS = [4, 12].freeze
+    VALID_DAY = 31
+
+    class << self
+      def call
+        return unless valid_date
+
+        avg_rates = create_average_rates
+        log_to_slack
+        build_average_rate_file(avg_rates)
+      end
+
+      private
+
+      def build_average_rate_file(avg_rates)
+        ExchangeRates::UploadFileService.new(
+          avg_rates,
+          Time.zone.today.iso8601,
+          :average_csv,
+        ).call
+      end
+
+      def valid_date
+        return false unless Time.zone.today.day == VALID_DAY
+        return false unless VALID_MONTHS.include?(Time.zone.today.month)
+      end
+
+      def create_average_rates
+        currency_codes = ExchangeRateCountryCurrency.live_currency_codes
+
+        currency_codes.map do |currency_code|
+          next unless valid_average_rate(currency_code)
+
+          avg_rate = valid_average_rate(currency_code)
+
+          ExchangeRateCurrencyRate.create(
+            currency_code:,
+            validity_start_date: Time.zone.today.beginning_of_month,
+            validity_end_date: nil,
+            rate_type: ExchangeRateCurrencyRate::AVERAGE_RATE_TYPE,
+            rate: avg_rate,
+          )
+        end
+      end
+
+      def valid_average_rate(currency_code)
+        rates = ExchangeRateCurrencyRate.by_currency_and_last_year(currency_code)
+
+        return unless rates.count >= 12
+        return unless rates.first.validity_start_date.month == Time.zone.today.month
+        return unless VALID_MONTHS.include?(rates.first.validity_start_date.month)
+
+        rates.pluck(:rate).sum.fdiv(rates.size)
+      end
+
+      def log_to_slack
+        message = 'Average exchange rates for the current period have been added and are accessible for viewing at /exchange_rates.'
+
+        logger.info message
+
+        SlackNotifierService.call(message)
+      end
+    end
+  end
+end

--- a/app/services/exchange_rates/average_exchange_rates_service.rb
+++ b/app/services/exchange_rates/average_exchange_rates_service.rb
@@ -3,11 +3,16 @@ module ExchangeRates
     VALID_MONTHS = [4, 12].freeze
     VALID_DAY = 31
 
-    def self.call(force_run)
-      new.call(force_run)
+    def self.call(force_run:, selected_date:)
+      new(force_run, selected_date).call
     end
 
-    def call(force_run)
+    def initialize(force_run, selected_date)
+      @force_run = force_run
+      @selected_date = Date.parse(selected_date)
+    end
+
+    def call
       return argument_error unless valid_date || force_run
 
       avg_rates = create_average_rates
@@ -17,6 +22,8 @@ module ExchangeRates
     end
 
     private
+
+    attr_reader :force_run, :selected_date
 
     def match_country_with_rates(avg_rates)
       live_countries_last_twelve_months.each_with_object({}) do |country, h|
@@ -34,14 +41,14 @@ module ExchangeRates
     def upload_average_rate_file(countries_and_rate)
       ExchangeRates::UploadFileService.new(
         countries_and_rate,
-        Time.zone.today,
+        selected_date,
         :average_csv,
       ).call
     end
 
     def valid_date
-      return false unless Time.zone.today.day == VALID_DAY
-      return false unless VALID_MONTHS.include?(Time.zone.today.month)
+      return false unless selected_date.day == VALID_DAY
+      return false unless VALID_MONTHS.include?(selected_date.month)
 
       true
     end
@@ -54,8 +61,8 @@ module ExchangeRates
 
         ExchangeRateCurrencyRate.create(
           currency_code:,
-          validity_start_date: Time.zone.today.beginning_of_month,
-          validity_end_date: Time.zone.today.end_of_month,
+          validity_start_date: selected_date.beginning_of_month,
+          validity_end_date: selected_date.end_of_month,
           rate_type: ExchangeRateCurrencyRate::AVERAGE_RATE_TYPE,
           rate: avg_rate,
         )
@@ -64,17 +71,17 @@ module ExchangeRates
 
     def live_countries_last_twelve_months
       # This needs to be all countries that have had a rate for a currency last 12 months
-      @live_countries_last_twelve_months ||= ExchangeRateCountryCurrency.live_last_twelve_months
+      @live_countries_last_twelve_months ||= ExchangeRateCountryCurrency.live_last_twelve_months(selected_date)
     end
 
     def valid_average_rate(currency_code)
-      rates = ExchangeRateCurrencyRate.monthly_by_currency_last_year(currency_code)
+      rates = ExchangeRateCurrencyRate.monthly_by_currency_last_year(currency_code, selected_date)
 
-      # Ensure the last month is not after the current date
-      return unless rates.last.validity_start_date <= Time.zone.today
+      # Ensure the last month is not after the selected date
+      return unless rates.last.validity_start_date <= selected_date
 
-      # Ensure the first month is not greater than 12 months ago
-      return unless rates.first.validity_end_date > Time.zone.today - 12.months
+      # Ensure the first month is not greater than 12 months before selected date
+      return unless rates.first.validity_end_date > selected_date - 12.months
 
       rates.pluck(:rate).sum.fdiv(rates.count)
     end

--- a/app/services/exchange_rates/create_average_exchange_rates_service.rb
+++ b/app/services/exchange_rates/create_average_exchange_rates_service.rb
@@ -1,9 +1,11 @@
 module ExchangeRates
-  class AverageExchangeRatesService
+  class CreateAverageExchangeRatesService
+    # Creates the average rates for countries that have had a live rate the last 12 months and upload the file
+
     VALID_MONTHS = [4, 12].freeze
     VALID_DAY = 31
 
-    def self.call(force_run:, selected_date:)
+    def self.call(selected_date:, force_run: false)
       new(force_run, selected_date).call
     end
 
@@ -13,7 +15,7 @@ module ExchangeRates
     end
 
     def call
-      return argument_error unless valid_date || force_run
+      return argument_error unless valid_date? || force_run
 
       avg_rates = create_average_rates
 
@@ -27,11 +29,8 @@ module ExchangeRates
 
     def match_country_with_rates(avg_rates)
       live_countries_last_twelve_months.each_with_object({}) do |country, h|
-        # Need to ensure unique rates are being collected
-        avg_rate = avg_rates
-                    .select { |rate| rate.currency_code == country.currency_code }
-                    .first
-                    .rate
+        avg_rate = avg_rates.find { |rate| rate.currency_code == country.currency_code }
+                            .rate
 
         # { ExchangeRateCountryCurrency => avg_rate }
         h[country] = avg_rate
@@ -46,25 +45,22 @@ module ExchangeRates
       ).call
     end
 
-    def valid_date
-      return false unless selected_date.day == VALID_DAY
-      return false unless VALID_MONTHS.include?(selected_date.month)
-
-      true
+    def valid_date?
+      selected_date.day == VALID_DAY && VALID_MONTHS.include?(selected_date.month)
     end
 
     def create_average_rates
       live_countries_last_twelve_months.select_map(:currency_code).uniq.map do |currency_code|
-        avg_rate = valid_average_rate(currency_code)
+        rates = ExchangeRateCurrencyRate.monthly_by_currency_last_year(currency_code, selected_date)
 
-        next unless avg_rate
+        next unless rates_valid?(rates)
 
         ExchangeRateCurrencyRate.create(
           currency_code:,
           validity_start_date: selected_date.beginning_of_month,
           validity_end_date: selected_date.end_of_month,
           rate_type: ExchangeRateCurrencyRate::AVERAGE_RATE_TYPE,
-          rate: avg_rate,
+          rate: rates.pluck(:rate).sum.fdiv(rates.count),
         )
       end
     end
@@ -74,20 +70,18 @@ module ExchangeRates
       @live_countries_last_twelve_months ||= ExchangeRateCountryCurrency.live_last_twelve_months(selected_date)
     end
 
-    def valid_average_rate(currency_code)
-      rates = ExchangeRateCurrencyRate.monthly_by_currency_last_year(currency_code, selected_date)
-
+    def rates_valid?(rates)
       # Ensure the last month is not after the selected date
       return unless rates.last.validity_start_date <= selected_date
 
       # Ensure the first month is not greater than 12 months before selected date
       return unless rates.first.validity_end_date > selected_date - 12.months
 
-      rates.pluck(:rate).sum.fdiv(rates.count)
+      true
     end
 
     def argument_error
-      error_message = 'Argument error, invalid date, average exchange rate creation'
+      error_message = "Argument error: #{selected_date} is not a valid date"
 
       Rails.logger.error(error_message)
 

--- a/app/services/exchange_rates/create_csv_average_rates_service.rb
+++ b/app/services/exchange_rates/create_csv_average_rates_service.rb
@@ -1,0 +1,45 @@
+module ExchangeRates
+  class CreateCsvAverageRatesService
+    HEADINGS = [
+      'Country',
+      'Unit Of Currency',
+      'Currency Code',
+      'Sterling value of Currency Unit £',
+      'Currency Units per £1',
+    ].freeze
+
+    def self.call(data)
+      new(data).call
+    end
+
+    def initialize(data)
+      @data = data
+    end
+
+    def call
+      CSV.generate do |csv|
+        csv << HEADINGS
+
+        @data.each do |rate|
+          csv << build_row(rate)
+        end
+      end
+    end
+
+    private
+
+    def build_row(rate)
+      [
+        rate.country_description,
+        rate.currency_description,
+        rate.currency_code,
+        sprintf('%.4f', 1 / rate.rate),
+        rate.presented_rate,
+      ]
+    end
+
+    def format_date(date)
+      date.strftime('%d/%b/%Y')
+    end
+  end
+end

--- a/app/services/exchange_rates/create_csv_average_rates_service.rb
+++ b/app/services/exchange_rates/create_csv_average_rates_service.rb
@@ -1,5 +1,8 @@
 module ExchangeRates
   class CreateCsvAverageRatesService
+    COUNTRY_INDEX = 0
+    RATE_INDEX = 1
+
     HEADINGS = [
       'Country',
       'Unit Of Currency',
@@ -20,21 +23,27 @@ module ExchangeRates
       CSV.generate do |csv|
         csv << HEADINGS
 
-        @data.each do |rate|
-          csv << build_row(rate)
+        # Data is in the format of { ExchangeRateCountryCurrency => avg_rate },{...}
+        data.each do |hash|
+          csv << build_row(hash)
         end
       end
     end
 
     private
 
-    def build_row(rate)
+    attr_reader :data
+
+    def build_row(rate_hash)
+      country = rate_hash[COUNTRY_INDEX]
+      rate = rate_hash[RATE_INDEX]
+
       [
-        rate.country_description,
-        rate.currency_description,
-        rate.currency_code,
-        sprintf('%.4f', 1 / rate.rate),
-        rate.presented_rate,
+        country.country_description,
+        country.currency_description,
+        country.currency_code,
+        sprintf('%.4f', 1 / rate),
+        sprintf('%.4f', rate),
       ]
     end
 

--- a/app/services/exchange_rates/monthly_exchange_rates_service.rb
+++ b/app/services/exchange_rates/monthly_exchange_rates_service.rb
@@ -15,32 +15,33 @@ module ExchangeRates
         raise DataNotFoundError, "No exchange rate data found for month #{date.month} and year #{date.year}."
       end
 
-      ExchangeRates::UploadMonthlyFileService.new(
+      ExchangeRates::UploadFileService.new(
         rates,
         date,
         :monthly_csv,
       ).call
 
-      ExchangeRates::UploadMonthlyFileService.new(
+      ExchangeRates::UploadFileService.new(
         rates,
         date,
         :monthly_xml,
       ).call
 
-      ExchangeRates::UploadMonthlyFileService.new(
+      ExchangeRates::UploadFileService.new(
         rates,
         date,
         :monthly_csv_hmrc,
       ).call
     end
 
+      # Moved this as couldnt find where rates is called outside and as a service should probably have only 1 call action
+    private
+
     def rates
       @rates ||= ::ExchangeRateCurrencyRate
         .for_month(date.month, date.year, ExchangeRateCurrencyRate::MONTHLY_RATE_TYPE)
         .sort_by { |rate| [rate.country_description, rate.currency_description] }
     end
-
-    private
 
     attr_reader :date, :sample_date, :download
   end

--- a/app/services/exchange_rates/spot_exchange_rates_service.rb
+++ b/app/services/exchange_rates/spot_exchange_rates_service.rb
@@ -14,7 +14,7 @@ module ExchangeRates
         raise DataNotFoundError, "No exchange rate data found for month #{sample_date.month} and year #{sample_date.year}."
       end
 
-      ExchangeRates::UploadMonthlyFileService.new(
+      ExchangeRates::UploadFileService.new(
         rates,
         sample_date,
         :spot_csv,

--- a/app/services/exchange_rates/upload_file_service.rb
+++ b/app/services/exchange_rates/upload_file_service.rb
@@ -17,7 +17,7 @@ module ExchangeRates
       when :spot_csv
         upload_data(:csv, ExchangeRates::CreateCsvSpotService)
       when :average_csv
-        upload_data(:csv, ExchangeRates::CreateCsvSpotService)
+        upload_data(:csv, ExchangeRates::CreateCsvAverageRatesService)
       end
     end
 

--- a/app/services/exchange_rates/upload_file_service.rb
+++ b/app/services/exchange_rates/upload_file_service.rb
@@ -1,5 +1,5 @@
 module ExchangeRates
-  class UploadMonthlyFileService
+  class UploadFileService
     def initialize(rates, date, type)
       @rates = rates
       @date = date
@@ -15,6 +15,8 @@ module ExchangeRates
       when :monthly_csv_hmrc
         upload_data(:csv, ExchangeRates::CreateCsvHmrcService)
       when :spot_csv
+        upload_data(:csv, ExchangeRates::CreateCsvSpotService)
+      when :average_csv
         upload_data(:csv, ExchangeRates::CreateCsvSpotService)
       end
     end

--- a/app/workers/average_exchange_rates_worker.rb
+++ b/app/workers/average_exchange_rates_worker.rb
@@ -4,13 +4,13 @@ class AverageExchangeRatesWorker
   sidekiq_options retry: 1, retry_in: 1.hour
 
   def perform
-    ExchangeRates::AverageExchangeRatesService.call(force_run: false, selected_date: Time.zone.today.iso8601)
+    ExchangeRates::CreateAverageExchangeRatesService.call(force_run: false, selected_date: Time.zone.today.iso8601)
 
     notify
   end
 
   def notify
-    message = 'Average exchange rates for the current period have been added and are accessible for viewing at /exchange_rates.'
+    message = 'Average exchange rates for the current period are ready. You can view them at /exchange_rates.'
 
     logger.info message
 

--- a/app/workers/average_exchange_rates_worker.rb
+++ b/app/workers/average_exchange_rates_worker.rb
@@ -4,7 +4,7 @@ class AverageExchangeRatesWorker
   sidekiq_options retry: 1, retry_in: 1.hour
 
   def perform
-    ExchangeRates::AverageExchangeRatesService.call(false)
+    ExchangeRates::AverageExchangeRatesService.call(force_run: false, selected_date: Time.zone.today.iso8601)
 
     notify
   end

--- a/app/workers/average_exchange_rates_worker.rb
+++ b/app/workers/average_exchange_rates_worker.rb
@@ -1,0 +1,19 @@
+class AverageExchangeRatesWorker
+  include Sidekiq::Worker
+
+  sidekiq_options retry: 1, retry_in: 1.hour
+
+  def perform
+    ExchangeRates::AverageExchangeRatesService.call(false)
+
+    notify
+  end
+
+  def notify
+    message = 'Average exchange rates for the current period have been added and are accessible for viewing at /exchange_rates.'
+
+    logger.info message
+
+    SlackNotifierService.call(message)
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -77,3 +77,6 @@
     SpotExchangeRatesWorker:
       cron: '0 21 31 3,12 *' # Runs on end of March and December
       description: Update spot rates data from XE API and Upload files to S3
+    AverageExchangeRatesWorker:
+      cron: '0 21 31 3,12 *' # Runs on end of March and December
+      description: Creates average rates from downloaded data and uploads file to S3

--- a/docs/exchange_rate_average_rates.md
+++ b/docs/exchange_rate_average_rates.md
@@ -1,0 +1,13 @@
+# Exchange rates average rates
+
+This page is designed to explain about average rates, how they are run and how to force running them should something go wrong.
+
+Average rates are calculated based on the live countries in the last 12 months from the date selected in the `ExchangeRates::AverageExchangeRatesService` class. Normally the worker class `AverageExchangeRatesWorker` Will run on the 31st March and 31st Dec. It will select all the countries that have had a live rate for the last year through working out the end of the month date selected *(eg. if the service is run on the 12th May then it will use 31st May for that year going back to the 1st of June for the previous year hgathering all country and currency parings).* This solved the issue if a country might have multiple currencies in one year and we have to display the average for currencies that country has had even if its just one day.
+
+## Force running the proces
+
+Should anything fail with the average rate service then it can be force run by the following command:
+
+`ExchangeRates::AverageExchangeRatesService.call(force_run: true, selected_date: '2023-10-25')`
+
+You can then navigate to https://www.trade-tariff.service.gov.uk/exchange_rates/average and the latest CSV will be available and a view online option.app/workers/average_exchange_rates_worker.rb

--- a/spec/factories/exchange_rate_country_currency.rb
+++ b/spec/factories/exchange_rate_country_currency.rb
@@ -6,5 +6,47 @@ FactoryBot.define do
     currency_description { 'Euro' }
     validity_start_date { '2020-01-01' }
     validity_end_date { nil }
+
+    trait :us do
+      country_code { 'US' }
+      currency_code { 'USD' }
+      country_description { 'United States' }
+      currency_description { 'Dollar' }
+    end
+
+    trait :eu do
+      country_code { 'EU' }
+      currency_code { 'EUR' }
+      country_description { 'Eurozone' }
+      currency_description { 'Euro' }
+    end
+
+    trait :au do
+      country_code { 'AU' }
+      currency_code { 'AUD' }
+      country_description { 'Australia' }
+      currency_description { 'Dollar' }
+    end
+
+    trait :du do
+      country_code { 'DU' }
+      currency_code { 'AED' }
+      country_description { 'Dubai' }
+      currency_description { 'Dirham' }
+    end
+
+    trait :kz do
+      country_code { 'KZ' }
+      currency_code { 'KZT' }
+      country_description { 'Kazakhstan' }
+      currency_description { 'Tenge' }
+    end
+
+    trait :dh do
+      country_code { 'DH' }
+      currency_code { 'AED' }
+      country_description { 'Abu Dhabi' }
+      currency_description { 'Dirham' }
+    end
   end
 end

--- a/spec/factories/exchange_rate_country_currency.rb
+++ b/spec/factories/exchange_rate_country_currency.rb
@@ -48,5 +48,19 @@ FactoryBot.define do
       country_description { 'Abu Dhabi' }
       currency_description { 'Dirham' }
     end
+
+    trait :bd do
+      country_code { 'BD' }
+      currency_code { 'BDD' }
+      country_description { 'Barbados' }
+      currency_description { 'Dollar' }
+    end
+
+    trait :zw do
+      country_code { 'ZW' }
+      currency_code { 'ZWD' }
+      country_description { 'Zimbabwe' }
+      currency_description { 'Dollar' }
+    end
   end
 end

--- a/spec/factories/exchange_rate_currency_rate_factory.rb
+++ b/spec/factories/exchange_rate_currency_rate_factory.rb
@@ -22,6 +22,22 @@ FactoryBot.define do
       end
     end
 
+    trait :with_eur do
+      currency_code { 'EUR' }
+
+      after(:create) do |currency_rate|
+        create(
+          :exchange_rate_country_currency,
+          currency_code: currency_rate.currency_code,
+          country_code: 'EU',
+          country_description: 'Eurozone',
+          currency_description: 'Euro',
+          validity_start_date: currency_rate.validity_start_date,
+          validity_end_date: currency_rate.validity_end_date,
+        )
+      end
+    end
+
     trait :monthly_rate do
       rate_type { 'monthly' }
     end

--- a/spec/models/exchange_rate_country_currency_spec.rb
+++ b/spec/models/exchange_rate_country_currency_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe ExchangeRateCountryCurrency do
+
+
+
+  describe '.live_currency_codes' do
+    before do
+      create(:exchange_rate_country_currency)
+    end
+
+    it 'retuns all the live currency_codes' do
+      expect(described_class.live_currency_codes).to eq(['EUR'])
+    end
+  end
+end

--- a/spec/models/exchange_rate_country_currency_spec.rb
+++ b/spec/models/exchange_rate_country_currency_spec.rb
@@ -34,9 +34,11 @@ RSpec.describe ExchangeRateCountryCurrency do
              validity_end_date: Time.zone.today.end_of_month - 12.months)
     end
 
+    let(:test_date) { Time.zone.today }
+
     it 'retuns all the live currency_codes', :aggregate_failures do
-      expect(described_class.live_last_twelve_months.count).to eq(3)
-      expect(described_class.live_last_twelve_months.pluck(:country_code)).to eq(%w[EU KZ ZW])
+      expect(described_class.live_last_twelve_months(test_date).count).to eq(3)
+      expect(described_class.live_last_twelve_months(test_date).pluck(:country_code)).to eq(%w[EU KZ ZW])
     end
   end
 end

--- a/spec/models/exchange_rate_country_currency_spec.rb
+++ b/spec/models/exchange_rate_country_currency_spec.rb
@@ -1,14 +1,42 @@
 RSpec.describe ExchangeRateCountryCurrency do
-
-
-
   describe '.live_currency_codes' do
     before do
-      create(:exchange_rate_country_currency)
+      create(:exchange_rate_country_currency, :eu)
+      create(:exchange_rate_country_currency, :kz,
+             validity_end_date: Time.zone.today.end_of_month - 1.month)
     end
 
     it 'retuns all the live currency_codes' do
-      expect(described_class.live_currency_codes).to eq(['EUR'])
+      expect(described_class.live_currency_codes).to eq(%w[EUR])
+    end
+  end
+
+  describe '.live_last_twelve_months' do
+    before do
+      # ======= Live Countries last 12 months =======
+
+      # Since 2020
+      create(:exchange_rate_country_currency, :eu)
+      # Starts end of the month
+      create(:exchange_rate_country_currency, :kz,
+             validity_start_date: Time.zone.today.end_of_month)
+      # Ended beginning of current month minus 11 months
+      create(:exchange_rate_country_currency, :zw,
+             validity_end_date: Time.zone.today.beginning_of_month - 11.months)
+
+      # ======= Not live last 12 months =======
+
+      # Live beginning next Month
+      create(:exchange_rate_country_currency, :bd,
+             validity_start_date: Time.zone.today.beginning_of_month + 1.month)
+      # Ended beginning of current month - 12 months ago - 1 day
+      create(:exchange_rate_country_currency, :du,
+             validity_end_date: Time.zone.today.end_of_month - 12.months)
+    end
+
+    it 'retuns all the live currency_codes', :aggregate_failures do
+      expect(described_class.live_last_twelve_months.count).to eq(3)
+      expect(described_class.live_last_twelve_months.pluck(:country_code)).to eq(%w[EU KZ ZW])
     end
   end
 end

--- a/spec/models/exchange_rate_currency_rate_spec.rb
+++ b/spec/models/exchange_rate_currency_rate_spec.rb
@@ -367,24 +367,26 @@ RSpec.describe ExchangeRateCurrencyRate do
   end
 
   describe '.monthly_by_currency_last_year' do
-    subject(:dataset) { described_class.monthly_by_currency_last_year(currency_code) }
+    subject(:dataset) { described_class.monthly_by_currency_last_year(currency_code, today) }
+
+    let(:today) { Time.zone.today }
 
     before do
       create(:exchange_rate_currency_rate, :monthly_rate, :with_usa,
-             validity_start_date: Time.zone.today.beginning_of_month + 1.month,
-             validity_end_date: Time.zone.today.end_of_month + 1.month)
+             validity_start_date: today.beginning_of_month + 1.month,
+             validity_end_date: today.end_of_month + 1.month)
       create(:exchange_rate_currency_rate, :monthly_rate, :with_usa,
-             validity_start_date: Time.zone.today.end_of_month,
-             validity_end_date: Time.zone.today.end_of_month)
+             validity_start_date: today.end_of_month,
+             validity_end_date: today.end_of_month)
       create(:exchange_rate_currency_rate, :monthly_rate, :with_usa,
-             validity_start_date: Time.zone.today.beginning_of_month - 11.months,
-             validity_end_date: Time.zone.today.end_of_month - 11.months)
+             validity_start_date: today.beginning_of_month - 11.months,
+             validity_end_date: today.end_of_month - 11.months)
       create(:exchange_rate_currency_rate, :monthly_rate, :with_usa,
-             validity_start_date: Time.zone.today.end_of_month - 12.months,
-             validity_end_date: Time.zone.today.end_of_month - 12.months)
+             validity_start_date: today.end_of_month - 12.months,
+             validity_end_date: today.end_of_month - 12.months)
       create(:exchange_rate_currency_rate, :monthly_rate, :with_eur,
-             validity_start_date: Time.zone.today.beginning_of_month,
-             validity_end_date: Time.zone.today.end_of_month)
+             validity_start_date: today.beginning_of_month,
+             validity_end_date: today.end_of_month)
     end
 
     context 'when currency code is lower case' do

--- a/spec/models/exchange_rate_currency_rate_spec.rb
+++ b/spec/models/exchange_rate_currency_rate_spec.rb
@@ -358,18 +358,13 @@ RSpec.describe ExchangeRateCurrencyRate do
 
       it { expect(dataset.pluck(:currency_code)).to eq(%w[USD]) }
     end
-
-    context 'when currency code is upper case' do
-      let(:currency_code) { 'USD' }
-
-      it { expect(dataset.pluck(:currency_code)).to eq(%w[USD]) }
-    end
   end
 
   describe '.monthly_by_currency_last_year' do
     subject(:dataset) { described_class.monthly_by_currency_last_year(currency_code, today) }
 
     let(:today) { Time.zone.today }
+    let(:currency_code) { 'usd' }
 
     before do
       create(:exchange_rate_currency_rate, :monthly_rate, :with_usa,
@@ -389,22 +384,9 @@ RSpec.describe ExchangeRateCurrencyRate do
              validity_end_date: today.end_of_month)
     end
 
-    context 'when currency code is lower case' do
-      let(:currency_code) { 'usd' }
-
-      it 'will return the correct results', :aggregate_failures do
-        expect(dataset.count).to eq(2)
-        expect(dataset.pluck(:currency_code).uniq).to eq(%w[USD])
-      end
-    end
-
-    context 'when currency code is upper case' do
-      let(:currency_code) { 'USD' }
-
-      it 'will return the correct results', :aggregate_failures do
-        expect(dataset.count).to eq(2)
-        expect(dataset.pluck(:currency_code).uniq).to eq(%w[USD])
-      end
+    it 'will return the correct results', :aggregate_failures do
+      expect(dataset.count).to eq(2)
+      expect(dataset.pluck(:currency_code).uniq).to eq(%w[USD])
     end
   end
 

--- a/spec/models/exchange_rate_currency_rate_spec.rb
+++ b/spec/models/exchange_rate_currency_rate_spec.rb
@@ -345,6 +345,67 @@ RSpec.describe ExchangeRateCurrencyRate do
     it { expect(dataset.pluck(:rate_type)).to eq(%w[monthly]) }
   end
 
+  describe '.by_currency' do
+    subject(:dataset) { described_class.by_currency(currency_code) }
+
+    before do
+      create(:exchange_rate_currency_rate, :with_usa)
+      create(:exchange_rate_currency_rate, :with_eur)
+    end
+
+    context 'when currency code is lower case' do
+      let(:currency_code) { 'usd' }
+
+      it { expect(dataset.pluck(:currency_code)).to eq(%w[USD]) }
+    end
+
+    context 'when currency code is upper case' do
+      let(:currency_code) { 'USD' }
+
+      it { expect(dataset.pluck(:currency_code)).to eq(%w[USD]) }
+    end
+  end
+
+  describe '.monthly_by_currency_last_year' do
+    subject(:dataset) { described_class.monthly_by_currency_last_year(currency_code) }
+
+    before do
+      create(:exchange_rate_currency_rate, :monthly_rate, :with_usa,
+             validity_start_date: Time.zone.today.beginning_of_month + 1.month,
+             validity_end_date: Time.zone.today.end_of_month + 1.month)
+      create(:exchange_rate_currency_rate, :monthly_rate, :with_usa,
+             validity_start_date: Time.zone.today.end_of_month,
+             validity_end_date: Time.zone.today.end_of_month)
+      create(:exchange_rate_currency_rate, :monthly_rate, :with_usa,
+             validity_start_date: Time.zone.today.beginning_of_month - 11.months,
+             validity_end_date: Time.zone.today.end_of_month - 11.months)
+      create(:exchange_rate_currency_rate, :monthly_rate, :with_usa,
+             validity_start_date: Time.zone.today.end_of_month - 12.months,
+             validity_end_date: Time.zone.today.end_of_month - 12.months)
+      create(:exchange_rate_currency_rate, :monthly_rate, :with_eur,
+             validity_start_date: Time.zone.today.beginning_of_month,
+             validity_end_date: Time.zone.today.end_of_month)
+    end
+
+    context 'when currency code is lower case' do
+      let(:currency_code) { 'usd' }
+
+      it 'will return the correct results', :aggregate_failures do
+        expect(dataset.count).to eq(2)
+        expect(dataset.pluck(:currency_code).uniq).to eq(%w[USD])
+      end
+    end
+
+    context 'when currency code is upper case' do
+      let(:currency_code) { 'USD' }
+
+      it 'will return the correct results', :aggregate_failures do
+        expect(dataset.count).to eq(2)
+        expect(dataset.pluck(:currency_code).uniq).to eq(%w[USD])
+      end
+    end
+  end
+
   describe '.by_year' do
     subject(:dataset) { described_class.with_applicable_date.by_year(2023) }
 

--- a/spec/services/exchange_rates/average_exchange_rates_service_spec.rb
+++ b/spec/services/exchange_rates/average_exchange_rates_service_spec.rb
@@ -1,0 +1,377 @@
+require 'rails_helper'
+
+RSpec.describe ExchangeRates::AverageExchangeRatesService do
+  describe '.call' do
+    subject(:create_average_rates) { described_class.call }
+
+    before do
+      setup_standard_data
+    end
+
+    context 'when run on a valid date' do
+      # This is when we 12 months exactly for particular currencies and countries
+      context 'with 12 months only of data' do
+
+        it 'creates the average rates' do
+          create_average_rates
+          binding.pry
+        end
+      end
+    end
+
+    context 'when run on an invalid date' do
+      it 'will return some error' do
+      end
+    end
+  end
+
+  def setup_standard_data
+    # Run for dec run
+    # 12 full months including dec
+    us = create(:exchange_rate_country_currency, :us)
+    eu = create(:exchange_rate_country_currency, :eu)
+    au = create(:exchange_rate_country_currency, :au)
+    du = create(:exchange_rate_country_currency, :du)
+
+    # Last 2 months only
+    kz = create(:exchange_rate_country_currency, :kz)
+
+    # Only one month in the middle but another currency has it
+    dh = create(:exchange_rate_country_currency, :dh)
+
+    # KZ
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: kz.currency_code,
+            rate: 560.7196,
+            validity_start_date: Time.zone.today.beginning_of_month,
+            validity_end_date: Time.zone.today.end_of_month)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: kz.currency_code,
+            rate: 529.4648,
+            validity_start_date: Time.zone.today.beginning_of_month - 1.month,
+            validity_end_date: Time.zone.today.end_of_month - 1.month)
+
+    # US
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: us.currency_code,
+            rate: 1.2366758567,
+            validity_start_date: Time.zone.today.beginning_of_month + 1.month,
+            validity_end_date: Time.zone.today.end_of_month + 1.month)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: us.currency_code,
+            rate: 1.2630673403,
+            validity_start_date: Time.zone.today.beginning_of_month,
+            validity_end_date: Time.zone.today.end_of_month)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: us.currency_code,
+            rate: 1.2886,
+            validity_start_date: Time.zone.today.beginning_of_month - 1.month,
+            validity_end_date: Time.zone.today.end_of_month - 1.month)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: us.currency_code,
+            rate: 1.2732,
+            validity_start_date: Time.zone.today.beginning_of_month - 2.months,
+            validity_end_date: Time.zone.today.end_of_month - 2.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: us.currency_code,
+            rate: 1.2366,
+            validity_start_date: Time.zone.today.beginning_of_month - 3.months,
+            validity_end_date: Time.zone.today.end_of_month - 3.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: us.currency_code,
+            rate: 1.245,
+            validity_start_date: Time.zone.today.beginning_of_month - 4.months,
+            validity_end_date: Time.zone.today.end_of_month - 4.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: us.currency_code,
+            rate: 1.2231,
+            validity_start_date: Time.zone.today.beginning_of_month - 5.months,
+            validity_end_date: Time.zone.today.end_of_month - 5.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: us.currency_code,
+            rate: 1.2002,
+            validity_start_date: Time.zone.today.beginning_of_month - 6.months,
+            validity_end_date: Time.zone.today.end_of_month - 6.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: us.currency_code,
+            rate: 1.2392,
+            validity_start_date: Time.zone.today.beginning_of_month - 7.months,
+            validity_end_date: Time.zone.today.end_of_month - 7.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: us.currency_code,
+            rate: 1.2406,
+            validity_start_date: Time.zone.today.beginning_of_month - 8.months,
+            validity_end_date: Time.zone.today.end_of_month - 8.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: us.currency_code,
+            rate: 1.2065,
+            validity_start_date: Time.zone.today.beginning_of_month - 9.months,
+            validity_end_date: Time.zone.today.end_of_month - 9.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: us.currency_code,
+            rate: 1.1259,
+            validity_start_date: Time.zone.today.beginning_of_month - 10.months,
+            validity_end_date: Time.zone.today.end_of_month - 10.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: us.currency_code,
+            rate: 1.1749,
+            validity_start_date: Time.zone.today.beginning_of_month - 11.months,
+            validity_end_date: Time.zone.today.end_of_month - 11.months)
+
+    # EU
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: eu.currency_code,
+            rate: 1.1555189008,
+            validity_start_date: Time.zone.today.beginning_of_month + 1.month,
+            validity_end_date: Time.zone.today.end_of_month + 1.month)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: eu.currency_code,
+            rate: 1.1682854042,
+            validity_start_date: Time.zone.today.beginning_of_month,
+            validity_end_date: Time.zone.today.end_of_month)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: eu.currency_code,
+            rate: 1.1515,
+            validity_start_date: Time.zone.today.beginning_of_month - 1.month,
+            validity_end_date: Time.zone.today.end_of_month - 1.month)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: eu.currency_code,
+            rate: 1.1622,
+            validity_start_date: Time.zone.today.beginning_of_month - 2.months,
+            validity_end_date: Time.zone.today.end_of_month - 2.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: eu.currency_code,
+            rate: 1.1489,
+            validity_start_date: Time.zone.today.beginning_of_month - 3.months,
+            validity_end_date: Time.zone.today.end_of_month - 3.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: eu.currency_code,
+            rate: 1.1361,
+            validity_start_date: Time.zone.today.beginning_of_month - 4.months,
+            validity_end_date: Time.zone.today.end_of_month - 4.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: eu.currency_code,
+            rate: 1.1334,
+            validity_start_date: Time.zone.today.beginning_of_month - 5.months,
+            validity_end_date: Time.zone.today.end_of_month - 5.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: eu.currency_code,
+            rate: 1.1242,
+            validity_start_date: Time.zone.today.beginning_of_month - 6.months,
+            validity_end_date: Time.zone.today.end_of_month - 6.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: eu.currency_code,
+            rate: 1.1441,
+            validity_start_date: Time.zone.today.beginning_of_month - 7.months,
+            validity_end_date: Time.zone.today.end_of_month - 7.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: eu.currency_code,
+            rate: 1.1652,
+            validity_start_date: Time.zone.today.beginning_of_month - 8.months,
+            validity_end_date: Time.zone.today.end_of_month - 8.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: eu.currency_code,
+            rate: 1.163,
+            validity_start_date: Time.zone.today.beginning_of_month - 9.months,
+            validity_end_date: Time.zone.today.end_of_month - 9.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: eu.currency_code,
+            rate: 1.15,
+            validity_start_date: Time.zone.today.beginning_of_month - 10.months,
+            validity_end_date: Time.zone.today.end_of_month - 10.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: eu.currency_code,
+            rate: 1.143,
+            validity_start_date: Time.zone.today.beginning_of_month - 11.months,
+            validity_end_date: Time.zone.today.end_of_month - 11.months)
+
+    # AU
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: au.currency_code,
+            rate: 1.906730541,
+            validity_start_date: Time.zone.today.beginning_of_month + 1.month,
+            validity_end_date: Time.zone.today.end_of_month + 1.month)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: au.currency_code,
+            rate: 1.9676556304,
+            validity_start_date: Time.zone.today.beginning_of_month,
+            validity_end_date: Time.zone.today.end_of_month)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: au.currency_code,
+            rate: 1.907,
+            validity_start_date: Time.zone.today.beginning_of_month - 1.month,
+            validity_end_date: Time.zone.today.end_of_month - 1.month)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: au.currency_code,
+            rate: 1.8804,
+            validity_start_date: Time.zone.today.beginning_of_month - 2.months,
+            validity_end_date: Time.zone.today.end_of_month - 2.months)
+
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: au.currency_code,
+            rate: 1.8915,
+            validity_start_date: Time.zone.today.beginning_of_month - 3.months,
+            validity_end_date: Time.zone.today.end_of_month - 3.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: au.currency_code,
+            rate: 1.852,
+            validity_start_date: Time.zone.today.beginning_of_month - 4.months,
+            validity_end_date: Time.zone.today.end_of_month - 4.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: au.currency_code,
+            rate: 1.8295,
+            validity_start_date: Time.zone.today.beginning_of_month - 5.months,
+            validity_end_date: Time.zone.today.end_of_month - 5.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: au.currency_code,
+            rate: 1.7446,
+            validity_start_date: Time.zone.today.beginning_of_month - 6.months,
+            validity_end_date: Time.zone.today.end_of_month - 6.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: au.currency_code,
+            rate: 1.7679,
+            validity_start_date: Time.zone.today.beginning_of_month - 7.months,
+            validity_end_date: Time.zone.today.end_of_month - 7.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: au.currency_code,
+            rate: 1.807,
+            validity_start_date: Time.zone.today.beginning_of_month - 8.months,
+            validity_end_date: Time.zone.today.end_of_month - 8.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: au.currency_code,
+            rate: 1.7951,
+            validity_start_date: Time.zone.today.beginning_of_month - 9.months,
+            validity_end_date: Time.zone.today.end_of_month - 9.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: au.currency_code,
+            rate: 1.7896,
+            validity_start_date: Time.zone.today.beginning_of_month - 10.months,
+            validity_end_date: Time.zone.today.end_of_month - 10.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: au.currency_code,
+            rate: 1.7816,
+            validity_start_date: Time.zone.today.beginning_of_month - 11.months,
+            validity_end_date: Time.zone.today.end_of_month - 11.months)
+
+    # DU
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: du.currency_code,
+            rate: 4.5416920836,
+            validity_start_date: Time.zone.today.beginning_of_month + 1.month,
+            validity_end_date: Time.zone.today.end_of_month + 1.month)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: du.currency_code,
+            rate: 4.6386148073,
+            validity_start_date: Time.zone.today.beginning_of_month,
+            validity_end_date: Time.zone.today.end_of_month)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: du.currency_code,
+            rate: 4.7333,
+            validity_start_date: Time.zone.today.beginning_of_month - 1.month,
+            validity_end_date: Time.zone.today.end_of_month - 1.month)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: du.currency_code,
+            rate: 4.6766,
+            validity_start_date: Time.zone.today.beginning_of_month - 2.months,
+            validity_end_date: Time.zone.today.end_of_month - 2.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: du.currency_code,
+            rate: 4.5409,
+            validity_start_date: Time.zone.today.beginning_of_month - 3.months,
+            validity_end_date: Time.zone.today.end_of_month - 3.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: du.currency_code,
+            rate: 4.5722,
+            validity_start_date: Time.zone.today.beginning_of_month - 4.months,
+            validity_end_date: Time.zone.today.end_of_month - 4.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: du.currency_code,
+            rate: 4.4918,
+            validity_start_date: Time.zone.today.beginning_of_month - 5.months,
+            validity_end_date: Time.zone.today.end_of_month - 5.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: du.currency_code,
+            rate: 4.4228,
+            validity_start_date: Time.zone.today.beginning_of_month - 6.months,
+            validity_end_date: Time.zone.today.end_of_month - 6.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: du.currency_code,
+            rate: 4.4084,
+            validity_start_date: Time.zone.today.beginning_of_month - 7.months,
+            validity_end_date: Time.zone.today.end_of_month - 7.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: du.currency_code,
+            rate: 4.5516,
+            validity_start_date: Time.zone.today.beginning_of_month - 8.months,
+            validity_end_date: Time.zone.today.end_of_month - 8.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: du.currency_code,
+            rate: 4.5569,
+            validity_start_date: Time.zone.today.beginning_of_month - 9.months,
+            validity_end_date: Time.zone.today.end_of_month - 9.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: du.currency_code,
+            rate: 4.4317,
+            validity_start_date: Time.zone.today.beginning_of_month - 10.months,
+            validity_end_date: Time.zone.today.end_of_month - 10.months)
+    create(:exchange_rate_currency_rate,
+            :monthly_rate,
+            currency_code: du.currency_code,
+            rate: 4.1355,
+            validity_start_date: Time.zone.today.beginning_of_month - 11.months,
+            validity_end_date: Time.zone.today.end_of_month - 11.months)
+  end
+end

--- a/spec/services/exchange_rates/average_exchange_rates_service_spec.rb
+++ b/spec/services/exchange_rates/average_exchange_rates_service_spec.rb
@@ -2,40 +2,136 @@ require 'rails_helper'
 
 RSpec.describe ExchangeRates::AverageExchangeRatesService do
   describe '.call' do
-    subject(:create_average_rates) { described_class.call }
+    subject(:create_average_rates) { described_class.call(force_run) }
 
-    before do
-      setup_standard_data
+    let(:force_run) { false }
+
+    let(:expected_filepath) { "data/exchange_rates/#{test_date.year}/#{test_date.month}/average_csv_#{test_date.year}-#{test_date.month}.csv" }
+    let(:expected_csv) do
+      <<~CSV
+        Country,Unit Of Currency,Currency Code,Sterling value of Currency Unit £,Currency Units per £1
+        Australia,Dollar,AUD,0.5264,1.8997
+        Dubai,Dirham,AED,0.2286,4.3747
+        Eurozone,Euro,EUR,0.8702,1.1492
+        Kazakhstan,Tenge,USD,0.8154,1.2264
+        Kazakhstan,Euro,EUR,0.8702,1.1492
+        Kazakhstan,Tenge,KZT,0.0018,545.0922
+        United States,Dollar,USD,0.8154,1.2264
+      CSV
     end
 
-    context 'when run on a valid date' do
-      # This is when we 12 months exactly for particular currencies and countries
-      context 'with 12 months only of data' do
-        it 'creates the average rates' do
-          create_average_rates
-        end
+    before do
+      travel_to test_date
+      setup_data
+
+      allow(TariffSynchronizer::FileService)
+       .to receive(:write_file)
+       .with(expected_filepath, expected_csv)
+      allow(TariffSynchronizer::FileService).to receive(:file_size).and_return(1)
+    end
+
+    shared_examples 'creating the average rates' do
+      it 'creates the average rates', :aggregate_failures do
+        create_average_rates
+
+        avg_rates = ExchangeRateCurrencyRate.by_type(ExchangeRateCurrencyRate::AVERAGE_RATE_TYPE)
+
+        expect(avg_rates.all? { |r| r.validity_start_date == Time.zone.today.beginning_of_month }).to be true
+        expect(avg_rates.all? { |r| r.validity_end_date == Time.zone.today.end_of_month }).to be true
+
+        expect(avg_rates.by_currency('USD').first.rate).to eq(1.2264056116916666)
+        expect(avg_rates.by_currency('EUR').first.rate).to eq(1.1491571170166666)
+        expect(avg_rates.by_currency('AUD').first.rate).to eq(1.8997111260800001)
+        expect(avg_rates.by_currency('AED').first.rate).to eq(4.3747)
+        expect(avg_rates.by_currency('KZT').first.rate).to eq(545.0922)
+        expect(TariffSynchronizer::FileService).to have_received(:write_file).with(expected_filepath, expected_csv)
       end
     end
 
+    context 'when run on a valid date' do
+      let(:test_date) { Date.new(2023, 12, 31) }
+
+      after do
+        travel_back
+      end
+
+      it_behaves_like 'creating the average rates'
+    end
+
     context 'when run on an invalid date' do
-      it 'will return some error' do
+      let(:test_date) { Date.new(2023, 10, 25) }
+
+      after do
+        travel_back
+      end
+
+      it 'will return an argument error' do
+        expect { create_average_rates }.to raise_error(ArgumentError)
+      end
+
+      context 'with force run enabled' do
+        let(:force_run) { true }
+
+        it_behaves_like 'creating the average rates'
       end
     end
   end
 
-  def setup_standard_data
-    # Run for dec run
-    # 12 full months including dec
+  def setup_data
+    # 13 months of data
     us = create(:exchange_rate_country_currency, :us)
+
+    # 12 months of data
     eu = create(:exchange_rate_country_currency, :eu)
+
+    # Last 5 months of data with AUD
     au = create(:exchange_rate_country_currency, :au)
+
+    # First 3 months of data
     du = create(:exchange_rate_country_currency, :du)
 
-    # Last 2 months only
-    kz = create(:exchange_rate_country_currency, :kz)
+    # First 6 months in USD
+    create(:exchange_rate_country_currency, :kz,
+           currency_code: us.currency_code,
+           validity_start_date: Time.zone.today.beginning_of_month - 11.months,
+           validity_end_date: Time.zone.today.end_of_month - 6.months)
 
-    # Only one month in the middle but another currency has it
-    create(:exchange_rate_country_currency, :dh)
+    # Middle 4 months in EUR
+    create(:exchange_rate_country_currency, :kz,
+           currency_code: eu.currency_code,
+           currency_description: eu.currency_description,
+           validity_start_date: Time.zone.today.beginning_of_month - 5.months,
+           validity_end_date: Time.zone.today.end_of_month - 2.months)
+
+    # Last 2 months in Tenge
+    kz = create(:exchange_rate_country_currency, :kz,
+                validity_start_date: Time.zone.today.end_of_month - 1.month)
+
+    # Older than 12 months
+    zw = create(:exchange_rate_country_currency, :zw,
+                validity_start_date: Time.zone.today.end_of_month - 13.months,
+                validity_end_date: Time.zone.today.end_of_month - 12.months)
+
+    # Not valid till next month
+    bd = create(:exchange_rate_country_currency, :bd,
+                validity_start_date: Time.zone.today.end_of_month + 1.month,
+                validity_end_date: Time.zone.today.end_of_month + 1.month)
+
+    # BD
+    create(:exchange_rate_currency_rate,
+           :monthly_rate,
+           currency_code: bd.currency_code,
+           rate: 2.5678,
+           validity_start_date: Time.zone.today.beginning_of_month + 1.month,
+           validity_end_date: Time.zone.today.end_of_month + 1.month)
+
+    # ZW
+    create(:exchange_rate_currency_rate,
+           :monthly_rate,
+           currency_code: zw.currency_code,
+           rate: 447.5529925241,
+           validity_start_date: Time.zone.today.beginning_of_month - 12.months,
+           validity_end_date: Time.zone.today.end_of_month - 12.months)
 
     # KZ
     create(:exchange_rate_currency_rate,
@@ -51,7 +147,7 @@ RSpec.describe ExchangeRates::AverageExchangeRatesService do
            validity_start_date: Time.zone.today.beginning_of_month - 1.month,
            validity_end_date: Time.zone.today.end_of_month - 1.month)
 
-    # US
+    # US 13 months including next months avg rate
     create(:exchange_rate_currency_rate,
            :monthly_rate,
            currency_code: us.currency_code,
@@ -131,13 +227,7 @@ RSpec.describe ExchangeRates::AverageExchangeRatesService do
            validity_start_date: Time.zone.today.beginning_of_month - 11.months,
            validity_end_date: Time.zone.today.end_of_month - 11.months)
 
-    # EU
-    create(:exchange_rate_currency_rate,
-           :monthly_rate,
-           currency_code: eu.currency_code,
-           rate: 1.1555189008,
-           validity_start_date: Time.zone.today.beginning_of_month + 1.month,
-           validity_end_date: Time.zone.today.end_of_month + 1.month)
+    # EU 12 months only
     create(:exchange_rate_currency_rate,
            :monthly_rate,
            currency_code: eu.currency_code,
@@ -211,13 +301,7 @@ RSpec.describe ExchangeRates::AverageExchangeRatesService do
            validity_start_date: Time.zone.today.beginning_of_month - 11.months,
            validity_end_date: Time.zone.today.end_of_month - 11.months)
 
-    # AU
-    create(:exchange_rate_currency_rate,
-           :monthly_rate,
-           currency_code: au.currency_code,
-           rate: 1.906730541,
-           validity_start_date: Time.zone.today.beginning_of_month + 1.month,
-           validity_end_date: Time.zone.today.end_of_month + 1.month)
+    # AU Last 5 months only
     create(:exchange_rate_currency_rate,
            :monthly_rate,
            currency_code: au.currency_code,
@@ -236,7 +320,6 @@ RSpec.describe ExchangeRates::AverageExchangeRatesService do
            rate: 1.8804,
            validity_start_date: Time.zone.today.beginning_of_month - 2.months,
            validity_end_date: Time.zone.today.end_of_month - 2.months)
-
     create(:exchange_rate_currency_rate,
            :monthly_rate,
            currency_code: au.currency_code,
@@ -249,110 +332,8 @@ RSpec.describe ExchangeRates::AverageExchangeRatesService do
            rate: 1.852,
            validity_start_date: Time.zone.today.beginning_of_month - 4.months,
            validity_end_date: Time.zone.today.end_of_month - 4.months)
-    create(:exchange_rate_currency_rate,
-           :monthly_rate,
-           currency_code: au.currency_code,
-           rate: 1.8295,
-           validity_start_date: Time.zone.today.beginning_of_month - 5.months,
-           validity_end_date: Time.zone.today.end_of_month - 5.months)
-    create(:exchange_rate_currency_rate,
-           :monthly_rate,
-           currency_code: au.currency_code,
-           rate: 1.7446,
-           validity_start_date: Time.zone.today.beginning_of_month - 6.months,
-           validity_end_date: Time.zone.today.end_of_month - 6.months)
-    create(:exchange_rate_currency_rate,
-           :monthly_rate,
-           currency_code: au.currency_code,
-           rate: 1.7679,
-           validity_start_date: Time.zone.today.beginning_of_month - 7.months,
-           validity_end_date: Time.zone.today.end_of_month - 7.months)
-    create(:exchange_rate_currency_rate,
-           :monthly_rate,
-           currency_code: au.currency_code,
-           rate: 1.807,
-           validity_start_date: Time.zone.today.beginning_of_month - 8.months,
-           validity_end_date: Time.zone.today.end_of_month - 8.months)
-    create(:exchange_rate_currency_rate,
-           :monthly_rate,
-           currency_code: au.currency_code,
-           rate: 1.7951,
-           validity_start_date: Time.zone.today.beginning_of_month - 9.months,
-           validity_end_date: Time.zone.today.end_of_month - 9.months)
-    create(:exchange_rate_currency_rate,
-           :monthly_rate,
-           currency_code: au.currency_code,
-           rate: 1.7896,
-           validity_start_date: Time.zone.today.beginning_of_month - 10.months,
-           validity_end_date: Time.zone.today.end_of_month - 10.months)
-    create(:exchange_rate_currency_rate,
-           :monthly_rate,
-           currency_code: au.currency_code,
-           rate: 1.7816,
-           validity_start_date: Time.zone.today.beginning_of_month - 11.months,
-           validity_end_date: Time.zone.today.end_of_month - 11.months)
 
-    # DU
-    create(:exchange_rate_currency_rate,
-           :monthly_rate,
-           currency_code: du.currency_code,
-           rate: 4.5416920836,
-           validity_start_date: Time.zone.today.beginning_of_month + 1.month,
-           validity_end_date: Time.zone.today.end_of_month + 1.month)
-    create(:exchange_rate_currency_rate,
-           :monthly_rate,
-           currency_code: du.currency_code,
-           rate: 4.6386148073,
-           validity_start_date: Time.zone.today.beginning_of_month,
-           validity_end_date: Time.zone.today.end_of_month)
-    create(:exchange_rate_currency_rate,
-           :monthly_rate,
-           currency_code: du.currency_code,
-           rate: 4.7333,
-           validity_start_date: Time.zone.today.beginning_of_month - 1.month,
-           validity_end_date: Time.zone.today.end_of_month - 1.month)
-    create(:exchange_rate_currency_rate,
-           :monthly_rate,
-           currency_code: du.currency_code,
-           rate: 4.6766,
-           validity_start_date: Time.zone.today.beginning_of_month - 2.months,
-           validity_end_date: Time.zone.today.end_of_month - 2.months)
-    create(:exchange_rate_currency_rate,
-           :monthly_rate,
-           currency_code: du.currency_code,
-           rate: 4.5409,
-           validity_start_date: Time.zone.today.beginning_of_month - 3.months,
-           validity_end_date: Time.zone.today.end_of_month - 3.months)
-    create(:exchange_rate_currency_rate,
-           :monthly_rate,
-           currency_code: du.currency_code,
-           rate: 4.5722,
-           validity_start_date: Time.zone.today.beginning_of_month - 4.months,
-           validity_end_date: Time.zone.today.end_of_month - 4.months)
-    create(:exchange_rate_currency_rate,
-           :monthly_rate,
-           currency_code: du.currency_code,
-           rate: 4.4918,
-           validity_start_date: Time.zone.today.beginning_of_month - 5.months,
-           validity_end_date: Time.zone.today.end_of_month - 5.months)
-    create(:exchange_rate_currency_rate,
-           :monthly_rate,
-           currency_code: du.currency_code,
-           rate: 4.4228,
-           validity_start_date: Time.zone.today.beginning_of_month - 6.months,
-           validity_end_date: Time.zone.today.end_of_month - 6.months)
-    create(:exchange_rate_currency_rate,
-           :monthly_rate,
-           currency_code: du.currency_code,
-           rate: 4.4084,
-           validity_start_date: Time.zone.today.beginning_of_month - 7.months,
-           validity_end_date: Time.zone.today.end_of_month - 7.months)
-    create(:exchange_rate_currency_rate,
-           :monthly_rate,
-           currency_code: du.currency_code,
-           rate: 4.5516,
-           validity_start_date: Time.zone.today.beginning_of_month - 8.months,
-           validity_end_date: Time.zone.today.end_of_month - 8.months)
+    # DU First 3 months
     create(:exchange_rate_currency_rate,
            :monthly_rate,
            currency_code: du.currency_code,

--- a/spec/services/exchange_rates/average_exchange_rates_service_spec.rb
+++ b/spec/services/exchange_rates/average_exchange_rates_service_spec.rb
@@ -11,10 +11,8 @@ RSpec.describe ExchangeRates::AverageExchangeRatesService do
     context 'when run on a valid date' do
       # This is when we 12 months exactly for particular currencies and countries
       context 'with 12 months only of data' do
-
         it 'creates the average rates' do
           create_average_rates
-          binding.pry
         end
       end
     end
@@ -37,341 +35,341 @@ RSpec.describe ExchangeRates::AverageExchangeRatesService do
     kz = create(:exchange_rate_country_currency, :kz)
 
     # Only one month in the middle but another currency has it
-    dh = create(:exchange_rate_country_currency, :dh)
+    create(:exchange_rate_country_currency, :dh)
 
     # KZ
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: kz.currency_code,
-            rate: 560.7196,
-            validity_start_date: Time.zone.today.beginning_of_month,
-            validity_end_date: Time.zone.today.end_of_month)
+           :monthly_rate,
+           currency_code: kz.currency_code,
+           rate: 560.7196,
+           validity_start_date: Time.zone.today.beginning_of_month,
+           validity_end_date: Time.zone.today.end_of_month)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: kz.currency_code,
-            rate: 529.4648,
-            validity_start_date: Time.zone.today.beginning_of_month - 1.month,
-            validity_end_date: Time.zone.today.end_of_month - 1.month)
+           :monthly_rate,
+           currency_code: kz.currency_code,
+           rate: 529.4648,
+           validity_start_date: Time.zone.today.beginning_of_month - 1.month,
+           validity_end_date: Time.zone.today.end_of_month - 1.month)
 
     # US
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: us.currency_code,
-            rate: 1.2366758567,
-            validity_start_date: Time.zone.today.beginning_of_month + 1.month,
-            validity_end_date: Time.zone.today.end_of_month + 1.month)
+           :monthly_rate,
+           currency_code: us.currency_code,
+           rate: 1.2366758567,
+           validity_start_date: Time.zone.today.beginning_of_month + 1.month,
+           validity_end_date: Time.zone.today.end_of_month + 1.month)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: us.currency_code,
-            rate: 1.2630673403,
-            validity_start_date: Time.zone.today.beginning_of_month,
-            validity_end_date: Time.zone.today.end_of_month)
+           :monthly_rate,
+           currency_code: us.currency_code,
+           rate: 1.2630673403,
+           validity_start_date: Time.zone.today.beginning_of_month,
+           validity_end_date: Time.zone.today.end_of_month)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: us.currency_code,
-            rate: 1.2886,
-            validity_start_date: Time.zone.today.beginning_of_month - 1.month,
-            validity_end_date: Time.zone.today.end_of_month - 1.month)
+           :monthly_rate,
+           currency_code: us.currency_code,
+           rate: 1.2886,
+           validity_start_date: Time.zone.today.beginning_of_month - 1.month,
+           validity_end_date: Time.zone.today.end_of_month - 1.month)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: us.currency_code,
-            rate: 1.2732,
-            validity_start_date: Time.zone.today.beginning_of_month - 2.months,
-            validity_end_date: Time.zone.today.end_of_month - 2.months)
+           :monthly_rate,
+           currency_code: us.currency_code,
+           rate: 1.2732,
+           validity_start_date: Time.zone.today.beginning_of_month - 2.months,
+           validity_end_date: Time.zone.today.end_of_month - 2.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: us.currency_code,
-            rate: 1.2366,
-            validity_start_date: Time.zone.today.beginning_of_month - 3.months,
-            validity_end_date: Time.zone.today.end_of_month - 3.months)
+           :monthly_rate,
+           currency_code: us.currency_code,
+           rate: 1.2366,
+           validity_start_date: Time.zone.today.beginning_of_month - 3.months,
+           validity_end_date: Time.zone.today.end_of_month - 3.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: us.currency_code,
-            rate: 1.245,
-            validity_start_date: Time.zone.today.beginning_of_month - 4.months,
-            validity_end_date: Time.zone.today.end_of_month - 4.months)
+           :monthly_rate,
+           currency_code: us.currency_code,
+           rate: 1.245,
+           validity_start_date: Time.zone.today.beginning_of_month - 4.months,
+           validity_end_date: Time.zone.today.end_of_month - 4.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: us.currency_code,
-            rate: 1.2231,
-            validity_start_date: Time.zone.today.beginning_of_month - 5.months,
-            validity_end_date: Time.zone.today.end_of_month - 5.months)
+           :monthly_rate,
+           currency_code: us.currency_code,
+           rate: 1.2231,
+           validity_start_date: Time.zone.today.beginning_of_month - 5.months,
+           validity_end_date: Time.zone.today.end_of_month - 5.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: us.currency_code,
-            rate: 1.2002,
-            validity_start_date: Time.zone.today.beginning_of_month - 6.months,
-            validity_end_date: Time.zone.today.end_of_month - 6.months)
+           :monthly_rate,
+           currency_code: us.currency_code,
+           rate: 1.2002,
+           validity_start_date: Time.zone.today.beginning_of_month - 6.months,
+           validity_end_date: Time.zone.today.end_of_month - 6.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: us.currency_code,
-            rate: 1.2392,
-            validity_start_date: Time.zone.today.beginning_of_month - 7.months,
-            validity_end_date: Time.zone.today.end_of_month - 7.months)
+           :monthly_rate,
+           currency_code: us.currency_code,
+           rate: 1.2392,
+           validity_start_date: Time.zone.today.beginning_of_month - 7.months,
+           validity_end_date: Time.zone.today.end_of_month - 7.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: us.currency_code,
-            rate: 1.2406,
-            validity_start_date: Time.zone.today.beginning_of_month - 8.months,
-            validity_end_date: Time.zone.today.end_of_month - 8.months)
+           :monthly_rate,
+           currency_code: us.currency_code,
+           rate: 1.2406,
+           validity_start_date: Time.zone.today.beginning_of_month - 8.months,
+           validity_end_date: Time.zone.today.end_of_month - 8.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: us.currency_code,
-            rate: 1.2065,
-            validity_start_date: Time.zone.today.beginning_of_month - 9.months,
-            validity_end_date: Time.zone.today.end_of_month - 9.months)
+           :monthly_rate,
+           currency_code: us.currency_code,
+           rate: 1.2065,
+           validity_start_date: Time.zone.today.beginning_of_month - 9.months,
+           validity_end_date: Time.zone.today.end_of_month - 9.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: us.currency_code,
-            rate: 1.1259,
-            validity_start_date: Time.zone.today.beginning_of_month - 10.months,
-            validity_end_date: Time.zone.today.end_of_month - 10.months)
+           :monthly_rate,
+           currency_code: us.currency_code,
+           rate: 1.1259,
+           validity_start_date: Time.zone.today.beginning_of_month - 10.months,
+           validity_end_date: Time.zone.today.end_of_month - 10.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: us.currency_code,
-            rate: 1.1749,
-            validity_start_date: Time.zone.today.beginning_of_month - 11.months,
-            validity_end_date: Time.zone.today.end_of_month - 11.months)
+           :monthly_rate,
+           currency_code: us.currency_code,
+           rate: 1.1749,
+           validity_start_date: Time.zone.today.beginning_of_month - 11.months,
+           validity_end_date: Time.zone.today.end_of_month - 11.months)
 
     # EU
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: eu.currency_code,
-            rate: 1.1555189008,
-            validity_start_date: Time.zone.today.beginning_of_month + 1.month,
-            validity_end_date: Time.zone.today.end_of_month + 1.month)
+           :monthly_rate,
+           currency_code: eu.currency_code,
+           rate: 1.1555189008,
+           validity_start_date: Time.zone.today.beginning_of_month + 1.month,
+           validity_end_date: Time.zone.today.end_of_month + 1.month)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: eu.currency_code,
-            rate: 1.1682854042,
-            validity_start_date: Time.zone.today.beginning_of_month,
-            validity_end_date: Time.zone.today.end_of_month)
+           :monthly_rate,
+           currency_code: eu.currency_code,
+           rate: 1.1682854042,
+           validity_start_date: Time.zone.today.beginning_of_month,
+           validity_end_date: Time.zone.today.end_of_month)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: eu.currency_code,
-            rate: 1.1515,
-            validity_start_date: Time.zone.today.beginning_of_month - 1.month,
-            validity_end_date: Time.zone.today.end_of_month - 1.month)
+           :monthly_rate,
+           currency_code: eu.currency_code,
+           rate: 1.1515,
+           validity_start_date: Time.zone.today.beginning_of_month - 1.month,
+           validity_end_date: Time.zone.today.end_of_month - 1.month)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: eu.currency_code,
-            rate: 1.1622,
-            validity_start_date: Time.zone.today.beginning_of_month - 2.months,
-            validity_end_date: Time.zone.today.end_of_month - 2.months)
+           :monthly_rate,
+           currency_code: eu.currency_code,
+           rate: 1.1622,
+           validity_start_date: Time.zone.today.beginning_of_month - 2.months,
+           validity_end_date: Time.zone.today.end_of_month - 2.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: eu.currency_code,
-            rate: 1.1489,
-            validity_start_date: Time.zone.today.beginning_of_month - 3.months,
-            validity_end_date: Time.zone.today.end_of_month - 3.months)
+           :monthly_rate,
+           currency_code: eu.currency_code,
+           rate: 1.1489,
+           validity_start_date: Time.zone.today.beginning_of_month - 3.months,
+           validity_end_date: Time.zone.today.end_of_month - 3.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: eu.currency_code,
-            rate: 1.1361,
-            validity_start_date: Time.zone.today.beginning_of_month - 4.months,
-            validity_end_date: Time.zone.today.end_of_month - 4.months)
+           :monthly_rate,
+           currency_code: eu.currency_code,
+           rate: 1.1361,
+           validity_start_date: Time.zone.today.beginning_of_month - 4.months,
+           validity_end_date: Time.zone.today.end_of_month - 4.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: eu.currency_code,
-            rate: 1.1334,
-            validity_start_date: Time.zone.today.beginning_of_month - 5.months,
-            validity_end_date: Time.zone.today.end_of_month - 5.months)
+           :monthly_rate,
+           currency_code: eu.currency_code,
+           rate: 1.1334,
+           validity_start_date: Time.zone.today.beginning_of_month - 5.months,
+           validity_end_date: Time.zone.today.end_of_month - 5.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: eu.currency_code,
-            rate: 1.1242,
-            validity_start_date: Time.zone.today.beginning_of_month - 6.months,
-            validity_end_date: Time.zone.today.end_of_month - 6.months)
+           :monthly_rate,
+           currency_code: eu.currency_code,
+           rate: 1.1242,
+           validity_start_date: Time.zone.today.beginning_of_month - 6.months,
+           validity_end_date: Time.zone.today.end_of_month - 6.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: eu.currency_code,
-            rate: 1.1441,
-            validity_start_date: Time.zone.today.beginning_of_month - 7.months,
-            validity_end_date: Time.zone.today.end_of_month - 7.months)
+           :monthly_rate,
+           currency_code: eu.currency_code,
+           rate: 1.1441,
+           validity_start_date: Time.zone.today.beginning_of_month - 7.months,
+           validity_end_date: Time.zone.today.end_of_month - 7.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: eu.currency_code,
-            rate: 1.1652,
-            validity_start_date: Time.zone.today.beginning_of_month - 8.months,
-            validity_end_date: Time.zone.today.end_of_month - 8.months)
+           :monthly_rate,
+           currency_code: eu.currency_code,
+           rate: 1.1652,
+           validity_start_date: Time.zone.today.beginning_of_month - 8.months,
+           validity_end_date: Time.zone.today.end_of_month - 8.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: eu.currency_code,
-            rate: 1.163,
-            validity_start_date: Time.zone.today.beginning_of_month - 9.months,
-            validity_end_date: Time.zone.today.end_of_month - 9.months)
+           :monthly_rate,
+           currency_code: eu.currency_code,
+           rate: 1.163,
+           validity_start_date: Time.zone.today.beginning_of_month - 9.months,
+           validity_end_date: Time.zone.today.end_of_month - 9.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: eu.currency_code,
-            rate: 1.15,
-            validity_start_date: Time.zone.today.beginning_of_month - 10.months,
-            validity_end_date: Time.zone.today.end_of_month - 10.months)
+           :monthly_rate,
+           currency_code: eu.currency_code,
+           rate: 1.15,
+           validity_start_date: Time.zone.today.beginning_of_month - 10.months,
+           validity_end_date: Time.zone.today.end_of_month - 10.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: eu.currency_code,
-            rate: 1.143,
-            validity_start_date: Time.zone.today.beginning_of_month - 11.months,
-            validity_end_date: Time.zone.today.end_of_month - 11.months)
+           :monthly_rate,
+           currency_code: eu.currency_code,
+           rate: 1.143,
+           validity_start_date: Time.zone.today.beginning_of_month - 11.months,
+           validity_end_date: Time.zone.today.end_of_month - 11.months)
 
     # AU
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: au.currency_code,
-            rate: 1.906730541,
-            validity_start_date: Time.zone.today.beginning_of_month + 1.month,
-            validity_end_date: Time.zone.today.end_of_month + 1.month)
+           :monthly_rate,
+           currency_code: au.currency_code,
+           rate: 1.906730541,
+           validity_start_date: Time.zone.today.beginning_of_month + 1.month,
+           validity_end_date: Time.zone.today.end_of_month + 1.month)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: au.currency_code,
-            rate: 1.9676556304,
-            validity_start_date: Time.zone.today.beginning_of_month,
-            validity_end_date: Time.zone.today.end_of_month)
+           :monthly_rate,
+           currency_code: au.currency_code,
+           rate: 1.9676556304,
+           validity_start_date: Time.zone.today.beginning_of_month,
+           validity_end_date: Time.zone.today.end_of_month)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: au.currency_code,
-            rate: 1.907,
-            validity_start_date: Time.zone.today.beginning_of_month - 1.month,
-            validity_end_date: Time.zone.today.end_of_month - 1.month)
+           :monthly_rate,
+           currency_code: au.currency_code,
+           rate: 1.907,
+           validity_start_date: Time.zone.today.beginning_of_month - 1.month,
+           validity_end_date: Time.zone.today.end_of_month - 1.month)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: au.currency_code,
-            rate: 1.8804,
-            validity_start_date: Time.zone.today.beginning_of_month - 2.months,
-            validity_end_date: Time.zone.today.end_of_month - 2.months)
+           :monthly_rate,
+           currency_code: au.currency_code,
+           rate: 1.8804,
+           validity_start_date: Time.zone.today.beginning_of_month - 2.months,
+           validity_end_date: Time.zone.today.end_of_month - 2.months)
 
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: au.currency_code,
-            rate: 1.8915,
-            validity_start_date: Time.zone.today.beginning_of_month - 3.months,
-            validity_end_date: Time.zone.today.end_of_month - 3.months)
+           :monthly_rate,
+           currency_code: au.currency_code,
+           rate: 1.8915,
+           validity_start_date: Time.zone.today.beginning_of_month - 3.months,
+           validity_end_date: Time.zone.today.end_of_month - 3.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: au.currency_code,
-            rate: 1.852,
-            validity_start_date: Time.zone.today.beginning_of_month - 4.months,
-            validity_end_date: Time.zone.today.end_of_month - 4.months)
+           :monthly_rate,
+           currency_code: au.currency_code,
+           rate: 1.852,
+           validity_start_date: Time.zone.today.beginning_of_month - 4.months,
+           validity_end_date: Time.zone.today.end_of_month - 4.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: au.currency_code,
-            rate: 1.8295,
-            validity_start_date: Time.zone.today.beginning_of_month - 5.months,
-            validity_end_date: Time.zone.today.end_of_month - 5.months)
+           :monthly_rate,
+           currency_code: au.currency_code,
+           rate: 1.8295,
+           validity_start_date: Time.zone.today.beginning_of_month - 5.months,
+           validity_end_date: Time.zone.today.end_of_month - 5.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: au.currency_code,
-            rate: 1.7446,
-            validity_start_date: Time.zone.today.beginning_of_month - 6.months,
-            validity_end_date: Time.zone.today.end_of_month - 6.months)
+           :monthly_rate,
+           currency_code: au.currency_code,
+           rate: 1.7446,
+           validity_start_date: Time.zone.today.beginning_of_month - 6.months,
+           validity_end_date: Time.zone.today.end_of_month - 6.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: au.currency_code,
-            rate: 1.7679,
-            validity_start_date: Time.zone.today.beginning_of_month - 7.months,
-            validity_end_date: Time.zone.today.end_of_month - 7.months)
+           :monthly_rate,
+           currency_code: au.currency_code,
+           rate: 1.7679,
+           validity_start_date: Time.zone.today.beginning_of_month - 7.months,
+           validity_end_date: Time.zone.today.end_of_month - 7.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: au.currency_code,
-            rate: 1.807,
-            validity_start_date: Time.zone.today.beginning_of_month - 8.months,
-            validity_end_date: Time.zone.today.end_of_month - 8.months)
+           :monthly_rate,
+           currency_code: au.currency_code,
+           rate: 1.807,
+           validity_start_date: Time.zone.today.beginning_of_month - 8.months,
+           validity_end_date: Time.zone.today.end_of_month - 8.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: au.currency_code,
-            rate: 1.7951,
-            validity_start_date: Time.zone.today.beginning_of_month - 9.months,
-            validity_end_date: Time.zone.today.end_of_month - 9.months)
+           :monthly_rate,
+           currency_code: au.currency_code,
+           rate: 1.7951,
+           validity_start_date: Time.zone.today.beginning_of_month - 9.months,
+           validity_end_date: Time.zone.today.end_of_month - 9.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: au.currency_code,
-            rate: 1.7896,
-            validity_start_date: Time.zone.today.beginning_of_month - 10.months,
-            validity_end_date: Time.zone.today.end_of_month - 10.months)
+           :monthly_rate,
+           currency_code: au.currency_code,
+           rate: 1.7896,
+           validity_start_date: Time.zone.today.beginning_of_month - 10.months,
+           validity_end_date: Time.zone.today.end_of_month - 10.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: au.currency_code,
-            rate: 1.7816,
-            validity_start_date: Time.zone.today.beginning_of_month - 11.months,
-            validity_end_date: Time.zone.today.end_of_month - 11.months)
+           :monthly_rate,
+           currency_code: au.currency_code,
+           rate: 1.7816,
+           validity_start_date: Time.zone.today.beginning_of_month - 11.months,
+           validity_end_date: Time.zone.today.end_of_month - 11.months)
 
     # DU
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: du.currency_code,
-            rate: 4.5416920836,
-            validity_start_date: Time.zone.today.beginning_of_month + 1.month,
-            validity_end_date: Time.zone.today.end_of_month + 1.month)
+           :monthly_rate,
+           currency_code: du.currency_code,
+           rate: 4.5416920836,
+           validity_start_date: Time.zone.today.beginning_of_month + 1.month,
+           validity_end_date: Time.zone.today.end_of_month + 1.month)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: du.currency_code,
-            rate: 4.6386148073,
-            validity_start_date: Time.zone.today.beginning_of_month,
-            validity_end_date: Time.zone.today.end_of_month)
+           :monthly_rate,
+           currency_code: du.currency_code,
+           rate: 4.6386148073,
+           validity_start_date: Time.zone.today.beginning_of_month,
+           validity_end_date: Time.zone.today.end_of_month)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: du.currency_code,
-            rate: 4.7333,
-            validity_start_date: Time.zone.today.beginning_of_month - 1.month,
-            validity_end_date: Time.zone.today.end_of_month - 1.month)
+           :monthly_rate,
+           currency_code: du.currency_code,
+           rate: 4.7333,
+           validity_start_date: Time.zone.today.beginning_of_month - 1.month,
+           validity_end_date: Time.zone.today.end_of_month - 1.month)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: du.currency_code,
-            rate: 4.6766,
-            validity_start_date: Time.zone.today.beginning_of_month - 2.months,
-            validity_end_date: Time.zone.today.end_of_month - 2.months)
+           :monthly_rate,
+           currency_code: du.currency_code,
+           rate: 4.6766,
+           validity_start_date: Time.zone.today.beginning_of_month - 2.months,
+           validity_end_date: Time.zone.today.end_of_month - 2.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: du.currency_code,
-            rate: 4.5409,
-            validity_start_date: Time.zone.today.beginning_of_month - 3.months,
-            validity_end_date: Time.zone.today.end_of_month - 3.months)
+           :monthly_rate,
+           currency_code: du.currency_code,
+           rate: 4.5409,
+           validity_start_date: Time.zone.today.beginning_of_month - 3.months,
+           validity_end_date: Time.zone.today.end_of_month - 3.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: du.currency_code,
-            rate: 4.5722,
-            validity_start_date: Time.zone.today.beginning_of_month - 4.months,
-            validity_end_date: Time.zone.today.end_of_month - 4.months)
+           :monthly_rate,
+           currency_code: du.currency_code,
+           rate: 4.5722,
+           validity_start_date: Time.zone.today.beginning_of_month - 4.months,
+           validity_end_date: Time.zone.today.end_of_month - 4.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: du.currency_code,
-            rate: 4.4918,
-            validity_start_date: Time.zone.today.beginning_of_month - 5.months,
-            validity_end_date: Time.zone.today.end_of_month - 5.months)
+           :monthly_rate,
+           currency_code: du.currency_code,
+           rate: 4.4918,
+           validity_start_date: Time.zone.today.beginning_of_month - 5.months,
+           validity_end_date: Time.zone.today.end_of_month - 5.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: du.currency_code,
-            rate: 4.4228,
-            validity_start_date: Time.zone.today.beginning_of_month - 6.months,
-            validity_end_date: Time.zone.today.end_of_month - 6.months)
+           :monthly_rate,
+           currency_code: du.currency_code,
+           rate: 4.4228,
+           validity_start_date: Time.zone.today.beginning_of_month - 6.months,
+           validity_end_date: Time.zone.today.end_of_month - 6.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: du.currency_code,
-            rate: 4.4084,
-            validity_start_date: Time.zone.today.beginning_of_month - 7.months,
-            validity_end_date: Time.zone.today.end_of_month - 7.months)
+           :monthly_rate,
+           currency_code: du.currency_code,
+           rate: 4.4084,
+           validity_start_date: Time.zone.today.beginning_of_month - 7.months,
+           validity_end_date: Time.zone.today.end_of_month - 7.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: du.currency_code,
-            rate: 4.5516,
-            validity_start_date: Time.zone.today.beginning_of_month - 8.months,
-            validity_end_date: Time.zone.today.end_of_month - 8.months)
+           :monthly_rate,
+           currency_code: du.currency_code,
+           rate: 4.5516,
+           validity_start_date: Time.zone.today.beginning_of_month - 8.months,
+           validity_end_date: Time.zone.today.end_of_month - 8.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: du.currency_code,
-            rate: 4.5569,
-            validity_start_date: Time.zone.today.beginning_of_month - 9.months,
-            validity_end_date: Time.zone.today.end_of_month - 9.months)
+           :monthly_rate,
+           currency_code: du.currency_code,
+           rate: 4.5569,
+           validity_start_date: Time.zone.today.beginning_of_month - 9.months,
+           validity_end_date: Time.zone.today.end_of_month - 9.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: du.currency_code,
-            rate: 4.4317,
-            validity_start_date: Time.zone.today.beginning_of_month - 10.months,
-            validity_end_date: Time.zone.today.end_of_month - 10.months)
+           :monthly_rate,
+           currency_code: du.currency_code,
+           rate: 4.4317,
+           validity_start_date: Time.zone.today.beginning_of_month - 10.months,
+           validity_end_date: Time.zone.today.end_of_month - 10.months)
     create(:exchange_rate_currency_rate,
-            :monthly_rate,
-            currency_code: du.currency_code,
-            rate: 4.1355,
-            validity_start_date: Time.zone.today.beginning_of_month - 11.months,
-            validity_end_date: Time.zone.today.end_of_month - 11.months)
+           :monthly_rate,
+           currency_code: du.currency_code,
+           rate: 4.1355,
+           validity_start_date: Time.zone.today.beginning_of_month - 11.months,
+           validity_end_date: Time.zone.today.end_of_month - 11.months)
   end
 end

--- a/spec/services/exchange_rates/average_exchange_rates_service_spec.rb
+++ b/spec/services/exchange_rates/average_exchange_rates_service_spec.rb
@@ -2,11 +2,12 @@ require 'rails_helper'
 
 RSpec.describe ExchangeRates::AverageExchangeRatesService do
   describe '.call' do
-    subject(:create_average_rates) { described_class.call(force_run) }
+    subject(:create_average_rates) { described_class.call(force_run:, selected_date: test_date) }
 
     let(:force_run) { false }
+    let(:parsed_date) { Date.parse(test_date) }
 
-    let(:expected_filepath) { "data/exchange_rates/#{test_date.year}/#{test_date.month}/average_csv_#{test_date.year}-#{test_date.month}.csv" }
+    let(:expected_filepath) { "data/exchange_rates/#{parsed_date.year}/#{parsed_date.month}/average_csv_#{parsed_date.year}-#{parsed_date.month}.csv" }
     let(:expected_csv) do
       <<~CSV
         Country,Unit Of Currency,Currency Code,Sterling value of Currency Unit £,Currency Units per £1
@@ -21,7 +22,7 @@ RSpec.describe ExchangeRates::AverageExchangeRatesService do
     end
 
     before do
-      travel_to test_date
+      travel_to parsed_date
       setup_data
 
       allow(TariffSynchronizer::FileService)
@@ -49,7 +50,7 @@ RSpec.describe ExchangeRates::AverageExchangeRatesService do
     end
 
     context 'when run on a valid date' do
-      let(:test_date) { Date.new(2023, 12, 31) }
+      let(:test_date) { '2023-12-31' }
 
       after do
         travel_back
@@ -59,7 +60,7 @@ RSpec.describe ExchangeRates::AverageExchangeRatesService do
     end
 
     context 'when run on an invalid date' do
-      let(:test_date) { Date.new(2023, 10, 25) }
+      let(:test_date) { '2023-10-25' }
 
       after do
         travel_back

--- a/spec/services/exchange_rates/create_average_exchange_rates_service_spec.rb
+++ b/spec/services/exchange_rates/create_average_exchange_rates_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ExchangeRates::AverageExchangeRatesService do
+RSpec.describe ExchangeRates::CreateAverageExchangeRatesService do
   describe '.call' do
     subject(:create_average_rates) { described_class.call(force_run:, selected_date: test_date) }
 
@@ -79,7 +79,7 @@ RSpec.describe ExchangeRates::AverageExchangeRatesService do
   end
 
   def setup_data
-    # 13 months of data
+    # 13 months of data 1 in the future
     us = create(:exchange_rate_country_currency, :us)
 
     # 12 months of data

--- a/spec/services/exchange_rates/create_csv_average_rates_service_spec.rb
+++ b/spec/services/exchange_rates/create_csv_average_rates_service_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe ExchangeRates::CreateCsvAverageRatesService do
+  subject(:create_csv) { described_class.call(data) }
+
+  let(:data) do
+    {
+      create(:exchange_rate_country_currency, :eu) => 1.2434658,
+      create(:exchange_rate_country_currency, :us) => 1.453546,
+      create(:exchange_rate_country_currency, :kz) => 453.46583,
+      create(:exchange_rate_country_currency, :kz, currency_description: 'Dollar', currency_code: 'USD') => 1.453546,
+    }
+  end
+
+  let(:parsed_csv) do
+    <<~CSV
+      Country,Unit Of Currency,Currency Code,Sterling value of Currency Unit £,Currency Units per £1
+      Eurozone,Euro,EUR,0.8042,1.2435
+      United States,Dollar,USD,0.6880,1.4535
+      Kazakhstan,Tenge,KZT,0.0022,453.4658
+      Kazakhstan,Dollar,USD,0.6880,1.4535
+    CSV
+  end
+
+  it { expect(create_csv).to eq(parsed_csv) }
+end

--- a/spec/services/exchange_rates/monthly_exchange_rates_service_spec.rb
+++ b/spec/services/exchange_rates/monthly_exchange_rates_service_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ExchangeRates::MonthlyExchangeRatesService do
         validity_start_date: date,
       )
       allow(ExchangeRates::UpdateCurrencyRatesService).to receive(:new).with(date, sample_date, 'monthly').and_return(update_service)
-      allow(ExchangeRates::UploadMonthlyFileService).to receive(:new).and_call_original
+      allow(ExchangeRates::UploadFileService).to receive(:new).and_call_original
 
       call
     end
@@ -27,9 +27,9 @@ RSpec.describe ExchangeRates::MonthlyExchangeRatesService do
 
       it { expect(update_service).to have_received(:call) }
 
-      it { expect(ExchangeRates::UploadMonthlyFileService).to have_received(:new).with(anything, date, :monthly_csv) }
-      it { expect(ExchangeRates::UploadMonthlyFileService).to have_received(:new).with(anything, date, :monthly_xml) }
-      it { expect(ExchangeRates::UploadMonthlyFileService).to have_received(:new).with(anything, date, :monthly_csv_hmrc) }
+      it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(anything, date, :monthly_csv) }
+      it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(anything, date, :monthly_xml) }
+      it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(anything, date, :monthly_csv_hmrc) }
     end
 
     context 'when download is false' do
@@ -37,9 +37,9 @@ RSpec.describe ExchangeRates::MonthlyExchangeRatesService do
 
       it { expect(update_service).not_to have_received(:call) }
 
-      it { expect(ExchangeRates::UploadMonthlyFileService).to have_received(:new).with(anything, date, :monthly_csv) }
-      it { expect(ExchangeRates::UploadMonthlyFileService).to have_received(:new).with(anything, date, :monthly_xml) }
-      it { expect(ExchangeRates::UploadMonthlyFileService).to have_received(:new).with(anything, date, :monthly_csv_hmrc) }
+      it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(anything, date, :monthly_csv) }
+      it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(anything, date, :monthly_xml) }
+      it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(anything, date, :monthly_csv_hmrc) }
     end
   end
 end

--- a/spec/services/exchange_rates/spot_exchange_rates_service_spec.rb
+++ b/spec/services/exchange_rates/spot_exchange_rates_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ExchangeRates::SpotExchangeRatesService do
 
         allow(ExchangeRateCurrencyRate).to receive(:for_month).and_return(spot_rates)
 
-        allow(ExchangeRates::UploadMonthlyFileService).to receive(:new).and_call_original
+        allow(ExchangeRates::UploadFileService).to receive(:new).and_call_original
 
         call
       end
@@ -33,7 +33,7 @@ RSpec.describe ExchangeRates::SpotExchangeRatesService do
 
         it { expect(update_service).to have_received(:call) }
 
-        it { expect(ExchangeRates::UploadMonthlyFileService).to have_received(:new).with(spot_rates, sample_date, :spot_csv) }
+        it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(spot_rates, sample_date, :spot_csv) }
 
         it { expect(ExchangeRateCurrencyRate).to have_received(:for_month).with(sample_date.month, sample_date.year, 'spot') }
       end
@@ -43,7 +43,7 @@ RSpec.describe ExchangeRates::SpotExchangeRatesService do
 
         it { expect(update_service).not_to have_received(:call) }
 
-        it { expect(ExchangeRates::UploadMonthlyFileService).to have_received(:new).with(spot_rates, sample_date, :spot_csv) }
+        it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(spot_rates, sample_date, :spot_csv) }
 
         it { expect(ExchangeRateCurrencyRate).to have_received(:for_month).with(sample_date.month, sample_date.year, 'spot') }
       end

--- a/spec/services/exchange_rates/upload_file_service_spec.rb
+++ b/spec/services/exchange_rates/upload_file_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ExchangeRates::UploadMonthlyFileService do
+RSpec.describe ExchangeRates::UploadFileService do
   subject(:call) { described_class.new(rates, date, type).call }
 
   let(:rates) { create_list(:exchange_rate_currency_rate, 1, :with_usa) }

--- a/spec/workers/average_exchange_rates_worker_spec.rb
+++ b/spec/workers/average_exchange_rates_worker_spec.rb
@@ -1,16 +1,18 @@
 RSpec.describe AverageExchangeRatesWorker, type: :worker do
   subject(:perform) { described_class.new.perform }
 
+  let(:today) { Time.zone.today.iso8601 }
+
   describe '#perform' do
     before do
-      allow(ExchangeRates::AverageExchangeRatesService).to receive(:call).with(false).and_return(true)
+      allow(ExchangeRates::AverageExchangeRatesService).to receive(:call).with(force_run: false, selected_date: today).and_return(true)
       allow(SlackNotifierService).to receive(:call).and_call_original
 
       perform
     end
 
     it 'will behave as expected', :aggregate_failures do
-      expect(ExchangeRates::AverageExchangeRatesService).to have_received(:call).with(false)
+      expect(ExchangeRates::AverageExchangeRatesService).to have_received(:call).with(force_run: false, selected_date: today)
       expect(SlackNotifierService).to have_received(:call).with(match(/Average/))
     end
   end

--- a/spec/workers/average_exchange_rates_worker_spec.rb
+++ b/spec/workers/average_exchange_rates_worker_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe AverageExchangeRatesWorker, type: :worker do
+  subject(:perform) { described_class.new.perform }
+
+  describe '#perform' do
+    before do
+      allow(ExchangeRates::AverageExchangeRatesService).to receive(:call).with(false).and_return(true)
+      allow(SlackNotifierService).to receive(:call).and_call_original
+
+      perform
+    end
+
+    it 'will behave as expected', :aggregate_failures do
+      expect(ExchangeRates::AverageExchangeRatesService).to have_received(:call).with(false)
+      expect(SlackNotifierService).to have_received(:call).with(match(/Average/))
+    end
+  end
+end

--- a/spec/workers/average_exchange_rates_worker_spec.rb
+++ b/spec/workers/average_exchange_rates_worker_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe AverageExchangeRatesWorker, type: :worker do
 
   describe '#perform' do
     before do
-      allow(ExchangeRates::AverageExchangeRatesService).to receive(:call).with(force_run: false, selected_date: today).and_return(true)
+      allow(ExchangeRates::CreateAverageExchangeRatesService).to receive(:call).with(force_run: false, selected_date: today).and_return(true)
       allow(SlackNotifierService).to receive(:call).and_call_original
 
       perform
     end
 
     it 'will behave as expected', :aggregate_failures do
-      expect(ExchangeRates::AverageExchangeRatesService).to have_received(:call).with(force_run: false, selected_date: today)
+      expect(ExchangeRates::CreateAverageExchangeRatesService).to have_received(:call).with(force_run: false, selected_date: today)
       expect(SlackNotifierService).to have_received(:call).with(match(/Average/))
     end
   end


### PR DESCRIPTION
### Jira link

HOTT-3401

### What?

I have added/removed/altered:

- [ ] Created method for returning the live currency_codes for countries
- [ ] Created method for returning the live countries for last year
- [ ] Created method for returning by currency
- [ ] Method for returning monthly rates by currency last year
- [ ] Average rates service creating and instructing the file upload 
- [ ] Create CSV of the average rates 
- [ ] Orchestration of the file upload
- [ ] Changes file name of the monthly file service to just file service
- [ ] Ensured the monthly exchange rates service has a single method call
- [ ] Added extra factories for testing
- [ ] Orchestration for when the job is kicked off and worker with test


See screenshots taken on local env after running `ExchangeRates::AverageExchangeRatesService.call(force_run: true, selected_date: '2023-10-25')`
 
![Screenshot 2023-10-25 at 12 27 53](https://github.com/trade-tariff/trade-tariff-backend/assets/5055757/a8de74d3-c9bd-49c3-8fec-f48db523656e)


![Screenshot 2023-10-25 at 12 27 24](https://github.com/trade-tariff/trade-tariff-backend/assets/5055757/4561a588-97d2-4b44-b1f3-501cf1d27697)
