### PR TITLE
HOTT-4904 Update Article 9 to 8 for Cumulation For Iceland-Norway

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk/articles/iceland-norway/cumulation-export.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/iceland-norway/cumulation-export.md
@@ -26,4 +26,4 @@ Where preferential trade agreements are in effect between the exporting Party an
 
 4. The Parties shall use their best endeavours to ensure that the Joint Committee shall reach an appropriate decision promptly on the request of any Party and, if that decision lays down further conditions, that such conditions shall be the least trade-restrictive conditions reasonable in the circumstances.
 
-{{ Article 9 }}
+{{ Article 8 }}

--- a/db/rules_of_origin/roo_schemes_uk/articles/iceland-norway/cumulation-import.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/iceland-norway/cumulation-import.md
@@ -26,4 +26,4 @@ Where preferential trade agreements are in effect between the exporting Party an
 
 4. The Parties shall use their best endeavours to ensure that the Joint Committee shall reach an appropriate decision promptly on the request of any Party and, if that decision lays down further conditions, that such conditions shall be the least trade-restrictive conditions reasonable in the circumstances.
 
-{{ Article 9 }}
+{{ Article 8 }}


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4904

### What?

I have altered:

- [x] Article reference in db/rules_of_origin/roo_schemes_uk/articles/iceland-norway/cumulation-export.md
- [x] Article reference in db/rules_of_origin/roo_schemes_uk/articles/iceland-norway/cumulation-import.md

### Why?

I am doing this because:

- The Article number has changed in the Rules of Origin Reference Document

<img width="521" alt="image" src="https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/5eed660c-e3d0-41f5-b747-56b146d49676">


![image](https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/a5313be1-54ab-4cc8-8517-bf06c874cc00)

