### PR TITLE
BAU: Fixes package path for development

### DIFF
--- a/terraform/config_development.tfvars
+++ b/terraform/config_development.tfvars
@@ -4,5 +4,5 @@ base_domain                           = "dev.trade-tariff.service.gov.uk"
 cpu                                   = 1024
 memory                                = 2048
 alcohol_coercian_starts_from          = "2022-01-01"
-stemming_exclusion_reference_analyzer = "analyzers/F102794475"
-synonym_reference_analyzer            = "analyzers/F135140295"
+stemming_exclusion_reference_analyzer = "analyzers/F159568045"
+synonym_reference_analyzer            = "analyzers/F202143497"


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Altered the paths for the beta search packages

### Why?

I am doing this because:

- These packages got recreated after the development cluster was deleted and this is breaking the smoke tests that run on development
