### PR TITLE
HOTT-4567 add category assessment model

### DIFF
--- a/app/models/base_regulation.rb
+++ b/app/models/base_regulation.rb
@@ -7,6 +7,9 @@ class BaseRegulation < Sequel::Model
   one_to_one :complete_abrogation_regulation, key: %i[complete_abrogation_regulation_id
                                                       complete_abrogation_regulation_role]
 
+  one_to_many :green_lanes_category_assessments, class: :'GreenLanes::CategoryAssessment',
+                                                 key: %i[regulation_id regulation_role]
+
   def regulation_id
     base_regulation_id
   end

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -3,6 +3,8 @@ module GreenLanes
     plugin :timestamps, update_on_create: true
     plugin :auto_validations, not_null: :presence
 
+    many_to_one :theme
+
     def validate
       super
 

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -1,0 +1,21 @@
+module GreenLanes
+  class CategoryAssessment < Sequel::Model(:green_lanes_category_assessments)
+    plugin :timestamps, update_on_create: true
+    plugin :auto_validations, not_null: :presence
+
+    def validate
+      super
+
+      validates_presence :regulation_role if regulation_id.present?
+      validates_presence :regulation_id if regulation_role.present?
+
+      validates_unique %i[measure_type_id regulation_id regulation_role], where: (lambda do |ds, obj, _cols|
+        if obj.regulation_id.blank?
+          ds.where(measure_type_id: obj.measure_type_id)
+        else
+          ds.where(measure_type_id: obj.measure_type_id, regulation_id: nil, regulation_role: nil)
+        end
+      end)
+    end
+  end
+end

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -24,5 +24,26 @@ module GreenLanes
         end
       end)
     end
+
+    def regulation
+      case regulation_role
+      when nil then nil
+      when Measure::MODIFICATION_REGULATION_ROLE then modification_regulation
+      else base_regulation
+      end
+    end
+
+    def regulation=(regulation)
+      case regulation
+      when nil
+        self.base_regulation = self.modification_regulation = nil
+      when ModificationRegulation
+        self.base_regulation = nil
+        self.modification_regulation = regulation
+      else
+        self.modification_regulation = nil
+        self.base_regulation = regulation
+      end
+    end
   end
 end

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -4,6 +4,10 @@ module GreenLanes
     plugin :auto_validations, not_null: :presence
 
     many_to_one :measure_type, class: :MeasureType
+    many_to_one :base_regulation, class: :BaseRegulation,
+                                  key: %i[regulation_id regulation_role]
+    many_to_one :modification_regulation, class: :ModificationRegulation,
+                                          key: %i[regulation_id regulation_role]
     many_to_one :theme
 
     def validate

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -3,6 +3,7 @@ module GreenLanes
     plugin :timestamps, update_on_create: true
     plugin :auto_validations, not_null: :presence
 
+    many_to_one :measure_type, class: :MeasureType
     many_to_one :theme
 
     def validate

--- a/app/models/green_lanes/theme.rb
+++ b/app/models/green_lanes/theme.rb
@@ -2,5 +2,7 @@ module GreenLanes
   class Theme < Sequel::Model(:green_lanes_themes)
     plugin :timestamps, update_on_create: true
     plugin :auto_validations, not_null: :presence
+
+    one_to_many :category_assessments
   end
 end

--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -65,6 +65,8 @@ class MeasureType < Sequel::Model
 
   many_to_one :measure_type_series_description, key: :measure_type_series_id
 
+  one_to_many :green_lanes_category_assessments, class: :'GreenLanes::CategoryAssessment'
+
   delegate :description, to: :measure_type_description
 
   dataset_module do

--- a/app/models/modification_regulation.rb
+++ b/app/models/modification_regulation.rb
@@ -8,6 +8,9 @@ class ModificationRegulation < Sequel::Model
   one_to_one :base_regulation, key: %i[base_regulation_id base_regulation_role],
                                primary_key: %i[base_regulation_id base_regulation_role]
 
+  one_to_many :green_lanes_category_assessments, class: :'GreenLanes::CategoryAssessment',
+                                                 key: %i[regulation_id regulation_role]
+
   def regulation_id
     modification_regulation_id
   end

--- a/spec/factories/green_lanes/category_assessment_factory.rb
+++ b/spec/factories/green_lanes/category_assessment_factory.rb
@@ -24,18 +24,18 @@ FactoryBot.define do
         (400 + index + 1).to_s
     end
 
-    theme_id { create(:green_lanes_theme).id }
+    theme { create :green_lanes_theme }
 
     trait :category1 do
-      theme_id { create(:green_lanes_theme, :category1).id }
+      theme { create :green_lanes_theme, :category1 }
     end
 
     trait :category2 do
-      theme_id { create(:green_lanes_theme, :category2).id }
+      theme { create :green_lanes_theme, :category2 }
     end
 
     trait :category3 do
-      theme_id { create(:green_lanes_theme, :category3).id }
+      theme { create :green_lanes_theme, :category3 }
     end
   end
 end

--- a/spec/factories/green_lanes/category_assessment_factory.rb
+++ b/spec/factories/green_lanes/category_assessment_factory.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :category_assessment, class: 'GreenLanes::CategoryAssessment' do
     transient do
       regulation { nil }
-      measure_type { nil }
       measure { nil }
     end
 
@@ -18,12 +17,7 @@ FactoryBot.define do
         1
     end
 
-    sequence(:measure_type_id) do |index|
-      measure_type&.measure_type_id ||
-        measure&.measure_type_id ||
-        (400 + index + 1).to_s
-    end
-
+    measure_type { measure&.measure_type_id || create(:measure_type) }
     theme { create :green_lanes_theme }
 
     trait :category1 do

--- a/spec/factories/green_lanes/category_assessment_factory.rb
+++ b/spec/factories/green_lanes/category_assessment_factory.rb
@@ -1,23 +1,11 @@
 FactoryBot.define do
   factory :category_assessment, class: 'GreenLanes::CategoryAssessment' do
     transient do
-      regulation { nil }
       measure { nil }
     end
 
-    sequence(:regulation_id) do |index|
-      regulation&.regulation_id ||
-        measure&.measure_generating_regulation_id ||
-        sprintf('D%07d', index + 1)
-    end
-
-    regulation_role do
-      regulation&.regulation_role ||
-        measure&.measure_generating_regulation_role ||
-        1
-    end
-
-    measure_type { measure&.measure_type_id || create(:measure_type) }
+    regulation { measure&.regulation || create(:base_regulation) }
+    measure_type { measure&.measure_type || create(:measure_type) }
     theme { create :green_lanes_theme }
 
     trait :category1 do

--- a/spec/factories/green_lanes/category_assessment_factory.rb
+++ b/spec/factories/green_lanes/category_assessment_factory.rb
@@ -1,0 +1,41 @@
+FactoryBot.define do
+  factory :category_assessment, class: 'GreenLanes::CategoryAssessment' do
+    transient do
+      regulation { nil }
+      measure_type { nil }
+      measure { nil }
+    end
+
+    sequence(:regulation_id) do |index|
+      regulation&.regulation_id ||
+        measure&.measure_generating_regulation_id ||
+        sprintf('D%07d', index + 1)
+    end
+
+    regulation_role do
+      regulation&.regulation_role ||
+        measure&.measure_generating_regulation_role ||
+        1
+    end
+
+    sequence(:measure_type_id) do |index|
+      measure_type&.measure_type_id ||
+        measure&.measure_type_id ||
+        (400 + index + 1).to_s
+    end
+
+    theme_id { create(:green_lanes_theme).id }
+
+    trait :category1 do
+      theme_id { create(:green_lanes_theme, :category1).id }
+    end
+
+    trait :category2 do
+      theme_id { create(:green_lanes_theme, :category2).id }
+    end
+
+    trait :category3 do
+      theme_id { create(:green_lanes_theme, :category3).id }
+    end
+  end
+end

--- a/spec/factories/green_lanes/theme_factory.rb
+++ b/spec/factories/green_lanes/theme_factory.rb
@@ -5,5 +5,17 @@ FactoryBot.define do
     sequence(:theme)      { |n| "Theme #{n}" }
     description           { 'Some description' }
     category              { 2 }
+
+    trait :category1 do
+      category { 1 }
+    end
+
+    trait :category2 do
+      category { 2 }
+    end
+
+    trait :category3 do
+      category { 3 }
+    end
   end
 end

--- a/spec/models/base_regulation_spec.rb
+++ b/spec/models/base_regulation_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe BaseRegulation do
+  describe 'standardisation' do
+    subject(:regulation) { build :base_regulation }
+
+    it { is_expected.to have_attributes regulation_id: regulation.base_regulation_id }
+    it { is_expected.to have_attributes role: regulation.base_regulation_role }
+  end
+
+  describe 'associations' do
+    describe 'green_lanes_category_assessments' do
+      subject { base_regulation.reload.green_lanes_category_assessments }
+
+      before { category_assessment }
+
+      let(:base_regulation) { create :base_regulation }
+      let(:category_assessment) { create :category_assessment, base_regulation: }
+
+      it { is_expected.to include category_assessment }
+
+      context 'with for different regulation' do
+        subject { create(:base_regulation).reload.green_lanes_category_assessments }
+
+        it { is_expected.not_to include category_assessment }
+      end
+    end
+  end
+end

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe GreenLanes::CategoryAssessment do
+  describe 'attributes' do
+    it { is_expected.to respond_to :id }
+    it { is_expected.to respond_to :measure_type_id }
+    it { is_expected.to respond_to :regulation_id }
+    it { is_expected.to respond_to :theme_id }
+    it { is_expected.to respond_to :created_at }
+    it { is_expected.to respond_to :updated_at }
+  end
+
+  describe 'validations' do
+    subject(:errors) { instance.tap(&:valid?).errors }
+
+    let(:instance) { described_class.new }
+
+    it { is_expected.to include measure_type_id: ['is not present'] }
+    it { is_expected.not_to include :regulation_id }
+    it { is_expected.not_to include :regulation_role }
+    it { is_expected.to include theme_id: ['is not present'] }
+
+    context 'with regulation_id but not regulation_role' do
+      let(:instance) { described_class.new regulation_id: 1 }
+
+      it { is_expected.to include regulation_role: ['is not present'] }
+    end
+
+    context 'without regulation_id but with regulation_role' do
+      let(:instance) { described_class.new regulation_role: 1 }
+
+      it { is_expected.to include regulation_id: ['is not present'] }
+    end
+
+    context 'with duplicate measure_type_id and regulation_id' do
+      let(:existing) { create :category_assessment }
+
+      let :instance do
+        described_class.new measure_type_id: existing.measure_type_id,
+                            regulation_id: existing.regulation_id,
+                            regulation_role: existing.regulation_role
+      end
+
+      it { is_expected.to include %i[measure_type_id regulation_id regulation_role] => ['is already taken'] }
+    end
+
+    context 'with new category assessment for specific regulation and with existing category assessment for all regulations' do
+      let(:existing) { create :category_assessment, regulation_id: nil, regulation_role: nil }
+      let(:instance) { build :category_assessment, measure_type_id: existing.measure_type_id }
+
+      it { is_expected.to include %i[measure_type_id regulation_id regulation_role] => ['is already taken'] }
+    end
+
+    context 'with new category assessment for all regulations and existing assessment for specific regulations' do
+      let(:existing) { create :category_assessment }
+
+      let :instance do
+        build :category_assessment, measure_type_id: existing.measure_type_id,
+                                    regulation_id: nil,
+                                    regulation_role: nil
+      end
+
+      it { is_expected.to include %i[measure_type_id regulation_id regulation_role] => ['is already taken'] }
+    end
+
+    context 'with new category assessment for all regulations and existing assessment for all regulations' do
+      let(:existing) { create :category_assessment, regulation_id: nil, regulation_role: nil }
+
+      let :instance do
+        build :category_assessment, measure_type_id: existing.measure_type_id,
+                                    regulation_id: nil,
+                                    regulation_role: nil
+      end
+
+      it { is_expected.to include %i[measure_type_id regulation_id regulation_role] => ['is already taken'] }
+    end
+  end
+
+  describe 'date fields' do
+    subject { create(:category_assessment).reload }
+
+    it { is_expected.to have_attributes created_at: be_within(1.minute).of(Time.zone.now) }
+    it { is_expected.to have_attributes updated_at: be_within(1.minute).of(Time.zone.now) }
+  end
+end

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -144,4 +144,89 @@ RSpec.describe GreenLanes::CategoryAssessment do
       end
     end
   end
+
+  describe '#regulation' do
+    subject { assessment.reload.regulation }
+
+    let :assessment do
+      create :category_assessment, regulation_id: regulation&.regulation_id,
+                                   regulation_role: regulation&.role
+    end
+
+    context 'without regulation' do
+      let(:regulation) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with modification regulation' do
+      let(:regulation) { create :base_regulation }
+
+      it { is_expected.to eq regulation }
+    end
+
+    context 'with base regulation' do
+      let(:regulation) { create :modification_regulation }
+
+      it { is_expected.to eq regulation }
+    end
+  end
+
+  describe '#regulation=' do
+    subject { assessment }
+
+    before { assessment.regulation = new_regulation }
+
+    let(:persisted) { assessment.tap(&:save).reload }
+    let(:regulation) { create :base_regulation }
+
+    let :assessment do
+      create :category_assessment, regulation_id: regulation&.regulation_id,
+                                   regulation_role: regulation&.role
+    end
+
+    context 'with nil' do
+      let(:new_regulation) { nil }
+
+      it { is_expected.to have_attributes base_regulation: nil }
+      it { is_expected.to have_attributes modification_regulation: nil }
+      it { is_expected.to have_attributes regulation_id: nil, regulation_role: nil }
+      it { expect(persisted).to have_attributes regulation_id: nil, regulation_role: nil }
+    end
+
+    context 'with modification regulation' do
+      let(:new_regulation) { create :modification_regulation }
+
+      it { is_expected.to have_attributes base_regulation: nil }
+      it { is_expected.to have_attributes modification_regulation: new_regulation }
+
+      it 'is updates relationship attributes' do
+        expect(assessment).to have_attributes regulation_id: new_regulation.regulation_id,
+                                              regulation_role: new_regulation.role
+      end
+
+      it 'is is still updated after save and reload' do
+        expect(persisted).to have_attributes regulation_id: new_regulation.regulation_id,
+                                             regulation_role: new_regulation.role
+      end
+    end
+
+    context 'with base regulation' do
+      let(:regulation) { create :modification_regulation }
+      let(:new_regulation) { create :base_regulation }
+
+      it { is_expected.to have_attributes base_regulation: new_regulation }
+      it { is_expected.to have_attributes modification_regulation: nil }
+
+      it 'is updates relationship attributes' do
+        expect(assessment).to have_attributes regulation_id: new_regulation.regulation_id,
+                                              regulation_role: new_regulation.role
+      end
+
+      it 'is is still updated after save and reload' do
+        expect(persisted).to have_attributes regulation_id: new_regulation.regulation_id,
+                                             regulation_role: new_regulation.role
+      end
+    end
+  end
 end

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -82,4 +82,21 @@ RSpec.describe GreenLanes::CategoryAssessment do
     it { is_expected.to have_attributes created_at: be_within(1.minute).of(Time.zone.now) }
     it { is_expected.to have_attributes updated_at: be_within(1.minute).of(Time.zone.now) }
   end
+
+  describe 'associations' do
+    describe '#theme' do
+      subject { category_assessment.reload.theme }
+
+      let(:category_assessment) { create :category_assessment, theme: }
+      let(:theme) { create :green_lanes_theme }
+
+      it { is_expected.to eq theme }
+
+      context 'with for different theme' do
+        let(:second_theme) { create :green_lanes_theme }
+
+        it { is_expected.not_to eq second_theme }
+      end
+    end
+  end
 end

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -98,5 +98,20 @@ RSpec.describe GreenLanes::CategoryAssessment do
         it { is_expected.not_to eq second_theme }
       end
     end
+
+    describe '#measure_type' do
+      subject { category_assessment.reload.measure_type }
+
+      let(:category_assessment) { create :category_assessment, measure_type: }
+      let(:measure_type) { create :measure_type }
+
+      it { is_expected.to eq measure_type }
+
+      context 'with for different measure_type' do
+        let(:second_measure_type) { create :measure_type }
+
+        it { is_expected.not_to eq second_measure_type }
+      end
+    end
   end
 end

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -107,10 +107,40 @@ RSpec.describe GreenLanes::CategoryAssessment do
 
       it { is_expected.to eq measure_type }
 
-      context 'with for different measure_type' do
+      context 'with different measure_type' do
         let(:second_measure_type) { create :measure_type }
 
         it { is_expected.not_to eq second_measure_type }
+      end
+    end
+
+    describe '#base_regulation' do
+      subject { category_assessment.reload.base_regulation }
+
+      let(:category_assessment) { create :category_assessment, base_regulation: }
+      let(:base_regulation) { create :base_regulation }
+
+      it { is_expected.to eq base_regulation }
+
+      context 'with different base_regulation' do
+        let(:second_regulation) { create :base_regulation }
+
+        it { is_expected.not_to eq second_regulation }
+      end
+    end
+
+    describe '#modification_regulation' do
+      subject { category_assessment.reload.modification_regulation }
+
+      let(:category_assessment) { create :category_assessment, modification_regulation: }
+      let(:modification_regulation) { create :modification_regulation }
+
+      it { is_expected.to eq modification_regulation }
+
+      context 'with different modification_regulation' do
+        let(:second_regulation) { create :modification_regulation }
+
+        it { is_expected.not_to eq second_regulation }
       end
     end
   end

--- a/spec/models/green_lanes/theme_spec.rb
+++ b/spec/models/green_lanes/theme_spec.rb
@@ -46,4 +46,23 @@ RSpec.describe GreenLanes::Theme do
     it { is_expected.to have_attributes created_at: be_within(1.minute).of(Time.zone.now) }
     it { is_expected.to have_attributes updated_at: be_within(1.minute).of(Time.zone.now) }
   end
+
+  describe 'associations' do
+    describe '#category_assessments' do
+      subject { theme.reload.category_assessments }
+
+      before { category_assessment }
+
+      let(:theme) { create :green_lanes_theme }
+      let(:category_assessment) { create :category_assessment, theme: }
+
+      it { is_expected.to include category_assessment }
+
+      context 'with for different theme' do
+        subject { create(:green_lanes_theme).reload.category_assessments }
+
+        it { is_expected.not_to include category_assessment }
+      end
+    end
+  end
 end

--- a/spec/models/measure_type_spec.rb
+++ b/spec/models/measure_type_spec.rb
@@ -1,4 +1,23 @@
 RSpec.describe MeasureType do
+  describe 'associations' do
+    describe '#category_assessments' do
+      subject { measure_type.reload.green_lanes_category_assessments }
+
+      before { category_assessment }
+
+      let(:measure_type) { create :measure_type }
+      let(:category_assessment) { create :category_assessment, measure_type: }
+
+      it { is_expected.to include category_assessment }
+
+      context 'with for different measure type' do
+        subject { create(:measure_type).reload.green_lanes_category_assessments }
+
+        it { is_expected.not_to include category_assessment }
+      end
+    end
+  end
+
   describe '.excluded_measure_types' do
     subject(:excluded_measure_types) { described_class.excluded_measure_types }
 

--- a/spec/models/modification_regulation_spec.rb
+++ b/spec/models/modification_regulation_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe ModificationRegulation do
+  describe 'standardisation' do
+    subject(:regulation) { build :modification_regulation }
+
+    it { is_expected.to have_attributes regulation_id: regulation.modification_regulation_id }
+    it { is_expected.to have_attributes role: regulation.modification_regulation_role }
+  end
+
+  describe 'associations' do
+    describe 'green_lanes_category_assessments' do
+      subject { modification_regulation.reload.green_lanes_category_assessments }
+
+      before { category_assessment }
+
+      let(:modification_regulation) { create :modification_regulation }
+      let(:category_assessment) { create :category_assessment, modification_regulation: }
+
+      it { is_expected.to include category_assessment }
+
+      context 'with for different regulation' do
+        subject { create(:modification_regulation).reload.green_lanes_category_assessments }
+
+        it { is_expected.not_to include category_assessment }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-4567

### What?

I have added/removed/altered:

- [x] Added a CategoryAssessment model
- [x] Associated it with Themes, MeasureTypes, BaseRegulations and ModificationRegulations
- [x] Added standardised `regulation` accessors to hide the BaseRegulation / ModificationRegulation split

### Why?

I am doing this because:

- We will need this to implement a database backed version of the green lanes api

### Deployment risks (optional)

- Low, not used anywhere yet
