### PR TITLE
BAU: Remove init container config from API app

### DIFF
--- a/terraform/backend_xi.tf
+++ b/terraform/backend_xi.tf
@@ -33,10 +33,6 @@ module "backend_xi" {
     aws_iam_policy.secrets.arn
   ]
 
-  init_container            = true
-  init_container_entrypoint = [""]
-  init_container_command    = local.init_command
-
   service_environment_config = flatten([local.backend_common_vars,
     [
       {


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Removed `init_container` config from `backend_xi`.

### Why?

I am doing this because:

- It has no effect but produces errors because the database connection string is read-only.