### PR TITLE
HOTT-4814 Disable ETag caching for exchange rates

### DIFF
--- a/app/controllers/api/v2/exchange_rates/base_controller.rb
+++ b/app/controllers/api/v2/exchange_rates/base_controller.rb
@@ -2,6 +2,8 @@ module Api
   module V2
     module ExchangeRates
       class BaseController < ApiController
+        include NoCaching
+
         before_action :validate_exchange_rate_type
 
         private


### PR DESCRIPTION
### Jira link

HOTT-4814

### What?

I have added/removed/altered:

- [x] Prevents ExchangeRates giving out invalid cache info to the frontend

### Why?

I am doing this because:

- ExchangeRates API responses are getting cached and should not be

### Deployment risks (optional)

- May increase backend load on server
