### PR TITLE
HOTT-4930 Added simple check that sync is happening

### DIFF
--- a/app/workers/synchronizer_check_worker.rb
+++ b/app/workers/synchronizer_check_worker.rb
@@ -1,7 +1,7 @@
 class SynchronizerCheckWorker
   include Sidekiq::Worker
 
-  RECENCY_THRESHOLD = 5 # days ago
+  RECENCY_THRESHOLD = 4 # days ago
 
   def perform(check_since = RECENCY_THRESHOLD)
     latest_qbe = QuotaBalanceEvent::Operation.order_by(Sequel.desc(:oid)).first

--- a/app/workers/synchronizer_check_worker.rb
+++ b/app/workers/synchronizer_check_worker.rb
@@ -1,0 +1,16 @@
+class SynchronizerCheckWorker
+  include Sidekiq::Worker
+
+  RECENCY_THRESHOLD = 5 # days ago
+
+  def perform(check_since = RECENCY_THRESHOLD)
+    latest_qbe = QuotaBalanceEvent::Operation.order_by(Sequel.desc(:oid)).first
+
+    unless latest_qbe && latest_qbe.created_at >= check_since.days.ago
+      msg = "Potential sync problem on #{TradeTariffBackend.service&.upcase} service - last update: #{latest_qbe&.created_at}"
+
+      Sentry.capture_message(msg)
+      Rails.logger.warn(msg)
+    end
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -83,3 +83,6 @@
     AverageExchangeRatesWorker:
       cron: '0 21 31 3,12 *' # Runs on end of March and December
       description: Creates average rates from downloaded data and uploads file to S3
+    SynchronizerCheckWorker:
+      cron: "30 08 * * *"
+      description: Checks we have recent Quota Balance Events - this is an early warning that our sync process has a potential issue

--- a/spec/workers/synchronizer_check_worker_spec.rb
+++ b/spec/workers/synchronizer_check_worker_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe SynchronizerCheckWorker, type: :worker do
         let(:created_at) { 10.days.ago }
 
         it 'alerts with the failing service' do
-          expect(Sentry).to have_received(:capture_message).with \
-            %r{Potential sync problem on UK service}
+          expect(Sentry).to have_received(:capture_message).with %r{CDS sync problem}
         end
       end
     end
@@ -33,8 +32,7 @@ RSpec.describe SynchronizerCheckWorker, type: :worker do
       before { described_class.new.perform }
 
       it 'alerts with the failing service' do
-        expect(Sentry).to have_received(:capture_message).with \
-          %r{Potential sync problem on UK service}
+        expect(Sentry).to have_received(:capture_message).with %r{CDS sync problem}
       end
     end
   end

--- a/spec/workers/synchronizer_check_worker_spec.rb
+++ b/spec/workers/synchronizer_check_worker_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe SynchronizerCheckWorker, type: :worker do
+  describe '#perform' do
+    before { allow(::Sentry).to receive(:capture_message) }
+
+    context 'with data' do
+      before do
+        QuotaBalanceEvent::Operation.where(oid: qbe.oid).update(created_at:)
+
+        described_class.new.perform
+      end
+
+      let(:qbe) { create :quota_balance_event }
+
+      context 'when it is up to date' do
+        let(:created_at) { 1.day.ago }
+
+        it 'takes no action' do
+          expect(Sentry).not_to have_received(:capture_message)
+        end
+      end
+
+      context 'when it is outdated' do
+        let(:created_at) { 10.days.ago }
+
+        it 'alerts with the failing service' do
+          expect(Sentry).to have_received(:capture_message).with \
+            %r{Potential sync problem on UK service}
+        end
+      end
+    end
+
+    context 'with no data' do
+      before { described_class.new.perform }
+
+      it 'alerts with the failing service' do
+        expect(Sentry).to have_received(:capture_message).with \
+          %r{Potential sync problem on UK service}
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-4930

### What?

I have added/removed/altered:

- [x] Added worker task which checks QuotaBalanceEvents have updated in the last 5 days and notifies Sentry if that is not the case

### Why?

I am doing this because:

- It should alert us if data is getting out of sync - QuotaBalanceEvent is our most frequently changing table

### Deployment risks (optional)

- None - background job, just checks the data is recent
