### PR TITLE
HOTT-5091 Increase size of worker nodes

### DIFF
--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -21,7 +21,7 @@ module "worker_uk" {
   private_dns_namespace = "tariff.internal"
 
   cpu    = 2048
-  memory = 5120
+  memory = 8192
 
   task_role_policy_arns = [
     aws_iam_policy.exec.arn,

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -21,7 +21,7 @@ module "worker_xi" {
   private_dns_namespace = "tariff.internal"
 
   cpu    = 2048
-  memory = 5120
+  memory = 8192
 
   task_role_policy_arns = [
     aws_iam_policy.exec.arn,


### PR DESCRIPTION
### Jira link

HOTT-5091

### What?

I have added/removed/altered:

- [x] Upped the size of the worker nodes

### Why?

I am doing this because:

- We were running out of memory
- Not the best solution, code is loading a lot of data all at once but lacks tests so this is the safer fix for now

### Deployment risks (optional)

- Low, should just resize worker nodes
