### PR TITLE
HOTT-4239: Fixes reading subheadings with search references

### DIFF
--- a/app/controllers/api/admin/commodities_controller.rb
+++ b/app/controllers/api/admin/commodities_controller.rb
@@ -23,10 +23,14 @@ module Api
       private
 
       def find_commodity
-        @commodity = Commodity.actual
-                              .by_productline_suffix(productline_suffix)
-                              .by_code(commodity_code)
-                              .take
+        @commodity = GoodsNomenclature
+          .actual
+          .with_leaf_column
+          .where(
+            goods_nomenclatures__goods_nomenclature_item_id: commodity_code,
+            goods_nomenclatures__producline_suffix: productline_suffix,
+          )
+          .take
 
         raise Sequel::RecordNotFound if @commodity.goods_nomenclature_item_id.in? HiddenGoodsNomenclature.codes
       end

--- a/spec/requests/api/admin/commodities_controller_spec.rb
+++ b/spec/requests/api/admin/commodities_controller_spec.rb
@@ -1,13 +1,45 @@
 RSpec.describe Api::Admin::CommoditiesController, type: :request do
   describe 'GET #show' do
     subject(:do_request) do
-      authenticated_get api_commodity_path(id: commodity.goods_nomenclature_item_id)
+      authenticated_get api_commodity_path(id: goods_nomenclature.to_admin_param)
       response
     end
 
-    let(:commodity) { create(:commodity) }
+    context 'when fetching a commodity' do
+      let(:goods_nomenclature) do
+        create(
+          :commodity,
+          goods_nomenclature_item_id: '0101010100',
+          producline_suffix: '80',
+        )
+      end
 
-    it_behaves_like 'a successful jsonapi response'
+      it_behaves_like 'a successful jsonapi response'
+
+      it 'returns the commodity' do
+        json_response = JSON.parse(do_request.body)
+
+        expect(json_response.dig('data', 'id')).to eq('0101010100')
+      end
+    end
+
+    context 'when fetching a subheading' do
+      let(:goods_nomenclature) do
+        create(
+          :subheading,
+          goods_nomenclature_item_id: '0101010100',
+          producline_suffix: '10',
+        )
+      end
+
+      it_behaves_like 'a successful jsonapi response'
+
+      it 'returns the subheading' do
+        json_response = JSON.parse(do_request.body)
+
+        expect(json_response.dig('data', 'id')).to eq('0101010100-10')
+      end
+    end
   end
 
   describe 'GET #index' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4239

### What?

I have added/removed/altered:

- [x] Altered commodities controller to surface subheadings
- [x] Added some coverage for these two scenarios to avoid regression

### Why?

I am doing this because:

- This was preventing us from subsequently fetching search references for the returned goods nomenclature
