### PR TITLE
HOTT-2796: Enable reporting in the new world

### DIFF
--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -225,10 +225,6 @@ module TradeTariffBackend
       ENV.fetch('BETA_SEARCH_GUIDES_ENABLED', 'false') == 'true'
     end
 
-    def reporting_enabled?
-      ENV.fetch('REPORTING_ENABLED', 'false') == 'true'
-    end
-
     def opensearch_client
       @opensearch_client ||= OpenSearch::Client.new(opensearch_configuration)
     end

--- a/app/workers/report_worker.rb
+++ b/app/workers/report_worker.rb
@@ -4,16 +4,14 @@ class ReportWorker
   sidekiq_options retry: false
 
   def perform
-    if TradeTariffBackend.reporting_enabled?
-      Reporting::Commodities.generate
-      Reporting::Basic.generate
-      Reporting::SupplementaryUnits.generate
-      Reporting::DeclarableDuties.generate
-      Reporting::Prohibitions.generate
-      Reporting::GeographicalAreaGroups.generate
+    Reporting::Commodities.generate
+    Reporting::Basic.generate
+    Reporting::SupplementaryUnits.generate
+    Reporting::DeclarableDuties.generate
+    Reporting::Prohibitions.generate
+    Reporting::GeographicalAreaGroups.generate
 
-      mail_differences if mail_differences?
-    end
+    mail_differences if mail_differences?
   end
 
   private

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -34,14 +34,15 @@ Terraform to deploy the service into AWS.
 | [aws_iam_policy.task_role_kms_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.s3_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.spelling_corrector_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.task_role_kms_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_kms_key.opensearch_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
-| [aws_kms_key.persistence_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
+| [aws_kms_key.s3_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_kms_key.secretsmanager_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
 | [aws_s3_bucket.persistence](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
+| [aws_s3_bucket.reporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 | [aws_s3_bucket.spelling_corrector](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 | [aws_secretsmanager_secret.database_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.differences_to_emails](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -40,7 +40,7 @@ data "aws_kms_key" "opensearch_key" {
   key_id = "alias/opensearch-key"
 }
 
-data "aws_kms_key" "persistence_key" {
+data "aws_kms_key" "s3_key" {
   key_id = "alias/s3-key"
 }
 
@@ -106,4 +106,8 @@ data "aws_s3_bucket" "spelling_corrector" {
 
 data "aws_s3_bucket" "persistence" {
   bucket = "trade-tariff-persistence-${local.account_id}"
+}
+
+data "aws_s3_bucket" "reporting" {
+  bucket = "trade-tariff-reporting-${local.account_id}"
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -91,7 +91,7 @@ data "aws_iam_policy_document" "task_role_kms_keys" {
     ]
     resources = [
       data.aws_kms_key.opensearch_key.arn,
-      data.aws_kms_key.persistence_key.arn,
+      data.aws_kms_key.s3_key.arn,
     ]
   }
 }
@@ -122,13 +122,14 @@ resource "aws_iam_policy" "exec" {
   policy = data.aws_iam_policy_document.exec.json
 }
 
-data "aws_iam_policy_document" "spelling_corrector_bucket" {
+data "aws_iam_policy_document" "s3_policy" {
   statement {
     effect  = "Allow"
     actions = ["s3:ListBucket"]
     resources = [
       data.aws_s3_bucket.spelling_corrector.arn,
-      data.aws_s3_bucket.persistence.arn
+      data.aws_s3_bucket.persistence.arn,
+      data.aws_s3_bucket.reporting.arn
     ]
   }
 
@@ -140,12 +141,13 @@ data "aws_iam_policy_document" "spelling_corrector_bucket" {
     ]
     resources = [
       "${data.aws_s3_bucket.spelling_corrector.arn}/*",
-      "${data.aws_s3_bucket.persistence.arn}/*"
+      "${data.aws_s3_bucket.persistence.arn}/*",
+      "${data.aws_s3_bucket.reporting.arn}/*"
     ]
   }
 }
 
 resource "aws_iam_policy" "s3" {
   name   = "backend-task-role-s3-policy"
-  policy = data.aws_iam_policy_document.spelling_corrector_bucket.json
+  policy = data.aws_iam_policy_document.s3_policy.json
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -82,6 +82,10 @@ locals {
       value = data.aws_s3_bucket.spelling_corrector.bucket
     },
     {
+      name  = "TARIFF_SUPPORT_EMAIL"
+      value = "hmrc-trade-tariff-support-g@digital.hmrc.gov.uk"
+    },
+    {
       name  = "STEMMING_EXCLUSION_REFERENCE_ANALYZER"
       value = var.stemming_exclusion_reference_analyzer
     },
@@ -109,8 +113,12 @@ locals {
 
   backend_common_worker_vars = [
     {
+      name  = "AWS_REPORTING_BUCKET_NAME"
+      value = "trade-tariff-reporting-${local.account_id}"
+    },
+    {
       name  = "REPORTING_CDN_HOST"
-      value = "https://reporting.trade-tariff.service.gov.uk"
+      value = "https://reporting.${var.base_domain}/"
     },
     {
       name  = "SLACK_CHANNEL"


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2796

### What?

I have added/removed/altered:

- [x] Removes the env var used to toggle whether reporting is enabled
- [x] Adds the configuration required so that we can enable reporting in all environments

### Why?

I am doing this because:

- This is required to avoid special casing features only in production - we can run reports in development or staging and verify they integrate cleanly now
