### PR TITLE
HOTT-5132 Rename entity to CategoryAssessment

### DIFF
--- a/app/serializers/api/v2/green_lanes/category_assessment_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/category_assessment_serializer.rb
@@ -4,7 +4,7 @@ module Api
       class CategoryAssessmentSerializer
         include JSONAPI::Serializer
 
-        set_type :green_lanes_category_assessment
+        set_type :category_assessment
 
         set_id :id
 

--- a/app/serializers/api/v2/green_lanes/goods_nomenclature_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/goods_nomenclature_serializer.rb
@@ -17,7 +17,7 @@ module Api
                    :description_plain,
                    :producline_suffix
 
-        has_many :applicable_category_assessments, record_type: :green_lanes_category_assessment, serializer: Api::V2::GreenLanes::CategoryAssessmentSerializer
+        has_many :applicable_category_assessments, record_type: :category_assessment, serializer: Api::V2::GreenLanes::CategoryAssessmentSerializer
       end
     end
   end

--- a/spec/serializers/api/v2/green_lanes/category_assessment_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/category_assessment_serializer_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentSerializer do
     {
       data: [
         id: be_a(String),
-        type: 'green_lanes_category_assessment',
+        type: 'category_assessment',
         attributes: {
           category: '1',
           theme: '1.1 Sanctions',

--- a/spec/serializers/api/v2/green_lanes/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/goods_nomenclature_serializer_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclatureSerializer do
           "applicable_category_assessments": {
             "data": [{
               "id": GreenLanes::CategoryAssessment.all[0].id,
-              type: eq(:green_lanes_category_assessment),
+              type: eq(:category_assessment),
             }],
           },
         },
@@ -47,7 +47,7 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclatureSerializer do
         },
         {
           id: GreenLanes::CategoryAssessment.all[0].id,
-          type: eq(:green_lanes_category_assessment),
+          type: eq(:category_assessment),
           relationships: {
             measures: {
               data: [


### PR DESCRIPTION
Was previously `green_lanes_category_assessment` but thats not the name we've been using in the docs

### Jira link

HOTT-5132

### What?

I have added/removed/altered:

- [x] Renamed `green_lanes_category_assessment` entity to `category_assessment`

### Why?

I am doing this because:

- It brings it inline with the documentation

### Deployment risks (optional)

- Low
