### PR TITLE
HOTT-4564 Ignore green lanes categorisation data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ searches_without_match_or_synonym.csv
 
 # Ignore all json files in the cds dump directory
 /data/cds_dumps/*.json
+
+# Ignore Green Lanes categorisation data for now
+/data/green_lanes/categories.json


### PR DESCRIPTION
### Jira link

HOTT-4564

### What?

I have added/removed/altered:

- [x] Added green_lanes/categories.json to `.gitignore`

### Why?

I am doing this because:

- it should help prevent accidental inclusion of temporary development data

### Deployment risks (optional)

- Low
