### PR TITLE
HOTT-4302 Updated bin/setup and README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ data/failed-measures-report*
 
 # Environment files
 .env
-.env.*.local
+.env*.local
 
 # Cloud Foundry manifest files
 *_manifest.yml

--- a/bin/setup
+++ b/bin/setup
@@ -5,7 +5,7 @@ require "fileutils"
 APP_ROOT = File.expand_path("..", __dir__)
 
 def system!(*args)
-  system(*args) || abort("\n== Command #{args} failed ==")
+  system(*args, exception: true)
 end
 
 FileUtils.chdir APP_ROOT do
@@ -13,13 +13,40 @@ FileUtils.chdir APP_ROOT do
   # This script is idempotent, so that you can run it at any time and get an expectable outcome.
   # Add necessary setup steps to this file.
 
+  if ARGV[0] && !File.exist?(ARGV[0])
+    puts "Error: Cannot read #{ARGV[0]}!"
+    exit
+  end
+
   puts "== Installing dependencies =="
   system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
 
+  puts "\n== Creating database =="
+  system! "bin/rake db:create"
+
+  if ARGV[0]
+    puts "\n== Importing database dump =="
+    system! "psql tariff_development < #{ARGV[0]}"
+  else
+    puts "\n== Loading database structure =="
+    system! "bin/rake db:structure:load"
+
+    puts "\n== Loading seed data =="
+    system! "bin/rake db:seed"
+  end
+
+  puts "\n== Preparing test database =="
+  system! "bin/rake db:test:prepare"
+
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 
-  puts "\n== Restarting application server =="
-  system! "bin/rails restart"
+  puts "\n== Scheduling reindexing =="
+  system! "bin/rails tariff:reindex"
+
+  if ARGV[0]
+    puts "\n== Running reindex jobs =="
+    system! "bundle exec sidekiq"
+  end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - dev-env-redis-volume:/data
   hmrc-postgres:
     container_name: postgres
-    image: postgres:13.10
+    image: postgres:13
     environment:
       - PGDATA=/var/lib/postgresql/data/pgdata
       - POSTGRES_USER=${USER}
@@ -29,7 +29,7 @@ services:
     environment:
       - bootstrap.memory_lock=true
       - discovery.type=single-node
-      - "OPENSEARCH_JAVA_OPTS=-Xms2g -Xmx2g"
+      - "OPENSEARCH_JAVA_OPTS=-Xms500m -Xmx500m"
       - cluster.routing.allocation.disk.threshold_enabled=false
       - plugins.security.disabled=true
     ulimits:


### PR DESCRIPTION
### Jira link

HOTT-4302

### What?

I have added/removed/altered:

- [x] Updated `bin/setup` to configure a developers installation of the tariff backend app
- [x] Simplified the README.md to reflect the bin/setup changes and remove unneeded or incorrect information
- [x] Added information for running an XI service
- [x] Tweaked docker-compose to run latest Postgres
- [x] Tweaked docker-compose to restrict OpenSearch's memory usage since a default docker-for-mac installation only allocates 2G to the VM and a 4G mem allocation is excessive for the search indexes

### Why?

I am doing this because:

- Developer onboarding is too complicated and wastes valuable developer time

### Deployment risks (optional)

- Low, development focused changes
