### PR TITLE
HOTT-4847 Combine Article placeholders on one page for Iceland-Norway Origin Proof Verification

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk/articles/iceland-norway/verification.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/iceland-norway/verification.md
@@ -25,8 +25,6 @@ An exporter who has completed an origin declaration must keep a copy of the orig
 
 If an exporter has completed an origin declaration for a product referred to in paragraph 2 of Article 8 (Cumulation), the exporter must possess a completed and signed supplier’s declaration in accordance with Appendix 5 to this Annex or Appendix 6 to this Annex from the supplier of the non-originating materials used in the production of the product. The customs authority of the exporting Party may, subject to its domestic requirements, allow the supplier’s declaration to be completed without signature.
 
-{{ Article 19 }}
-
 ## Approved Exporter
 
 The customs authorities of Iceland or Norway may, subject to domestic requirements, authorise an exporter of that Party (hereinafter referred to as “approved exporter”) to complete origin declarations without signature.
@@ -37,4 +35,4 @@ The customs authorities of Iceland or Norway shall provide, to the approved expo
 
 The customs authorities of Iceland or Norway shall monitor the proper use of an authorisation and may withdraw it if the exporter no longer meets the conditions or otherwise makes improper use of it.
 
-{{ Article 20 }}
+{{ Articles 19 and 20 }}


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4847

### What?

I have altered:

- [x] db/rules_of_origin/roo_schemes_uk/articles/iceland-norway/verification.md to combine two place holders into one for articles 19 & 20 of Iceland Norway RoO Agreement.  This is similar to how the file was before when it was articles 32 & 33. 

 See diff docs from previous PR here:

https://github.com/trade-tariff/trade-tariff-backend/pull/1656/files#diff-42fbea93715ff1a1777ace7aea21f8e73eed3f8bf29f39f6820ee1a16c7034d6 

### Why?

I am doing this because:

- Following recent Iceland-Norway Roo updates had a discussion with Chris B to agree that this how it should look to resolve the bug on the page.

**Before Fix**
![image](https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/7bc8809e-fb49-491d-b18e-5add1376d5a2)


**After Fix**
![image](https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/634f0715-1ccc-4fe9-a375-e31c2443ffc6)