### PR TITLE
HOTT-4557: Publication date data fix

### DIFF
--- a/db/data_migrations/20231213154345_fix_publication_date.rb
+++ b/db/data_migrations/20231213154345_fix_publication_date.rb
@@ -1,0 +1,28 @@
+Sequel.migration do
+  # IMPORTANT! Data migrations up block should be idempotent (reruns of up should produce the same effect)
+  # they may get re-run as part of data rollbacks but the rollback (down) function of the data migration will not get invoked
+  up do
+    if TradeTariffBackend.uk?
+      files_to_update = ExchangeRateFile.where(period_year: 2023, period_month: [10, 11, 12], type: ["monthly_csv_hmrc", "monthly_csv", "monthly_xml"])
+
+      files_to_update.each do |file|
+        new_publication_date =
+          case file.period_month
+          when 10
+            Date.new(2023, 9, 20)
+          when 11
+            Date.new(2023, 10, 18)
+          when 12
+            Date.new(2023, 11, 22)
+          end
+
+        file.update(publication_date: new_publication_date)
+      end
+
+    end
+  end
+
+  down do
+    # We don't want to rollback to incorrect dates.
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4557

### What?

I have added/removed/altered:

- Fixed the ExchangeRateFile publication dates starting from late October

### Why?

I am doing this because:

- We were displaying the incorrect date on ExchangeRate pages

<img width="719" alt="Screenshot 2023-12-13 at 16 51 37" src="https://github.com/trade-tariff/trade-tariff-backend/assets/12201130/2cf31717-9f2f-478f-a83d-6267e48e14ae">

