### PR TITLE
HOTT-4557: Publication date code fix

### DIFF
--- a/app/services/exchange_rates/create_average_exchange_rates_service.rb
+++ b/app/services/exchange_rates/create_average_exchange_rates_service.rb
@@ -42,6 +42,7 @@ module ExchangeRates
         countries_and_rate,
         selected_date,
         :average_csv,
+        selected_date,
       ).call
     end
 

--- a/app/services/exchange_rates/monthly_exchange_rates_service.rb
+++ b/app/services/exchange_rates/monthly_exchange_rates_service.rb
@@ -19,18 +19,21 @@ module ExchangeRates
         rates,
         date,
         :monthly_csv,
+        sample_date,
       ).call
 
       ExchangeRates::UploadFileService.new(
         rates,
         date,
         :monthly_xml,
+        sample_date,
       ).call
 
       ExchangeRates::UploadFileService.new(
         rates,
         date,
         :monthly_csv_hmrc,
+        sample_date,
       ).call
     end
 

--- a/app/services/exchange_rates/spot_exchange_rates_service.rb
+++ b/app/services/exchange_rates/spot_exchange_rates_service.rb
@@ -18,6 +18,7 @@ module ExchangeRates
         rates,
         sample_date,
         :spot_csv,
+        sample_date,
       ).call
     end
 

--- a/app/services/exchange_rates/upload_file_service.rb
+++ b/app/services/exchange_rates/upload_file_service.rb
@@ -1,9 +1,10 @@
 module ExchangeRates
   class UploadFileService
-    def initialize(rates, date, type)
+    def initialize(rates, date, type, sample_date)
       @rates = rates
       @date = date
       @type = type
+      @sample_date = sample_date
     end
 
     def call
@@ -23,7 +24,7 @@ module ExchangeRates
 
     private
 
-    attr_reader :rates, :date, :type
+    attr_reader :rates, :date, :type, :sample_date
 
     def upload_data(format, file_creation_service)
       exchange_rate_file = file_creation_service.call(rates)
@@ -38,7 +39,7 @@ module ExchangeRates
         format:,
         type:,
         file_size:,
-        publication_date: date,
+        publication_date: sample_date,
       )
 
       Rails.logger.info("Generated file name: #{file_path}, size: #{file_size}")

--- a/spec/services/exchange_rates/monthly_exchange_rates_service_spec.rb
+++ b/spec/services/exchange_rates/monthly_exchange_rates_service_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe ExchangeRates::MonthlyExchangeRatesService do
 
       it { expect(update_service).to have_received(:call) }
 
-      it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(anything, date, :monthly_csv) }
-      it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(anything, date, :monthly_xml) }
-      it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(anything, date, :monthly_csv_hmrc) }
+      it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(anything, date, :monthly_csv, sample_date) }
+      it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(anything, date, :monthly_xml, sample_date) }
+      it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(anything, date, :monthly_csv_hmrc, sample_date) }
     end
 
     context 'when download is false' do
@@ -37,9 +37,9 @@ RSpec.describe ExchangeRates::MonthlyExchangeRatesService do
 
       it { expect(update_service).not_to have_received(:call) }
 
-      it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(anything, date, :monthly_csv) }
-      it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(anything, date, :monthly_xml) }
-      it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(anything, date, :monthly_csv_hmrc) }
+      it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(anything, date, :monthly_csv, sample_date) }
+      it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(anything, date, :monthly_xml, sample_date) }
+      it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(anything, date, :monthly_csv_hmrc, sample_date) }
     end
   end
 end

--- a/spec/services/exchange_rates/spot_exchange_rates_service_spec.rb
+++ b/spec/services/exchange_rates/spot_exchange_rates_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ExchangeRates::SpotExchangeRatesService do
 
         it { expect(update_service).to have_received(:call) }
 
-        it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(spot_rates, sample_date, :spot_csv) }
+        it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(spot_rates, sample_date, :spot_csv, sample_date) }
 
         it { expect(ExchangeRateCurrencyRate).to have_received(:for_month).with(sample_date.month, sample_date.year, 'spot') }
       end
@@ -43,7 +43,7 @@ RSpec.describe ExchangeRates::SpotExchangeRatesService do
 
         it { expect(update_service).not_to have_received(:call) }
 
-        it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(spot_rates, sample_date, :spot_csv) }
+        it { expect(ExchangeRates::UploadFileService).to have_received(:new).with(spot_rates, sample_date, :spot_csv, sample_date) }
 
         it { expect(ExchangeRateCurrencyRate).to have_received(:for_month).with(sample_date.month, sample_date.year, 'spot') }
       end

--- a/spec/services/exchange_rates/upload_file_service_spec.rb
+++ b/spec/services/exchange_rates/upload_file_service_spec.rb
@@ -1,8 +1,9 @@
 RSpec.describe ExchangeRates::UploadFileService do
-  subject(:call) { described_class.new(rates, date, type).call }
+  subject(:call) { described_class.new(rates, date, type, sample_date).call }
 
   let(:rates) { create_list(:exchange_rate_currency_rate, 1, :with_usa) }
   let(:date) { Time.zone.today }
+  let(:sample_date) { date + 1 }
 
   before do
     allow(TariffSynchronizer::FileService).to receive(:write_file)
@@ -67,5 +68,14 @@ RSpec.describe ExchangeRates::UploadFileService do
       expect(ExchangeRateFile.count).to eq(1)
       expect(ExchangeRates::CreateCsvAverageRatesService).to have_received(:new).with(rates)
     end
+  end
+
+  context 'when saving to database it saves the correct dates' do
+    let(:type) { :monthly_csv }
+
+    it { expect(ExchangeRateFile.count).to eq(1) }
+    it { expect(ExchangeRateFile.first.publication_date).to eq(sample_date) }
+    it { expect(ExchangeRateFile.first.period_year).to eq(date.year) }
+    it { expect(ExchangeRateFile.first.period_month).to eq(date.month) }
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4557

### What?

I have added/removed/altered:

- [ ] updated the code to use the correct publication date when creating ExchangeRateFiles

### Why?

I am doing this because:

- We were saving/displaying the incorrect date on ExchangeRates

<img width="719" alt="Screenshot 2023-12-13 at 16 51 37" src="https://github.com/trade-tariff/trade-tariff-backend/assets/12201130/0815bfd5-16a3-4d10-84e5-19d59ba2e12a">
