### PR TITLE
BAU: Only deploy a single worker for each backend

### DIFF
--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -1,17 +1,17 @@
 module "worker_uk" {
   source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.12.0"
 
-  service_name  = "worker-uk"
-  service_count = var.service_count
-  region        = var.region
+  service_name = "worker-uk"
+  region       = var.region
 
   cluster_name              = "trade-tariff-cluster-${var.environment}"
   subnet_ids                = data.aws_subnets.private.ids
   security_groups           = [data.aws_security_group.this.id]
   cloudwatch_log_group_name = "platform-logs-${var.environment}"
 
-  min_capacity = var.min_capacity
-  max_capacity = var.max_capacity
+  service_count = 1
+  min_capacity  = 1
+  max_capacity  = var.max_capacity
 
   docker_image = data.aws_ssm_parameter.ecr_url.value
   docker_tag   = var.docker_tag

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -1,17 +1,17 @@
 module "worker_xi" {
   source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.12.0"
 
-  service_name  = "worker-xi"
-  service_count = var.service_count
-  region        = var.region
+  service_name = "worker-xi"
+  region       = var.region
 
   cluster_name              = "trade-tariff-cluster-${var.environment}"
   subnet_ids                = data.aws_subnets.private.ids
   security_groups           = [data.aws_security_group.this.id]
   cloudwatch_log_group_name = "platform-logs-${var.environment}"
 
-  min_capacity = var.min_capacity
-  max_capacity = var.max_capacity
+  service_count = 1
+  min_capacity  = 1
+  max_capacity  = var.max_capacity
 
   docker_image = data.aws_ssm_parameter.ecr_url.value
   docker_tag   = var.docker_tag


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Set service count, min and max capacities to `1` for the workers.

### Why?

I am doing this because:

- Multiple deployed workers leads to multiple init containers, where the database migrations run, and this leads to concurrent migrations run against the db throwing alerts.