### PR TITLE
Runs specs for dependabot PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ filter-not-main: &filter-not-main
     branches:
       ignore:
         - main
-        - /^dependabot/(?!docker/).*/
         - /^hotfix\/.+/
 
 filter-main: &filter-main


### PR DESCRIPTION
Also allows deploying PR to QA for testing

### Jira link

HOTT-???

### What?

I have added/removed/altered:

- [x] Run specs and allow deploying dependabot PRs

### Why?

I am doing this because:

- At present dependabot PRs don't get tested at either DEV or Staging steps in the pipeline allowing us to unintentionally merge and deploy a dependabot PR which breaks our code base

### Deployment risks (optional)

- Low, just affects dependabot PRs
