### PR TITLE
Add ability for only failures with rspec running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ vendor/*
 !/log/.keep
 /tmp/*
 .byebug_history
+/spec/support/examples.txt
 
 # Local tariff files
 data/*/*

--- a/.rspec
+++ b/.rspec
@@ -2,3 +2,4 @@
 --require rails_helper
 --tag ~roo_data
 --tag ~flaky
+--format documentation

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ RSpec.configure do |config|
   config.expose_dsl_globally = false
 
   config.order = :random
+  config.example_status_persistence_file_path = 'spec/support/examples.txt'
 
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce


### PR DESCRIPTION
This PR will allow devs to use the flag `--only-failures` when running rspec and give more detailed output of the test suite
