### PR TITLE
HOTT-5064 Added Sequel::ConnectionValidator plugin

### DIFF
--- a/config/initializers/sequel.rb
+++ b/config/initializers/sequel.rb
@@ -1,5 +1,6 @@
 Sequel.default_timezone = :utc
 Sequel.extension :pg_json
+Sequel.extension :connection_validator
 Sequel.split_symbols = true
 
 # TimeMachine is incompatible with caching of associations dataset objects. This


### PR DESCRIPTION
### Jira link

HOTT-5064

### What?

I have added/removed/altered:

- [x] Added Sequel's connection validator plugin

### Why?

I am doing this because:

- We were getting database disconnection errors over the weekend. I'm thinking this is caused by the connection timing out at points when the sites are not seeing much/any usage
- I've used this instead of the newer TransactionConnectionValidator since the majority of our queries are `SELECT` occurring outside of transactions so whilst that is lower overhead it is not well suited to our use case.

### Deployment risks (optional)

- Notable, changes database connection logic and the problem it tries to solve only occurs out of hours when we are unable to monitor the impact
