### PR TITLE
BAU: Fix docker-compose file on SE Linux systems

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,8 @@ services:
       test: curl -s http://localhost:9200/_cluster/health | grep -vq '"status":"red"'
     volumes:
       - hmrc-os:/usr/share/opensearch/data
-      - ./config/opensearch/synonyms_all.txt:/usr/share/opensearch/config/synonyms_all.txt
-      - ./config/opensearch/stemming_exclusions_all.txt:/usr/share/opensearch/config/stemming_exclusions_all.txt
+      - ./config/opensearch/synonyms_all.txt:/usr/share/opensearch/config/synonyms_all.txt:z
+      - ./config/opensearch/stemming_exclusions_all.txt:/usr/share/opensearch/config/stemming_exclusions_all.txt:z
 
 volumes:
   dev-env-redis-volume:


### PR DESCRIPTION
### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [x] Enable relabelling for direct file references in docker-compose file

### Why?

I am doing this because:

- current config is incompatible with systems using Security Enhanced Linux, ie RedHat/Fedora/Oracle

### Deployment risks (optional)

- Low, just changes the development docker-compose flie
