### PR TITLE
BAU: Fixes no-reply address

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,6 +1,6 @@
 locals {
   account_id     = data.aws_caller_identity.current.account_id
-  no_reply       = "no-reply@trade-tariff.service.gov.uk"
+  no_reply       = "no-reply@${var.base_domain}"
   worker_command = ["/bin/sh", "-c", "bundle exec sidekiq -C ./config/sidekiq.yml"]
   init_command   = ["/bin/sh", "-c", "bundle exec rails db:migrate && bundle exec rails data:migrate"]
 


### PR DESCRIPTION
### Jira link

BAU

### What?

Each account is responsible for a main zone:

- dev.trade-tariff.service.gov.uk for development (delegated)
- staging.trade-tariff.service.gov.uk for staging (delegated)
- trade-tariff.service.gov.uk for production

We have verified identities in each account for each zone and need to
reflect that in the from address for the differences emails

I have added/removed/altered:

- [x] Added base domain to no-reply address

### Why?

I am doing this because:

- This enables emails to be sent from a verified zone
