### PR TITLE
Allow the worker to have access to use the delete object method on the AWS servers for exchange rate path.

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -151,6 +151,14 @@ data "aws_iam_policy_document" "s3_policy" {
       "${data.aws_s3_bucket.reporting.arn}/*"
     ]
   }
+
+  statement {
+    effect  = "Allow"
+    actions = ["s3:DeleteObject"]
+    resources = [
+      "${data.aws_s3_bucket.persistence.arn}/data/exchange_rates/*",
+    ]
+  }
 }
 
 resource "aws_iam_policy" "s3" {


### PR DESCRIPTION
### Jira link

HOTT-5069

### What?

I have added/removed/altered:

- [ ] Allow the workers to use delete object off the S3 buckets under the exchange rate path.

### Why?

I am doing this to allow the rake tasks for rebuilding the exchange rate files to have delete access.
