### PR TITLE
HOTT-4323: Fixes candidate supplementary units

### DIFF
--- a/app/lib/reporting/differences/candidate_supplementary_unit.rb
+++ b/app/lib/reporting/differences/candidate_supplementary_unit.rb
@@ -76,36 +76,54 @@ module Reporting
       attr_reader :report
 
       def each_row
+        each_declarable do |declarable|
+          units = candidate_units_for(declarable)
+          unit_codes = units.map do |unit|
+            "#{unit[:measurement_unit_code]}#{unit[:measurement_unit_qualifier_code]}"
+          end
+
+          next unless units.any?
+
+          yield [
+            declarable.goods_nomenclature_item_id,
+            unit_codes.uniq.sort.join(', '),
+          ]
+        end
+      end
+
+      # There are three rules for when a unit that is associated with a measure
+      # (and therefore a commodity) could potentially be a supplementary unit that
+      # should be declared:
+      #
+      # 1. The commodity has no supplementary units associated with it and there are units
+      #    associated with the commodities measures.
+      # 2. The commodity has supplementary units associated with it and there are units
+      #    of a different class/or type.
+      # 3. We have specific heuristics/business rules that tell us that a unit should be ignored
+      def candidate_units_for(declarable)
+        supplementary_unit_measures = declarable.applicable_measures.select(&:supplementary?)
+        relevant_measures = declarable.applicable_measures - supplementary_unit_measures
+        units = relevant_measures.flat_map(&:units)
+
+        if supplementary_unit_measures.any?
+          supplementary_unit_types = supplementary_unit_types_for(supplementary_unit_measures)
+
+          units.reject do |unit|
+            type = MeasurementUnit.type_for(
+              "#{unit[:measurement_unit_code]}#{unit[:measurement_unit_qualifier_code]}",
+            )
+
+            supplementary_unit_types.include?(type) || ignore_unit?(unit)
+          end
+        else
+          units.reject(&method(:ignore_unit?))
+        end
+      end
+
+      def each_declarable
         each_chapter(eager: Differences::GOODS_NOMENCLATURE_MEASURE_WITH_UNIT_EAGER) do |eager_chapter|
           eager_chapter.descendants.each do |chapter_descendant|
-            next unless chapter_descendant.declarable?
-
-            supplementary_unit_measures = chapter_descendant.applicable_measures.select(&:supplementary?)
-            relevant_measures = chapter_descendant.applicable_measures - supplementary_unit_measures
-            units = relevant_measures.flat_map(&:units)
-
-            units = if supplementary_unit_measures.any?
-                      supplementary_unit_types = supplementary_unit_types_for(supplementary_unit_measures)
-
-                      units.reject do |unit|
-                        type = MeasurementUnit.type_for(
-                          "#{unit[:measurement_unit_code]}#{unit[:measurement_unit_qualifier_code]}",
-                        )
-
-                        supplementary_unit_types.include?(type) || ignore_unit?(unit)
-                      end
-                    else
-                      units.reject(&method(:ignore_unit?))
-                    end
-
-            units = units.map { |unit| "#{unit[:measurement_unit_code]}#{unit[:measurement_unit_qualifier_code]}" }
-
-            next if units.blank?
-
-            yield [
-              chapter_descendant.goods_nomenclature_item_id,
-              units.uniq.join(', '),
-            ]
+            yield chapter_descendant if chapter_descendant.declarable?
           end
         end
       end

--- a/app/models/measurement_unit.rb
+++ b/app/models/measurement_unit.rb
@@ -28,6 +28,20 @@ class MeasurementUnit < Sequel::Model
       end
     end
 
+    def type_for(unit_code)
+      measurement_units.dig(unit_code, 'measurement_unit_type')
+    end
+
+    def coerced_unit_for(unit_code)
+      coerced_units.fetch(unit_code, unit_code)
+    end
+
+    def coerced_units
+      @coerced_units ||= measurement_units.each_with_object({}) do |(k, v), acc|
+        acc[k] = v['coerced_measurement_unit_code'] if v['coerced_measurement_unit_code'].present?
+      end
+    end
+
     def weight_units
       @weight_units ||= begin
         units = measurement_units.select { |_k, v| v['measurement_unit_type'] == 'weight' }.keys

--- a/db/measurement_units.json
+++ b/db/measurement_units.json
@@ -98,9 +98,9 @@
     "unit_question": "What is the weight of dihydrostreptomycin in the goods you will be importing?",
     "unit_hint": "Enter the value in kilograms",
     "unit": "kilograms",
-    "multiplier": "0.01",
-    "coerced_measurement_unit_code": "KGM",
-    "original_unit": "x 100 kg",
+    "multiplier": null,
+    "coerced_measurement_unit_code": null,
+    "original_unit": null,
     "measurement_unit_type": "weight"
   },
   "DTN": {
@@ -297,7 +297,7 @@
     "multiplier": null,
     "coerced_measurement_unit_code": null,
     "original_unit": null,
-    "measurement_unit_type": "number"
+    "measurement_unit_type": "length"
   },
   "KCC": {
     "measurement_unit_code": "KCC",
@@ -453,7 +453,7 @@
     "multiplier": null,
     "coerced_measurement_unit_code": null,
     "original_unit": null,
-    "measurement_unit_type": "number"
+    "measurement_unit_type": "length"
   },
   "KNI": {
     "measurement_unit_code": "KNI",
@@ -622,7 +622,7 @@
     "multiplier": "0.001",
     "coerced_measurement_unit_code": null,
     "original_unit": "x 1,000 pairs",
-    "measurement_unit_type": "number"
+    "measurement_unit_type": "pairs"
   },
   "MTK": {
     "measurement_unit_code": "MTK",
@@ -674,7 +674,7 @@
     "multiplier": null,
     "coerced_measurement_unit_code": null,
     "original_unit": null,
-    "measurement_unit_type": "number"
+    "measurement_unit_type": "length"
   },
   "MWH": {
     "measurement_unit_code": "MWH",
@@ -739,7 +739,7 @@
     "multiplier": null,
     "coerced_measurement_unit_code": null,
     "original_unit": null,
-    "measurement_unit_type": "number"
+    "measurement_unit_type": "pairs"
   },
   "RET": {
     "measurement_unit_code": "RET",
@@ -837,9 +837,9 @@
     "unit_question": "What is the weight of the goods you will be importing?",
     "unit_hint": "Enter the value in tonnes (1,000 kg)",
     "unit": "tonnes",
-    "multiplier": null,
-    "coerced_measurement_unit_code": null,
-    "original_unit": null,
+    "multiplier": "0.001",
+    "coerced_measurement_unit_code": "KGM",
+    "original_unit": "x 1,000 kg",
     "measurement_unit_type": "weight"
   },
   "TNEE": {
@@ -850,9 +850,9 @@
     "unit_question": "What is the net drained weight of the goods you will be importing?",
     "unit_hint": "Enter the value in tonnes (1,000 kg)",
     "unit": "tonnes",
-    "multiplier": null,
-    "coerced_measurement_unit_code": null,
-    "original_unit": null,
+    "multiplier": "0.001",
+    "coerced_measurement_unit_code": "KGM",
+    "original_unit": "x 1,000 kg",
     "measurement_unit_type": "weight"
   },
   "TNEI": {
@@ -863,9 +863,9 @@
     "unit_question": "What is the weight of biodiesel in the goods you will be importing?",
     "unit_hint": "Enter the value in tonnes (1,000 kg)",
     "unit": "tonnes",
-    "multiplier": null,
-    "coerced_measurement_unit_code": null,
-    "original_unit": null,
+    "multiplier": "0.001",
+    "coerced_measurement_unit_code": "KGM",
+    "original_unit": "x 1,000 kg",
     "measurement_unit_type": "weight"
   },
   "TNEJ": {
@@ -876,9 +876,9 @@
     "unit_question": "What is the weight of the fuel content in the goods you will be importing?",
     "unit_hint": "Enter the value in tonnes (1,000 kg)",
     "unit": "tonnes",
-    "multiplier": null,
-    "coerced_measurement_unit_code": null,
-    "original_unit": null,
+    "multiplier": "0.001",
+    "coerced_measurement_unit_code": "KGM",
+    "original_unit": "x 1,000 kg",
     "measurement_unit_type": "weight"
   },
   "TNEK": {
@@ -889,9 +889,9 @@
     "unit_question": "What is the weight of bioethanol in the goods you will be importing?",
     "unit_hint": "Enter the value in tonnes (1,000 kg)",
     "unit": "tonnes",
-    "multiplier": null,
-    "coerced_measurement_unit_code": null,
-    "original_unit": null,
+    "multiplier": "0.001",
+    "coerced_measurement_unit_code": "KGM",
+    "original_unit": "x 1,000 kg",
     "measurement_unit_type": "weight"
   },
   "TNEM": {
@@ -902,9 +902,9 @@
     "unit_question": "What is the weight net of dry matter of the goods you will be importing ?",
     "unit_hint": "Enter the value in tonnes (1,000 kg)",
     "unit": "tonnes",
-    "multiplier": null,
-    "coerced_measurement_unit_code": null,
-    "original_unit": null,
+    "multiplier": "0.001",
+    "coerced_measurement_unit_code": "KGM",
+    "original_unit": "x 1,000 kg",
     "measurement_unit_type": "weight"
   },
   "TNER": {
@@ -915,9 +915,9 @@
     "unit_question": "What is the weight net of the standard quality of the goods you will be importing?",
     "unit_hint": "Enter the value in tonnes (1,000 kg)",
     "unit": "tonnes",
-    "multiplier": null,
-    "coerced_measurement_unit_code": null,
-    "original_unit": null,
+    "multiplier": "0.001",
+    "coerced_measurement_unit_code": "KGM",
+    "original_unit": "x 1,000 kg",
     "measurement_unit_type": "weight"
   },
   "TNEZ": {
@@ -928,9 +928,9 @@
     "unit_question": "What is the weight per 1% by weight of sucrose in the goods you will be importing?",
     "unit_hint": "Enter the value in tonnes (1,000 kg)",
     "unit": "tonnes",
-    "multiplier": null,
-    "coerced_measurement_unit_code": null,
-    "original_unit": null,
+    "multiplier": "0.001",
+    "coerced_measurement_unit_code": "KGM",
+    "original_unit": "x 1,000 kg",
     "measurement_unit_type": "weight"
   },
   "WAT": {

--- a/spec/models/measurement_unit_spec.rb
+++ b/spec/models/measurement_unit_spec.rb
@@ -118,6 +118,47 @@ RSpec.describe MeasurementUnit do
     end
   end
 
+  describe '.type_for' do
+    subject { described_class.type_for('LTR') }
+
+    it { is_expected.to eq('volume') }
+  end
+
+  describe '.coerced_unit_for' do
+    subject { described_class.coerced_unit_for('DTN') }
+
+    it { is_expected.to eq('KGM') }
+  end
+
+  describe '.coerced_units' do
+    subject { described_class.coerced_units }
+
+    let(:expected_units) do
+      {
+        'DTN' => 'KGM',
+        'DTNE' => 'KGM',
+        'DTNF' => 'KGM',
+        'DTNG' => 'KGM',
+        'DTNL' => 'KGM',
+        'DTNM' => 'KGM',
+        'DTNR' => 'KGM',
+        'DTNS' => 'KGM',
+        'HLT' => 'LTR',
+        'KLT' => 'LTR',
+        'TNE' => 'KGM',
+        'TNEE' => 'KGM',
+        'TNEI' => 'KGM',
+        'TNEJ' => 'KGM',
+        'TNEK' => 'KGM',
+        'TNEM' => 'KGM',
+        'TNER' => 'KGM',
+        'TNEZ' => 'KGM',
+      }
+    end
+
+    it { is_expected.to eq(expected_units) }
+  end
+
   describe '.weight_units' do
     subject { described_class.weight_units.to_a }
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4323

### What?

I have added/removed/altered:

- [x] Fixes a bunch of measurement units in the json file
- [x] Adds support for working out which units are coerced
- [x] Adds support for working out the type of a given full unit code
- [x] Fix logic in supplementary unit candidate worksheet

### Why?

I am doing this because:

- This is required to unblock the delivery of the differences report
