### PR TITLE
HOTT-??? Fixed logging to rails console

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -9,6 +9,7 @@ class SchemaQueryFilterLogger < SimpleDelegator
     super(progname, &block)
   end
 end
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -78,4 +79,6 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  config.logger = SchemaQueryFilterLogger.new(ActiveSupport::Logger.new($stdout))
 end


### PR DESCRIPTION
This was broken during the Rails 7.1 upgrade

### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [x] Fixed Log output in `Rails.env.development?`

### Why?

I am doing this because:

- It was broken by the Rails 7.1 update

### Notes

Not entirely convinced by this fix _but_ it appears to work and is better than log output being broken, and only affects the local development environment

### Deployment risks (optional)

- Low, only affects local development environment
