### PR TITLE
HOTT-4913 XI workers have the CDS variable set to true

### DIFF
--- a/terraform/admin_xi.tf
+++ b/terraform/admin_xi.tf
@@ -38,7 +38,7 @@ module "backend_admin_xi" {
     [
       {
         name  = "CDS"
-        value = "true"
+        value = "false"
       },
       {
         name  = "GOVUK_APP_DOMAIN"

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -49,7 +49,7 @@ module "worker_xi" {
     [
       {
         name  = "CDS"
-        value = "true"
+        value = "false"
       },
       {
         name  = "GOVUK_APP_DOMAIN"


### PR DESCRIPTION
### Jira link

HOTT-4913

### What?

I have added/removed/altered:

- [x] Change the CDS environment variable to false for XI admin API worker
- [x] Change the CDS environment variable to false for XI worker

### Why?

I am doing this because:

- Admin: It is incorrect an _could_ cause issues if copied to other apps where it does have impact
- Worker: This breaks the sync on XI, and ends up following some unexpected/unintended code paths that seem to have come about as a consequence of separation of CDS and Taric synchronisers
- In general this env var is there to support a scenario we no longer require, is dangerous, and should be removed

### Deployment risks (optional)

- Changes server configuration across all environments
