### PR TITLE
HOTT-4350: Green Lanes: Create Stub API end point

### DIFF
--- a/app/controllers/api/v2/green_lanes/subheadings_controller.rb
+++ b/app/controllers/api/v2/green_lanes/subheadings_controller.rb
@@ -2,13 +2,11 @@ module Api
   module V2
     module GreenLanes
       class SubheadingsController < ApiController
-
         def show
           subheading = Subheading.actual.where(goods_nomenclature_item_id: "#{params[:id]}0000", producline_suffix: '80').take
           serializer = Api::V2::GreenLanes::SubheadingSerializer.new(subheading)
           render json: serializer.serializable_hash
         end
-
       end
     end
   end

--- a/app/controllers/api/v2/green_lanes/subheadings_controller.rb
+++ b/app/controllers/api/v2/green_lanes/subheadings_controller.rb
@@ -4,7 +4,9 @@ module Api
       class SubheadingsController < ApiController
 
         def show
-          render json: {data: 'Rasika'}
+          subheading = Subheading.actual.where(goods_nomenclature_item_id: "#{params[:id]}0000", producline_suffix: '80').take
+          serializer = Api::V2::GreenLanes::SubheadingSerializer.new(subheading)
+          render json: serializer.serializable_hash
         end
 
       end

--- a/app/controllers/api/v2/green_lanes/subheadings_controller.rb
+++ b/app/controllers/api/v2/green_lanes/subheadings_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V2
+    module GreenLanes
+      class SubheadingsController < ApiController
+
+        def show
+          render json: {data: 'Rasika'}
+        end
+
+      end
+    end
+  end
+end

--- a/app/serializers/api/v2/green_lanes/subheading_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/subheading_serializer.rb
@@ -1,0 +1,22 @@
+module Api
+  module V2
+    module GreenLanes
+      class SubheadingSerializer
+        include JSONAPI::Serializer
+
+        set_type :subheading
+
+        set_id :goods_nomenclature_sid
+
+        attributes :goods_nomenclature_sid,
+                   :goods_nomenclature_item_id,
+                   :description,
+                   :formatted_description,
+                   :validity_start_date,
+                   :validity_end_date,
+                   :description_plain,
+                   :producline_suffix
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -217,6 +217,10 @@ Rails.application.routes.draw do
       get 'goods_nomenclatures/section/:position', to: 'goods_nomenclatures#show_by_section', constraints: { position: /\d+/ }
       get 'goods_nomenclatures/chapter/:chapter_id', to: 'goods_nomenclatures#show_by_chapter', constraints: { chapter_id: /\d{2}/ }
       get 'goods_nomenclatures/heading/:heading_id', to: 'goods_nomenclatures#show_by_heading', constraints: { heading_id: /\d{4}/ }
+
+      namespace :green_lanes do
+        resources :subheadings, only: %i[show]
+      end
     end
 
     scope module: :v1, constraints: ApiConstraints.new(version: 1) do

--- a/spec/requests/api/v2/green_lanes/subheadings_controller_spec.rb
+++ b/spec/requests/api/v2/green_lanes/subheadings_controller_spec.rb
@@ -4,11 +4,15 @@ RSpec.describe Api::V2::GreenLanes::SubheadingsController do
   describe 'GET #show' do
     subject(:rendered) { make_request && response }
 
+    before do
+      create :subheading, goods_nomenclature_item_id: '1234560000' 
+    end
+
     let :make_request do
-      get api_green_lanes_subheading_path(1, format: :json),
+      get api_green_lanes_subheading_path(123456, format: :json),
           headers: { 'Accept' => 'application/vnd.uktt.v2' }
     end
 
-    it_behaves_like 'a successful jsonapi response'
+    it_behaves_like 'a successful jsonapi response',1
   end
 end

--- a/spec/requests/api/v2/green_lanes/subheadings_controller_spec.rb
+++ b/spec/requests/api/v2/green_lanes/subheadings_controller_spec.rb
@@ -4,15 +4,21 @@ RSpec.describe Api::V2::GreenLanes::SubheadingsController do
   describe 'GET #show' do
     subject(:rendered) { make_request && response }
 
-    before do
-      create :subheading, goods_nomenclature_item_id: '1234560000', producline_suffix: '80'
-    end
-
     let :make_request do
       get api_green_lanes_subheading_path(123_456, format: :json),
           headers: { 'Accept' => 'application/vnd.uktt.v2' }
     end
 
-    it_behaves_like 'a successful jsonapi response', 3
+    context 'when the good nomenclature id is found' do
+      before do
+        create :subheading, goods_nomenclature_item_id: '1234560000', producline_suffix: '80'
+      end
+
+      it_behaves_like 'a successful jsonapi response', 3
+    end
+
+    context 'when the good nomenclature id is not found' do
+      it { is_expected.to have_http_status(:not_found) }
+    end
   end
 end

--- a/spec/requests/api/v2/green_lanes/subheadings_controller_spec.rb
+++ b/spec/requests/api/v2/green_lanes/subheadings_controller_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe Api::V2::GreenLanes::SubheadingsController do
     subject(:rendered) { make_request && response }
 
     before do
-      create :subheading, goods_nomenclature_item_id: '1234560000' 
+      create :subheading, goods_nomenclature_item_id: '1234560000', producline_suffix: '80'
     end
 
     let :make_request do
-      get api_green_lanes_subheading_path(123456, format: :json),
+      get api_green_lanes_subheading_path(123_456, format: :json),
           headers: { 'Accept' => 'application/vnd.uktt.v2' }
     end
 
-    it_behaves_like 'a successful jsonapi response',1
+    it_behaves_like 'a successful jsonapi response', 3
   end
 end

--- a/spec/requests/api/v2/green_lanes/subheadings_controller_spec.rb
+++ b/spec/requests/api/v2/green_lanes/subheadings_controller_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Api::V2::GreenLanes::SubheadingsController do
+  describe 'GET #show' do
+    subject(:rendered) { make_request && response }
+
+    let :make_request do
+      get api_green_lanes_subheading_path(1, format: :json),
+          headers: { 'Accept' => 'application/vnd.uktt.v2' }
+    end
+
+    it_behaves_like 'a successful jsonapi response'
+  end
+end

--- a/spec/serializers/api/v2/green_lanes/subheading_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/subheading_serializer_spec.rb
@@ -10,7 +10,13 @@ RSpec.describe Api::V2::GreenLanes::SubheadingSerializer do
     context 'attributes' do
       subject {serialized[:attributes]}
 
-      it { is_expected.to include goods_nomenclature_item_id: subheading.goods_nomenclature_item_id.to_s  }
+      it { is_expected.to include goods_nomenclature_item_id: subheading.goods_nomenclature_item_id.to_s }
+      it { is_expected.to include description: subheading.description }
+      it { is_expected.to include formatted_description: subheading.formatted_description }
+      it { is_expected.to include validity_start_date: subheading.validity_start_date }
+      it { is_expected.to include validity_end_date: subheading.validity_end_date }
+      it { is_expected.to include description_plain: subheading.description_plain }
+      it { is_expected.to include producline_suffix: subheading.producline_suffix }
     end
   end
 end

--- a/spec/serializers/api/v2/green_lanes/subheading_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/subheading_serializer_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe Api::V2::GreenLanes::SubheadingSerializer do
+  subject(:serialized) { described_class.new(subheading).serializable_hash[:data] }
+
+  let(:subheading) { build :subheading }
+
+  describe '#serializable_hash' do
+    it { is_expected.to include type: :subheading  }
+    it { is_expected.to include id: subheading.goods_nomenclature_sid.to_s  }
+
+    context 'attributes' do
+      subject {serialized[:attributes]}
+
+      it { is_expected.to include goods_nomenclature_item_id: subheading.goods_nomenclature_item_id.to_s  }
+    end
+  end
+end

--- a/spec/serializers/api/v2/green_lanes/subheading_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/subheading_serializer_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe Api::V2::GreenLanes::SubheadingSerializer do
   let(:subheading) { build :subheading }
 
   describe '#serializable_hash' do
-    it { is_expected.to include type: :subheading  }
-    it { is_expected.to include id: subheading.goods_nomenclature_sid.to_s  }
+    it { is_expected.to include type: :subheading }
+    it { is_expected.to include id: subheading.goods_nomenclature_sid.to_s }
 
-    context 'attributes' do
-      subject {serialized[:attributes]}
+    context 'with attributes' do
+      subject { serialized[:attributes] }
 
       it { is_expected.to include goods_nomenclature_item_id: subheading.goods_nomenclature_item_id.to_s }
       it { is_expected.to include description: subheading.description }


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-4350

### What?
Added Green Lanes Subheading Stub API end point

I have added/removed/altered:

- [x] Created API Stub Endpoint and relevant tests
- [x] Added Serializer and routes

### Why?

I am doing this because:

- To start green lanes work
- I should be able to query an end point which will eventually provide 6 digit permutations information but is currently just a stub

