### PR TITLE
HOTT-4377: Fix bug for the endpoint /api/v2/exchange_rates/files/monthly_xml_2023-<??>.xml

### DIFF
--- a/app/models/exchange_rate_file.rb
+++ b/app/models/exchange_rate_file.rb
@@ -51,7 +51,8 @@ class ExchangeRateFile < Sequel::Model
     end
 
     def filename_for_download(type, format, year, month)
-      month_with_zero = sprintf('%02i', month)
+      # `to_i` is vital, since a number starting with 0 is interpreted as octal.
+      month_with_zero = sprintf('%02i', month.to_i(10))
 
       case type
       when 'monthly_csv_hmrc'

--- a/spec/models/exchange_rate_file_spec.rb
+++ b/spec/models/exchange_rate_file_spec.rb
@@ -49,6 +49,17 @@ RSpec.describe ExchangeRateFile, type: :model do
     end
   end
 
+  describe '.filename_for_download' do
+    let(:type) { 'monthly_csv_hmrc' }
+    let(:format) { 'csv' }
+    let(:year) { '2023' }
+    let(:month) { '09' }
+
+    it 'returns the correct filename' do
+      expect(described_class.filename_for_download(type, format, year, month)).to eq('202309MonthlyRates.csv')
+    end
+  end
+
   describe '.applicable_files_for' do
     before do
       expected_files


### PR DESCRIPTION
### What?
Fix bug for the endpoint:
/api/v2/exchange_rates/files/monthly_xml_2023-<??>.xml 

endpoint, which happens only for the months "08" and "09". The reason for the bug is that 08 and 09 are interpreted as not valid octal numbers.

### Jira link
https://transformuk.atlassian.net/browse/HOTT-4350

### Why?
It is a bug, 
To reproduce it:

This works:
https://www.trade-tariff.service.gov.uk/api/v2/exchange_rates/files/monthly_xml_2023-08.xml

These do not work:
https://www.trade-tariff.service.gov.uk/api/v2/exchange_rates/files/monthly_xml_2023-08.xml
https://www.trade-tariff.service.gov.uk/api/v2/exchange_rates/files/monthly_xml_2023-09.xml

But they should work!
