### PR TITLE
HOTT-4816 remove error handling duplication

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -12,16 +12,6 @@ module Api
 
     respond_to :json
 
-    rescue_from Sequel::NoMatchingRow, Sequel::RecordNotFound do |_exception|
-      serializer = TradeTariffBackend.error_serializer(request)
-      render json: serializer.serialized_errors({ error: 'not found', url: request.url }), status: :not_found
-    end
-
-    rescue_from ActionController::ParameterMissing, NotImplementedError do |exception|
-      serializer = TradeTariffBackend.error_serializer(request)
-      render json: serializer.serialized_errors({ error: exception.message, url: request.url }), status: :unprocessable_entity
-    end
-
     protected
 
     def current_page

--- a/config/initializers/exceptions.rb
+++ b/config/initializers/exceptions.rb
@@ -1,7 +1,9 @@
 ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
   'ArgumentError' => :bad_request,
-  'NotImplementedError' => :bad_request,
+  'NotImplementedError' => :unprocessable_entity,
+  'ActionController::ParameterMissing' => :unprocessable_entity,
   'Sequel::RecordNotFound' => :not_found,
+  'Sequel::NoMatchingRow' => :not_found,
   'BulkSearch::ResultCollection::RecordNotFound' => :not_found,
   'ActionController::RoutingError' => :not_found,
   'AbstractController::ActionNotFound' => :not_found,

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -5,6 +5,8 @@ Sentry.init do |config|
     Sequel::Plugins::RailsExtensions::ModelNotFound
     Sequel::NoMatchingRow
     Sequel::RecordNotFound
+    ActionController::ParameterMissing
+    NotImplementedError
     BulkSearch::ResultCollection::RecordNotFound
     MaintenanceMode::MaintenanceModeActive
   ]

--- a/spec/controllers/api/admin/chapters/chapter_notes_controller_spec.rb
+++ b/spec/controllers/api/admin/chapters/chapter_notes_controller_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe Api::Admin::Chapters::ChapterNotesController do
       let(:chapter) { create :chapter }
 
       it 'returns not found if record was not found' do
-        get :show, params: { chapter_id: chapter.to_param }, format: :json
-
-        expect(response.status).to eq 404
+        expect {
+          get :show, params: { chapter_id: chapter.to_param }, format: :json
+        }.to raise_exception Sequel::RecordNotFound
       end
     end
   end
@@ -162,9 +162,9 @@ RSpec.describe Api::Admin::Chapters::ChapterNotesController do
       let(:chapter) { create :chapter }
 
       it 'responds with 404 not found' do
-        delete :destroy, params: { chapter_id: chapter.to_param }, format: :json
-
-        expect(response.status).to eq 404
+        expect {
+          delete :destroy, params: { chapter_id: chapter.to_param }, format: :json
+        }.to raise_exception Sequel::RecordNotFound
       end
     end
   end

--- a/spec/controllers/api/admin/commodities/search_references_controller_spec.rb
+++ b/spec/controllers/api/admin/commodities/search_references_controller_spec.rb
@@ -51,8 +51,11 @@ RSpec.describe Api::Admin::Commodities::SearchReferencesController do
         }
       end
 
-      it { is_expected.to have_http_status(:not_found) }
-      it { expect { do_post }.not_to change(SearchReference, :count) }
+      it 'raises a 404 and does not change the data' do
+        expect { do_post }
+          .to raise_exception(Sequel::RecordNotFound)
+          .and not_change(SearchReference, :count)
+      end
     end
 
     context 'when not passing a productline suffix' do

--- a/spec/controllers/api/admin/footnotes_controller_spec.rb
+++ b/spec/controllers/api/admin/footnotes_controller_spec.rb
@@ -64,9 +64,9 @@ RSpec.describe Api::Admin::FootnotesController do
     end
 
     specify 'does not return non-national footnote' do
-      get :show, params: { id: non_national_footnote.pk.join }, format: :json
-
-      expect(response.status).to eq 404
+      expect {
+        get :show, params: { id: non_national_footnote.pk.join }, format: :json
+      }.to raise_exception Sequel::NoMatchingRow
     end
   end
 
@@ -83,9 +83,9 @@ RSpec.describe Api::Admin::FootnotesController do
     end
 
     specify 'does not update non-national footnote' do
-      put :update, params: { id: non_national_footnote.pk.join, data: {} }, format: :json
-
-      expect(response.status).to eq 404
+      expect {
+        put :update, params: { id: non_national_footnote.pk.join, data: {} }, format: :json
+      }.to raise_exception Sequel::NoMatchingRow
     end
   end
 end

--- a/spec/controllers/api/admin/sections/section_notes_controller_spec.rb
+++ b/spec/controllers/api/admin/sections/section_notes_controller_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe Api::Admin::Sections::SectionNotesController do
       let(:section) { create :section }
 
       it 'returns not found if record was not found' do
-        get :show, params: { section_id: section.id }, format: :json
-
-        expect(response.status).to eq 404
+        expect {
+          get :show, params: { section_id: section.id }, format: :json
+        }.to raise_exception(Sequel::RecordNotFound)
       end
     end
   end
@@ -132,7 +132,8 @@ RSpec.describe Api::Admin::Sections::SectionNotesController do
       it 'does not change section_note content' do
         expect {
           put :update, params: { section_id: section.id, section_note: { content: '' } }, format: :json
-        }.not_to(change { section.reload.section_note.content })
+        }.to raise_exception(ActionController::ParameterMissing)
+        .and(not_change { section.reload.section_note.content })
       end
     end
   end
@@ -160,9 +161,9 @@ RSpec.describe Api::Admin::Sections::SectionNotesController do
       let(:section) { create :section }
 
       it 'responds with 404 not found' do
-        delete :destroy, params: { section_id: section.id }, format: :json
-
-        expect(response.status).to eq 404
+        expect {
+          delete :destroy, params: { section_id: section.id }, format: :json
+        }.to raise_exception Sequel::RecordNotFound
       end
     end
   end

--- a/spec/controllers/api/admin/updates_controller_spec.rb
+++ b/spec/controllers/api/admin/updates_controller_spec.rb
@@ -70,14 +70,7 @@ RSpec.describe Api::Admin::UpdatesController do
     context 'when records are not present' do
       subject(:do_request) { get :show, params: { id: 'foo', format: :json } }
 
-      let(:pattern) do
-        {
-          error: 'not found',
-          url: 'http://test.host/admin/updates/foo',
-        }
-      end
-
-      it { expect(do_request.body).to match_json_expression pattern }
+      it { expect { do_request.body }.to raise_exception Sequel::RecordNotFound }
     end
   end
 end

--- a/spec/controllers/api/v1/chapters_controller_spec.rb
+++ b/spec/controllers/api/v1/chapters_controller_spec.rb
@@ -49,18 +49,20 @@ RSpec.describe Api::V1::ChaptersController do
     context 'when record is not present' do
       it 'returns not found if record was not found' do
         id = chapter.goods_nomenclature_item_id.first(2).to_i + 1
-        get :show, params: { id: }, format: :json
 
-        expect(response.status).to eq 404
+        expect {
+          get :show, params: { id: }, format: :json
+        }.to raise_exception Sequel::RecordNotFound
       end
     end
 
     context 'when record is hidden' do
       it 'returns not found' do
         create :hidden_goods_nomenclature, goods_nomenclature_item_id: chapter.goods_nomenclature_item_id
-        get :show, params: { id: chapter.goods_nomenclature_item_id.first(2) }, format: :json
 
-        expect(response.status).to eq 404
+        expect {
+          get :show, params: { id: chapter.goods_nomenclature_item_id.first(2) }, format: :json
+        }.to raise_exception Sequel::RecordNotFound
       end
     end
   end

--- a/spec/controllers/api/v1/commodities_controller_spec.rb
+++ b/spec/controllers/api/v1/commodities_controller_spec.rb
@@ -32,9 +32,10 @@ RSpec.describe Api::V1::CommoditiesController do
     context 'when record is not present' do
       it 'returns not found if record was not found' do
         id = commodity.goods_nomenclature_item_id.next
-        get :show, params: { id: }, format: :json
 
-        expect(response.status).to eq 404
+        expect {
+          get :show, params: { id: }, format: :json
+        }.to raise_exception Sequel::RecordNotFound
       end
     end
 
@@ -42,9 +43,9 @@ RSpec.describe Api::V1::CommoditiesController do
       before { create :hidden_goods_nomenclature, goods_nomenclature_item_id: commodity.goods_nomenclature_item_id }
 
       it 'returns not found' do
-        get :show, params: { id: commodity.goods_nomenclature_item_id }, format: :json
-
-        expect(response.status).to eq 404
+        expect {
+          get :show, params: { id: commodity.goods_nomenclature_item_id }, format: :json
+        }.to raise_exception Sequel::RecordNotFound
       end
     end
 
@@ -70,9 +71,9 @@ RSpec.describe Api::V1::CommoditiesController do
       end
 
       it 'returns not found (is not declarable)' do
-        get :show, params: { id: parent_commodity.goods_nomenclature_item_id }, format: :json
-
-        expect(response.status).to eq 404
+        expect {
+          get :show, params: { id: parent_commodity.goods_nomenclature_item_id }, format: :json
+        }.to raise_exception Sequel::RecordNotFound
       end
     end
   end

--- a/spec/controllers/api/v1/sections_controller_spec.rb
+++ b/spec/controllers/api/v1/sections_controller_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe Api::V1::SectionsController do
 
     context 'when record is not present' do
       it 'returns not found if record was not found' do
-        get :show, params: { id: section.position + 1 }, format: :json
-
-        expect(response.status).to eq 404
+        expect {
+          get :show, params: { id: section.position + 1 }, format: :json
+        }.to raise_exception Sequel::RecordNotFound
       end
     end
   end

--- a/spec/controllers/api/v2/chapters_controller_spec.rb
+++ b/spec/controllers/api/v2/chapters_controller_spec.rb
@@ -103,9 +103,10 @@ RSpec.describe Api::V2::ChaptersController do
     context 'when record is not present' do
       it 'returns not found if record was not found' do
         id = chapter.goods_nomenclature_item_id.first(2).to_i + 1
-        get :show, params: { id: }, format: :json
 
-        expect(response.status).to eq 404
+        expect {
+          get :show, params: { id: }, format: :json
+        }.to raise_exception Sequel::RecordNotFound
       end
     end
 
@@ -115,9 +116,9 @@ RSpec.describe Api::V2::ChaptersController do
       end
 
       it 'returns not found' do
-        get :show, params: { id: chapter.goods_nomenclature_item_id.first(2) }, format: :json
-
-        expect(response.status).to eq 404
+        expect {
+          get :show, params: { id: chapter.goods_nomenclature_item_id.first(2) }, format: :json
+        }.to raise_exception Sequel::RecordNotFound
       end
     end
   end

--- a/spec/controllers/api/v2/chemicals_controller_spec.rb
+++ b/spec/controllers/api/v2/chemicals_controller_spec.rb
@@ -177,25 +177,25 @@ RSpec.describe Api::V2::ChemicalsController, type: :controller do
 
   context 'with an invalid `:id` parameter, GET #show' do
     it 'returns 404' do
-      get :show, params: { id: 'FOOBAR' }, format: :json
-
-      expect(response.code.to_i).to eq 404
+      expect {
+        get :show, params: { id: 'FOOBAR' }, format: :json
+      }.to raise_exception Sequel::RecordNotFound
     end
   end
 
   context 'with an invalid `:cas` parameter, GET #search' do
     it 'returns 404' do
-      get :search, params: { cas: 'FOOBAR' }, format: :json
-
-      expect(response.code.to_i).to eq 404
+      expect {
+        get :search, params: { cas: 'FOOBAR' }, format: :json
+      }.to raise_exception Sequel::RecordNotFound
     end
   end
 
   context 'with an invalid `:name` parameter, GET #search' do
     it 'returns 404' do
-      get :search, params: { name: 'FOOBAR' }, format: :json
-
-      expect(response.code.to_i).to eq 404
+      expect {
+        get :search, params: { name: 'FOOBAR' }, format: :json
+      }.to raise_exception Sequel::RecordNotFound
     end
   end
 end

--- a/spec/controllers/api/v2/commodities_controller_spec.rb
+++ b/spec/controllers/api/v2/commodities_controller_spec.rb
@@ -70,12 +70,12 @@ RSpec.describe Api::V2::CommoditiesController do
     context 'when fetching a commodity that does not exist' do
       subject(:do_response) { get :show, params: { id: commodity.goods_nomenclature_item_id.next } }
 
-      it { is_expected.to have_http_status(:not_found) }
+      it { expect { do_response }.to raise_exception Sequel::RecordNotFound }
     end
   end
 
   context 'when record is hidden' do
-    before do
+    subject :do_request do
       create(
         :hidden_goods_nomenclature,
         goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
@@ -84,11 +84,11 @@ RSpec.describe Api::V2::CommoditiesController do
       get :show, params: { id: commodity.goods_nomenclature_item_id }, format: :json
     end
 
-    it { expect(response).to have_http_status(:not_found) }
+    it { expect { do_request }.to raise_exception Sequel::RecordNotFound }
   end
 
   context 'when commodity has children' do
-    before do
+    subject :do_request do
       create :goods_nomenclature, goods_nomenclature_item_id: '3903000000'
 
       create :commodity, :with_indent,
@@ -105,7 +105,9 @@ RSpec.describe Api::V2::CommoditiesController do
       get :show, params: { id: parent_commodity.goods_nomenclature_item_id }, format: :json
     end
 
-    it { expect(response).to have_http_status(:not_found) }
+    it 'raises an RecordNotFound exception' do
+      expect { do_request }.to raise_exception Sequel::RecordNotFound
+    end
   end
 
   describe 'GET /changes' do

--- a/spec/controllers/api/v2/goods_nomenclatures_controller_spec.rb
+++ b/spec/controllers/api/v2/goods_nomenclatures_controller_spec.rb
@@ -23,9 +23,11 @@ RSpec.describe Api::V2::GoodsNomenclaturesController do
     end
 
     context 'with an incorrect short code' do
-      before { get :show_by_section, params: { position: '99' }, format: :json }
+      subject :do_request do
+        get :show_by_section, params: { position: '99' }, format: :json
+      end
 
-      it { is_expected.to have_http_status :not_found }
+      it { expect { do_request }.to raise_exception Sequel::RecordNotFound }
     end
   end
 
@@ -52,9 +54,11 @@ RSpec.describe Api::V2::GoodsNomenclaturesController do
     end
 
     context 'with an incorrect short code' do
-      before { get :show_by_chapter, params: { chapter_id: '99' }, format: :json }
+      subject :do_request do
+        get :show_by_chapter, params: { chapter_id: '99' }, format: :json
+      end
 
-      it { is_expected.to have_http_status :not_found }
+      it { expect { do_request }.to raise_exception Sequel::RecordNotFound }
     end
   end
 
@@ -82,9 +86,11 @@ RSpec.describe Api::V2::GoodsNomenclaturesController do
     end
 
     context 'with an incorrect short code' do
-      before { get :show_by_heading, params: { heading_id: '9999' }, format: :json }
+      subject :do_request do
+        get :show_by_heading, params: { heading_id: '9999' }, format: :json
+      end
 
-      it { is_expected.to have_http_status :not_found }
+      it { expect { do_request }.to raise_exception Sequel::RecordNotFound }
     end
   end
 

--- a/spec/controllers/api/v2/headings_controller_spec.rb
+++ b/spec/controllers/api/v2/headings_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Api::V2::HeadingsController, type: :controller do
       context 'when the heading does not exist' do
         let(:id) { heading.short_code.next }
 
-        it { expect(do_response).to have_http_status(:not_found) }
+        it { expect { do_response }.to raise_exception Sequel::RecordNotFound }
       end
 
       context 'when the heading is not declarable' do
@@ -120,7 +120,7 @@ RSpec.describe Api::V2::HeadingsController, type: :controller do
         context 'when the record is not present' do
           let(:id) { heading.short_code.next }
 
-          it { expect(do_response).to have_http_status(:not_found) }
+          it { expect { do_response }.to raise_exception Sequel::RecordNotFound }
         end
       end
     end

--- a/spec/controllers/api/v2/measure_types_controller_spec.rb
+++ b/spec/controllers/api/v2/measure_types_controller_spec.rb
@@ -60,9 +60,7 @@ RSpec.describe Api::V2::MeasureTypesController, type: :controller do
         }
       end
 
-      it { expect(do_request.body).to match_json_expression pattern }
-
-      it { is_expected.to have_http_status :not_found }
+      it { expect { do_request }.to raise_exception Sequel::RecordNotFound }
     end
   end
 end

--- a/spec/controllers/api/v2/sections_controller_spec.rb
+++ b/spec/controllers/api/v2/sections_controller_spec.rb
@@ -81,9 +81,9 @@ RSpec.describe Api::V2::SectionsController do
 
     context 'when record is not present' do
       it 'returns not found if record was not found' do
-        get :show, params: { id: section.position + 1 }, format: :json
-
-        expect(response.status).to eq 404
+        expect {
+          get :show, params: { id: section.position + 1 }, format: :json
+        }.to raise_exception Sequel::RecordNotFound
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,8 @@ RSpec.configure do |config|
   config.include RescueHelper
   config.include ActiveSupport::Testing::TimeHelpers
 
+  RSpec::Matchers.define_negated_matcher :not_change, :change
+
   config.include_context 'with fake global rules of origin data'
 
   config.around do |example|

--- a/spec/requests/api/v2/exchange_rates/period_lists_controller_spec.rb
+++ b/spec/requests/api/v2/exchange_rates/period_lists_controller_spec.rb
@@ -124,15 +124,7 @@ RSpec.describe Api::V2::ExchangeRates::PeriodListsController, type: :request do
         )
       end
 
-      let(:pattern) do
-        {
-          error: 'not found',
-          url: 'http://www.example.com/exchange_rates/period_lists/2023idadas?filter%5Btype%5D=monthly',
-        }
-      end
-
       it { is_expected.to have_http_status(:not_found) }
-      it { expect(response.body).to match_json_expression(pattern) }
     end
 
     context 'when the type parameter is invalid' do
@@ -146,15 +138,7 @@ RSpec.describe Api::V2::ExchangeRates::PeriodListsController, type: :request do
         )
       end
 
-      let(:pattern) do
-        {
-          error: 'invalid',
-          url: 'http://www.example.com/exchange_rates/period_lists/2023?filter%5Btype%5D=invalid',
-        }
-      end
-
       it { is_expected.to have_http_status(:unprocessable_entity) }
-      it { expect(response.body).to match_json_expression(pattern) }
     end
   end
 end

--- a/spec/requests/api/v2/exchange_rates_controller_spec.rb
+++ b/spec/requests/api/v2/exchange_rates_controller_spec.rb
@@ -58,16 +58,7 @@ RSpec.describe Api::V2::ExchangeRatesController, type: :request do
         )
       end
 
-      let(:pattern) do
-        {
-          error: 'not found',
-          url: 'http://www.example.com/exchange_rates/2023idadas-6?filter%5Btype%5D=monthly',
-        }
-      end
-
       it { is_expected.to have_http_status(:not_found) }
-
-      it { expect(response.body).to match_json_expression(pattern) }
 
       it { expect(ExchangeRates::ExchangeRateCollection).not_to have_received(:build) }
     end
@@ -81,16 +72,7 @@ RSpec.describe Api::V2::ExchangeRatesController, type: :request do
         )
       end
 
-      let(:pattern) do
-        {
-          'error' => 'invalid',
-          'url' => 'http://www.example.com/exchange_rates/2023-6?filter%5Btype%5D=invalid',
-        }
-      end
-
       it { is_expected.to have_http_status(:unprocessable_entity) }
-
-      it { expect(response.body).to match_json_expression(pattern) }
 
       it { expect(ExchangeRates::ExchangeRateCollection).not_to have_received(:build) }
     end

--- a/spec/support/shared_examples/v2_search_reference_controller_examples.rb
+++ b/spec/support/shared_examples/v2_search_reference_controller_examples.rb
@@ -230,16 +230,17 @@ RSpec.shared_examples_for 'v2 search references controller' do
             id: bogus_search_ref_id,
             format: :json,
           }.merge(collection_query)
-        }.not_to change(SearchReference, :count)
+        }.to raise_exception(Sequel::NoMatchingRow)
+        .and not_change(SearchReference, :count)
       end
 
       it 'returns 404 response' do
-        delete :destroy, params: {
-          id: bogus_search_ref_id,
-          format: :json,
-        }.merge(collection_query)
-
-        expect(response.status).to eq 404
+        expect {
+          delete :destroy, params: {
+            id: bogus_search_ref_id,
+            format: :json,
+          }.merge(collection_query)
+        }.to raise_exception(Sequel::NoMatchingRow)
       end
     end
   end


### PR DESCRIPTION
### Jira link

HOTT-4816

### What?

I have added/removed/altered:

- [x] Removed the duplicate error handling in api controller
- [x] Fixed up various controller tests which expected exceptions to be rescued which is no longer the case

### Why?

I am doing this because:

- This is duplicating rails' own functionality
- This means we also need to try and keep this in sync with Errors Controller
- It is reporting our internal exception messages to users which seems like a bad idea
- It shows the minimal error message rather than the stock rails exception screen in development mode making it harder for developers to discover the origin of an error

### Deployment risks (optional)

- Changes exception handling code
- May result in increased error reporting if there is something which was previously getting rescued and which has not been added to the Sentry exclusions lists
