### PR TITLE
HOTT-4856: Restrict APIs to XI service only

### DIFF
--- a/app/controllers/api/v2/green_lanes/base_controller.rb
+++ b/app/controllers/api/v2/green_lanes/base_controller.rb
@@ -4,9 +4,15 @@ module Api
       class BaseController < ApiController
         include ActionController::HttpAuthentication::Token::ControllerMethods
 
-        before_action :authenticate
+        before_action :check_service, :authenticate
 
         private
+
+        def check_service
+          if TradeTariffBackend.uk?
+            raise ActionController::RoutingError, 'Invalid service'
+          end
+        end
 
         def authenticate
           authenticate_or_request_with_http_token do |provided_token, _options|

--- a/spec/requests/api/v2/green_lanes/categorisation_controller_spec.rb
+++ b/spec/requests/api/v2/green_lanes/categorisation_controller_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Api::V2::GreenLanes::CategorisationsController do
+  before do
+    allow(TradeTariffBackend).to receive(:service).and_return 'xi'
+  end
+
   describe 'GET #index' do
     subject(:rendered) { make_request && response }
 
@@ -23,6 +27,16 @@ RSpec.describe Api::V2::GreenLanes::CategorisationsController do
       it_behaves_like 'a successful jsonapi response' do
         let(:test_file) { file_fixture 'green_lanes/categorisations.json' }
       end
+    end
+
+    context 'when request on uk service' do
+      before do
+        allow(TradeTariffBackend).to receive(:service).and_return 'uk'
+      end
+
+      let(:test_file) { file_fixture 'green_lanes/categorisations.json' }
+
+      it { is_expected.to have_http_status(:not_found) }
     end
   end
 

--- a/spec/requests/api/v2/green_lanes/subheadings_controller_spec.rb
+++ b/spec/requests/api/v2/green_lanes/subheadings_controller_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Api::V2::GreenLanes::SubheadingsController do
+  before do
+    allow(TradeTariffBackend).to receive(:service).and_return 'xi'
+  end
+
   describe 'GET #show' do
     subject(:rendered) { make_request && response }
 
@@ -27,6 +31,14 @@ RSpec.describe Api::V2::GreenLanes::SubheadingsController do
     end
 
     context 'when the good nomenclature id is not found' do
+      it { is_expected.to have_http_status(:not_found) }
+    end
+
+    context 'when request on uk service' do
+      before do
+        allow(TradeTariffBackend).to receive(:service).and_return 'uk'
+      end
+
       it { is_expected.to have_http_status(:not_found) }
     end
   end


### PR DESCRIPTION
### Jira link

[HOTT-4856](https://transformuk.atlassian.net/browse/HOTT-4856)

### What?

I have added/removed/altered:

- [ ] Added a before_action to green lanes api and block UK service


### Why?

I am doing this because:

- This is to avoid api consumers inadvertently consuming the incorrect data
-
-

### Have you? (optional)

- [ ] Added documentation for new apis
- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical data
- Changes an api that is used in production
