### PR TITLE
HOTT-5114 add measures to category assessments

### DIFF
--- a/app/controllers/api/v2/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/api/v2/green_lanes/category_assessments_controller.rb
@@ -3,8 +3,8 @@ module Api
     module GreenLanes
       class CategoryAssessmentsController < BaseController
         def index
-          category_assessment = ::GreenLanes::CategoryAssessment.load_category_assessment
-          serializer = Api::V2::GreenLanes::CategoryAssessmentSerializer.new(category_assessment, include: %w[geographical_area excluded_geographical_areas])
+          category_assessments = ::GreenLanes::CategoryAssessment.all
+          serializer = Api::V2::GreenLanes::CategoryAssessmentSerializer.new(category_assessments, include: %w[geographical_area excluded_geographical_areas])
 
           render json: serializer.serializable_hash
         end

--- a/app/controllers/api/v2/green_lanes/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/green_lanes/goods_nomenclatures_controller.rb
@@ -10,7 +10,7 @@ module Api
               geographical_area_id: filter_params[:geographical_area_id],
             )
 
-          presented_gn = GoodsNomenclaturePresenter.new(gn, applicable_assessments_and_measures.map(&:first))
+          presented_gn = GoodsNomenclaturePresenter.new(gn, applicable_assessments_and_measures)
           serializer = Api::V2::GreenLanes::GoodsNomenclatureSerializer.new(
             presented_gn, include: %w[
               applicable_measures

--- a/app/controllers/api/v2/green_lanes/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/green_lanes/goods_nomenclatures_controller.rb
@@ -19,6 +19,7 @@ module Api
               applicable_category_assessments.geographical_area
               applicable_category_assessments.excluded_geographical_areas
               applicable_category_assessments.measures
+              applicable_category_assessments.measures.footnotes
             ]
           )
 

--- a/app/controllers/api/v2/green_lanes/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/green_lanes/goods_nomenclatures_controller.rb
@@ -4,12 +4,13 @@ module Api
       class GoodsNomenclaturesController < BaseController
         def show
           gn = ::GreenLanes::FetchGoodsNomenclatureService.new(params[:id]).call
-          applicable_category_assessments = ::GreenLanes::FindCategoryAssessmentsService.call(
-            goods_nomenclature: gn,
-            geographical_area_id: filter_params[:geographical_area_id],
-          )
+          applicable_assessments_and_measures =
+            ::GreenLanes::FindCategoryAssessmentsService.call(
+              goods_nomenclature: gn,
+              geographical_area_id: filter_params[:geographical_area_id],
+            )
 
-          presented_gn = GoodsNomenclaturePresenter.new(gn, applicable_category_assessments)
+          presented_gn = GoodsNomenclaturePresenter.new(gn, applicable_assessments_and_measures.map(&:first))
           serializer = Api::V2::GreenLanes::GoodsNomenclatureSerializer.new(
             presented_gn, include: %w[
               applicable_measures

--- a/app/controllers/api/v2/green_lanes/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/green_lanes/goods_nomenclatures_controller.rb
@@ -18,6 +18,7 @@ module Api
               applicable_category_assessments.exemptions
               applicable_category_assessments.geographical_area
               applicable_category_assessments.excluded_geographical_areas
+              applicable_category_assessments.measures
             ]
           )
 

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -50,7 +50,7 @@ module GreenLanes
 
       def load_from_string(data)
         json_array = JSON.parse(data)
-        @all = json_array.map { |json| new(json) }
+        @all = json_array.map { |json| new(json).tap(&:id).tap(&:freeze) }
       end
 
       def all

--- a/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
@@ -1,0 +1,18 @@
+module Api
+  module V2
+    module GreenLanes
+      class CategoryAssessmentPresenter < SimpleDelegator
+        attr_reader :measures
+
+        def initialize(category_assessment, measures)
+          super(category_assessment)
+          @measures = measures
+        end
+
+        def measure_ids
+          @measure_ids = measures.map(&:measure_sid)
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
@@ -6,7 +6,7 @@ module Api
 
         def initialize(category_assessment, measures)
           super(category_assessment)
-          @measures = measures
+          @measures = MeasurePresenter.wrap(measures)
         end
 
         def measure_ids

--- a/app/presenters/api/v2/green_lanes/goods_nomenclature_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/goods_nomenclature_presenter.rb
@@ -6,11 +6,9 @@ module Api
       class GoodsNomenclaturePresenter < SimpleDelegator
         attr_reader :applicable_category_assessments
 
-        def initialize(goods_nomenclature, categories_and_measures)
+        def initialize(goods_nomenclature, presented_category_assessments)
           super(goods_nomenclature)
-          @applicable_category_assessments = categories_and_measures.map do |ca, measures|
-            CategoryAssessmentPresenter.new(ca, measures)
-          end
+          @applicable_category_assessments = presented_category_assessments
         end
 
         def applicable_measure_ids

--- a/app/presenters/api/v2/green_lanes/goods_nomenclature_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/goods_nomenclature_presenter.rb
@@ -6,9 +6,11 @@ module Api
       class GoodsNomenclaturePresenter < SimpleDelegator
         attr_reader :applicable_category_assessments
 
-        def initialize(subheading, categories)
-          super(subheading)
-          @applicable_category_assessments = categories
+        def initialize(goods_nomenclature, categories_and_measures)
+          super(goods_nomenclature)
+          @applicable_category_assessments = categories_and_measures.map do |ca, measures|
+            CategoryAssessmentPresenter.new(ca, measures)
+          end
         end
 
         def applicable_measure_ids

--- a/app/presenters/api/v2/green_lanes/measure_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/measure_presenter.rb
@@ -1,0 +1,11 @@
+module Api
+  module V2
+    module GreenLanes
+      class MeasurePresenter < WrapDelegator
+        def footnote_ids
+          @footnote_ids = footnotes.map(&:code)
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/v2/green_lanes/category_assessment_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/category_assessment_serializer.rb
@@ -23,8 +23,12 @@ module Api
             raise 'Unknown type'
           end
         }
+
         has_one :geographical_area, record_type: :geographical_area, serializer: Api::V2::GeographicalAreaSerializer
         has_many :excluded_geographical_areas, record_type: :geographical_area, serializer: Api::V2::GeographicalAreaSerializer
+        has_many :measures, record_type: :measure,
+                            serializer: Api::V2::GreenLanes::MeasureSerializer,
+                            if: ->(record) { record.is_a? Api::V2::GreenLanes::CategoryAssessmentPresenter }
       end
     end
   end

--- a/app/serializers/api/v2/green_lanes/measure_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/measure_serializer.rb
@@ -1,0 +1,14 @@
+module Api
+  module V2
+    module GreenLanes
+      class MeasureSerializer
+        include JSONAPI::Serializer
+
+        set_id :measure_sid
+
+        attributes :effective_start_date,
+                   :effective_end_date
+      end
+    end
+  end
+end

--- a/app/serializers/api/v2/green_lanes/measure_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/measure_serializer.rb
@@ -9,6 +9,7 @@ module Api
         attributes :effective_start_date,
                    :effective_end_date
 
+        has_one :measure_type, type: :measure_type, serializer: Api::V2::Measures::MeasureTypeSerializer
         has_many :footnotes, type: :footnote, serializer: Api::V2::Measures::FootnoteSerializer
       end
     end

--- a/app/serializers/api/v2/green_lanes/measure_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/measure_serializer.rb
@@ -8,6 +8,8 @@ module Api
 
         attributes :effective_start_date,
                    :effective_end_date
+
+        has_many :footnotes, type: :footnote, serializer: Api::V2::Measures::FootnoteSerializer
       end
     end
   end

--- a/app/services/green_lanes/find_category_assessments_service.rb
+++ b/app/services/green_lanes/find_category_assessments_service.rb
@@ -2,11 +2,11 @@ module GreenLanes
   class FindCategoryAssessmentsService
     class << self
       def call(goods_nomenclature:, geographical_area_id: nil)
-        goods_nomenclature.applicable_measures.flat_map do |measure|
+        goods_nomenclature.applicable_measures.flat_map { |measure|
           CategoryAssessment.filter(regulation_id: measure.measure_generating_regulation_id,
                                     measure_type_id: measure.measure_type_id,
                                     geographical_area: geographical_area_id)
-        end
+        }.uniq
       end
     end
   end

--- a/app/services/green_lanes/find_category_assessments_service.rb
+++ b/app/services/green_lanes/find_category_assessments_service.rb
@@ -6,7 +6,7 @@ module GreenLanes
           CategoryAssessment.filter(regulation_id: measure.measure_generating_regulation_id,
                                     measure_type_id: measure.measure_type_id,
                                     geographical_area: geographical_area_id)
-        }.uniq
+        }.uniq(&:id)
       end
     end
   end

--- a/app/services/green_lanes/find_category_assessments_service.rb
+++ b/app/services/green_lanes/find_category_assessments_service.rb
@@ -9,7 +9,9 @@ module GreenLanes
                                        geographical_area: geographical_area_id)
           end
 
-          matches.any? ? [category_assessment, matches] : nil
+          if matches.any?
+            ::Api::V2::GreenLanes::CategoryAssessmentPresenter.new(category_assessment, matches)
+          end
         }.compact
       end
     end

--- a/app/services/green_lanes/find_category_assessments_service.rb
+++ b/app/services/green_lanes/find_category_assessments_service.rb
@@ -2,11 +2,15 @@ module GreenLanes
   class FindCategoryAssessmentsService
     class << self
       def call(goods_nomenclature:, geographical_area_id: nil)
-        goods_nomenclature.applicable_measures.flat_map { |measure|
-          CategoryAssessment.filter(regulation_id: measure.measure_generating_regulation_id,
-                                    measure_type_id: measure.measure_type_id,
-                                    geographical_area: geographical_area_id)
-        }.uniq(&:id)
+        CategoryAssessment.all.map { |category_assessment|
+          matches = goods_nomenclature.applicable_measures.select do |measure|
+            category_assessment.match?(regulation_id: measure.measure_generating_regulation_id,
+                                       measure_type_id: measure.measure_type_id,
+                                       geographical_area: geographical_area_id)
+          end
+
+          matches.any? ? [category_assessment, matches] : nil
+        }.compact
       end
     end
   end

--- a/app/services/green_lanes/find_category_assessments_service.rb
+++ b/app/services/green_lanes/find_category_assessments_service.rb
@@ -2,18 +2,40 @@ module GreenLanes
   class FindCategoryAssessmentsService
     class << self
       def call(goods_nomenclature:, geographical_area_id: nil)
-        CategoryAssessment.all.map { |category_assessment|
-          matches = goods_nomenclature.applicable_measures.select do |measure|
-            category_assessment.match?(regulation_id: measure.measure_generating_regulation_id,
-                                       measure_type_id: measure.measure_type_id,
-                                       geographical_area: geographical_area_id)
-          end
-
-          if matches.any?
-            ::Api::V2::GreenLanes::CategoryAssessmentPresenter.new(category_assessment, matches)
-          end
-        }.compact
+        new(goods_nomenclature, geographical_area_id).call
       end
+    end
+
+    def initialize(goods_nomenclature, geographical_area_id)
+      @goods_nomenclature = goods_nomenclature
+      @geographical_area_id = geographical_area_id
+    end
+
+    def call
+      CategoryAssessment.all
+                        .map(&method(:presented_matching_assessment))
+                        .compact
+    end
+
+  private
+
+    def assessment_matches_measure?(category_assessment, measure)
+      category_assessment.match?(regulation_id: measure.measure_generating_regulation_id,
+                                 measure_type_id: measure.measure_type_id,
+                                 geographical_area: @geographical_area_id)
+    end
+
+    def matching_measures(category_assessment)
+      @goods_nomenclature.applicable_measures.select do |measure|
+        assessment_matches_measure?(category_assessment, measure)
+      end
+    end
+
+    def presented_matching_assessment(category_assessment)
+      matches = matching_measures(category_assessment)
+      return if matches.empty?
+
+      ::Api::V2::GreenLanes::CategoryAssessmentPresenter.new(category_assessment, matches)
     end
   end
 end

--- a/spec/factories/green_lanes/category_assessment_factory.rb
+++ b/spec/factories/green_lanes/category_assessment_factory.rb
@@ -1,0 +1,41 @@
+FactoryBot.define do
+  factory :category_assessment, class: 'GreenLanes::CategoryAssessment' do
+    transient do
+      regulation { nil }
+      measure_type { nil }
+      measure { nil }
+      geographical_area { nil }
+    end
+
+    sequence(:regulation_id) do |index|
+      regulation&.regulation_id ||
+        measure&.measure_generating_regulation_id ||
+        sprintf('D%07d', index + 1)
+    end
+
+    sequence(:measure_type_id) do |index|
+      measure_type&.measure_type_id ||
+        measure&.measure_type_id ||
+        (400 + index + 1).to_s
+    end
+
+    geographical_area_id do
+      geographical_area&.geographical_area_id ||
+        measure&.geographical_area_id ||
+        GeographicalArea::ERGA_OMNES_ID
+    end
+
+    category { 1 }
+    document_codes { [] }
+    additional_codes { [] }
+    theme { 'test theme' }
+
+    trait :category2 do
+      category { 2 }
+    end
+
+    trait :category3 do
+      category { 3 }
+    end
+  end
+end

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe GreenLanes::CategoryAssessment do
 
       it { is_expected.to be_an Array }
       it { is_expected.to all be_instance_of described_class }
+      it { is_expected.to all be_frozen }
       it { is_expected.to have_attributes length: 10 }
 
       context 'with attributes' do
@@ -146,6 +147,7 @@ RSpec.describe GreenLanes::CategoryAssessment do
 
       it { is_expected.to be_an Array }
       it { is_expected.to all be_instance_of described_class }
+      it { is_expected.to all be_frozen }
       it { is_expected.to have_attributes length: 1 }
     end
 

--- a/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Api::V2::GreenLanes::CategoryAssessmentPresenter do
-  subject { described_class.new(category_assessment, measures) }
+  subject(:presented) { described_class.new(category_assessment, measures) }
 
   let :category_assessment do
     GreenLanes::CategoryAssessment.new(category: 1,
@@ -14,6 +14,5 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentPresenter do
   end
 
   it { is_expected.to have_attributes id: category_assessment.id }
-  it { is_expected.to have_attributes measures: }
   it { is_expected.to have_attributes measure_ids: measures.map(&:measure_sid) }
 end

--- a/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Api::V2::GreenLanes::CategoryAssessmentPresenter do
+  subject { described_class.new(category_assessment, measures) }
+
+  let :category_assessment do
+    GreenLanes::CategoryAssessment.new(category: 1,
+                                       regulation_id: 'D0000001',
+                                       measure_type_id: '400',
+                                       geographical_area_id: 'CH')
+  end
+
+  let :measures do
+    create_list(:measure, 1, measure_generating_regulation_id: 'D0000001',
+                             measure_type_id: '400')
+  end
+
+  it { is_expected.to have_attributes id: category_assessment.id }
+  it { is_expected.to have_attributes measures: }
+  it { is_expected.to have_attributes measure_ids: measures.map(&:measure_sid) }
+end

--- a/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
@@ -2,10 +2,8 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentPresenter do
   subject(:presented) { described_class.new(category_assessment, measures) }
 
   let :category_assessment do
-    GreenLanes::CategoryAssessment.new(category: 1,
-                                       regulation_id: 'D0000001',
-                                       measure_type_id: '400',
-                                       geographical_area_id: 'CH')
+    build(:category_assessment, measure: measures.first,
+                                geographical_area_id: 'CH')
   end
 
   let :measures do

--- a/spec/presenters/api/v2/green_lanes/goods_nomenclature_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/goods_nomenclature_presenter_spec.rb
@@ -1,16 +1,17 @@
 RSpec.describe Api::V2::GreenLanes::GoodsNomenclaturePresenter do
-  subject(:presenter) { described_class.new(gn, GreenLanes::CategoryAssessment.load_from_string(json_string)) }
+  subject(:presenter) { described_class.new(gn, [assessment_and_measures]) }
 
   let(:gn) { create :goods_nomenclature, :with_measures }
-  let(:json_string) do
-    '[{
-          "category": "1",
-          "regulation_id": "D0000001",
-          "measure_type_id": "400",
-          "geographical_area_id": "1000",
-          "document_codes": [],
-          "additional_codes": []
-        }]'
+  let(:first_measure) { gn.measures.first }
+  let(:assessment_and_measures) { [category_assessment, [first_measure]] }
+
+  let(:category_assessment) do
+    GreenLanes::CategoryAssessment.new \
+      regulation_id: first_measure.measure_generating_regulation_id,
+      measure_type_id: first_measure.measure_type_id,
+      geographical_area_id: '1000',
+      document_codes: [],
+      additional_codes: []
   end
 
   it { is_expected.to have_attributes goods_nomenclature_sid: gn.goods_nomenclature_sid }
@@ -20,7 +21,7 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclaturePresenter do
   end
 
   it 'includes applicable category assessment ids' do
-    expect(presenter.applicable_category_assessment_ids).to eq [GreenLanes::CategoryAssessment.all[0].id]
+    expect(presenter.applicable_category_assessment_ids).to eq [category_assessment.id]
   end
 
   describe '#applicable_measures' do
@@ -36,6 +37,6 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclaturePresenter do
 
     it { is_expected.to all(be_an(Api::V2::GreenLanes::CategoryAssessmentPresenter)) }
 
-    it { expect(applicable_category_assessments.first.id).to eq(GreenLanes::CategoryAssessment.all[0].id) }
+    it { expect(applicable_category_assessments.first.id).to eq(category_assessment.id) }
   end
 end

--- a/spec/presenters/api/v2/green_lanes/goods_nomenclature_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/goods_nomenclature_presenter_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclaturePresenter do
   describe '#applicable_category_assessments' do
     subject(:applicable_category_assessments) { presenter.applicable_category_assessments }
 
-    it { is_expected.to all(be_an(GreenLanes::CategoryAssessment)) }
+    it { is_expected.to all(be_an(Api::V2::GreenLanes::CategoryAssessmentPresenter)) }
 
     it { expect(applicable_category_assessments.first.id).to eq(GreenLanes::CategoryAssessment.all[0].id) }
   end

--- a/spec/presenters/api/v2/green_lanes/goods_nomenclature_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/goods_nomenclature_presenter_spec.rb
@@ -1,9 +1,12 @@
 RSpec.describe Api::V2::GreenLanes::GoodsNomenclaturePresenter do
-  subject(:presenter) { described_class.new(gn, [assessment_and_measures]) }
+  subject(:presenter) { described_class.new(gn, [presented_category_assessment]) }
 
   let(:gn) { create :goods_nomenclature, :with_measures }
   let(:first_measure) { gn.measures.first }
-  let(:assessment_and_measures) { [category_assessment, [first_measure]] }
+
+  let :presented_category_assessment do
+    ::Api::V2::GreenLanes::CategoryAssessmentPresenter.new category_assessment, [first_measure]
+  end
 
   let(:category_assessment) do
     build :category_assessment, measure: first_measure,

--- a/spec/presenters/api/v2/green_lanes/goods_nomenclature_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/goods_nomenclature_presenter_spec.rb
@@ -6,12 +6,8 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclaturePresenter do
   let(:assessment_and_measures) { [category_assessment, [first_measure]] }
 
   let(:category_assessment) do
-    GreenLanes::CategoryAssessment.new \
-      regulation_id: first_measure.measure_generating_regulation_id,
-      measure_type_id: first_measure.measure_type_id,
-      geographical_area_id: '1000',
-      document_codes: [],
-      additional_codes: []
+    build :category_assessment, measure: first_measure,
+                                geographical_area_id: '1000'
   end
 
   it { is_expected.to have_attributes goods_nomenclature_sid: gn.goods_nomenclature_sid }

--- a/spec/presenters/api/v2/green_lanes/measure_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/measure_presenter_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Api::V2::GreenLanes::MeasurePresenter do
+  subject { described_class.new(measure) }
+
+  let(:measure) { create :measure, :with_footnote_association }
+  let(:footnotes) { measure.footnotes }
+
+  it { is_expected.to have_attributes id: measure.measure_sid }
+  it { is_expected.to have_attributes footnotes: }
+  it { is_expected.to have_attributes footnote_ids: footnotes.map(&:code) }
+end

--- a/spec/requests/api/v2/green_lanes/category_assessments_controller_controller_spec.rb
+++ b/spec/requests/api/v2/green_lanes/category_assessments_controller_controller_spec.rb
@@ -5,7 +5,11 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentsController do
     allow(TradeTariffBackend).to receive(:service).and_return 'xi'
     create(:geographical_area, :with_reference_group_and_members, :with_description)
     create(:geographical_area, :with_reference_group_and_members, :with_description, geographical_area_id: '1008')
+    allow(GreenLanes::CategoryAssessment).to receive(:all).and_return(category_assessments)
   end
+
+  let(:category_assessments) { build_pair :category_assessment, geographical_area: }
+  let(:geographical_area) { create :geographical_area, :erga_omnes, :with_description }
 
   describe 'GET #index' do
     subject(:rendered) { make_request && response }
@@ -22,21 +26,16 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentsController do
 
     before do
       allow(TradeTariffBackend).to receive(:green_lanes_api_tokens).and_return 'Trade-Tariff-Test'
-      allow(::GreenLanes::CategoryAssessment).to receive(:load_category_assessment).and_return(::GreenLanes::CategoryAssessment.load_from_file(test_file))
     end
 
     context 'when categorisation data is found' do
-      it_behaves_like 'a successful jsonapi response' do
-        let(:test_file) { file_fixture 'green_lanes/categorisations.json' }
-      end
+      it_behaves_like 'a successful jsonapi response'
     end
 
     context 'when request on uk service' do
       before do
         allow(TradeTariffBackend).to receive(:service).and_return 'uk'
       end
-
-      let(:test_file) { file_fixture 'green_lanes/categorisations.json' }
 
       it { is_expected.to have_http_status(:not_found) }
     end
@@ -45,17 +44,11 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentsController do
   describe 'User authentication' do
     subject(:rendered) { make_request && response }
 
-    before do
-      allow(::GreenLanes::CategoryAssessment).to receive(:load_category_assessment).and_return(::GreenLanes::CategoryAssessment.load_from_file(test_file))
-    end
-
     let :make_request do
       get api_green_lanes_category_assessments_path(format: :json),
           headers: { 'Accept' => 'application/vnd.uktt.v2',
                      'HTTP_AUTHORIZATION' => authorization }
     end
-
-    let(:test_file) { file_fixture 'green_lanes/categorisations.json' }
 
     context 'when presence of incorrect bearer token' do
       let :authorization do

--- a/spec/requests/api/v2/green_lanes/goods_nomenclatures_controller_spec.rb
+++ b/spec/requests/api/v2/green_lanes/goods_nomenclatures_controller_spec.rb
@@ -3,7 +3,10 @@ require 'rails_helper'
 RSpec.describe Api::V2::GreenLanes::GoodsNomenclaturesController do
   before do
     allow(TradeTariffBackend).to receive(:service).and_return 'xi'
+    allow(GreenLanes::CategoryAssessment).to receive(:all).and_return(category_assessments)
   end
+
+  let(:category_assessments) { build_pair :category_assessment }
 
   describe 'GET #show' do
     subject(:rendered) { make_request && response }
@@ -58,23 +61,6 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclaturesController do
                :with_measures,
                goods_nomenclature_item_id: '1234560000',
                producline_suffix: '80')
-
-        GreenLanes::CategoryAssessment.load_from_string json_string
-      end
-
-      let(:json_string) do
-        '[{
-          "category": "1",
-          "regulation_id": "D0000001",
-          "measure_type_id": "400",
-          "geographical_area_id": "1000"
-        },
-        {
-          "category": "1",
-          "regulation_id": "D0000002",
-          "measure_type_id": "500",
-          "geographical_area_id": "1000"
-        }]'
       end
 
       it_behaves_like 'a successful jsonapi response'

--- a/spec/serializers/api/v2/green_lanes/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/goods_nomenclature_serializer_spec.rb
@@ -1,10 +1,11 @@
 RSpec.describe Api::V2::GreenLanes::GoodsNomenclatureSerializer do
   subject(:serialized) do
-    assessments_with_measures = [[category_assessment, [first_measure]]]
+    presented_assessments = [
+      ::Api::V2::GreenLanes::CategoryAssessmentPresenter.new(category_assessment, [first_measure]),
+    ]
 
     gn_presenter = \
-      Api::V2::GreenLanes::GoodsNomenclaturePresenter.new(subheading,
-                                                          assessments_with_measures)
+      Api::V2::GreenLanes::GoodsNomenclaturePresenter.new(subheading, presented_assessments)
 
     described_class.new(
       gn_presenter,

--- a/spec/serializers/api/v2/green_lanes/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/goods_nomenclature_serializer_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclatureSerializer do
     gn_presenter = \
       Api::V2::GreenLanes::GoodsNomenclaturePresenter.new(subheading,
                                                           assessments_with_measures)
+
     described_class.new(
       gn_presenter,
       include: %w[applicable_measures

--- a/spec/serializers/api/v2/green_lanes/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/goods_nomenclature_serializer_spec.rb
@@ -77,12 +77,7 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclatureSerializer do
   let(:first_measure) { subheading.applicable_measures.first }
 
   let :category_assessment do
-    GreenLanes::CategoryAssessment.new \
-      regulation_id: first_measure.measure_generating_regulation_id,
-      measure_type_id: first_measure.measure_type_id,
-      geographical_area_id: geographical_area.geographical_area_id,
-      document_codes: [],
-      additional_codes: []
+    build :category_assessment, measure: first_measure, geographical_area:
   end
 
   let :geographical_area do

--- a/spec/serializers/api/v2/green_lanes/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/goods_nomenclature_serializer_spec.rb
@@ -1,19 +1,22 @@
 RSpec.describe Api::V2::GreenLanes::GoodsNomenclatureSerializer do
   subject(:serialized) do
-    described_class.new(gn_presenter, include: %w[applicable_measures applicable_category_assessments applicable_category_assessments.geographical_area]).serializable_hash
+    assessments_with_measures = [[category_assessment, [first_measure]]]
+
+    gn_presenter = \
+      Api::V2::GreenLanes::GoodsNomenclaturePresenter.new(subheading,
+                                                          assessments_with_measures)
+    described_class.new(
+      gn_presenter,
+      include: %w[applicable_measures
+                  applicable_category_assessments
+                  applicable_category_assessments.geographical_area],
+    ).serializable_hash
   end
 
-  let(:gn_presenter) { Api::V2::GreenLanes::GoodsNomenclaturePresenter.new(subheading, categorisations) }
-  let(:json_string) do
-    '[{
-          "category": "1",
-          "regulation_id": "D0000001",
-          "measure_type_id": "400",
-          "geographical_area_id": "1000",
-          "document_codes": [],
-          "additional_codes": []
-        }]'
+  before do
+    allow(GreenLanes::CategoryAssessment).to receive(:all).and_return([category_assessment])
   end
+
   let(:expected_pattern) do
     {
       data: {
@@ -30,7 +33,7 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclatureSerializer do
         "relationships": {
           "applicable_measures": {
             "data": [{
-              "id": subheading.applicable_measures.first.id.to_s,
+              "id": first_measure.id.to_s,
               type: eq(:measure),
             }],
           },
@@ -54,16 +57,34 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclatureSerializer do
         {
           id: GreenLanes::CategoryAssessment.all[0].id,
           type: eq(:green_lanes_category_assessment),
+          relationships: {
+            measures: {
+              data: [
+                {
+                  id: first_measure.measure_sid.to_s,
+                  type: eq(:measure),
+                },
+              ],
+            },
+          },
         },
       ],
     }
   end
 
   let(:subheading) { create :subheading, :with_measures }
+  let(:first_measure) { subheading.applicable_measures.first }
 
-  let(:categorisations) { GreenLanes::CategoryAssessment.load_from_string(json_string) }
+  let :category_assessment do
+    GreenLanes::CategoryAssessment.new \
+      regulation_id: first_measure.measure_generating_regulation_id,
+      measure_type_id: first_measure.measure_type_id,
+      geographical_area_id: geographical_area.geographical_area_id,
+      document_codes: [],
+      additional_codes: []
+  end
 
-  before do
+  let :geographical_area do
     create(:geographical_area, :with_reference_group_and_members, :with_description, geographical_area_id: '1000')
   end
 

--- a/spec/serializers/api/v2/green_lanes/measure_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/measure_serializer_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe Api::V2::GreenLanes::MeasureSerializer do
+  subject { described_class.new(measure).serializable_hash.as_json }
+
+  let(:measure) { create :measure }
+
+  let :expected_pattern do
+    {
+      data: {
+        id: measure.measure_sid.to_s,
+        type: 'measure',
+        attributes: {
+          effective_start_date: measure.effective_start_date,
+          effective_end_date: measure.effective_end_date,
+        },
+      },
+    }
+  end
+
+  it { is_expected.to include_json(expected_pattern) }
+end

--- a/spec/serializers/api/v2/green_lanes/measure_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/measure_serializer_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe Api::V2::GreenLanes::MeasureSerializer do
           effective_end_date: measure.effective_end_date,
         },
         relationships: {
+          measure_type: {
+            data: { id: measure.measure_type.measure_type_id.to_s, type: 'measure_type' },
+          },
           footnotes: {
             data: [
               { id: measure.footnotes.first.code.to_s, type: 'footnote' },

--- a/spec/serializers/api/v2/green_lanes/measure_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/measure_serializer_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe Api::V2::GreenLanes::MeasureSerializer do
-  subject { described_class.new(measure).serializable_hash.as_json }
+  subject { described_class.new(presented).serializable_hash.as_json }
 
-  let(:measure) { create :measure }
+  let(:presented) { Api::V2::GreenLanes::MeasurePresenter.new measure }
+  let(:measure) { create :measure, :with_footnote_association }
 
   let :expected_pattern do
     {
@@ -11,6 +12,13 @@ RSpec.describe Api::V2::GreenLanes::MeasureSerializer do
         attributes: {
           effective_start_date: measure.effective_start_date,
           effective_end_date: measure.effective_end_date,
+        },
+        relationships: {
+          footnotes: {
+            data: [
+              { id: measure.footnotes.first.code.to_s, type: 'footnote' },
+            ],
+          },
         },
       },
     }

--- a/spec/services/green_lanes/find_category_assessments_service_spec.rb
+++ b/spec/services/green_lanes/find_category_assessments_service_spec.rb
@@ -41,15 +41,22 @@ RSpec.describe GreenLanes::FindCategoryAssessmentsService do
 
     context 'without origin filter' do
       it { is_expected.to have_attributes length: 4 }
+
+      it { expect(matches[0][1]).to match_array [measures[0]] }
+      it { expect(matches[1][1]).to match_array [measures[0]] }
+      it { expect(matches[2][1]).to match_array [measures[1]] }
+      it { expect(matches[3][1]).to match_array [measures[2]] }
     end
 
-    context 'when geographical_area_id is provided' do
-      subject { described_class.call(goods_nomenclature:, geographical_area_id: 'AU') }
+    context 'when origin is provided' do
+      subject(:matches) { described_class.call(goods_nomenclature:, geographical_area_id: 'AU') }
 
       it { is_expected.to have_attributes length: 2 }
+      it { expect(matches[0][1]).to match_array [measures[0]] }
+      it { expect(matches[1][1]).to match_array [measures[2]] }
     end
 
-    context 'with duplicate measures' do
+    context 'with multiple measures' do
       let(:measures) do
         [
           create(:measure, measure_generating_regulation_id: 'D0000002', measure_type_id: '500'),
@@ -58,13 +65,16 @@ RSpec.describe GreenLanes::FindCategoryAssessmentsService do
         ]
       end
 
-      let(:matched_regulation_ids) { matches.map(&:regulation_id) }
+      let(:matched_regulation_ids) { matches.map(&:first).map(&:regulation_id) }
 
       it { is_expected.to have_attributes length: 2 }
 
       it 'includes expected category assessments' do
         expect(matched_regulation_ids).to match_array %w[D0000002 D0000003]
       end
+
+      it { expect(matches[0][1]).to match_array [measures[0]] }
+      it { expect(matches[1][1]).to match_array [measures[1], measures[2]] }
     end
   end
 end

--- a/spec/services/green_lanes/find_category_assessments_service_spec.rb
+++ b/spec/services/green_lanes/find_category_assessments_service_spec.rb
@@ -38,18 +38,18 @@ RSpec.describe GreenLanes::FindCategoryAssessmentsService do
     context 'without origin filter' do
       it { is_expected.to have_attributes length: 4 }
 
-      it { expect(matches[0][1]).to match_array [measures[0]] }
-      it { expect(matches[1][1]).to match_array [measures[0]] }
-      it { expect(matches[2][1]).to match_array [measures[1]] }
-      it { expect(matches[3][1]).to match_array [measures[2]] }
+      it { expect(matches[0].measure_ids).to match_array [measures[0].measure_sid] }
+      it { expect(matches[1].measure_ids).to match_array [measures[0].measure_sid] }
+      it { expect(matches[2].measure_ids).to match_array [measures[1].measure_sid] }
+      it { expect(matches[3].measure_ids).to match_array [measures[2].measure_sid] }
     end
 
     context 'when origin is provided' do
       subject(:matches) { described_class.call(goods_nomenclature:, geographical_area_id: 'AU') }
 
       it { is_expected.to have_attributes length: 2 }
-      it { expect(matches[0][1]).to match_array [measures[0]] }
-      it { expect(matches[1][1]).to match_array [measures[2]] }
+      it { expect(matches[0].measure_ids).to match_array [measures[0].measure_sid] }
+      it { expect(matches[1].measure_ids).to match_array [measures[2].measure_sid] }
     end
 
     context 'with multiple measures' do
@@ -61,7 +61,7 @@ RSpec.describe GreenLanes::FindCategoryAssessmentsService do
         ]
       end
 
-      let(:matched_regulation_ids) { matches.map(&:first).map(&:regulation_id) }
+      let(:matched_regulation_ids) { matches.map(&:regulation_id) }
 
       it { is_expected.to have_attributes length: 2 }
 
@@ -69,8 +69,8 @@ RSpec.describe GreenLanes::FindCategoryAssessmentsService do
         expect(matched_regulation_ids).to match_array %w[D0000002 D0000003]
       end
 
-      it { expect(matches[0][1]).to match_array [measures[0]] }
-      it { expect(matches[1][1]).to match_array [measures[1], measures[2]] }
+      it { expect(matches[0].measure_ids).to match_array [measures[0].measure_sid] }
+      it { expect(matches[1].measure_ids).to match_array [measures[1].measure_sid, measures[2].measure_sid] }
     end
   end
 end

--- a/spec/services/green_lanes/find_category_assessments_service_spec.rb
+++ b/spec/services/green_lanes/find_category_assessments_service_spec.rb
@@ -20,22 +20,18 @@ RSpec.describe GreenLanes::FindCategoryAssessmentsService do
 
     let :category_assessments do
       [
-        GreenLanes::CategoryAssessment.new(category: 1,
-                                           regulation_id: 'D0000001',
-                                           measure_type_id: '400',
-                                           geographical_area_id: 'CH'),
-        GreenLanes::CategoryAssessment.new(category: 1,
-                                           regulation_id: 'D0000001',
-                                           measure_type_id: '400',
-                                           geographical_area_id: 'AU'),
-        GreenLanes::CategoryAssessment.new(category: 1,
-                                           regulation_id: 'D0000002',
-                                           measure_type_id: '500',
-                                           geographical_area_id: 'CH'),
-        GreenLanes::CategoryAssessment.new(category: 1,
-                                           regulation_id: 'D0000003',
-                                           measure_type_id: '713',
-                                           geographical_area_id: '1011'),
+        build(:category_assessment, regulation_id: 'D0000001',
+                                    measure_type_id: '400',
+                                    geographical_area_id: 'CH'),
+        build(:category_assessment, regulation_id: 'D0000001',
+                                    measure_type_id: '400',
+                                    geographical_area_id: 'AU'),
+        build(:category_assessment, regulation_id: 'D0000002',
+                                    measure_type_id: '500',
+                                    geographical_area_id: 'CH'),
+        build(:category_assessment, regulation_id: 'D0000003',
+                                    measure_type_id: '713',
+                                    geographical_area_id: '1011'),
       ]
     end
 

--- a/spec/services/green_lanes/find_category_assessments_service_spec.rb
+++ b/spec/services/green_lanes/find_category_assessments_service_spec.rb
@@ -1,19 +1,21 @@
 RSpec.describe GreenLanes::FindCategoryAssessmentsService do
   describe '#call' do
-    subject(:service) { described_class }
+    subject(:matches) { described_class.call goods_nomenclature: }
 
     before do
       GreenLanes::CategoryAssessment.load_from_string json_categorisations
 
-      allow(subheading).to receive(:applicable_measures).and_return measures
+      allow(goods_nomenclature).to receive(:applicable_measures).and_return measures
     end
 
-    let(:subheading) { create(:subheading) }
+    let(:goods_nomenclature) { create(:subheading) }
 
     let(:measures) do
-      [create(:measure, measure_generating_regulation_id: 'D0000001', measure_type_id: '400'),
-       create(:measure, measure_generating_regulation_id: 'D0000002', measure_type_id: '500'),
-       create(:measure, measure_generating_regulation_id: 'D0000003', measure_type_id: '713')]
+      [
+        create(:measure, measure_generating_regulation_id: 'D0000001', measure_type_id: '400'),
+        create(:measure, measure_generating_regulation_id: 'D0000002', measure_type_id: '500'),
+        create(:measure, measure_generating_regulation_id: 'D0000003', measure_type_id: '713'),
+      ]
     end
 
     let(:json_categorisations) do
@@ -43,17 +45,31 @@ RSpec.describe GreenLanes::FindCategoryAssessmentsService do
        }].to_json
     end
 
-    it 'returns categorisations based on applicable measures' do
-      result = service.call(goods_nomenclature: subheading)
-
-      expect(result).to have_attributes length: 4
+    context 'without origin filter' do
+      it { is_expected.to have_attributes length: 4 }
     end
 
     context 'when geographical_area_id is provided' do
-      it 'filter categorisations by geographical_area_id' do
-        result = service.call(goods_nomenclature: subheading, geographical_area_id: 'AU')
+      subject { described_class.call(goods_nomenclature:, geographical_area_id: 'AU') }
 
-        expect(result).to have_attributes length: 2
+      it { is_expected.to have_attributes length: 2 }
+    end
+
+    context 'with duplicate measures' do
+      let(:measures) do
+        [
+          create(:measure, measure_generating_regulation_id: 'D0000002', measure_type_id: '500'),
+          create(:measure, measure_generating_regulation_id: 'D0000003', measure_type_id: '713'),
+          create(:measure, measure_generating_regulation_id: 'D0000003', measure_type_id: '713'),
+        ]
+      end
+
+      let(:matched_regulation_ids) { matches.map(&:regulation_id) }
+
+      it { is_expected.to have_attributes length: 2 }
+
+      it 'includes expected category assessments' do
+        expect(matched_regulation_ids).to match_array %w[D0000002 D0000003]
       end
     end
   end

--- a/spec/services/green_lanes/find_category_assessments_service_spec.rb
+++ b/spec/services/green_lanes/find_category_assessments_service_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe GreenLanes::FindCategoryAssessmentsService do
     subject(:matches) { described_class.call goods_nomenclature: }
 
     before do
-      GreenLanes::CategoryAssessment.load_from_string json_categorisations
+      allow(GreenLanes::CategoryAssessment).to receive(:all).and_return(category_assessments)
 
       allow(goods_nomenclature).to receive(:applicable_measures).and_return measures
     end
@@ -18,31 +18,25 @@ RSpec.describe GreenLanes::FindCategoryAssessmentsService do
       ]
     end
 
-    let(:json_categorisations) do
-      [{
-        "category": '1',
-        "regulation_id": 'D0000001',
-        "measure_type_id": '400',
-        "geographical_area_id": 'CH',
-      },
-       {
-         "category": '2',
-         "regulation_id": 'D0000001',
-         "measure_type_id": '400',
-         "geographical_area_id": 'AU',
-       },
-       {
-         "category": '1',
-         "regulation_id": 'D0000002',
-         "measure_type_id": '500',
-         "geographical_area_id": 'CH',
-       },
-       {
-         "category": '2',
-         "regulation_id": 'D0000003',
-         "measure_type_id": '713',
-         "geographical_area_id": '1011', # Erga Omnes
-       }].to_json
+    let :category_assessments do
+      [
+        GreenLanes::CategoryAssessment.new(category: 1,
+                                           regulation_id: 'D0000001',
+                                           measure_type_id: '400',
+                                           geographical_area_id: 'CH'),
+        GreenLanes::CategoryAssessment.new(category: 1,
+                                           regulation_id: 'D0000001',
+                                           measure_type_id: '400',
+                                           geographical_area_id: 'AU'),
+        GreenLanes::CategoryAssessment.new(category: 1,
+                                           regulation_id: 'D0000002',
+                                           measure_type_id: '500',
+                                           geographical_area_id: 'CH'),
+        GreenLanes::CategoryAssessment.new(category: 1,
+                                           regulation_id: 'D0000003',
+                                           measure_type_id: '713',
+                                           geographical_area_id: '1011'),
+      ]
     end
 
     context 'without origin filter' do


### PR DESCRIPTION
### Jira link

HOTT-5114

### What?

I have added/removed/altered:

- [x] Reworked to FindCategoryAssessmentService to also return matching measures
- [x] Added a serialization of the matching measures
- [x] Added a serialization of the measure groups
- [x] Added a serialization of the footnotes for those measures

### Why?

I am doing this because:

- Our proposed API needs to serialize out the measures relating to CategoryAssessments

### Deployment risks (optional)

- Low, private (for now) API
