### PR TITLE
HOTT-4598: Update Releases Context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,8 +435,8 @@ workflows:
 
       - tariff/create-production-release:
           name: create-production-release
-          context: trade-tariff
-          image-name: tariff-backend
+          context: trade-tariff-releases
+          image-name: tariff-backend-production
           requires:
             - promote-to-production?
           <<: *filter-main
@@ -464,7 +464,7 @@ workflows:
           <<: *filter-release
 
       - notify-production-deployment:
-          context: trade-tariff
+          context: trade-tariff-releases
           requires:
             - apply-terraform-prod
           <<: *filter-release


### PR DESCRIPTION
### Jira link

[HOTT-4598](https://transformuk.atlassian.net/browse/HOTT-4598)

### What?

I have added/removed/altered:

- Updated releases context in CircleCi config.

### Why?

I am doing this because:

- We now have a new context that we can use for releases, so we'll want to use this.