### PR TITLE
HOTT-4561: Categorisation API

### DIFF
--- a/app/controllers/api/v2/green_lanes/categorisations_controller.rb
+++ b/app/controllers/api/v2/green_lanes/categorisations_controller.rb
@@ -1,0 +1,14 @@
+module Api
+  module V2
+    module GreenLanes
+      class CategorisationsController < ApiController
+        def index
+          categorisation = ::GreenLanes::Categorisation.load_from_file
+          serializer = Api::V2::GreenLanes::CategorisationSerializer.new(categorisation)
+
+          render json: serializer.serializable_hash
+        end
+      end
+    end
+  end
+end

--- a/app/models/green_lanes/categorisation.rb
+++ b/app/models/green_lanes/categorisation.rb
@@ -3,8 +3,12 @@
 module GreenLanes
   class Categorisation
     include ActiveModel::Model
+    include ContentAddressableId
 
     DEFAULT_JSON = 'data/green_lanes/categories.json'
+
+    content_addressable_fields 'regulation_id', 'measure_type_id', 'geographical_area', 'document_codes', 'additional_codes'
+
 
     attr_accessor :category,
                   :regulation_id,

--- a/app/models/green_lanes/categorisation.rb
+++ b/app/models/green_lanes/categorisation.rb
@@ -5,7 +5,11 @@ module GreenLanes
     include ActiveModel::Model
     include ContentAddressableId
 
-    DEFAULT_JSON = 'data/green_lanes/categories.json'
+    DEFAULT_JSON = if Rails.env.development?
+                     'data/green_lanes/categories.json'
+                   else
+                     'data/green_lanes/stub_categories.json'
+                   end
 
     content_addressable_fields 'regulation_id', 'measure_type_id', 'geographical_area', 'document_codes', 'additional_codes'
 

--- a/app/models/green_lanes/categorisation.rb
+++ b/app/models/green_lanes/categorisation.rb
@@ -13,7 +13,6 @@ module GreenLanes
 
     content_addressable_fields 'regulation_id', 'measure_type_id', 'geographical_area', 'document_codes', 'additional_codes'
 
-
     attr_accessor :category,
                   :regulation_id,
                   :measure_type_id,

--- a/app/serializers/api/v2/green_lanes/categorisation_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/categorisation_serializer.rb
@@ -1,0 +1,19 @@
+module Api
+  module V2
+    module GreenLanes
+      class CategorisationSerializer
+        include JSONAPI::Serializer
+
+        set_type :green_lanes_categorisation
+
+        attributes :category,
+                   :regulation_id,
+                   :measure_type_id,
+                   :geographical_area,
+                   :document_codes,
+                   :additional_codes
+
+      end
+    end
+  end
+end

--- a/app/serializers/api/v2/green_lanes/categorisation_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/categorisation_serializer.rb
@@ -12,7 +12,6 @@ module Api
                    :geographical_area,
                    :document_codes,
                    :additional_codes
-
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -222,6 +222,8 @@ Rails.application.routes.draw do
       scope '/experimental' do
         namespace :green_lanes do
           resources :subheadings, only: %i[show], constraints: { id: /\d{6,10}/ }
+
+          resources :categorisations, only: %i[index]
         end
       end
     end

--- a/spec/models/green_lanes/categorisation_spec.rb
+++ b/spec/models/green_lanes/categorisation_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe GreenLanes::Categorisation do
       context 'with attributes' do
         subject(:first_element) { categorisation.first }
 
+        it { is_expected.to have_attributes id: a_string_matching(/\A.+\z/)}
         it { is_expected.to have_attributes category: '1' }
         it { is_expected.to have_attributes regulation_id: 'D0000001' }
         it { is_expected.to have_attributes measure_type_id: '400' }
@@ -64,6 +65,7 @@ RSpec.describe GreenLanes::Categorisation do
       context 'with attributes' do
         subject(:first_element) { categorisation_file.first }
 
+        it { is_expected.to have_attributes id: a_string_matching(/\A.+\z/)}
         it { is_expected.to have_attributes category: '1' }
         it { is_expected.to have_attributes regulation_id: 'D000001' }
         it { is_expected.to have_attributes measure_type_id: '400' }

--- a/spec/models/green_lanes/categorisation_spec.rb
+++ b/spec/models/green_lanes/categorisation_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe GreenLanes::Categorisation do
       context 'with attributes' do
         subject(:first_element) { categorisation.first }
 
-        it { is_expected.to have_attributes id: a_string_matching(/\A.+\z/)}
+        it { is_expected.to have_attributes id: a_string_matching(/\A.+\z/) }
         it { is_expected.to have_attributes category: '1' }
         it { is_expected.to have_attributes regulation_id: 'D0000001' }
         it { is_expected.to have_attributes measure_type_id: '400' }
@@ -65,7 +65,7 @@ RSpec.describe GreenLanes::Categorisation do
       context 'with attributes' do
         subject(:first_element) { categorisation_file.first }
 
-        it { is_expected.to have_attributes id: a_string_matching(/\A.+\z/)}
+        it { is_expected.to have_attributes id: a_string_matching(/\A.+\z/) }
         it { is_expected.to have_attributes category: '1' }
         it { is_expected.to have_attributes regulation_id: 'D000001' }
         it { is_expected.to have_attributes measure_type_id: '400' }

--- a/spec/requests/api/v2/green_lanes/categorisation_controller_spec.rb
+++ b/spec/requests/api/v2/green_lanes/categorisation_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Api::V2::GreenLanes::CategorisationsController do
+  describe 'GET #index' do
+    subject(:rendered) { make_request && response }
+
+    let :make_request do
+      get api_green_lanes_categorisations_path(format: :json),
+          headers: { 'Accept' => 'application/vnd.uktt.v2' }
+    end
+
+    before do
+      allow(::GreenLanes::Categorisation).to receive(:load_from_file).and_return(::GreenLanes::Categorisation.load_from_file test_file)
+    end
+
+    context 'when categorisation data is found' do
+      it_behaves_like 'a successful jsonapi response' do
+        let(:test_file) { file_fixture 'green_lanes/categorisations.json' }
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/green_lanes/categorisation_controller_spec.rb
+++ b/spec/requests/api/v2/green_lanes/categorisation_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Api::V2::GreenLanes::CategorisationsController do
     end
 
     before do
-      allow(::GreenLanes::Categorisation).to receive(:load_from_file).and_return(::GreenLanes::Categorisation.load_from_file test_file)
+      allow(::GreenLanes::Categorisation).to receive(:load_from_file).and_return(::GreenLanes::Categorisation.load_from_file(test_file))
     end
 
     context 'when categorisation data is found' do

--- a/spec/serializers/api/v2/green_lanes/categorisation_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/categorisation_serializer_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe Api::V2::GreenLanes::CategorisationSerializer do
+  subject(:serialized) do
+    described_class.new(::GreenLanes::Categorisation.load_from_string json_string).serializable_hash.as_json
+  end
+
+  let(:json_string) do
+    '[{
+          "category": "1",
+          "regulation_id": "D0000001",
+          "measure_type_id": "400",
+          "geographical_area": "1000",
+          "document_codes": [],
+          "additional_codes": []
+        }]'
+  end
+
+  let(:expected_pattern) do
+    {
+      data: [
+        id: be_a(String),
+        type: 'green_lanes_categorisation',
+        attributes: {
+          category: '1',
+          regulation_id: 'D0000001',
+          measure_type_id: '400',
+          geographical_area: '1000',
+          document_codes: [],
+          additional_codes: []
+        }
+      ]
+    }
+  end
+
+  it { is_expected.to include_json(expected_pattern) }
+end

--- a/spec/serializers/api/v2/green_lanes/categorisation_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/categorisation_serializer_spec.rb
@@ -1,17 +1,17 @@
 RSpec.describe Api::V2::GreenLanes::CategorisationSerializer do
   subject(:serialized) do
-    described_class.new(::GreenLanes::Categorisation.load_from_string json_string).serializable_hash.as_json
+    described_class.new(::GreenLanes::Categorisation.load_from_string(json_string)).serializable_hash.as_json
   end
 
   let(:json_string) do
-    '[{
-          "category": "1",
-          "regulation_id": "D0000001",
-          "measure_type_id": "400",
-          "geographical_area": "1000",
-          "document_codes": [],
-          "additional_codes": []
-        }]'
+    [{
+      'category' => '1',
+      'regulation_id' => 'D0000001',
+      'measure_type_id' => '400',
+      'geographical_area' => '1000',
+      'document_codes' => [],
+      'additional_codes' => [],
+    }].to_json
   end
 
   let(:expected_pattern) do
@@ -25,9 +25,9 @@ RSpec.describe Api::V2::GreenLanes::CategorisationSerializer do
           measure_type_id: '400',
           geographical_area: '1000',
           document_codes: [],
-          additional_codes: []
-        }
-      ]
+          additional_codes: [],
+        },
+      ],
     }
   end
 


### PR DESCRIPTION
### Jira link

[HOTT-4561]<https://transformuk.atlassian.net/browse/HOTT-4561>

### What?

I have added/removed/altered:

- [ ] Added a simple API to serialize all of the categorisation records


### Why?

I am doing this because:

- This will facilitate service like TSS to implement green lanes if they plan to fully recalculate the logic and use over night scrapes
-
-

### Have you? (optional)

- [ ] Added documentation for new apis
- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical data
- Changes an api that is used in production
