### PR TITLE
Rename Green Lane origin filter

### DIFF
--- a/app/controllers/api/v2/green_lanes/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/green_lanes/goods_nomenclatures_controller.rb
@@ -6,7 +6,7 @@ module Api
           gn = ::GreenLanes::FetchGoodsNomenclatureService.new(params[:id]).call
           applicable_category_assessments = ::GreenLanes::FindCategoryAssessmentsService.call(
             goods_nomenclature: gn,
-            origin: filter_params[:origin],
+            geographical_area_id: filter_params[:geographical_area_id],
           )
 
           presented_gn = GoodsNomenclaturePresenter.new(gn, applicable_category_assessments)
@@ -25,7 +25,7 @@ module Api
 
         def filter_params
           params.fetch(:filter, {})
-                .permit(:origin)
+                .permit(:geographical_area_id)
         end
       end
     end

--- a/app/services/green_lanes/find_category_assessments_service.rb
+++ b/app/services/green_lanes/find_category_assessments_service.rb
@@ -1,11 +1,11 @@
 module GreenLanes
   class FindCategoryAssessmentsService
     class << self
-      def call(goods_nomenclature:, origin: nil)
+      def call(goods_nomenclature:, geographical_area_id: nil)
         goods_nomenclature.applicable_measures.flat_map do |measure|
           CategoryAssessment.filter(regulation_id: measure.measure_generating_regulation_id,
                                     measure_type_id: measure.measure_type_id,
-                                    geographical_area: origin)
+                                    geographical_area: geographical_area_id)
         end
       end
     end

--- a/spec/requests/api/v2/green_lanes/goods_nomenclatures_controller_spec.rb
+++ b/spec/requests/api/v2/green_lanes/goods_nomenclatures_controller_spec.rb
@@ -88,8 +88,8 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclaturesController do
       it { is_expected.to have_http_status(:not_found) }
     end
 
-    context 'when the filter "origin" is provided' do
-      let(:params) { { filter: { origin: 'AU' } } }
+    context 'when the filter "geographical_area_id" is provided' do
+      let(:params) { { filter: { geographical_area_id: 'AU' } } }
 
       before do
         allow(GreenLanes::FindCategoryAssessmentsService).to receive(:call).and_call_original
@@ -102,7 +102,7 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclaturesController do
 
         expect(GreenLanes::FindCategoryAssessmentsService)
           .to have_received(:call)
-          .with(goods_nomenclature: gn, origin: 'AU')
+          .with(goods_nomenclature: gn, geographical_area_id: 'AU')
       end
     end
   end

--- a/spec/services/green_lanes/find_category_assessments_service_spec.rb
+++ b/spec/services/green_lanes/find_category_assessments_service_spec.rb
@@ -49,9 +49,9 @@ RSpec.describe GreenLanes::FindCategoryAssessmentsService do
       expect(result).to have_attributes length: 4
     end
 
-    context 'when origin is provided' do
-      it 'filter categorisations based on origin' do
-        result = service.call(goods_nomenclature: subheading, origin: 'AU')
+    context 'when geographical_area_id is provided' do
+      it 'filter categorisations by geographical_area_id' do
+        result = service.call(goods_nomenclature: subheading, geographical_area_id: 'AU')
 
         expect(result).to have_attributes length: 2
       end


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-5113

### What?
Rename Green Lane filter[origin] to filter[geographical_area_id].

### Why?
To comply with the design in the API doc 
