### PR TITLE
HOTT-4238: Surface producline suffix values for chapters/headings

### DIFF
--- a/app/serializers/api/admin/chapters/chapter_list_serializer.rb
+++ b/app/serializers/api/admin/chapters/chapter_list_serializer.rb
@@ -8,7 +8,9 @@ module Api
 
         set_id :goods_nomenclature_sid
 
-        attributes :goods_nomenclature_sid, :goods_nomenclature_item_id
+        attributes :goods_nomenclature_sid,
+                   :goods_nomenclature_item_id,
+                   :producline_suffix
 
         attribute :chapter_note_id do |chapter|
           chapter.chapter_note.try(:id)

--- a/app/serializers/api/admin/chapters/chapter_serializer.rb
+++ b/app/serializers/api/admin/chapters/chapter_serializer.rb
@@ -8,7 +8,13 @@ module Api
 
         set_id :goods_nomenclature_sid
 
-        attributes :goods_nomenclature_sid, :goods_nomenclature_item_id, :headings_from, :headings_to, :description, :section_id
+        attributes :goods_nomenclature_sid,
+                   :goods_nomenclature_item_id,
+                   :producline_suffix,
+                   :headings_from,
+                   :headings_to,
+                   :description,
+                   :section_id
 
         attribute :chapter_note_id do |chapter|
           chapter.chapter_note.try(:id)
@@ -18,9 +24,7 @@ module Api
           chapter.section.id
         end
 
-        has_one :chapter_note, serializer: Api::Admin::Chapters::ChapterNoteSerializer, id_method_name: :id do |chapter|
-          chapter.chapter_note
-        end
+        has_one :chapter_note, serializer: Api::Admin::Chapters::ChapterNoteSerializer, id_method_name: :id, &:chapter_note
         has_many :headings, serializer: Api::Admin::Chapters::HeadingSerializer
         has_one :section, serializer: Api::Admin::Chapters::SectionSerializer
       end

--- a/app/serializers/api/admin/chapters/heading_serializer.rb
+++ b/app/serializers/api/admin/chapters/heading_serializer.rb
@@ -8,7 +8,10 @@ module Api
 
         set_id :goods_nomenclature_sid
 
-        attributes :goods_nomenclature_sid, :goods_nomenclature_item_id, :description
+        attributes :goods_nomenclature_sid,
+                   :goods_nomenclature_item_id,
+                   :description,
+                   :producline_suffix
 
         attribute :declarable, &:declarable?
 

--- a/app/serializers/api/admin/headings/chapter_serializer.rb
+++ b/app/serializers/api/admin/headings/chapter_serializer.rb
@@ -8,7 +8,7 @@ module Api
 
         set_id :goods_nomenclature_sid
 
-        attributes :goods_nomenclature_item_id, :description
+        attributes :goods_nomenclature_item_id, :producline_suffix, :description
       end
     end
   end

--- a/app/serializers/api/admin/headings/heading_serializer.rb
+++ b/app/serializers/api/admin/headings/heading_serializer.rb
@@ -9,6 +9,7 @@ module Api
         set_id :goods_nomenclature_sid
 
         attributes :goods_nomenclature_item_id,
+                   :producline_suffix,
                    :description,
                    :search_references_count
 

--- a/spec/serializers/api/admin/chapters/chapter_list_serializer_spec.rb
+++ b/spec/serializers/api/admin/chapters/chapter_list_serializer_spec.rb
@@ -1,25 +1,24 @@
-RSpec.describe Api::Admin::Chapters::HeadingSerializer do
+RSpec.describe Api::Admin::Chapters::ChapterListSerializer do
   subject(:serialized) { described_class.new(serializable).serializable_hash }
 
-  let(:serializable) { create(:heading, :with_chapter, :with_descendants) }
+  let(:serializable) { create(:chapter) }
+
   let(:expected) do
     {
       data: {
         id: serializable.goods_nomenclature_sid.to_s,
-        type: eq(:heading),
+        type: :chapter,
         attributes: {
           goods_nomenclature_sid: serializable.goods_nomenclature_sid,
           goods_nomenclature_item_id: serializable.goods_nomenclature_item_id,
           producline_suffix: serializable.producline_suffix,
-          description: serializable.description,
-          declarable: serializable.declarable?,
-          search_references_count: 0,
+          chapter_note_id: nil,
         },
       },
     }
   end
 
   describe '#serializable_hash' do
-    it { expect(serialized).to include_json(expected) }
+    it { expect(serialized).to eq(expected) }
   end
 end

--- a/spec/serializers/api/admin/chapters/chapter_serializer_spec.rb
+++ b/spec/serializers/api/admin/chapters/chapter_serializer_spec.rb
@@ -1,19 +1,27 @@
-RSpec.describe Api::Admin::Chapters::HeadingSerializer do
+RSpec.describe Api::Admin::Chapters::ChapterSerializer do
   subject(:serialized) { described_class.new(serializable).serializable_hash }
 
-  let(:serializable) { create(:heading, :with_chapter, :with_descendants) }
+  let(:serializable) { create(:chapter, :with_heading, :with_section) }
+
   let(:expected) do
     {
       data: {
         id: serializable.goods_nomenclature_sid.to_s,
-        type: eq(:heading),
+        type: eq(:chapter),
         attributes: {
           goods_nomenclature_sid: serializable.goods_nomenclature_sid,
           goods_nomenclature_item_id: serializable.goods_nomenclature_item_id,
           producline_suffix: serializable.producline_suffix,
+          headings_to: serializable.headings_to,
+          headings_from: serializable.headings_from,
+          chapter_note_id: nil,
           description: serializable.description,
-          declarable: serializable.declarable?,
-          search_references_count: 0,
+          section_id: serializable.section_id,
+        },
+        relationships: {
+          section: be_a(Hash),
+          headings: be_a(Hash),
+          chapter_note: be_a(Hash),
         },
       },
     }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4238

### What?

I have added/removed/altered:

- [x] Added producline suffix attribute to heading and chapter serializers
- [x] Added coverage for serializers

### Why?

I am doing this because:

- This is required for the admin UI to be consistent in its handling of these types of goods nomenclature
