### PR TITLE
HOTT-4221 Rake task to generate green lanes categories.json

### DIFF
--- a/lib/tasks/green_lanes.rake
+++ b/lib/tasks/green_lanes.rake
@@ -7,15 +7,16 @@ namespace :green_lanes do
     @json = @data.map do |row|
       {
         category: row['Primary category'],
-        constraints: {
-          regulation_id: row['Regulation id'].presence.strip,
-          measure_type_id: row['Measure type ID'].presence.strip,
-          geographical_area: row['Geographical area']&.presence&.strip,
-          document_codes: row['Document codes'].to_s.split.map(&:strip),
-          additional_codes: row['Additional codes'].to_s.split.map(&:strip),
-        },
+        regulation_id: row['Regulation id'].presence.strip,
+        measure_type_id: row['Measure type ID'].presence.strip,
+        geographical_area: row['Geographical area']&.presence&.strip,
+        document_codes: row['Document codes'].to_s.split.map(&:strip),
+        additional_codes: row['Additional codes'].to_s.split.map(&:strip),
       }
     end
+
+    path = Rails.root.join('data/green_lanes').to_s
+    Dir.mkdir path unless Dir.exist? path
 
     Rails.root.join('data/green_lanes/categories.json').write \
       JSON.pretty_generate(@json)

--- a/lib/tasks/green_lanes.rake
+++ b/lib/tasks/green_lanes.rake
@@ -1,0 +1,23 @@
+namespace :green_lanes do
+  desc 'Convert a CSV of the categorisation data to JSON format CSVFILE=path/to/file.csv'
+  task generate_categorisation_data: :environment do
+    raise "Cannot read file '#{ENV['CSVFILE']}'" unless File.file?(ENV['CSVFILE'].to_s)
+
+    @data = CSV.read(ENV['CSVFILE'], headers: true)
+    @json = @data.map do |row|
+      {
+        category: row['Primary category'],
+        constraints: {
+          regulation_id: row['Regulation id'].presence.strip,
+          measure_type_id: row['Measure type ID'].presence.strip,
+          geographical_area: row['Geographical area']&.presence&.strip,
+          document_codes: row['Document codes'].to_s.split.map(&:strip),
+          additional_codes: row['Additional codes'].to_s.split.map(&:strip),
+        },
+      }
+    end
+
+    Rails.root.join('data/green_lanes/categories.json').write \
+      JSON.pretty_generate(@json)
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-4221

### What?

I have added/removed/altered:

- [x] Added a rake task to convert the categorisation CSV to a categories.json data file

### Why?

I am doing this because:

- So we can use it in the categorisation of green lanes in the API response

### Deployment risks (optional)

- Low, just adds a rake task
