### PR TITLE
HOTT-4410: Fixes national filter after rubocop failure

### DIFF
--- a/app/lib/sequel/plugins/national.rb
+++ b/app/lib/sequel/plugins/national.rb
@@ -3,7 +3,11 @@ module Sequel
     module National
       module DatasetMethods
         def national
-          where(Sequel.qualify(model.table_name, model.primary_key).negative?).order(Sequel.qualify(model.table_name, model.primary_key).desc)
+          pk = Sequel.qualify(model.table_name, model.primary_key)
+
+          # rubocop:disable Style/NumericPredicate
+          where { pk < 0 }.order(pk.desc)
+          # rubocop:enable Style/NumericPredicate
         end
       end
 

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -1479,4 +1479,16 @@ RSpec.describe Measure do
       it { expect(dataset.pluck(:footnote_type_id)).to eq %w[Y N] }
     end
   end
+
+  describe '.national' do
+    let(:national_measure) { create(:measure, :national) }
+    let(:non_national_measure) { create(:measure) }
+
+    before do
+      national_measure
+      non_national_measure
+    end
+
+    it { expect(described_class.national.all).to eq([national_measure]) }
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4410

### What?

I have added/removed/altered:

- [x] Fixes national filter after rubocop fixes

### Why?

I am doing this because:

- Rubocop isn't sequel aware with predicate method checks and this is breaking taric data loads
