### PR TITLE
HOTT-4822 Add approval before releasing to dev server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,15 +339,21 @@ workflows:
           ssm_parameter: "/development/BACKEND_ECR_URL"
           <<: *filter-not-main
 
-      - apply-terraform:
-          name: apply-terraform-dev
-          context: trade-tariff-terraform-aws-development
-          environment: development
+      - confirm-deploy-for-qa?:
+          type: approval
           requires:
             - test
             - ruby-checks
             - plan-terraform-dev
             - build-and-push-dev
+          <<: *filter-not-main
+
+      - apply-terraform:
+          name: apply-terraform-dev
+          context: trade-tariff-terraform-aws-development
+          environment: development
+          requires:
+            - confirm-deploy-for-qa?
           <<: *filter-not-main
 
       - sync-opensearch-packages:


### PR DESCRIPTION
### Jira link

HOTT-4822

### What?

I have added/removed/altered:

- [x] Added an approval step before deploying to the Dev server

### Why?

I am doing this because:

- Whilst it arguably adds friction to the dev process pre-merge, it makes the dev server QA-able, in turn removing friction around the process post-merge which is where our actual primary contention is

### Deployment risks (optional)

- Low, should only impact dev server
