### PR TITLE
HOTT-4893: Add contraint for numeric values for GET measures API.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,7 +160,7 @@ Rails.application.routes.draw do
       resources :measure_condition_codes, only: %i[index]
       resources :quota_order_numbers, only: %i[index]
       resources :measure_types, only: %i[index show]
-      resources :measures, only: %i[show]
+      resources :measures, only: %i[show], constraints: { id: /\d+/ }
 
       resources :additional_codes, only: [] do
         collection { get :search }


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-4893

### What?
Add contraint for numeric values for GET measures API.

### Why?
To prevent this kind of error: https://engine-le.sentry.io/issues/4874789117/?alert_rule_id=3445710&alert_type=issue&environment=production&notification_uuid=0babcc27-f829-4032-97af-df6eba72c9f3&project=5557005&referrer=slack