### PR TITLE
HOTT-4685 Japan RoO PSRs copy error fix

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/japan.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/japan.json
@@ -2,7 +2,7 @@
       "rule_sets": [
             {
                   "heading": "0101-0106",
-                  "subdivision": "",
+                  "subdivision": "0101-0106",
                   "min": "0101000000",
                   "max": "0106999999",
                   "rules": [
@@ -22,7 +22,7 @@
             },
             {
                   "heading": "0201-0210",
-                  "subdivision": "",
+                  "subdivision": "0201-0210",
                   "min": "0201000000",
                   "max": "0210999999",
                   "rules": [
@@ -91,7 +91,7 @@
             },
             {
                   "heading": "0401-0410",
-                  "subdivision": "",
+                  "subdivision": "0401-0410",
                   "min": "0401000000",
                   "max": "0410999999",
                   "rules": [
@@ -111,7 +111,7 @@
             },
             {
                   "heading": "0501-0511",
-                  "subdivision": "",
+                  "subdivision": "0501-0511",
                   "min": "0501000000",
                   "max": "0511999999",
                   "rules": [
@@ -131,7 +131,7 @@
             },
             {
                   "heading": "0601-0604",
-                  "subdivision": "",
+                  "subdivision": "0601-0604",
                   "min": "0601000000",
                   "max": "0604999999",
                   "rules": [
@@ -151,7 +151,7 @@
             },
             {
                   "heading": "0701-0714",
-                  "subdivision": "",
+                  "subdivision": "0701-0714",
                   "min": "0701000000",
                   "max": "0714999999",
                   "rules": [
@@ -171,7 +171,7 @@
             },
             {
                   "heading": "0801-0814",
-                  "subdivision": "",
+                  "subdivision": "0801-0814",
                   "min": "0801000000",
                   "max": "0814999999",
                   "rules": [
@@ -191,7 +191,7 @@
             },
             {
                   "heading": "0901",
-                  "subdivision": "",
+                  "subdivision": "Heading 0901",
                   "min": "0901000000",
                   "max": "0901999999",
                   "rules": [
@@ -220,7 +220,7 @@
             },
             {
                   "heading": "090210-090220",
-                  "subdivision": "",
+                  "subdivision": "090210-090220",
                   "min": "0902100000",
                   "max": "0902299999",
                   "rules": [
@@ -240,7 +240,7 @@
             },
             {
                   "heading": "090230-090300",
-                  "subdivision": "",
+                  "subdivision": "090230-090300",
                   "min": "0902300000",
                   "max": "0903999999",
                   "rules": [
@@ -269,7 +269,7 @@
             },
             {
                   "heading": "0904-0910",
-                  "subdivision": "",
+                  "subdivision": "0904-0910",
                   "min": "0904000000",
                   "max": "0910999999",
                   "rules": [
@@ -298,7 +298,7 @@
             },
             {
                   "heading": "1001-1008",
-                  "subdivision": "",
+                  "subdivision": "1001-1008",
                   "min": "1001000000",
                   "max": "1008999999",
                   "rules": [
@@ -318,7 +318,7 @@
             },
             {
                   "heading": "1101",
-                  "subdivision": "",
+                  "subdivision": "Heading 1101",
                   "min": "1101000000",
                   "max": "1101999999",
                   "rules": [
@@ -338,7 +338,7 @@
             },
             {
                   "heading": "1102-1103",
-                  "subdivision": "",
+                  "subdivision": "1102-1103",
                   "min": "1102000000",
                   "max": "1103999999",
                   "rules": [
@@ -358,7 +358,7 @@
             },
             {
                   "heading": "1104",
-                  "subdivision": "",
+                  "subdivision": "Heading 1104",
                   "min": "1104000000",
                   "max": "1104999999",
                   "rules": [
@@ -378,7 +378,7 @@
             },
             {
                   "heading": "1105-1109",
-                  "subdivision": "",
+                  "subdivision": "1105-1109",
                   "min": "1105000000",
                   "max": "1109999999",
                   "rules": [
@@ -398,7 +398,7 @@
             },
             {
                   "heading": "1201",
-                  "subdivision": "",
+                  "subdivision": "Heading 1201",
                   "min": "1201000000",
                   "max": "1201999999",
                   "rules": [
@@ -418,7 +418,7 @@
             },
             {
                   "heading": "1202-1214",
-                  "subdivision": "",
+                  "subdivision": "1202-1214",
                   "min": "1202000000",
                   "max": "1214999999",
                   "rules": [
@@ -438,7 +438,7 @@
             },
             {
                   "heading": "130120-130219",
-                  "subdivision": "",
+                  "subdivision": "130120-130219",
                   "min": "1301200000",
                   "max": "1302199999",
                   "rules": [
@@ -458,7 +458,7 @@
             },
             {
                   "heading": "130220",
-                  "subdivision": "",
+                  "subdivision": "Subheading 130220",
                   "min": "1302200000",
                   "max": "1302299999",
                   "rules": [
@@ -487,7 +487,7 @@
             },
             {
                   "heading": "130231",
-                  "subdivision": "",
+                  "subdivision": "Subheading 130231",
                   "min": "1302310000",
                   "max": "1302319999",
                   "rules": [
@@ -507,7 +507,7 @@
             },
             {
                   "heading": "130232",
-                  "subdivision": "",
+                  "subdivision": "Subheading 130232",
                   "min": "1302320000",
                   "max": "1302329999",
                   "rules": [
@@ -536,7 +536,7 @@
             },
             {
                   "heading": "130239",
-                  "subdivision": "",
+                  "subdivision": "Subheading 130239",
                   "min": "1302390000",
                   "max": "1302399999",
                   "rules": [
@@ -556,7 +556,7 @@
             },
             {
                   "heading": "1401-1404",
-                  "subdivision": "",
+                  "subdivision": "1401-1404",
                   "min": "1401000000",
                   "max": "1404999999",
                   "rules": [
@@ -576,7 +576,7 @@
             },
             {
                   "heading": "1501-1506",
-                  "subdivision": "",
+                  "subdivision": "1501-1506",
                   "min": "1501000000",
                   "max": "1506999999",
                   "rules": [
@@ -596,7 +596,7 @@
             },
             {
                   "heading": "1507",
-                  "subdivision": "",
+                  "subdivision": "Heading 1507",
                   "min": "1507000000",
                   "max": "1507999999",
                   "rules": [
@@ -616,7 +616,7 @@
             },
             {
                   "heading": "1508",
-                  "subdivision": "",
+                  "subdivision": "Heading 1508",
                   "min": "1508000000",
                   "max": "1508999999",
                   "rules": [
@@ -636,7 +636,7 @@
             },
             {
                   "heading": "1509-1510",
-                  "subdivision": "",
+                  "subdivision": "1509-1510",
                   "min": "1509000000",
                   "max": "1510999999",
                   "rules": [
@@ -656,7 +656,7 @@
             },
             {
                   "heading": "1511-1513",
-                  "subdivision": "",
+                  "subdivision": "1511-1513",
                   "min": "1511000000",
                   "max": "1513999999",
                   "rules": [
@@ -756,7 +756,7 @@
             },
             {
                   "heading": "151610-151710",
-                  "subdivision": "",
+                  "subdivision": "151610-151710",
                   "min": "1516100000",
                   "max": "1517199999",
                   "rules": [
@@ -816,7 +816,7 @@
             },
             {
                   "heading": "1518-1522",
-                  "subdivision": "",
+                  "subdivision": "1518-1522",
                   "min": "1518000000",
                   "max": "1522999999",
                   "rules": [
@@ -836,12 +836,12 @@
             },
             {
                   "heading": "1601",
-                  "subdivision": "",
+                  "subdivision": "Heading 1601",
                   "min": "1601000000",
                   "max": "1601999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapters 02](/chapters/02), 3 and 16 and heading\n\n10.06 used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;2](/chapters/02), [chapter&nbsp;3](/chapters/03) and [chapter&nbsp;16](/chapters/16) and heading\n\n10.06 used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -856,7 +856,7 @@
             },
             {
                   "heading": "160210-160231",
-                  "subdivision": "",
+                  "subdivision": "160210-160231",
                   "min": "1602100000",
                   "max": "1602319999",
                   "rules": [
@@ -876,7 +876,7 @@
             },
             {
                   "heading": "160232",
-                  "subdivision": "",
+                  "subdivision": "Subheading 160232",
                   "min": "1602320000",
                   "max": "1602329999",
                   "rules": [
@@ -918,7 +918,7 @@
             },
             {
                   "heading": "160239",
-                  "subdivision": "",
+                  "subdivision": "Subheading 160239",
                   "min": "1602390000",
                   "max": "1602399999",
                   "rules": [
@@ -938,7 +938,7 @@
             },
             {
                   "heading": "160241-160250",
-                  "subdivision": "",
+                  "subdivision": "160241-160250",
                   "min": "1602410000",
                   "max": "1602599999",
                   "rules": [
@@ -980,7 +980,7 @@
             },
             {
                   "heading": "160290",
-                  "subdivision": "",
+                  "subdivision": "Subheading 160290",
                   "min": "1602900000",
                   "max": "1602999999",
                   "rules": [
@@ -1000,12 +1000,12 @@
             },
             {
                   "heading": "1603",
-                  "subdivision": "",
+                  "subdivision": "Heading 1603",
                   "min": "1603000000",
                   "max": "1603999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapters 02](/chapters/02), 3 and 16 used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;2](/chapters/02), [chapter&nbsp;3](/chapters/03) and [chapter&nbsp;16](/chapters/16) used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1020,12 +1020,12 @@
             },
             {
                   "heading": "1604-1605",
-                  "subdivision": "",
+                  "subdivision": "1604-1605",
                   "min": "1604000000",
                   "max": "1605999999",
                   "rules": [
                         {
-                              "rule": "Production in which all the materials of [chapters 02](/chapters/02), 3 and 16 and heading\n\n10.06 used are wholly obtained.",
+                              "rule": "Production in which all the materials of [chapter&nbsp;2](/chapters/02), [chapter&nbsp;3](/chapters/03) and [chapter&nbsp;16](/chapters/16) and heading\n\n10.06 used are wholly obtained.",
                               "class": [
                                     "WO"
                               ],
@@ -1040,7 +1040,7 @@
             },
             {
                   "heading": "1701",
-                  "subdivision": "",
+                  "subdivision": "Heading 1701",
                   "min": "1701000000",
                   "max": "1701999999",
                   "rules": [
@@ -1060,7 +1060,7 @@
             },
             {
                   "heading": "1702",
-                  "subdivision": "",
+                  "subdivision": "Heading 1702",
                   "min": "1702000000",
                   "max": "1702999999",
                   "rules": [
@@ -1090,7 +1090,7 @@
             },
             {
                   "heading": "1703-1704",
-                  "subdivision": "",
+                  "subdivision": "1703-1704",
                   "min": "1703000000",
                   "max": "1704999999",
                   "rules": [
@@ -1110,7 +1110,7 @@
             },
             {
                   "heading": "1801-1805",
-                  "subdivision": "",
+                  "subdivision": "1801-1805",
                   "min": "1801000000",
                   "max": "1805999999",
                   "rules": [
@@ -1130,12 +1130,12 @@
             },
             {
                   "heading": "1806",
-                  "subdivision": "",
+                  "subdivision": "Heading 1806",
                   "min": "1806000000",
                   "max": "1806999999",
                   "rules": [
                         {
-                              "rule": "<abbr title='Change of tariff heading'>CTH</abbr>: All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- the total weight of non-originating materials of [chapter&nbsp;4](/chapters/04) and heading\n\n19.01 used does not exceed **10%** of the weight of the product, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **30%** of the weight of the product.",
+                              "rule": "<abbr title='Change of tariff heading'>CTH</abbr>: All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading), provided that:\n\n- the total weight of non-originating materials of [chapter&nbsp;4](/chapters/04) and [heading&nbsp;1901](/headings/1901) used does not exceed **10%** of the weight of the product, *and*\n\n- the total weight of non-originating materials of [heading&nbsp;1701](/headings/1701) and [heading&nbsp;1702](/headings/1702) used does not exceed **30%** of the weight of the product.",
                               "class": [
                                     "CTH",
                                     "MAXNOM"
@@ -1351,7 +1351,7 @@
             },
             {
                   "heading": "1902",
-                  "subdivision": "",
+                  "subdivision": "Heading 1902",
                   "min": "1902000000",
                   "max": "1902999999",
                   "rules": [
@@ -1371,7 +1371,7 @@
             },
             {
                   "heading": "1903",
-                  "subdivision": "",
+                  "subdivision": "Heading 1903",
                   "min": "1903000000",
                   "max": "1903999999",
                   "rules": [
@@ -1391,7 +1391,7 @@
             },
             {
                   "heading": "1904",
-                  "subdivision": "",
+                  "subdivision": "Heading 1904",
                   "min": "1904000000",
                   "max": "1904999999",
                   "rules": [
@@ -1411,7 +1411,7 @@
             },
             {
                   "heading": "1905",
-                  "subdivision": "",
+                  "subdivision": "Heading 1905",
                   "min": "1905000000",
                   "max": "1905999999",
                   "rules": [
@@ -1431,7 +1431,7 @@
             },
             {
                   "heading": "2001",
-                  "subdivision": "",
+                  "subdivision": "Heading 2001",
                   "min": "2001000000",
                   "max": "2001999999",
                   "rules": [
@@ -1451,7 +1451,7 @@
             },
             {
                   "heading": "2002-2003",
-                  "subdivision": "",
+                  "subdivision": "2002-2003",
                   "min": "2002000000",
                   "max": "2003999999",
                   "rules": [
@@ -1471,7 +1471,7 @@
             },
             {
                   "heading": "2004-2008",
-                  "subdivision": "",
+                  "subdivision": "2004-2008",
                   "min": "2004000000",
                   "max": "2008999999",
                   "rules": [
@@ -1491,7 +1491,7 @@
             },
             {
                   "heading": "2009",
-                  "subdivision": "",
+                  "subdivision": "Heading 2009",
                   "min": "2009000000",
                   "max": "2009999999",
                   "rules": [
@@ -1511,7 +1511,7 @@
             },
             {
                   "heading": "210111-210120",
-                  "subdivision": "",
+                  "subdivision": "210111-210120",
                   "min": "2101110000",
                   "max": "2101299999",
                   "rules": [
@@ -1571,7 +1571,7 @@
             },
             {
                   "heading": "210210-210310",
-                  "subdivision": "",
+                  "subdivision": "210210-210310",
                   "min": "2102100000",
                   "max": "2103199999",
                   "rules": [
@@ -1591,7 +1591,7 @@
             },
             {
                   "heading": "210320",
-                  "subdivision": "",
+                  "subdivision": "Subheading 210320",
                   "min": "2103200000",
                   "max": "2103299999",
                   "rules": [
@@ -1611,7 +1611,7 @@
             },
             {
                   "heading": "210330",
-                  "subdivision": "",
+                  "subdivision": "Subheading 210330",
                   "min": "2103300000",
                   "max": "2103399999",
                   "rules": [
@@ -1640,7 +1640,7 @@
             },
             {
                   "heading": "210390",
-                  "subdivision": "",
+                  "subdivision": "Subheading 210390",
                   "min": "2103900000",
                   "max": "2103999999",
                   "rules": [
@@ -1660,7 +1660,7 @@
             },
             {
                   "heading": "2104",
-                  "subdivision": "",
+                  "subdivision": "Heading 2104",
                   "min": "2104000000",
                   "max": "2104999999",
                   "rules": [
@@ -1680,7 +1680,7 @@
             },
             {
                   "heading": "2105",
-                  "subdivision": "",
+                  "subdivision": "Heading 2105",
                   "min": "2105000000",
                   "max": "2105999999",
                   "rules": [
@@ -1701,7 +1701,7 @@
             },
             {
                   "heading": "2106",
-                  "subdivision": "",
+                  "subdivision": "Heading 2106",
                   "min": "2106000000",
                   "max": "2106999999",
                   "rules": [
@@ -1721,7 +1721,7 @@
             },
             {
                   "heading": "2201",
-                  "subdivision": "",
+                  "subdivision": "Heading 2201",
                   "min": "2201000000",
                   "max": "2201999999",
                   "rules": [
@@ -1741,7 +1741,7 @@
             },
             {
                   "heading": "2202",
-                  "subdivision": "",
+                  "subdivision": "Heading 2202",
                   "min": "2202000000",
                   "max": "2202999999",
                   "rules": [
@@ -1762,7 +1762,7 @@
             },
             {
                   "heading": "2203-2208",
-                  "subdivision": "",
+                  "subdivision": "2203-2208",
                   "min": "2203000000",
                   "max": "2208999999",
                   "rules": [
@@ -1782,7 +1782,7 @@
             },
             {
                   "heading": "2209",
-                  "subdivision": "",
+                  "subdivision": "Heading 2209",
                   "min": "2209000000",
                   "max": "2209999999",
                   "rules": [
@@ -1802,7 +1802,7 @@
             },
             {
                   "heading": "2301",
-                  "subdivision": "",
+                  "subdivision": "Heading 2301",
                   "min": "2301000000",
                   "max": "2301999999",
                   "rules": [
@@ -1822,7 +1822,7 @@
             },
             {
                   "heading": "2302-2303",
-                  "subdivision": "",
+                  "subdivision": "2302-2303",
                   "min": "2302000000",
                   "max": "2303999999",
                   "rules": [
@@ -1843,7 +1843,7 @@
             },
             {
                   "heading": "2304-2308",
-                  "subdivision": "",
+                  "subdivision": "2304-2308",
                   "min": "2304000000",
                   "max": "2308999999",
                   "rules": [
@@ -1863,7 +1863,7 @@
             },
             {
                   "heading": "230910",
-                  "subdivision": "",
+                  "subdivision": "Subheading 230910",
                   "min": "2309100000",
                   "max": "2309199999",
                   "rules": [
@@ -1963,7 +1963,7 @@
             },
             {
                   "heading": "2401",
-                  "subdivision": "",
+                  "subdivision": "Heading 2401",
                   "min": "2401000000",
                   "max": "2401999999",
                   "rules": [
@@ -1983,7 +1983,7 @@
             },
             {
                   "heading": "240210",
-                  "subdivision": "",
+                  "subdivision": "Subheading 240210",
                   "min": "2402100000",
                   "max": "2402199999",
                   "rules": [
@@ -2004,7 +2004,7 @@
             },
             {
                   "heading": "240220-240399",
-                  "subdivision": "",
+                  "subdivision": "240220-240399",
                   "min": "2402200000",
                   "max": "2403999999",
                   "rules": [
@@ -2046,7 +2046,7 @@
             },
             {
                   "heading": "2404",
-                  "subdivision": "",
+                  "subdivision": "Heading 2404",
                   "min": "2404000000",
                   "max": "2404999999",
                   "rules": [
@@ -2088,7 +2088,7 @@
             },
             {
                   "heading": "2501",
-                  "subdivision": "",
+                  "subdivision": "Heading 2501",
                   "min": "2501000000",
                   "max": "2501999999",
                   "rules": [
@@ -2108,7 +2108,7 @@
             },
             {
                   "heading": "2502-2530",
-                  "subdivision": "",
+                  "subdivision": "2502-2530",
                   "min": "2502000000",
                   "max": "2530999999",
                   "rules": [
@@ -2150,7 +2150,7 @@
             },
             {
                   "heading": "2601-2621",
-                  "subdivision": "",
+                  "subdivision": "2601-2621",
                   "min": "2601000000",
                   "max": "2621999999",
                   "rules": [
@@ -2170,7 +2170,7 @@
             },
             {
                   "heading": "2701-2709",
-                  "subdivision": "",
+                  "subdivision": "2701-2709",
                   "min": "2701000000",
                   "max": "2709999999",
                   "rules": [
@@ -2221,7 +2221,7 @@
             },
             {
                   "heading": "2710",
-                  "subdivision": "",
+                  "subdivision": "Heading 2710",
                   "min": "2710000000",
                   "max": "2710999999",
                   "rules": [
@@ -2250,7 +2250,7 @@
             },
             {
                   "heading": "2711",
-                  "subdivision": "",
+                  "subdivision": "Heading 2711",
                   "min": "2711000000",
                   "max": "2711999999",
                   "rules": [
@@ -2279,7 +2279,7 @@
             },
             {
                   "heading": "2712-2715",
-                  "subdivision": "",
+                  "subdivision": "2712-2715",
                   "min": "2712000000",
                   "max": "2715999999",
                   "rules": [
@@ -2330,7 +2330,7 @@
             },
             {
                   "heading": "2801-2853",
-                  "subdivision": "",
+                  "subdivision": "2801-2853",
                   "min": "2801000000",
                   "max": "2853999999",
                   "rules": [
@@ -2381,7 +2381,7 @@
             },
             {
                   "heading": "290110-290542",
-                  "subdivision": "",
+                  "subdivision": "290110-290542",
                   "min": "2901100000",
                   "max": "2905429999",
                   "rules": [
@@ -2432,7 +2432,7 @@
             },
             {
                   "heading": "290543-290544",
-                  "subdivision": "",
+                  "subdivision": "290543-290544",
                   "min": "2905430000",
                   "max": "2905449999",
                   "rules": [
@@ -2452,7 +2452,7 @@
             },
             {
                   "heading": "290545",
-                  "subdivision": "",
+                  "subdivision": "Subheading 290545",
                   "min": "2905450000",
                   "max": "2905459999",
                   "rules": [
@@ -2505,7 +2505,7 @@
             },
             {
                   "heading": "290549-290559",
-                  "subdivision": "",
+                  "subdivision": "290549-290559",
                   "min": "2905490000",
                   "max": "2905599999",
                   "rules": [
@@ -2556,7 +2556,7 @@
             },
             {
                   "heading": "290611",
-                  "subdivision": "",
+                  "subdivision": "Subheading 290611",
                   "min": "2906110000",
                   "max": "2906119999",
                   "rules": [
@@ -2576,7 +2576,7 @@
             },
             {
                   "heading": "290612-291813",
-                  "subdivision": "",
+                  "subdivision": "290612-291813",
                   "min": "2906120000",
                   "max": "2918139999",
                   "rules": [
@@ -2627,7 +2627,7 @@
             },
             {
                   "heading": "291814-291815",
-                  "subdivision": "",
+                  "subdivision": "291814-291815",
                   "min": "2918140000",
                   "max": "2918159999",
                   "rules": [
@@ -2647,7 +2647,7 @@
             },
             {
                   "heading": "291816-292241",
-                  "subdivision": "",
+                  "subdivision": "291816-292241",
                   "min": "2918160000",
                   "max": "2922419999",
                   "rules": [
@@ -2698,7 +2698,7 @@
             },
             {
                   "heading": "292242",
-                  "subdivision": "",
+                  "subdivision": "Subheading 292242",
                   "min": "2922420000",
                   "max": "2922429999",
                   "rules": [
@@ -2718,7 +2718,7 @@
             },
             {
                   "heading": "292243-292310",
-                  "subdivision": "",
+                  "subdivision": "292243-292310",
                   "min": "2922430000",
                   "max": "2923199999",
                   "rules": [
@@ -2769,7 +2769,7 @@
             },
             {
                   "heading": "292320",
-                  "subdivision": "",
+                  "subdivision": "Subheading 292320",
                   "min": "2923200000",
                   "max": "2923299999",
                   "rules": [
@@ -2811,7 +2811,7 @@
             },
             {
                   "heading": "292330-292424",
-                  "subdivision": "",
+                  "subdivision": "292330-292424",
                   "min": "2923300000",
                   "max": "2924249999",
                   "rules": [
@@ -2862,7 +2862,7 @@
             },
             {
                   "heading": "292425-292429",
-                  "subdivision": "",
+                  "subdivision": "292425-292429",
                   "min": "2924250000",
                   "max": "2924299999",
                   "rules": [
@@ -2904,7 +2904,7 @@
             },
             {
                   "heading": "292511-293810",
-                  "subdivision": "",
+                  "subdivision": "292511-293810",
                   "min": "2925110000",
                   "max": "2938199999",
                   "rules": [
@@ -2955,7 +2955,7 @@
             },
             {
                   "heading": "293890",
-                  "subdivision": "",
+                  "subdivision": "Subheading 293890",
                   "min": "2938900000",
                   "max": "2938999999",
                   "rules": [
@@ -2997,7 +2997,7 @@
             },
             {
                   "heading": "2939",
-                  "subdivision": "",
+                  "subdivision": "Heading 2939",
                   "min": "2939000000",
                   "max": "2939999999",
                   "rules": [
@@ -3048,7 +3048,7 @@
             },
             {
                   "heading": "2940",
-                  "subdivision": "",
+                  "subdivision": "Heading 2940",
                   "min": "2940000000",
                   "max": "2940999999",
                   "rules": [
@@ -3068,7 +3068,7 @@
             },
             {
                   "heading": "2941-2942",
-                  "subdivision": "",
+                  "subdivision": "2941-2942",
                   "min": "2941000000",
                   "max": "2942999999",
                   "rules": [
@@ -3119,7 +3119,7 @@
             },
             {
                   "heading": "3001-3006",
-                  "subdivision": "",
+                  "subdivision": "3001-3006",
                   "min": "3001000000",
                   "max": "3006999999",
                   "rules": [
@@ -3170,7 +3170,7 @@
             },
             {
                   "heading": "3101-3104",
-                  "subdivision": "",
+                  "subdivision": "3101-3104",
                   "min": "3101000000",
                   "max": "3104999999",
                   "rules": [
@@ -3319,7 +3319,7 @@
             },
             {
                   "heading": "3201-3205",
-                  "subdivision": "",
+                  "subdivision": "3201-3205",
                   "min": "3201000000",
                   "max": "3205999999",
                   "rules": [
@@ -3370,7 +3370,7 @@
             },
             {
                   "heading": "320611-320619",
-                  "subdivision": "",
+                  "subdivision": "320611-320619",
                   "min": "3206110000",
                   "max": "3206199999",
                   "rules": [
@@ -3423,7 +3423,7 @@
             },
             {
                   "heading": "320620-321590",
-                  "subdivision": "",
+                  "subdivision": "320620-321590",
                   "min": "3206200000",
                   "max": "3215999999",
                   "rules": [
@@ -3474,7 +3474,7 @@
             },
             {
                   "heading": "330112-330210",
-                  "subdivision": "",
+                  "subdivision": "330112-330210",
                   "min": "3301120000",
                   "max": "3302199999",
                   "rules": [
@@ -3516,7 +3516,7 @@
             },
             {
                   "heading": "330290-330300",
-                  "subdivision": "",
+                  "subdivision": "330290-330300",
                   "min": "3302900000",
                   "max": "3303999999",
                   "rules": [
@@ -3567,7 +3567,7 @@
             },
             {
                   "heading": "3304",
-                  "subdivision": "",
+                  "subdivision": "Heading 3304",
                   "min": "3304000000",
                   "max": "3304999999",
                   "rules": [
@@ -3618,7 +3618,7 @@
             },
             {
                   "heading": "3305-3307",
-                  "subdivision": "",
+                  "subdivision": "3305-3307",
                   "min": "3305000000",
                   "max": "3307999999",
                   "rules": [
@@ -3669,7 +3669,7 @@
             },
             {
                   "heading": "3401-3407",
-                  "subdivision": "",
+                  "subdivision": "3401-3407",
                   "min": "3401000000",
                   "max": "3407999999",
                   "rules": [
@@ -3720,7 +3720,7 @@
             },
             {
                   "heading": "3501",
-                  "subdivision": "",
+                  "subdivision": "Heading 3501",
                   "min": "3501000000",
                   "max": "3501999999",
                   "rules": [
@@ -3740,7 +3740,7 @@
             },
             {
                   "heading": "350211-350219",
-                  "subdivision": "",
+                  "subdivision": "350211-350219",
                   "min": "3502110000",
                   "max": "3502199999",
                   "rules": [
@@ -3760,7 +3760,7 @@
             },
             {
                   "heading": "350220-350400",
-                  "subdivision": "",
+                  "subdivision": "350220-350400",
                   "min": "3502200000",
                   "max": "3504999999",
                   "rules": [
@@ -3780,7 +3780,7 @@
             },
             {
                   "heading": "3505",
-                  "subdivision": "",
+                  "subdivision": "Heading 3505",
                   "min": "3505000000",
                   "max": "3505999999",
                   "rules": [
@@ -3800,7 +3800,7 @@
             },
             {
                   "heading": "3506-3507",
-                  "subdivision": "",
+                  "subdivision": "3506-3507",
                   "min": "3506000000",
                   "max": "3507999999",
                   "rules": [
@@ -3851,7 +3851,7 @@
             },
             {
                   "heading": "3601-3606",
-                  "subdivision": "",
+                  "subdivision": "3601-3606",
                   "min": "3601000000",
                   "max": "3606999999",
                   "rules": [
@@ -3902,7 +3902,7 @@
             },
             {
                   "heading": "3701-3707",
-                  "subdivision": "",
+                  "subdivision": "3701-3707",
                   "min": "3701000000",
                   "max": "3707999999",
                   "rules": [
@@ -3953,7 +3953,7 @@
             },
             {
                   "heading": "3801-3808",
-                  "subdivision": "",
+                  "subdivision": "3801-3808",
                   "min": "3801000000",
                   "max": "3808999999",
                   "rules": [
@@ -4004,7 +4004,7 @@
             },
             {
                   "heading": "380910",
-                  "subdivision": "",
+                  "subdivision": "Subheading 380910",
                   "min": "3809100000",
                   "max": "3809199999",
                   "rules": [
@@ -4024,7 +4024,7 @@
             },
             {
                   "heading": "380991-382200",
-                  "subdivision": "",
+                  "subdivision": "380991-382200",
                   "min": "3809910000",
                   "max": "3822999999",
                   "rules": [
@@ -4075,7 +4075,7 @@
             },
             {
                   "heading": "3823",
-                  "subdivision": "",
+                  "subdivision": "Heading 3823",
                   "min": "3823000000",
                   "max": "3823999999",
                   "rules": [
@@ -4095,7 +4095,7 @@
             },
             {
                   "heading": "382410-382450",
-                  "subdivision": "",
+                  "subdivision": "382410-382450",
                   "min": "3824100000",
                   "max": "3824599999",
                   "rules": [
@@ -4146,7 +4146,7 @@
             },
             {
                   "heading": "382460",
-                  "subdivision": "",
+                  "subdivision": "Subheading 382460",
                   "min": "3824600000",
                   "max": "3824699999",
                   "rules": [
@@ -4166,7 +4166,7 @@
             },
             {
                   "heading": "382471-382491",
-                  "subdivision": "",
+                  "subdivision": "382471-382491",
                   "min": "3824710000",
                   "max": "3824919999",
                   "rules": [
@@ -4288,7 +4288,7 @@
             },
             {
                   "heading": "3825",
-                  "subdivision": "",
+                  "subdivision": "Heading 3825",
                   "min": "3825000000",
                   "max": "3825999999",
                   "rules": [
@@ -4339,7 +4339,7 @@
             },
             {
                   "heading": "3826",
-                  "subdivision": "",
+                  "subdivision": "Heading 3826",
                   "min": "3826000000",
                   "max": "3826999999",
                   "rules": [
@@ -4359,7 +4359,7 @@
             },
             {
                   "heading": "3827",
-                  "subdivision": "",
+                  "subdivision": "Heading 3827",
                   "min": "3827000000",
                   "max": "3827999999",
                   "rules": [
@@ -4410,7 +4410,7 @@
             },
             {
                   "heading": "3901-3903",
-                  "subdivision": "",
+                  "subdivision": "3901-3903",
                   "min": "3901000000",
                   "max": "3903999999",
                   "rules": [
@@ -4461,7 +4461,7 @@
             },
             {
                   "heading": "3904-3906",
-                  "subdivision": "",
+                  "subdivision": "3904-3906",
                   "min": "3904000000",
                   "max": "3906999999",
                   "rules": [
@@ -4512,7 +4512,7 @@
             },
             {
                   "heading": "3907-3908",
-                  "subdivision": "",
+                  "subdivision": "3907-3908",
                   "min": "3907000000",
                   "max": "3908999999",
                   "rules": [
@@ -4554,7 +4554,7 @@
             },
             {
                   "heading": "3909-3910",
-                  "subdivision": "",
+                  "subdivision": "3909-3910",
                   "min": "3909000000",
                   "max": "3910999999",
                   "rules": [
@@ -4605,7 +4605,7 @@
             },
             {
                   "heading": "3911",
-                  "subdivision": "",
+                  "subdivision": "Heading 3911",
                   "min": "3911000000",
                   "max": "3911999999",
                   "rules": [
@@ -4656,7 +4656,7 @@
             },
             {
                   "heading": "3912-3915",
-                  "subdivision": "",
+                  "subdivision": "3912-3915",
                   "min": "3912000000",
                   "max": "3915999999",
                   "rules": [
@@ -4707,7 +4707,7 @@
             },
             {
                   "heading": "3916-3926",
-                  "subdivision": "",
+                  "subdivision": "3916-3926",
                   "min": "3916000000",
                   "max": "3926999999",
                   "rules": [
@@ -4749,7 +4749,7 @@
             },
             {
                   "heading": "4001-4011",
-                  "subdivision": "",
+                  "subdivision": "4001-4011",
                   "min": "4001000000",
                   "max": "4011999999",
                   "rules": [
@@ -4791,7 +4791,7 @@
             },
             {
                   "heading": "401211-401219",
-                  "subdivision": "",
+                  "subdivision": "401211-401219",
                   "min": "4012110000",
                   "max": "4012199999",
                   "rules": [
@@ -4844,7 +4844,7 @@
             },
             {
                   "heading": "401220-401700",
-                  "subdivision": "",
+                  "subdivision": "401220-401700",
                   "min": "4012200000",
                   "max": "4017999999",
                   "rules": [
@@ -4886,7 +4886,7 @@
             },
             {
                   "heading": "4101-4103",
-                  "subdivision": "",
+                  "subdivision": "4101-4103",
                   "min": "4101000000",
                   "max": "4103999999",
                   "rules": [
@@ -4906,7 +4906,7 @@
             },
             {
                   "heading": "410411-410419",
-                  "subdivision": "",
+                  "subdivision": "410411-410419",
                   "min": "4104110000",
                   "max": "4104199999",
                   "rules": [
@@ -4926,13 +4926,15 @@
             },
             {
                   "heading": "410441-410449",
-                  "subdivision": "",
+                  "subdivision": "410441-410449",
                   "min": "4104410000",
                   "max": "4104499999",
                   "rules": [
                         {
-                              "rule": "CTSH except from [subheading&nbsp;410441](/subheading/4104410000-80) to [subheading&nbsp;410449](/subheading/4104490000-80).",
-                              "class": [],
+                              "rule": "<abbr title='Change of tariff heading'>CTH</abbr>: All non-originating materials used in the production of the good have undergone a change in tariff classification at the 4-digit level (tariff heading) except from [subheading&nbsp;410441](/subheading/4104410000-80) to [subheading&nbsp;410449](/subheading/4104490000-80).",
+                              "class": [
+                                    "CTSH"
+                              ],
                               "footnotes": [],
                               "operator": null,
                               "quota": false,
@@ -4944,7 +4946,7 @@
             },
             {
                   "heading": "410510",
-                  "subdivision": "",
+                  "subdivision": "Subheading 410510",
                   "min": "4105100000",
                   "max": "4105199999",
                   "rules": [
@@ -4964,7 +4966,7 @@
             },
             {
                   "heading": "410530",
-                  "subdivision": "",
+                  "subdivision": "Subheading 410530",
                   "min": "4105300000",
                   "max": "4105399999",
                   "rules": [
@@ -4984,7 +4986,7 @@
             },
             {
                   "heading": "410621",
-                  "subdivision": "",
+                  "subdivision": "Subheading 410621",
                   "min": "4106210000",
                   "max": "4106219999",
                   "rules": [
@@ -5004,7 +5006,7 @@
             },
             {
                   "heading": "410622",
-                  "subdivision": "",
+                  "subdivision": "Subheading 410622",
                   "min": "4106220000",
                   "max": "4106229999",
                   "rules": [
@@ -5024,7 +5026,7 @@
             },
             {
                   "heading": "410631",
-                  "subdivision": "",
+                  "subdivision": "Subheading 410631",
                   "min": "4106310000",
                   "max": "4106319999",
                   "rules": [
@@ -5044,7 +5046,7 @@
             },
             {
                   "heading": "410632",
-                  "subdivision": "",
+                  "subdivision": "Subheading 410632",
                   "min": "4106320000",
                   "max": "4106329999",
                   "rules": [
@@ -5113,7 +5115,7 @@
             },
             {
                   "heading": "410691",
-                  "subdivision": "",
+                  "subdivision": "Subheading 410691",
                   "min": "4106910000",
                   "max": "4106919999",
                   "rules": [
@@ -5133,7 +5135,7 @@
             },
             {
                   "heading": "410692",
-                  "subdivision": "",
+                  "subdivision": "Subheading 410692",
                   "min": "4106920000",
                   "max": "4106929999",
                   "rules": [
@@ -5153,7 +5155,7 @@
             },
             {
                   "heading": "4107-4113",
-                  "subdivision": "",
+                  "subdivision": "4107-4113",
                   "min": "4107000000",
                   "max": "4113999999",
                   "rules": [
@@ -5182,7 +5184,7 @@
             },
             {
                   "heading": "4114-4115",
-                  "subdivision": "",
+                  "subdivision": "4114-4115",
                   "min": "4114000000",
                   "max": "4115999999",
                   "rules": [
@@ -5202,7 +5204,7 @@
             },
             {
                   "heading": "4201-4206",
-                  "subdivision": "",
+                  "subdivision": "4201-4206",
                   "min": "4201000000",
                   "max": "4206999999",
                   "rules": [
@@ -5245,7 +5247,7 @@
             },
             {
                   "heading": "4301",
-                  "subdivision": "",
+                  "subdivision": "Heading 4301",
                   "min": "4301000000",
                   "max": "4301999999",
                   "rules": [
@@ -5265,7 +5267,7 @@
             },
             {
                   "heading": "4302-4304",
-                  "subdivision": "",
+                  "subdivision": "4302-4304",
                   "min": "4302000000",
                   "max": "4304999999",
                   "rules": [
@@ -5285,7 +5287,7 @@
             },
             {
                   "heading": "4401-4421",
-                  "subdivision": "",
+                  "subdivision": "4401-4421",
                   "min": "4401000000",
                   "max": "4421999999",
                   "rules": [
@@ -5327,7 +5329,7 @@
             },
             {
                   "heading": "4501-4504",
-                  "subdivision": "",
+                  "subdivision": "4501-4504",
                   "min": "4501000000",
                   "max": "4504999999",
                   "rules": [
@@ -5369,7 +5371,7 @@
             },
             {
                   "heading": "460121-460122",
-                  "subdivision": "",
+                  "subdivision": "460121-460122",
                   "min": "4601210000",
                   "max": "4601229999",
                   "rules": [
@@ -5411,7 +5413,7 @@
             },
             {
                   "heading": "460129",
-                  "subdivision": "",
+                  "subdivision": "Subheading 460129",
                   "min": "4601290000",
                   "max": "4601299999",
                   "rules": [
@@ -5431,7 +5433,7 @@
             },
             {
                   "heading": "460192-460193",
-                  "subdivision": "",
+                  "subdivision": "460192-460193",
                   "min": "4601920000",
                   "max": "4601939999",
                   "rules": [
@@ -5473,7 +5475,7 @@
             },
             {
                   "heading": "460194",
-                  "subdivision": "",
+                  "subdivision": "Subheading 460194",
                   "min": "4601940000",
                   "max": "4601949999",
                   "rules": [
@@ -5493,7 +5495,7 @@
             },
             {
                   "heading": "460199-460212",
-                  "subdivision": "",
+                  "subdivision": "460199-460212",
                   "min": "4601990000",
                   "max": "4602129999",
                   "rules": [
@@ -5535,7 +5537,7 @@
             },
             {
                   "heading": "460219",
-                  "subdivision": "",
+                  "subdivision": "Subheading 460219",
                   "min": "4602190000",
                   "max": "4602199999",
                   "rules": [
@@ -5555,7 +5557,7 @@
             },
             {
                   "heading": "460290",
-                  "subdivision": "",
+                  "subdivision": "Subheading 460290",
                   "min": "4602900000",
                   "max": "4602999999",
                   "rules": [
@@ -5597,7 +5599,7 @@
             },
             {
                   "heading": "4701-4707",
-                  "subdivision": "",
+                  "subdivision": "4701-4707",
                   "min": "4701000000",
                   "max": "4707999999",
                   "rules": [
@@ -5639,7 +5641,7 @@
             },
             {
                   "heading": "4801-4823",
-                  "subdivision": "",
+                  "subdivision": "4801-4823",
                   "min": "4801000000",
                   "max": "4823999999",
                   "rules": [
@@ -5681,7 +5683,7 @@
             },
             {
                   "heading": "4901-4911",
-                  "subdivision": "",
+                  "subdivision": "4901-4911",
                   "min": "4901000000",
                   "max": "4911999999",
                   "rules": [
@@ -5723,7 +5725,7 @@
             },
             {
                   "heading": "5001",
-                  "subdivision": "",
+                  "subdivision": "Heading 5001",
                   "min": "5001000000",
                   "max": "5001999999",
                   "rules": [
@@ -5743,7 +5745,7 @@
             },
             {
                   "heading": "5002",
-                  "subdivision": "",
+                  "subdivision": "Heading 5002",
                   "min": "5002000000",
                   "max": "5002999999",
                   "rules": [
@@ -5803,7 +5805,7 @@
             },
             {
                   "heading": "5004-5005",
-                  "subdivision": "",
+                  "subdivision": "5004-5005",
                   "min": "5004000000",
                   "max": "5005999999",
                   "rules": [
@@ -5917,7 +5919,7 @@
             },
             {
                   "heading": "5007",
-                  "subdivision": "",
+                  "subdivision": "Heading 5007",
                   "min": "5007000000",
                   "max": "5007999999",
                   "rules": [
@@ -5993,7 +5995,7 @@
             },
             {
                   "heading": "5101-5105",
-                  "subdivision": "",
+                  "subdivision": "5101-5105",
                   "min": "5101000000",
                   "max": "5105999999",
                   "rules": [
@@ -6013,7 +6015,7 @@
             },
             {
                   "heading": "5106-5110",
-                  "subdivision": "",
+                  "subdivision": "5106-5110",
                   "min": "5106000000",
                   "max": "5110999999",
                   "rules": [
@@ -6053,7 +6055,7 @@
             },
             {
                   "heading": "5111-5113",
-                  "subdivision": "",
+                  "subdivision": "5111-5113",
                   "min": "5111000000",
                   "max": "5113999999",
                   "rules": [
@@ -6120,7 +6122,7 @@
             },
             {
                   "heading": "5201-5203",
-                  "subdivision": "",
+                  "subdivision": "5201-5203",
                   "min": "5201000000",
                   "max": "5203999999",
                   "rules": [
@@ -6140,7 +6142,7 @@
             },
             {
                   "heading": "5204-5207",
-                  "subdivision": "",
+                  "subdivision": "5204-5207",
                   "min": "5204000000",
                   "max": "5207999999",
                   "rules": [
@@ -6180,7 +6182,7 @@
             },
             {
                   "heading": "5208-5212",
-                  "subdivision": "",
+                  "subdivision": "5208-5212",
                   "min": "5208000000",
                   "max": "5212999999",
                   "rules": [
@@ -6256,7 +6258,7 @@
             },
             {
                   "heading": "5301-5305",
-                  "subdivision": "",
+                  "subdivision": "5301-5305",
                   "min": "5301000000",
                   "max": "5305999999",
                   "rules": [
@@ -6276,7 +6278,7 @@
             },
             {
                   "heading": "5306-5308",
-                  "subdivision": "",
+                  "subdivision": "5306-5308",
                   "min": "5306000000",
                   "max": "5308999999",
                   "rules": [
@@ -6316,7 +6318,7 @@
             },
             {
                   "heading": "5309-5311",
-                  "subdivision": "",
+                  "subdivision": "5309-5311",
                   "min": "5309000000",
                   "max": "5311999999",
                   "rules": [
@@ -6383,7 +6385,7 @@
             },
             {
                   "heading": "5401-5406",
-                  "subdivision": "",
+                  "subdivision": "5401-5406",
                   "min": "5401000000",
                   "max": "5406999999",
                   "rules": [
@@ -6423,7 +6425,7 @@
             },
             {
                   "heading": "5407-5408",
-                  "subdivision": "",
+                  "subdivision": "5407-5408",
                   "min": "5407000000",
                   "max": "5408999999",
                   "rules": [
@@ -6499,7 +6501,7 @@
             },
             {
                   "heading": "5501-5507",
-                  "subdivision": "",
+                  "subdivision": "5501-5507",
                   "min": "5501000000",
                   "max": "5507999999",
                   "rules": [
@@ -6519,7 +6521,7 @@
             },
             {
                   "heading": "5508-5511",
-                  "subdivision": "",
+                  "subdivision": "5508-5511",
                   "min": "5508000000",
                   "max": "5511999999",
                   "rules": [
@@ -6559,7 +6561,7 @@
             },
             {
                   "heading": "5512-5516",
-                  "subdivision": "",
+                  "subdivision": "5512-5516",
                   "min": "5512000000",
                   "max": "5516999999",
                   "rules": [
@@ -6635,7 +6637,7 @@
             },
             {
                   "heading": "5601",
-                  "subdivision": "",
+                  "subdivision": "Heading 5601",
                   "min": "5601000000",
                   "max": "5601999999",
                   "rules": [
@@ -6784,7 +6786,7 @@
             },
             {
                   "heading": "560311-560314",
-                  "subdivision": "",
+                  "subdivision": "560311-560314",
                   "min": "5603110000",
                   "max": "5603149999",
                   "rules": [
@@ -6820,7 +6822,7 @@
             },
             {
                   "heading": "560391-560394",
-                  "subdivision": "",
+                  "subdivision": "560391-560394",
                   "min": "5603910000",
                   "max": "5603949999",
                   "rules": [
@@ -6856,7 +6858,7 @@
             },
             {
                   "heading": "560410",
-                  "subdivision": "",
+                  "subdivision": "Subheading 560410",
                   "min": "5604100000",
                   "max": "5604199999",
                   "rules": [
@@ -6876,7 +6878,7 @@
             },
             {
                   "heading": "560490",
-                  "subdivision": "",
+                  "subdivision": "Subheading 560490",
                   "min": "5604900000",
                   "max": "5604999999",
                   "rules": [
@@ -6916,7 +6918,7 @@
             },
             {
                   "heading": "5605",
-                  "subdivision": "",
+                  "subdivision": "Heading 5605",
                   "min": "5605000000",
                   "max": "5605999999",
                   "rules": [
@@ -6956,7 +6958,7 @@
             },
             {
                   "heading": "5606",
-                  "subdivision": "",
+                  "subdivision": "Heading 5606",
                   "min": "5606000000",
                   "max": "5606999999",
                   "rules": [
@@ -7005,7 +7007,7 @@
             },
             {
                   "heading": "5607-5609",
-                  "subdivision": "",
+                  "subdivision": "5607-5609",
                   "min": "5607000000",
                   "max": "5609999999",
                   "rules": [
@@ -7036,7 +7038,7 @@
             },
             {
                   "heading": "5701-5705",
-                  "subdivision": "",
+                  "subdivision": "5701-5705",
                   "min": "5701000000",
                   "max": "5705999999",
                   "rules": [
@@ -7103,7 +7105,7 @@
             },
             {
                   "heading": "5801-5804",
-                  "subdivision": "",
+                  "subdivision": "5801-5804",
                   "min": "5801000000",
                   "max": "5804999999",
                   "rules": [
@@ -7190,7 +7192,7 @@
             },
             {
                   "heading": "5805",
-                  "subdivision": "",
+                  "subdivision": "Heading 5805",
                   "min": "5805000000",
                   "max": "5805999999",
                   "rules": [
@@ -7210,7 +7212,7 @@
             },
             {
                   "heading": "5806-5809",
-                  "subdivision": "",
+                  "subdivision": "5806-5809",
                   "min": "5806000000",
                   "max": "5809999999",
                   "rules": [
@@ -7297,7 +7299,7 @@
             },
             {
                   "heading": "5810",
-                  "subdivision": "",
+                  "subdivision": "Heading 5810",
                   "min": "5810000000",
                   "max": "5810999999",
                   "rules": [
@@ -7317,7 +7319,7 @@
             },
             {
                   "heading": "5811",
-                  "subdivision": "",
+                  "subdivision": "Heading 5811",
                   "min": "5811000000",
                   "max": "5811999999",
                   "rules": [
@@ -7404,7 +7406,7 @@
             },
             {
                   "heading": "5901",
-                  "subdivision": "",
+                  "subdivision": "Heading 5901",
                   "min": "5901000000",
                   "max": "5901999999",
                   "rules": [
@@ -7469,7 +7471,7 @@
             },
             {
                   "heading": "5903",
-                  "subdivision": "",
+                  "subdivision": "Heading 5903",
                   "min": "5903000000",
                   "max": "5903999999",
                   "rules": [
@@ -7505,7 +7507,7 @@
             },
             {
                   "heading": "5904",
-                  "subdivision": "",
+                  "subdivision": "Heading 5904",
                   "min": "5904000000",
                   "max": "5904999999",
                   "rules": [
@@ -7704,7 +7706,7 @@
             },
             {
                   "heading": "5907",
-                  "subdivision": "",
+                  "subdivision": "Heading 5907",
                   "min": "5907000000",
                   "max": "5907999999",
                   "rules": [
@@ -7782,7 +7784,7 @@
             },
             {
                   "heading": "5909-5911",
-                  "subdivision": "",
+                  "subdivision": "5909-5911",
                   "min": "5909000000",
                   "max": "5911999999",
                   "rules": [
@@ -7829,7 +7831,7 @@
             },
             {
                   "heading": "6001-6006",
-                  "subdivision": "",
+                  "subdivision": "6001-6006",
                   "min": "6001000000",
                   "max": "6006999999",
                   "rules": [
@@ -7978,7 +7980,7 @@
             },
             {
                   "heading": "6201",
-                  "subdivision": "",
+                  "subdivision": "Heading 6201",
                   "min": "6201000000",
                   "max": "6201999999",
                   "rules": [
@@ -8104,7 +8106,7 @@
             },
             {
                   "heading": "6203",
-                  "subdivision": "",
+                  "subdivision": "Heading 6203",
                   "min": "6203000000",
                   "max": "6203999999",
                   "rules": [
@@ -8230,7 +8232,7 @@
             },
             {
                   "heading": "6205",
-                  "subdivision": "",
+                  "subdivision": "Heading 6205",
                   "min": "6205000000",
                   "max": "6205999999",
                   "rules": [
@@ -8356,7 +8358,7 @@
             },
             {
                   "heading": "6207-6208",
-                  "subdivision": "",
+                  "subdivision": "6207-6208",
                   "min": "6207000000",
                   "max": "6208999999",
                   "rules": [
@@ -8829,7 +8831,7 @@
             },
             {
                   "heading": "6215",
-                  "subdivision": "",
+                  "subdivision": "Heading 6215",
                   "min": "6215000000",
                   "max": "6215999999",
                   "rules": [
@@ -9121,7 +9123,7 @@
             },
             {
                   "heading": "6301-6304",
-                  "subdivision": "Others\n\n-\n- Embroidered",
+                  "subdivision": "Others\n- - Embroidered",
                   "min": "6301000000",
                   "max": "6304999999",
                   "rules": [
@@ -9152,7 +9154,7 @@
             },
             {
                   "heading": "6301-6304",
-                  "subdivision": "\n-\n- Others",
+                  "subdivision": "- - Others",
                   "min": "6301000000",
                   "max": "6304999999",
                   "rules": [
@@ -9172,7 +9174,7 @@
             },
             {
                   "heading": "6305",
-                  "subdivision": "",
+                  "subdivision": "Heading 6305",
                   "min": "6305000000",
                   "max": "6305999999",
                   "rules": [
@@ -9232,7 +9234,7 @@
             },
             {
                   "heading": "6307",
-                  "subdivision": "",
+                  "subdivision": "Heading 6307",
                   "min": "6307000000",
                   "max": "6307999999",
                   "rules": [
@@ -9263,7 +9265,7 @@
             },
             {
                   "heading": "6308",
-                  "subdivision": "",
+                  "subdivision": "Heading 6308",
                   "min": "6308000000",
                   "max": "6308999999",
                   "rules": [
@@ -9292,7 +9294,7 @@
             },
             {
                   "heading": "6309-6310",
-                  "subdivision": "",
+                  "subdivision": "6309-6310",
                   "min": "6309000000",
                   "max": "6310999999",
                   "rules": [
@@ -9312,7 +9314,7 @@
             },
             {
                   "heading": "6401-6406",
-                  "subdivision": "",
+                  "subdivision": "6401-6406",
                   "min": "6401000000",
                   "max": "6406999999",
                   "rules": [
@@ -9355,7 +9357,7 @@
             },
             {
                   "heading": "6501-6507",
-                  "subdivision": "",
+                  "subdivision": "6501-6507",
                   "min": "6501000000",
                   "max": "6507999999",
                   "rules": [
@@ -9375,7 +9377,7 @@
             },
             {
                   "heading": "6601-6603",
-                  "subdivision": "",
+                  "subdivision": "6601-6603",
                   "min": "6601000000",
                   "max": "6603999999",
                   "rules": [
@@ -9417,7 +9419,7 @@
             },
             {
                   "heading": "6701-6704",
-                  "subdivision": "",
+                  "subdivision": "6701-6704",
                   "min": "6701000000",
                   "max": "6704999999",
                   "rules": [
@@ -9437,7 +9439,7 @@
             },
             {
                   "heading": "6801-6815",
-                  "subdivision": "",
+                  "subdivision": "6801-6815",
                   "min": "6801000000",
                   "max": "6815999999",
                   "rules": [
@@ -9479,7 +9481,7 @@
             },
             {
                   "heading": "6901-6914",
-                  "subdivision": "",
+                  "subdivision": "6901-6914",
                   "min": "6901000000",
                   "max": "6914999999",
                   "rules": [
@@ -9499,7 +9501,7 @@
             },
             {
                   "heading": "7001-7005",
-                  "subdivision": "",
+                  "subdivision": "7001-7005",
                   "min": "7001000000",
                   "max": "7005999999",
                   "rules": [
@@ -9590,7 +9592,7 @@
             },
             {
                   "heading": "7007-7009",
-                  "subdivision": "",
+                  "subdivision": "7007-7009",
                   "min": "7007000000",
                   "max": "7009999999",
                   "rules": [
@@ -9632,7 +9634,7 @@
             },
             {
                   "heading": "700711",
-                  "subdivision": "",
+                  "subdivision": "Subheading 700711",
                   "min": "7007110000",
                   "max": "7007119999",
                   "rules": [
@@ -9650,7 +9652,7 @@
             },
             {
                   "heading": "700721",
-                  "subdivision": "",
+                  "subdivision": "Subheading 700721",
                   "min": "7007210000",
                   "max": "7007219999",
                   "rules": [
@@ -9741,7 +9743,7 @@
             },
             {
                   "heading": "7011",
-                  "subdivision": "",
+                  "subdivision": "Heading 7011",
                   "min": "7011000000",
                   "max": "7011999999",
                   "rules": [
@@ -9783,7 +9785,7 @@
             },
             {
                   "heading": "7013",
-                  "subdivision": "",
+                  "subdivision": "Heading 7013",
                   "min": "7013000000",
                   "max": "7013999999",
                   "rules": [
@@ -9814,7 +9816,7 @@
             },
             {
                   "heading": "7014-7017",
-                  "subdivision": "",
+                  "subdivision": "7014-7017",
                   "min": "7014000000",
                   "max": "7017999999",
                   "rules": [
@@ -9856,7 +9858,7 @@
             },
             {
                   "heading": "701810",
-                  "subdivision": "",
+                  "subdivision": "Subheading 701810",
                   "min": "7018100000",
                   "max": "7018199999",
                   "rules": [
@@ -9876,7 +9878,7 @@
             },
             {
                   "heading": "701820",
-                  "subdivision": "",
+                  "subdivision": "Subheading 701820",
                   "min": "7018200000",
                   "max": "7018299999",
                   "rules": [
@@ -9918,7 +9920,7 @@
             },
             {
                   "heading": "701890",
-                  "subdivision": "",
+                  "subdivision": "Subheading 701890",
                   "min": "7018900000",
                   "max": "7018999999",
                   "rules": [
@@ -9938,7 +9940,7 @@
             },
             {
                   "heading": "7019-7020",
-                  "subdivision": "",
+                  "subdivision": "7019-7020",
                   "min": "7019000000",
                   "max": "7020999999",
                   "rules": [
@@ -9980,7 +9982,7 @@
             },
             {
                   "heading": "7101",
-                  "subdivision": "",
+                  "subdivision": "Heading 7101",
                   "min": "7101000000",
                   "max": "7101999999",
                   "rules": [
@@ -10000,7 +10002,7 @@
             },
             {
                   "heading": "7102-7104",
-                  "subdivision": "",
+                  "subdivision": "7102-7104",
                   "min": "7102000000",
                   "max": "7104999999",
                   "rules": [
@@ -10020,7 +10022,7 @@
             },
             {
                   "heading": "7105",
-                  "subdivision": "",
+                  "subdivision": "Heading 7105",
                   "min": "7105000000",
                   "max": "7105999999",
                   "rules": [
@@ -10334,7 +10336,7 @@
             },
             {
                   "heading": "7112",
-                  "subdivision": "",
+                  "subdivision": "Heading 7112",
                   "min": "7112000000",
                   "max": "7112999999",
                   "rules": [
@@ -10354,7 +10356,7 @@
             },
             {
                   "heading": "7113-7117",
-                  "subdivision": "",
+                  "subdivision": "7113-7117",
                   "min": "7113000000",
                   "max": "7117999999",
                   "rules": [
@@ -10396,7 +10398,7 @@
             },
             {
                   "heading": "7118",
-                  "subdivision": "",
+                  "subdivision": "Heading 7118",
                   "min": "7118000000",
                   "max": "7118999999",
                   "rules": [
@@ -10416,7 +10418,7 @@
             },
             {
                   "heading": "7201-7206",
-                  "subdivision": "",
+                  "subdivision": "7201-7206",
                   "min": "7201000000",
                   "max": "7206999999",
                   "rules": [
@@ -10436,7 +10438,7 @@
             },
             {
                   "heading": "7207",
-                  "subdivision": "",
+                  "subdivision": "Heading 7207",
                   "min": "7207000000",
                   "max": "7207999999",
                   "rules": [
@@ -10456,7 +10458,7 @@
             },
             {
                   "heading": "7208-7217",
-                  "subdivision": "",
+                  "subdivision": "7208-7217",
                   "min": "7208000000",
                   "max": "7217999999",
                   "rules": [
@@ -10476,7 +10478,7 @@
             },
             {
                   "heading": "721810",
-                  "subdivision": "",
+                  "subdivision": "Subheading 721810",
                   "min": "7218100000",
                   "max": "7218199999",
                   "rules": [
@@ -10496,7 +10498,7 @@
             },
             {
                   "heading": "721891-721899",
-                  "subdivision": "",
+                  "subdivision": "721891-721899",
                   "min": "7218910000",
                   "max": "7218999999",
                   "rules": [
@@ -10516,7 +10518,7 @@
             },
             {
                   "heading": "7219-7223",
-                  "subdivision": "",
+                  "subdivision": "7219-7223",
                   "min": "7219000000",
                   "max": "7223999999",
                   "rules": [
@@ -10536,7 +10538,7 @@
             },
             {
                   "heading": "722410",
-                  "subdivision": "",
+                  "subdivision": "Subheading 722410",
                   "min": "7224100000",
                   "max": "7224199999",
                   "rules": [
@@ -10556,7 +10558,7 @@
             },
             {
                   "heading": "722490",
-                  "subdivision": "",
+                  "subdivision": "Subheading 722490",
                   "min": "7224900000",
                   "max": "7224999999",
                   "rules": [
@@ -10576,7 +10578,7 @@
             },
             {
                   "heading": "7225-7229",
-                  "subdivision": "",
+                  "subdivision": "7225-7229",
                   "min": "7225000000",
                   "max": "7229999999",
                   "rules": [
@@ -10596,7 +10598,7 @@
             },
             {
                   "heading": "730110",
-                  "subdivision": "",
+                  "subdivision": "Subheading 730110",
                   "min": "7301100000",
                   "max": "7301199999",
                   "rules": [
@@ -10616,7 +10618,7 @@
             },
             {
                   "heading": "730120",
-                  "subdivision": "",
+                  "subdivision": "Subheading 730120",
                   "min": "7301200000",
                   "max": "7301299999",
                   "rules": [
@@ -10636,7 +10638,7 @@
             },
             {
                   "heading": "7302",
-                  "subdivision": "",
+                  "subdivision": "Heading 7302",
                   "min": "7302000000",
                   "max": "7302999999",
                   "rules": [
@@ -10656,7 +10658,7 @@
             },
             {
                   "heading": "7303",
-                  "subdivision": "",
+                  "subdivision": "Heading 7303",
                   "min": "7303000000",
                   "max": "7303999999",
                   "rules": [
@@ -10676,7 +10678,7 @@
             },
             {
                   "heading": "7304-7306",
-                  "subdivision": "",
+                  "subdivision": "7304-7306",
                   "min": "7304000000",
                   "max": "7306999999",
                   "rules": [
@@ -10747,7 +10749,7 @@
             },
             {
                   "heading": "7308",
-                  "subdivision": "",
+                  "subdivision": "Heading 7308",
                   "min": "7308000000",
                   "max": "7308999999",
                   "rules": [
@@ -10789,7 +10791,7 @@
             },
             {
                   "heading": "730900-731519",
-                  "subdivision": "",
+                  "subdivision": "730900-731519",
                   "min": "7309000000",
                   "max": "7315199999",
                   "rules": [
@@ -10809,7 +10811,7 @@
             },
             {
                   "heading": "731520",
-                  "subdivision": "",
+                  "subdivision": "Subheading 731520",
                   "min": "7315200000",
                   "max": "7315299999",
                   "rules": [
@@ -10851,7 +10853,7 @@
             },
             {
                   "heading": "731581-731990",
-                  "subdivision": "",
+                  "subdivision": "731581-731990",
                   "min": "7315810000",
                   "max": "7319999999",
                   "rules": [
@@ -10871,7 +10873,7 @@
             },
             {
                   "heading": "732010",
-                  "subdivision": "",
+                  "subdivision": "Subheading 732010",
                   "min": "7320100000",
                   "max": "7320199999",
                   "rules": [
@@ -10913,7 +10915,7 @@
             },
             {
                   "heading": "732020-732690",
-                  "subdivision": "",
+                  "subdivision": "732020-732690",
                   "min": "7320200000",
                   "max": "7326999999",
                   "rules": [
@@ -10933,7 +10935,7 @@
             },
             {
                   "heading": "7401-7402",
-                  "subdivision": "",
+                  "subdivision": "7401-7402",
                   "min": "7401000000",
                   "max": "7402999999",
                   "rules": [
@@ -10953,7 +10955,7 @@
             },
             {
                   "heading": "7403",
-                  "subdivision": "",
+                  "subdivision": "Heading 7403",
                   "min": "7403000000",
                   "max": "7403999999",
                   "rules": [
@@ -10973,7 +10975,7 @@
             },
             {
                   "heading": "7404-7419",
-                  "subdivision": "",
+                  "subdivision": "7404-7419",
                   "min": "7404000000",
                   "max": "7419999999",
                   "rules": [
@@ -10993,7 +10995,7 @@
             },
             {
                   "heading": "7501-7504",
-                  "subdivision": "",
+                  "subdivision": "7501-7504",
                   "min": "7501000000",
                   "max": "7504999999",
                   "rules": [
@@ -11013,7 +11015,7 @@
             },
             {
                   "heading": "7505-7508",
-                  "subdivision": "",
+                  "subdivision": "7505-7508",
                   "min": "7505000000",
                   "max": "7508999999",
                   "rules": [
@@ -11033,7 +11035,7 @@
             },
             {
                   "heading": "7601",
-                  "subdivision": "",
+                  "subdivision": "Heading 7601",
                   "min": "7601000000",
                   "max": "7601999999",
                   "rules": [
@@ -11053,7 +11055,7 @@
             },
             {
                   "heading": "7602-7606",
-                  "subdivision": "",
+                  "subdivision": "7602-7606",
                   "min": "7602000000",
                   "max": "7606999999",
                   "rules": [
@@ -11085,7 +11087,7 @@
             },
             {
                   "heading": "7607",
-                  "subdivision": "",
+                  "subdivision": "Heading 7607",
                   "min": "7607000000",
                   "max": "7607999999",
                   "rules": [
@@ -11105,7 +11107,7 @@
             },
             {
                   "heading": "760810-761691",
-                  "subdivision": "",
+                  "subdivision": "760810-761691",
                   "min": "7608100000",
                   "max": "7616919999",
                   "rules": [
@@ -11137,7 +11139,7 @@
             },
             {
                   "heading": "761699",
-                  "subdivision": "",
+                  "subdivision": "Subheading 761699",
                   "min": "7616990000",
                   "max": "7616999999",
                   "rules": [
@@ -11179,7 +11181,7 @@
             },
             {
                   "heading": "780110",
-                  "subdivision": "",
+                  "subdivision": "Subheading 780110",
                   "min": "7801100000",
                   "max": "7801199999",
                   "rules": [
@@ -11199,7 +11201,7 @@
             },
             {
                   "heading": "780191-780199",
-                  "subdivision": "",
+                  "subdivision": "780191-780199",
                   "min": "7801910000",
                   "max": "7801999999",
                   "rules": [
@@ -11219,7 +11221,7 @@
             },
             {
                   "heading": "7802-7804",
-                  "subdivision": "",
+                  "subdivision": "7802-7804",
                   "min": "7802000000",
                   "max": "7804999999",
                   "rules": [
@@ -11239,7 +11241,7 @@
             },
             {
                   "heading": "7806",
-                  "subdivision": "",
+                  "subdivision": "Heading 7806",
                   "min": "7806000000",
                   "max": "7806999999",
                   "rules": [
@@ -11281,7 +11283,7 @@
             },
             {
                   "heading": "7901-7907",
-                  "subdivision": "",
+                  "subdivision": "7901-7907",
                   "min": "7901000000",
                   "max": "7907999999",
                   "rules": [
@@ -11301,7 +11303,7 @@
             },
             {
                   "heading": "8001-8007",
-                  "subdivision": "",
+                  "subdivision": "8001-8007",
                   "min": "8001000000",
                   "max": "8007999999",
                   "rules": [
@@ -11321,7 +11323,7 @@
             },
             {
                   "heading": "8101-8113",
-                  "subdivision": "",
+                  "subdivision": "8101-8113",
                   "min": "8101000000",
                   "max": "8113999999",
                   "rules": [
@@ -11352,7 +11354,7 @@
             },
             {
                   "heading": "820110-820570",
-                  "subdivision": "",
+                  "subdivision": "820110-820570",
                   "min": "8201100000",
                   "max": "8205799999",
                   "rules": [
@@ -11394,7 +11396,7 @@
             },
             {
                   "heading": "820590",
-                  "subdivision": "",
+                  "subdivision": "Subheading 820590",
                   "min": "8205900000",
                   "max": "8205999999",
                   "rules": [
@@ -11425,7 +11427,7 @@
             },
             {
                   "heading": "8206",
-                  "subdivision": "",
+                  "subdivision": "Heading 8206",
                   "min": "8206000000",
                   "max": "8206999999",
                   "rules": [
@@ -11456,7 +11458,7 @@
             },
             {
                   "heading": "8207-8215",
-                  "subdivision": "",
+                  "subdivision": "8207-8215",
                   "min": "8207000000",
                   "max": "8215999999",
                   "rules": [
@@ -11498,7 +11500,7 @@
             },
             {
                   "heading": "8301-8311",
-                  "subdivision": "",
+                  "subdivision": "8301-8311",
                   "min": "8301000000",
                   "max": "8311999999",
                   "rules": [
@@ -11540,7 +11542,7 @@
             },
             {
                   "heading": "8401-8406",
-                  "subdivision": "",
+                  "subdivision": "8401-8406",
                   "min": "8401000000",
                   "max": "8406999999",
                   "rules": [
@@ -11582,7 +11584,7 @@
             },
             {
                   "heading": "8407-8408",
-                  "subdivision": "",
+                  "subdivision": "8407-8408",
                   "min": "8407000000",
                   "max": "8408999999",
                   "rules": [
@@ -11613,7 +11615,7 @@
             },
             {
                   "heading": "8409-8411",
-                  "subdivision": "",
+                  "subdivision": "8409-8411",
                   "min": "8409000000",
                   "max": "8411999999",
                   "rules": [
@@ -11655,7 +11657,7 @@
             },
             {
                   "heading": "8412",
-                  "subdivision": "",
+                  "subdivision": "Heading 8412",
                   "min": "8412000000",
                   "max": "8412999999",
                   "rules": [
@@ -11697,7 +11699,7 @@
             },
             {
                   "heading": "8413",
-                  "subdivision": "",
+                  "subdivision": "Heading 8413",
                   "min": "8413000000",
                   "max": "8413999999",
                   "rules": [
@@ -11739,7 +11741,7 @@
             },
             {
                   "heading": "8414-8415",
-                  "subdivision": "",
+                  "subdivision": "8414-8415",
                   "min": "8414000000",
                   "max": "8415999999",
                   "rules": [
@@ -11781,7 +11783,7 @@
             },
             {
                   "heading": "8416-8424",
-                  "subdivision": "",
+                  "subdivision": "8416-8424",
                   "min": "8416000000",
                   "max": "8424999999",
                   "rules": [
@@ -11823,7 +11825,7 @@
             },
             {
                   "heading": "8425-8430",
-                  "subdivision": "",
+                  "subdivision": "8425-8430",
                   "min": "8425000000",
                   "max": "8430999999",
                   "rules": [
@@ -11865,7 +11867,7 @@
             },
             {
                   "heading": "8431-8443",
-                  "subdivision": "",
+                  "subdivision": "8431-8443",
                   "min": "8431000000",
                   "max": "8443999999",
                   "rules": [
@@ -11907,7 +11909,7 @@
             },
             {
                   "heading": "8444-8447",
-                  "subdivision": "",
+                  "subdivision": "8444-8447",
                   "min": "8444000000",
                   "max": "8447999999",
                   "rules": [
@@ -11949,7 +11951,7 @@
             },
             {
                   "heading": "8448-8468",
-                  "subdivision": "",
+                  "subdivision": "8448-8468",
                   "min": "8448000000",
                   "max": "8468999999",
                   "rules": [
@@ -11991,7 +11993,7 @@
             },
             {
                   "heading": "8470-8472",
-                  "subdivision": "",
+                  "subdivision": "8470-8472",
                   "min": "8470000000",
                   "max": "8472999999",
                   "rules": [
@@ -12033,7 +12035,7 @@
             },
             {
                   "heading": "8473-8487",
-                  "subdivision": "",
+                  "subdivision": "8473-8487",
                   "min": "8473000000",
                   "max": "8487999999",
                   "rules": [
@@ -12075,7 +12077,7 @@
             },
             {
                   "heading": "8501",
-                  "subdivision": "",
+                  "subdivision": "Heading 8501",
                   "min": "8501000000",
                   "max": "8501999999",
                   "rules": [
@@ -12117,7 +12119,7 @@
             },
             {
                   "heading": "8502-8518",
-                  "subdivision": "",
+                  "subdivision": "8502-8518",
                   "min": "8502000000",
                   "max": "8518999999",
                   "rules": [
@@ -12159,7 +12161,7 @@
             },
             {
                   "heading": "8519-8521",
-                  "subdivision": "",
+                  "subdivision": "8519-8521",
                   "min": "8519000000",
                   "max": "8521999999",
                   "rules": [
@@ -12201,7 +12203,7 @@
             },
             {
                   "heading": "8522-8527",
-                  "subdivision": "",
+                  "subdivision": "8522-8527",
                   "min": "8522000000",
                   "max": "8527999999",
                   "rules": [
@@ -12243,7 +12245,7 @@
             },
             {
                   "heading": "8528",
-                  "subdivision": "",
+                  "subdivision": "Heading 8528",
                   "min": "8528000000",
                   "max": "8528999999",
                   "rules": [
@@ -12285,7 +12287,7 @@
             },
             {
                   "heading": "8529-8534",
-                  "subdivision": "",
+                  "subdivision": "8529-8534",
                   "min": "8529000000",
                   "max": "8534999999",
                   "rules": [
@@ -12327,7 +12329,7 @@
             },
             {
                   "heading": "8535-8537",
-                  "subdivision": "",
+                  "subdivision": "8535-8537",
                   "min": "8535000000",
                   "max": "8537999999",
                   "rules": [
@@ -12369,7 +12371,7 @@
             },
             {
                   "heading": "8538-8539",
-                  "subdivision": "",
+                  "subdivision": "8538-8539",
                   "min": "8538000000",
                   "max": "8539999999",
                   "rules": [
@@ -12411,7 +12413,7 @@
             },
             {
                   "heading": "854011-854012",
-                  "subdivision": "",
+                  "subdivision": "854011-854012",
                   "min": "8540110000",
                   "max": "8540129999",
                   "rules": [
@@ -12453,7 +12455,7 @@
             },
             {
                   "heading": "854020-854099",
-                  "subdivision": "",
+                  "subdivision": "854020-854099",
                   "min": "8540200000",
                   "max": "8540999999",
                   "rules": [
@@ -12495,7 +12497,7 @@
             },
             {
                   "heading": "854110-854160",
-                  "subdivision": "",
+                  "subdivision": "854110-854160",
                   "min": "8541100000",
                   "max": "8541699999",
                   "rules": [
@@ -12546,7 +12548,7 @@
             },
             {
                   "heading": "854190",
-                  "subdivision": "",
+                  "subdivision": "Subheading 854190",
                   "min": "8541900000",
                   "max": "8541999999",
                   "rules": [
@@ -12588,7 +12590,7 @@
             },
             {
                   "heading": "854231-854239",
-                  "subdivision": "",
+                  "subdivision": "854231-854239",
                   "min": "8542310000",
                   "max": "8542399999",
                   "rules": [
@@ -12639,7 +12641,7 @@
             },
             {
                   "heading": "854290-854390",
-                  "subdivision": "",
+                  "subdivision": "854290-854390",
                   "min": "8542900000",
                   "max": "8543999999",
                   "rules": [
@@ -12681,7 +12683,7 @@
             },
             {
                   "heading": "854411-854460",
-                  "subdivision": "",
+                  "subdivision": "854411-854460",
                   "min": "8544110000",
                   "max": "8544699999",
                   "rules": [
@@ -12723,7 +12725,7 @@
             },
             {
                   "heading": "854470",
-                  "subdivision": "",
+                  "subdivision": "Subheading 854470",
                   "min": "8544700000",
                   "max": "8544799999",
                   "rules": [
@@ -12765,7 +12767,7 @@
             },
             {
                   "heading": "8545-8549",
-                  "subdivision": "",
+                  "subdivision": "8545-8549",
                   "min": "8545000000",
                   "max": "8549999999",
                   "rules": [
@@ -12807,7 +12809,7 @@
             },
             {
                   "heading": "8601-8609",
-                  "subdivision": "",
+                  "subdivision": "8601-8609",
                   "min": "8601000000",
                   "max": "8609999999",
                   "rules": [
@@ -12849,7 +12851,7 @@
             },
             {
                   "heading": "8701",
-                  "subdivision": "",
+                  "subdivision": "Heading 8701",
                   "min": "8701000000",
                   "max": "8701999999",
                   "rules": [
@@ -12880,7 +12882,7 @@
             },
             {
                   "heading": "8702-8705",
-                  "subdivision": "",
+                  "subdivision": "8702-8705",
                   "min": "8702000000",
                   "max": "8705999999",
                   "rules": [
@@ -12911,7 +12913,7 @@
             },
             {
                   "heading": "8703",
-                  "subdivision": "",
+                  "subdivision": "Heading 8703",
                   "min": "8703000000",
                   "max": "8703999999",
                   "rules": [
@@ -12986,7 +12988,7 @@
             },
             {
                   "heading": "8706",
-                  "subdivision": "",
+                  "subdivision": "Heading 8706",
                   "min": "8706000000",
                   "max": "8706999999",
                   "rules": [
@@ -13039,7 +13041,7 @@
             },
             {
                   "heading": "8707",
-                  "subdivision": "",
+                  "subdivision": "Heading 8707",
                   "min": "8707000000",
                   "max": "8707999999",
                   "rules": [
@@ -13092,7 +13094,7 @@
             },
             {
                   "heading": "870710",
-                  "subdivision": "",
+                  "subdivision": "Subheading 870710",
                   "min": "8707100000",
                   "max": "8707199999",
                   "rules": [
@@ -13110,7 +13112,7 @@
             },
             {
                   "heading": "8708-8711",
-                  "subdivision": "",
+                  "subdivision": "8708-8711",
                   "min": "8708000000",
                   "max": "8711999999",
                   "rules": [
@@ -13152,7 +13154,7 @@
             },
             {
                   "heading": "870810",
-                  "subdivision": "",
+                  "subdivision": "Subheading 870810",
                   "min": "8708100000",
                   "max": "8708199999",
                   "rules": [
@@ -13242,7 +13244,7 @@
             },
             {
                   "heading": "8712",
-                  "subdivision": "",
+                  "subdivision": "Heading 8712",
                   "min": "8712000000",
                   "max": "8712999999",
                   "rules": [
@@ -13273,7 +13275,7 @@
             },
             {
                   "heading": "8713-8716",
-                  "subdivision": "",
+                  "subdivision": "8713-8716",
                   "min": "8713000000",
                   "max": "8716999999",
                   "rules": [
@@ -13315,7 +13317,7 @@
             },
             {
                   "heading": "8801-8805",
-                  "subdivision": "",
+                  "subdivision": "8801-8805",
                   "min": "8801000000",
                   "max": "8805999999",
                   "rules": [
@@ -13357,7 +13359,7 @@
             },
             {
                   "heading": "8806-8807",
-                  "subdivision": "",
+                  "subdivision": "8806-8807",
                   "min": "8806000000",
                   "max": "8807999999",
                   "rules": [
@@ -13399,7 +13401,7 @@
             },
             {
                   "heading": "8901-8908",
-                  "subdivision": "",
+                  "subdivision": "8901-8908",
                   "min": "8901000000",
                   "max": "8908999999",
                   "rules": [
@@ -13441,7 +13443,7 @@
             },
             {
                   "heading": "900110-900140",
-                  "subdivision": "",
+                  "subdivision": "900110-900140",
                   "min": "9001100000",
                   "max": "9001499999",
                   "rules": [
@@ -13483,7 +13485,7 @@
             },
             {
                   "heading": "900150",
-                  "subdivision": "",
+                  "subdivision": "Subheading 900150",
                   "min": "9001500000",
                   "max": "9001599999",
                   "rules": [
@@ -13543,7 +13545,7 @@
             },
             {
                   "heading": "900190-903300",
-                  "subdivision": "",
+                  "subdivision": "900190-903300",
                   "min": "9001900000",
                   "max": "9033999999",
                   "rules": [
@@ -13585,7 +13587,7 @@
             },
             {
                   "heading": "910111-911320",
-                  "subdivision": "",
+                  "subdivision": "910111-911320",
                   "min": "9101110000",
                   "max": "9113299999",
                   "rules": [
@@ -13627,7 +13629,7 @@
             },
             {
                   "heading": "911390",
-                  "subdivision": "",
+                  "subdivision": "Subheading 911390",
                   "min": "9113900000",
                   "max": "9113999999",
                   "rules": [
@@ -13647,7 +13649,7 @@
             },
             {
                   "heading": "9114",
-                  "subdivision": "",
+                  "subdivision": "Heading 9114",
                   "min": "9114000000",
                   "max": "9114999999",
                   "rules": [
@@ -13689,7 +13691,7 @@
             },
             {
                   "heading": "9201-9209",
-                  "subdivision": "",
+                  "subdivision": "9201-9209",
                   "min": "9201000000",
                   "max": "9209999999",
                   "rules": [
@@ -13720,7 +13722,7 @@
             },
             {
                   "heading": "9301-9307",
-                  "subdivision": "",
+                  "subdivision": "9301-9307",
                   "min": "9301000000",
                   "max": "9307999999",
                   "rules": [
@@ -13751,7 +13753,7 @@
             },
             {
                   "heading": "940110-940180",
-                  "subdivision": "",
+                  "subdivision": "940110-940180",
                   "min": "9401100000",
                   "max": "9401899999",
                   "rules": [
@@ -13793,7 +13795,7 @@
             },
             {
                   "heading": "940190",
-                  "subdivision": "",
+                  "subdivision": "Subheading 940190",
                   "min": "9401900000",
                   "max": "9401999999",
                   "rules": [
@@ -13813,7 +13815,7 @@
             },
             {
                   "heading": "9402-9406",
-                  "subdivision": "",
+                  "subdivision": "9402-9406",
                   "min": "9402000000",
                   "max": "9406999999",
                   "rules": [
@@ -13855,7 +13857,7 @@
             },
             {
                   "heading": "9503-9505",
-                  "subdivision": "",
+                  "subdivision": "9503-9505",
                   "min": "9503000000",
                   "max": "9505999999",
                   "rules": [
@@ -13968,7 +13970,7 @@
             },
             {
                   "heading": "9507-9508",
-                  "subdivision": "",
+                  "subdivision": "9507-9508",
                   "min": "9507000000",
                   "max": "9508999999",
                   "rules": [
@@ -14010,7 +14012,7 @@
             },
             {
                   "heading": "9601",
-                  "subdivision": "",
+                  "subdivision": "Heading 9601",
                   "min": "9601000000",
                   "max": "9601999999",
                   "rules": [
@@ -14030,7 +14032,7 @@
             },
             {
                   "heading": "9602-9604",
-                  "subdivision": "",
+                  "subdivision": "9602-9604",
                   "min": "9602000000",
                   "max": "9604999999",
                   "rules": [
@@ -14072,7 +14074,7 @@
             },
             {
                   "heading": "9605",
-                  "subdivision": "",
+                  "subdivision": "Heading 9605",
                   "min": "9605000000",
                   "max": "9605999999",
                   "rules": [
@@ -14092,7 +14094,7 @@
             },
             {
                   "heading": "9606-9620",
-                  "subdivision": "",
+                  "subdivision": "9606-9620",
                   "min": "9606000000",
                   "max": "9620999999",
                   "rules": [
@@ -14134,7 +14136,7 @@
             },
             {
                   "heading": "9701-9706",
-                  "subdivision": "",
+                  "subdivision": "9701-9706",
                   "min": "9701000000",
                   "max": "9706999999",
                   "rules": [


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4685

### What?

I have altered:

- [x] db/rules_of_origin/roo_schemes_uk/rule_sets/japan.json

### Why?

I am doing this because:

- There was a copy error for Sugar CTH (Chapter & Heading) 1806 for Japan Rules of Origin Product Specific Rules

BEFORE
![image](https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/5318956c-cc2c-474e-98b8-209bc22d52af)

AFTER
![image](https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/8ff7c92b-6ac7-4f8b-bb57-9fa8361a9461)
