### PR TITLE
HOTT-4264 Fix to Japan rules of origin on fish: any comm code in heading 0301

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/japan.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/japan.json
@@ -58,10 +58,8 @@
                               "export": true
                         },
                         {
-                              "rule": "Production in which Atlantic Bluefin tuna (Thunnus thynnus) is subject to caging in farms with subsequent feeding and fattening or farming for a minimum period of three months in a Party. The duration of the fattening or farming shall be established according to the date of the caging operation and the date of harvesting recorded in the electronic Bluefin tuna Catch Document (eBCD) of the International Commission for the Conservation of Atlantic Tunas (I<abbr title='Change of tariff chapter'>CC</abbr>: All non-originating materials used in the production of the good have undergone a change in tariff classification at the 2-digit level (chapter)AT).",
-                              "class": [
-                                    "CC"
-                              ],
+                              "rule": "Production in which Atlantic Bluefin tuna (Thunnus thynnus) is subject to caging in farms with subsequent feeding and fattening or farming for a minimum period of three months in a Party. The duration of the fattening or farming shall be established according to the date of the caging operation and the date of harvesting recorded in the electronic Bluefin tuna Catch Document (eBCD) of the International Commission for the Conservation of Atlantic Tunas (ICCAT).",
+                              "class": [],
                               "footnotes": [],
                               "operator": "or",
                               "quota": false,
@@ -9639,7 +9637,7 @@
                   "max": "7007119999",
                   "rules": [
                         {
-                              "rule": "Tempering of non-originating materials, provided that nonoriginating materials of [heading&nbsp;7007](/headings/7007) are not used.",
+                              "rule": "Tempering of non-originating materials, provided that non-originating materials of [heading&nbsp;7007](/headings/7007) are not used.",
                               "class": [],
                               "footnotes": [],
                               "operator": null,


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-4264

### What?

I have altered:

- [x] japan.json ROO file

### Why?

I am doing this because:

- One of the governing bodies for fish ICCAT should be abbreviated.

![image](https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/489d388e-8601-43ee-a042-33e3bdd8d119)
