### PR TITLE
BAU: Adds 8080 to signon links

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -51,7 +51,7 @@ locals {
     },
     {
       name  = "PLEK_SERVICE_SIGNON_URI"
-      value = "http://signon.tariff.internal"
+      value = "http://signon.tariff.internal:8080"
     },
     {
       name  = "RACK_TIMEOUT_SERVICE"


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added missing 8080 on signon internal url

### Why?

I am doing this because:

- This is what the container exposes
