### PR TITLE
HOTT-4893 Allow measures API for negative measures

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,7 +160,7 @@ Rails.application.routes.draw do
       resources :measure_condition_codes, only: %i[index]
       resources :quota_order_numbers, only: %i[index]
       resources :measure_types, only: %i[index show]
-      resources :measures, only: %i[show], constraints: { id: /\d+/ }
+      resources :measures, only: %i[show], constraints: { id: /-?\d+/ }
 
       resources :additional_codes, only: [] do
         collection { get :search }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -74,6 +74,8 @@ RSpec.configure do |config|
     # things like nomenclature item id's risk wrapping otherwise
     FactoryBot.rewind_sequences
   end
+
+  config.after { travel_back }
 end
 
 def silence

--- a/spec/requests/api/v2/measures_controller_spec.rb
+++ b/spec/requests/api/v2/measures_controller_spec.rb
@@ -18,5 +18,11 @@ RSpec.describe Api::V2::MeasuresController do
 
       it { is_expected.to have_http_status :not_found }
     end
+
+    context 'for negative measure' do
+      let(:measure) { create(:measure, measure_sid: -2000) }
+
+      it_behaves_like 'a successful jsonapi response'
+    end
   end
 end


### PR DESCRIPTION
Previous addition of a numeric constraint on :id only allowed access to measures with sids > 0

### Jira link

HOTT-4893

### What?

I have added/removed/altered:

- [x] Allow api access to negative measures

### Why?

I am doing this because:

- we have measures with negative sids and the change to restrict id to numeric values prevented access to measures with negative sids

### Deployment risks (optional)

- Low, minor slackening of routing constraint with additional specs to cover scenario
