### PR TITLE
HOTT-4690 Just use SERVICE for cache namespace

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   config.cache_store = :redis_cache_store,
                        TradeTariffBackend.redis_config.merge({
                          expires_in: 1.day,
-                         namespace: ENV['GOVUK_APP_DOMAIN'],
+                         namespace: "rails-cache-#{ENV['SERVICE'].presence || 'uk'}",
                          pool: { size: Integer(ENV['MAX_THREADS'] || 5) },
                        })
 


### PR DESCRIPTION
### Jira link

HOTT-4690

### What?

I have added/removed/altered:

- [x] Changed the Rails Cache namespace (prefix) to derive from the `SERVICE` environment variable instead of `GOVUK_APP_DOMAIN`

### Why?

I am doing this because:

- To date we've been using GOVUK_APP_DOMAIN for our cache prefix and our workers were configured with this environment variable to match to webapps. This is no longer the case and that means the workers are clearing/modifying different cache keys than the webapps are using resulting in the "clear cache" button being broken
- We have separate Redis instances for different environments so the old approach to namespacing wasn't required and is now actually problematic
- This means all apps for a service will share a common cache - allowing workers or backend admin webapps to modify the cache used by the main readonly webapp

### Deployment risks (optional)

- Changes the Cache prefix, so this will effectively clear the cache on deploy
- It makes sense to deploy it later in the day when load is lighter
