### PR TITLE
HOTT-4994 Added theme to categorisation model

### DIFF
--- a/app/models/green_lanes/categorisation.rb
+++ b/app/models/green_lanes/categorisation.rb
@@ -20,7 +20,8 @@ module GreenLanes
                   :measure_type_id,
                   :geographical_area,
                   :document_codes,
-                  :additional_codes
+                  :additional_codes,
+                  :theme
 
     class << self
       def load_categorisation

--- a/lib/tasks/green_lanes.rake
+++ b/lib/tasks/green_lanes.rake
@@ -7,11 +7,12 @@ namespace :green_lanes do
     @json = @data.map do |row|
       {
         category: row['Primary category'],
-        regulation_id: row['Regulation id'].presence.strip,
-        measure_type_id: row['Measure type ID'].presence.strip,
+        regulation_id: row['Regulation id'].presence&.strip,
+        measure_type_id: row['Measure type ID'].presence&.strip,
         geographical_area: row['Geographical area']&.presence&.strip,
         document_codes: row['Document codes'].to_s.split.map(&:strip),
         additional_codes: row['Additional codes'].to_s.split.map(&:strip),
+        theme: row['Theme'].to_s.strip,
       }
     end
 

--- a/spec/models/green_lanes/categorisation_spec.rb
+++ b/spec/models/green_lanes/categorisation_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe GreenLanes::Categorisation do
           "measure_type_id": "400",
           "geographical_area": "1000",
           "document_codes": [],
-          "additional_codes": []
+          "additional_codes": [],
+          "theme": "1.1 Sanctions"
         }]'
       end
 
@@ -28,6 +29,7 @@ RSpec.describe GreenLanes::Categorisation do
         it { is_expected.to have_attributes geographical_area: '1000' }
         it { is_expected.to have_attributes document_codes: [] }
         it { is_expected.to have_attributes additional_codes: [] }
+        it { is_expected.to have_attributes theme: '1.1 Sanctions' }
       end
     end
 
@@ -72,6 +74,7 @@ RSpec.describe GreenLanes::Categorisation do
         it { is_expected.to have_attributes geographical_area: '1000' }
         it { is_expected.to have_attributes document_codes: %w[C004 N800] }
         it { is_expected.to have_attributes additional_codes: %w[A5 R2D2] }
+        it { is_expected.to have_attributes theme: nil }
       end
     end
 


### PR DESCRIPTION
### Jira link

HOTT-4994

### What?

I have added/removed/altered:

- [x] Added theme attribute to green lanes `Categorisation` model

### Why?

I am doing this because:

- We will want to expose this in the API

### Deployment risks (optional)

- Low, private API - specs test both with and without key in JSON
