### PR TITLE
HOTT-4683 Update Canada Rules Of Origin Product Specific Rules

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/canada.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/canada.json
@@ -2,7 +2,7 @@
       "rule_sets": [
             {
                   "heading": "0101-0106",
-                  "subdivision": "",
+                  "subdivision": "0101-0106",
                   "min": "0101000000",
                   "max": "0106999999",
                   "rules": [
@@ -22,7 +22,7 @@
             },
             {
                   "heading": "0201-0210",
-                  "subdivision": "",
+                  "subdivision": "0201-0210",
                   "min": "0201000000",
                   "max": "0210999999",
                   "rules": [
@@ -41,10 +41,10 @@
                   "valid": true
             },
             {
-                  "heading": "0301-0309",
-                  "subdivision": "",
+                  "heading": "0301-0308",
+                  "subdivision": "0301-0308",
                   "min": "0301000000",
-                  "max": "0309999999",
+                  "max": "0308999999",
                   "rules": [
                         {
                               "rule": "Production in which all the material of [chapter&nbsp;3](/chapters/03) used is wholly obtained.",
@@ -62,16 +62,18 @@
             },
             {
                   "heading": "ex 030483",
-                  "subdivision": "",
+                  "subdivision": "Frozen fillets of halibut, other than Reinhardtius hippoglossoides (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "0304830000",
                   "max": "0304839999",
                   "rules": [
                         {
-                              "rule": "Frozen fillets of halibut, other than Reinhardtius hippoglossoides, a change from any other heading, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other heading. It is understood that the production is beyond the insufficient production provided in Article 7.",
+                              "class": [
+                                    "CTH"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -80,16 +82,18 @@
             },
             {
                   "heading": "ex 030612",
-                  "subdivision": "",
+                  "subdivision": "Cooked and frozen lobster (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "0306120000",
                   "max": "0306129999",
                   "rules": [
                         {
-                              "rule": "Cooked and frozen lobster, a change from any other subheading, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other subheading.",
+                              "class": [
+                                    "CTSH"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -98,7 +102,7 @@
             },
             {
                   "heading": "0401",
-                  "subdivision": "",
+                  "subdivision": "Heading 0401",
                   "min": "0401000000",
                   "max": "0401999999",
                   "rules": [
@@ -119,16 +123,14 @@
             },
             {
                   "heading": "040210",
-                  "subdivision": "",
+                  "subdivision": "Subheading 040210",
                   "min": "0402100000",
                   "max": "0402199999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, except from dairy preparations of [subheading&nbsp;190190](/subheading/1901900000-80) containing more than **10%** by dry weight of milk solids, provided that:\n\n\n- a) all the material of [chapter&nbsp;4](/chapters/04) used is wholly obtained, *and*\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product.",
+                              "rule": "A change from any other chapter, except from dairy preparations of [subheading&nbsp;190190](/subheading/1901900000-80) containing more than **10%** by dry weight of milk solids, provided that:\n\n- all the material of [chapter&nbsp;4](/chapters/04) used is wholly obtained, and \n\n- the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product.",
                               "class": [
-                                    "WO",
-                                    "CC EXCEPT RESTRICTION WO",
-                                    "MAXWEIGHT"
+                                    "WO"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -141,16 +143,14 @@
             },
             {
                   "heading": "040221-040299",
-                  "subdivision": "",
+                  "subdivision": "040221-040299",
                   "min": "0402210000",
                   "max": "0402999999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, except from dairy preparations of [subheading&nbsp;190190](/subheading/1901900000-80) containing more than **10%** by dry weight of milk solids, provided that:\n\n\n- a) all the material of [chapter&nbsp;4](/chapters/04) used is wholly obtained, *and*\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other chapter, except from dairy preparations of [subheading&nbsp;190190](/subheading/1901900000-80) containing more than **10%** by dry weight of milk solids, provided that: \n\n- all the material of [chapter&nbsp;4](/chapters/04) used is wholly obtained, and \n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
-                                    "WO",
-                                    "CC EXCEPT RESTRICTION WO",
-                                    "MAXWEIGHT"
+                                    "WO"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -163,16 +163,14 @@
             },
             {
                   "heading": "0403-0406",
-                  "subdivision": "",
+                  "subdivision": "0403-0406",
                   "min": "0403000000",
                   "max": "0406999999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, except from dairy preparations of [subheading&nbsp;190190](/subheading/1901900000-80) containing more than **10%** by dry weight of milk solids, provided that:\n\n- a) all the material of [chapter&nbsp;4](/chapters/04) used is wholly obtained, *and*\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other chapter, except from dairy preparations of [subheading&nbsp;190190](/subheading/1901900000-80) containing more than **10%** by dry weight of milk solids, provided that: \n\n- all the material of [chapter&nbsp;4](/chapters/04) used is wholly obtained, *and*\n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
-                                    "WO",
-                                    "CC EXCEPT RESTRICTION WO",
-                                    "MAXWEIGHT"
+                                    "WO"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -185,15 +183,14 @@
             },
             {
                   "heading": "0407-0410",
-                  "subdivision": "",
+                  "subdivision": "0407-0410",
                   "min": "0407000000",
                   "max": "0410999999",
                   "rules": [
                         {
-                              "rule": "Production in which:\n\n- a) all the material of [chapter&nbsp;4](/chapters/04) used is wholly obtained, *and*\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "Production in which: \n\n- all the material of [chapter&nbsp;4](/chapters/04) used is wholly obtained, *and*\n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
-                                    "WO",
-                                    "MAXWEIGHT"
+                                    "WO"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -206,7 +203,7 @@
             },
             {
                   "heading": "050100-051199",
-                  "subdivision": "",
+                  "subdivision": "050100-051199",
                   "min": "0501000000",
                   "max": "0511999999",
                   "rules": [
@@ -226,7 +223,7 @@
             },
             {
                   "heading": "0601-0604",
-                  "subdivision": "",
+                  "subdivision": "0601-0604",
                   "min": "0601000000",
                   "max": "0604999999",
                   "rules": [
@@ -246,7 +243,7 @@
             },
             {
                   "heading": "0701-0709",
-                  "subdivision": "",
+                  "subdivision": "0701-0709",
                   "min": "0701000000",
                   "max": "0709999999",
                   "rules": [
@@ -266,7 +263,7 @@
             },
             {
                   "heading": "071010-071080",
-                  "subdivision": "",
+                  "subdivision": "071010-071080",
                   "min": "0710100000",
                   "max": "0710899999",
                   "rules": [
@@ -286,16 +283,13 @@
             },
             {
                   "heading": "071090",
-                  "subdivision": "",
+                  "subdivision": "Subheading 071090",
                   "min": "0710900000",
                   "max": "0710999999",
                   "rules": [
                         {
-                              "rule": "A change from any other subheading, provided that:\n\n- a) the net weight of non-originating asparagus, beans, broccoli, cabbage, carrots, cauliflower, courgettes, cucumbers, gherkins, globe artichokes, mushrooms, onions, peas, potatoes, sweet corn, sweet peppers and tomatoes of [chapter&nbsp;7](/chapters/07) used in production does not exceed **20%** of the net weight of the product, *and*\n\n- b) the net weight of non-originating vegetables of [chapter&nbsp;7](/chapters/07) used in production does not exceed **50%** of the net weight of the product.",
-                              "class": [
-                                    "CTSH RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
-                              ],
+                              "rule": "A change from any other subheading, provided that:\n\n- the net weight of non-originating asparagus, beans, broccoli, cabbage, carrots, cauliflower, courgettes, cucumbers, gherkins, globe artichokes, mushrooms, onions, peas, potatoes, sweet corn, sweet peppers and tomatoes of [chapter&nbsp;7](/chapters/07) used in production does not exceed **20%** of the net weight of the product, *and*\n\n- the net weight of non-originating vegetables of [chapter&nbsp;7](/chapters/07) used in production does not exceed **50%** of the net weight of the product.",
+                              "class": [],
                               "footnotes": [],
                               "operator": null,
                               "quota": false,
@@ -307,7 +301,7 @@
             },
             {
                   "heading": "0711",
-                  "subdivision": "",
+                  "subdivision": "Heading 0711",
                   "min": "0711000000",
                   "max": "0711999999",
                   "rules": [
@@ -327,7 +321,7 @@
             },
             {
                   "heading": "071220-071239",
-                  "subdivision": "",
+                  "subdivision": "071220-071239",
                   "min": "0712200000",
                   "max": "0712399999",
                   "rules": [
@@ -347,16 +341,13 @@
             },
             {
                   "heading": "071290",
-                  "subdivision": "",
+                  "subdivision": "Subheading 071290",
                   "min": "0712900000",
                   "max": "0712999999",
                   "rules": [
                         {
-                              "rule": "A change to mixtures of dried vegetables from single dried vegetables from within this subheading or any other subheading, provided that:\n\n- a) the net weight of non-originating cabbage, carrots, courgettes, cucumbers, gherkins, globe artichokes, mushrooms, potatoes, sweet corn, sweet peppers, tomatoes and turnips of [chapter&nbsp;7](/chapters/07) used in production does not exceed **20%** of the net weight of the product, *and*\n\n- b) the net weight of non-originating vegetables of [chapter&nbsp;7](/chapters/07) used in production does not exceed **50%** of the net weight of the product.",
-                              "class": [
-                                    "AH RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
-                              ],
+                              "rule": "A change to mixtures of dried vegetables from single dried vegetables from within this subheading or any other subheading, provided that: \n\n- the net weight of non-originating cabbage, carrots, courgettes, cucumbers, gherkins, globe artichokes, mushrooms, potatoes, sweet corn, sweet peppers, tomatoes and turnips of [chapter&nbsp;7](/chapters/07) used in production does not exceed **20%** of the net weight of the product, *and*\n\n- the net weight of non-originating vegetables of [chapter&nbsp;7](/chapters/07) used in production does not exceed **50%** of the net weight of the product.",
+                              "class": [],
                               "footnotes": [],
                               "operator": null,
                               "quota": false,
@@ -379,7 +370,7 @@
             },
             {
                   "heading": "0713-0714",
-                  "subdivision": "",
+                  "subdivision": "0713-0714",
                   "min": "0713000000",
                   "max": "0714999999",
                   "rules": [
@@ -399,7 +390,7 @@
             },
             {
                   "heading": "0801-0810",
-                  "subdivision": "",
+                  "subdivision": "0801-0810",
                   "min": "0801000000",
                   "max": "0810999999",
                   "rules": [
@@ -419,15 +410,14 @@
             },
             {
                   "heading": "0811",
-                  "subdivision": "",
+                  "subdivision": "Heading 0811",
                   "min": "0811000000",
                   "max": "0811999999",
                   "rules": [
                         {
-                              "rule": "Production in which:\n\n- a) all the material of [chapter&nbsp;8](/chapters/08) used is wholly obtained, *and*\n\n- b) the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product.",
+                              "rule": "Production in which:\n\n- all the material of [chapter&nbsp;8](/chapters/08) used is wholly obtained, and \n\n- the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product.",
                               "class": [
-                                    "WO",
-                                    "MAXWEIGHT"
+                                    "WO"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -440,7 +430,7 @@
             },
             {
                   "heading": "0812",
-                  "subdivision": "",
+                  "subdivision": "Heading 0812",
                   "min": "0812000000",
                   "max": "0812999999",
                   "rules": [
@@ -460,7 +450,7 @@
             },
             {
                   "heading": "081310-081340",
-                  "subdivision": "",
+                  "subdivision": "081310-081340",
                   "min": "0813100000",
                   "max": "0813499999",
                   "rules": [
@@ -480,16 +470,13 @@
             },
             {
                   "heading": "081350",
-                  "subdivision": "",
+                  "subdivision": "Subheading 081350",
                   "min": "0813500000",
                   "max": "0813599999",
                   "rules": [
                         {
-                              "rule": "A change from any other subheading, provided that:\n\n- a) the net weight of non-originating almonds, apples, apricots, bananas, cherries, chestnuts, citrus fruit, figs, grapes, hazelnuts, nectarines, peaches, pears, plums and walnuts of [chapter&nbsp;8](/chapters/08) used in production does not exceed **20%** of the net weight of the product,\n\n- b) the net weight of non-originating fruits and nuts other than almonds, apples, apricots, bananas, brazil nuts, carambola, cashew apples, cashew nuts, cherries, chestnuts, citrus fruit, coconuts, figs, grapes, guava, hazelnuts, jackfruit, lychees, macadamia nuts, mangoes, mangosteens, nectarines, papaws (papaya), passion fruit, peaches, pears, pistachios, pitahaya, plums, tamarinds or walnuts of [chapter&nbsp;8](/chapters/08) used in production does not exceed **50%** of the net weight of the product, *and*\n\n- c) the net weight of non-originating fruits and nuts of [chapter&nbsp;8](/chapters/08) used in production does not exceed **80%** of the net weight of the product.",
-                              "class": [
-                                    "CTSH RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
-                              ],
+                              "rule": "A change from any other subheading, provided that: \n\n- the net weight of non-originating almonds, apples, apricots, bananas, cherries, chestnuts, citrus fruit, figs, grapes, hazelnuts, nectarines, peaches, pears, plums and walnuts of [chapter&nbsp;8](/chapters/08) used in production does not exceed **20%** of the net weight of the product, \n\n- the net weight of non-originating fruits and nuts other than almonds, apples, apricots, bananas, brazil nuts, carambola, cashew apples, cashew nuts, cherries, chestnuts, citrus fruit, coconuts, figs, grapes, guava, hazelnuts, jackfruit, lychees, macadamia nuts, mangoes, mangosteens, nectarines, papaws (papaya), passion fruit, peaches, pears, pistachios, pitahaya, plums, tamarinds or walnuts of [chapter&nbsp;8](/chapters/08) used in production does not exceed **50%** of the net weight of the product, and \n\n- the net weight of non-originating fruits and nuts of [chapter&nbsp;8](/chapters/08) used in production does not exceed **80%** of the net weight of the product.",
+                              "class": [],
                               "footnotes": [],
                               "operator": null,
                               "quota": false,
@@ -501,7 +488,7 @@
             },
             {
                   "heading": "0814",
-                  "subdivision": "",
+                  "subdivision": "Heading 0814",
                   "min": "0814000000",
                   "max": "0814999999",
                   "rules": [
@@ -521,7 +508,7 @@
             },
             {
                   "heading": "090111-090190",
-                  "subdivision": "",
+                  "subdivision": "090111-090190",
                   "min": "0901110000",
                   "max": "0901999999",
                   "rules": [
@@ -541,7 +528,7 @@
             },
             {
                   "heading": "090210-091099",
-                  "subdivision": "",
+                  "subdivision": "090210-091099",
                   "min": "0902100000",
                   "max": "0910999999",
                   "rules": [
@@ -561,7 +548,7 @@
             },
             {
                   "heading": "1001-1008",
-                  "subdivision": "",
+                  "subdivision": "1001-1008",
                   "min": "1001000000",
                   "max": "1008999999",
                   "rules": [
@@ -581,7 +568,7 @@
             },
             {
                   "heading": "1101-1109",
-                  "subdivision": "",
+                  "subdivision": "1101-1109",
                   "min": "1101000000",
                   "max": "1109999999",
                   "rules": [
@@ -601,7 +588,7 @@
             },
             {
                   "heading": "1201-1207",
-                  "subdivision": "",
+                  "subdivision": "1201-1207",
                   "min": "1201000000",
                   "max": "1207999999",
                   "rules": [
@@ -621,7 +608,7 @@
             },
             {
                   "heading": "1208",
-                  "subdivision": "",
+                  "subdivision": "Heading 1208",
                   "min": "1208000000",
                   "max": "1208999999",
                   "rules": [
@@ -641,7 +628,7 @@
             },
             {
                   "heading": "1209-1214",
-                  "subdivision": "",
+                  "subdivision": "1209-1214",
                   "min": "1209000000",
                   "max": "1214999999",
                   "rules": [
@@ -661,7 +648,7 @@
             },
             {
                   "heading": "130120-130190",
-                  "subdivision": "",
+                  "subdivision": "130120-130190",
                   "min": "1301200000",
                   "max": "1301999999",
                   "rules": [
@@ -680,9 +667,69 @@
                   "valid": true
             },
             {
-                  "heading": "130211-130239",
-                  "subdivision": "",
+                  "heading": "130211-130219",
+                  "subdivision": "130211-130219",
                   "min": "1302110000",
+                  "max": "1302199999",
+                  "rules": [
+                        {
+                              "rule": "A change from within any one of these subheading or any other subheading, provided that the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
+                              "class": [
+                                    "AH RESTRICTION MAXWEIGHT"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "130220",
+                  "subdivision": "Pectic substances, pectinates and pectates, containing added sugar of subheading 170191 through 170199 (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "1302200000",
+                  "max": "1302299999",
+                  "rules": [
+                        {
+                              "rule": "A change from within this subheading or any other subheading, except from [subheading&nbsp;170191](/subheading/1701910000-80) through 170199.",
+                              "class": [
+                                    "CTSH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "130220",
+                  "subdivision": "Other pectic substances, pectinates and pectates",
+                  "min": "1302200000",
+                  "max": "1302299999",
+                  "rules": [
+                        {
+                              "rule": "A change from within any one of these subheading or any other subheading, provided that the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
+                              "class": [
+                                    "AH RESTRICTION MAXWEIGHT"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "130231-130239",
+                  "subdivision": "130231-130239",
+                  "min": "1302310000",
                   "max": "1302399999",
                   "rules": [
                         {
@@ -700,26 +747,8 @@
                   "valid": true
             },
             {
-                  "heading": "ex 130220",
-                  "subdivision": "",
-                  "min": "1302200000",
-                  "max": "1302299999",
-                  "rules": [
-                        {
-                              "rule": "A change from within this subheading or any other subheading, except from [subheading&nbsp;170191](/subheading/1701910000-80) through 170199, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "140110-140490",
-                  "subdivision": "",
+                  "subdivision": "140110-140490",
                   "min": "1401100000",
                   "max": "1404999999",
                   "rules": [
@@ -739,7 +768,7 @@
             },
             {
                   "heading": "1501-1504",
-                  "subdivision": "",
+                  "subdivision": "1501-1504",
                   "min": "1501000000",
                   "max": "1504999999",
                   "rules": [
@@ -759,7 +788,7 @@
             },
             {
                   "heading": "1505",
-                  "subdivision": "",
+                  "subdivision": "Heading 1505",
                   "min": "1505000000",
                   "max": "1505999999",
                   "rules": [
@@ -779,7 +808,7 @@
             },
             {
                   "heading": "1506",
-                  "subdivision": "",
+                  "subdivision": "Heading 1506",
                   "min": "1506000000",
                   "max": "1506999999",
                   "rules": [
@@ -799,7 +828,7 @@
             },
             {
                   "heading": "1507-1508",
-                  "subdivision": "",
+                  "subdivision": "1507-1508",
                   "min": "1507000000",
                   "max": "1508999999",
                   "rules": [
@@ -819,7 +848,7 @@
             },
             {
                   "heading": "1509-1510",
-                  "subdivision": "",
+                  "subdivision": "1509-1510",
                   "min": "1509000000",
                   "max": "1510999999",
                   "rules": [
@@ -839,7 +868,7 @@
             },
             {
                   "heading": "1511-1515",
-                  "subdivision": "",
+                  "subdivision": "1511-1515",
                   "min": "1511000000",
                   "max": "1515999999",
                   "rules": [
@@ -859,7 +888,7 @@
             },
             {
                   "heading": "151610",
-                  "subdivision": "",
+                  "subdivision": "Subheading 151610",
                   "min": "1516100000",
                   "max": "1516199999",
                   "rules": [
@@ -879,7 +908,7 @@
             },
             {
                   "heading": "151620",
-                  "subdivision": "",
+                  "subdivision": "Subheading 151620",
                   "min": "1516200000",
                   "max": "1516299999",
                   "rules": [
@@ -899,7 +928,7 @@
             },
             {
                   "heading": "1517",
-                  "subdivision": "",
+                  "subdivision": "Heading 1517",
                   "min": "1517000000",
                   "max": "1517999999",
                   "rules": [
@@ -920,13 +949,15 @@
             },
             {
                   "heading": "1518",
-                  "subdivision": "",
+                  "subdivision": "Heading 1518",
                   "min": "1518000000",
                   "max": "1518999999",
                   "rules": [
                         {
-                              "rule": "Note:\n\nFor the purposes of the rule of origin for [heading&nbsp;1518](/headings/1518) which references insoluble impurity content, this content is to be measured using American Oil Chemists' Society method Ca 3a-46.\n\nA change to single vegetable fats or oils or their fractions from any other chapter.",
-                              "class": [],
+                              "rule": "A change to single vegetable fats or oils or their fractions from any other chapter.",
+                              "class": [
+                                    "CC"
+                              ],
                               "footnotes": [],
                               "operator": null,
                               "quota": false,
@@ -943,7 +974,7 @@
                               "export": true
                         },
                         {
-                              "rule": "A change to any other product of [heading&nbsp;1518](/headings/1518) from any other heading.",
+                              "rule": "A change to any other product of [heading&nbsp;1518](/headings/1518) from any other heading.\n\n**Note:**\n\nFor the purposes of the rule of origin for [heading&nbsp;1518](/headings/1518) which references insoluble impurity content, this content is to be measured using American Oil Chemists' Society method Ca 3a-46.",
                               "class": [],
                               "footnotes": [],
                               "operator": "or",
@@ -956,7 +987,7 @@
             },
             {
                   "heading": "1520",
-                  "subdivision": "",
+                  "subdivision": "Heading 1520",
                   "min": "1520000000",
                   "max": "1520999999",
                   "rules": [
@@ -976,7 +1007,7 @@
             },
             {
                   "heading": "1521-1522",
-                  "subdivision": "",
+                  "subdivision": "1521-1522",
                   "min": "1521000000",
                   "max": "1522999999",
                   "rules": [
@@ -996,7 +1027,7 @@
             },
             {
                   "heading": "1601-1602",
-                  "subdivision": "",
+                  "subdivision": "1601-1602",
                   "min": "1601000000",
                   "max": "1602999999",
                   "rules": [
@@ -1016,7 +1047,7 @@
             },
             {
                   "heading": "1603",
-                  "subdivision": "",
+                  "subdivision": "Heading 1603",
                   "min": "1603000000",
                   "max": "1603999999",
                   "rules": [
@@ -1036,7 +1067,7 @@
             },
             {
                   "heading": "1604-1605",
-                  "subdivision": "",
+                  "subdivision": "1604-1605",
                   "min": "1604000000",
                   "max": "1605999999",
                   "rules": [
@@ -1056,16 +1087,18 @@
             },
             {
                   "heading": "160411",
-                  "subdivision": "",
+                  "subdivision": "Prepared or preserved salmon",
                   "min": "1604110000",
                   "max": "1604119999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter.",
+                              "class": [
+                                    "CC"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -1074,16 +1107,18 @@
             },
             {
                   "heading": "160412",
-                  "subdivision": "",
+                  "subdivision": "Prepared or preserved herring (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "1604120000",
                   "max": "1604129999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter.",
+                              "class": [
+                                    "CC"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -1092,16 +1127,18 @@
             },
             {
                   "heading": "ex 160413",
-                  "subdivision": "",
+                  "subdivision": "Prepared or preserved sardines, sardinella and brisling or sprats, excluding Sardina pilchardus (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "1604130000",
                   "max": "1604139999",
                   "rules": [
                         {
-                              "rule": "Prepared or preserved sardines, sardinella and brisling or sprats, excluding Sardina pilchardus, a change from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter.",
+                              "class": [
+                                    "CC"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -1110,16 +1147,18 @@
             },
             {
                   "heading": "ex 160510",
-                  "subdivision": "",
+                  "subdivision": "Prepared or preserved crab, other than Cancer pagurus (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "1605100000",
                   "max": "1605199999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter.",
+                              "class": [
+                                    "CC"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -1128,16 +1167,18 @@
             },
             {
                   "heading": "160521-160529",
-                  "subdivision": "",
+                  "subdivision": "Prepared or preserved shrimps and prawns (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "1605210000",
                   "max": "1605299999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter.",
+                              "class": [
+                                    "CC"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -1146,16 +1187,18 @@
             },
             {
                   "heading": "160530",
-                  "subdivision": "",
+                  "subdivision": "Prepared and preserved lobster (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "1605300000",
                   "max": "1605399999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter.",
+                              "class": [
+                                    "CC"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -1164,7 +1207,7 @@
             },
             {
                   "heading": "1701",
-                  "subdivision": "",
+                  "subdivision": "Heading 1701",
                   "min": "1701000000",
                   "max": "1701999999",
                   "rules": [
@@ -1184,7 +1227,7 @@
             },
             {
                   "heading": "1702",
-                  "subdivision": "",
+                  "subdivision": "Heading 1702",
                   "min": "1702000000",
                   "max": "1702999999",
                   "rules": [
@@ -1206,7 +1249,7 @@
             },
             {
                   "heading": "1703",
-                  "subdivision": "",
+                  "subdivision": "Heading 1703",
                   "min": "1703000000",
                   "max": "1703999999",
                   "rules": [
@@ -1226,16 +1269,14 @@
             },
             {
                   "heading": "1704",
-                  "subdivision": "",
+                  "subdivision": "Sugar confectionery (including white chocolate), not containing cocoa (*quota for exports from Canada into the United Kingdom*)",
                   "min": "1704000000",
                   "max": "1704999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n- a) \n\n- i) the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product or (ii) the value of non-originating sugar used in production does not exceed **30%** of the transaction value or ex-works price of the product *and*\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other heading.",
                               "class": [
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT OR MAXNOM",
-                                    "MAXWEIGHT"
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -1248,18 +1289,18 @@
             },
             {
                   "heading": "1704",
-                  "subdivision": "",
+                  "subdivision": "Other sugar confectionery (including white chocolate), not containing cocoa",
                   "min": "1704000000",
                   "max": "1704999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading. **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product, or\n\n- the value of non-originating sugar used in production does not exceed **30%** of the transaction value or ex-works price of the product, *and*\n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
-                                    "CTH"
+                                    "MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -1268,7 +1309,7 @@
             },
             {
                   "heading": "1801-1802",
-                  "subdivision": "",
+                  "subdivision": "1801-1802",
                   "min": "1801000000",
                   "max": "1802999999",
                   "rules": [
@@ -1288,7 +1329,7 @@
             },
             {
                   "heading": "180310-180320",
-                  "subdivision": "",
+                  "subdivision": "180310-180320",
                   "min": "1803100000",
                   "max": "1803299999",
                   "rules": [
@@ -1308,7 +1349,7 @@
             },
             {
                   "heading": "1804-1805",
-                  "subdivision": "",
+                  "subdivision": "1804-1805",
                   "min": "1804000000",
                   "max": "1805999999",
                   "rules": [
@@ -1327,18 +1368,14 @@
                   "valid": true
             },
             {
-                  "heading": "1806",
-                  "subdivision": "",
-                  "min": "1806000000",
-                  "max": "1806999999",
+                  "heading": "ex 180610",
+                  "subdivision": "Cocoa powder, containing added sugar of subheading 170191 through 170199 (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "1806100000",
+                  "max": "1806199999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n- a) \n\n- i) the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product or (ii) the value of non-originating sugar used in production does not exceed **30%** of the transaction value or ex-works price of the product, *and*\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT OR MAXNOM",
-                                    "MAXWEIGHT"
-                              ],
+                              "rule": "A change from any other subheading, except from [subheading&nbsp;170191](/subheading/1701910000-80) through 170199.",
+                              "class": [],
                               "footnotes": [],
                               "operator": null,
                               "quota": false,
@@ -1350,16 +1387,18 @@
             },
             {
                   "heading": "ex 180610",
-                  "subdivision": "",
+                  "subdivision": "Other cocoa powder, containing added sugar or other sweetening matter",
                   "min": "1806100000",
                   "max": "1806199999",
                   "rules": [
                         {
-                              "rule": "A change from any other subheading, except from [subheading&nbsp;170191](/subheading/1701910000-80) through 170199. **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product, or\n\n- the value of non-originating sugar used in production does not exceed **30%** of the transaction value or ex-works price of the product, *and*\n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -1368,16 +1407,18 @@
             },
             {
                   "heading": "ex 180620",
-                  "subdivision": "",
+                  "subdivision": "Preparations containing added sugar of subheading 170191 through 170199 for the preparation of chocolate beverages (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "1806200000",
                   "max": "1806299999",
                   "rules": [
                         {
-                              "rule": "A change from within this subheading or any other subheading, except from [subheading&nbsp;170191](/subheading/1701910000-80) through 170199. **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from within this subheading or any other subheading, except from [subheading&nbsp;170191](/subheading/1701910000-80) through 170199.",
+                              "class": [
+                                    "CTSH"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -1385,17 +1426,39 @@
                   "valid": true
             },
             {
-                  "heading": "180631",
-                  "subdivision": "",
+                  "heading": "ex 180620",
+                  "subdivision": "Other preparations in blocks, slabs or bars weighing more than 2 kg or in liquid, paste, powder, granular or other bulk form in containers or immediate packings, of a content exceeding 2 kg",
+                  "min": "1806200000",
+                  "max": "1806299999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product, or\n\n- the value of non-originating sugar used in production does not exceed **30%** of the transaction value or ex-works price of the product, *and*\n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex 180631",
+                  "subdivision": "Chocolate and other food preparations containing cocoa, in blocks, slabs or bars, filled, weighing no more than 2 kilograms (*quota for exports from Canada into the United Kingdom*)",
                   "min": "1806310000",
                   "max": "1806319999",
                   "rules": [
                         {
-                              "rule": "A change from any other subheading, provided that the change is the result of more than packaging. **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other subheading, provided that the change is the result of more than packaging.",
+                              "class": [
+                                    "CTSH RESTRICTION MINOP"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -1403,17 +1466,39 @@
                   "valid": true
             },
             {
-                  "heading": "180632",
-                  "subdivision": "",
+                  "heading": "ex 180631",
+                  "subdivision": "Others",
+                  "min": "1806310000",
+                  "max": "1806319999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product, or\n\n- the value of non-originating sugar used in production does not exceed **30%** of the transaction value or ex-works price of the product, *and*\n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex 180632",
+                  "subdivision": "Chocolate and other food preparations containing cocoa, in blocks, slabs or bars, not filled, weighing no more than 2 kilograms (*quota for exports from Canada into the United Kingdom*)",
                   "min": "1806320000",
                   "max": "1806329999",
                   "rules": [
                         {
-                              "rule": "A change from any other subheading, provided that the change is the result of more than packaging. **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other subheading, provided that the change is the result of more than packaging.",
+                              "class": [
+                                    "CTSH RESTRICTION MINOP"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -1421,17 +1506,39 @@
                   "valid": true
             },
             {
-                  "heading": "180690",
-                  "subdivision": "",
+                  "heading": "ex 180632",
+                  "subdivision": "Others",
+                  "min": "1806320000",
+                  "max": "1806329999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product, or\n\n- the value of non-originating sugar used in production does not exceed **30%** of the transaction value or ex-works price of the product, *and*\n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex 180690",
+                  "subdivision": "Chocolate and other food preparations containing cocoa other than those of subheading 180610 through 180632 (*quota for exports from Canada into the United Kingdom*)",
                   "min": "1806900000",
                   "max": "1806999999",
                   "rules": [
                         {
-                              "rule": "A change from any other subheading, provided that the change is the result of more than packaging. **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other subheading, provided that the change is the result of more than packaging.",
+                              "class": [
+                                    "CTSH RESTRICTION MINOP"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -1439,18 +1546,15 @@
                   "valid": true
             },
             {
-                  "heading": "1901",
-                  "subdivision": "",
-                  "min": "1901000000",
-                  "max": "1901999999",
+                  "heading": "ex 180690",
+                  "subdivision": "Others",
+                  "min": "1806900000",
+                  "max": "1806999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n- a) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n- b) the net weight of non-originating sugar used in production does not exceed **30%** of the net weight of the product,\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product, *and*\n\n- d) the net weight of non-originating sugar and non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **40%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product, or\n\n- the value of non-originating sugar used in production does not exceed **30%** of the transaction value or ex-works price of the product, *and*\n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
-                                    "CTH",
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
+                                    "MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -1463,18 +1567,18 @@
             },
             {
                   "heading": "1901",
-                  "subdivision": "",
+                  "subdivision": "Malt extract; food preparations of flour, groats, meal, starch or malt extract, not containing cocoa or containing less than 40 per cent by weight of cocoa calculated on a totally defatted basis, not elsewhere specified or included; food preparations of goods of heading 0401 through 0404, not containing cocoa or containing less than 5 per cent by weight of cocoa calculated on a totally defatted basis, not elsewhere specified or included (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "1901000000",
                   "max": "1901999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading. **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "A change from any other heading.",
                               "class": [
                                     "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -1482,18 +1586,77 @@
                   "valid": true
             },
             {
-                  "heading": "190211-190219",
-                  "subdivision": "",
+                  "heading": "1901",
+                  "subdivision": "Others",
+                  "min": "1901000000",
+                  "max": "1901999999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product, \n\n- the net weight of non-originating sugar used in production does not exceed **30%** of the net weight of the product, \n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product, *and*\n\n- the net weight of non-originating sugar and non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **40%** of the net weight of the product.",
+                              "class": [
+                                    "CTH",
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "190211",
+                  "subdivision": "Uncooked pasta, not stuffed or otherwise prepared, containing eggs and rice (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "1902110000",
+                  "max": "1902119999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other heading.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "190211",
+                  "subdivision": "Others",
+                  "min": "1902110000",
+                  "max": "1902119999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product, \n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, and \n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the weight of the net weight of the product.",
+                              "class": [
+                                    "CTH",
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "190219",
+                  "subdivision": "Uncooked pasta, not stuffed or otherwise prepared, other, containing rice (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "1902190000",
                   "max": "1902199999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the weight of the net weight of the product.",
+                              "rule": "A change from any other heading.",
                               "class": [
-                                    "CTH",
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -1505,59 +1668,20 @@
                   "valid": true
             },
             {
-                  "heading": "1902110020",
-                  "subdivision": "",
-                  "min": "1902110020",
-                  "max": "1902110029",
+                  "heading": "190219",
+                  "subdivision": "Others",
+                  "min": "1902190000",
+                  "max": "1902199999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading. **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product, \n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, and \n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the weight of the net weight of the product.",
                               "class": [
-                                    "CTH"
+                                    "CTH",
+                                    "MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "1902191020",
-                  "subdivision": "",
-                  "min": "1902191020",
-                  "max": "1902191029",
-                  "rules": [
-                        {
-                              "rule": "A change from any other heading. **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "1902199020",
-                  "subdivision": "",
-                  "min": "1902199020",
-                  "max": "1902199029",
-                  "rules": [
-                        {
-                              "rule": "A change from any other heading. **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -1566,17 +1690,14 @@
             },
             {
                   "heading": "190220",
-                  "subdivision": "",
+                  "subdivision": "Stuffed pasta, whether or not cooked or otherwise prepared, containing rice (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "1902200000",
                   "max": "1902299999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating material of [chapter&nbsp;2](/chapters/02), [chapter&nbsp;3](/chapters/03) or [chapter&nbsp;16](/chapters/16) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n\n- c) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- d) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other heading.",
                               "class": [
-                                    "CTH",
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -1588,19 +1709,20 @@
                   "valid": true
             },
             {
-                  "heading": "ex 190220",
-                  "subdivision": "",
+                  "heading": "190220",
+                  "subdivision": "Others",
                   "min": "1902200000",
                   "max": "1902299999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading. **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating material of [chapter&nbsp;2](/chapters/02), [chapter&nbsp;3](/chapters/03) or [chapter&nbsp;16](/chapters/16) used in production does not exceed **20%** of the net weight of the product, \n\n- the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product, \n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, and \n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
-                                    "CTH"
+                                    "CTH",
+                                    "MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -1608,62 +1730,61 @@
                   "valid": true
             },
             {
-                  "heading": "190230-190240",
-                  "subdivision": "",
+                  "heading": "190230",
+                  "subdivision": "Other pasta, containing rice (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "1902300000",
+                  "max": "1902399999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other heading.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "190230",
+                  "subdivision": "Others",
+                  "min": "1902300000",
+                  "max": "1902399999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product, \n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
+                              "class": [
+                                    "CTH",
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "190240",
+                  "subdivision": "Subheading 190240",
+                  "min": "1902400000",
                   "max": "1902499999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product, \n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
                                     "CTH",
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
+                                    "MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
                               "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "1902301020",
-                  "subdivision": "",
-                  "min": "1902301020",
-                  "max": "1902301029",
-                  "rules": [
-                        {
-                              "rule": "A change from any other heading. **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "1902309020",
-                  "subdivision": "",
-                  "min": "1902309020",
-                  "max": "1902309029",
-                  "rules": [
-                        {
-                              "rule": "A change from any other heading. **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
                               "import": true,
                               "export": true
                         }
@@ -1672,17 +1793,15 @@
             },
             {
                   "heading": "1903",
-                  "subdivision": "",
+                  "subdivision": "Heading 1903",
                   "min": "1903000000",
                   "max": "1903999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product, *and*\n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
                                     "CTH",
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
+                                    "MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -1695,27 +1814,27 @@
             },
             {
                   "heading": "190410",
-                  "subdivision": "",
+                  "subdivision": "Prepared foods obtained by the swelling or roasting of cereals or cereal products (for example, corn flakes) (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "1904100000",
                   "max": "1904199999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "<abbr title='Change of tariff heading'>CTH</abbr>: All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading).",
                               "class": [
                                     "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         },
                         {
-                              "rule": "A change from within this heading, whether or not there is also a change from any other heading, provided that the weight of the non-originating materials of this heading does not exceed **30%** of either the net weight of the product or the net weight of all material used in production **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "A change from within this heading, whether or not there is also a change from any other heading, provided that the weight of the non-originating materials of this heading does not exceed **30%** of either the net weight of the product or the net weight of all material used in production.",
                               "class": [],
                               "footnotes": [],
                               "operator": "or",
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -1723,18 +1842,16 @@
                   "valid": true
             },
             {
-                  "heading": "190410-190420",
-                  "subdivision": "",
+                  "heading": "190410",
+                  "subdivision": "Others",
                   "min": "1904100000",
-                  "max": "1904299999",
+                  "max": "1904199999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **30%** of the net weight of the product,\n\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- d) the net weight of non-originating sugar and non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **40%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n- the net weight of non-originating sugar used in production does not exceed **30%** of the net weight of the product,\n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product, and \n\n- the net weight of non-originating sugar and non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **40%** of the net weight of the product.",
                               "class": [
                                     "CTH",
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
+                                    "MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -1747,27 +1864,48 @@
             },
             {
                   "heading": "190420",
-                  "subdivision": "",
+                  "subdivision": "Prepared foods obtained from unroasted cereal flakes or from mixtures of unroasted cereal flakes and roasted cereal flakes or swelled cereals (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "1904200000",
                   "max": "1904299999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "<abbr title='Change of tariff heading'>CTH</abbr>: All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading).",
                               "class": [
                                     "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         },
                         {
-                              "rule": "A change from within this heading, whether or not there is also a change from any other heading, provided that the weight of the non-originating materials of this heading does not exceed **30%** of either the net weight of the product or the net weight of all material used in production **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "A change from within this heading, whether or not there is also a change from any other heading, provided that the weight of the non-originating materials of this heading does not exceed **30%** of either the net weight of the product or the net weight of all material used in production.",
                               "class": [],
                               "footnotes": [],
                               "operator": "or",
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "190420",
+                  "subdivision": "Others",
+                  "min": "1904200000",
+                  "max": "1904299999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n- the net weight of non-originating sugar used in production does not exceed **30%** of the net weight of the product,\n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product, and \n\n- the net weight of non-originating sugar and non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **40%** of the net weight of the product.",
+                              "class": [
+                                    "CTH",
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -1776,17 +1914,15 @@
             },
             {
                   "heading": "190430",
-                  "subdivision": "",
+                  "subdivision": "Subheading 190430",
                   "min": "1904300000",
                   "max": "1904399999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product, *and*\n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
                                     "CTH",
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
+                                    "MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -1799,17 +1935,14 @@
             },
             {
                   "heading": "190490",
-                  "subdivision": "",
+                  "subdivision": "Prepared foods other than those of subheading 190410 through 190430 (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "1904900000",
                   "max": "1904999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **30%** of the net weight of the product,\n\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- d) the net weight of non-originating sugar and non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **40%** of the net weight of the product.",
+                              "rule": "A change from any other heading.",
                               "class": [
-                                    "CTH",
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -1822,37 +1955,15 @@
             },
             {
                   "heading": "190490",
-                  "subdivision": "",
+                  "subdivision": "Others",
                   "min": "1904900000",
                   "max": "1904999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "1905",
-                  "subdivision": "",
-                  "min": "1905000000",
-                  "max": "1905999999",
-                  "rules": [
-                        {
-                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product,\n\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- d) the net weight of non-originating sugar and non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **50%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product, \n\n- the net weight of non-originating sugar used in production does not exceed **30%** of the net weight of the product,\n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product, and \n\n- the net weight of non-originating sugar and non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **40%** of the net weight of the product.",
                               "class": [
                                     "CTH",
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
+                                    "MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -1865,18 +1976,39 @@
             },
             {
                   "heading": "1905",
-                  "subdivision": "",
+                  "subdivision": "Bread, pastry, cakes, biscuits and other bakers' wares, whether or not containing cocoa; communion wafers, empty cachets of a kind suitable for pharmaceutical use, sealing wafers, rice paper and similar products (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "1905000000",
                   "max": "1905999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "A change from any other heading.",
                               "class": [
                                     "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "1905",
+                  "subdivision": "Others",
+                  "min": "1905000000",
+                  "max": "1905999999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating material of [heading&nbsp;1006](/headings/1006) or [heading&nbsp;1101](/headings/1101) to [heading&nbsp;1108](/headings/1108) used in production does not exceed **20%** of the net weight of the product, \n\n- the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product, \n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product, *and*\n\n- the net weight of non-originating sugar and non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **50%** of the net weight of the product.",
+                              "class": [
+                                    "CTH",
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -1885,7 +2017,7 @@
             },
             {
                   "heading": "2001",
-                  "subdivision": "",
+                  "subdivision": "Heading 2001",
                   "min": "2001000000",
                   "max": "2001999999",
                   "rules": [
@@ -1905,7 +2037,7 @@
             },
             {
                   "heading": "2002-2003",
-                  "subdivision": "",
+                  "subdivision": "2002-2003",
                   "min": "2002000000",
                   "max": "2003999999",
                   "rules": [
@@ -1926,7 +2058,7 @@
             },
             {
                   "heading": "2004-2005",
-                  "subdivision": "",
+                  "subdivision": "2004-2005",
                   "min": "2004000000",
                   "max": "2005999999",
                   "rules": [
@@ -1946,7 +2078,7 @@
             },
             {
                   "heading": "2006",
-                  "subdivision": "",
+                  "subdivision": "Heading 2006",
                   "min": "2006000000",
                   "max": "2006999999",
                   "rules": [
@@ -1975,7 +2107,7 @@
             },
             {
                   "heading": "200710-200791",
-                  "subdivision": "",
+                  "subdivision": "200710-200791",
                   "min": "2007100000",
                   "max": "2007919999",
                   "rules": [
@@ -1997,7 +2129,7 @@
             },
             {
                   "heading": "200799",
-                  "subdivision": "",
+                  "subdivision": "Subheading 200799",
                   "min": "2007990000",
                   "max": "2007999999",
                   "rules": [
@@ -2013,7 +2145,7 @@
                               "export": true
                         },
                         {
-                              "rule": "A change to any other product of [subheading&nbsp;200799](/subheading/2007990000-80) from any other heading provided that the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.\n\nNote:\n\nFor the purposes of the rules of origin for preparations of blueberries, cherries, cranberries, loganberries, raspberries, Saskatoon berries or strawberries of [heading&nbsp;2008](/headings/2008), the net weight of the product may be the net weight of all material used in production of the product excluding the net weight of water of [heading&nbsp;2201](/headings/2201) that is added during the production of the product. The net weight of any fruit used in production may be the net weight of the fruit whether or not frozen or cut but not further processed.",
+                              "rule": "A change to any other product of [subheading&nbsp;200799](/subheading/2007990000-80) from any other heading provided that the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
                               "class": [],
                               "footnotes": [],
                               "operator": "or",
@@ -2026,16 +2158,15 @@
             },
             {
                   "heading": "200811-200819",
-                  "subdivision": "",
+                  "subdivision": "200811-200819",
                   "min": "2008110000",
                   "max": "2008199999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product.\n\n**Note:**\n\nFor the purposes of the rules of origin for preparations of blueberries, cherries, cranberries, loganberries, raspberries, Saskatoon berries or strawberries of [heading&nbsp;2008](/headings/2008), the net weight of the product may be the net weight of all material used in production of the product excluding the net weight of water of [heading&nbsp;2201](/headings/2201) that is added during the production of the product. The net weight of any fruit used in production may be the net weight of the fruit whether or not frozen or cut but not further processed.",
                               "class": [
                                     "CTH",
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT"
+                                    "MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -2048,16 +2179,15 @@
             },
             {
                   "heading": "200820-200850",
-                  "subdivision": "",
+                  "subdivision": "200820-200850",
                   "min": "2008200000",
                   "max": "2008599999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.\n\n**Note:**\n\nFor the purposes of the rules of origin for preparations of blueberries, cherries, cranberries, loganberries, raspberries, Saskatoon berries or strawberries of [heading&nbsp;2008](/headings/2008), the net weight of the product may be the net weight of all material used in production of the product excluding the net weight of water of [heading&nbsp;2201](/headings/2201) that is added during the production of the product. The net weight of any fruit used in production may be the net weight of the fruit whether or not frozen or cut but not further processed.",
                               "class": [
                                     "CTH",
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT"
+                                    "MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -2070,7 +2200,7 @@
             },
             {
                   "heading": "200860",
-                  "subdivision": "",
+                  "subdivision": "Subheading 200860",
                   "min": "2008600000",
                   "max": "2008699999",
                   "rules": [
@@ -2092,16 +2222,15 @@
             },
             {
                   "heading": "200870",
-                  "subdivision": "",
+                  "subdivision": "Subheading 200870",
                   "min": "2008700000",
                   "max": "2008799999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.\n\n**Note:**\n\nFor the purposes of the rules of origin for preparations of blueberries, cherries, cranberries, loganberries, raspberries, Saskatoon berries or strawberries of [heading&nbsp;2008](/headings/2008), the net weight of the product may be the net weight of all material used in production of the product excluding the net weight of water of [heading&nbsp;2201](/headings/2201) that is added during the production of the product. The net weight of any fruit used in production may be the net weight of the fruit whether or not frozen or cut but not further processed.",
                               "class": [
                                     "CTH",
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT"
+                                    "MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -2114,16 +2243,15 @@
             },
             {
                   "heading": "200880",
-                  "subdivision": "",
+                  "subdivision": "Subheading 200880",
                   "min": "2008800000",
                   "max": "2008899999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that the net weight of non-originating sugar used in production does not exceed **60%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that the net weight of non-originating sugar used in production does not exceed **60%** of the net weight of the product.\n\n**Note:**\n\nFor the purposes of the rules of origin for preparations of blueberries, cherries, cranberries, loganberries, raspberries, Saskatoon berries or strawberries of [heading&nbsp;2008](/headings/2008), the net weight of the product may be the net weight of all material used in production of the product excluding the net weight of water of [heading&nbsp;2201](/headings/2201) that is added during the production of the product. The net weight of any fruit used in production may be the net weight of the fruit whether or not frozen or cut but not further processed.",
                               "class": [
                                     "CTH",
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT"
+                                    "MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -2136,16 +2264,15 @@
             },
             {
                   "heading": "200891",
-                  "subdivision": "",
+                  "subdivision": "Subheading 200891",
                   "min": "2008910000",
                   "max": "2008919999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.\n\n**Note:**\n\nFor the purposes of the rules of origin for preparations of blueberries, cherries, cranberries, loganberries, raspberries, Saskatoon berries or strawberries of [heading&nbsp;2008](/headings/2008), the net weight of the product may be the net weight of all material used in production of the product excluding the net weight of water of [heading&nbsp;2201](/headings/2201) that is added during the production of the product. The net weight of any fruit used in production may be the net weight of the fruit whether or not frozen or cut but not further processed.",
                               "class": [
                                     "CTH",
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT"
+                                    "MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -2158,16 +2285,15 @@
             },
             {
                   "heading": "200893",
-                  "subdivision": "",
+                  "subdivision": "Subheading 200893",
                   "min": "2008930000",
                   "max": "2008939999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that the net weight of non-originating sugar used in production does not exceed **60%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that the net weight of non-originating sugar used in production does not exceed **60%** of the net weight of the product.\n\n**Note:**\n\nFor the purposes of the rules of origin for preparations of blueberries, cherries, cranberries, loganberries, raspberries, Saskatoon berries or strawberries of [heading&nbsp;2008](/headings/2008), the net weight of the product may be the net weight of all material used in production of the product excluding the net weight of water of [heading&nbsp;2201](/headings/2201) that is added during the production of the product. The net weight of any fruit used in production may be the net weight of the fruit whether or not frozen or cut but not further processed.",
                               "class": [
                                     "CTH",
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT"
+                                    "MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -2180,7 +2306,7 @@
             },
             {
                   "heading": "200897",
-                  "subdivision": "",
+                  "subdivision": "Subheading 200897",
                   "min": "2008970000",
                   "max": "2008979999",
                   "rules": [
@@ -2196,7 +2322,7 @@
                               "export": true
                         },
                         {
-                              "rule": "A change to any other product of [subheading&nbsp;200897](/subheading/2008970000-80) from any other heading, provided that the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product.",
+                              "rule": "A change to any other product of [subheading&nbsp;200897](/subheading/2008970000-80) from any other heading, provided that the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product.\n\n**Note:**\n\nFor the purposes of the rules of origin for preparations of blueberries, cherries, cranberries, loganberries, raspberries, Saskatoon berries or strawberries of [heading&nbsp;2008](/headings/2008), the net weight of the product may be the net weight of all material used in production of the product excluding the net weight of water of [heading&nbsp;2201](/headings/2201) that is added during the production of the product. The net weight of any fruit used in production may be the net weight of the fruit whether or not frozen or cut but not further processed.",
                               "class": [],
                               "footnotes": [],
                               "operator": "or",
@@ -2209,7 +2335,7 @@
             },
             {
                   "heading": "200899",
-                  "subdivision": "",
+                  "subdivision": "Subheading 200899",
                   "min": "2008990000",
                   "max": "2008999999",
                   "rules": [
@@ -2225,7 +2351,7 @@
                               "export": true
                         },
                         {
-                              "rule": "A change to any other product of [subheading&nbsp;200899](/subheading/2008990000-80) from any other heading, provided that the net weight of non-originating sugar used in production does not exceed 20 percent of the net weight of the product.",
+                              "rule": "A change to any other product of [subheading&nbsp;200899](/subheading/2008990000-80) from any other heading, provided that the net weight of non-originating sugar used in production does not exceed 20 percent of the net weight of the product.\n\n**Note:**\n\nFor the purposes of the rules of origin for preparations of blueberries, cherries, cranberries, loganberries, raspberries, Saskatoon berries or strawberries of [heading&nbsp;2008](/headings/2008), the net weight of the product may be the net weight of all material used in production of the product excluding the net weight of water of [heading&nbsp;2201](/headings/2201) that is added during the production of the product. The net weight of any fruit used in production may be the net weight of the fruit whether or not frozen or cut but not further processed.",
                               "class": [],
                               "footnotes": [],
                               "operator": "or",
@@ -2238,7 +2364,7 @@
             },
             {
                   "heading": "200911-200979",
-                  "subdivision": "",
+                  "subdivision": "200911-200979",
                   "min": "2009110000",
                   "max": "2009799999",
                   "rules": [
@@ -2260,7 +2386,27 @@
             },
             {
                   "heading": "200981",
-                  "subdivision": "",
+                  "subdivision": "Cranberry juice (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "2009810000",
+                  "max": "2009819999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other heading.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "200981",
+                  "subdivision": "Others",
                   "min": "2009810000",
                   "max": "2009819999",
                   "rules": [
@@ -2276,48 +2422,24 @@
                               "quota": false,
                               "import": true,
                               "export": true
-                        },
-                        {
-                              "rule": "A change from any other heading **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": true,
-                              "export": true
                         }
                   ],
                   "valid": true
             },
             {
                   "heading": "200989",
-                  "subdivision": "Blueberry juice",
+                  "subdivision": "Cranberry juice (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "2009890000",
                   "max": "2009899999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
-                              "class": [
-                                    "CTH",
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "A change from any other heading **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "A change from any other heading.",
                               "class": [
                                     "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -2348,16 +2470,13 @@
             },
             {
                   "heading": "200990",
-                  "subdivision": "",
+                  "subdivision": "Subheading 200990",
                   "min": "2009900000",
                   "max": "2009999999",
                   "rules": [
                         {
-                              "rule": "A change to mixtures containing blueberry juice, cranberry juice, elderberry juice, loganberry juice or Saskatoon berry juice from any other subheading, except from non-originating blueberry juice, cranberry juice, elderberry juice, loganberry juice or Saskatoon berry juice of [heading&nbsp;2009](/headings/2009), provided that:\n\n\n- a) the net weight of non-originating juice of [heading&nbsp;2009](/headings/2009) in single strength form used in production does not exceed **40%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
-                              "class": [
-                                    "CTH RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
-                              ],
+                              "rule": "A change to mixtures containing blueberry juice, cranberry juice, elderberry juice, loganberry juice or Saskatoon berry juice from any other subheading, except from non-originating blueberry juice, cranberry juice, elderberry juice, loganberry juice or Saskatoon berry juice of [heading&nbsp;2009](/headings/2009), provided that: \n\n- the net weight of non-originating juice of [heading&nbsp;2009](/headings/2009) in single strength form used in production does not exceed **40%** of the net weight of the product, and \n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product.",
+                              "class": [],
                               "footnotes": [],
                               "operator": null,
                               "quota": false,
@@ -2377,16 +2496,87 @@
                   "valid": true
             },
             {
-                  "heading": "210111-210130",
-                  "subdivision": "",
+                  "heading": "210111",
+                  "subdivision": "Subheading 210111",
                   "min": "2101110000",
+                  "max": "2101119999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other subheading, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex 210112",
+                  "subdivision": "Preparations with a basis of extracts, essences or concentrates of coffee or with a basis of coffee containing added sugar of subheading 170191 through 170199 (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "2101120000",
+                  "max": "2101129999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other subheading, except from [subheading&nbsp;170191](/subheading/1701910000-80) through 170199.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex 210112",
+                  "subdivision": "Other preparations with a basis of these extracts, essences or concentrates or with a basis of coffee",
+                  "min": "2101120000",
+                  "max": "2101129999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other subheading, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "210120-210130",
+                  "subdivision": "210120-210130",
+                  "min": "2101200000",
                   "max": "2101399999",
                   "rules": [
                         {
-                              "rule": "A change from any other subheading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other subheading, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "210210",
+                  "subdivision": "Subheading 210210",
+                  "min": "2102100000",
+                  "max": "2102199999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other subheading.",
                               "class": [
-                                    "CTSH RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
+                                    "CTSH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -2398,17 +2588,19 @@
                   "valid": true
             },
             {
-                  "heading": "210112",
-                  "subdivision": "",
-                  "min": "2101120000",
-                  "max": "2101129999",
+                  "heading": "210220",
+                  "subdivision": "Preparations with a basis of extracts, essences or concentrates of tea or mat\u00e9, or with a basis of tea or mat\u00e9 containing added sugar of subheading 170191 through 170199 (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "2102200000",
+                  "max": "2102299999",
                   "rules": [
                         {
-                              "rule": "A change from any other subheading, except from [subheading&nbsp;170191](/subheading/1701910000-80) through 170199. **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from within this subheading or any other subheading, except from [subheading&nbsp;170191](/subheading/1701910000-80) through 170199.",
+                              "class": [
+                                    "CTSH"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -2416,17 +2608,19 @@
                   "valid": true
             },
             {
-                  "heading": "ex 210120",
-                  "subdivision": "",
-                  "min": "2101200000",
-                  "max": "2101299999",
+                  "heading": "210220",
+                  "subdivision": "Other extracts, essences and concentrates, of tea or mat\u00e9, and preparations with a basis of these extracts, essences or concentrates, or with a basis of tea or mat\u00e9",
+                  "min": "2102200000",
+                  "max": "2102299999",
                   "rules": [
                         {
-                              "rule": "A change from within this subheading or any other subheading, except from [subheading&nbsp;170191](/subheading/1701910000-80) through 170199. **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other subheading.",
+                              "class": [
+                                    "CTSH"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -2434,9 +2628,9 @@
                   "valid": true
             },
             {
-                  "heading": "210210-210230",
-                  "subdivision": "",
-                  "min": "2102100000",
+                  "heading": "210230",
+                  "subdivision": "Subheading 210230",
+                  "min": "2102300000",
                   "max": "2102399999",
                   "rules": [
                         {
@@ -2455,16 +2649,13 @@
             },
             {
                   "heading": "210310",
-                  "subdivision": "",
+                  "subdivision": "Subheading 210310",
                   "min": "2103100000",
                   "max": "2103199999",
                   "rules": [
                         {
-                              "rule": "A change from any other subheading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating material of [heading&nbsp;0407](/headings/0407) to [heading&nbsp;0410](/headings/0410) used in production does not exceed **20%** of the net weight of the product.",
-                              "class": [
-                                    "CTSH RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
-                              ],
+                              "rule": "A change from any other subheading, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, and \n\n- the net weight of non-originating material of [heading&nbsp;0407](/headings/0407) to [heading&nbsp;0410](/headings/0410) used in production does not exceed **20%** of the net weight of the product.",
+                              "class": [],
                               "footnotes": [],
                               "operator": null,
                               "quota": false,
@@ -2476,16 +2667,13 @@
             },
             {
                   "heading": "210320",
-                  "subdivision": "",
+                  "subdivision": "Subheading 210320",
                   "min": "2103200000",
                   "max": "2103299999",
                   "rules": [
                         {
-                              "rule": "A change to tomato ketchup or barbeque sauce from any other subheading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product,\n\n\n- b) the net weight of non-originating material of [heading&nbsp;0407](/headings/0407), [heading&nbsp;0408](/headings/0408) or [heading&nbsp;0410](/headings/0410) used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- c) the net weight of non-originating sugar and non-originating material of [heading&nbsp;0407](/headings/0407), [heading&nbsp;0408](/headings/0408) or [heading&nbsp;0410](/headings/0410) used in production does not exceed **50%** of the net weight of the product.",
-                              "class": [
-                                    "CTSH RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
-                              ],
+                              "rule": "A change to tomato ketchup or barbeque sauce from any other subheading, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product,\n\n- the net weight of non-originating material of [heading&nbsp;0407](/headings/0407), [heading&nbsp;0408](/headings/0408) or [heading&nbsp;0410](/headings/0410) used in production does not exceed **20%** of the net weight of the product, and \n\n- the net weight of non-originating sugar and non-originating material of [heading&nbsp;0407](/headings/0407), [heading&nbsp;0408](/headings/0408) or [heading&nbsp;0410](/headings/0410) used in production does not exceed **50%** of the net weight of the product.",
+                              "class": [],
                               "footnotes": [],
                               "operator": null,
                               "quota": false,
@@ -2493,7 +2681,7 @@
                               "export": true
                         },
                         {
-                              "rule": "A change to any other product of [subheading&nbsp;210320](/subheading/2103200000-80) from any other subheading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating material of [heading&nbsp;0407](/headings/0407) to [heading&nbsp;0410](/headings/0410) used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change to any other product of [subheading&nbsp;210320](/subheading/2103200000-80) from any other subheading, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n- the net weight of non-originating material of [heading&nbsp;0407](/headings/0407) to [heading&nbsp;0410](/headings/0410) used in production does not exceed **20%** of the net weight of the product.",
                               "class": [],
                               "footnotes": [],
                               "operator": "or",
@@ -2506,12 +2694,12 @@
             },
             {
                   "heading": "210330",
-                  "subdivision": "",
+                  "subdivision": "Subheading 210330",
                   "min": "2103300000",
                   "max": "2103399999",
                   "rules": [
                         {
-                              "rule": "A change from any other subheading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating material of [heading&nbsp;0407](/headings/0407) to [heading&nbsp;0410](/headings/0410) used in production does not exceed **20%** of the net weight of the product.\n\nNote:\n\nFor the purposes of the rule of origin for [subheading&nbsp;210390](/subheading/2103900000-80), mixed condiments and mixed seasonings are food preparations that may be added to a food in order to enhance or impart flavour during the food's manufacture or preparation before it is served, or after the food has been served.",
+                              "rule": "A change from any other subheading, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, and \n\n- the net weight of non-originating material of [heading&nbsp;0407](/headings/0407) to [heading&nbsp;0410](/headings/0410) used in production does not exceed **20%** of the net weight of the product.",
                               "class": [],
                               "footnotes": [],
                               "operator": null,
@@ -2524,36 +2712,45 @@
             },
             {
                   "heading": "210390",
-                  "subdivision": "",
+                  "subdivision": "Other sauces and preparations therefor, other mixed condiments and mixed seasonings (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "2103900000",
                   "max": "2103999999",
                   "rules": [
                         {
-                              "rule": "A change to barbeque sauce, fruit-based sauces, mixed condiments or mixed seasonings from any other subheading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product,\n\n\n- b) the net weight of non-originating material of [heading&nbsp;0407](/headings/0407), [heading&nbsp;0408](/headings/0408) or [heading&nbsp;0410](/headings/0410) used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- c) the net weight of non-originating sugar and non-originating material of [heading&nbsp;0407](/headings/0407), [heading&nbsp;0408](/headings/0408) or [heading&nbsp;0410](/headings/0410) used in production does not exceed **50%** of the net weight of the product.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "A change to any other product of [subheading&nbsp;210390](/subheading/2103900000-80) from any other subheading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating material of [heading&nbsp;0407](/headings/0407) to [heading&nbsp;0410](/headings/0410) used in production does not exceed **20%** of the net weight of the product.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "A change from any other heading **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "A change from any other heading.\n\n**Note:**\n\nFor the purposes of the rule of origin for [subheading&nbsp;210390](/subheading/2103900000-80), mixed condiments and mixed seasonings are food preparations that may be added to a food in order to enhance or impart flavour during the food's manufacture or preparation before it is served, or after the food has been served.",
                               "class": [
                                     "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "210390",
+                  "subdivision": "Others",
+                  "min": "2103900000",
+                  "max": "2103999999",
+                  "rules": [
+                        {
+                              "rule": "A change to barbeque sauce, fruit-based sauces, mixed condiments or mixed seasonings from any other subheading, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product, \n\n- the net weight of non-originating material of [heading&nbsp;0407](/headings/0407), [heading&nbsp;0408](/headings/0408) or [heading&nbsp;0410](/headings/0410) used in production does not exceed **20%** of the net weight of the product, and \n\nthe net weight of non-originating sugar and non-originating material of [heading&nbsp;0407](/headings/0407), [heading&nbsp;0408](/headings/0408) or [heading&nbsp;0410](/headings/0410) used in production does not exceed **50%** of the net weight of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "A change to any other product of [subheading&nbsp;210390](/subheading/2103900000-80) from any other subheading, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n- the net weight of non-originating material of [heading&nbsp;0407](/headings/0407) to [heading&nbsp;0410](/headings/0410) used in production does not exceed **20%** of the net weight of the product.\n\n**Note:**\n\nFor the purposes of the rule of origin for [subheading&nbsp;210390](/subheading/2103900000-80), mixed condiments and mixed seasonings are food preparations that may be added to a food in order to enhance or impart flavour during the food's manufacture or preparation before it is served, or after the food has been served.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -2562,16 +2759,13 @@
             },
             {
                   "heading": "210410-210500",
-                  "subdivision": "",
+                  "subdivision": "210410-210500",
                   "min": "2104100000",
                   "max": "2105999999",
                   "rules": [
                         {
-                              "rule": "A change from any other subheading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
-                              "class": [
-                                    "CTSH RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
-                              ],
+                              "rule": "A change from any other subheading, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, and \n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
+                              "class": [],
                               "footnotes": [],
                               "operator": null,
                               "quota": false,
@@ -2582,49 +2776,49 @@
                   "valid": true
             },
             {
-                  "heading": "2106",
-                  "subdivision": "",
-                  "min": "2106000000",
-                  "max": "2106999999",
-                  "rules": [
-                        {
-                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
-                              "class": [
-                                    "CTH",
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex 210610",
-                  "subdivision": "",
+                  "heading": "210610",
+                  "subdivision": "Protein concentrates and textured protein substances, not containing added sugar of subheading 170191 through 170199 or containing less than 65 per cent by net weight of added sugar of subheading 170191 through 170199 (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "2106100000",
                   "max": "2106199999",
                   "rules": [
                         {
-                              "rule": "A change from any other subheading **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other subheading.",
+                              "class": [
+                                    "CTSH"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         },
                         {
-                              "rule": "A change from within the same subheading, whether or not there is also a change from any other subheading, provided that the net weight of non-originating material from within that subheading does not exceed **30%** of either the net weight of the product or the net weight of all material used in production **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "A change from within the same subheading, whether or not there is also a change from any other subheading, provided that the net weight of non-originating material from within that subheading does not exceed **30%** of either the net weight of the product or the net weight of all material used in production.",
                               "class": [],
                               "footnotes": [],
                               "operator": "or",
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "210610",
+                  "subdivision": "Others",
+                  "min": "2106100000",
+                  "max": "2106199999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product, and \n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
+                              "class": [
+                                    "CTH",
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -2633,34 +2827,68 @@
             },
             {
                   "heading": "ex 210690",
-                  "subdivision": "",
+                  "subdivision": "Food preparations containing added sugar of subheading 170191 through 170199 (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "2106900000",
                   "max": "2106999999",
                   "rules": [
                         {
-                              "rule": "A change from within this subheading or any other subheading, except from [subheading&nbsp;170191](/subheading/1701910000-80) through 170199. **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from within this subheading or any other subheading, except from [subheading&nbsp;170191](/subheading/1701910000-80) through 170199.",
+                              "class": [
+                                    "CTSH"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex 210690",
+                  "subdivision": "Other food preparations not elsewhere specified or included, not containing added sugar of subheading 170191 through 170199 or containing less than 65 per cent by net weight of added sugar of subheading 170191 through 170199 (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "2106900000",
+                  "max": "2106999999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other subheading.",
+                              "class": [
+                                    "CTSH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
                               "import": true,
                               "export": true
                         },
                         {
-                              "rule": "A change from any other subheading **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "A change from within the same subheading, whether or not there is also a change from any other subheading, provided that the net weight of non-originating material from within that subheading does not exceed **30%** of either the net weight of the product or the net weight of all material used in production **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "A change from within the same subheading, whether or not there is also a change from any other subheading, provided that the net weight of non-originating material from within that subheading does not exceed **30%** of either the net weight of the product or the net weight of all material used in production.",
                               "class": [],
                               "footnotes": [],
                               "operator": "or",
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex 210690",
+                  "subdivision": "Food preparations not elsewhere specified or included, other than protein concentrates and textured protein substances",
+                  "min": "2106900000",
+                  "max": "2106999999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **40%** of the net weight of the product, and \n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
+                              "class": [
+                                    "CTH",
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -2669,7 +2897,7 @@
             },
             {
                   "heading": "2201",
-                  "subdivision": "",
+                  "subdivision": "Heading 2201",
                   "min": "2201000000",
                   "max": "2201999999",
                   "rules": [
@@ -2689,17 +2917,15 @@
             },
             {
                   "heading": "220210",
-                  "subdivision": "",
+                  "subdivision": "Subheading 220210",
                   "min": "2202100000",
                   "max": "2202199999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from any other heading, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
                               "class": [
                                     "CTH",
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
+                                    "MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -2712,16 +2938,13 @@
             },
             {
                   "heading": "220290",
-                  "subdivision": "",
+                  "subdivision": "Subheading 220290",
                   "min": "2202900000",
                   "max": "2202999999",
                   "rules": [
                         {
-                              "rule": "A change to beverages containing milk from any other heading, except from [heading&nbsp;0401](/headings/0401) to [heading&nbsp;0406](/headings/0406) or dairy preparations of [subheading&nbsp;190190](/subheading/1901900000-80) containing more than **10%** by dry weight of milk solids, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating material of [heading&nbsp;0407](/headings/0407) to [heading&nbsp;0410](/headings/0410) used in production does not exceed **20%** of the net weight of the product.",
-                              "class": [
-                                    "CTH EXCEPT RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
-                              ],
+                              "rule": "A change to beverages containing milk from any other heading, except from [heading&nbsp;0401](/headings/0401) to [heading&nbsp;0406](/headings/0406) or dairy preparations of [subheading&nbsp;190190](/subheading/1901900000-80) containing more than **10%** by dry weight of milk solids, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, and \n\n- the net weight of non-originating material of [heading&nbsp;0407](/headings/0407) to [heading&nbsp;0410](/headings/0410) used in production does not exceed **20%** of the net weight of the product.",
+                              "class": [],
                               "footnotes": [],
                               "operator": null,
                               "quota": false,
@@ -2729,7 +2952,7 @@
                               "export": true
                         },
                         {
-                              "rule": "A change to any other product of [subheading&nbsp;220290](/subheading/2202900000-80) from any other heading, provided that:\n\n\n- a) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- b) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change to any other product of [subheading&nbsp;220290](/subheading/2202900000-80) from any other heading, provided that: \n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
                               "class": [],
                               "footnotes": [],
                               "operator": "or",
@@ -2742,7 +2965,7 @@
             },
             {
                   "heading": "2203",
-                  "subdivision": "",
+                  "subdivision": "Heading 2203",
                   "min": "2203000000",
                   "max": "2203999999",
                   "rules": [
@@ -2762,7 +2985,7 @@
             },
             {
                   "heading": "2204",
-                  "subdivision": "",
+                  "subdivision": "Heading 2204",
                   "min": "2204000000",
                   "max": "2204999999",
                   "rules": [
@@ -2783,7 +3006,7 @@
             },
             {
                   "heading": "2205-2206",
-                  "subdivision": "",
+                  "subdivision": "2205-2206",
                   "min": "2205000000",
                   "max": "2206999999",
                   "rules": [
@@ -2803,7 +3026,7 @@
             },
             {
                   "heading": "2207-2209",
-                  "subdivision": "",
+                  "subdivision": "2207-2209",
                   "min": "2207000000",
                   "max": "2209999999",
                   "rules": [
@@ -2824,7 +3047,7 @@
             },
             {
                   "heading": "2301",
-                  "subdivision": "",
+                  "subdivision": "Heading 2301",
                   "min": "2301000000",
                   "max": "2301999999",
                   "rules": [
@@ -2844,7 +3067,7 @@
             },
             {
                   "heading": "2302",
-                  "subdivision": "",
+                  "subdivision": "Heading 2302",
                   "min": "2302000000",
                   "max": "2302999999",
                   "rules": [
@@ -2866,7 +3089,7 @@
             },
             {
                   "heading": "230310",
-                  "subdivision": "",
+                  "subdivision": "Subheading 230310",
                   "min": "2303100000",
                   "max": "2303199999",
                   "rules": [
@@ -2888,7 +3111,7 @@
             },
             {
                   "heading": "230320-230330",
-                  "subdivision": "",
+                  "subdivision": "230320-230330",
                   "min": "2303200000",
                   "max": "2303399999",
                   "rules": [
@@ -2908,7 +3131,7 @@
             },
             {
                   "heading": "2304-2308",
-                  "subdivision": "",
+                  "subdivision": "2304-2308",
                   "min": "2304000000",
                   "max": "2308999999",
                   "rules": [
@@ -2927,18 +3150,15 @@
                   "valid": true
             },
             {
-                  "heading": "2309",
-                  "subdivision": "",
-                  "min": "2309000000",
-                  "max": "2309999999",
+                  "heading": "230910",
+                  "subdivision": "Dog or cat food, put up for retail sale (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "2309100000",
+                  "max": "2309199999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, except from [chapter&nbsp;2](/chapters/02) or [chapter&nbsp;3](/chapters/03), provided that:\n\n\n- a) the net weight of non-originating material of [chapter&nbsp;10](/chapters/10) or [chapter&nbsp;11](/chapters/11) used in production does not exceed **20%** of the net weight of the product,\n\n\n- b) the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n\n- c) the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
+                              "rule": "A change from [subheading&nbsp;230990](/subheading/2309900000-80) or any other heading, except from dog or cat food of [subheading&nbsp;230990](/subheading/2309900000-80).",
                               "class": [
-                                    "CTH",
-                                    "MAXNOM",
-                                    "CTH EXCEPT RESTRICTION MAXWEIGHT",
-                                    "MAXWEIGHT"
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -2951,16 +3171,19 @@
             },
             {
                   "heading": "230910",
-                  "subdivision": "",
+                  "subdivision": "Others",
                   "min": "2309100000",
                   "max": "2309199999",
                   "rules": [
                         {
-                              "rule": "A change from [subheading&nbsp;230990](/subheading/2309900000-80) or any other heading, except from dog or cat food of [subheading&nbsp;230990](/subheading/2309900000-80) **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other heading, except from [chapter&nbsp;2](/chapters/02) or [chapter&nbsp;3](/chapters/03), provided that: \n\n- the net weight of non-originating material of [chapter&nbsp;10](/chapters/10) or [chapter&nbsp;11](/chapters/11) used in production does not exceed **20%** of the net weight of the product,\n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
+                              "class": [
+                                    "CTH",
+                                    "MAXNOM"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -2968,17 +3191,20 @@
                   "valid": true
             },
             {
-                  "heading": "ex 230990",
-                  "subdivision": "",
+                  "heading": "230990",
+                  "subdivision": "Subheading 230990",
                   "min": "2309900000",
                   "max": "2309999999",
                   "rules": [
                         {
-                              "rule": "A change from within this subheading or any other heading, except from dog or cat food from within this subheading **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other heading, except from [chapter&nbsp;2](/chapters/02) or [chapter&nbsp;3](/chapters/03), provided that: \n\n- the net weight of non-originating material of [chapter&nbsp;10](/chapters/10) or [chapter&nbsp;11](/chapters/11) used in production does not exceed **20%** of the net weight of the product,\n\n- the net weight of non-originating sugar used in production does not exceed **20%** of the net weight of the product, *and*\n\n- the net weight of non-originating material of [chapter&nbsp;4](/chapters/04) used in production does not exceed **20%** of the net weight of the product.",
+                              "class": [
+                                    "CTH",
+                                    "MAXNOM"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -2987,7 +3213,7 @@
             },
             {
                   "heading": "2401",
-                  "subdivision": "",
+                  "subdivision": "Heading 2401",
                   "min": "2401000000",
                   "max": "2401999999",
                   "rules": [
@@ -3007,7 +3233,7 @@
             },
             {
                   "heading": "240210",
-                  "subdivision": "",
+                  "subdivision": "Subheading 240210",
                   "min": "2402100000",
                   "max": "2402199999",
                   "rules": [
@@ -3029,7 +3255,7 @@
             },
             {
                   "heading": "240220",
-                  "subdivision": "",
+                  "subdivision": "Subheading 240220",
                   "min": "2402200000",
                   "max": "2402299999",
                   "rules": [
@@ -3050,7 +3276,7 @@
             },
             {
                   "heading": "240290",
-                  "subdivision": "",
+                  "subdivision": "Subheading 240290",
                   "min": "2402900000",
                   "max": "2402999999",
                   "rules": [
@@ -3072,7 +3298,7 @@
             },
             {
                   "heading": "2403",
-                  "subdivision": "",
+                  "subdivision": "Heading 2403",
                   "min": "2403000000",
                   "max": "2403999999",
                   "rules": [
@@ -3093,30 +3319,8 @@
                   "valid": true
             },
             {
-                  "heading": "2404",
-                  "subdivision": "",
-                  "min": "2404000000",
-                  "max": "2404999999",
-                  "rules": [
-                        {
-                              "rule": "A change from any other heading, provided that the net weight of non-originating material of [chapter&nbsp;24](/chapters/24) used in production does not exceed **30%** of the net weight of all the material of [chapter&nbsp;24](/chapters/24) used in the production of the product.",
-                              "class": [
-                                    "CTH",
-                                    "MAXNOM",
-                                    "CTH RESTRICTION MAXWEIGHT"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "2501-2503",
-                  "subdivision": "",
+                  "subdivision": "2501-2503",
                   "min": "2501000000",
                   "max": "2503999999",
                   "rules": [
@@ -3136,7 +3340,7 @@
             },
             {
                   "heading": "250410-250490",
-                  "subdivision": "",
+                  "subdivision": "250410-250490",
                   "min": "2504100000",
                   "max": "2504999999",
                   "rules": [
@@ -3156,7 +3360,7 @@
             },
             {
                   "heading": "2505-2514",
-                  "subdivision": "",
+                  "subdivision": "2505-2514",
                   "min": "2505000000",
                   "max": "2514999999",
                   "rules": [
@@ -3176,7 +3380,7 @@
             },
             {
                   "heading": "251511-251690",
-                  "subdivision": "",
+                  "subdivision": "251511-251690",
                   "min": "2515110000",
                   "max": "2516999999",
                   "rules": [
@@ -3196,7 +3400,7 @@
             },
             {
                   "heading": "2517",
-                  "subdivision": "",
+                  "subdivision": "Heading 2517",
                   "min": "2517000000",
                   "max": "2517999999",
                   "rules": [
@@ -3216,7 +3420,7 @@
             },
             {
                   "heading": "251810-252020",
-                  "subdivision": "",
+                  "subdivision": "251810-252020",
                   "min": "2518100000",
                   "max": "2520299999",
                   "rules": [
@@ -3236,7 +3440,7 @@
             },
             {
                   "heading": "2521-2523",
-                  "subdivision": "",
+                  "subdivision": "2521-2523",
                   "min": "2521000000",
                   "max": "2523999999",
                   "rules": [
@@ -3256,7 +3460,7 @@
             },
             {
                   "heading": "252410-252530",
-                  "subdivision": "",
+                  "subdivision": "252410-252530",
                   "min": "2524100000",
                   "max": "2525399999",
                   "rules": [
@@ -3276,7 +3480,7 @@
             },
             {
                   "heading": "2526-2529",
-                  "subdivision": "",
+                  "subdivision": "2526-2529",
                   "min": "2526000000",
                   "max": "2529999999",
                   "rules": [
@@ -3296,7 +3500,7 @@
             },
             {
                   "heading": "253010-253090",
-                  "subdivision": "",
+                  "subdivision": "253010-253090",
                   "min": "2530100000",
                   "max": "2530999999",
                   "rules": [
@@ -3316,7 +3520,7 @@
             },
             {
                   "heading": "2601-2621",
-                  "subdivision": "",
+                  "subdivision": "2601-2621",
                   "min": "2601000000",
                   "max": "2621999999",
                   "rules": [
@@ -3336,7 +3540,7 @@
             },
             {
                   "heading": "2701-2709",
-                  "subdivision": "",
+                  "subdivision": "2701-2709",
                   "min": "2701000000",
                   "max": "2709999999",
                   "rules": [
@@ -3356,7 +3560,7 @@
             },
             {
                   "heading": "2710",
-                  "subdivision": "",
+                  "subdivision": "Heading 2710",
                   "min": "2710000000",
                   "max": "2710999999",
                   "rules": [
@@ -3376,7 +3580,7 @@
             },
             {
                   "heading": "2711-2716",
-                  "subdivision": "",
+                  "subdivision": "2711-2716",
                   "min": "2711000000",
                   "max": "2716999999",
                   "rules": [
@@ -3396,7 +3600,7 @@
             },
             {
                   "heading": "280110-285300",
-                  "subdivision": "",
+                  "subdivision": "280110-285300",
                   "min": "2801100000",
                   "max": "2853999999",
                   "rules": [
@@ -3427,7 +3631,7 @@
             },
             {
                   "heading": "290110-294200",
-                  "subdivision": "",
+                  "subdivision": "290110-294200",
                   "min": "2901100000",
                   "max": "2942999999",
                   "rules": [
@@ -3458,7 +3662,7 @@
             },
             {
                   "heading": "300120-300590",
-                  "subdivision": "",
+                  "subdivision": "300120-300590",
                   "min": "3001200000",
                   "max": "3005999999",
                   "rules": [
@@ -3478,7 +3682,7 @@
             },
             {
                   "heading": "300610-300660",
-                  "subdivision": "",
+                  "subdivision": "300610-300660",
                   "min": "3006100000",
                   "max": "3006699999",
                   "rules": [
@@ -3498,7 +3702,7 @@
             },
             {
                   "heading": "300670-300692",
-                  "subdivision": "",
+                  "subdivision": "300670-300692",
                   "min": "3006700000",
                   "max": "3006929999",
                   "rules": [
@@ -3518,7 +3722,7 @@
             },
             {
                   "heading": "3101",
-                  "subdivision": "",
+                  "subdivision": "Heading 3101",
                   "min": "3101000000",
                   "max": "3101999999",
                   "rules": [
@@ -3538,7 +3742,7 @@
             },
             {
                   "heading": "3102",
-                  "subdivision": "",
+                  "subdivision": "Heading 3102",
                   "min": "3102000000",
                   "max": "3102999999",
                   "rules": [
@@ -3569,7 +3773,7 @@
             },
             {
                   "heading": "310310-310490",
-                  "subdivision": "",
+                  "subdivision": "310310-310490",
                   "min": "3103100000",
                   "max": "3104999999",
                   "rules": [
@@ -3589,7 +3793,7 @@
             },
             {
                   "heading": "3105",
-                  "subdivision": "",
+                  "subdivision": "Heading 3105",
                   "min": "3105000000",
                   "max": "3105999999",
                   "rules": [
@@ -3620,7 +3824,7 @@
             },
             {
                   "heading": "320110-321000",
-                  "subdivision": "",
+                  "subdivision": "320110-321000",
                   "min": "3201100000",
                   "max": "3210999999",
                   "rules": [
@@ -3640,7 +3844,7 @@
             },
             {
                   "heading": "3211-3212",
-                  "subdivision": "",
+                  "subdivision": "3211-3212",
                   "min": "3211000000",
                   "max": "3212999999",
                   "rules": [
@@ -3671,7 +3875,7 @@
             },
             {
                   "heading": "321310",
-                  "subdivision": "",
+                  "subdivision": "Subheading 321310",
                   "min": "3213100000",
                   "max": "3213199999",
                   "rules": [
@@ -3702,7 +3906,7 @@
             },
             {
                   "heading": "321390",
-                  "subdivision": "",
+                  "subdivision": "Subheading 321390",
                   "min": "3213900000",
                   "max": "3213999999",
                   "rules": [
@@ -3733,7 +3937,7 @@
             },
             {
                   "heading": "3214-3215",
-                  "subdivision": "",
+                  "subdivision": "3214-3215",
                   "min": "3214000000",
                   "max": "3215999999",
                   "rules": [
@@ -3764,7 +3968,7 @@
             },
             {
                   "heading": "330112-330190",
-                  "subdivision": "",
+                  "subdivision": "330112-330190",
                   "min": "3301120000",
                   "max": "3301999999",
                   "rules": [
@@ -3795,7 +3999,7 @@
             },
             {
                   "heading": "330210",
-                  "subdivision": "",
+                  "subdivision": "Subheading 330210",
                   "min": "3302100000",
                   "max": "3302199999",
                   "rules": [
@@ -3817,7 +4021,7 @@
             },
             {
                   "heading": "330290",
-                  "subdivision": "",
+                  "subdivision": "Subheading 330290",
                   "min": "3302900000",
                   "max": "3302999999",
                   "rules": [
@@ -3837,7 +4041,7 @@
             },
             {
                   "heading": "3303",
-                  "subdivision": "",
+                  "subdivision": "Heading 3303",
                   "min": "3303000000",
                   "max": "3303999999",
                   "rules": [
@@ -3868,7 +4072,7 @@
             },
             {
                   "heading": "3304-3307",
-                  "subdivision": "",
+                  "subdivision": "3304-3307",
                   "min": "3304000000",
                   "max": "3307999999",
                   "rules": [
@@ -3899,7 +4103,7 @@
             },
             {
                   "heading": "340111-340120",
-                  "subdivision": "",
+                  "subdivision": "340111-340120",
                   "min": "3401110000",
                   "max": "3401299999",
                   "rules": [
@@ -3930,7 +4134,7 @@
             },
             {
                   "heading": "340130",
-                  "subdivision": "",
+                  "subdivision": "Subheading 340130",
                   "min": "3401300000",
                   "max": "3401399999",
                   "rules": [
@@ -3962,7 +4166,7 @@
             },
             {
                   "heading": "340211-340219",
-                  "subdivision": "",
+                  "subdivision": "340211-340219",
                   "min": "3402110000",
                   "max": "3402199999",
                   "rules": [
@@ -3993,7 +4197,7 @@
             },
             {
                   "heading": "340220",
-                  "subdivision": "",
+                  "subdivision": "Subheading 340220",
                   "min": "3402200000",
                   "max": "3402299999",
                   "rules": [
@@ -4012,39 +4216,8 @@
                   "valid": true
             },
             {
-                  "heading": "340230",
-                  "subdivision": "",
-                  "min": "3402300000",
-                  "max": "3402399999",
-                  "rules": [
-                        {
-                              "rule": "A change from any other subheading.",
-                              "class": [
-                                    "CTSH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "A change from within this subheading, whether or not there is also a change from any other subheading, provided that the value of non-originating materials of this subheading does not exceed **20%** of the transaction value or ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "340290",
-                  "subdivision": "",
+                  "subdivision": "Subheading 340290",
                   "min": "3402900000",
                   "max": "3402999999",
                   "rules": [
@@ -4075,7 +4248,7 @@
             },
             {
                   "heading": "340311-340590",
-                  "subdivision": "",
+                  "subdivision": "340311-340590",
                   "min": "3403110000",
                   "max": "3405999999",
                   "rules": [
@@ -4095,7 +4268,7 @@
             },
             {
                   "heading": "3406",
-                  "subdivision": "",
+                  "subdivision": "Heading 3406",
                   "min": "3406000000",
                   "max": "3406999999",
                   "rules": [
@@ -4126,7 +4299,7 @@
             },
             {
                   "heading": "3407",
-                  "subdivision": "",
+                  "subdivision": "Heading 3407",
                   "min": "3407000000",
                   "max": "3407999999",
                   "rules": [
@@ -4142,7 +4315,7 @@
                               "export": true
                         },
                         {
-                              "rule": "A change from within this heading, whether or not there is also a change from any other heading, provided that:\n\n\n- a) at least one of the component products of the set is originating *and*\n\n\n- b) the value of the non-originating component products of this heading does not exceed **50%** of the transaction value or ex-works price of the set.",
+                              "rule": "A change from within this heading, whether or not there is also a change from any other heading, provided that:\n\n- at least one of the component products of the set is originating, *and*\n\n- the value of the non-originating component products of this heading does not exceed **50%** of the transaction value or ex-works price of the set.",
                               "class": [],
                               "footnotes": [],
                               "operator": "or",
@@ -4155,7 +4328,7 @@
             },
             {
                   "heading": "3501-3502",
-                  "subdivision": "",
+                  "subdivision": "3501-3502",
                   "min": "3501000000",
                   "max": "3502999999",
                   "rules": [
@@ -4187,7 +4360,7 @@
             },
             {
                   "heading": "3503",
-                  "subdivision": "",
+                  "subdivision": "Heading 3503",
                   "min": "3503000000",
                   "max": "3503999999",
                   "rules": [
@@ -4219,7 +4392,7 @@
             },
             {
                   "heading": "3504",
-                  "subdivision": "",
+                  "subdivision": "Heading 3504",
                   "min": "3504000000",
                   "max": "3504999999",
                   "rules": [
@@ -4238,7 +4411,7 @@
                               "rule": "A change to any other product of [heading&nbsp;3504](/headings/3504) from any other heading, except from non-originating material of [chapter&nbsp;2](/chapters/02) to [chapter&nbsp;4](/chapters/04) or [heading&nbsp;1108](/headings/1108).",
                               "class": [],
                               "footnotes": [],
-                              "operator": "or",
+                              "operator": null,
                               "quota": false,
                               "import": true,
                               "export": true
@@ -4259,7 +4432,7 @@
             },
             {
                   "heading": "3505",
-                  "subdivision": "",
+                  "subdivision": "Heading 3505",
                   "min": "3505000000",
                   "max": "3505999999",
                   "rules": [
@@ -4291,7 +4464,7 @@
             },
             {
                   "heading": "3506-3507",
-                  "subdivision": "",
+                  "subdivision": "3506-3507",
                   "min": "3506000000",
                   "max": "3507999999",
                   "rules": [
@@ -4322,7 +4495,7 @@
             },
             {
                   "heading": "3601-3606",
-                  "subdivision": "",
+                  "subdivision": "3601-3606",
                   "min": "3601000000",
                   "max": "3606999999",
                   "rules": [
@@ -4353,7 +4526,7 @@
             },
             {
                   "heading": "3701",
-                  "subdivision": "",
+                  "subdivision": "Heading 3701",
                   "min": "3701000000",
                   "max": "3701999999",
                   "rules": [
@@ -4384,7 +4557,7 @@
             },
             {
                   "heading": "3702",
-                  "subdivision": "",
+                  "subdivision": "Heading 3702",
                   "min": "3702000000",
                   "max": "3702999999",
                   "rules": [
@@ -4405,7 +4578,7 @@
             },
             {
                   "heading": "3703-3706",
-                  "subdivision": "",
+                  "subdivision": "3703-3706",
                   "min": "3703000000",
                   "max": "3706999999",
                   "rules": [
@@ -4436,7 +4609,7 @@
             },
             {
                   "heading": "370710-370790",
-                  "subdivision": "",
+                  "subdivision": "370710-370790",
                   "min": "3707100000",
                   "max": "3707999999",
                   "rules": [
@@ -4456,7 +4629,7 @@
             },
             {
                   "heading": "3801-3802",
-                  "subdivision": "",
+                  "subdivision": "3801-3802",
                   "min": "3801000000",
                   "max": "3802999999",
                   "rules": [
@@ -4487,7 +4660,7 @@
             },
             {
                   "heading": "3803",
-                  "subdivision": "",
+                  "subdivision": "Heading 3803",
                   "min": "3803000000",
                   "max": "3803999999",
                   "rules": [
@@ -4507,7 +4680,7 @@
             },
             {
                   "heading": "3804",
-                  "subdivision": "",
+                  "subdivision": "Heading 3804",
                   "min": "3804000000",
                   "max": "3804999999",
                   "rules": [
@@ -4527,7 +4700,7 @@
             },
             {
                   "heading": "380510",
-                  "subdivision": "",
+                  "subdivision": "Subheading 380510",
                   "min": "3805100000",
                   "max": "3805199999",
                   "rules": [
@@ -4556,7 +4729,7 @@
             },
             {
                   "heading": "380590",
-                  "subdivision": "",
+                  "subdivision": "Subheading 380590",
                   "min": "3805900000",
                   "max": "3805999999",
                   "rules": [
@@ -4576,7 +4749,7 @@
             },
             {
                   "heading": "380610-380690",
-                  "subdivision": "",
+                  "subdivision": "380610-380690",
                   "min": "3806100000",
                   "max": "3806999999",
                   "rules": [
@@ -4596,7 +4769,7 @@
             },
             {
                   "heading": "3807",
-                  "subdivision": "",
+                  "subdivision": "Heading 3807",
                   "min": "3807000000",
                   "max": "3807999999",
                   "rules": [
@@ -4627,7 +4800,7 @@
             },
             {
                   "heading": "380850-380899",
-                  "subdivision": "",
+                  "subdivision": "380850-380899",
                   "min": "3808500000",
                   "max": "3808999999",
                   "rules": [
@@ -4647,7 +4820,7 @@
             },
             {
                   "heading": "380910",
-                  "subdivision": "",
+                  "subdivision": "Subheading 380910",
                   "min": "3809100000",
                   "max": "3809199999",
                   "rules": [
@@ -4677,7 +4850,7 @@
             },
             {
                   "heading": "380991-380993",
-                  "subdivision": "",
+                  "subdivision": "380991-380993",
                   "min": "3809910000",
                   "max": "3809939999",
                   "rules": [
@@ -4708,7 +4881,7 @@
             },
             {
                   "heading": "3810",
-                  "subdivision": "",
+                  "subdivision": "Heading 3810",
                   "min": "3810000000",
                   "max": "3810999999",
                   "rules": [
@@ -4739,7 +4912,7 @@
             },
             {
                   "heading": "381111-381190",
-                  "subdivision": "",
+                  "subdivision": "381111-381190",
                   "min": "3811110000",
                   "max": "3811999999",
                   "rules": [
@@ -4759,7 +4932,7 @@
             },
             {
                   "heading": "3812",
-                  "subdivision": "",
+                  "subdivision": "Heading 3812",
                   "min": "3812000000",
                   "max": "3812999999",
                   "rules": [
@@ -4790,7 +4963,7 @@
             },
             {
                   "heading": "3813-3814",
-                  "subdivision": "",
+                  "subdivision": "3813-3814",
                   "min": "3813000000",
                   "max": "3814999999",
                   "rules": [
@@ -4810,7 +4983,7 @@
             },
             {
                   "heading": "381511-381590",
-                  "subdivision": "",
+                  "subdivision": "381511-381590",
                   "min": "3815110000",
                   "max": "3815999999",
                   "rules": [
@@ -4830,7 +5003,7 @@
             },
             {
                   "heading": "3816-3819",
-                  "subdivision": "",
+                  "subdivision": "3816-3819",
                   "min": "3816000000",
                   "max": "3819999999",
                   "rules": [
@@ -4850,7 +5023,7 @@
             },
             {
                   "heading": "3820",
-                  "subdivision": "",
+                  "subdivision": "Heading 3820",
                   "min": "3820000000",
                   "max": "3820999999",
                   "rules": [
@@ -4882,7 +5055,7 @@
             },
             {
                   "heading": "3821-3822",
-                  "subdivision": "",
+                  "subdivision": "3821-3822",
                   "min": "3821000000",
                   "max": "3822999999",
                   "rules": [
@@ -4913,7 +5086,7 @@
             },
             {
                   "heading": "382311-382370",
-                  "subdivision": "",
+                  "subdivision": "382311-382370",
                   "min": "3823110000",
                   "max": "3823799999",
                   "rules": [
@@ -4933,7 +5106,7 @@
             },
             {
                   "heading": "382410-382450",
-                  "subdivision": "",
+                  "subdivision": "382410-382450",
                   "min": "3824100000",
                   "max": "3824599999",
                   "rules": [
@@ -4964,7 +5137,7 @@
             },
             {
                   "heading": "382460",
-                  "subdivision": "",
+                  "subdivision": "Subheading 382460",
                   "min": "3824600000",
                   "max": "3824699999",
                   "rules": [
@@ -4993,7 +5166,7 @@
             },
             {
                   "heading": "382471-382483",
-                  "subdivision": "",
+                  "subdivision": "382471-382483",
                   "min": "3824710000",
                   "max": "3824839999",
                   "rules": [
@@ -5013,7 +5186,7 @@
             },
             {
                   "heading": "382490",
-                  "subdivision": "",
+                  "subdivision": "Subheading 382490",
                   "min": "3824900000",
                   "max": "3824999999",
                   "rules": [
@@ -5032,7 +5205,7 @@
                               "rule": "A change to products containing ethanol from any other heading, except from ethanol of [heading&nbsp;2207](/headings/2207) or [subheading&nbsp;220890](/subheading/2208900000-80).",
                               "class": [],
                               "footnotes": [],
-                              "operator": "or",
+                              "operator": null,
                               "quota": false,
                               "import": true,
                               "export": true
@@ -5051,7 +5224,7 @@
             },
             {
                   "heading": "3825",
-                  "subdivision": "",
+                  "subdivision": "Heading 3825",
                   "min": "3825000000",
                   "max": "3825999999",
                   "rules": [
@@ -5071,7 +5244,7 @@
             },
             {
                   "heading": "3826",
-                  "subdivision": "",
+                  "subdivision": "Heading 3826",
                   "min": "3826000000",
                   "max": "3826999999",
                   "rules": [
@@ -5092,28 +5265,8 @@
                   "valid": true
             },
             {
-                  "heading": "3827",
-                  "subdivision": "",
-                  "min": "3827000000",
-                  "max": "3827999999",
-                  "rules": [
-                        {
-                              "rule": "A change from any other heading.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "3901-3915",
-                  "subdivision": "",
+                  "subdivision": "3901-3915",
                   "min": "3901000000",
                   "max": "3915999999",
                   "rules": [
@@ -5153,7 +5306,7 @@
             },
             {
                   "heading": "3916-3926",
-                  "subdivision": "",
+                  "subdivision": "3916-3926",
                   "min": "3916000000",
                   "max": "3926999999",
                   "rules": [
@@ -5173,7 +5326,7 @@
             },
             {
                   "heading": "4001-4011",
-                  "subdivision": "",
+                  "subdivision": "4001-4011",
                   "min": "4001000000",
                   "max": "4011999999",
                   "rules": [
@@ -5193,7 +5346,7 @@
             },
             {
                   "heading": "401211-401219",
-                  "subdivision": "",
+                  "subdivision": "401211-401219",
                   "min": "4012110000",
                   "max": "4012199999",
                   "rules": [
@@ -5213,7 +5366,7 @@
             },
             {
                   "heading": "401220-401290",
-                  "subdivision": "",
+                  "subdivision": "401220-401290",
                   "min": "4012200000",
                   "max": "4012999999",
                   "rules": [
@@ -5233,7 +5386,7 @@
             },
             {
                   "heading": "4013-4016",
-                  "subdivision": "",
+                  "subdivision": "4013-4016",
                   "min": "4013000000",
                   "max": "4016999999",
                   "rules": [
@@ -5253,7 +5406,7 @@
             },
             {
                   "heading": "4017",
-                  "subdivision": "",
+                  "subdivision": "Heading 4017",
                   "min": "4017000000",
                   "max": "4017999999",
                   "rules": [
@@ -5273,7 +5426,7 @@
             },
             {
                   "heading": "4101-4103",
-                  "subdivision": "",
+                  "subdivision": "4101-4103",
                   "min": "4101000000",
                   "max": "4103999999",
                   "rules": [
@@ -5293,7 +5446,7 @@
             },
             {
                   "heading": "410411-410419",
-                  "subdivision": "",
+                  "subdivision": "410411-410419",
                   "min": "4104110000",
                   "max": "4104199999",
                   "rules": [
@@ -5313,7 +5466,7 @@
             },
             {
                   "heading": "410441-410449",
-                  "subdivision": "",
+                  "subdivision": "410441-410449",
                   "min": "4104410000",
                   "max": "4104499999",
                   "rules": [
@@ -5333,7 +5486,7 @@
             },
             {
                   "heading": "410510",
-                  "subdivision": "",
+                  "subdivision": "Subheading 410510",
                   "min": "4105100000",
                   "max": "4105199999",
                   "rules": [
@@ -5353,7 +5506,7 @@
             },
             {
                   "heading": "410530",
-                  "subdivision": "",
+                  "subdivision": "Subheading 410530",
                   "min": "4105300000",
                   "max": "4105399999",
                   "rules": [
@@ -5373,7 +5526,7 @@
             },
             {
                   "heading": "410621",
-                  "subdivision": "",
+                  "subdivision": "Subheading 410621",
                   "min": "4106210000",
                   "max": "4106219999",
                   "rules": [
@@ -5393,7 +5546,7 @@
             },
             {
                   "heading": "410622",
-                  "subdivision": "",
+                  "subdivision": "Subheading 410622",
                   "min": "4106220000",
                   "max": "4106229999",
                   "rules": [
@@ -5413,7 +5566,7 @@
             },
             {
                   "heading": "410631",
-                  "subdivision": "",
+                  "subdivision": "Subheading 410631",
                   "min": "4106310000",
                   "max": "4106319999",
                   "rules": [
@@ -5433,7 +5586,7 @@
             },
             {
                   "heading": "410632",
-                  "subdivision": "",
+                  "subdivision": "Subheading 410632",
                   "min": "4106320000",
                   "max": "4106329999",
                   "rules": [
@@ -5453,7 +5606,7 @@
             },
             {
                   "heading": "410640",
-                  "subdivision": "",
+                  "subdivision": "Subheading 410640",
                   "min": "4106400000",
                   "max": "4106499999",
                   "rules": [
@@ -5473,7 +5626,7 @@
             },
             {
                   "heading": "410691",
-                  "subdivision": "",
+                  "subdivision": "Subheading 410691",
                   "min": "4106910000",
                   "max": "4106919999",
                   "rules": [
@@ -5493,7 +5646,7 @@
             },
             {
                   "heading": "410692",
-                  "subdivision": "",
+                  "subdivision": "Subheading 410692",
                   "min": "4106920000",
                   "max": "4106929999",
                   "rules": [
@@ -5513,7 +5666,7 @@
             },
             {
                   "heading": "4107-4113",
-                  "subdivision": "",
+                  "subdivision": "4107-4113",
                   "min": "4107000000",
                   "max": "4113999999",
                   "rules": [
@@ -5543,7 +5696,7 @@
             },
             {
                   "heading": "4114-4115",
-                  "subdivision": "",
+                  "subdivision": "4114-4115",
                   "min": "4114000000",
                   "max": "4115999999",
                   "rules": [
@@ -5563,7 +5716,7 @@
             },
             {
                   "heading": "4201-4206",
-                  "subdivision": "",
+                  "subdivision": "4201-4206",
                   "min": "4201000000",
                   "max": "4206999999",
                   "rules": [
@@ -5583,7 +5736,7 @@
             },
             {
                   "heading": "4301",
-                  "subdivision": "",
+                  "subdivision": "Heading 4301",
                   "min": "4301000000",
                   "max": "4301999999",
                   "rules": [
@@ -5603,7 +5756,7 @@
             },
             {
                   "heading": "430211-430230",
-                  "subdivision": "",
+                  "subdivision": "430211-430230",
                   "min": "4302110000",
                   "max": "4302399999",
                   "rules": [
@@ -5623,7 +5776,7 @@
             },
             {
                   "heading": "4303-4304",
-                  "subdivision": "",
+                  "subdivision": "4303-4304",
                   "min": "4303000000",
                   "max": "4304999999",
                   "rules": [
@@ -5643,7 +5796,7 @@
             },
             {
                   "heading": "4401-4421",
-                  "subdivision": "",
+                  "subdivision": "4401-4421",
                   "min": "4401000000",
                   "max": "4421999999",
                   "rules": [
@@ -5663,7 +5816,7 @@
             },
             {
                   "heading": "4501-4504",
-                  "subdivision": "",
+                  "subdivision": "4501-4504",
                   "min": "4501000000",
                   "max": "4504999999",
                   "rules": [
@@ -5683,7 +5836,7 @@
             },
             {
                   "heading": "4601-4602",
-                  "subdivision": "",
+                  "subdivision": "4601-4602",
                   "min": "4601000000",
                   "max": "4602999999",
                   "rules": [
@@ -5703,7 +5856,7 @@
             },
             {
                   "heading": "4701-4707",
-                  "subdivision": "",
+                  "subdivision": "4701-4707",
                   "min": "4701000000",
                   "max": "4707999999",
                   "rules": [
@@ -5723,7 +5876,7 @@
             },
             {
                   "heading": "4801-4809",
-                  "subdivision": "",
+                  "subdivision": "4801-4809",
                   "min": "4801000000",
                   "max": "4809999999",
                   "rules": [
@@ -5743,7 +5896,7 @@
             },
             {
                   "heading": "481013-481190",
-                  "subdivision": "",
+                  "subdivision": "481013-481190",
                   "min": "4810130000",
                   "max": "4811999999",
                   "rules": [
@@ -5763,7 +5916,7 @@
             },
             {
                   "heading": "4812-4823",
-                  "subdivision": "",
+                  "subdivision": "4812-4823",
                   "min": "4812000000",
                   "max": "4823999999",
                   "rules": [
@@ -5783,7 +5936,7 @@
             },
             {
                   "heading": "4901-4911",
-                  "subdivision": "",
+                  "subdivision": "4901-4911",
                   "min": "4901000000",
                   "max": "4911999999",
                   "rules": [
@@ -5803,7 +5956,7 @@
             },
             {
                   "heading": "5001-5002",
-                  "subdivision": "",
+                  "subdivision": "5001-5002",
                   "min": "5001000000",
                   "max": "5002999999",
                   "rules": [
@@ -5823,7 +5976,7 @@
             },
             {
                   "heading": "5003",
-                  "subdivision": "",
+                  "subdivision": "Heading 5003",
                   "min": "5003000000",
                   "max": "5003999999",
                   "rules": [
@@ -5843,7 +5996,7 @@
             },
             {
                   "heading": "5004-5006",
-                  "subdivision": "",
+                  "subdivision": "5004-5006",
                   "min": "5004000000",
                   "max": "5006999999",
                   "rules": [
@@ -5863,7 +6016,7 @@
             },
             {
                   "heading": "5007",
-                  "subdivision": "",
+                  "subdivision": "Heading 5007",
                   "min": "5007000000",
                   "max": "5007999999",
                   "rules": [
@@ -5882,7 +6035,7 @@
                               "rule": "Weaving accompanied by dyeing.",
                               "class": [],
                               "footnotes": [],
-                              "operator": "or",
+                              "operator": null,
                               "quota": false,
                               "import": true,
                               "export": true
@@ -5891,7 +6044,7 @@
                               "rule": "Yarn dyeing accompanied by weaving.",
                               "class": [],
                               "footnotes": [],
-                              "operator": "or",
+                              "operator": null,
                               "quota": false,
                               "import": true,
                               "export": true
@@ -5909,26 +6062,8 @@
                   "valid": true
             },
             {
-                  "heading": "500720",
-                  "subdivision": "",
-                  "min": "5007200000",
-                  "max": "5007299999",
-                  "rules": [
-                        {
-                              "rule": "Weaving (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "5101-5105",
-                  "subdivision": "",
+                  "subdivision": "5101-5105",
                   "min": "5101000000",
                   "max": "5105999999",
                   "rules": [
@@ -5948,7 +6083,7 @@
             },
             {
                   "heading": "5106-5110",
-                  "subdivision": "",
+                  "subdivision": "5106-5110",
                   "min": "5106000000",
                   "max": "5110999999",
                   "rules": [
@@ -5968,18 +6103,29 @@
             },
             {
                   "heading": "510720",
-                  "subdivision": "",
+                  "subdivision": "Yarn of combed wool, not put up for retail sale, containing less than 85 per cent by weight of wool (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "5107200000",
                   "max": "5107299999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "<abbr title='Change of tariff heading'>CTH</abbr>: All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading).",
                               "class": [
                                     "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Spinning of natural fibres or extrusion of man-made fibres accompanied by spinning.",
+                              "class": [
+                                    "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -5988,7 +6134,7 @@
             },
             {
                   "heading": "5111-5113",
-                  "subdivision": "",
+                  "subdivision": "5111-5113",
                   "min": "5111000000",
                   "max": "5113999999",
                   "rules": [
@@ -6034,44 +6180,8 @@
                   "valid": true
             },
             {
-                  "heading": "511130",
-                  "subdivision": "",
-                  "min": "5111300000",
-                  "max": "5111399999",
-                  "rules": [
-                        {
-                              "rule": "Weaving (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "5112",
-                  "subdivision": "",
-                  "min": "5112000000",
-                  "max": "5112999999",
-                  "rules": [
-                        {
-                              "rule": "Weaving (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "5201-5203",
-                  "subdivision": "",
+                  "subdivision": "5201-5203",
                   "min": "5201000000",
                   "max": "5203999999",
                   "rules": [
@@ -6091,7 +6201,7 @@
             },
             {
                   "heading": "5204-5207",
-                  "subdivision": "",
+                  "subdivision": "5204-5207",
                   "min": "5204000000",
                   "max": "5207999999",
                   "rules": [
@@ -6111,18 +6221,29 @@
             },
             {
                   "heading": "520512",
-                  "subdivision": "",
+                  "subdivision": "Cotton yarn not elsewhere specified or included, 85 per cent or more by weight of cotton, not put up for retail sale, single uncombed yarn, over 14 nm but not over 43 nm (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "5205120000",
                   "max": "5205129999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "<abbr title='Change of tariff heading'>CTH</abbr>: All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading).",
                               "class": [
                                     "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Spinning of natural fibres or extrusion of man-made fibres accompanied by spinning.",
+                              "class": [
+                                    "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -6131,7 +6252,7 @@
             },
             {
                   "heading": "5208-5212",
-                  "subdivision": "",
+                  "subdivision": "5208-5212",
                   "min": "5208000000",
                   "max": "5212999999",
                   "rules": [
@@ -6177,37 +6298,46 @@
                   "valid": true
             },
             {
-                  "heading": "520839",
-                  "subdivision": "",
-                  "min": "5208390000",
-                  "max": "5208399999",
-                  "rules": [
-                        {
-                              "rule": "Weaving (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "520859",
-                  "subdivision": "",
+                  "subdivision": "Woven fabrics of cotton, 85 per cent or more cotton by weight, printed, other than plain weave, not elsewhere specified or included, weighing not over 200 g/m2 (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "5208590000",
                   "max": "5208599999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "A change from any other heading, or:\n\nSpinning of natural or man-made staple fibres or extrusion of man-made filament yarn, in each case accompanied by weaving.",
                               "class": [
                                     "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Weaving, accompanied by dyeing or coating.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Yarn dyeing accompanied by weaving.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Printing, accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the transaction value or ex-works price of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -6216,18 +6346,45 @@
             },
             {
                   "heading": "520959",
-                  "subdivision": "",
+                  "subdivision": "Woven fabrics of cotton, 85 per cent or more cotton by weight, printed, other than plain weave, not elsewhere specified or included, weighing over 200 g/m2 (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "5209590000",
                   "max": "5209599999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "A change from any other heading, or:\n\nSpinning of natural or man-made staple fibres or extrusion of man-made filament yarn, in each case accompanied by weaving.",
                               "class": [
                                     "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Weaving, accompanied by dyeing or coating.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Yarn dyeing accompanied by weaving.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Printing, accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the transaction value or ex-works price of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -6236,7 +6393,7 @@
             },
             {
                   "heading": "5301-5305",
-                  "subdivision": "",
+                  "subdivision": "5301-5305",
                   "min": "5301000000",
                   "max": "5305999999",
                   "rules": [
@@ -6256,7 +6413,7 @@
             },
             {
                   "heading": "5306-5308",
-                  "subdivision": "",
+                  "subdivision": "5306-5308",
                   "min": "5306000000",
                   "max": "5308999999",
                   "rules": [
@@ -6276,7 +6433,7 @@
             },
             {
                   "heading": "5309-5311",
-                  "subdivision": "",
+                  "subdivision": "5309-5311",
                   "min": "5309000000",
                   "max": "5311999999",
                   "rules": [
@@ -6323,7 +6480,7 @@
             },
             {
                   "heading": "5401-5406",
-                  "subdivision": "",
+                  "subdivision": "5401-5406",
                   "min": "5401000000",
                   "max": "5406999999",
                   "rules": [
@@ -6342,46 +6499,30 @@
                   "valid": true
             },
             {
-                  "heading": "540110",
-                  "subdivision": "",
-                  "min": "5401100000",
-                  "max": "5401199999",
-                  "rules": [
-                        {
-                              "rule": "Extrusion of man-made filament yarn whether or not accompanied by spinning (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        },
-                        {
-                              "rule": "Spinning (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "5402",
-                  "subdivision": "",
+                  "subdivision": "Synthetic filament yarn (other than sewing thread), not put up for retail sale, including synthetic monofilaments of less than 67 decitex (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "5402000000",
                   "max": "5402999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "<abbr title='Change of tariff heading'>CTH</abbr>: All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading).",
                               "class": [
                                     "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Extrusion of man-made fibres accompanied, if necessary, by spinning or spinning of natural fibres.",
+                              "class": [
+                                    "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -6389,73 +6530,30 @@
                   "valid": true
             },
             {
-                  "heading": "540211",
-                  "subdivision": "",
-                  "min": "5402110000",
-                  "max": "5402119999",
-                  "rules": [
-                        {
-                              "rule": "Extrusion of man-made filament yarn whether or not accompanied by spinning (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        },
-                        {
-                              "rule": "Spinning (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "5404",
-                  "subdivision": "",
-                  "min": "5404000000",
-                  "max": "5404999999",
-                  "rules": [
-                        {
-                              "rule": "Extrusion of man-made filament yarn whether or not accompanied by spinning (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        },
-                        {
-                              "rule": "Spinning (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "540419",
-                  "subdivision": "",
+                  "subdivision": "Synthetic monofilament of 67 decitex or more and of which no cross\n-sectional dimension exceeds 1 mm, not elsewhere specified or included (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "5404190000",
                   "max": "5404199999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "<abbr title='Change of tariff heading'>CTH</abbr>: All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading).",
                               "class": [
                                     "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Extrusion of man-made fibres accompanied, if necessary, by spinning or spinning of natural fibres.",
+                              "class": [
+                                    "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -6464,28 +6562,57 @@
             },
             {
                   "heading": "5407",
-                  "subdivision": "",
+                  "subdivision": "Woven fabrics of synthetic filament yarn, including woven fabrics obtained from materials of heading 5404 (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "5407000000",
                   "max": "5407999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "<abbr title='Change of tariff heading'>CTH</abbr>: All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading).",
                               "class": [
                                     "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         },
                         {
-                              "rule": "Weaving (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
+                              "rule": "Spinning of natural or man-made staple fibres or extrusion of man-made filament yarn, in each case accompanied by weaving.",
+                              "class": [
+                                    "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Weaving, accompanied by dyeing or coating.",
                               "class": [],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
-                              "import": false,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Twisting or texturing, accompanied by weaving, provided that the value of the non-twisted or non-textured yarns used does not exceed **47.5%** of the transaction value or ex-works price of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Printing or dyeing, accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerizing, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the non-originating fabric does not exceed **47.5%** of the transaction value or ex-works price of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
                               "export": true
                         }
                   ],
@@ -6493,7 +6620,7 @@
             },
             {
                   "heading": "5407-5408",
-                  "subdivision": "",
+                  "subdivision": "5407-5408",
                   "min": "5407000000",
                   "max": "5408999999",
                   "rules": [
@@ -6540,7 +6667,7 @@
             },
             {
                   "heading": "5501-5507",
-                  "subdivision": "",
+                  "subdivision": "5501-5507",
                   "min": "5501000000",
                   "max": "5507999999",
                   "rules": [
@@ -6560,18 +6687,29 @@
             },
             {
                   "heading": "550510",
-                  "subdivision": "",
+                  "subdivision": "Waste (including noils, yarn waste and garnetted stock), of synthetic fibres (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "5505100000",
                   "max": "5505199999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "<abbr title='Change of tariff heading'>CTH</abbr>: All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading).",
                               "class": [
                                     "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Extrusion of man-made fibres.",
+                              "class": [
+                                    "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -6580,7 +6718,7 @@
             },
             {
                   "heading": "5508-5511",
-                  "subdivision": "",
+                  "subdivision": "5508-5511",
                   "min": "5508000000",
                   "max": "5511999999",
                   "rules": [
@@ -6600,7 +6738,7 @@
             },
             {
                   "heading": "5512-5516",
-                  "subdivision": "",
+                  "subdivision": "5512-5516",
                   "min": "5512000000",
                   "max": "5516999999",
                   "rules": [
@@ -6647,18 +6785,56 @@
             },
             {
                   "heading": "551311",
-                  "subdivision": "",
+                  "subdivision": "Woven fabrics of polyester staple fibres, under 85 per cent (wt) of such fibres, unbleached or bleached, plain weave, mixed mainly or solely with cotton, not over 170 g/m2 (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "5513110000",
                   "max": "5513119999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "<abbr title='Change of tariff heading'>CTH</abbr>: All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading).",
                               "class": [
                                     "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Spinning of natural or man-made staple fibres or extrusion of man-made filament yarn, in each case accompanied by weaving.",
+                              "class": [
+                                    "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Weaving, accompanied by dyeing or coating.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Yarn dyeing accompanied by weaving.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Printing, accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the transaction value or ex-works price of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -6667,7 +6843,7 @@
             },
             {
                   "heading": "5601",
-                  "subdivision": "",
+                  "subdivision": "Heading 5601",
                   "min": "5601000000",
                   "max": "5601999999",
                   "rules": [
@@ -6687,16 +6863,18 @@
             },
             {
                   "heading": "5602",
-                  "subdivision": "",
+                  "subdivision": "Felt, whether or not impregnated, coated, covered or laminated (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "5602000000",
                   "max": "5602999999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter.",
+                              "class": [
+                                    "CC"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -6705,7 +6883,7 @@
             },
             {
                   "heading": "560210",
-                  "subdivision": "",
+                  "subdivision": "Subheading 560210",
                   "min": "5602100000",
                   "max": "5602199999",
                   "rules": [
@@ -6735,7 +6913,7 @@
             },
             {
                   "heading": "560221-560290",
-                  "subdivision": "",
+                  "subdivision": "560221-560290",
                   "min": "5602210000",
                   "max": "5602999999",
                   "rules": [
@@ -6764,17 +6942,30 @@
             },
             {
                   "heading": "5603",
-                  "subdivision": "",
+                  "subdivision": "Nonwovens (of textile materials), whether or not impregnated, coated, covered or laminated (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "5603000000",
                   "max": "5603999999",
                   "rules": [
                         {
-                              "rule": "Any non-woven process including needle punching (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
+                              "rule": "A change from any other chapter.",
+                              "class": [
+                                    "CC"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
-                              "import": false,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Extrusion of man-made fibres or use of natural fibres, accompanied by nonwoven techniques including needle punching.",
+                              "class": [
+                                    "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
                               "export": true
                         }
                   ],
@@ -6782,7 +6973,7 @@
             },
             {
                   "heading": "5603",
-                  "subdivision": "",
+                  "subdivision": "Others",
                   "min": "5603000000",
                   "max": "5603999999",
                   "rules": [
@@ -6796,22 +6987,13 @@
                               "quota": false,
                               "import": true,
                               "export": true
-                        },
-                        {
-                              "rule": "A change from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": true,
-                              "export": true
                         }
                   ],
                   "valid": true
             },
             {
                   "heading": "560410",
-                  "subdivision": "",
+                  "subdivision": "Subheading 560410",
                   "min": "5604100000",
                   "max": "5604199999",
                   "rules": [
@@ -6871,7 +7053,7 @@
             },
             {
                   "heading": "5605",
-                  "subdivision": "",
+                  "subdivision": "Heading 5605",
                   "min": "5605000000",
                   "max": "5605999999",
                   "rules": [
@@ -6903,7 +7085,7 @@
             },
             {
                   "heading": "5606",
-                  "subdivision": "",
+                  "subdivision": "Heading 5606",
                   "min": "5606000000",
                   "max": "5606999999",
                   "rules": [
@@ -6953,7 +7135,7 @@
             },
             {
                   "heading": "5607",
-                  "subdivision": "",
+                  "subdivision": "Heading 5607",
                   "min": "5607000000",
                   "max": "5607999999",
                   "rules": [
@@ -6993,44 +7175,8 @@
                   "valid": true
             },
             {
-                  "heading": "560741",
-                  "subdivision": "",
-                  "min": "5607410000",
-                  "max": "5607419999",
-                  "rules": [
-                        {
-                              "rule": "Any non-woven process including needle punching (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "560749",
-                  "subdivision": "",
-                  "min": "5607490000",
-                  "max": "5607499999",
-                  "rules": [
-                        {
-                              "rule": "Any non-woven process including needle punching (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "5608",
-                  "subdivision": "",
+                  "subdivision": "Heading 5608",
                   "min": "5608000000",
                   "max": "5608999999",
                   "rules": [
@@ -7059,7 +7205,7 @@
             },
             {
                   "heading": "5609",
-                  "subdivision": "",
+                  "subdivision": "Heading 5609",
                   "min": "5609000000",
                   "max": "5609999999",
                   "rules": [
@@ -7100,7 +7246,7 @@
             },
             {
                   "heading": "5701-5705",
-                  "subdivision": "",
+                  "subdivision": "5701-5705",
                   "min": "5701000000",
                   "max": "5705999999",
                   "rules": [
@@ -7155,44 +7301,66 @@
                   "valid": true
             },
             {
-                  "heading": "570242",
-                  "subdivision": "",
-                  "min": "5702420000",
-                  "max": "5702429999",
-                  "rules": [
-                        {
-                              "rule": "Weaving (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        },
-                        {
-                              "rule": "Use of any non-woven process including needle punching (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "5703",
-                  "subdivision": "",
+                  "subdivision": "Carpets and other textile floor coverings, tufted, whether or not made\n-up (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "5703000000",
                   "max": "5703999999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "A change from any other chapter.",
+                              "class": [
+                                    "CC"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Spinning of natural or man-made staple fibres or extrusion of man-made filament yarn, in each case accompanied by weaving.",
+                              "class": [
+                                    "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Production from coir yarn, sisal yarn or jute yarn.",
                               "class": [],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Flocking, accompanied by dyeing or printing.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Tufting, accompanied by dyeing or printing.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Extrusion of man-made fibres accompanied by non-woven techniques including needle punching, however polypropylene filament of [heading&nbsp;5402](/headings/5402), polypropylene fibres of [heading&nbsp;5503](/headings/5503) or [heading&nbsp;5506](/headings/5506), or polypropylene filament tow of [heading&nbsp;5501](/headings/5501), of which the denomination in all cases of a single filament or fibre is less than 9 decitex, may be used, provided that their total value does not exceed **40%** of the transaction value or ex-works price of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -7200,62 +7368,8 @@
                   "valid": true
             },
             {
-                  "heading": "570320",
-                  "subdivision": "",
-                  "min": "5703200000",
-                  "max": "5703299999",
-                  "rules": [
-                        {
-                              "rule": "Weaving (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        },
-                        {
-                              "rule": "Use of any non-woven process including needle punching (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "570490",
-                  "subdivision": "",
-                  "min": "5704900000",
-                  "max": "5704999999",
-                  "rules": [
-                        {
-                              "rule": "Weaving (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        },
-                        {
-                              "rule": "Use of any non-woven process including needle punching (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "5801-5804",
-                  "subdivision": "",
+                  "subdivision": "5801-5804",
                   "min": "5801000000",
                   "max": "5804999999",
                   "rules": [
@@ -7311,7 +7425,7 @@
             },
             {
                   "heading": "5805",
-                  "subdivision": "",
+                  "subdivision": "Heading 5805",
                   "min": "5805000000",
                   "max": "5805999999",
                   "rules": [
@@ -7331,18 +7445,65 @@
             },
             {
                   "heading": "5806",
-                  "subdivision": "",
+                  "subdivision": "Narrow woven fabrics, other than goods of heading 5807 (other than labels, badges and similar articles, in the piece etc); narrow fabrics consisting of warp without weft assembled by means of an adhesive (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "5806000000",
                   "max": "5806999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "<abbr title='Change of tariff heading'>CTH</abbr>: All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading).",
                               "class": [
                                     "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Spinning of natural or man-made staple fibres or extrusion of man-made filament yarn, in each case accompanied by weaving or fabric formation.",
+                              "class": [
+                                    "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Weaving or fabric formation, accompanied by dyeing, flocking or coating.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Flocking, accompanied by dyeing or printing.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Yarn dyeing, accompanied by weaving or fabric formation.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the transaction value or ex-works price of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -7351,7 +7512,7 @@
             },
             {
                   "heading": "5806-5809",
-                  "subdivision": "",
+                  "subdivision": "5806-5809",
                   "min": "5806000000",
                   "max": "5809999999",
                   "rules": [
@@ -7407,7 +7568,7 @@
             },
             {
                   "heading": "5810",
-                  "subdivision": "",
+                  "subdivision": "Heading 5810",
                   "min": "5810000000",
                   "max": "5810999999",
                   "rules": [
@@ -7427,7 +7588,74 @@
             },
             {
                   "heading": "5811",
-                  "subdivision": "",
+                  "subdivision": "Quilted textile products in the piece (one or more layers assembled with padding by stitching etc), other than embroidery of heading 5810 (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "5811000000",
+                  "max": "5811999999",
+                  "rules": [
+                        {
+                              "rule": "<abbr title='Change of tariff heading'>CTH</abbr>: All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading).",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Spinning of natural or man-made staple fibres or extrusion of man-made filament yarn, in each case accompanied by weaving, knitting or non-woven process.",
+                              "class": [
+                                    "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Weaving, knitting or non-woven process, in each case accompanied by dyeing, flocking or coating.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Flocking, accompanied by dyeing or printing.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Yarn dyeing, accompanied by weaving, knitting or non-woven process.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the transaction value or ex-works price of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "5811",
+                  "subdivision": "Others",
                   "min": "5811000000",
                   "max": "5811999999",
                   "rules": [
@@ -7477,24 +7705,13 @@
                               "quota": false,
                               "import": true,
                               "export": true
-                        },
-                        {
-                              "rule": "A change from any other heading, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": true,
-                              "export": true
                         }
                   ],
                   "valid": true
             },
             {
                   "heading": "5901",
-                  "subdivision": "",
+                  "subdivision": "Heading 5901",
                   "min": "5901000000",
                   "max": "5901999999",
                   "rules": [
@@ -7563,7 +7780,47 @@
             },
             {
                   "heading": "5903",
-                  "subdivision": "",
+                  "subdivision": "Textile fabrics impregnated, coated, covered or laminated with plastics, other than those of heading 5902 (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "5903000000",
+                  "max": "5903999999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other chapter, provided that the value of the non-originating fabric does not exceed **60%** of the transaction value or ex-works price of the product.",
+                              "class": [
+                                    "CC RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Weaving, knitting or a non-woven process, in each case accompanied by dyeing or coating.",
+                              "class": [
+                                    "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the transaction value or ex-works price of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "5903",
+                  "subdivision": "Others",
                   "min": "5903000000",
                   "max": "5903999999",
                   "rules": [
@@ -7586,40 +7843,13 @@
                               "quota": false,
                               "import": true,
                               "export": true
-                        },
-                        {
-                              "rule": "A change from any other chapter, provided that the value of the non-originating fabric does not exceed **60%** of the transaction value or ex-works price of the product, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Weaving (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        },
-                        {
-                              "rule": "Coating, flocking, laminating or metalising, in each case accompanied by at least two other main preparatory finishing operations (such as calendering, shrinking resistance processing) confer origin provided that at least **52.5%** value was added based on the transaction value or ex-work price of product (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": true,
-                              "import": false,
-                              "export": true
                         }
                   ],
                   "valid": true
             },
             {
                   "heading": "5904",
-                  "subdivision": "",
+                  "subdivision": "Heading 5904",
                   "min": "5904000000",
                   "max": "5904999999",
                   "rules": [
@@ -7638,44 +7868,30 @@
                   "valid": true
             },
             {
-                  "heading": "590410",
-                  "subdivision": "",
-                  "min": "5904100000",
-                  "max": "5904199999",
-                  "rules": [
-                        {
-                              "rule": "Weaving (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        },
-                        {
-                              "rule": "Coating, flocking, laminating or metalising, in each case accompanied by at least two other main preparatory finishing operations (such as calendering, shrinking resistance processing) confer origin provided that at least **52.5%** value was added based on ex-work price of product (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "590490",
-                  "subdivision": "",
+                  "subdivision": "Floor coverings, consisting of a coating or covering applied on a textile backing, whether or not cut to shape, excluding linoleum (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "5904900000",
                   "max": "5904999999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, provided that the value of the non-originating fabric does not exceed **60%** of the transaction value or ex-works price of the product, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the value of the non-originating fabric does not exceed **60%** of the transaction value or ex-works price of the product.",
+                              "class": [
+                                    "CC RESTRICTION MAXNOM"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Weaving, knitting or a non-woven process, in each case accompanied by dyeing or coating.",
+                              "class": [
+                                    "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -7776,15 +7992,6 @@
                               "quota": false,
                               "import": true,
                               "export": true
-                        },
-                        {
-                              "rule": "A change from any other chapter, provided that the value of the non-originating fabric does not exceed **60%** of the transaction value or ex-works price of the product, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": true,
-                              "export": true
                         }
                   ],
                   "valid": true
@@ -7805,13 +8012,24 @@
                               "quota": false,
                               "import": true,
                               "export": true
-                        },
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "5906",
+                  "subdivision": "Rubberized textile fabrics, other than those of heading 5902 (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "5906000000",
+                  "max": "5906999999",
+                  "rules": [
                         {
-                              "rule": "A change from any other chapter, provided that the value of the non-originating fabric does not exceed **60%** of the transaction value or ex-works price of the product, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the value of the non-originating fabric does not exceed **60%** of the transaction value or ex-works price of the product.",
+                              "class": [
+                                    "CC RESTRICTION MAXNOM"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -7843,22 +8061,13 @@
                               "quota": false,
                               "import": true,
                               "export": true
-                        },
-                        {
-                              "rule": "A change from any other chapter, provided that the value of the non-originating fabric does not exceed **60%** of the transaction value or ex-works price of the product, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": true,
-                              "export": true
                         }
                   ],
                   "valid": true
             },
             {
                   "heading": "5907",
-                  "subdivision": "",
+                  "subdivision": "Heading 5907",
                   "min": "5907000000",
                   "max": "5907999999",
                   "rules": [
@@ -7899,13 +8108,109 @@
                               "quota": false,
                               "import": true,
                               "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "5907",
+                  "subdivision": "Textile fabrics otherwise impregnated, coated or covered; painted canvas being theatrical scenery, studio back\n-cloths or the like (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "5907000000",
+                  "max": "5907999999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other chapter, provided that the value of the non-originating fabric does not exceed **60%** of the transaction value or ex-works price of the product.",
+                              "class": [
+                                    "CC RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
                         },
                         {
-                              "rule": "A change from any other chapter, provided that the value of the non-originating fabric does not exceed **60%** of the transaction value or ex-works price of the product, **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "A change from any other chapter, except from fabric of [heading&nbsp;5007](/headings/5007), [heading&nbsp;5111](/headings/5111) to [heading&nbsp;5113](/headings/5113), 5208 to 5212, 5310, 5311, 5407, 5408, 5512 to 5516, 5602, 5603, [chapter&nbsp;57](/chapters/57), [heading&nbsp;5803](/headings/5803), [heading&nbsp;5806](/headings/5806), [heading&nbsp;5808](/headings/5808) or [heading&nbsp;6002](/headings/6002) to [heading&nbsp;6006](/headings/6006).",
+                              "class": [
+                                    "CC EXCEPT"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Weaving, accompanied by dyeing, flocking or coating.",
                               "class": [],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Flocking, accompanied by dyeing or printing.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Printing, accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the transaction value or ex-works price of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "5907",
+                  "subdivision": "Others",
+                  "min": "5907000000",
+                  "max": "5907999999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other chapter, except from fabric of [heading&nbsp;5007](/headings/5007), [heading&nbsp;5111](/headings/5111) to [heading&nbsp;5113](/headings/5113), 5208 to 5212, 5310, 5311, 5407, 5408, 5512 to 5516, 5602, 5603, [chapter&nbsp;57](/chapters/57), [heading&nbsp;5803](/headings/5803), [heading&nbsp;5806](/headings/5806), [heading&nbsp;5808](/headings/5808) or [heading&nbsp;6002](/headings/6002) to [heading&nbsp;6006](/headings/6006).",
+                              "class": [
+                                    "CC EXCEPT"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Weaving, accompanied by dyeing, flocking or coating.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Flocking, accompanied by dyeing or printing.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Printing, accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the transaction value or ex-works price of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -7990,7 +8295,7 @@
                               "export": true
                         },
                         {
-                              "rule": "Weaving, knitting or a non-woven process, in each case accompanied by dyeing or coating, provided that only one or more of the following materials are used:\n\n- coir yarn,\n\n- yarn of polytetrafluoroethylene,\n\n- yarn, multiple, of polyamide, coated, impregnated or covered with a phenolic resin,\n\n- yarn of synthetic textile fibres of aromatic polyamides, obtained by polycondensation of m-phenylenediamine and isophthalic acid,\n\n- monofil of polytetrafluoroethylene,\n\n- yarn of synthetic textile fibres of poly(p-phenylene terephthalamide),\n\n- glass fibre yarn, coated with phenol resin and gimped with acrylic yarn,\n\n- copolyester monofilaments of a polyester, a resin of terephthalic acid, 1,4-cyclohexanediethanol and isophthalic acid.",
+                              "rule": "Weaving, knitting or a non-woven process, in each case accompanied by dyeing or coating, provided that only one or more of the following materials are used: \n\n- coir yarn,\n\n- yarn of polytetrafluoroethylene,\n\n- yarn, multiple, of polyamide, coated, impregnated or covered with a phenolic resin,\n\n- yarn of synthetic textile fibres of aromatic polyamides, obtained by polycondensation of m-phenylenediamine and isophthalic acid,\n\n- monofil of polytetrafluoroethylene,\n\n- yarn of synthetic textile fibres of poly(p-phenylene terephthalamide),\n\n- glass fibre yarn, coated with phenol resin and gimped with acrylic yarn,\n\n- copolyester monofilaments of a polyester, a resin of terephthalic acid, 1,4-cyclohexanediethanol and isophthalic acid.",
                               "class": [],
                               "footnotes": [],
                               "operator": "or",
@@ -8033,81 +8338,20 @@
                   "valid": true
             },
             {
-                  "heading": "5910",
-                  "subdivision": "",
-                  "min": "5910000000",
-                  "max": "5910999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacturing from yarn or waste fabrics or rags of [heading&nbsp;6310](/headings/6310) (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        },
-                        {
-                              "rule": "Weaving (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        },
-                        {
-                              "rule": "Coating, flocking, laminating or metalising, in each case accompanied by at least two other main preparatory finishing operations (such as calendering, shrinking resistance processing) confer origin provided that at least **52.5%** value was added based on ex-work price of product (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "5911",
-                  "subdivision": "",
+                  "subdivision": "Textile products and articles for specified technical uses (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "5911000000",
                   "max": "5911999999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, provided that the value of the non-originating fabric does not exceed **60%** of the transaction value or ex-works price of the product, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the value of the non-originating fabric does not exceed **60%** of the transaction value or ex-works price of the product.",
+                              "class": [
+                                    "CC RESTRICTION MAXNOM"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacturing from yarn or waste fabrics or rags of [heading&nbsp;6310](/headings/6310) (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        },
-                        {
-                              "rule": "Weaving (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        },
-                        {
-                              "rule": "Coating, flocking, laminating or metalising, in each case accompanied by at least two other main preparatory finishing operations (such as calendering, shrinking resistance processing) confer origin provided that at least **52.5%** value was added based on ex-work price of product (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": true,
-                              "import": false,
                               "export": true
                         }
                   ],
@@ -8115,7 +8359,7 @@
             },
             {
                   "heading": "6001-6006",
-                  "subdivision": "",
+                  "subdivision": "6001-6006",
                   "min": "6001000000",
                   "max": "6006999999",
                   "rules": [
@@ -8170,28 +8414,194 @@
                   "valid": true
             },
             {
-                  "heading": "6004-6006",
-                  "subdivision": "",
+                  "heading": "6004",
+                  "subdivision": "Knitted or crocheted fabrics of a width exceeding 30 cm, containing by weight 5 per cent or more elastomeric yarn or rubber thread, other than those of heading 6001 (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "6004000000",
-                  "max": "6006999999",
+                  "max": "6004999999",
                   "rules": [
                         {
-                              "rule": "A change from any other heading, **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "<abbr title='Change of tariff heading'>CTH</abbr>: All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading).",
                               "class": [
                                     "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         },
                         {
-                              "rule": "Printing or dyeing, accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerizing, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the non-originating fabric does not exceed **47.5%** of the transaction value or ex-works price of the product, **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "Printing or dyeing, accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerizing, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the non-originating fabric does not exceed **47.5%** of the transaction value or ex-works price of the product.\n\nSpinning of natural or man-made staple fibres or extrusion of man-made filament yarn, in each case accompanied by knitting.",
                               "class": [],
                               "footnotes": [],
                               "operator": "or",
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Knitting, accompanied by dyeing, flocking or coating.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Flocking, accompanied by dyeing or printing.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Dyeing of yarn of natural fibres accompanied by knitting.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Twisting or texturing, accompanied by knitting provided that the value of the non-twisted or non-textured yarns used does not exceed **47.5%** of the transaction value or ex-works price of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "6005",
+                  "subdivision": "Warp knit fabrics (including those made on galloon knitting machines), other than those of heading 6001 \n- 6004 (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "6005000000",
+                  "max": "6005999999",
+                  "rules": [
+                        {
+                              "rule": "<abbr title='Change of tariff heading'>CTH</abbr>: All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading).",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Printing or dyeing, accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerizing, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the non-originating fabric does not exceed **47.5%** of the transaction value or ex-works price of the product.\n\nSpinning of natural or man-made staple fibres or extrusion of man-made filament yarn, in each case accompanied by knitting.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Knitting, accompanied by dyeing, flocking or coating.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Flocking, accompanied by dyeing or printing.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Dyeing of yarn of natural fibres accompanied by knitting.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Twisting or texturing, accompanied by knitting provided that the value of the non-twisted or non-textured yarns used does not exceed **47.5%** of the transaction value or ex-works price of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "6006",
+                  "subdivision": "Knitted or crocheted fabrics, not elsewhere specified or included (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "6006000000",
+                  "max": "6006999999",
+                  "rules": [
+                        {
+                              "rule": "<abbr title='Change of tariff heading'>CTH</abbr>: All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading).",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Printing or dyeing, accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerizing, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the non-originating fabric does not exceed **47.5%** of the transaction value or ex-works price of the product.\n\nSpinning of natural or man-made staple fibres or extrusion of man-made filament yarn, in each case accompanied by knitting.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Knitting, accompanied by dyeing, flocking or coating.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Flocking, accompanied by dyeing or printing.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Dyeing of yarn of natural fibres accompanied by knitting.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Twisting or texturing, accompanied by knitting provided that the value of the non-twisted or non-textured yarns used does not exceed **47.5%** of the transaction value or ex-works price of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -8249,25 +8659,27 @@
             },
             {
                   "heading": "610130",
-                  "subdivision": "",
+                  "subdivision": "Men's or boys' overcoats, car coats, capes, cloaks, anoraks, ski\n-jackets, and similar articles of manmade fibres, knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "6101300000",
                   "max": "6101399999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         },
                         {
-                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
                               "class": [],
                               "footnotes": [],
                               "operator": "or",
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -8276,24 +8688,26 @@
             },
             {
                   "heading": "610230",
-                  "subdivision": "",
+                  "subdivision": "Women's or girls' overcoats, car coats, capes, cloaks, anoraks, ski\n-jackets and similar articles of manmade fibres, knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "6102300000",
                   "max": "6102399999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         },
                         {
-                              "rule": "Or.",
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
                               "class": [],
                               "footnotes": [],
-                              "operator": null,
+                              "operator": "or",
                               "quota": false,
                               "import": true,
                               "export": true
@@ -8303,53 +8717,28 @@
             },
             {
                   "heading": "6104",
-                  "subdivision": "",
+                  "subdivision": "Women's or girls' suits, ensembles, suit\n-type jackets, blazers, dresses, skirts, divided skirts, trousers, etc (no swimwear), knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "6104000000",
                   "max": "6104999999",
                   "rules": [
                         {
-                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "610510",
-                  "subdivision": "",
-                  "min": "6105100000",
-                  "max": "6105199999",
-                  "rules": [
+                        },
                         {
-                              "rule": "Cutting of fabric and making up, within annual quota volumes of apparel exported from the United Kingdom to Canada.",
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
                               "class": [],
                               "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "6106",
-                  "subdivision": "",
-                  "min": "6106000000",
-                  "max": "6106999999",
-                  "rules": [
-                        {
-                              "rule": "Cutting of fabric and making up, within annual quota volumes of apparel exported from the United Kingdom to Canada.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
                               "export": true
                         }
                   ],
@@ -8357,24 +8746,26 @@
             },
             {
                   "heading": "610620",
-                  "subdivision": "",
+                  "subdivision": "Women's or girls' blouses and shirts of manmade fibres, knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "6106200000",
                   "max": "6106299999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         },
                         {
-                              "rule": "Or.",
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
                               "class": [],
                               "footnotes": [],
-                              "operator": null,
+                              "operator": "or",
                               "quota": false,
                               "import": true,
                               "export": true
@@ -8384,16 +8775,27 @@
             },
             {
                   "heading": "610822",
-                  "subdivision": "",
+                  "subdivision": "Women's or girls' briefs and panties of manmade fibres, knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "6108220000",
                   "max": "6108229999",
                   "rules": [
                         {
-                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -8402,24 +8804,26 @@
             },
             {
                   "heading": "610892",
-                  "subdivision": "",
+                  "subdivision": "Women's or girls' negligees, bathrobes, dressing gowns and similar articles of manmade fibres, knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "6108920000",
                   "max": "6108929999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         },
                         {
-                              "rule": "Or.",
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
                               "class": [],
                               "footnotes": [],
-                              "operator": null,
+                              "operator": "or",
                               "quota": false,
                               "import": true,
                               "export": true
@@ -8428,35 +8832,28 @@
                   "valid": true
             },
             {
-                  "heading": "6109",
-                  "subdivision": "",
-                  "min": "6109000000",
-                  "max": "6109999999",
-                  "rules": [
-                        {
-                              "rule": "Cutting of fabric and making up, within annual quota volumes of apparel exported from the United Kingdom to Canada.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "610910",
-                  "subdivision": "",
+                  "subdivision": "T\n-shirts, singlets and other vests, of cotton, knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "6109100000",
                   "max": "6109199999",
                   "rules": [
                         {
-                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -8465,24 +8862,26 @@
             },
             {
                   "heading": "610990",
-                  "subdivision": "",
+                  "subdivision": "T\n-shirts, singlets and other vests, of textile materials not elsewhere specified or included, knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "6109900000",
                   "max": "6109999999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         },
                         {
-                              "rule": "Or.",
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
                               "class": [],
                               "footnotes": [],
-                              "operator": null,
+                              "operator": "or",
                               "quota": false,
                               "import": true,
                               "export": true
@@ -8492,43 +8891,27 @@
             },
             {
                   "heading": "6110",
-                  "subdivision": "",
+                  "subdivision": "Jerseys, pullovers, cardigans, waistcoats and similar articles, knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "6110000000",
                   "max": "6110999999",
                   "rules": [
                         {
-                              "rule": "Cutting of fabric and making up within annual quota volumes of apparel exported from the United Kingdom to Canada.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
-                              "import": false,
+                              "quota": false,
+                              "import": true,
                               "export": true
                         },
                         {
-                              "rule": "Knitting to shape for products for which no sewing or other assembly is required within annual quota volumes of apparel exported from the United Kingdom to Canada.",
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
                               "class": [],
                               "footnotes": [],
                               "operator": "or",
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "6110",
-                  "subdivision": "",
-                  "min": "6110000000",
-                  "max": "6110999999",
-                  "rules": [
-                        {
-                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -8537,24 +8920,26 @@
             },
             {
                   "heading": "611241",
-                  "subdivision": "",
+                  "subdivision": "Women's or girls' swimwear of synthetic fibres, knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "6112410000",
                   "max": "6112419999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         },
                         {
-                              "rule": "Or.",
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
                               "class": [],
                               "footnotes": [],
-                              "operator": null,
+                              "operator": "or",
                               "quota": false,
                               "import": true,
                               "export": true
@@ -8563,44 +8948,57 @@
                   "valid": true
             },
             {
-                  "heading": "6114-6115",
-                  "subdivision": "",
+                  "heading": "6114",
+                  "subdivision": "Garments not elsewhere specified or included, knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "6114000000",
-                  "max": "6115999999",
+                  "max": "6114999999",
                   "rules": [
                         {
-                              "rule": "Cutting of fabric and making up, within annual quota volumes of apparel exported from the United Kingdom to Canada.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
-                              "import": false,
+                              "quota": false,
+                              "import": true,
                               "export": true
                         },
                         {
-                              "rule": "Knitting to shape for products for which no sewing or other assembly is required, within annual quota volumes of apparel exported from the United Kingdom to Canada.",
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
                               "class": [],
                               "footnotes": [],
                               "operator": "or",
-                              "quota": true,
-                              "import": false,
+                              "quota": false,
+                              "import": true,
                               "export": true
                         }
                   ],
                   "valid": true
             },
             {
-                  "heading": "6114-6115",
-                  "subdivision": "",
-                  "min": "6114000000",
+                  "heading": "6115",
+                  "subdivision": "Pantyhose, tights, stockings, socks and other hosiery, including graduated compression hosiery (for example stockings for varicose veins) and footwear without applied soles, knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "6115000000",
                   "max": "6115999999",
                   "rules": [
                         {
-                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -8609,7 +9007,36 @@
             },
             {
                   "heading": "6201",
-                  "subdivision": "",
+                  "subdivision": "Men's or boys' overcoats car coats, capes, cloaks, anoraks (including ski\n-jackets), windcheaters, wind\n-jackets and similar articles, not knitted or crocheted, other than those of heading 6203 (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "6201000000",
+                  "max": "6201999999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "6201",
+                  "subdivision": "Others",
                   "min": "6201000000",
                   "max": "6201999999",
                   "rules": [
@@ -8637,25 +9064,27 @@
                   "valid": true
             },
             {
-                  "heading": "6201-6206",
-                  "subdivision": "",
-                  "min": "6201000000",
-                  "max": "6206999999",
+                  "heading": "6202",
+                  "subdivision": "Women's or girls' overcoats, car coats, capes, cloaks, anoraks (including ski\n-jackets), windcheaters, wind\n-jackets and similar articles, not knitted or crocheted, other than those of heading 6204 (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "6202000000",
+                  "max": "6202999999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         },
                         {
-                              "rule": "Or.",
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
                               "class": [],
                               "footnotes": [],
-                              "operator": null,
+                              "operator": "or",
                               "quota": false,
                               "import": true,
                               "export": true
@@ -8722,36 +9151,29 @@
                   "valid": true
             },
             {
-                  "heading": "620211",
-                  "subdivision": "",
-                  "min": "6202110000",
-                  "max": "6202119999",
+                  "heading": "6203",
+                  "subdivision": "Men's or boys' suits, ensembles, jackets, blazers, trousers, bib and brace overalls, breeches and shorts (other than swimwear), not knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "6203000000",
+                  "max": "6203999999",
                   "rules": [
                         {
-                              "rule": "Cutting of fabric and making up, within annual quota volumes of apparel exported from the United Kingdom to Canada.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
-                              "import": false,
+                              "quota": false,
+                              "import": true,
                               "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "620293",
-                  "subdivision": "",
-                  "min": "6202930000",
-                  "max": "6202939999",
-                  "rules": [
+                        },
                         {
-                              "rule": "Cutting of fabric and making up, within annual quota volumes of apparel exported from the United Kingdom to Canada.",
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
                               "class": [],
                               "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
                               "export": true
                         }
                   ],
@@ -8759,7 +9181,7 @@
             },
             {
                   "heading": "6203",
-                  "subdivision": "",
+                  "subdivision": "Others",
                   "min": "6203000000",
                   "max": "6203999999",
                   "rules": [
@@ -8787,54 +9209,29 @@
                   "valid": true
             },
             {
-                  "heading": "620311",
-                  "subdivision": "",
-                  "min": "6203110000",
-                  "max": "6203119999",
-                  "rules": [
-                        {
-                              "rule": "Cutting of fabric and making up, within annual quota volumes of apparel exported from the United Kingdom to Canada.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "620312-620349",
-                  "subdivision": "",
-                  "min": "6203120000",
-                  "max": "6203499999",
-                  "rules": [
-                        {
-                              "rule": "Cutting of fabric and making up, within annual quota volumes of apparel exported from the United Kingdom to Canada.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "6204",
-                  "subdivision": "",
+                  "subdivision": "Women's or girls' suits, ensembles, jackets, blazers, dresses, skirts, divided skirts, trousers, bib and brace overalls, breeches and shorts (other than swimwear), not knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "6204000000",
                   "max": "6204999999",
                   "rules": [
                         {
-                              "rule": "Cutting of fabric and making up, within annual quota volumes of apparel exported from the United Kingdom to Canada.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
-                              "import": false,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
                               "export": true
                         }
                   ],
@@ -8900,7 +9297,36 @@
             },
             {
                   "heading": "6205",
-                  "subdivision": "",
+                  "subdivision": "Men's or boys' shirts, not knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "6205000000",
+                  "max": "6205999999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "6205",
+                  "subdivision": "Others",
                   "min": "6205000000",
                   "max": "6205999999",
                   "rules": [
@@ -8928,18 +9354,29 @@
                   "valid": true
             },
             {
-                  "heading": "620520",
-                  "subdivision": "",
-                  "min": "6205200000",
-                  "max": "6205299999",
+                  "heading": "6206",
+                  "subdivision": "Women's or girls' blouses, shirts and shirt\n-blouses, not knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "6206000000",
+                  "max": "6206999999",
                   "rules": [
                         {
-                              "rule": "Cutting of fabric and making up, within annual quota volumes of apparel exported from the United Kingdom to Canada.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
-                              "import": false,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
                               "export": true
                         }
                   ],
@@ -9005,7 +9442,7 @@
             },
             {
                   "heading": "6207-6208",
-                  "subdivision": "",
+                  "subdivision": "6207-6208",
                   "min": "6207000000",
                   "max": "6208999999",
                   "rules": [
@@ -9149,35 +9586,28 @@
                   "valid": true
             },
             {
-                  "heading": "6210-6212",
-                  "subdivision": "",
-                  "min": "6210000000",
-                  "max": "6212999999",
-                  "rules": [
-                        {
-                              "rule": "Cutting of fabric and making up, within annual quota volumes of apparel exported from the United Kingdom to Canada.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "621040",
-                  "subdivision": "",
+                  "subdivision": "Men's or boys' garments, made up of fabrics of heading 5903, 5906 or 5907, not elsewhere specified or included, not knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "6210400000",
                   "max": "6210499999",
                   "rules": [
                         {
-                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -9186,24 +9616,26 @@
             },
             {
                   "heading": "621050",
-                  "subdivision": "",
+                  "subdivision": "Women's or girls' garments, made up of fabrics of heading 5903, 5906 or 5907, not elsewhere specified or included, not knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "6210500000",
                   "max": "6210599999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         },
                         {
-                              "rule": "Or.",
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
                               "class": [],
                               "footnotes": [],
-                              "operator": null,
+                              "operator": "or",
                               "quota": false,
                               "import": true,
                               "export": true
@@ -9213,16 +9645,27 @@
             },
             {
                   "heading": "6211",
-                  "subdivision": "",
+                  "subdivision": "Track suits, ski\n-suits and swimwear, other garments not elsewhere specified or included, not knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "6211000000",
                   "max": "6211999999",
                   "rules": [
                         {
-                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -9289,7 +9732,7 @@
             },
             {
                   "heading": "6212",
-                  "subdivision": "",
+                  "subdivision": "Heading 6212",
                   "min": "6212000000",
                   "max": "6212999999",
                   "rules": [
@@ -9317,25 +9760,85 @@
                   "valid": true
             },
             {
-                  "heading": "621210-621230",
-                  "subdivision": "",
+                  "heading": "621210",
+                  "subdivision": "Brassieres, whether or not knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "6212100000",
-                  "max": "6212399999",
+                  "max": "6212199999",
                   "rules": [
                         {
-                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
                               "export": true
                         },
                         {
-                              "rule": "Or.",
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
                               "class": [],
                               "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "621220",
+                  "subdivision": "Girdles and panty girdles, whether or not knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "6212200000",
+                  "max": "6212299999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
+                              "footnotes": [],
                               "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "621230",
+                  "subdivision": "Corselettes, whether or not knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "6212300000",
+                  "max": "6212399999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
                               "quota": false,
                               "import": true,
                               "export": true
@@ -9345,16 +9848,27 @@
             },
             {
                   "heading": "621290",
-                  "subdivision": "",
+                  "subdivision": "Braces, suspenders, garters and similar articles and parts thereof, whether or not knitted or crocheted (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "6212900000",
                   "max": "6212999999",
                   "rules": [
                         {
-                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter, provided that the product is both cut (or knit to shape) and sewn or otherwise assembled in the territory of a Party.",
+                              "class": [
+                                    "CC RESTRICTION PROCESSING"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "A change to a good knit to shape, for which no sewing or other assembly is required, from any other chapter.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -9430,7 +9944,7 @@
             },
             {
                   "heading": "6215",
-                  "subdivision": "",
+                  "subdivision": "Heading 6215",
                   "min": "6215000000",
                   "max": "6215999999",
                   "rules": [
@@ -9663,98 +10177,8 @@
                   "valid": true
             },
             {
-                  "heading": "630211",
-                  "subdivision": "",
-                  "min": "6302110000",
-                  "max": "6302119999",
-                  "rules": [
-                        {
-                              "rule": "Cutting of fabric and making up.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Use of any non-woven process including needle punching accompanied by making up (including cutting).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "630221",
-                  "subdivision": "",
-                  "min": "6302210000",
-                  "max": "6302219999",
-                  "rules": [
-                        {
-                              "rule": "Cutting of fabric and making up(applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        },
-                        {
-                              "rule": "Use of any non-woven process including needle punching accompanied by making up (including cutting) (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "630291",
-                  "subdivision": "",
-                  "min": "6302910000",
-                  "max": "6302919999",
-                  "rules": [
-                        {
-                              "rule": "Use of any non-woven process including needle punching accompanied by making up (including cutting) (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        },
-                        {
-                              "rule": "Cutting of fabric and making up (applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        },
-                        {
-                              "rule": "Making up preceded by printing(applies only to textiles exported within quota volumes from the United Kingdom to Canada).",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": true,
-                              "import": false,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "6305",
-                  "subdivision": "",
+                  "subdivision": "Heading 6305",
                   "min": "6305000000",
                   "max": "6305999999",
                   "rules": [
@@ -9797,15 +10221,6 @@
                               "quota": false,
                               "import": true,
                               "export": true
-                        },
-                        {
-                              "rule": "A change from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": true,
-                              "export": true
                         }
                   ],
                   "valid": true
@@ -9835,13 +10250,75 @@
                               "quota": false,
                               "import": true,
                               "export": true
-                        },
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "6306",
+                  "subdivision": "Tarpaulins, awnings, sunblinds, tents, sails for boats, sailboards or landcraft, and camping goods, of textile materials (*Quota for exports from Canada into the United Kingdom*)\n-Of nonwovens",
+                  "min": "6306000000",
+                  "max": "6306999999",
+                  "rules": [
                         {
-                              "rule": "A change from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
+                              "rule": "A change from any other chapter.",
+                              "class": [
+                                    "CC"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Extrusion of man-made fibres or use of natural fibres, in each case accompanied by any non-woven techniques including needle punching.",
+                              "class": [
+                                    "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "6306",
+                  "subdivision": "Tarpaulins, awnings, sunblinds, tents, sails for boats, sailboards or landcraft, and camping goods, of textile materials (*Quota for exports from Canada into the United Kingdom*)\n-Other",
+                  "min": "6306000000",
+                  "max": "6306999999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other chapter.",
+                              "class": [
+                                    "CC"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Weaving accompanied by making-up (including cutting).",
+                              "class": [
+                                    "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Coating, provided that the value of the uncoated fabric used does not exceed **40%** of the transaction value or ex-works price of the product, accompanied by making-up (including cutting).",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
                               "import": true,
                               "export": true
                         }
@@ -9850,7 +10327,38 @@
             },
             {
                   "heading": "6307",
-                  "subdivision": "",
+                  "subdivision": "Made\n-up articles of textile materials, not elsewhere specified or included (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "6307000000",
+                  "max": "6307999999",
+                  "rules": [
+                        {
+                              "rule": "A change from any other chapter.",
+                              "class": [
+                                    "CC"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Production in which the value of non-originating materials used does not exceed **40%** of the transaction value or ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "6307",
+                  "subdivision": "Others",
                   "min": "6307000000",
                   "max": "6307999999",
                   "rules": [
@@ -9864,22 +10372,13 @@
                               "quota": false,
                               "import": true,
                               "export": true
-                        },
-                        {
-                              "rule": "A change from any other chapter, **within annual quota volumes, exported from Canada to UK**.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": true,
-                              "import": true,
-                              "export": true
                         }
                   ],
                   "valid": true
             },
             {
                   "heading": "6308",
-                  "subdivision": "",
+                  "subdivision": "Heading 6308",
                   "min": "6308000000",
                   "max": "6308999999",
                   "rules": [
@@ -9899,7 +10398,7 @@
             },
             {
                   "heading": "6309",
-                  "subdivision": "",
+                  "subdivision": "Heading 6309",
                   "min": "6309000000",
                   "max": "6309999999",
                   "rules": [
@@ -9919,7 +10418,7 @@
             },
             {
                   "heading": "6310",
-                  "subdivision": "",
+                  "subdivision": "Heading 6310",
                   "min": "6310000000",
                   "max": "6310999999",
                   "rules": [
@@ -9939,7 +10438,7 @@
             },
             {
                   "heading": "6401-6405",
-                  "subdivision": "",
+                  "subdivision": "6401-6405",
                   "min": "6401000000",
                   "max": "6405999999",
                   "rules": [
@@ -9960,7 +10459,7 @@
             },
             {
                   "heading": "6406",
-                  "subdivision": "",
+                  "subdivision": "Heading 6406",
                   "min": "6406000000",
                   "max": "6406999999",
                   "rules": [
@@ -9980,7 +10479,7 @@
             },
             {
                   "heading": "6501-6507",
-                  "subdivision": "",
+                  "subdivision": "6501-6507",
                   "min": "6501000000",
                   "max": "6507999999",
                   "rules": [
@@ -10000,7 +10499,7 @@
             },
             {
                   "heading": "6601-6603",
-                  "subdivision": "",
+                  "subdivision": "6601-6603",
                   "min": "6601000000",
                   "max": "6603999999",
                   "rules": [
@@ -10020,7 +10519,7 @@
             },
             {
                   "heading": "6701",
-                  "subdivision": "",
+                  "subdivision": "Heading 6701",
                   "min": "6701000000",
                   "max": "6701999999",
                   "rules": [
@@ -10049,7 +10548,7 @@
             },
             {
                   "heading": "6702-6704",
-                  "subdivision": "",
+                  "subdivision": "6702-6704",
                   "min": "6702000000",
                   "max": "6704999999",
                   "rules": [
@@ -10069,7 +10568,7 @@
             },
             {
                   "heading": "6801-6802",
-                  "subdivision": "",
+                  "subdivision": "6801-6802",
                   "min": "6801000000",
                   "max": "6802999999",
                   "rules": [
@@ -10089,7 +10588,7 @@
             },
             {
                   "heading": "6803",
-                  "subdivision": "",
+                  "subdivision": "Heading 6803",
                   "min": "6803000000",
                   "max": "6803999999",
                   "rules": [
@@ -10109,7 +10608,7 @@
             },
             {
                   "heading": "6804-6811",
-                  "subdivision": "",
+                  "subdivision": "6804-6811",
                   "min": "6804000000",
                   "max": "6811999999",
                   "rules": [
@@ -10129,7 +10628,7 @@
             },
             {
                   "heading": "681280-681299",
-                  "subdivision": "",
+                  "subdivision": "681280-681299",
                   "min": "6812800000",
                   "max": "6812999999",
                   "rules": [
@@ -10149,7 +10648,7 @@
             },
             {
                   "heading": "6813",
-                  "subdivision": "",
+                  "subdivision": "Heading 6813",
                   "min": "6813000000",
                   "max": "6813999999",
                   "rules": [
@@ -10169,7 +10668,7 @@
             },
             {
                   "heading": "681410-681490",
-                  "subdivision": "",
+                  "subdivision": "681410-681490",
                   "min": "6814100000",
                   "max": "6814999999",
                   "rules": [
@@ -10189,7 +10688,7 @@
             },
             {
                   "heading": "6815",
-                  "subdivision": "",
+                  "subdivision": "Heading 6815",
                   "min": "6815000000",
                   "max": "6815999999",
                   "rules": [
@@ -10209,7 +10708,7 @@
             },
             {
                   "heading": "6901-6914",
-                  "subdivision": "",
+                  "subdivision": "6901-6914",
                   "min": "6901000000",
                   "max": "6914999999",
                   "rules": [
@@ -10229,7 +10728,7 @@
             },
             {
                   "heading": "7001-7005",
-                  "subdivision": "",
+                  "subdivision": "7001-7005",
                   "min": "7001000000",
                   "max": "7005999999",
                   "rules": [
@@ -10249,7 +10748,7 @@
             },
             {
                   "heading": "7006",
-                  "subdivision": "",
+                  "subdivision": "Heading 7006",
                   "min": "7006000000",
                   "max": "7006999999",
                   "rules": [
@@ -10269,7 +10768,7 @@
             },
             {
                   "heading": "7007-7008",
-                  "subdivision": "",
+                  "subdivision": "7007-7008",
                   "min": "7007000000",
                   "max": "7008999999",
                   "rules": [
@@ -10289,7 +10788,7 @@
             },
             {
                   "heading": "700910",
-                  "subdivision": "",
+                  "subdivision": "Subheading 700910",
                   "min": "7009100000",
                   "max": "7009199999",
                   "rules": [
@@ -10309,7 +10808,7 @@
             },
             {
                   "heading": "700991-700992",
-                  "subdivision": "",
+                  "subdivision": "700991-700992",
                   "min": "7009910000",
                   "max": "7009929999",
                   "rules": [
@@ -10329,7 +10828,7 @@
             },
             {
                   "heading": "7010",
-                  "subdivision": "",
+                  "subdivision": "Heading 7010",
                   "min": "7010000000",
                   "max": "7010999999",
                   "rules": [
@@ -10358,7 +10857,7 @@
             },
             {
                   "heading": "7011",
-                  "subdivision": "",
+                  "subdivision": "Heading 7011",
                   "min": "7011000000",
                   "max": "7011999999",
                   "rules": [
@@ -10378,7 +10877,7 @@
             },
             {
                   "heading": "7013",
-                  "subdivision": "",
+                  "subdivision": "Heading 7013",
                   "min": "7013000000",
                   "max": "7013999999",
                   "rules": [
@@ -10407,7 +10906,7 @@
             },
             {
                   "heading": "7014-7018",
-                  "subdivision": "",
+                  "subdivision": "7014-7018",
                   "min": "7014000000",
                   "max": "7018999999",
                   "rules": [
@@ -10427,7 +10926,7 @@
             },
             {
                   "heading": "701911-701940",
-                  "subdivision": "",
+                  "subdivision": "701911-701940",
                   "min": "7019110000",
                   "max": "7019499999",
                   "rules": [
@@ -10447,7 +10946,7 @@
             },
             {
                   "heading": "701951",
-                  "subdivision": "",
+                  "subdivision": "Subheading 701951",
                   "min": "7019510000",
                   "max": "7019519999",
                   "rules": [
@@ -10467,7 +10966,7 @@
             },
             {
                   "heading": "701952-701990",
-                  "subdivision": "",
+                  "subdivision": "701952-701990",
                   "min": "7019520000",
                   "max": "7019999999",
                   "rules": [
@@ -10487,7 +10986,7 @@
             },
             {
                   "heading": "7020",
-                  "subdivision": "",
+                  "subdivision": "Heading 7020",
                   "min": "7020000000",
                   "max": "7020999999",
                   "rules": [
@@ -10507,7 +11006,7 @@
             },
             {
                   "heading": "7101",
-                  "subdivision": "",
+                  "subdivision": "Heading 7101",
                   "min": "7101000000",
                   "max": "7101999999",
                   "rules": [
@@ -10527,7 +11026,7 @@
             },
             {
                   "heading": "710210",
-                  "subdivision": "",
+                  "subdivision": "Subheading 710210",
                   "min": "7102100000",
                   "max": "7102199999",
                   "rules": [
@@ -10547,7 +11046,7 @@
             },
             {
                   "heading": "710221-710239",
-                  "subdivision": "",
+                  "subdivision": "710221-710239",
                   "min": "7102210000",
                   "max": "7102399999",
                   "rules": [
@@ -10567,7 +11066,7 @@
             },
             {
                   "heading": "710310-710490",
-                  "subdivision": "",
+                  "subdivision": "710310-710490",
                   "min": "7103100000",
                   "max": "7104999999",
                   "rules": [
@@ -10587,7 +11086,7 @@
             },
             {
                   "heading": "7105",
-                  "subdivision": "",
+                  "subdivision": "Heading 7105",
                   "min": "7105000000",
                   "max": "7105999999",
                   "rules": [
@@ -10607,7 +11106,7 @@
             },
             {
                   "heading": "710610-710692",
-                  "subdivision": "",
+                  "subdivision": "710610-710692",
                   "min": "7106100000",
                   "max": "7106929999",
                   "rules": [
@@ -10636,7 +11135,7 @@
             },
             {
                   "heading": "7107",
-                  "subdivision": "",
+                  "subdivision": "Heading 7107",
                   "min": "7107000000",
                   "max": "7107999999",
                   "rules": [
@@ -10656,7 +11155,7 @@
             },
             {
                   "heading": "710811-710820",
-                  "subdivision": "",
+                  "subdivision": "710811-710820",
                   "min": "7108110000",
                   "max": "7108299999",
                   "rules": [
@@ -10685,7 +11184,7 @@
             },
             {
                   "heading": "7109",
-                  "subdivision": "",
+                  "subdivision": "Heading 7109",
                   "min": "7109000000",
                   "max": "7109999999",
                   "rules": [
@@ -10705,7 +11204,7 @@
             },
             {
                   "heading": "711011-711049",
-                  "subdivision": "",
+                  "subdivision": "711011-711049",
                   "min": "7110110000",
                   "max": "7110499999",
                   "rules": [
@@ -10734,7 +11233,7 @@
             },
             {
                   "heading": "7111",
-                  "subdivision": "",
+                  "subdivision": "Heading 7111",
                   "min": "7111000000",
                   "max": "7111999999",
                   "rules": [
@@ -10754,7 +11253,7 @@
             },
             {
                   "heading": "7112-7115",
-                  "subdivision": "",
+                  "subdivision": "7112-7115",
                   "min": "7112000000",
                   "max": "7115999999",
                   "rules": [
@@ -10774,7 +11273,7 @@
             },
             {
                   "heading": "7116-7117",
-                  "subdivision": "",
+                  "subdivision": "7116-7117",
                   "min": "7116000000",
                   "max": "7117999999",
                   "rules": [
@@ -10805,7 +11304,7 @@
             },
             {
                   "heading": "7118",
-                  "subdivision": "",
+                  "subdivision": "Heading 7118",
                   "min": "7118000000",
                   "max": "7118999999",
                   "rules": [
@@ -10825,7 +11324,7 @@
             },
             {
                   "heading": "7201-7207",
-                  "subdivision": "",
+                  "subdivision": "7201-7207",
                   "min": "7201000000",
                   "max": "7207999999",
                   "rules": [
@@ -10845,7 +11344,7 @@
             },
             {
                   "heading": "7208-7217",
-                  "subdivision": "",
+                  "subdivision": "7208-7217",
                   "min": "7208000000",
                   "max": "7217999999",
                   "rules": [
@@ -10865,7 +11364,7 @@
             },
             {
                   "heading": "7218",
-                  "subdivision": "",
+                  "subdivision": "Heading 7218",
                   "min": "7218000000",
                   "max": "7218999999",
                   "rules": [
@@ -10885,7 +11384,7 @@
             },
             {
                   "heading": "7219-7223",
-                  "subdivision": "",
+                  "subdivision": "7219-7223",
                   "min": "7219000000",
                   "max": "7223999999",
                   "rules": [
@@ -10905,7 +11404,7 @@
             },
             {
                   "heading": "7224",
-                  "subdivision": "",
+                  "subdivision": "Heading 7224",
                   "min": "7224000000",
                   "max": "7224999999",
                   "rules": [
@@ -10925,7 +11424,7 @@
             },
             {
                   "heading": "7225-7229",
-                  "subdivision": "",
+                  "subdivision": "7225-7229",
                   "min": "7225000000",
                   "max": "7229999999",
                   "rules": [
@@ -10945,7 +11444,7 @@
             },
             {
                   "heading": "7301-7303",
-                  "subdivision": "",
+                  "subdivision": "7301-7303",
                   "min": "7301000000",
                   "max": "7303999999",
                   "rules": [
@@ -10965,7 +11464,7 @@
             },
             {
                   "heading": "730411-730439",
-                  "subdivision": "",
+                  "subdivision": "730411-730439",
                   "min": "7304110000",
                   "max": "7304399999",
                   "rules": [
@@ -10985,7 +11484,7 @@
             },
             {
                   "heading": "730441",
-                  "subdivision": "",
+                  "subdivision": "Subheading 730441",
                   "min": "7304410000",
                   "max": "7304419999",
                   "rules": [
@@ -11005,7 +11504,7 @@
             },
             {
                   "heading": "730449-730490",
-                  "subdivision": "",
+                  "subdivision": "730449-730490",
                   "min": "7304490000",
                   "max": "7304999999",
                   "rules": [
@@ -11025,7 +11524,7 @@
             },
             {
                   "heading": "7305-7306",
-                  "subdivision": "",
+                  "subdivision": "7305-7306",
                   "min": "7305000000",
                   "max": "7306999999",
                   "rules": [
@@ -11045,7 +11544,7 @@
             },
             {
                   "heading": "730711-730719",
-                  "subdivision": "",
+                  "subdivision": "730711-730719",
                   "min": "7307110000",
                   "max": "7307199999",
                   "rules": [
@@ -11065,7 +11564,7 @@
             },
             {
                   "heading": "730721-730729",
-                  "subdivision": "",
+                  "subdivision": "730721-730729",
                   "min": "7307210000",
                   "max": "7307299999",
                   "rules": [
@@ -11095,7 +11594,7 @@
             },
             {
                   "heading": "730791-730799",
-                  "subdivision": "",
+                  "subdivision": "730791-730799",
                   "min": "7307910000",
                   "max": "7307999999",
                   "rules": [
@@ -11115,7 +11614,7 @@
             },
             {
                   "heading": "7308",
-                  "subdivision": "",
+                  "subdivision": "Heading 7308",
                   "min": "7308000000",
                   "max": "7308999999",
                   "rules": [
@@ -11147,7 +11646,7 @@
             },
             {
                   "heading": "7309-7314",
-                  "subdivision": "",
+                  "subdivision": "7309-7314",
                   "min": "7309000000",
                   "max": "7314999999",
                   "rules": [
@@ -11167,7 +11666,7 @@
             },
             {
                   "heading": "7315",
-                  "subdivision": "",
+                  "subdivision": "Heading 7315",
                   "min": "7315000000",
                   "max": "7315999999",
                   "rules": [
@@ -11198,7 +11697,7 @@
             },
             {
                   "heading": "7316-7320",
-                  "subdivision": "",
+                  "subdivision": "7316-7320",
                   "min": "7316000000",
                   "max": "7320999999",
                   "rules": [
@@ -11218,7 +11717,7 @@
             },
             {
                   "heading": "7321",
-                  "subdivision": "",
+                  "subdivision": "Heading 7321",
                   "min": "7321000000",
                   "max": "7321999999",
                   "rules": [
@@ -11249,7 +11748,7 @@
             },
             {
                   "heading": "7322-7323",
-                  "subdivision": "",
+                  "subdivision": "7322-7323",
                   "min": "7322000000",
                   "max": "7323999999",
                   "rules": [
@@ -11269,7 +11768,7 @@
             },
             {
                   "heading": "7324",
-                  "subdivision": "",
+                  "subdivision": "Heading 7324",
                   "min": "7324000000",
                   "max": "7324999999",
                   "rules": [
@@ -11300,7 +11799,7 @@
             },
             {
                   "heading": "7325-7326",
-                  "subdivision": "",
+                  "subdivision": "7325-7326",
                   "min": "7325000000",
                   "max": "7326999999",
                   "rules": [
@@ -11320,7 +11819,7 @@
             },
             {
                   "heading": "7401-7402",
-                  "subdivision": "",
+                  "subdivision": "7401-7402",
                   "min": "7401000000",
                   "max": "7402999999",
                   "rules": [
@@ -11340,7 +11839,7 @@
             },
             {
                   "heading": "740311-740329",
-                  "subdivision": "",
+                  "subdivision": "740311-740329",
                   "min": "7403110000",
                   "max": "7403299999",
                   "rules": [
@@ -11360,7 +11859,7 @@
             },
             {
                   "heading": "7404-7419",
-                  "subdivision": "",
+                  "subdivision": "7404-7419",
                   "min": "7404000000",
                   "max": "7419999999",
                   "rules": [
@@ -11380,7 +11879,7 @@
             },
             {
                   "heading": "7501-7508",
-                  "subdivision": "",
+                  "subdivision": "7501-7508",
                   "min": "7501000000",
                   "max": "7508999999",
                   "rules": [
@@ -11400,7 +11899,7 @@
             },
             {
                   "heading": "760110-760120",
-                  "subdivision": "",
+                  "subdivision": "760110-760120",
                   "min": "7601100000",
                   "max": "7601299999",
                   "rules": [
@@ -11420,7 +11919,7 @@
             },
             {
                   "heading": "7602-7606",
-                  "subdivision": "",
+                  "subdivision": "7602-7606",
                   "min": "7602000000",
                   "max": "7606999999",
                   "rules": [
@@ -11440,7 +11939,7 @@
             },
             {
                   "heading": "7607",
-                  "subdivision": "",
+                  "subdivision": "Heading 7607",
                   "min": "7607000000",
                   "max": "7607999999",
                   "rules": [
@@ -11471,7 +11970,7 @@
             },
             {
                   "heading": "7608-7616",
-                  "subdivision": "",
+                  "subdivision": "7608-7616",
                   "min": "7608000000",
                   "max": "7616999999",
                   "rules": [
@@ -11491,7 +11990,7 @@
             },
             {
                   "heading": "780110",
-                  "subdivision": "",
+                  "subdivision": "Subheading 780110",
                   "min": "7801100000",
                   "max": "7801199999",
                   "rules": [
@@ -11511,7 +12010,7 @@
             },
             {
                   "heading": "780191-780199",
-                  "subdivision": "",
+                  "subdivision": "780191-780199",
                   "min": "7801910000",
                   "max": "7801999999",
                   "rules": [
@@ -11531,7 +12030,7 @@
             },
             {
                   "heading": "7802-7806",
-                  "subdivision": "",
+                  "subdivision": "7802-7806",
                   "min": "7802000000",
                   "max": "7806999999",
                   "rules": [
@@ -11551,7 +12050,7 @@
             },
             {
                   "heading": "7901-7907",
-                  "subdivision": "",
+                  "subdivision": "7901-7907",
                   "min": "7901000000",
                   "max": "7907999999",
                   "rules": [
@@ -11571,7 +12070,7 @@
             },
             {
                   "heading": "8001-8007",
-                  "subdivision": "",
+                  "subdivision": "8001-8007",
                   "min": "8001000000",
                   "max": "8007999999",
                   "rules": [
@@ -11591,7 +12090,7 @@
             },
             {
                   "heading": "810110-811300",
-                  "subdivision": "",
+                  "subdivision": "810110-811300",
                   "min": "8101100000",
                   "max": "8113999999",
                   "rules": [
@@ -11611,7 +12110,7 @@
             },
             {
                   "heading": "8201-8204",
-                  "subdivision": "",
+                  "subdivision": "8201-8204",
                   "min": "8201000000",
                   "max": "8204999999",
                   "rules": [
@@ -11642,7 +12141,7 @@
             },
             {
                   "heading": "820510-820570",
-                  "subdivision": "",
+                  "subdivision": "820510-820570",
                   "min": "8205100000",
                   "max": "8205799999",
                   "rules": [
@@ -11673,7 +12172,7 @@
             },
             {
                   "heading": "820590",
-                  "subdivision": "",
+                  "subdivision": "Subheading 820590",
                   "min": "8205900000",
                   "max": "8205999999",
                   "rules": [
@@ -11711,7 +12210,7 @@
             },
             {
                   "heading": "8206",
-                  "subdivision": "",
+                  "subdivision": "Heading 8206",
                   "min": "8206000000",
                   "max": "8206999999",
                   "rules": [
@@ -11741,7 +12240,7 @@
             },
             {
                   "heading": "820713",
-                  "subdivision": "",
+                  "subdivision": "Subheading 820713",
                   "min": "8207130000",
                   "max": "8207139999",
                   "rules": [
@@ -11773,7 +12272,7 @@
             },
             {
                   "heading": "820719-820790",
-                  "subdivision": "",
+                  "subdivision": "820719-820790",
                   "min": "8207190000",
                   "max": "8207999999",
                   "rules": [
@@ -11804,7 +12303,7 @@
             },
             {
                   "heading": "8208-8210",
-                  "subdivision": "",
+                  "subdivision": "8208-8210",
                   "min": "8208000000",
                   "max": "8210999999",
                   "rules": [
@@ -11824,7 +12323,7 @@
             },
             {
                   "heading": "821110",
-                  "subdivision": "",
+                  "subdivision": "Subheading 821110",
                   "min": "8211100000",
                   "max": "8211199999",
                   "rules": [
@@ -11853,7 +12352,7 @@
             },
             {
                   "heading": "821191-821193",
-                  "subdivision": "",
+                  "subdivision": "821191-821193",
                   "min": "8211910000",
                   "max": "8211939999",
                   "rules": [
@@ -11884,7 +12383,7 @@
             },
             {
                   "heading": "821194-821195",
-                  "subdivision": "",
+                  "subdivision": "821194-821195",
                   "min": "8211940000",
                   "max": "8211959999",
                   "rules": [
@@ -11904,7 +12403,7 @@
             },
             {
                   "heading": "8212-8213",
-                  "subdivision": "",
+                  "subdivision": "8212-8213",
                   "min": "8212000000",
                   "max": "8213999999",
                   "rules": [
@@ -11924,7 +12423,7 @@
             },
             {
                   "heading": "821410",
-                  "subdivision": "",
+                  "subdivision": "Subheading 821410",
                   "min": "8214100000",
                   "max": "8214199999",
                   "rules": [
@@ -11944,7 +12443,7 @@
             },
             {
                   "heading": "821420",
-                  "subdivision": "",
+                  "subdivision": "Subheading 821420",
                   "min": "8214200000",
                   "max": "8214299999",
                   "rules": [
@@ -11973,7 +12472,7 @@
             },
             {
                   "heading": "821490",
-                  "subdivision": "",
+                  "subdivision": "Subheading 821490",
                   "min": "8214900000",
                   "max": "8214999999",
                   "rules": [
@@ -11993,7 +12492,7 @@
             },
             {
                   "heading": "821510-821520",
-                  "subdivision": "",
+                  "subdivision": "821510-821520",
                   "min": "8215100000",
                   "max": "8215299999",
                   "rules": [
@@ -12022,7 +12521,7 @@
             },
             {
                   "heading": "821591-821599",
-                  "subdivision": "",
+                  "subdivision": "821591-821599",
                   "min": "8215910000",
                   "max": "8215999999",
                   "rules": [
@@ -12042,7 +12541,7 @@
             },
             {
                   "heading": "830110-830150",
-                  "subdivision": "",
+                  "subdivision": "830110-830150",
                   "min": "8301100000",
                   "max": "8301599999",
                   "rules": [
@@ -12073,7 +12572,7 @@
             },
             {
                   "heading": "830160-830170",
-                  "subdivision": "",
+                  "subdivision": "830160-830170",
                   "min": "8301600000",
                   "max": "8301799999",
                   "rules": [
@@ -12093,7 +12592,7 @@
             },
             {
                   "heading": "830210-830230",
-                  "subdivision": "",
+                  "subdivision": "830210-830230",
                   "min": "8302100000",
                   "max": "8302399999",
                   "rules": [
@@ -12113,7 +12612,7 @@
             },
             {
                   "heading": "830241",
-                  "subdivision": "",
+                  "subdivision": "Subheading 830241",
                   "min": "8302410000",
                   "max": "8302419999",
                   "rules": [
@@ -12144,7 +12643,7 @@
             },
             {
                   "heading": "830242-830250",
-                  "subdivision": "",
+                  "subdivision": "830242-830250",
                   "min": "8302420000",
                   "max": "8302599999",
                   "rules": [
@@ -12164,7 +12663,7 @@
             },
             {
                   "heading": "830260",
-                  "subdivision": "",
+                  "subdivision": "Subheading 830260",
                   "min": "8302600000",
                   "max": "8302699999",
                   "rules": [
@@ -12195,7 +12694,7 @@
             },
             {
                   "heading": "8303-8304",
-                  "subdivision": "",
+                  "subdivision": "8303-8304",
                   "min": "8303000000",
                   "max": "8304999999",
                   "rules": [
@@ -12215,7 +12714,7 @@
             },
             {
                   "heading": "8305",
-                  "subdivision": "",
+                  "subdivision": "Heading 8305",
                   "min": "8305000000",
                   "max": "8305999999",
                   "rules": [
@@ -12246,7 +12745,7 @@
             },
             {
                   "heading": "8306",
-                  "subdivision": "",
+                  "subdivision": "Heading 8306",
                   "min": "8306000000",
                   "max": "8306999999",
                   "rules": [
@@ -12277,7 +12776,7 @@
             },
             {
                   "heading": "8307",
-                  "subdivision": "",
+                  "subdivision": "Heading 8307",
                   "min": "8307000000",
                   "max": "8307999999",
                   "rules": [
@@ -12297,7 +12796,7 @@
             },
             {
                   "heading": "8308",
-                  "subdivision": "",
+                  "subdivision": "Heading 8308",
                   "min": "8308000000",
                   "max": "8308999999",
                   "rules": [
@@ -12328,7 +12827,7 @@
             },
             {
                   "heading": "8309-8310",
-                  "subdivision": "",
+                  "subdivision": "8309-8310",
                   "min": "8309000000",
                   "max": "8310999999",
                   "rules": [
@@ -12348,7 +12847,7 @@
             },
             {
                   "heading": "8311",
-                  "subdivision": "",
+                  "subdivision": "Heading 8311",
                   "min": "8311000000",
                   "max": "8311999999",
                   "rules": [
@@ -12379,7 +12878,7 @@
             },
             {
                   "heading": "8401-8412",
-                  "subdivision": "",
+                  "subdivision": "8401-8412",
                   "min": "8401000000",
                   "max": "8412999999",
                   "rules": [
@@ -12410,7 +12909,7 @@
             },
             {
                   "heading": "841311-841382",
-                  "subdivision": "",
+                  "subdivision": "841311-841382",
                   "min": "8413110000",
                   "max": "8413829999",
                   "rules": [
@@ -12430,7 +12929,7 @@
             },
             {
                   "heading": "841391-841392",
-                  "subdivision": "",
+                  "subdivision": "841391-841392",
                   "min": "8413910000",
                   "max": "8413929999",
                   "rules": [
@@ -12450,7 +12949,7 @@
             },
             {
                   "heading": "8414-8415",
-                  "subdivision": "",
+                  "subdivision": "8414-8415",
                   "min": "8414000000",
                   "max": "8415999999",
                   "rules": [
@@ -12481,7 +12980,7 @@
             },
             {
                   "heading": "841610-841790",
-                  "subdivision": "",
+                  "subdivision": "841610-841790",
                   "min": "8416100000",
                   "max": "8417999999",
                   "rules": [
@@ -12501,7 +13000,7 @@
             },
             {
                   "heading": "8418-8422",
-                  "subdivision": "",
+                  "subdivision": "8418-8422",
                   "min": "8418000000",
                   "max": "8422999999",
                   "rules": [
@@ -12532,7 +13031,7 @@
             },
             {
                   "heading": "842310-842699",
-                  "subdivision": "",
+                  "subdivision": "842310-842699",
                   "min": "8423100000",
                   "max": "8426999999",
                   "rules": [
@@ -12552,7 +13051,7 @@
             },
             {
                   "heading": "8427",
-                  "subdivision": "",
+                  "subdivision": "Heading 8427",
                   "min": "8427000000",
                   "max": "8427999999",
                   "rules": [
@@ -12584,7 +13083,7 @@
             },
             {
                   "heading": "842810-843069",
-                  "subdivision": "",
+                  "subdivision": "842810-843069",
                   "min": "8428100000",
                   "max": "8430699999",
                   "rules": [
@@ -12604,7 +13103,7 @@
             },
             {
                   "heading": "8431",
-                  "subdivision": "",
+                  "subdivision": "Heading 8431",
                   "min": "8431000000",
                   "max": "8431999999",
                   "rules": [
@@ -12635,7 +13134,7 @@
             },
             {
                   "heading": "843210-844250",
-                  "subdivision": "",
+                  "subdivision": "843210-844250",
                   "min": "8432100000",
                   "max": "8442599999",
                   "rules": [
@@ -12655,7 +13154,7 @@
             },
             {
                   "heading": "8443",
-                  "subdivision": "",
+                  "subdivision": "Heading 8443",
                   "min": "8443000000",
                   "max": "8443999999",
                   "rules": [
@@ -12686,7 +13185,7 @@
             },
             {
                   "heading": "844400-844900",
-                  "subdivision": "",
+                  "subdivision": "844400-844900",
                   "min": "8444000000",
                   "max": "8449999999",
                   "rules": [
@@ -12706,7 +13205,7 @@
             },
             {
                   "heading": "8450-8452",
-                  "subdivision": "",
+                  "subdivision": "8450-8452",
                   "min": "8450000000",
                   "max": "8452999999",
                   "rules": [
@@ -12737,7 +13236,7 @@
             },
             {
                   "heading": "845310-845490",
-                  "subdivision": "",
+                  "subdivision": "845310-845490",
                   "min": "8453100000",
                   "max": "8454999999",
                   "rules": [
@@ -12757,7 +13256,7 @@
             },
             {
                   "heading": "8455",
-                  "subdivision": "",
+                  "subdivision": "Heading 8455",
                   "min": "8455000000",
                   "max": "8455999999",
                   "rules": [
@@ -12788,7 +13287,7 @@
             },
             {
                   "heading": "8456-8465",
-                  "subdivision": "",
+                  "subdivision": "8456-8465",
                   "min": "8456000000",
                   "max": "8465999999",
                   "rules": [
@@ -12820,7 +13319,7 @@
             },
             {
                   "heading": "8466",
-                  "subdivision": "",
+                  "subdivision": "Heading 8466",
                   "min": "8466000000",
                   "max": "8466999999",
                   "rules": [
@@ -12840,7 +13339,7 @@
             },
             {
                   "heading": "8467-8468",
-                  "subdivision": "",
+                  "subdivision": "8467-8468",
                   "min": "8467000000",
                   "max": "8468999999",
                   "rules": [
@@ -12870,9 +13369,9 @@
                   "valid": true
             },
             {
-                  "heading": "846900-847290",
-                  "subdivision": "",
-                  "min": "8469000000",
+                  "heading": "847000-847290",
+                  "subdivision": "847000-847290",
+                  "min": "8470000000",
                   "max": "8472999999",
                   "rules": [
                         {
@@ -12891,7 +13390,7 @@
             },
             {
                   "heading": "8473",
-                  "subdivision": "",
+                  "subdivision": "Heading 8473",
                   "min": "8473000000",
                   "max": "8473999999",
                   "rules": [
@@ -12922,7 +13421,7 @@
             },
             {
                   "heading": "847410-847990",
-                  "subdivision": "",
+                  "subdivision": "847410-847990",
                   "min": "8474100000",
                   "max": "8479999999",
                   "rules": [
@@ -12942,7 +13441,7 @@
             },
             {
                   "heading": "8480-8483",
-                  "subdivision": "",
+                  "subdivision": "8480-8483",
                   "min": "8480000000",
                   "max": "8483999999",
                   "rules": [
@@ -12973,7 +13472,7 @@
             },
             {
                   "heading": "848410-848420",
-                  "subdivision": "",
+                  "subdivision": "848410-848420",
                   "min": "8484100000",
                   "max": "8484299999",
                   "rules": [
@@ -12993,7 +13492,7 @@
             },
             {
                   "heading": "848490",
-                  "subdivision": "",
+                  "subdivision": "Subheading 848490",
                   "min": "8484900000",
                   "max": "8484999999",
                   "rules": [
@@ -13013,7 +13512,7 @@
             },
             {
                   "heading": "8486",
-                  "subdivision": "",
+                  "subdivision": "Heading 8486",
                   "min": "8486000000",
                   "max": "8486999999",
                   "rules": [
@@ -13044,7 +13543,7 @@
             },
             {
                   "heading": "848710-848790",
-                  "subdivision": "",
+                  "subdivision": "848710-848790",
                   "min": "8487100000",
                   "max": "8487999999",
                   "rules": [
@@ -13064,7 +13563,7 @@
             },
             {
                   "heading": "8501-8502",
-                  "subdivision": "",
+                  "subdivision": "8501-8502",
                   "min": "8501000000",
                   "max": "8502999999",
                   "rules": [
@@ -13096,7 +13595,7 @@
             },
             {
                   "heading": "8503-8516",
-                  "subdivision": "",
+                  "subdivision": "8503-8516",
                   "min": "8503000000",
                   "max": "8516999999",
                   "rules": [
@@ -13127,7 +13626,7 @@
             },
             {
                   "heading": "851711-851762",
-                  "subdivision": "",
+                  "subdivision": "851711-851762",
                   "min": "8517110000",
                   "max": "8517629999",
                   "rules": [
@@ -13147,7 +13646,7 @@
             },
             {
                   "heading": "851769-851770",
-                  "subdivision": "",
+                  "subdivision": "851769-851770",
                   "min": "8517690000",
                   "max": "8517799999",
                   "rules": [
@@ -13178,7 +13677,7 @@
             },
             {
                   "heading": "8518",
-                  "subdivision": "",
+                  "subdivision": "Heading 8518",
                   "min": "8518000000",
                   "max": "8518999999",
                   "rules": [
@@ -13209,7 +13708,7 @@
             },
             {
                   "heading": "8519-8521",
-                  "subdivision": "",
+                  "subdivision": "8519-8521",
                   "min": "8519000000",
                   "max": "8521999999",
                   "rules": [
@@ -13241,7 +13740,7 @@
             },
             {
                   "heading": "8522",
-                  "subdivision": "",
+                  "subdivision": "Heading 8522",
                   "min": "8522000000",
                   "max": "8522999999",
                   "rules": [
@@ -13272,7 +13771,7 @@
             },
             {
                   "heading": "8523",
-                  "subdivision": "",
+                  "subdivision": "Heading 8523",
                   "min": "8523000000",
                   "max": "8523999999",
                   "rules": [
@@ -13292,7 +13791,7 @@
             },
             {
                   "heading": "8525",
-                  "subdivision": "",
+                  "subdivision": "Heading 8525",
                   "min": "8525000000",
                   "max": "8525999999",
                   "rules": [
@@ -13312,7 +13811,7 @@
             },
             {
                   "heading": "8526-8528",
-                  "subdivision": "",
+                  "subdivision": "8526-8528",
                   "min": "8526000000",
                   "max": "8528999999",
                   "rules": [
@@ -13344,7 +13843,7 @@
             },
             {
                   "heading": "8529",
-                  "subdivision": "",
+                  "subdivision": "Heading 8529",
                   "min": "8529000000",
                   "max": "8529999999",
                   "rules": [
@@ -13375,7 +13874,7 @@
             },
             {
                   "heading": "853010-853090",
-                  "subdivision": "",
+                  "subdivision": "853010-853090",
                   "min": "8530100000",
                   "max": "8530999999",
                   "rules": [
@@ -13395,7 +13894,7 @@
             },
             {
                   "heading": "8531",
-                  "subdivision": "",
+                  "subdivision": "Heading 8531",
                   "min": "8531000000",
                   "max": "8531999999",
                   "rules": [
@@ -13426,7 +13925,7 @@
             },
             {
                   "heading": "853210-853400",
-                  "subdivision": "",
+                  "subdivision": "853210-853400",
                   "min": "8532100000",
                   "max": "8534999999",
                   "rules": [
@@ -13446,7 +13945,7 @@
             },
             {
                   "heading": "8535-8537",
-                  "subdivision": "",
+                  "subdivision": "8535-8537",
                   "min": "8535000000",
                   "max": "8537999999",
                   "rules": [
@@ -13478,7 +13977,7 @@
             },
             {
                   "heading": "8538-8548",
-                  "subdivision": "",
+                  "subdivision": "8538-8548",
                   "min": "8538000000",
                   "max": "8548999999",
                   "rules": [
@@ -13509,7 +14008,7 @@
             },
             {
                   "heading": "8601-8606",
-                  "subdivision": "",
+                  "subdivision": "8601-8606",
                   "min": "8601000000",
                   "max": "8606999999",
                   "rules": [
@@ -13541,7 +14040,7 @@
             },
             {
                   "heading": "8607",
-                  "subdivision": "",
+                  "subdivision": "Heading 8607",
                   "min": "8607000000",
                   "max": "8607999999",
                   "rules": [
@@ -13572,7 +14071,7 @@
             },
             {
                   "heading": "8608-8609",
-                  "subdivision": "",
+                  "subdivision": "8608-8609",
                   "min": "8608000000",
                   "max": "8609999999",
                   "rules": [
@@ -13592,7 +14091,7 @@
             },
             {
                   "heading": "8701",
-                  "subdivision": "",
+                  "subdivision": "Heading 8701",
                   "min": "8701000000",
                   "max": "8701999999",
                   "rules": [
@@ -13612,7 +14111,7 @@
             },
             {
                   "heading": "8702",
-                  "subdivision": "",
+                  "subdivision": "Heading 8702",
                   "min": "8702000000",
                   "max": "8702999999",
                   "rules": [
@@ -13632,7 +14131,7 @@
             },
             {
                   "heading": "8703",
-                  "subdivision": "",
+                  "subdivision": "Heading 8703",
                   "min": "8703000000",
                   "max": "8703999999",
                   "rules": [
@@ -13651,62 +14150,224 @@
                   "valid": true
             },
             {
-                  "heading": "870321-870324",
-                  "subdivision": "",
+                  "heading": "870321",
+                  "subdivision": "Other vehicles, with spark\n-ignition internal combustion reciprocating piston engine: of a cylinder capacity not exceeding 1,000 cc (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "8703210000",
-                  "max": "8703249999",
+                  "max": "8703219999",
                   "rules": [
                         {
-                              "rule": "Production in which the value of all non-originating materials used does not exceed: \n\n\n- a) **70%** of the transaction value or ex-works price of the product or\n\n\n- b) **80%** of the net cost of the product (within annual quota allocation for vehicles exported from Canada to the United Kingdom).",
+                              "rule": "Production in which the value of all non-originating materials used does not exceed: \n\n- **70%** of the transaction value or ex-works price of the product.",
                               "class": [],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
-                              "export": false
+                              "export": true
+                        },
+                        {
+                              "rule": "80% of the net cost of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
                         }
                   ],
                   "valid": true
             },
             {
-                  "heading": "870331-870333",
-                  "subdivision": "",
-                  "min": "8703310000",
-                  "max": "8703339999",
+                  "heading": "870322",
+                  "subdivision": "Other vehicles, with spark\n-ignition internal combustion reciprocating piston engine: of a cylinder capacity exceeding 1,000 cc but not exceeding 1,500 cc (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "8703220000",
+                  "max": "8703229999",
                   "rules": [
                         {
-                              "rule": "Production in which the value of all non-originating materials used does not exceed: \n\n\n- a) **70%** of the transaction value or ex-works price of the product or\n\n\n- b) **80%** of the net cost of the product (within annual quota allocation for vehicles exported from Canada to the United Kingdom).",
+                              "rule": "Production in which the value of all non-originating materials used does not exceed: \n\n- **70%** of the transaction value or ex-works price of the product.",
                               "class": [],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
-                              "export": false
+                              "export": true
+                        },
+                        {
+                              "rule": "80% of the net cost of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "870323",
+                  "subdivision": "Other vehicles, with spark\n-ignition internal combustion reciprocating piston engine: of a cylinder capacity exceeding 1,500 cc but not exceeding 3,000 cc (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "8703230000",
+                  "max": "8703239999",
+                  "rules": [
+                        {
+                              "rule": "Production in which the value of all non-originating materials used does not exceed: \n\n- **70%** of the transaction value or ex-works price of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "80% of the net cost of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "870324",
+                  "subdivision": "Other vehicles, with spark\n-ignition internal combustion reciprocating piston engine: of a cylinder capacity exceeding 3,000 cc (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "8703240000",
+                  "max": "8703249999",
+                  "rules": [
+                        {
+                              "rule": "Production in which the value of all non-originating materials used does not exceed: \n\n- **70%** of the transaction value or ex-works price of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "80% of the net cost of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "870331",
+                  "subdivision": "Other vehicles, with compression\n-ignition internal combustion piston engine (diesel or semi\n-diesel): of a cylinder capacity not exceeding 1,500 cc (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "8703310000",
+                  "max": "8703319999",
+                  "rules": [
+                        {
+                              "rule": "Production in which the value of all non-originating materials used does not exceed: \n\n- **70%** of the transaction value or ex-works price of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "80% of the net cost of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "870332",
+                  "subdivision": "Other vehicles, with compression\n-ignition internal combustion piston engine (diesel or semi\n-diesel): of a cylinder capacity exceeding 1,500 cc but not exceeding 2,500 cc (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "8703320000",
+                  "max": "8703329999",
+                  "rules": [
+                        {
+                              "rule": "Production in which the value of all non-originating materials used does not exceed: \n\n- **70%** of the transaction value or ex-works price of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "80% of the net cost of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "870333",
+                  "subdivision": "Other vehicles, with compression\n-ignition internal combustion piston engine (diesel or semi\n-diesel): of a cylinder capacity exceeding 2,500 cc (*Quota for exports from Canada into the United Kingdom*)",
+                  "min": "8703330000",
+                  "max": "8703339999",
+                  "rules": [
+                        {
+                              "rule": "Production in which the value of all non-originating materials used does not exceed: \n\n- **70%** of the transaction value or ex-works price of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "80% of the net cost of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
                         }
                   ],
                   "valid": true
             },
             {
                   "heading": "870390",
-                  "subdivision": "",
+                  "subdivision": "Motor cars and other motor vehicles principally designed for the transport of persons (other than those of heading 8702), including station wagons and racing cars\n-Other (*Quota for exports from Canada into the United Kingdom*)",
                   "min": "8703900000",
                   "max": "8703999999",
                   "rules": [
                         {
-                              "rule": "Production in which the value of all non-originating materials used does not exceed: \n\n\n- a) **70%** of the transaction value or ex-works price of the product or\n\n\n- b) **80%** of the net cost of the product (within annual quota allocation for vehicles exported from Canada to the United Kingdom).",
+                              "rule": "Production in which the value of all non-originating materials used does not exceed: \n\n- **70%** of the transaction value or ex-works price of the product.",
                               "class": [],
                               "footnotes": [],
                               "operator": null,
-                              "quota": true,
+                              "quota": false,
                               "import": true,
-                              "export": false
+                              "export": true
+                        },
+                        {
+                              "rule": "80% of the net cost of the product.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
                         }
                   ],
                   "valid": true
             },
             {
                   "heading": "8704",
-                  "subdivision": "",
+                  "subdivision": "Heading 8704",
                   "min": "8704000000",
                   "max": "8704999999",
                   "rules": [
@@ -13726,7 +14387,7 @@
             },
             {
                   "heading": "8705",
-                  "subdivision": "",
+                  "subdivision": "Heading 8705",
                   "min": "8705000000",
                   "max": "8705999999",
                   "rules": [
@@ -13746,7 +14407,7 @@
             },
             {
                   "heading": "8706",
-                  "subdivision": "",
+                  "subdivision": "Heading 8706",
                   "min": "8706000000",
                   "max": "8706999999",
                   "rules": [
@@ -13778,7 +14439,7 @@
             },
             {
                   "heading": "8707",
-                  "subdivision": "",
+                  "subdivision": "Heading 8707",
                   "min": "8707000000",
                   "max": "8707999999",
                   "rules": [
@@ -13810,7 +14471,7 @@
             },
             {
                   "heading": "8708",
-                  "subdivision": "",
+                  "subdivision": "Heading 8708",
                   "min": "8708000000",
                   "max": "8708999999",
                   "rules": [
@@ -13841,7 +14502,7 @@
             },
             {
                   "heading": "8709",
-                  "subdivision": "",
+                  "subdivision": "Heading 8709",
                   "min": "8709000000",
                   "max": "8709999999",
                   "rules": [
@@ -13872,7 +14533,7 @@
             },
             {
                   "heading": "8710-8711",
-                  "subdivision": "",
+                  "subdivision": "8710-8711",
                   "min": "8710000000",
                   "max": "8711999999",
                   "rules": [
@@ -13892,7 +14553,7 @@
             },
             {
                   "heading": "8712",
-                  "subdivision": "",
+                  "subdivision": "Heading 8712",
                   "min": "8712000000",
                   "max": "8712999999",
                   "rules": [
@@ -13924,7 +14585,7 @@
             },
             {
                   "heading": "8713",
-                  "subdivision": "",
+                  "subdivision": "Heading 8713",
                   "min": "8713000000",
                   "max": "8713999999",
                   "rules": [
@@ -13944,7 +14605,7 @@
             },
             {
                   "heading": "8714-8716",
-                  "subdivision": "",
+                  "subdivision": "8714-8716",
                   "min": "8714000000",
                   "max": "8716999999",
                   "rules": [
@@ -13975,7 +14636,7 @@
             },
             {
                   "heading": "8801",
-                  "subdivision": "",
+                  "subdivision": "Heading 8801",
                   "min": "8801000000",
                   "max": "8801999999",
                   "rules": [
@@ -13995,7 +14656,7 @@
             },
             {
                   "heading": "8802-8805",
-                  "subdivision": "",
+                  "subdivision": "8802-8805",
                   "min": "8802000000",
                   "max": "8805999999",
                   "rules": [
@@ -14026,7 +14687,7 @@
             },
             {
                   "heading": "8901-8906",
-                  "subdivision": "",
+                  "subdivision": "8901-8906",
                   "min": "8901000000",
                   "max": "8906999999",
                   "rules": [
@@ -14057,7 +14718,7 @@
             },
             {
                   "heading": "8907-8908",
-                  "subdivision": "",
+                  "subdivision": "8907-8908",
                   "min": "8907000000",
                   "max": "8908999999",
                   "rules": [
@@ -14077,7 +14738,7 @@
             },
             {
                   "heading": "9001",
-                  "subdivision": "",
+                  "subdivision": "Heading 9001",
                   "min": "9001000000",
                   "max": "9001999999",
                   "rules": [
@@ -14097,7 +14758,7 @@
             },
             {
                   "heading": "9002",
-                  "subdivision": "",
+                  "subdivision": "Heading 9002",
                   "min": "9002000000",
                   "max": "9002999999",
                   "rules": [
@@ -14129,7 +14790,7 @@
             },
             {
                   "heading": "9003-9033",
-                  "subdivision": "",
+                  "subdivision": "9003-9033",
                   "min": "9003000000",
                   "max": "9033999999",
                   "rules": [
@@ -14160,7 +14821,7 @@
             },
             {
                   "heading": "9101-9107",
-                  "subdivision": "",
+                  "subdivision": "9101-9107",
                   "min": "9101000000",
                   "max": "9107999999",
                   "rules": [
@@ -14192,7 +14853,7 @@
             },
             {
                   "heading": "9108-9114",
-                  "subdivision": "",
+                  "subdivision": "9108-9114",
                   "min": "9108000000",
                   "max": "9114999999",
                   "rules": [
@@ -14223,7 +14884,7 @@
             },
             {
                   "heading": "9201-9208",
-                  "subdivision": "",
+                  "subdivision": "9201-9208",
                   "min": "9201000000",
                   "max": "9208999999",
                   "rules": [
@@ -14255,7 +14916,7 @@
             },
             {
                   "heading": "9209",
-                  "subdivision": "",
+                  "subdivision": "Heading 9209",
                   "min": "9209000000",
                   "max": "9209999999",
                   "rules": [
@@ -14286,7 +14947,7 @@
             },
             {
                   "heading": "9301-9304",
-                  "subdivision": "",
+                  "subdivision": "9301-9304",
                   "min": "9301000000",
                   "max": "9304999999",
                   "rules": [
@@ -14318,7 +14979,7 @@
             },
             {
                   "heading": "9305-9307",
-                  "subdivision": "",
+                  "subdivision": "9305-9307",
                   "min": "9305000000",
                   "max": "9307999999",
                   "rules": [
@@ -14349,7 +15010,7 @@
             },
             {
                   "heading": "9401-9406",
-                  "subdivision": "",
+                  "subdivision": "9401-9406",
                   "min": "9401000000",
                   "max": "9406999999",
                   "rules": [
@@ -14380,7 +15041,7 @@
             },
             {
                   "heading": "9503-9505",
-                  "subdivision": "",
+                  "subdivision": "9503-9505",
                   "min": "9503000000",
                   "max": "9505999999",
                   "rules": [
@@ -14411,7 +15072,7 @@
             },
             {
                   "heading": "950611-950629",
-                  "subdivision": "",
+                  "subdivision": "950611-950629",
                   "min": "9506110000",
                   "max": "9506299999",
                   "rules": [
@@ -14442,7 +15103,7 @@
             },
             {
                   "heading": "950631",
-                  "subdivision": "",
+                  "subdivision": "Subheading 950631",
                   "min": "9506310000",
                   "max": "9506319999",
                   "rules": [
@@ -14473,7 +15134,7 @@
             },
             {
                   "heading": "950632-950699",
-                  "subdivision": "",
+                  "subdivision": "950632-950699",
                   "min": "9506320000",
                   "max": "9506999999",
                   "rules": [
@@ -14504,7 +15165,7 @@
             },
             {
                   "heading": "9507-9508",
-                  "subdivision": "",
+                  "subdivision": "9507-9508",
                   "min": "9507000000",
                   "max": "9508999999",
                   "rules": [
@@ -14524,7 +15185,7 @@
             },
             {
                   "heading": "960110-960200",
-                  "subdivision": "",
+                  "subdivision": "960110-960200",
                   "min": "9601100000",
                   "max": "9602999999",
                   "rules": [
@@ -14544,7 +15205,7 @@
             },
             {
                   "heading": "9603-9604",
-                  "subdivision": "",
+                  "subdivision": "9603-9604",
                   "min": "9603000000",
                   "max": "9604999999",
                   "rules": [
@@ -14564,7 +15225,7 @@
             },
             {
                   "heading": "9605",
-                  "subdivision": "",
+                  "subdivision": "Heading 9605",
                   "min": "9605000000",
                   "max": "9605999999",
                   "rules": [
@@ -14586,7 +15247,7 @@
             },
             {
                   "heading": "9606-9607",
-                  "subdivision": "",
+                  "subdivision": "9606-9607",
                   "min": "9606000000",
                   "max": "9607999999",
                   "rules": [
@@ -14617,7 +15278,7 @@
             },
             {
                   "heading": "960810-960840",
-                  "subdivision": "",
+                  "subdivision": "960810-960840",
                   "min": "9608100000",
                   "max": "9608499999",
                   "rules": [
@@ -14648,7 +15309,7 @@
             },
             {
                   "heading": "960850",
-                  "subdivision": "",
+                  "subdivision": "Subheading 960850",
                   "min": "9608500000",
                   "max": "9608599999",
                   "rules": [
@@ -14677,7 +15338,7 @@
             },
             {
                   "heading": "960860-960899",
-                  "subdivision": "",
+                  "subdivision": "960860-960899",
                   "min": "9608600000",
                   "max": "9608999999",
                   "rules": [
@@ -14708,7 +15369,7 @@
             },
             {
                   "heading": "9609",
-                  "subdivision": "",
+                  "subdivision": "Heading 9609",
                   "min": "9609000000",
                   "max": "9609999999",
                   "rules": [
@@ -14739,7 +15400,7 @@
             },
             {
                   "heading": "9610-9612",
-                  "subdivision": "",
+                  "subdivision": "9610-9612",
                   "min": "9610000000",
                   "max": "9612999999",
                   "rules": [
@@ -14759,7 +15420,7 @@
             },
             {
                   "heading": "9613",
-                  "subdivision": "",
+                  "subdivision": "Heading 9613",
                   "min": "9613000000",
                   "max": "9613999999",
                   "rules": [
@@ -14790,7 +15451,7 @@
             },
             {
                   "heading": "9614",
-                  "subdivision": "",
+                  "subdivision": "Heading 9614",
                   "min": "9614000000",
                   "max": "9614999999",
                   "rules": [
@@ -14810,7 +15471,7 @@
             },
             {
                   "heading": "9615",
-                  "subdivision": "",
+                  "subdivision": "Heading 9615",
                   "min": "9615000000",
                   "max": "9615999999",
                   "rules": [
@@ -14841,7 +15502,7 @@
             },
             {
                   "heading": "9616-9618",
-                  "subdivision": "",
+                  "subdivision": "9616-9618",
                   "min": "9616000000",
                   "max": "9618999999",
                   "rules": [
@@ -14861,7 +15522,7 @@
             },
             {
                   "heading": "9619",
-                  "subdivision": "",
+                  "subdivision": "Heading 9619",
                   "min": "9619000000",
                   "max": "9619999999",
                   "rules": [
@@ -14881,7 +15542,7 @@
             },
             {
                   "heading": "9701-9706",
-                  "subdivision": "",
+                  "subdivision": "9701-9706",
                   "min": "9701000000",
                   "max": "9706999999",
                   "rules": [


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4683

### What?

I have altered:

- [x] db/rules_of_origin/roo_schemes_uk/rule_sets/canada.json

### Why?

I am doing this because:

- Canada RoO PSRs are currently incorrect in Production

Test case for 1704101000 Sugar Containing less than 60% by weight of sucrose (including invert sugar expressed as sucrose)

BEFORE
![image](https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/2343247d-ea63-40b1-b64b-6d30977d4948)

AFTER
![image](https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/76562d78-6bc4-4902-93c0-db0cf13c28ef)
