### PR TITLE
HOTT-4957 Separated and delayed generation of differences report

### DIFF
--- a/app/workers/differences_report_worker.rb
+++ b/app/workers/differences_report_worker.rb
@@ -1,0 +1,23 @@
+class DifferencesReportWorker
+  include Sidekiq::Worker
+
+  sidekiq_options retry: 1, retry_in: 1.hour
+
+  def perform(deliver_email = true)
+    differences = generate_differences
+
+    if deliver_email
+      send_differences_email(differences)
+    end
+  end
+
+  private
+
+  def generate_differences
+    Reporting::Differences.generate
+  end
+
+  def send_differences_email(differences)
+    ReportsMailer.differences(differences).deliver_now
+  end
+end

--- a/lib/tasks/reporting.rake
+++ b/lib/tasks/reporting.rake
@@ -1,0 +1,11 @@
+namespace :reporting do
+  desc 'Generate all reports except differences report'
+  task generate_daily_reports: :environment do
+    ReportWorker.perform_async(false)
+  end
+
+  desc 'Generate differences report, add NOEMAIL=true to not send email'
+  task generate_differences_report: :environment do
+    DifferencesReportWorker.perform_async(ENV['NOEMAIL'] != 'true')
+  end
+end

--- a/spec/workers/differences_report_worker_spec.rb
+++ b/spec/workers/differences_report_worker_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe DifferencesReportWorker, type: :worker do
+  subject(:worker) { described_class.new }
+
+  describe '#perform' do
+    before do
+      allow(Reporting::Differences).to receive(:generate).and_return(differences)
+    end
+
+    let(:differences) { Reporting::Differences.new }
+
+    context 'when delivering email' do
+      before { worker.perform }
+
+      it { expect(Reporting::Differences).to have_received(:generate) }
+      it { expect(ActionMailer::Base.deliveries.count).to eq(1) }
+    end
+
+    context 'when not delivering email' do
+      before { worker.perform(false) }
+
+      it { expect(Reporting::Differences).to have_received(:generate) }
+      it { expect(ActionMailer::Base.deliveries.count).to eq(0) }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-4957

### What?

I have added/removed/altered:

- [x] Separated the generation of Differences report from the other reports which it depends upon
- [x] Deferred the generation of the differences report to allow for reports from both environments to be completed
- [x] Added rake tasks to manually trigger the generation of reports

### Why?

I am doing this because:

- We have had the differences report fail, this allows it to retry
- This avoids it trying to create a differences report on UK before the source reports have finished generating on XI
- This allows manually trigger report generation on days other than monday

### Deployment risks (optional)

- Low, impacts generation of reports
