### PR TITLE
Fix average rate creation bugs

### DIFF
--- a/app/models/exchange_rate_country_currency.rb
+++ b/app/models/exchange_rate_country_currency.rb
@@ -16,7 +16,7 @@ class ExchangeRateCountryCurrency < Sequel::Model(:exchange_rate_countries_curre
 
   def self.live_currency_codes
     # Criteria:
-    # Countries that are live in the current month
+    # Currency codes that are live in the current month
 
     where(
       (Sequel[:validity_end_date] =~ (Time.zone.today.beginning_of_month..Time.zone.today.end_of_month)) |
@@ -25,16 +25,14 @@ class ExchangeRateCountryCurrency < Sequel::Model(:exchange_rate_countries_curre
     ).distinct(:currency_code).select_map(:currency_code)
   end
 
-  def self.live_last_twelve_months(date)
+  def self.live_countries
     # Criteria:
-    # Countries that have had a live rate in the last 12 months whole months
-    # So end of the current month minus 12 months
+    # ExchangeRateCountryCurrency objects that are live in the current month
 
     where(
-      (Sequel[:validity_start_date] <= date.end_of_month) &
-      (Sequel[:validity_end_date] =~ nil) |
-      (Sequel[:validity_start_date] <= date.end_of_month) &
-      (Sequel[:validity_end_date] >= date.beginning_of_month - 11.months),
-    ).order_by(:country_description)
+      (Sequel[:validity_end_date] =~ (Time.zone.today.beginning_of_month..Time.zone.today.end_of_month)) |
+      (Sequel[:validity_end_date] =~ nil) &
+      (Sequel[:validity_start_date] <= Time.zone.today.end_of_month),
+    ).order(:country_description)
   end
 end

--- a/app/services/exchange_rates/create_average_exchange_rates_service.rb
+++ b/app/services/exchange_rates/create_average_exchange_rates_service.rb
@@ -2,7 +2,7 @@ module ExchangeRates
   class CreateAverageExchangeRatesService
     # Creates the average rates for countries that have had a live rate the last 12 months and upload the file
 
-    VALID_MONTHS = [4, 12].freeze
+    VALID_MONTHS = [3, 12].freeze
     VALID_DAY = 31
 
     def self.call(selected_date:, force_run: false)
@@ -28,9 +28,11 @@ module ExchangeRates
     attr_reader :force_run, :selected_date
 
     def match_country_with_rates(avg_rates)
-      live_countries_last_twelve_months.each_with_object({}) do |country, h|
-        avg_rate = avg_rates.find { |rate| rate.currency_code == country.currency_code }
-                            .rate
+      live_countries.each_with_object({}) do |country, h|
+        avg_rate = avg_rates
+                    .find { |rate| rate.currency_code == country.currency_code }&.rate
+
+        next unless avg_rate
 
         # { ExchangeRateCountryCurrency => avg_rate }
         h[country] = avg_rate
@@ -51,27 +53,30 @@ module ExchangeRates
     end
 
     def create_average_rates
-      live_countries_last_twelve_months.select_map(:currency_code).uniq.map do |currency_code|
+      live_countries.select_map(:currency_code).uniq.map { |currency_code|
         rates = ExchangeRateCurrencyRate.monthly_by_currency_last_year(currency_code, selected_date)
 
         next unless rates_valid?(rates)
 
         ExchangeRateCurrencyRate.create(
           currency_code:,
-          validity_start_date: selected_date.beginning_of_month,
+          validity_start_date: selected_date.beginning_of_month - 11.months,
           validity_end_date: selected_date.end_of_month,
           rate_type: ExchangeRateCurrencyRate::AVERAGE_RATE_TYPE,
           rate: rates.pluck(:rate).sum.fdiv(rates.count),
         )
-      end
+      }.compact
     end
 
-    def live_countries_last_twelve_months
-      # This needs to be all countries that have had a rate for a currency last 12 months
-      @live_countries_last_twelve_months ||= ExchangeRateCountryCurrency.live_last_twelve_months(selected_date)
+    def live_countries
+      # This needs to be all countries that have a live rate in the selected month
+      @live_countries ||= ExchangeRateCountryCurrency.live_countries
     end
 
     def rates_valid?(rates)
+      # Ensure there is 12 months of rates to calculate an average against
+      return unless rates.count == 12
+
       # Ensure the last month is not after the selected date
       return unless rates.last.validity_start_date <= selected_date
 

--- a/spec/models/exchange_rate_country_currency_spec.rb
+++ b/spec/models/exchange_rate_country_currency_spec.rb
@@ -11,34 +11,17 @@ RSpec.describe ExchangeRateCountryCurrency do
     end
   end
 
-  describe '.live_last_twelve_months' do
+  describe '.live_countries' do
     before do
-      # ======= Live Countries last 12 months =======
-
-      # Since 2020
       create(:exchange_rate_country_currency, :eu)
-      # Starts end of the month
       create(:exchange_rate_country_currency, :kz,
-             validity_start_date: Time.zone.today.end_of_month)
-      # Ended beginning of current month minus 11 months
-      create(:exchange_rate_country_currency, :zw,
-             validity_end_date: Time.zone.today.beginning_of_month - 11.months)
-
-      # ======= Not live last 12 months =======
-
-      # Live beginning next Month
-      create(:exchange_rate_country_currency, :bd,
-             validity_start_date: Time.zone.today.beginning_of_month + 1.month)
-      # Ended beginning of current month - 12 months ago - 1 day
-      create(:exchange_rate_country_currency, :du,
-             validity_end_date: Time.zone.today.end_of_month - 12.months)
+             validity_end_date: Time.zone.today.end_of_month - 1.month)
     end
 
-    let(:test_date) { Time.zone.today }
-
     it 'retuns all the live currency_codes', :aggregate_failures do
-      expect(described_class.live_last_twelve_months(test_date).count).to eq(3)
-      expect(described_class.live_last_twelve_months(test_date).pluck(:country_code)).to eq(%w[EU KZ ZW])
+      expect(described_class.live_countries.count).to eq(1)
+      expect(described_class.live_countries.pluck(:country_code)).to eq(%w[EU])
+      expect(described_class.live_countries.pluck(:country_description)).to eq(%w[Eurozone])
     end
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-4754

### What?

I have added/removed/altered:

- [ ] Improved avg rate service to catch instances where a country might have been a live country but actually the test cases didnt cover if a rate wasnt valid for that period (ie not covering the full 12 periods)
- [ ] Improved some wording around comments
- [ ] Fixed bug where service would have created a rate no matter when the country was live or not
- [ ] Remove uneeded method `live_last_twelve_months`
- [ ] Changed validity start period to be the beginning of the first month 11 months previous to the run date

### Why?

I am doing this because:

- Previously the avg rate task would have generated a rate for any countries that had a live rate in the last 12 months
-
-

