### PR TITLE
HOTT-4691 Updated Central America RoO PSRs

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/central-america.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/central-america.json
@@ -1,7 +1,7 @@
 {
       "rule_sets": [
             {
-                  "heading": "Chapter 01",
+                  "heading": "Chapter 1",
                   "chapter": 1,
                   "subdivision": "Live animals",
                   "min": "0100000000",
@@ -22,7 +22,7 @@
                   "valid": true
             },
             {
-                  "heading": "Chapter 02",
+                  "heading": "Chapter 2",
                   "chapter": 2,
                   "subdivision": "Meat and edible meat offal",
                   "min": "0200000000",
@@ -43,7 +43,7 @@
                   "valid": true
             },
             {
-                  "heading": "Chapter 03",
+                  "heading": "Chapter 3",
                   "chapter": 3,
                   "subdivision": "Fish and crustaceans, molluscs and other aquatic invertebrates",
                   "min": "0300000000",
@@ -64,30 +64,10 @@
                   "valid": true
             },
             {
-                  "heading": "0401",
-                  "subdivision": "Dairy produce; birds' eggs; natural honey; edible products of animal origin, not elsewhere specified or included; except for",
+                  "heading": "ex Chapter 4",
+                  "chapter": 4,
+                  "subdivision": "Dairy produce; birds' eggs; natural honey; edible products of animal origin, not elsewhere specified or included",
                   "min": "0401000000",
-                  "max": "0401999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 4
-            },
-            {
-                  "heading": "0402",
-                  "subdivision": "Dairy produce; birds' eggs; natural honey; edible products of animal origin, not elsewhere specified or included; except for",
-                  "min": "0402000000",
                   "max": "0402999999",
                   "rules": [
                         {
@@ -102,8 +82,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 4
+                  "valid": true
             },
             {
                   "heading": "0403",
@@ -129,135 +108,10 @@
                   "valid": true
             },
             {
-                  "heading": "0404",
-                  "subdivision": "Dairy produce; birds' eggs; natural honey; edible products of animal origin, not elsewhere specified or included; except for",
+                  "heading": "ex Chapter 4",
+                  "chapter": 4,
+                  "subdivision": "Dairy produce; birds' eggs; natural honey; edible products of animal origin, not elsewhere specified or included",
                   "min": "0404000000",
-                  "max": "0404999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 4
-            },
-            {
-                  "heading": "0405",
-                  "subdivision": "Dairy produce; birds' eggs; natural honey; edible products of animal origin, not elsewhere specified or included; except for",
-                  "min": "0405000000",
-                  "max": "0405999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 4
-            },
-            {
-                  "heading": "0406",
-                  "subdivision": "Dairy produce; birds' eggs; natural honey; edible products of animal origin, not elsewhere specified or included; except for",
-                  "min": "0406000000",
-                  "max": "0406999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 4
-            },
-            {
-                  "heading": "0407",
-                  "subdivision": "Dairy produce; birds' eggs; natural honey; edible products of animal origin, not elsewhere specified or included; except for",
-                  "min": "0407000000",
-                  "max": "0407999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 4
-            },
-            {
-                  "heading": "0408",
-                  "subdivision": "Dairy produce; birds' eggs; natural honey; edible products of animal origin, not elsewhere specified or included; except for",
-                  "min": "0408000000",
-                  "max": "0408999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 4
-            },
-            {
-                  "heading": "0409",
-                  "subdivision": "Dairy produce; birds' eggs; natural honey; edible products of animal origin, not elsewhere specified or included; except for",
-                  "min": "0409000000",
-                  "max": "0409999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 4
-            },
-            {
-                  "heading": "0410",
-                  "subdivision": "Dairy produce; birds' eggs; natural honey; edible products of animal origin, not elsewhere specified or included; except for",
-                  "min": "0410000000",
                   "max": "0410999999",
                   "rules": [
                         {
@@ -272,18 +126,17 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 4
+                  "valid": true
             },
             {
-                  "heading": "ex Chapter 05",
+                  "heading": "ex Chapter 5",
                   "chapter": 5,
                   "subdivision": "Products of animal origin, not elsewhere specified or included",
-                  "min": "0500000000",
-                  "max": "0599999999",
+                  "min": "0501000000",
+                  "max": "0501999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained poo.",
                               "class": [
                                     "WO"
                               ],
@@ -318,7 +171,49 @@
                   "valid": true
             },
             {
-                  "heading": "Chapter 06",
+                  "heading": "ex Chapter 5",
+                  "chapter": 5,
+                  "subdivision": "Any other product from heading 0502",
+                  "min": "0502000000",
+                  "max": "0502999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained poo.",
+                              "class": [
+                                    "WO"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 5",
+                  "chapter": 5,
+                  "subdivision": "Products of animal origin, not elsewhere specified or included",
+                  "min": "0504000000",
+                  "max": "0511999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained poo.",
+                              "class": [
+                                    "WO"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "Chapter 6",
                   "chapter": 6,
                   "subdivision": "Live trees and other plants; bulbs, roots and the like; cut flowers and ornamental foliage",
                   "min": "0600000000",
@@ -339,7 +234,7 @@
                   "valid": true
             },
             {
-                  "heading": "Chapter 07",
+                  "heading": "Chapter 7",
                   "chapter": 7,
                   "subdivision": "Edible vegetables and certain roots and tubers",
                   "min": "0700000000",
@@ -360,7 +255,7 @@
                   "valid": true
             },
             {
-                  "heading": "Chapter 08",
+                  "heading": "Chapter 8",
                   "chapter": 8,
                   "subdivision": "Edible fruit and nuts; peel of citrus fruit or melons",
                   "min": "0800000000",
@@ -382,7 +277,7 @@
                   "valid": true
             },
             {
-                  "heading": "0901",
+                  "heading": "ex Chapter 9",
                   "chapter": 9,
                   "subdivision": "Coffee, tea, mate and spices",
                   "min": "0901000000",
@@ -424,136 +319,10 @@
                   "valid": true
             },
             {
-                  "heading": "0903",
+                  "heading": "ex Chapter 9",
                   "chapter": 9,
                   "subdivision": "Coffee, tea, mate and spices",
                   "min": "0903000000",
-                  "max": "0903999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "0904",
-                  "chapter": 9,
-                  "subdivision": "Coffee, tea, mate and spices",
-                  "min": "0904000000",
-                  "max": "0904999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "0905",
-                  "chapter": 9,
-                  "subdivision": "Coffee, tea, mate and spices",
-                  "min": "0905000000",
-                  "max": "0905999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "0906",
-                  "chapter": 9,
-                  "subdivision": "Coffee, tea, mate and spices",
-                  "min": "0906000000",
-                  "max": "0906999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "0907",
-                  "chapter": 9,
-                  "subdivision": "Coffee, tea, mate and spices",
-                  "min": "0907000000",
-                  "max": "0907999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "0908",
-                  "chapter": 9,
-                  "subdivision": "Coffee, tea, mate and spices",
-                  "min": "0908000000",
-                  "max": "0908999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "0909",
-                  "chapter": 9,
-                  "subdivision": "Coffee, tea, mate and spices",
-                  "min": "0909000000",
                   "max": "0909999999",
                   "rules": [
                         {
@@ -592,9 +361,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 0910",
+                  "heading": "ex Chapter 9",
                   "chapter": 9,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 0910",
                   "min": "0910000000",
                   "max": "0910999999",
                   "rules": [
@@ -676,9 +445,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 1102",
+                  "heading": "ex Chapter 11",
                   "chapter": 11,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 1102",
                   "min": "1102000000",
                   "max": "1102999999",
                   "rules": [
@@ -718,9 +487,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 1103",
+                  "heading": "ex Chapter 11",
                   "chapter": 11,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 1103",
                   "min": "1103000000",
                   "max": "1103999999",
                   "rules": [
@@ -739,31 +508,10 @@
                   "valid": true
             },
             {
-                  "heading": "1104",
+                  "heading": "ex Chapter 11",
                   "chapter": 11,
                   "subdivision": "Products of the milling industry; malt; starches; inulin; wheat gluten",
                   "min": "1104000000",
-                  "max": "1104999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the cereals, edible vegetables, roots and tubers of [heading&nbsp;0714](/headings/0714) or fruit used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "1105",
-                  "chapter": 11,
-                  "subdivision": "Products of the milling industry; malt; starches; inulin; wheat gluten",
-                  "min": "1105000000",
                   "max": "1105999999",
                   "rules": [
                         {
@@ -802,9 +550,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 1106",
+                  "heading": "ex Chapter 11",
                   "chapter": 11,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 1106",
                   "min": "1106000000",
                   "max": "1106999999",
                   "rules": [
@@ -823,52 +571,10 @@
                   "valid": true
             },
             {
-                  "heading": "1107",
+                  "heading": "ex Chapter 11",
                   "chapter": 11,
                   "subdivision": "Products of the milling industry; malt; starches; inulin; wheat gluten",
                   "min": "1107000000",
-                  "max": "1107999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the cereals, edible vegetables, roots and tubers of [heading&nbsp;0714](/headings/0714) or fruit used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "1108",
-                  "chapter": 11,
-                  "subdivision": "Products of the milling industry; malt; starches; inulin; wheat gluten",
-                  "min": "1108000000",
-                  "max": "1108999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the cereals, edible vegetables, roots and tubers of [heading&nbsp;0714](/headings/0714) or fruit used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "1109",
-                  "chapter": 11,
-                  "subdivision": "Products of the milling industry; malt; starches; inulin; wheat gluten",
-                  "min": "1109000000",
                   "max": "1109999999",
                   "rules": [
                         {
@@ -1075,9 +781,9 @@
                   "valid": true
             },
             {
-                  "heading": "1503",
+                  "heading": "ex Chapter 15",
                   "chapter": 15,
-                  "subdivision": "Animal or vegetable fats and oils and their cleavage products; prepared edible fats; animal or vegetable waxes; except for",
+                  "subdivision": "Animal or vegetable fats and oils and their cleavage products; prepared edible fats; animal or vegetable waxes",
                   "min": "1503000000",
                   "max": "1503999999",
                   "rules": [
@@ -1159,9 +865,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 1505",
+                  "heading": "ex Chapter 15",
                   "chapter": 15,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 1505",
                   "min": "1505000000",
                   "max": "1505999999",
                   "rules": [
@@ -1222,7 +928,7 @@
                   "valid": true
             },
             {
-                  "heading": "1507-1510",
+                  "heading": "1507 to 1510",
                   "chapter": 15,
                   "subdivision": "Soya oil, ground nut oil and oils for technical or industrial uses other than the manufacture of foodstuffs for human consumption.",
                   "min": "1507000000",
@@ -1243,9 +949,9 @@
                   "valid": true
             },
             {
-                  "heading": "1507-1510",
+                  "heading": "1507 to 1510",
                   "chapter": 15,
-                  "subdivision": "Other animal fats and oils and their fractions, whether or not refined, but not chemically modified \u25b8 Solid fractions",
+                  "subdivision": "Soya oil, ground nut oil and oils for technical or industrial uses other than the manufacture of foodstuffs for human consumption. \u25b8 Solid fractions",
                   "min": "1507000000",
                   "max": "1510999999",
                   "rules": [
@@ -1264,9 +970,9 @@
                   "valid": true
             },
             {
-                  "heading": "1507-1510",
+                  "heading": "1507 to 1510",
                   "chapter": 15,
-                  "subdivision": "Other animal fats and oils and their fractions, whether or not refined, but not chemically modified \u25b8 Other",
+                  "subdivision": "Soya oil, ground nut oil and oils for technical or industrial uses other than the manufacture of foodstuffs for human consumption. \u25b8 Other",
                   "min": "1507000000",
                   "max": "1510999999",
                   "rules": [
@@ -1308,7 +1014,7 @@
             {
                   "heading": "1512",
                   "chapter": 15,
-                  "subdivision": "Other animal fats and oils and their fractions, whether or not refined, but not chemically modified \u25b8 Oils for technical or industrial uses other than the manufacture of foodstuffs for human consumption",
+                  "subdivision": "Palm oil and its fractions, whether or not refined but not chemically modified \u25b8 Oils for technical or industrial uses other than the manufacture of foodstuffs for human consumption",
                   "min": "1512000000",
                   "max": "1512999999",
                   "rules": [
@@ -1329,7 +1035,7 @@
             {
                   "heading": "1512",
                   "chapter": 15,
-                  "subdivision": "Other animal fats and oils and their fractions, whether or not refined, but not chemically modified \u25b8 Solid fractions",
+                  "subdivision": "Palm oil and its fractions, whether or not refined but not chemically modified \u25b8 Solid fractions",
                   "min": "1512000000",
                   "max": "1512999999",
                   "rules": [
@@ -1350,7 +1056,7 @@
             {
                   "heading": "1512",
                   "chapter": 15,
-                  "subdivision": "Other animal fats and oils and their fractions, whether or not refined, but not chemically modified \u25b8 Other",
+                  "subdivision": "Palm oil and its fractions, whether or not refined but not chemically modified \u25b8 Other",
                   "min": "1512000000",
                   "max": "1512999999",
                   "rules": [
@@ -1390,9 +1096,9 @@
                   "valid": true
             },
             {
-                  "heading": "1514-1515",
+                  "heading": "1514 to 1515",
                   "chapter": 15,
-                  "subdivision": "Other animal fats and oils and their fractions, whether or not refined, but not chemically modified \u25b8 Tung and oiticica oil, myrtle wax and Japan wax, fractions of jojoba oil and oils for technical or industrial uses other than the manufacture of foodstuffs for human consumption",
+                  "subdivision": "Coconut (copra), palm kernel or babassu oil and fractions thereof, whether or not refined but not chemically modified \u25b8 Tung and oiticica oil, myrtle wax and Japan wax, fractions of jojoba oil and oils for technical or industrial uses other than the manufacture of foodstuffs for human consumption",
                   "min": "1514000000",
                   "max": "1515999999",
                   "rules": [
@@ -1411,9 +1117,9 @@
                   "valid": true
             },
             {
-                  "heading": "1514-1515",
+                  "heading": "1514 to 1515",
                   "chapter": 15,
-                  "subdivision": "Other animal fats and oils and their fractions, whether or not refined, but not chemically modified \u25b8 Solid fractions, except for that of jojoba oil",
+                  "subdivision": "Coconut (copra), palm kernel or babassu oil and fractions thereof, whether or not refined but not chemically modified \u25b8 Solid fractions that of jojoba oil",
                   "min": "1514000000",
                   "max": "1515999999",
                   "rules": [
@@ -1432,9 +1138,9 @@
                   "valid": true
             },
             {
-                  "heading": "1514-1515",
+                  "heading": "1514 to 1515",
                   "chapter": 15,
-                  "subdivision": "Other animal fats and oils and their fractions, whether or not refined, but not chemically modified \u25b8 Other",
+                  "subdivision": "Coconut (copra), palm kernel or babassu oil and fractions thereof, whether or not refined but not chemically modified \u25b8 Other",
                   "min": "1514000000",
                   "max": "1515999999",
                   "rules": [
@@ -1497,73 +1203,10 @@
                   "valid": true
             },
             {
-                  "heading": "1518",
+                  "heading": "ex Chapter 15",
                   "chapter": 15,
-                  "subdivision": "Animal or vegetable fats and oils and their cleavage products; prepared edible fats; animal or vegetable waxes; except for",
+                  "subdivision": "Animal or vegetable fats and oils and their cleavage products; prepared edible fats; animal or vegetable waxes",
                   "min": "1518000000",
-                  "max": "1518999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product in which all die vegetal materials of [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "1520",
-                  "chapter": 15,
-                  "subdivision": "Animal or vegetable fats and oils and their cleavage products; prepared edible fats; animal or vegetable waxes; except for",
-                  "min": "1520000000",
-                  "max": "1520999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product in which all die vegetal materials of [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "1521",
-                  "chapter": 15,
-                  "subdivision": "Animal or vegetable fats and oils and their cleavage products; prepared edible fats; animal or vegetable waxes; except for",
-                  "min": "1521000000",
-                  "max": "1521999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product in which all die vegetal materials of [heading&nbsp;1511](/headings/1511) and [heading&nbsp;1513](/headings/1513) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "1522",
-                  "chapter": 15,
-                  "subdivision": "Animal or vegetable fats and oils and their cleavage products; prepared edible fats; animal or vegetable waxes; except for",
-                  "min": "1522000000",
                   "max": "1522999999",
                   "rules": [
                         {
@@ -1923,9 +1566,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2001",
+                  "heading": "ex Chapter 20",
                   "chapter": 20,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2001",
                   "min": "2001000000",
                   "max": "2001999999",
                   "rules": [
@@ -1945,32 +1588,10 @@
                   "valid": true
             },
             {
-                  "heading": "2002",
+                  "heading": "ex Chapter 20",
                   "chapter": 20,
                   "subdivision": "Preparations of vegetables, fruit, nuts or other parts of plants",
                   "min": "2002000000",
-                  "max": "2002999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the vegetables, fruit or nuts used are wholly obtained. However, black split beans of heading ex 0713 may be used.",
-                              "class": [
-                                    "WO",
-                                    "WO TOLERANCE MAY BE USED"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2003",
-                  "chapter": 20,
-                  "subdivision": "Preparations of vegetables, fruit, nuts or other parts of plants",
-                  "min": "2003000000",
                   "max": "2003999999",
                   "rules": [
                         {
@@ -2010,9 +1631,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2004",
+                  "heading": "ex Chapter 20",
                   "chapter": 20,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2004",
                   "min": "2004000000",
                   "max": "2004999999",
                   "rules": [
@@ -2053,9 +1674,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2005",
+                  "heading": "ex Chapter 20",
                   "chapter": 20,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2005",
                   "min": "2005000000",
                   "max": "2005999999",
                   "rules": [
@@ -2121,7 +1742,7 @@
             {
                   "heading": "ex 2008",
                   "chapter": 20,
-                  "subdivision": "Pasta, whether or not cooked or stuffed (with meat or other substances) or otherwise prepared, such as spaghetti, macaroni, noodles, lasagne, gnocchi, ravioli, cannelloni; couscous, whether or not prepared \u25b8 Nuts, not containing added sugar or spirits",
+                  "subdivision": "Jams, fruit jellies, marmalades, fruit or nut puree and fruit or nut pastes, obtained by cooking, whether or not containing added sugar or other sweetening matter \u25b8 Nuts, not containing added sugar or spirits",
                   "min": "2008000000",
                   "max": "2008999999",
                   "rules": [
@@ -2142,7 +1763,7 @@
             {
                   "heading": "ex 2008",
                   "chapter": 20,
-                  "subdivision": "Pasta, whether or not cooked or stuffed (with meat or other substances) or otherwise prepared, such as spaghetti, macaroni, noodles, lasagne, gnocchi, ravioli, cannelloni; couscous, whether or not prepared \u25b8 Peanut butter; mixtures based on cereals; palm hearts; maize (com)",
+                  "subdivision": "Jams, fruit jellies, marmalades, fruit or nut puree and fruit or nut pastes, obtained by cooking, whether or not containing added sugar or other sweetening matter \u25b8 Peanut butter; mixtures based on cereals; palm hearts; maize (com)",
                   "min": "2008000000",
                   "max": "2008999999",
                   "rules": [
@@ -2163,7 +1784,7 @@
             {
                   "heading": "ex 2008",
                   "chapter": 20,
-                  "subdivision": "Pasta, whether or not cooked or stuffed (with meat or other substances) or otherwise prepared, such as spaghetti, macaroni, noodles, lasagne, gnocchi, ravioli, cannelloni; couscous, whether or not prepared \u25b8 Other except for fruit and nuts cooked otherwise than by steaming or boiling in water, not containing added sugar, frozen",
+                  "subdivision": "Jams, fruit jellies, marmalades, fruit or nut puree and fruit or nut pastes, obtained by cooking, whether or not containing added sugar or other sweetening matter \u25b8 Other except for: fruit and nuts cooked otherwise than by steaming or boiling in water, not containing added sugar, frozen",
                   "min": "2008000000",
                   "max": "2008999999",
                   "rules": [
@@ -2183,9 +1804,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2008",
+                  "heading": "ex Chapter 20",
                   "chapter": 20,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2008",
                   "min": "2008000000",
                   "max": "2008999999",
                   "rules": [
@@ -2249,7 +1870,7 @@
                   "valid": true
             },
             {
-                  "heading": "2102",
+                  "heading": "ex Chapter 21",
                   "chapter": 21,
                   "subdivision": "Miscellaneous edible preparations",
                   "min": "2102000000",
@@ -2333,9 +1954,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2104",
+                  "heading": "ex Chapter 21",
                   "chapter": 21,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2104",
                   "min": "2104000000",
                   "max": "2104999999",
                   "rules": [
@@ -2354,7 +1975,7 @@
                   "valid": true
             },
             {
-                  "heading": "2105",
+                  "heading": "ex Chapter 21",
                   "chapter": 21,
                   "subdivision": "Miscellaneous edible preparations",
                   "min": "2105000000",
@@ -2397,7 +2018,8 @@
                   "valid": true
             },
             {
-                  "heading": "2201",
+                  "heading": "ex Chapter 22",
+                  "chapter": 22,
                   "subdivision": "Beverages, spirits and vinegar",
                   "min": "2201000000",
                   "max": "2201999999",
@@ -2415,8 +2037,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 22
+                  "valid": true
             },
             {
                   "heading": "2202",
@@ -2441,75 +2062,10 @@
                   "valid": true
             },
             {
-                  "heading": "2203",
+                  "heading": "ex Chapter 22",
+                  "chapter": 22,
                   "subdivision": "Beverages, spirits and vinegar",
                   "min": "2203000000",
-                  "max": "2203999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which all the grapes or materials derived from grapes used are wholly obtained.",
-                              "class": [
-                                    "WO",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 22
-            },
-            {
-                  "heading": "2204",
-                  "subdivision": "Beverages, spirits and vinegar",
-                  "min": "2204000000",
-                  "max": "2204999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which all the grapes or materials derived from grapes used are wholly obtained.",
-                              "class": [
-                                    "WO",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 22
-            },
-            {
-                  "heading": "2205",
-                  "subdivision": "Beverages, spirits and vinegar",
-                  "min": "2205000000",
-                  "max": "2205999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which all the grapes or materials derived from grapes used are wholly obtained.",
-                              "class": [
-                                    "WO",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 22
-            },
-            {
-                  "heading": "2206",
-                  "subdivision": "Beverages, spirits and vinegar",
-                  "min": "2206000000",
                   "max": "2206999999",
                   "rules": [
                         {
@@ -2525,8 +2081,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 22
+                  "valid": true
             },
             {
                   "heading": "2207",
@@ -2594,7 +2149,8 @@
                   "valid": true
             },
             {
-                  "heading": "2209",
+                  "heading": "ex Chapter 22",
+                  "chapter": 22,
                   "subdivision": "Beverages, spirits and vinegar",
                   "min": "2209000000",
                   "max": "2209999999",
@@ -2612,8 +2168,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 22
+                  "valid": true
             },
             {
                   "heading": "ex 2301",
@@ -2637,9 +2192,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2301",
+                  "heading": "ex Chapter 23",
                   "chapter": 23,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2301",
                   "min": "2301000000",
                   "max": "2301999999",
                   "rules": [
@@ -2658,9 +2213,9 @@
                   "valid": true
             },
             {
-                  "heading": "2302",
+                  "heading": "ex Chapter 23",
                   "chapter": 23,
-                  "subdivision": "Residues and waste from the food industries; prepared animal fodder; except for;",
+                  "subdivision": "Residues and waste from the food industries; prepared animal fodder",
                   "min": "2302000000",
                   "max": "2302999999",
                   "rules": [
@@ -2700,9 +2255,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2303",
+                  "heading": "ex Chapter 23",
                   "chapter": 23,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2303",
                   "min": "2303000000",
                   "max": "2303999999",
                   "rules": [
@@ -2721,31 +2276,10 @@
                   "valid": true
             },
             {
-                  "heading": "2304",
+                  "heading": "ex Chapter 23",
                   "chapter": 23,
-                  "subdivision": "Residues and waste from the food industries; prepared animal fodder; except for;",
+                  "subdivision": "Residues and waste from the food industries; prepared animal fodder",
                   "min": "2304000000",
-                  "max": "2304999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2305",
-                  "chapter": 23,
-                  "subdivision": "Residues and waste from the food industries; prepared animal fodder; except for;",
-                  "min": "2305000000",
                   "max": "2305999999",
                   "rules": [
                         {
@@ -2784,9 +2318,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2306",
+                  "heading": "ex Chapter 23",
                   "chapter": 23,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2306",
                   "min": "2306000000",
                   "max": "2306999999",
                   "rules": [
@@ -2805,9 +2339,9 @@
                   "valid": true
             },
             {
-                  "heading": "2307",
+                  "heading": "ex Chapter 23",
                   "chapter": 23,
-                  "subdivision": "Residues and waste from the food industries; prepared animal fodder; except for;",
+                  "subdivision": "Residues and waste from the food industries; prepared animal fodder",
                   "min": "2307000000",
                   "max": "2307999999",
                   "rules": [
@@ -2847,9 +2381,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2308",
+                  "heading": "ex Chapter 23",
                   "chapter": 23,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2308",
                   "min": "2308000000",
                   "max": "2308999999",
                   "rules": [
@@ -2912,7 +2446,7 @@
                   "valid": true
             },
             {
-                  "heading": "2401",
+                  "heading": "ex Chapter 24",
                   "chapter": 24,
                   "subdivision": "Tobacco and manufactured tobacco substitutes",
                   "min": "2401000000",
@@ -2975,9 +2509,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2403",
+                  "heading": "ex Chapter 24",
                   "chapter": 24,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2403",
                   "min": "2403000000",
                   "max": "2403999999",
                   "rules": [
@@ -2996,7 +2530,7 @@
                   "valid": true
             },
             {
-                  "heading": "2404",
+                  "heading": "ex Chapter 24",
                   "chapter": 24,
                   "subdivision": "Tobacco and manufactured tobacco substitutes",
                   "min": "2404000000",
@@ -3019,9 +2553,9 @@
             {
                   "heading": "ex Chapter 25",
                   "chapter": 25,
-                  "subdivision": "Salt; sulphur; earths and stone; plastering materials, lime and cement; except for;",
-                  "min": "2500000000",
-                  "max": "2599999999",
+                  "subdivision": "Salt; sulphur; earths and stone; plastering materials, lime and cement",
+                  "min": "2501000000",
+                  "max": "2503999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product.",
@@ -3059,6 +2593,48 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Any other product from heading 2504",
+                  "min": "2504000000",
+                  "max": "2504999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Salt; sulphur; earths and stone; plastering materials, lime and cement",
+                  "min": "2505000000",
+                  "max": "2514999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 2515",
                   "chapter": 25,
                   "subdivision": "Marble, merely cut, by sawing or otherwise, into blocks or slabs of a rectangular (including square) shape, of a thickness not exceeding 25 cm",
@@ -3068,6 +2644,27 @@
                         {
                               "rule": "Cutting, by sawing or otherwise, of marble (even if already sawn) of a thickness exceeding 25&nbsp;cm.",
                               "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Any other product from heading 2515",
+                  "min": "2515000000",
+                  "max": "2515999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
                               "footnotes": [],
                               "operator": null,
                               "quota": false,
@@ -3097,6 +2694,48 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Any other product from heading 2516",
+                  "min": "2516000000",
+                  "max": "2516999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Salt; sulphur; earths and stone; plastering materials, lime and cement",
+                  "min": "2517000000",
+                  "max": "2517999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 2518",
                   "chapter": 25,
                   "subdivision": "Calcined dolomite",
@@ -3107,6 +2746,27 @@
                               "rule": "Calcination of dolomite not calcined.",
                               "class": [
                                     "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Any other product from heading 2518",
+                  "min": "2518000000",
+                  "max": "2518999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -3139,6 +2799,27 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Any other product from heading 2519",
+                  "min": "2519000000",
+                  "max": "2519999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 2520",
                   "chapter": 25,
                   "subdivision": "Plasters specially prepared for dentistry",
@@ -3149,6 +2830,48 @@
                               "rule": "Manufacture in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Any other product from heading 2520",
+                  "min": "2520000000",
+                  "max": "2520999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Salt; sulphur; earths and stone; plastering materials, lime and cement",
+                  "min": "2521000000",
+                  "max": "2523999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -3181,6 +2904,27 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Any other product from heading 2524",
+                  "min": "2524000000",
+                  "max": "2524999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 2525",
                   "chapter": 25,
                   "subdivision": "Mica powder",
@@ -3191,6 +2935,48 @@
                               "rule": "Grinding of mica or mica waste.",
                               "class": [
                                     "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Any other product from heading 2525",
+                  "min": "2525000000",
+                  "max": "2525999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Salt; sulphur; earths and stone; plastering materials, lime and cement",
+                  "min": "2526000000",
+                  "max": "2529999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -3223,6 +3009,27 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Any other product from heading 2530",
+                  "min": "2530000000",
+                  "max": "2530999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "Chapter 26",
                   "chapter": 26,
                   "subdivision": "Ores, slag and ash",
@@ -3244,115 +3051,10 @@
                   "valid": true
             },
             {
-                  "heading": "2701",
+                  "heading": "ex Chapter 27",
                   "chapter": 27,
-                  "subdivision": "Mineral fuels, mineral oils and products of their distillation; bituminous substances; mineral waxes; except for;",
+                  "subdivision": "Mineral fuels, mineral oils and products of their distillation; bituminous substances; mineral waxes",
                   "min": "2701000000",
-                  "max": "2701999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2702",
-                  "chapter": 27,
-                  "subdivision": "Mineral fuels, mineral oils and products of their distillation; bituminous substances; mineral waxes; except for;",
-                  "min": "2702000000",
-                  "max": "2702999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2703",
-                  "chapter": 27,
-                  "subdivision": "Mineral fuels, mineral oils and products of their distillation; bituminous substances; mineral waxes; except for;",
-                  "min": "2703000000",
-                  "max": "2703999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2704",
-                  "chapter": 27,
-                  "subdivision": "Mineral fuels, mineral oils and products of their distillation; bituminous substances; mineral waxes; except for;",
-                  "min": "2704000000",
-                  "max": "2704999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2705",
-                  "chapter": 27,
-                  "subdivision": "Mineral fuels, mineral oils and products of their distillation; bituminous substances; mineral waxes; except for;",
-                  "min": "2705000000",
-                  "max": "2705999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2706",
-                  "chapter": 27,
-                  "subdivision": "Mineral fuels, mineral oils and products of their distillation; bituminous substances; mineral waxes; except for;",
-                  "min": "2706000000",
                   "max": "2706999999",
                   "rules": [
                         {
@@ -3402,9 +3104,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2707",
+                  "heading": "ex Chapter 27",
                   "chapter": 27,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2707",
                   "min": "2707000000",
                   "max": "2707999999",
                   "rules": [
@@ -3423,9 +3125,9 @@
                   "valid": true
             },
             {
-                  "heading": "2708",
+                  "heading": "ex Chapter 27",
                   "chapter": 27,
-                  "subdivision": "Mineral fuels, mineral oils and products of their distillation; bituminous substances; mineral waxes; except for;",
+                  "subdivision": "Mineral fuels, mineral oils and products of their distillation; bituminous substances; mineral waxes",
                   "min": "2708000000",
                   "max": "2708999999",
                   "rules": [
@@ -3465,9 +3167,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2709",
+                  "heading": "ex Chapter 27",
                   "chapter": 27,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2709",
                   "min": "2709000000",
                   "max": "2709999999",
                   "rules": [
@@ -3678,9 +3380,9 @@
                   "valid": true
             },
             {
-                  "heading": "2716",
+                  "heading": "ex Chapter 27",
                   "chapter": 27,
-                  "subdivision": "Mineral fuels, mineral oils and products of their distillation; bituminous substances; mineral waxes; except for;",
+                  "subdivision": "Mineral fuels, mineral oils and products of their distillation; bituminous substances; mineral waxes",
                   "min": "2716000000",
                   "max": "2716999999",
                   "rules": [
@@ -3702,8 +3404,8 @@
                   "heading": "ex Chapter 28",
                   "chapter": 28,
                   "subdivision": "Inorganic chemicals; organic or inorganic compounds of precious metals, of rare- earth metals, of radioactive elements or of isotopes",
-                  "min": "2800000000",
-                  "max": "2899999999",
+                  "min": "2801000000",
+                  "max": "2804999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
@@ -3754,6 +3456,72 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 28",
+                  "chapter": 28,
+                  "subdivision": "Any other product from heading 2805",
+                  "min": "2805000000",
+                  "max": "2805999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 28",
+                  "chapter": 28,
+                  "subdivision": "Inorganic chemicals; organic or inorganic compounds of precious metals, of rare- earth metals, of radioactive elements or of isotopes",
+                  "min": "2806000000",
+                  "max": "2810999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 2811",
                   "chapter": 28,
                   "subdivision": "Sulphur trioxide",
@@ -3764,6 +3532,72 @@
                               "rule": "Manufacture from sulphur dioxide.",
                               "class": [
                                     "PRODUCTION FROM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 28",
+                  "chapter": 28,
+                  "subdivision": "Any other product from heading 2811",
+                  "min": "2811000000",
+                  "max": "2811999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 28",
+                  "chapter": 28,
+                  "subdivision": "Inorganic chemicals; organic or inorganic compounds of precious metals, of rare- earth metals, of radioactive elements or of isotopes",
+                  "min": "2812000000",
+                  "max": "2832999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -3807,6 +3641,72 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 28",
+                  "chapter": 28,
+                  "subdivision": "Any other product from heading 2833",
+                  "min": "2833000000",
+                  "max": "2833999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 28",
+                  "chapter": 28,
+                  "subdivision": "Inorganic chemicals; organic or inorganic compounds of precious metals, of rare- earth metals, of radioactive elements or of isotopes",
+                  "min": "2834000000",
+                  "max": "2839999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 2840",
                   "chapter": 28,
                   "subdivision": "Sodium perborate",
@@ -3839,9 +3739,75 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 28",
+                  "chapter": 28,
+                  "subdivision": "Any other product from heading 2840",
+                  "min": "2840000000",
+                  "max": "2840999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 28",
+                  "chapter": 28,
+                  "subdivision": "Inorganic chemicals; organic or inorganic compounds of precious metals, of rare- earth metals, of radioactive elements or of isotopes",
+                  "min": "2841000000",
+                  "max": "2850999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 2852",
                   "chapter": 28,
-                  "subdivision": "Preparations of a kind used in animal feeding \u25b8 Mercury compounds of internal ethers and their halogenated, sulphonated, nitrated or nitrosated derivatives",
+                  "subdivision": "Sodium perborate \u25b8 Mercury compounds of internal ethers and their halogenated, sulphonated, nitrated or nitrosated derivatives",
                   "min": "2852000000",
                   "max": "2852999999",
                   "rules": [
@@ -3873,7 +3839,7 @@
             {
                   "heading": "ex 2852",
                   "chapter": 28,
-                  "subdivision": "Preparations of a kind used in animal feeding \u25b8 Mercury compounds of nucleic acids and their salts, whether or not chemically defined; other heterocyclic mercury compounds",
+                  "subdivision": "Sodium perborate \u25b8 Mercury compounds of nucleic acids and their salts, whether or not chemically defined; other heterocyclic mercury compounds",
                   "min": "2852000000",
                   "max": "2852999999",
                   "rules": [
@@ -3905,7 +3871,7 @@
             {
                   "heading": "ex 2852",
                   "chapter": 28,
-                  "subdivision": "Preparations of a kind used in animal feeding \u25b8 Diagnostic or laboratory reagents on a backing, prepared diagnostic or laboratory reagents whether or not on a backing, other than those of heading 3002 or 3006; certified reference materials",
+                  "subdivision": "Sodium perborate \u25b8 Diagnostic or laboratory reagents on a backing, prepared diagnostic or laboratory reagents whether or not on a backing, other than those of heading 3002 or 3006; certified reference materials",
                   "min": "2852000000",
                   "max": "2852999999",
                   "rules": [
@@ -3916,6 +3882,72 @@
                               ],
                               "footnotes": [],
                               "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 28",
+                  "chapter": 28,
+                  "subdivision": "Any other product from heading 2852",
+                  "min": "2852000000",
+                  "max": "2852999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 28",
+                  "chapter": 28,
+                  "subdivision": "Inorganic chemicals; organic or inorganic compounds of precious metals, of rare- earth metals, of radioactive elements or of isotopes",
+                  "min": "2853000000",
+                  "max": "2853999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
                               "quota": false,
                               "import": true,
                               "export": true
@@ -3956,9 +3988,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2901",
+                  "heading": "ex Chapter 29",
                   "chapter": 29,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2901",
                   "min": "2901000000",
                   "max": "2901999999",
                   "rules": [
@@ -4021,9 +4053,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2902",
+                  "heading": "ex Chapter 29",
                   "chapter": 29,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2902",
                   "min": "2902000000",
                   "max": "2902999999",
                   "rules": [
@@ -4054,43 +4086,10 @@
                   "valid": true
             },
             {
-                  "heading": "2903",
+                  "heading": "ex Chapter 29",
                   "chapter": 29,
                   "subdivision": "Organic chemicals",
                   "min": "2903000000",
-                  "max": "2903999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2904",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2904000000",
                   "max": "2904999999",
                   "rules": [
                         {
@@ -4153,9 +4152,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2905",
+                  "heading": "ex Chapter 29",
                   "chapter": 29,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2905",
                   "min": "2905000000",
                   "max": "2905999999",
                   "rules": [
@@ -4186,274 +4185,10 @@
                   "valid": true
             },
             {
-                  "heading": "2906",
+                  "heading": "ex Chapter 29",
                   "chapter": 29,
                   "subdivision": "Organic chemicals",
                   "min": "2906000000",
-                  "max": "2906999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2907",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2907000000",
-                  "max": "2907999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2908",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2908000000",
-                  "max": "2908999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2909",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2909000000",
-                  "max": "2909999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2910",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2910000000",
-                  "max": "2910999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2911",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2911000000",
-                  "max": "2911999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2912",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2912000000",
-                  "max": "2912999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2913",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2913000000",
-                  "max": "2913999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2914",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2914000000",
                   "max": "2914999999",
                   "rules": [
                         {
@@ -4515,505 +4250,10 @@
                   "valid": true
             },
             {
-                  "heading": "2916",
+                  "heading": "ex Chapter 29",
                   "chapter": 29,
                   "subdivision": "Organic chemicals",
                   "min": "2916000000",
-                  "max": "2916999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2917",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2917000000",
-                  "max": "2917999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2918",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2918000000",
-                  "max": "2918999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2919",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2919000000",
-                  "max": "2919999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2920",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2920000000",
-                  "max": "2920999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2921",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2921000000",
-                  "max": "2921999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2922",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2922000000",
-                  "max": "2922999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2923",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2923000000",
-                  "max": "2923999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2924",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2924000000",
-                  "max": "2924999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2925",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2925000000",
-                  "max": "2925999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2926",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2926000000",
-                  "max": "2926999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2927",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2927000000",
-                  "max": "2927999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2928",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2928000000",
-                  "max": "2928999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2929",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2929000000",
-                  "max": "2929999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2930",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2930000000",
-                  "max": "2930999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2931",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2931000000",
                   "max": "2931999999",
                   "rules": [
                         {
@@ -5045,7 +4285,7 @@
             {
                   "heading": "ex 2932",
                   "chapter": 29,
-                  "subdivision": "Preparations of a kind used in animal feeding \u25b8 Internal ethers and their halogenated, sulphonated, nitrated or nitrosated derivatives",
+                  "subdivision": "Saturated acyclic monocarboxylic acids and their anhydrides, halides, peroxides and peroxyacids; their halogenated, sulphonated, nitrated or nitrosated derivatives \u25b8 Internal ethers and their halogenated, sulphonated, nitrated or nitrosated derivatives",
                   "min": "2932000000",
                   "max": "2932999999",
                   "rules": [
@@ -5077,7 +4317,7 @@
             {
                   "heading": "ex 2932",
                   "chapter": 29,
-                  "subdivision": "Preparations of a kind used in animal feeding \u25b8 Cyclic acetals and internal hemiacetals and their halogenated, sulphonated, nitrated or nitrosated derivatives",
+                  "subdivision": "Saturated acyclic monocarboxylic acids and their anhydrides, halides, peroxides and peroxyacids; their halogenated, sulphonated, nitrated or nitrosated derivatives \u25b8 Cyclic acetals and internal hemiacetals and their halogenated, sulphonated, nitrated or nitrosated derivatives",
                   "min": "2932000000",
                   "max": "2932999999",
                   "rules": [
@@ -5107,9 +4347,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2932",
+                  "heading": "ex Chapter 29",
                   "chapter": 29,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2932",
                   "min": "2932000000",
                   "max": "2932999999",
                   "rules": [
@@ -5204,109 +4444,10 @@
                   "valid": true
             },
             {
-                  "heading": "2935",
+                  "heading": "ex Chapter 29",
                   "chapter": 29,
                   "subdivision": "Organic chemicals",
                   "min": "2935000000",
-                  "max": "2935999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2936",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2936000000",
-                  "max": "2936999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2937",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2937000000",
-                  "max": "2937999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2938",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2938000000",
                   "max": "2938999999",
                   "rules": [
                         {
@@ -5357,9 +4498,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2939",
+                  "heading": "ex Chapter 29",
                   "chapter": 29,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2939",
                   "min": "2939000000",
                   "max": "2939999999",
                   "rules": [
@@ -5390,76 +4531,10 @@
                   "valid": true
             },
             {
-                  "heading": "2940",
+                  "heading": "ex Chapter 29",
                   "chapter": 29,
                   "subdivision": "Organic chemicals",
                   "min": "2940000000",
-                  "max": "2940999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2941",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2941000000",
-                  "max": "2941999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2942",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2942000000",
                   "max": "2942999999",
                   "rules": [
                         {
@@ -5531,9 +4606,9 @@
                   "valid": true
             },
             {
-                  "heading": "3003-3004",
+                  "heading": "3003 to 3004",
                   "chapter": 30,
-                  "subdivision": "Medicaments (excluding goods of heading 3002, 3005 or 3006):",
+                  "subdivision": "Medicaments (excluding goods of heading 3002, 3005 or 3006)",
                   "min": "3003000000",
                   "max": "3004999999",
                   "rules": [
@@ -5552,9 +4627,9 @@
                   "valid": true
             },
             {
-                  "heading": "3005",
+                  "heading": "ex Chapter 30",
                   "chapter": 30,
-                  "subdivision": "Pharmaceutical products; except for;",
+                  "subdivision": "Pharmaceutical products",
                   "min": "3005000000",
                   "max": "3005999999",
                   "rules": [
@@ -5576,7 +4651,7 @@
             {
                   "heading": "ex 3006",
                   "chapter": 30,
-                  "subdivision": "Preparations of a kind used in animal feeding \u25b8 Waste pharmaceuticals specified in note 4(k) to this Chapter",
+                  "subdivision": "Medicaments (excluding goods of heading 3002, 3005 or 3006) \u25b8 Waste pharmaceuticals specified in note 4(k) to this Chapter",
                   "min": "3006000000",
                   "max": "3006999999",
                   "rules": [
@@ -5595,7 +4670,7 @@
             {
                   "heading": "ex 3006",
                   "chapter": 30,
-                  "subdivision": "Preparations of a kind used in animal feeding \u25b8 Sterile surgical or dental adhesion barriers, whether or not absorbable \u25b8 made of plastics",
+                  "subdivision": "Medicaments (excluding goods of heading 3002, 3005 or 3006) \u25b8 Made of plastics",
                   "min": "3006000000",
                   "max": "3006999999",
                   "rules": [
@@ -5627,12 +4702,12 @@
             {
                   "heading": "ex 3006",
                   "chapter": 30,
-                  "subdivision": "Preparations of a kind used in animal feeding \u25b8 Sterile surgical or dental adhesion barriers, whether or not absorbable \u25b8 made of fabrics",
+                  "subdivision": "Medicaments (excluding goods of heading 3002, 3005 or 3006) \u25b8 Made of fabrics",
                   "min": "3006000000",
                   "max": "3006999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- natural fibres\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- natural fibres\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -5648,7 +4723,7 @@
             {
                   "heading": "ex 3006",
                   "chapter": 30,
-                  "subdivision": "Preparations of a kind used in animal feeding \u25b8 Sterile surgical or dental adhesion barriers, whether or not absorbable \u25b8 Appliances identifiable for ostomy use",
+                  "subdivision": "Medicaments (excluding goods of heading 3002, 3005 or 3006) \u25b8 Appliances identifiable for ostomy use",
                   "min": "3006000000",
                   "max": "3006999999",
                   "rules": [
@@ -5667,9 +4742,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3006",
+                  "heading": "ex Chapter 30",
                   "chapter": 30,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 3006",
                   "min": "3006000000",
                   "max": "3006999999",
                   "rules": [
@@ -5692,8 +4767,8 @@
                   "heading": "ex Chapter 31",
                   "chapter": 31,
                   "subdivision": "Fertilizers",
-                  "min": "3100000000",
-                  "max": "3199999999",
+                  "min": "3101000000",
+                  "max": "3104999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
@@ -5724,12 +4799,45 @@
             {
                   "heading": "ex 3105",
                   "chapter": 31,
-                  "subdivision": "Mineral or chemical fertilizers containing two or three of the fertilizing elements nitrogen, phosphorous and potassium; other fertilizers; goods of this chapter, in tablets or similar forms or in packages of a gross weight not exceeding 10 kg, except for:\nsodium nitrate\ncalcium cyanamide\npotassium sulphate\nmagnesium potassium sulphate",
+                  "subdivision": "Mineral or chemical fertilizers containing two or three of the fertilizing elements nitrogen, phosphorous and potassium; other fertilizers; goods of this chapter, in tablets or similar forms or in packages of a gross weight not exceeding 10 kg\nsodium nitrate\ncalcium cyanamide\npotassium sulphate\nmagnesium potassium sulphate",
                   "min": "3105000000",
                   "max": "3105999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **30%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 31",
+                  "chapter": 31,
+                  "subdivision": "Any other product from heading 3105",
+                  "min": "3105000000",
+                  "max": "3105999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM",
                                     "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
@@ -5787,9 +4895,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3201",
+                  "heading": "ex Chapter 32",
                   "chapter": 32,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 3201",
                   "min": "3201000000",
                   "max": "3201999999",
                   "rules": [
@@ -5820,76 +4928,10 @@
                   "valid": true
             },
             {
-                  "heading": "3202",
+                  "heading": "ex Chapter 32",
                   "chapter": 32,
                   "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
                   "min": "3202000000",
-                  "max": "3202999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3203",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3203000000",
-                  "max": "3203999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3204",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3204000000",
                   "max": "3204999999",
                   "rules": [
                         {
@@ -5952,307 +4994,10 @@
                   "valid": true
             },
             {
-                  "heading": "3206",
+                  "heading": "ex Chapter 32",
                   "chapter": 32,
                   "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
                   "min": "3206000000",
-                  "max": "3206999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3207",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3207000000",
-                  "max": "3207999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3208",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3208000000",
-                  "max": "3208999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3209",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3209000000",
-                  "max": "3209999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3210",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3210000000",
-                  "max": "3210999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3211",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3211000000",
-                  "max": "3211999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3212",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3212000000",
-                  "max": "3212999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3213",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3213000000",
-                  "max": "3213999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3214",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3214000000",
-                  "max": "3214999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3215",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3215000000",
                   "max": "3215999999",
                   "rules": [
                         {
@@ -6315,209 +5060,11 @@
                   "valid": true
             },
             {
-                  "heading": "3302",
+                  "heading": "ex Chapter 33",
+                  "chapter": 33,
                   "subdivision": "Essential oils and resinoids; perfumery, cosmetic or toilet preparations",
                   "min": "3302000000",
-                  "max": "3302999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 33
-            },
-            {
-                  "heading": "3303",
-                  "subdivision": "Essential oils and resinoids; perfumery, cosmetic or toilet preparations",
-                  "min": "3303000000",
-                  "max": "3303999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 33
-            },
-            {
-                  "heading": "3304",
-                  "subdivision": "Essential oils and resinoids; perfumery, cosmetic or toilet preparations",
-                  "min": "3304000000",
-                  "max": "3304999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 33
-            },
-            {
-                  "heading": "3305",
-                  "subdivision": "Essential oils and resinoids; perfumery, cosmetic or toilet preparations",
-                  "min": "3305000000",
-                  "max": "3305999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 33
-            },
-            {
-                  "heading": "3306",
-                  "subdivision": "Essential oils and resinoids; perfumery, cosmetic or toilet preparations",
-                  "min": "3306000000",
-                  "max": "3306999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 33
-            },
-            {
-                  "heading": "3307",
-                  "subdivision": "Essential oils and resinoids; perfumery, cosmetic or toilet preparations",
-                  "min": "3307000000",
                   "max": "3307999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 33
-            },
-            {
-                  "heading": "3401",
-                  "chapter": 34,
-                  "subdivision": "Soap, organic surface-active agents, washing preparations, lubricating preparations, artificial waxes, prepared waxes, polishing or scouring preparations, candles and similar articles, modelling pastes, \"dental waxes\" and dental preparations with a basis of plaster; except for;",
-                  "min": "3401000000",
-                  "max": "3401999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
@@ -6546,10 +5093,10 @@
                   "valid": true
             },
             {
-                  "heading": "3402",
+                  "heading": "ex Chapter 34",
                   "chapter": 34,
-                  "subdivision": "Soap, organic surface-active agents, washing preparations, lubricating preparations, artificial waxes, prepared waxes, polishing or scouring preparations, candles and similar articles, modelling pastes, \"dental waxes\" and dental preparations with a basis of plaster; except for;",
-                  "min": "3402000000",
+                  "subdivision": "Soap, organic surface-active agents, washing preparations, lubricating preparations, artificial waxes, prepared waxes, polishing or scouring preparations, candles and similar articles, modelling pastes, \"dental waxes\" and dental preparations with a basis of plaster",
+                  "min": "3401000000",
                   "max": "3402999999",
                   "rules": [
                         {
@@ -6586,7 +5133,7 @@
                   "max": "3403999999",
                   "rules": [
                         {
-                              "rule": "Operations of refining and&nbsp;/&nbsp;or one or more specific process (es).",
+                              "rule": "Operations of refining and&nbsp;/&nbsp;or one or more specific process(es).",
                               "class": [
                                     "PROCESSING"
                               ],
@@ -6611,9 +5158,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3403",
+                  "heading": "ex Chapter 34",
                   "chapter": 34,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 3403",
                   "min": "3403000000",
                   "max": "3403999999",
                   "rules": [
@@ -6673,7 +5220,7 @@
                   "max": "3404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except:\n\n- hydrogenated oils having the character of waxes of [heading&nbsp;1516](/headings/1516),\n\n- fatty acids not chemically defined or industrial fatty alcohols having the character of waxes of [heading&nbsp;3823](/headings/3823), *and*\n\n- materials of heading&nbsp;3404\n\nHowever, these materials may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "rule": "Manufacture from materials of any heading, except:\n\n- hydrogenated oils having the character of waxes of [heading&nbsp;1516](/headings/1516),\n\n- fatty acids not chemically defined or industrial fatty alcohols having the character of waxes of [heading&nbsp;3823](/headings/3823), *and*\n\n- materials of [heading&nbsp;3404](/headings/3404).\n\nHowever, these materials may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM",
                                     "AH EXCEPT TOLERANCE MAY BE USED RESTRICTION MAXNOM"
@@ -6699,76 +5246,10 @@
                   "valid": true
             },
             {
-                  "heading": "3405",
+                  "heading": "ex Chapter 34",
                   "chapter": 34,
-                  "subdivision": "Soap, organic surface-active agents, washing preparations, lubricating preparations, artificial waxes, prepared waxes, polishing or scouring preparations, candles and similar articles, modelling pastes, \"dental waxes\" and dental preparations with a basis of plaster; except for;",
+                  "subdivision": "Soap, organic surface-active agents, washing preparations, lubricating preparations, artificial waxes, prepared waxes, polishing or scouring preparations, candles and similar articles, modelling pastes, \"dental waxes\" and dental preparations with a basis of plaster",
                   "min": "3405000000",
-                  "max": "3405999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3406",
-                  "chapter": 34,
-                  "subdivision": "Soap, organic surface-active agents, washing preparations, lubricating preparations, artificial waxes, prepared waxes, polishing or scouring preparations, candles and similar articles, modelling pastes, \"dental waxes\" and dental preparations with a basis of plaster; except for;",
-                  "min": "3406000000",
-                  "max": "3406999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3407",
-                  "chapter": 34,
-                  "subdivision": "Soap, organic surface-active agents, washing preparations, lubricating preparations, artificial waxes, prepared waxes, polishing or scouring preparations, candles and similar articles, modelling pastes, \"dental waxes\" and dental preparations with a basis of plaster; except for;",
-                  "min": "3407000000",
                   "max": "3407999999",
                   "rules": [
                         {
@@ -6798,109 +5279,10 @@
                   "valid": true
             },
             {
-                  "heading": "3501",
+                  "heading": "ex Chapter 35",
                   "chapter": 35,
                   "subdivision": "Albuminoidal substances; modified starches; glues; enzymes",
                   "min": "3501000000",
-                  "max": "3501999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3502",
-                  "chapter": 35,
-                  "subdivision": "Albuminoidal substances; modified starches; glues; enzymes",
-                  "min": "3502000000",
-                  "max": "3502999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3503",
-                  "chapter": 35,
-                  "subdivision": "Albuminoidal substances; modified starches; glues; enzymes",
-                  "min": "3503000000",
-                  "max": "3503999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3504",
-                  "chapter": 35,
-                  "subdivision": "Albuminoidal substances; modified starches; glues; enzymes",
-                  "min": "3504000000",
                   "max": "3504999999",
                   "rules": [
                         {
@@ -6994,7 +5376,7 @@
                   "valid": true
             },
             {
-                  "heading": "3506",
+                  "heading": "ex Chapter 35",
                   "chapter": 35,
                   "subdivision": "Albuminoidal substances; modified starches; glues; enzymes",
                   "min": "3506000000",
@@ -7048,9 +5430,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3507",
+                  "heading": "ex Chapter 35",
                   "chapter": 35,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 3507",
                   "min": "3507000000",
                   "max": "3507999999",
                   "rules": [
@@ -7212,7 +5594,8 @@
                   "valid": true
             },
             {
-                  "heading": "3703",
+                  "heading": "ex Chapter 37",
+                  "chapter": 37,
                   "subdivision": "Photographic or cinematographic goods",
                   "min": "3703000000",
                   "max": "3703999999",
@@ -7241,8 +5624,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 37
+                  "valid": true
             },
             {
                   "heading": "3704",
@@ -7277,75 +5659,10 @@
                   "valid": true
             },
             {
-                  "heading": "3705",
+                  "heading": "ex Chapter 37",
+                  "chapter": 37,
                   "subdivision": "Photographic or cinematographic goods",
                   "min": "3705000000",
-                  "max": "3705999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 37
-            },
-            {
-                  "heading": "3706",
-                  "subdivision": "Photographic or cinematographic goods",
-                  "min": "3706000000",
-                  "max": "3706999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 37
-            },
-            {
-                  "heading": "3707",
-                  "subdivision": "Photographic or cinematographic goods",
-                  "min": "3707000000",
                   "max": "3707999999",
                   "rules": [
                         {
@@ -7372,13 +5689,12 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 37
+                  "valid": true
             },
             {
                   "heading": "ex 3801",
                   "chapter": 38,
-                  "subdivision": "Photographic plates and film in the flat, sensitised, unexposed, of any material other than paper, paperboard or textiles; instant print film in the flat, sensitised, unexposed, whether or not in packs \u25b8 Colloidal graphite in suspension in oil and semi-colloidal graphite; carbonaceous pastes for electrodes",
+                  "subdivision": "Miscellaneous chemical products \u25b8 Colloidal graphite in suspension in oil and semi-colloidal graphite; carbonaceous pastes for electrodes",
                   "min": "3801000000",
                   "max": "3801999999",
                   "rules": [
@@ -7399,7 +5715,7 @@
             {
                   "heading": "ex 3801",
                   "chapter": 38,
-                  "subdivision": "Photographic plates and film in the flat, sensitised, unexposed, of any material other than paper, paperboard or textiles; instant print film in the flat, sensitised, unexposed, whether or not in packs \u25b8 Graphite in paste form, being a mixture of more than 30% by weight of graphite with mineral oils",
+                  "subdivision": "Miscellaneous chemical products \u25b8 Graphite in paste form, being a mixture of more than 30% by weight of graphite with mineral oils",
                   "min": "3801000000",
                   "max": "3801999999",
                   "rules": [
@@ -7429,9 +5745,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3801",
+                  "heading": "ex Chapter 38",
                   "chapter": 38,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 3801",
                   "min": "3801000000",
                   "max": "3801999999",
                   "rules": [
@@ -7462,7 +5778,7 @@
                   "valid": true
             },
             {
-                  "heading": "3802",
+                  "heading": "ex Chapter 38",
                   "chapter": 38,
                   "subdivision": "Miscellaneous chemical products",
                   "min": "3802000000",
@@ -7527,9 +5843,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3803",
+                  "heading": "ex Chapter 38",
                   "chapter": 38,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 3803",
                   "min": "3803000000",
                   "max": "3803999999",
                   "rules": [
@@ -7560,7 +5876,7 @@
                   "valid": true
             },
             {
-                  "heading": "3804",
+                  "heading": "ex Chapter 38",
                   "chapter": 38,
                   "subdivision": "Miscellaneous chemical products",
                   "min": "3804000000",
@@ -7625,9 +5941,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3805",
+                  "heading": "ex Chapter 38",
                   "chapter": 38,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 3805",
                   "min": "3805000000",
                   "max": "3805999999",
                   "rules": [
@@ -7690,9 +6006,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3806",
+                  "heading": "ex Chapter 38",
                   "chapter": 38,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 3806",
                   "min": "3806000000",
                   "max": "3806999999",
                   "rules": [
@@ -7755,9 +6071,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3807",
+                  "heading": "ex Chapter 38",
                   "chapter": 38,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 3807",
                   "min": "3807000000",
                   "max": "3807999999",
                   "rules": [
@@ -7956,76 +6272,10 @@
                   "valid": true
             },
             {
-                  "heading": "3815",
+                  "heading": "ex Chapter 38",
                   "chapter": 38,
                   "subdivision": "Miscellaneous chemical products",
                   "min": "3815000000",
-                  "max": "3815999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3816",
-                  "chapter": 38,
-                  "subdivision": "Miscellaneous chemical products",
-                  "min": "3816000000",
-                  "max": "3816999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3817",
-                  "chapter": 38,
-                  "subdivision": "Miscellaneous chemical products",
-                  "min": "3817000000",
                   "max": "3817999999",
                   "rules": [
                         {
@@ -8139,9 +6389,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3821",
+                  "heading": "ex Chapter 38",
                   "chapter": 38,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 3821",
                   "min": "3821000000",
                   "max": "3821999999",
                   "rules": [
@@ -8237,7 +6487,7 @@
             {
                   "heading": "3824",
                   "chapter": 38,
-                  "subdivision": "The following of this heading:\n-- Prepared binders for foundry moulds or cores based on natural resinous products\nNaphthenic acids, their water-insoluble salts and their esters\n-- Sorbitol other than that of heading 2905\n-- Petroleum sulphonates, excluding petroleum sulphonates of alkali metals, of ammonium or of ethanol - mines; thiophenated sulphonic acids of oils obtained from bituminous minerals, and their salts\n-- Ion exchangers\nGetters for vacuum tubes\nAlkaline iron oxide for the purification of gas\nAmmoniacal gas liquors and spent oxide produced in coal gas purification\nSulphonaphthenic acids, their water- insoluble salts and their esters\nFusel oil and Dippel's oil\nMixtures of salts having different anions\nCopying pastes with a basis of gelatin, whether or not on a paper or textile backing",
+                  "subdivision": "The following of this heading:\n- Prepared binders for foundry moulds or cores based on natural resinous products\nNaphthenic acids, their water-insoluble salts and their esters\n- Sorbitol other than that of heading 2905\n- Petroleum sulphonates, excluding petroleum sulphonates of alkali metals, of ammonium or of ethanol - mines; thiophenated sulphonic acids of oils obtained from bituminous minerals, and their salts\n- Ion exchangers\n- Getters for vacuum tubes\n- Alkaline iron oxide for the purification of gas\n- Ammoniacal gas liquors and spent oxide produced in coal gas purification\n- Sulphonaphthenic acids, their water- insoluble salts and their esters\n- Fusel oil and Dippel's oil\n- Mixtures of salts having different anions\n- Copying pastes with a basis of gelatin, whether or not on a paper or textile backing",
                   "min": "3824000000",
                   "max": "3824999999",
                   "rules": [
@@ -8270,7 +6520,7 @@
             {
                   "heading": "3824",
                   "chapter": 38,
-                  "subdivision": "Prepared binders for foundry moulds or cores; chemical products and preparations of the chemical or allied industries (including those consisting of mixtures of natural products), not elsewhere specified or included; \u25b8 Other",
+                  "subdivision": "The following of this heading:\n- Prepared binders for foundry moulds or cores based on natural resinous products\nNaphthenic acids, their water-insoluble salts and their esters\n- Sorbitol other than that of heading 2905\n- Petroleum sulphonates, excluding petroleum sulphonates of alkali metals, of ammonium or of ethanol - mines; thiophenated sulphonic acids of oils obtained from bituminous minerals, and their salts\n- Ion exchangers\n- Getters for vacuum tubes\n- Alkaline iron oxide for the purification of gas\n- Ammoniacal gas liquors and spent oxide produced in coal gas purification\n- Sulphonaphthenic acids, their water- insoluble salts and their esters\n- Fusel oil and Dippel's oil\n- Mixtures of salts having different anions\n- Copying pastes with a basis of gelatin, whether or not on a paper or textile backing \u25b8 Other",
                   "min": "3824000000",
                   "max": "3824999999",
                   "rules": [
@@ -8289,76 +6539,10 @@
                   "valid": true
             },
             {
-                  "heading": "3825",
+                  "heading": "ex Chapter 38",
                   "chapter": 38,
                   "subdivision": "Miscellaneous chemical products",
                   "min": "3825000000",
-                  "max": "3825999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3826",
-                  "chapter": 38,
-                  "subdivision": "Miscellaneous chemical products",
-                  "min": "3826000000",
-                  "max": "3826999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3827",
-                  "chapter": 38,
-                  "subdivision": "Miscellaneous chemical products",
-                  "min": "3827000000",
                   "max": "3827999999",
                   "rules": [
                         {
@@ -8388,73 +6572,9 @@
                   "valid": true
             },
             {
-                  "heading": "3901-3915",
-                  "chapter": 39,
-                  "subdivision": "Plastics in primary forms, waste, parings and scrap, of plastic; except for headings ex 3907 and 3912 for which the rules are set out below \u25b8 Addition homopolymerisation\nproducts in which a single monomer contributes more than 99% by weight to the total polymer content",
-                  "min": "3901000000",
-                  "max": "3915999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which:\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product, *and*\n\n- within the above limit, the value of all the materials of [chapter&nbsp;39](/chapters/39) used does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **25%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3901-3915",
-                  "chapter": 39,
-                  "subdivision": "Plastics in primary forms, waste, parings and scrap, of plastic; except for headings ex 3907 and 3912 for which the rules are set out below \u25b8 Other",
-                  "min": "3901000000",
-                  "max": "3915999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of [chapter&nbsp;39](/chapters/39) used does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **25%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "ex 3907",
                   "chapter": 39,
-                  "subdivision": "Plastics in primary forms, waste, parings and scrap, of plastic; except for headings ex 3907 and 3912 for which the rules are set out below \u25b8 Copolymer, made from polycarbonate and acrylonitrile-butadiene-styrene copolymer (ABS)",
+                  "subdivision": "Plastics in primary forms, waste, parings and scrap, of plastic headings ex 3907 and 3912 for which the rules are set out below \u25b8 Copolymer, made from polycarbonate and acrylonitrile-butadiene-styrene copolymer (ABS)",
                   "min": "3907000000",
                   "max": "3907999999",
                   "rules": [
@@ -8476,7 +6596,7 @@
             {
                   "heading": "ex 3907",
                   "chapter": 39,
-                  "subdivision": "Plastics in primary forms, waste, parings and scrap, of plastic; except for headings ex 3907 and 3912 for which the rules are set out below \u25b8 Polyester",
+                  "subdivision": "Plastics in primary forms, waste, parings and scrap, of plastic headings ex 3907 and 3912 for which the rules are set out below \u25b8 Polyester",
                   "min": "3907000000",
                   "max": "3907999999",
                   "rules": [
@@ -8516,7 +6636,71 @@
                   "valid": true
             },
             {
-                  "heading": "3916-3919",
+                  "heading": "3901 to 3915",
+                  "chapter": 39,
+                  "subdivision": "Plastics in primary forms, waste, parings and scrap, of plastic headings ex 3907 and 3912 for which the rules are set out below \u25b8 Addition homopolymerisation\nproducts in which a single monomer contributes more than 99% by weight to the total polymer content",
+                  "min": "3901000000",
+                  "max": "3915999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture in which:\n\nthe value of all the materials used does not exceed **50%** of the ex-works price of the product, *and*\n\nwithin the above limit, the value of all the materials of [chapter&nbsp;39](/chapters/39) used does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **25%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "3901 to 3915",
+                  "chapter": 39,
+                  "subdivision": "Plastics in primary forms, waste, parings and scrap, of plastic headings ex 3907 and 3912 for which the rules are set out below \u25b8 Other",
+                  "min": "3901000000",
+                  "max": "3915999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture in which the value of all the materials of [chapter&nbsp;39](/chapters/39) used does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **25%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "3916 to 3919",
                   "chapter": 39,
                   "subdivision": "Semi-manufactures and articles of plastics",
                   "min": "3916000000",
@@ -8580,7 +6764,7 @@
                   "valid": true
             },
             {
-                  "heading": "3921-3926",
+                  "heading": "3921 to 3926",
                   "chapter": 39,
                   "subdivision": "Articles of plastics",
                   "min": "3921000000",
@@ -8612,73 +6796,10 @@
                   "valid": true
             },
             {
-                  "heading": "4001",
+                  "heading": "ex Chapter 40",
                   "chapter": 40,
-                  "subdivision": "Rubber and articles thereof; except for;",
+                  "subdivision": "Rubber and articles thereof",
                   "min": "4001000000",
-                  "max": "4001999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4002",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof; except for;",
-                  "min": "4002000000",
-                  "max": "4002999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4003",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof; except for;",
-                  "min": "4003000000",
-                  "max": "4003999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4004",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof; except for;",
-                  "min": "4004000000",
                   "max": "4004999999",
                   "rules": [
                         {
@@ -8717,115 +6838,10 @@
                   "valid": true
             },
             {
-                  "heading": "4006",
+                  "heading": "ex Chapter 40",
                   "chapter": 40,
-                  "subdivision": "Rubber and articles thereof; except for;",
+                  "subdivision": "Rubber and articles thereof",
                   "min": "4006000000",
-                  "max": "4006999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4007",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof; except for;",
-                  "min": "4007000000",
-                  "max": "4007999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4008",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof; except for;",
-                  "min": "4008000000",
-                  "max": "4008999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4009",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof; except for;",
-                  "min": "4009000000",
-                  "max": "4009999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4010",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof; except for;",
-                  "min": "4010000000",
-                  "max": "4010999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4011",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof; except for;",
-                  "min": "4011000000",
                   "max": "4011999999",
                   "rules": [
                         {
@@ -8885,73 +6901,10 @@
                   "valid": true
             },
             {
-                  "heading": "4013",
+                  "heading": "ex Chapter 40",
                   "chapter": 40,
-                  "subdivision": "Rubber and articles thereof; except for;",
+                  "subdivision": "Rubber and articles thereof",
                   "min": "4013000000",
-                  "max": "4013999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4014",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof; except for;",
-                  "min": "4014000000",
-                  "max": "4014999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4015",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof; except for;",
-                  "min": "4015000000",
-                  "max": "4015999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4016",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof; except for;",
-                  "min": "4016000000",
                   "max": "4016999999",
                   "rules": [
                         {
@@ -8990,9 +6943,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 4017",
+                  "heading": "ex Chapter 40",
                   "chapter": 40,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 4017",
                   "min": "4017000000",
                   "max": "4017999999",
                   "rules": [
@@ -9011,9 +6964,9 @@
                   "valid": true
             },
             {
-                  "heading": "4101",
+                  "heading": "ex Chapter 41",
                   "chapter": 41,
-                  "subdivision": "Raw hides and skins (other than furskins) and leather; except for;",
+                  "subdivision": "Raw hides and skins (other than furskins) and leather",
                   "min": "4101000000",
                   "max": "4101999999",
                   "rules": [
@@ -9053,9 +7006,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 4102",
+                  "heading": "ex Chapter 41",
                   "chapter": 41,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 4102",
                   "min": "4102000000",
                   "max": "4102999999",
                   "rules": [
@@ -9074,9 +7027,9 @@
                   "valid": true
             },
             {
-                  "heading": "4103",
+                  "heading": "ex Chapter 41",
                   "chapter": 41,
-                  "subdivision": "Raw hides and skins (other than furskins) and leather; except for;",
+                  "subdivision": "Raw hides and skins (other than furskins) and leather",
                   "min": "4103000000",
                   "max": "4103999999",
                   "rules": [
@@ -9095,7 +7048,7 @@
                   "valid": true
             },
             {
-                  "heading": "4104-4106",
+                  "heading": "4104 to 4106",
                   "chapter": 41,
                   "subdivision": "Tanned or crust hides and skins, without wool or hair on, whether or not split, but not further prepared",
                   "min": "4104000000",
@@ -9148,7 +7101,7 @@
                   "valid": true
             },
             {
-                  "heading": "4112-4113",
+                  "heading": "4112 to 4113",
                   "chapter": 41,
                   "subdivision": "Leather further prepared after tanning or crusting, including parchment-dressed leather, without wool or hair on, whether or not split, other than leather of heading 4114",
                   "min": "4112000000",
@@ -9191,9 +7144,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 4114",
+                  "heading": "ex Chapter 41",
                   "chapter": 41,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 4114",
                   "min": "4114000000",
                   "max": "4114999999",
                   "rules": [
@@ -9212,9 +7165,9 @@
                   "valid": true
             },
             {
-                  "heading": "4115",
+                  "heading": "ex Chapter 41",
                   "chapter": 41,
-                  "subdivision": "Raw hides and skins (other than furskins) and leather; except for;",
+                  "subdivision": "Raw hides and skins (other than furskins) and leather",
                   "min": "4115000000",
                   "max": "4115999999",
                   "rules": [
@@ -9254,7 +7207,7 @@
                   "valid": true
             },
             {
-                  "heading": "4301",
+                  "heading": "ex Chapter 43",
                   "chapter": 43,
                   "subdivision": "Furskins and artificial fun manufactures thereof",
                   "min": "4301000000",
@@ -9317,9 +7270,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 4302",
+                  "heading": "ex Chapter 43",
                   "chapter": 43,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 4302",
                   "min": "4302000000",
                   "max": "4302999999",
                   "rules": [
@@ -9359,7 +7312,7 @@
                   "valid": true
             },
             {
-                  "heading": "4304",
+                  "heading": "ex Chapter 43",
                   "chapter": 43,
                   "subdivision": "Furskins and artificial fun manufactures thereof",
                   "min": "4304000000",
@@ -9383,8 +7336,8 @@
                   "heading": "ex Chapter 44",
                   "chapter": 44,
                   "subdivision": "Wood and articles of wood; wood charcoal",
-                  "min": "4400000000",
-                  "max": "4499999999",
+                  "min": "4401000000",
+                  "max": "4402999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product.",
@@ -9422,6 +7375,48 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4403",
+                  "min": "4403000000",
+                  "max": "4403999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Wood and articles of wood; wood charcoal",
+                  "min": "4404000000",
+                  "max": "4406999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 4407",
                   "chapter": 44,
                   "subdivision": "Wood sawn or chipped lengthwise, sliced or peeled, of a thickness exceeding 6 mm, planed, sanded or end-jointed",
@@ -9443,6 +7438,27 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4407",
+                  "min": "4407000000",
+                  "max": "4407999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 4408",
                   "chapter": 44,
                   "subdivision": "Sheets for veneering (including those obtained by slicing laminated wood) and for plywood, of a thickness not exceeding\n6 mm, spliced, and other wood sawn lengthwise, sliced or peeled of a thickness not exceeding 6 mm, planed, sanded or end-jointed",
@@ -9453,6 +7469,27 @@
                               "rule": "Splicing, planing, sanding or end-jointing.",
                               "class": [
                                     "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4408",
+                  "min": "4408000000",
+                  "max": "4408999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -9506,6 +7543,27 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4409",
+                  "min": "4409000000",
+                  "max": "4409999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 4410",
                   "chapter": 44,
                   "subdivision": "Headings and mouldings, including moulded skirting and other moulded boards",
@@ -9516,6 +7574,27 @@
                               "rule": "Beading or moulding.",
                               "class": [
                                     "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4410",
+                  "min": "4410000000",
+                  "max": "4410999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -9548,6 +7627,27 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4411",
+                  "min": "4411000000",
+                  "max": "4411999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 4412",
                   "chapter": 44,
                   "subdivision": "Headings and mouldings, including moulded skirting and other moulded boards",
@@ -9558,6 +7658,27 @@
                               "rule": "Beading or moulding.",
                               "class": [
                                     "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4412",
+                  "min": "4412000000",
+                  "max": "4412999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -9590,6 +7711,48 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4413",
+                  "min": "4413000000",
+                  "max": "4413999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Wood and articles of wood; wood charcoal",
+                  "min": "4414000000",
+                  "max": "4414999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 4415",
                   "chapter": 44,
                   "subdivision": "Packing cases, boxes, crates, drums and similar packings, of wood",
@@ -9600,6 +7763,27 @@
                               "rule": "Manufacture from boards not cut to size.",
                               "class": [
                                     "PRODUCTION FROM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4415",
+                  "min": "4415000000",
+                  "max": "4415999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -9632,9 +7816,51 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4416",
+                  "min": "4416000000",
+                  "max": "4416999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Wood and articles of wood; wood charcoal",
+                  "min": "4417000000",
+                  "max": "4417999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 4418",
                   "chapter": 44,
-                  "subdivision": "Wood continuously shaped along any of its edges, ends or faces, whether or not planed, sanded or end-jointed \u25b8 Builders' joinery and carpentry of wood",
+                  "subdivision": "Casks, barrels, vats, tubs and other coopers' products and parts thereof, of wood \u25b8 Builders' joinery and carpentry of wood",
                   "min": "4418000000",
                   "max": "4418999999",
                   "rules": [
@@ -9655,7 +7881,7 @@
             {
                   "heading": "ex 4418",
                   "chapter": 44,
-                  "subdivision": "Wood continuously shaped along any of its edges, ends or faces, whether or not planed, sanded or end-jointed \u25b8 Beadings and mouldings",
+                  "subdivision": "Casks, barrels, vats, tubs and other coopers' products and parts thereof, of wood \u25b8 Beadings and mouldings",
                   "min": "4418000000",
                   "max": "4418999999",
                   "rules": [
@@ -9663,6 +7889,48 @@
                               "rule": "Beading or moulding.",
                               "class": [
                                     "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4418",
+                  "min": "4418000000",
+                  "max": "4418999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Wood and articles of wood; wood charcoal",
+                  "min": "4419000000",
+                  "max": "4420999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -9695,10 +7963,11 @@
                   "valid": true
             },
             {
-                  "heading": "4501",
-                  "subdivision": "Cork and articles of cork",
-                  "min": "4501000000",
-                  "max": "4501999999",
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4421",
+                  "min": "4421000000",
+                  "max": "4421999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product.",
@@ -9712,13 +7981,13 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 45
+                  "valid": true
             },
             {
-                  "heading": "4502",
+                  "heading": "ex Chapter 45",
+                  "chapter": 45,
                   "subdivision": "Cork and articles of cork",
-                  "min": "4502000000",
+                  "min": "4501000000",
                   "max": "4502999999",
                   "rules": [
                         {
@@ -9733,8 +8002,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 45
+                  "valid": true
             },
             {
                   "heading": "4503",
@@ -9758,7 +8026,8 @@
                   "valid": true
             },
             {
-                  "heading": "4504",
+                  "heading": "ex Chapter 45",
+                  "chapter": 45,
                   "subdivision": "Cork and articles of cork",
                   "min": "4504000000",
                   "max": "4504999999",
@@ -9775,8 +8044,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 45
+                  "valid": true
             },
             {
                   "heading": "Chapter 46",
@@ -9821,178 +8089,10 @@
                   "valid": true
             },
             {
-                  "heading": "4801",
+                  "heading": "ex Chapter 48",
                   "chapter": 48,
                   "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
                   "min": "4801000000",
-                  "max": "4801999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4802",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4802000000",
-                  "max": "4802999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4803",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4803000000",
-                  "max": "4803999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4804",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4804000000",
-                  "max": "4804999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4805",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4805000000",
-                  "max": "4805999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4806",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4806000000",
-                  "max": "4806999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4807",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4807000000",
-                  "max": "4807999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4808",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4808000000",
-                  "max": "4808999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4809",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4809000000",
                   "max": "4809999999",
                   "rules": [
                         {
@@ -10063,9 +8163,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 4811",
+                  "heading": "ex Chapter 48",
                   "chapter": 48,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 4811",
                   "min": "4811000000",
                   "max": "4811999999",
                   "rules": [
@@ -10084,52 +8184,10 @@
                   "valid": true
             },
             {
-                  "heading": "4812",
+                  "heading": "ex Chapter 48",
                   "chapter": 48,
                   "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
                   "min": "4812000000",
-                  "max": "4812999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4813",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4813000000",
-                  "max": "4813999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4814",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4814000000",
                   "max": "4814999999",
                   "rules": [
                         {
@@ -10244,9 +8302,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 4818",
+                  "heading": "ex Chapter 48",
                   "chapter": 48,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 4818",
                   "min": "4818000000",
                   "max": "4818999999",
                   "rules": [
@@ -10298,9 +8356,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 4819",
+                  "heading": "ex Chapter 48",
                   "chapter": 48,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 4819",
                   "min": "4819000000",
                   "max": "4819999999",
                   "rules": [
@@ -10351,9 +8409,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 4820",
+                  "heading": "ex Chapter 48",
                   "chapter": 48,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 4820",
                   "min": "4820000000",
                   "max": "4820999999",
                   "rules": [
@@ -10372,31 +8430,10 @@
                   "valid": true
             },
             {
-                  "heading": "4821",
+                  "heading": "ex Chapter 48",
                   "chapter": 48,
                   "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
                   "min": "4821000000",
-                  "max": "4821999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4822",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4822000000",
                   "max": "4822999999",
                   "rules": [
                         {
@@ -10446,9 +8483,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 4823",
+                  "heading": "ex Chapter 48",
                   "chapter": 48,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 4823",
                   "min": "4823000000",
                   "max": "4823999999",
                   "rules": [
@@ -10467,156 +8504,10 @@
                   "valid": true
             },
             {
-                  "heading": "4901",
-                  "subdivision": "Printed books, newspapers, pictures and other products of the printing industry; manuscripts, typescripts and plans; except for",
+                  "heading": "ex Chapter 49",
+                  "chapter": 49,
+                  "subdivision": "Printed books, newspapers, pictures and other products of the printing industry; manuscripts, typescripts and plans",
                   "min": "4901000000",
-                  "max": "4901999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 49
-            },
-            {
-                  "heading": "4902",
-                  "subdivision": "Printed books, newspapers, pictures and other products of the printing industry; manuscripts, typescripts and plans; except for",
-                  "min": "4902000000",
-                  "max": "4902999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 49
-            },
-            {
-                  "heading": "4903",
-                  "subdivision": "Printed books, newspapers, pictures and other products of the printing industry; manuscripts, typescripts and plans; except for",
-                  "min": "4903000000",
-                  "max": "4903999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 49
-            },
-            {
-                  "heading": "4904",
-                  "subdivision": "Printed books, newspapers, pictures and other products of the printing industry; manuscripts, typescripts and plans; except for",
-                  "min": "4904000000",
-                  "max": "4904999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 49
-            },
-            {
-                  "heading": "4905",
-                  "subdivision": "Printed books, newspapers, pictures and other products of the printing industry; manuscripts, typescripts and plans; except for",
-                  "min": "4905000000",
-                  "max": "4905999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 49
-            },
-            {
-                  "heading": "4906",
-                  "subdivision": "Printed books, newspapers, pictures and other products of the printing industry; manuscripts, typescripts and plans; except for",
-                  "min": "4906000000",
-                  "max": "4906999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 49
-            },
-            {
-                  "heading": "4907",
-                  "subdivision": "Printed books, newspapers, pictures and other products of the printing industry; manuscripts, typescripts and plans; except for",
-                  "min": "4907000000",
-                  "max": "4907999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 49
-            },
-            {
-                  "heading": "4908",
-                  "subdivision": "Printed books, newspapers, pictures and other products of the printing industry; manuscripts, typescripts and plans; except for",
-                  "min": "4908000000",
                   "max": "4908999999",
                   "rules": [
                         {
@@ -10631,8 +8522,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 49
+                  "valid": true
             },
             {
                   "heading": "4909",
@@ -10663,7 +8553,7 @@
                   "max": "4910999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture:\n\nfrom materials of any heading, except that of the product, *and*\n\nin which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM",
                                     "CTH"
@@ -10699,32 +8589,11 @@
                   "valid": true
             },
             {
-                  "heading": "4911",
-                  "subdivision": "Printed books, newspapers, pictures and other products of the printing industry; manuscripts, typescripts and plans; except for",
+                  "heading": "ex Chapter 49",
+                  "chapter": 49,
+                  "subdivision": "Printed books, newspapers, pictures and other products of the printing industry; manuscripts, typescripts and plans",
                   "min": "4911000000",
                   "max": "4911999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 49
-            },
-            {
-                  "heading": "5001",
-                  "chapter": 50,
-                  "subdivision": "Silk",
-                  "min": "5001000000",
-                  "max": "5001999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product.",
@@ -10741,10 +8610,10 @@
                   "valid": true
             },
             {
-                  "heading": "5002",
+                  "heading": "ex Chapter 50",
                   "chapter": 50,
                   "subdivision": "Silk",
-                  "min": "5002000000",
+                  "min": "5001000000",
                   "max": "5002999999",
                   "rules": [
                         {
@@ -10783,9 +8652,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 5003",
+                  "heading": "ex Chapter 50",
                   "chapter": 50,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 5003",
                   "min": "5003000000",
                   "max": "5003999999",
                   "rules": [
@@ -10804,14 +8673,14 @@
                   "valid": true
             },
             {
-                  "heading": "5004-5005",
+                  "heading": "5004 to 5005",
                   "chapter": 50,
                   "subdivision": "Silk yarn and yarn spun from silk waste",
                   "min": "5004000000",
                   "max": "5005999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- other natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- other natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -10832,7 +8701,7 @@
                   "max": "5006999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- other natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- other natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -10846,9 +8715,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 5006",
+                  "heading": "ex Chapter 50",
                   "chapter": 50,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 5006",
                   "min": "5006000000",
                   "max": "5006999999",
                   "rules": [
@@ -10895,7 +8764,7 @@
                   "max": "5007999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -10918,93 +8787,10 @@
                   "valid": true
             },
             {
-                  "heading": "5101",
+                  "heading": "ex Chapter 51",
+                  "chapter": 51,
                   "subdivision": "Wool, fine or coarse animal hair; horsehair yarn and woven fabric",
                   "min": "5101000000",
-                  "max": "5101999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 51
-            },
-            {
-                  "heading": "5102",
-                  "subdivision": "Wool, fine or coarse animal hair; horsehair yarn and woven fabric",
-                  "min": "5102000000",
-                  "max": "5102999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 51
-            },
-            {
-                  "heading": "5103",
-                  "subdivision": "Wool, fine or coarse animal hair; horsehair yarn and woven fabric",
-                  "min": "5103000000",
-                  "max": "5103999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 51
-            },
-            {
-                  "heading": "5104",
-                  "subdivision": "Wool, fine or coarse animal hair; horsehair yarn and woven fabric",
-                  "min": "5104000000",
-                  "max": "5104999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 51
-            },
-            {
-                  "heading": "5105",
-                  "subdivision": "Wool, fine or coarse animal hair; horsehair yarn and woven fabric",
-                  "min": "5105000000",
                   "max": "5105999999",
                   "rules": [
                         {
@@ -11019,18 +8805,17 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 51
+                  "valid": true
             },
             {
-                  "heading": "5106-5110",
+                  "heading": "5106 to 5110",
                   "chapter": 51,
                   "subdivision": "Yarn of wool, of fine or coarse animal hair or of horsehair",
                   "min": "5106000000",
                   "max": "5110999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11044,7 +8829,7 @@
                   "valid": true
             },
             {
-                  "heading": "5111-5113",
+                  "heading": "5111 to 5113",
                   "chapter": 51,
                   "subdivision": "Woven fabrics of wool, of fine or coarse animal hair or of horsehair \u25b8 Incorporating rubber thread",
                   "min": "5111000000",
@@ -11065,14 +8850,14 @@
                   "valid": true
             },
             {
-                  "heading": "5111-5113",
+                  "heading": "5111 to 5113",
                   "chapter": 51,
                   "subdivision": "Woven fabrics of wool, of fine or coarse animal hair or of horsehair \u25b8 Other",
                   "min": "5111000000",
                   "max": "5113999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11095,51 +8880,10 @@
                   "valid": true
             },
             {
-                  "heading": "5201",
+                  "heading": "ex Chapter 52",
+                  "chapter": 52,
                   "subdivision": "Cotton",
                   "min": "5201000000",
-                  "max": "5201999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 52
-            },
-            {
-                  "heading": "5202",
-                  "subdivision": "Cotton",
-                  "min": "5202000000",
-                  "max": "5202999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 52
-            },
-            {
-                  "heading": "5203",
-                  "subdivision": "Cotton",
-                  "min": "5203000000",
                   "max": "5203999999",
                   "rules": [
                         {
@@ -11154,18 +8898,17 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 52
+                  "valid": true
             },
             {
-                  "heading": "5204-5207",
+                  "heading": "5204 to 5207",
                   "chapter": 52,
                   "subdivision": "Yarn and thread of cotton",
                   "min": "5204000000",
                   "max": "5207999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11179,7 +8922,7 @@
                   "valid": true
             },
             {
-                  "heading": "5208-5212",
+                  "heading": "5208 to 5212",
                   "chapter": 52,
                   "subdivision": "Woven fabrics of cotton \u25b8 Incorporating rubber thread",
                   "min": "5208000000",
@@ -11200,14 +8943,14 @@
                   "valid": true
             },
             {
-                  "heading": "5208-5212",
+                  "heading": "5208 to 5212",
                   "chapter": 52,
                   "subdivision": "Woven fabrics of cotton \u25b8 Other",
                   "min": "5208000000",
                   "max": "5212999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11230,72 +8973,10 @@
                   "valid": true
             },
             {
-                  "heading": "5301",
+                  "heading": "ex Chapter 53",
+                  "chapter": 53,
                   "subdivision": "Other vegetable textile fibres; paper yarn and woven fabrics of paper yarn",
                   "min": "5301000000",
-                  "max": "5301999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 53
-            },
-            {
-                  "heading": "5302",
-                  "subdivision": "Other vegetable textile fibres; paper yarn and woven fabrics of paper yarn",
-                  "min": "5302000000",
-                  "max": "5302999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 53
-            },
-            {
-                  "heading": "5303",
-                  "subdivision": "Other vegetable textile fibres; paper yarn and woven fabrics of paper yarn",
-                  "min": "5303000000",
-                  "max": "5303999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 53
-            },
-            {
-                  "heading": "5305",
-                  "subdivision": "Other vegetable textile fibres; paper yarn and woven fabrics of paper yarn",
-                  "min": "5305000000",
                   "max": "5305999999",
                   "rules": [
                         {
@@ -11310,18 +8991,17 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 53
+                  "valid": true
             },
             {
-                  "heading": "5306-5308",
+                  "heading": "5306 to 5308",
                   "chapter": 53,
                   "subdivision": "Yarn of other vegetable textile fibres; paper yarn",
                   "min": "5306000000",
                   "max": "5308999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11335,7 +9015,7 @@
                   "valid": true
             },
             {
-                  "heading": "5309-5311",
+                  "heading": "5309 to 5311",
                   "chapter": 53,
                   "subdivision": "Woven fabrics of other vegetable textile fibres; woven fabrics of paper yarn \u25b8 Incorporating rubber thread",
                   "min": "5309000000",
@@ -11356,14 +9036,14 @@
                   "valid": true
             },
             {
-                  "heading": "5309-5311",
+                  "heading": "5309 to 5311",
                   "chapter": 53,
                   "subdivision": "Woven fabrics of other vegetable textile fibres; woven fabrics of paper yarn \u25b8 Other",
                   "min": "5309000000",
                   "max": "5311999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- jute yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- jute yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11386,14 +9066,14 @@
                   "valid": true
             },
             {
-                  "heading": "5401-5406",
+                  "heading": "5401 to 5406",
                   "chapter": 54,
                   "subdivision": "Yarn, monofilament and thread of manmade filaments",
                   "min": "5401000000",
                   "max": "5406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning, \n\n- natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning, \n\n- natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11407,7 +9087,7 @@
                   "valid": true
             },
             {
-                  "heading": "5407-5408",
+                  "heading": "5407 to 5408",
                   "chapter": 54,
                   "subdivision": "Woven fabrics of man-made filament yarn; \u25b8 Incorporating rubber thread",
                   "min": "5407000000",
@@ -11428,14 +9108,14 @@
                   "valid": true
             },
             {
-                  "heading": "5407-5408",
+                  "heading": "5407 to 5408",
                   "chapter": 54,
                   "subdivision": "Woven fabrics of man-made filament yarn; \u25b8 Other",
                   "min": "5407000000",
                   "max": "5408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11458,7 +9138,7 @@
                   "valid": true
             },
             {
-                  "heading": "5501-5507",
+                  "heading": "5501 to 5507",
                   "chapter": 55,
                   "subdivision": "Man-made staple fibres",
                   "min": "5501000000",
@@ -11479,14 +9159,14 @@
                   "valid": true
             },
             {
-                  "heading": "5508-5511",
+                  "heading": "5508 to 5511",
                   "chapter": 55,
                   "subdivision": "Yarn and sewing thread of man-made staple fibres",
                   "min": "5508000000",
                   "max": "5511999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11500,7 +9180,7 @@
                   "valid": true
             },
             {
-                  "heading": "5512-5516",
+                  "heading": "5512 to 5516",
                   "chapter": 55,
                   "subdivision": "Woven fabrics of man-made staple fibres \u25b8 Incorporating rubber thread",
                   "min": "5512000000",
@@ -11521,14 +9201,14 @@
                   "valid": true
             },
             {
-                  "heading": "5512-5516",
+                  "heading": "5512 to 5516",
                   "chapter": 55,
                   "subdivision": "Woven fabrics of man-made staple fibres \u25b8 Other",
                   "min": "5512000000",
                   "max": "5516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11551,13 +9231,14 @@
                   "valid": true
             },
             {
-                  "heading": "5601",
+                  "heading": "ex Chapter 56",
+                  "chapter": 56,
                   "subdivision": "Wadding, felt and non-wovens; special yarns; twine, cordage, ropes and cables and articles thereof",
                   "min": "5601000000",
                   "max": "5601999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11568,8 +9249,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 56
+                  "valid": true
             },
             {
                   "heading": "5602",
@@ -11579,7 +9259,7 @@
                   "max": "5602999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- natural fibres, or\n\n- chemical materials or textile pulp\n\nHowever: polypropylene filament of [heading&nbsp;5402](/headings/5402), polypropylene fibres of [heading&nbsp;5503](/headings/5503) or [heading&nbsp;5506](/headings/5506), or polypropylene filament tow of [heading&nbsp;5501](/headings/5501), of which the denomination in all cases of a single filament or fibre is less than 9 decitex, may be used, provided that their total value does not exceed **40%** of the ex-works price of the product.",
+                              "rule": "Manufacture from:\n\n- natural fibres, *or*\n\n- chemical materials or textile pulp\n\nHowever: polypropylene filament of [heading&nbsp;5402](/headings/5402), polypropylene fibres of [heading&nbsp;5503](/headings/5503) or [heading&nbsp;5506](/headings/5506), or polypropylene filament tow of [heading&nbsp;5501](/headings/5501), of which the denomination in all cases of a single filament or fibre is less than 9 decitex, may be used, provided that their total value does not exceed **40%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM",
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM TOLERANCE MAY BE USED RESTRICTION MAXNOM"
@@ -11601,7 +9281,7 @@
                   "max": "5602999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres made from casein, or\n\n- chemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres made from casein, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11615,13 +9295,14 @@
                   "valid": true
             },
             {
-                  "heading": "5603",
+                  "heading": "ex Chapter 56",
+                  "chapter": 56,
                   "subdivision": "Wadding, felt and non-wovens; special yarns; twine, cordage, ropes and cables and articles thereof",
                   "min": "5603000000",
                   "max": "5603999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11632,8 +9313,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 56
+                  "valid": true
             },
             {
                   "heading": "5604",
@@ -11664,7 +9344,7 @@
                   "max": "5604999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- natural fibres, not carded or combed or otherwise processed for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- natural fibres, not carded or combed or otherwise processed for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11685,7 +9365,7 @@
                   "max": "5605999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11706,7 +9386,7 @@
                   "max": "5606999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11720,55 +9400,14 @@
                   "valid": true
             },
             {
-                  "heading": "5607",
+                  "heading": "ex Chapter 56",
+                  "chapter": 56,
                   "subdivision": "Wadding, felt and non-wovens; special yarns; twine, cordage, ropes and cables and articles thereof",
                   "min": "5607000000",
-                  "max": "5607999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 56
-            },
-            {
-                  "heading": "5608",
-                  "subdivision": "Wadding, felt and non-wovens; special yarns; twine, cordage, ropes and cables and articles thereof",
-                  "min": "5608000000",
-                  "max": "5608999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 56
-            },
-            {
-                  "heading": "5609",
-                  "subdivision": "Wadding, felt and non-wovens; special yarns; twine, cordage, ropes and cables and articles thereof",
-                  "min": "5609000000",
                   "max": "5609999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11779,17 +9418,17 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 56
+                  "valid": true
             },
             {
-                  "heading": "5701",
+                  "heading": "Chapter 57",
+                  "chapter": 57,
                   "subdivision": "Carpets and other textile floor coverings; \u25b8 Of needleloom felt",
-                  "min": "5701000000",
-                  "max": "5701999999",
+                  "min": "5700000000",
+                  "max": "5799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- natural fibres, or\n\n- chemical materials or textile pulp\n\nHowever, polypropylene filament of [heading&nbsp;5402](/headings/5402), polypropylene fibres of [heading&nbsp;5503](/headings/5503) or [heading&nbsp;5506](/headings/5506), or polypropylene filament tow of [heading&nbsp;5501](/headings/5501), of which the denomination in all cases of a single filament or fibre is less than 9 decitex, may be used, provided that their total value does not exceed **40%** of the ex-works price of the product. Jute fabric may be used as a backing.",
+                              "rule": "Manufacture from:\n\n- natural fibres, *or*\n\n- chemical materials or textile pulp\n\nHowever, polypropylene filament of [heading&nbsp;5402](/headings/5402), polypropylene fibres of [heading&nbsp;5503](/headings/5503) or [heading&nbsp;5506](/headings/5506), or polypropylene filament tow of [heading&nbsp;5501](/headings/5501), of which the denomination in all cases of a single filament or fibre is less than 9 decitex, may be used, provided that their total value does not exceed **40%** of the ex-works price of the product. Jute fabric may be used as a backing.",
                               "class": [
                                     "MAXNOM",
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM TOLERANCE MAY BE USED RESTRICTION MAXNOM"
@@ -11801,17 +9440,17 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 57
+                  "valid": true
             },
             {
-                  "heading": "5701",
+                  "heading": "Chapter 57",
+                  "chapter": 57,
                   "subdivision": "Carpets and other textile floor coverings; \u25b8 Of other felt",
-                  "min": "5701000000",
-                  "max": "5701999999",
+                  "min": "5700000000",
+                  "max": "5799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- natural fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- natural fibres, not carded or combed or otherwise processed for spinning, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11822,17 +9461,17 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 57
+                  "valid": true
             },
             {
-                  "heading": "5701",
+                  "heading": "Chapter 57",
+                  "chapter": 57,
                   "subdivision": "Carpets and other textile floor coverings; \u25b8 Other",
-                  "min": "5701000000",
-                  "max": "5701999999",
+                  "min": "5700000000",
+                  "max": "5799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- coir yarn or jute yarn,\n\n- synthetic or artificial filament yarn,\n\n- natural fibres, or\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning.\n\nJute fabric may be used as a backing.",
+                              "rule": "Manufacture from:\n\n- coir yarn or jute yarn,\n\n- synthetic or artificial filament yarn,\n\n- natural fibres, *or*\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning.\n\nJute fabric may be used as a backing.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11843,270 +9482,14 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 57
+                  "valid": true
             },
             {
-                  "heading": "5702",
-                  "subdivision": "Carpets and other textile floor coverings; \u25b8 Of needleloom felt",
-                  "min": "5702000000",
-                  "max": "5702999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres, or\n\n- chemical materials or textile pulp\n\nHowever, polypropylene filament of [heading&nbsp;5402](/headings/5402), polypropylene fibres of [heading&nbsp;5503](/headings/5503) or [heading&nbsp;5506](/headings/5506), or polypropylene filament tow of [heading&nbsp;5501](/headings/5501), of which the denomination in all cases of a single filament or fibre is less than 9 decitex, may be used, provided that their total value does not exceed **40%** of the ex-works price of the product. Jute fabric may be used as a backing.",
-                              "class": [
-                                    "MAXNOM",
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5702",
-                  "subdivision": "Carpets and other textile floor coverings; \u25b8 Of other felt",
-                  "min": "5702000000",
-                  "max": "5702999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5702",
-                  "subdivision": "Carpets and other textile floor coverings; \u25b8 Other",
-                  "min": "5702000000",
-                  "max": "5702999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- coir yarn or jute yarn,\n\n- synthetic or artificial filament yarn,\n\n- natural fibres, or\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning.\n\nJute fabric may be used as a backing.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5703",
-                  "subdivision": "Carpets and other textile floor coverings; \u25b8 Of needleloom felt",
-                  "min": "5703000000",
-                  "max": "5703999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres, or\n\n- chemical materials or textile pulp\n\nHowever, polypropylene filament of [heading&nbsp;5402](/headings/5402), polypropylene fibres of [heading&nbsp;5503](/headings/5503) or [heading&nbsp;5506](/headings/5506), or polypropylene filament tow of [heading&nbsp;5501](/headings/5501), of which the denomination in all cases of a single filament or fibre is less than 9 decitex, may be used, provided that their total value does not exceed **40%** of the ex-works price of the product. Jute fabric may be used as a backing.",
-                              "class": [
-                                    "MAXNOM",
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5703",
-                  "subdivision": "Carpets and other textile floor coverings; \u25b8 Of other felt",
-                  "min": "5703000000",
-                  "max": "5703999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5703",
-                  "subdivision": "Carpets and other textile floor coverings; \u25b8 Other",
-                  "min": "5703000000",
-                  "max": "5703999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- coir yarn or jute yarn,\n\n- synthetic or artificial filament yarn,\n\n- natural fibres, or\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning.\n\nJute fabric may be used as a backing.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5704",
-                  "subdivision": "Carpets and other textile floor coverings; \u25b8 Of needleloom felt",
-                  "min": "5704000000",
-                  "max": "5704999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres, or\n\n- chemical materials or textile pulp\n\nHowever, polypropylene filament of [heading&nbsp;5402](/headings/5402), polypropylene fibres of [heading&nbsp;5503](/headings/5503) or [heading&nbsp;5506](/headings/5506), or polypropylene filament tow of [heading&nbsp;5501](/headings/5501), of which the denomination in all cases of a single filament or fibre is less than 9 decitex, may be used, provided that their total value does not exceed **40%** of the ex-works price of the product. Jute fabric may be used as a backing.",
-                              "class": [
-                                    "MAXNOM",
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5704",
-                  "subdivision": "Carpets and other textile floor coverings; \u25b8 Of other felt",
-                  "min": "5704000000",
-                  "max": "5704999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5704",
-                  "subdivision": "Carpets and other textile floor coverings; \u25b8 Other",
-                  "min": "5704000000",
-                  "max": "5704999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- coir yarn or jute yarn,\n\n- synthetic or artificial filament yarn,\n\n- natural fibres, or\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning.\n\nJute fabric may be used as a backing.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5705",
-                  "subdivision": "Carpets and other textile floor coverings; \u25b8 Of needleloom felt",
-                  "min": "5705000000",
-                  "max": "5705999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres, or\n\n- chemical materials or textile pulp\n\nHowever, polypropylene filament of [heading&nbsp;5402](/headings/5402), polypropylene fibres of [heading&nbsp;5503](/headings/5503) or [heading&nbsp;5506](/headings/5506), or polypropylene filament tow of [heading&nbsp;5501](/headings/5501), of which the denomination in all cases of a single filament or fibre is less than 9 decitex, may be used, provided that their total value does not exceed **40%** of the ex-works price of the product. Jute fabric may be used as a backing.",
-                              "class": [
-                                    "MAXNOM",
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5705",
-                  "subdivision": "Carpets and other textile floor coverings; \u25b8 Of other felt",
-                  "min": "5705000000",
-                  "max": "5705999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5705",
-                  "subdivision": "Carpets and other textile floor coverings; \u25b8 Other",
-                  "min": "5705000000",
-                  "max": "5705999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- coir yarn or jute yarn,\n\n- synthetic or artificial filament yarn,\n\n- natural fibres, or\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning.\n\nJute fabric may be used as a backing.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5801",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery; except for; \u25b8 Combined with rubber thread",
+                  "heading": "ex Chapter 58",
+                  "chapter": 58,
+                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery \u25b8 Combined with rubber thread",
                   "min": "5801000000",
-                  "max": "5801999999",
+                  "max": "5811999999",
                   "rules": [
                         {
                               "rule": "Manufacture from single yarn.",
@@ -12120,17 +9503,17 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 58
+                  "valid": true
             },
             {
-                  "heading": "5801",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery; except for; \u25b8 Other",
+                  "heading": "ex Chapter 58",
+                  "chapter": 58,
+                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery \u25b8 Other",
                   "min": "5801000000",
-                  "max": "5801999999",
+                  "max": "5811999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -12150,161 +9533,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5802",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery; except for; \u25b8 Combined with rubber thread",
-                  "min": "5802000000",
-                  "max": "5802999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from single yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5802",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery; except for; \u25b8 Other",
-                  "min": "5802000000",
-                  "max": "5802999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the ex-works price of the product.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5803",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery; except for; \u25b8 Combined with rubber thread",
-                  "min": "5803000000",
-                  "max": "5803999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from single yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5803",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery; except for; \u25b8 Other",
-                  "min": "5803000000",
-                  "max": "5803999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the ex-works price of the product.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5804",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery; except for; \u25b8 Combined with rubber thread",
-                  "min": "5804000000",
-                  "max": "5804999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from single yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5804",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery; except for; \u25b8 Other",
-                  "min": "5804000000",
-                  "max": "5804999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the ex-works price of the product.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
+                  "valid": true
             },
             {
                   "heading": "5805",
@@ -12328,210 +9557,6 @@
                   "valid": true
             },
             {
-                  "heading": "5806",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery; except for; \u25b8 Combined with rubber thread",
-                  "min": "5806000000",
-                  "max": "5806999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from single yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5806",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery; except for; \u25b8 Other",
-                  "min": "5806000000",
-                  "max": "5806999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the ex-works price of the product.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5807",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery; except for; \u25b8 Combined with rubber thread",
-                  "min": "5807000000",
-                  "max": "5807999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from single yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5807",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery; except for; \u25b8 Other",
-                  "min": "5807000000",
-                  "max": "5807999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the ex-works price of the product.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5808",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery; except for; \u25b8 Combined with rubber thread",
-                  "min": "5808000000",
-                  "max": "5808999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from single yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5808",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery; except for; \u25b8 Other",
-                  "min": "5808000000",
-                  "max": "5808999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the ex-works price of the product.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5809",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery; except for; \u25b8 Combined with rubber thread",
-                  "min": "5809000000",
-                  "max": "5809999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from single yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5809",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery; except for; \u25b8 Other",
-                  "min": "5809000000",
-                  "max": "5809999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the ex-works price of the product.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
                   "heading": "5810",
                   "chapter": 58,
                   "subdivision": "Embroidery in the piece, in strips or in motifs",
@@ -12552,57 +9577,6 @@
                         }
                   ],
                   "valid": true
-            },
-            {
-                  "heading": "5811",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery; except for; \u25b8 Combined with rubber thread",
-                  "min": "5811000000",
-                  "max": "5811999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from single yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5811",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery; except for; \u25b8 Other",
-                  "min": "5811000000",
-                  "max": "5811999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the ex-works price of the product.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
             },
             {
                   "heading": "5901",
@@ -12747,7 +9721,7 @@
                   "max": "5905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -12777,7 +9751,7 @@
                   "max": "5906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -12905,7 +9879,7 @@
                   "valid": true
             },
             {
-                  "heading": "5909-5911",
+                  "heading": "5909 to 5911",
                   "chapter": 59,
                   "subdivision": "Textile articles of a kind suitable for industrial use \u25b8 Polishing discs or rings other than of felt of heading 5911",
                   "min": "5909000000",
@@ -12926,14 +9900,14 @@
                   "valid": true
             },
             {
-                  "heading": "5909-5911",
+                  "heading": "5909 to 5911",
                   "chapter": 59,
                   "subdivision": "Textile articles of a kind suitable for industrial use \u25b8 Woven fabrics, of a kind commonly used in papermaking or other technical uses, felted or not, whether or not impregnated or coated, tubular or endless with single or multiple warp and/or weft, or flat woven with multiple warp and/or weft of heading 5911",
                   "min": "5909000000",
                   "max": "5911999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- the following materials: yarn of polytetrafluoroethylene, yarn, multiple, of polyamide, coated impregnated or covered with a phenolic resin, yarn of synthetic textile fibres of aromatic polyamides, obtained by polycondensation of m-phenylene- diamine and isophthalic acid, monofil of polytetrafluoroethylene (n), yarn of synthetic textile fibres of poly(p-phenylene terephthalamide), glass fibre yarn, coated with phenol resin and gimped with acrylic yarn (n), copolyester monofilaments of a polyester and a resin of terephthalic acid and 1,4-cydohexanediethanol and isophthalic acid, natural fibres, man-made staple fibres not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
+                              "rule": "Manufacture from coir yarn, or the following materials:\n\n- yarn of polytetrafluoroethylene,\n\n- yarn, multiple, of polyamide, coated impregnated or covered with a phenolic resin,\n\n- yarn of synthetic textile fibres of aromatic polyamides, obtained by polycondensation of m-phenylenediamine and isophthalic acid,\n\n- monofil of polytetrafluoroethylene\n\n- yarn of synthetic textile fibres of poly-p-phenylene terephthalamide,\n\n- glass fibre yarn, coated with phenol resin and gimped with acrylic yarn\n\n- copolyester monofilaments of a polyester and a resin of terephthalic acid and 1.4 -cyclohexanediethanol and isophthalic acid,\n\n- natural fibres,\n\n- man-made staple fibres not carded or combed or otherwise processed for spinning, *or*\n\n- chemical materials or textile pulp.",
                               "class": [],
                               "footnotes": [],
                               "operator": null,
@@ -12945,14 +9919,14 @@
                   "valid": true
             },
             {
-                  "heading": "5909-5911",
+                  "heading": "5909 to 5911",
                   "chapter": 59,
                   "subdivision": "Textile articles of a kind suitable for industrial use \u25b8 Other",
                   "min": "5909000000",
                   "max": "5911999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -12973,7 +9947,7 @@
                   "max": "6099999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -12987,10 +9961,11 @@
                   "valid": true
             },
             {
-                  "heading": "6101",
+                  "heading": "Chapter 61",
+                  "chapter": 61,
                   "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6101000000",
-                  "max": "6101999999",
+                  "min": "6100000000",
+                  "max": "6199999999",
                   "rules": [
                         {
                               "rule": "Manufacture from yarn.",
@@ -13004,17 +9979,17 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 61
+                  "valid": true
             },
             {
-                  "heading": "6101",
+                  "heading": "Chapter 61",
+                  "chapter": 61,
                   "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6101000000",
-                  "max": "6101999999",
+                  "min": "6100000000",
+                  "max": "6199999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -13025,683 +10000,10 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 61
+                  "valid": true
             },
             {
-                  "heading": "6102",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6102000000",
-                  "max": "6102999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6102",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6102000000",
-                  "max": "6102999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6103",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6103000000",
-                  "max": "6103999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6103",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6103000000",
-                  "max": "6103999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6104",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6104000000",
-                  "max": "6104999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6104",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6104000000",
-                  "max": "6104999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6105",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6105000000",
-                  "max": "6105999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6105",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6105000000",
-                  "max": "6105999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6106",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6106000000",
-                  "max": "6106999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6106",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6106000000",
-                  "max": "6106999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6107",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6107000000",
-                  "max": "6107999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6107",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6107000000",
-                  "max": "6107999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6108",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6108000000",
-                  "max": "6108999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6108",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6108000000",
-                  "max": "6108999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6109",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6109000000",
-                  "max": "6109999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6109",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6109000000",
-                  "max": "6109999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6110",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6110000000",
-                  "max": "6110999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6110",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6110000000",
-                  "max": "6110999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6111",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6111000000",
-                  "max": "6111999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6111",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6111000000",
-                  "max": "6111999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6112",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6112000000",
-                  "max": "6112999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6112",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6112000000",
-                  "max": "6112999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6113",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6113000000",
-                  "max": "6113999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6113",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6113000000",
-                  "max": "6113999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6114",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6114000000",
-                  "max": "6114999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6114",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6114000000",
-                  "max": "6114999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6115",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6115000000",
-                  "max": "6115999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6115",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6115000000",
-                  "max": "6115999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6116",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6116000000",
-                  "max": "6116999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6116",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6116000000",
-                  "max": "6116999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6117",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6117000000",
-                  "max": "6117999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6117",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6117000000",
-                  "max": "6117999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6201",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
                   "subdivision": "Articles of apparel and clothing accessories, not knitted or crocheted",
                   "min": "6201000000",
@@ -13754,9 +10056,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 6202",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 6202",
                   "min": "6202000000",
                   "max": "6202999999",
                   "rules": [
@@ -13775,7 +10077,7 @@
                   "valid": true
             },
             {
-                  "heading": "6203",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
                   "subdivision": "Articles of apparel and clothing accessories, not knitted or crocheted",
                   "min": "6203000000",
@@ -13828,9 +10130,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 6204",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 6204",
                   "min": "6204000000",
                   "max": "6204999999",
                   "rules": [
@@ -13849,7 +10151,7 @@
                   "valid": true
             },
             {
-                  "heading": "6205",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
                   "subdivision": "Articles of apparel and clothing accessories, not knitted or crocheted",
                   "min": "6205000000",
@@ -13902,9 +10204,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 6206",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 6206",
                   "min": "6206000000",
                   "max": "6206999999",
                   "rules": [
@@ -13923,31 +10225,10 @@
                   "valid": true
             },
             {
-                  "heading": "6207",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
                   "subdivision": "Articles of apparel and clothing accessories, not knitted or crocheted",
                   "min": "6207000000",
-                  "max": "6207999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "6208",
-                  "chapter": 62,
-                  "subdivision": "Articles of apparel and clothing accessories, not knitted or crocheted",
-                  "min": "6208000000",
                   "max": "6208999999",
                   "rules": [
                         {
@@ -13997,9 +10278,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 6209",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 6209",
                   "min": "6209000000",
                   "max": "6209999999",
                   "rules": [
@@ -14050,9 +10331,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 6210",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 6210",
                   "min": "6210000000",
                   "max": "6210999999",
                   "rules": [
@@ -14103,9 +10384,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 6211",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 6211",
                   "min": "6211000000",
                   "max": "6211999999",
                   "rules": [
@@ -14124,7 +10405,7 @@
                   "valid": true
             },
             {
-                  "heading": "6212",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
                   "subdivision": "Articles of apparel and clothing accessories, not knitted or crocheted",
                   "min": "6212000000",
@@ -14145,7 +10426,7 @@
                   "valid": true
             },
             {
-                  "heading": "6213-6214",
+                  "heading": "6213 to 6214",
                   "chapter": 62,
                   "subdivision": "Handkerchiefs, shawls, scarves, mufflers, mantillas, veils and the like \u25b8 Embroidered",
                   "min": "6213000000",
@@ -14177,7 +10458,7 @@
                   "valid": true
             },
             {
-                  "heading": "6213-6214",
+                  "heading": "6213 to 6214",
                   "chapter": 62,
                   "subdivision": "Handkerchiefs, shawls, scarves, mufflers, mantillas, veils and the like \u25b8 Other",
                   "min": "6213000000",
@@ -14207,7 +10488,7 @@
                   "valid": true
             },
             {
-                  "heading": "6215",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
                   "subdivision": "Articles of apparel and clothing accessories, not knitted or crocheted",
                   "min": "6215000000",
@@ -14260,9 +10541,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 6216",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 6216",
                   "min": "6216000000",
                   "max": "6216999999",
                   "rules": [
@@ -14388,14 +10669,14 @@
                   "valid": true
             },
             {
-                  "heading": "6301-6304",
+                  "heading": "6301 to 6304",
                   "chapter": 63,
                   "subdivision": "Blankets, travelling rugs, bed linen etc.; curtains etc.; other furnishing articles \u25b8 Of felt, of nonwovens",
                   "min": "6301000000",
                   "max": "6304999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\nnatural fibres, or\n\nchemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- natural fibres, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -14409,9 +10690,9 @@
                   "valid": true
             },
             {
-                  "heading": "6301-6304",
+                  "heading": "6301 to 6304",
                   "chapter": 63,
-                  "subdivision": "Blankets, travelling rugs, bed linen etc.; curtains etc.; other furnishing articles \u25b8 Other \u25b8 Embroidered",
+                  "subdivision": "Blankets, travelling rugs, bed linen etc.; curtains etc.; other furnishing articles \u25b8 Embroidered",
                   "min": "6301000000",
                   "max": "6304999999",
                   "rules": [
@@ -14441,9 +10722,9 @@
                   "valid": true
             },
             {
-                  "heading": "6301-6304",
+                  "heading": "6301 to 6304",
                   "chapter": 63,
-                  "subdivision": "Blankets, travelling rugs, bed linen etc.; curtains etc.; other furnishing articles \u25b8 Other \u25b8 Other",
+                  "subdivision": "Blankets, travelling rugs, bed linen etc.; curtains etc.; other furnishing articles \u25b8 Other",
                   "min": "6301000000",
                   "max": "6304999999",
                   "rules": [
@@ -14469,7 +10750,7 @@
                   "max": "6305999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -14490,7 +10771,7 @@
                   "max": "6306999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\nnatural fibres, or\n\nchemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- natural fibres, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -14568,30 +10849,10 @@
                   "valid": true
             },
             {
-                  "heading": "6309",
-                  "subdivision": "Other made-up textile articles; sets; worn clothing and worn textile articles; rags; except for;",
+                  "heading": "ex Chapter 63",
+                  "chapter": 63,
+                  "subdivision": "Other made-up textile articles; sets; worn clothing and worn textile articles; rags",
                   "min": "6309000000",
-                  "max": "6309999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 63
-            },
-            {
-                  "heading": "6310",
-                  "subdivision": "Other made-up textile articles; sets; worn clothing and worn textile articles; rags; except for;",
-                  "min": "6310000000",
                   "max": "6310999999",
                   "rules": [
                         {
@@ -14606,13 +10867,12 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 63
+                  "valid": true
             },
             {
                   "heading": "6401",
                   "chapter": 64,
-                  "subdivision": "Waterproof footwear with outer soles and uppers of rubber or of plastics, the uppers of which are neither fixed to the sole nor assembled by stitching, riveting, nailing, screwing, plugging or similar processes \u25b8 with customs value above 10 EUR",
+                  "subdivision": "Waterproof footwear with outer soles and uppers of rubber or of plastics, the uppers of which are neither fixed to the sole nor assembled by stitching, riveting, nailing, screwing, plugging or similar processes \u25b8 With customs value above 10 EUR",
                   "min": "6401000000",
                   "max": "6401999999",
                   "rules": [
@@ -14633,7 +10893,7 @@
             {
                   "heading": "6401",
                   "chapter": 64,
-                  "subdivision": "Waterproof footwear with outer soles and uppers of rubber or of plastics, the uppers of which are neither fixed to the sole nor assembled by stitching, riveting, nailing, screwing, plugging or similar processes \u25b8 with customs value of 10 EUR or less",
+                  "subdivision": "Waterproof footwear with outer soles and uppers of rubber or of plastics, the uppers of which are neither fixed to the sole nor assembled by stitching, riveting, nailing, screwing, plugging or similar processes \u25b8 With customs value of 10 EUR or less",
                   "min": "6401000000",
                   "max": "6401999999",
                   "rules": [
@@ -14654,7 +10914,7 @@
             {
                   "heading": "6402",
                   "chapter": 64,
-                  "subdivision": "Other footwear with outer soles and uppers of rubber or plastics \u25b8 with customs value above 8 EUR",
+                  "subdivision": "Other footwear with outer soles and uppers of rubber or plastics \u25b8 With customs value above 8 EUR",
                   "min": "6402000000",
                   "max": "6402999999",
                   "rules": [
@@ -14675,7 +10935,7 @@
             {
                   "heading": "6402",
                   "chapter": 64,
-                  "subdivision": "Other footwear with outer soles and uppers of rubber or plastics \u25b8 with customs value of 8 EUR or less",
+                  "subdivision": "Other footwear with outer soles and uppers of rubber or plastics \u25b8 With customs value of 8 EUR or less",
                   "min": "6402000000",
                   "max": "6402999999",
                   "rules": [
@@ -14696,7 +10956,7 @@
             {
                   "heading": "6403",
                   "chapter": 64,
-                  "subdivision": "Footwear with outer soles of rubber, plastics, leather or composition leather and uppers of leather \u25b8 with customs value above 24 EUR",
+                  "subdivision": "Footwear with outer soles of rubber, plastics, leather or composition leather and uppers of leather \u25b8 With customs value above 24 EUR",
                   "min": "6403000000",
                   "max": "6403999999",
                   "rules": [
@@ -14717,7 +10977,7 @@
             {
                   "heading": "6403",
                   "chapter": 64,
-                  "subdivision": "Footwear with outer soles of rubber, plastics, leather or composition leather and uppers of leather \u25b8 with customs value of 24 EUR or less",
+                  "subdivision": "Footwear with outer soles of rubber, plastics, leather or composition leather and uppers of leather \u25b8 With customs value of 24 EUR or less",
                   "min": "6403000000",
                   "max": "6403999999",
                   "rules": [
@@ -14738,7 +10998,7 @@
             {
                   "heading": "6404",
                   "chapter": 64,
-                  "subdivision": "Footwear with outer soles of rubber, plastics, leather or composition leather and uppers of textile materials \u25b8 with customs value above 13 EUR",
+                  "subdivision": "Footwear with outer soles of rubber, plastics, leather or composition leather and uppers of textile materials \u25b8 With customs value above 13 EUR",
                   "min": "6404000000",
                   "max": "6404999999",
                   "rules": [
@@ -14759,7 +11019,7 @@
             {
                   "heading": "6404",
                   "chapter": 64,
-                  "subdivision": "Footwear with outer soles of rubber, plastics, leather or composition leather and uppers of textile materials \u25b8 with customs value of 13 EUR or less",
+                  "subdivision": "Footwear with outer soles of rubber, plastics, leather or composition leather and uppers of textile materials \u25b8 With customs value of 13 EUR or less",
                   "min": "6404000000",
                   "max": "6404999999",
                   "rules": [
@@ -14780,7 +11040,7 @@
             {
                   "heading": "6405",
                   "chapter": 64,
-                  "subdivision": "Other footwear \u25b8 with customs value above 9 EUR",
+                  "subdivision": "Other footwear \u25b8 With customs value above 9 EUR",
                   "min": "6405000000",
                   "max": "6405999999",
                   "rules": [
@@ -14801,7 +11061,7 @@
             {
                   "heading": "6405",
                   "chapter": 64,
-                  "subdivision": "Other footwear \u25b8 with customs value of 9 EUR or less",
+                  "subdivision": "Other footwear \u25b8 With customs value of 9 EUR or less",
                   "min": "6405000000",
                   "max": "6405999999",
                   "rules": [
@@ -14841,51 +11101,10 @@
                   "valid": true
             },
             {
-                  "heading": "6501",
+                  "heading": "ex Chapter 65",
+                  "chapter": 65,
                   "subdivision": "Headgear and parts thereof",
                   "min": "6501000000",
-                  "max": "6501999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 65
-            },
-            {
-                  "heading": "6502",
-                  "subdivision": "Headgear and parts thereof",
-                  "min": "6502000000",
-                  "max": "6502999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 65
-            },
-            {
-                  "heading": "6504",
-                  "subdivision": "Headgear and parts thereof",
-                  "min": "6504000000",
                   "max": "6504999999",
                   "rules": [
                         {
@@ -14900,8 +11119,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 65
+                  "valid": true
             },
             {
                   "heading": "6505",
@@ -14911,7 +11129,7 @@
                   "max": "6505999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from yarn or textile fibres(\").",
+                              "rule": "Manufacture from yarn or textile fibres.",
                               "class": [
                                     "PRODUCTION FROM"
                               ],
@@ -14925,30 +11143,10 @@
                   "valid": true
             },
             {
-                  "heading": "6506",
+                  "heading": "ex Chapter 65",
+                  "chapter": 65,
                   "subdivision": "Headgear and parts thereof",
                   "min": "6506000000",
-                  "max": "6506999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 65
-            },
-            {
-                  "heading": "6507",
-                  "subdivision": "Headgear and parts thereof",
-                  "min": "6507000000",
                   "max": "6507999999",
                   "rules": [
                         {
@@ -14963,8 +11161,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 65
+                  "valid": true
             },
             {
                   "heading": "6601",
@@ -14988,30 +11185,10 @@
                   "valid": true
             },
             {
-                  "heading": "6602",
+                  "heading": "ex Chapter 66",
+                  "chapter": 66,
                   "subdivision": "Umbrellas, sun umbrellas, walking-sticks, seat-sticks, whips, riding-crops, and parts thereof",
                   "min": "6602000000",
-                  "max": "6602999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 66
-            },
-            {
-                  "heading": "6603",
-                  "subdivision": "Umbrellas, sun umbrellas, walking-sticks, seat-sticks, whips, riding-crops, and parts thereof",
-                  "min": "6603000000",
                   "max": "6603999999",
                   "rules": [
                         {
@@ -15026,8 +11203,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 66
+                  "valid": true
             },
             {
                   "heading": "Chapter 67",
@@ -15054,8 +11230,8 @@
                   "heading": "ex Chapter 68",
                   "chapter": 68,
                   "subdivision": "Articles of stone, plaster, cement, asbestos, mica or similar materials",
-                  "min": "6800000000",
-                  "max": "6899999999",
+                  "min": "6801000000",
+                  "max": "6801999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product.",
@@ -15093,6 +11269,27 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 68",
+                  "chapter": 68,
+                  "subdivision": "Any other product from heading 6802",
+                  "min": "6802000000",
+                  "max": "6802999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 6803",
                   "chapter": 68,
                   "subdivision": "Articles of slate or of agglomerated slate",
@@ -15103,6 +11300,48 @@
                               "rule": "Manufacture from worked slate.",
                               "class": [
                                     "PRODUCTION FROM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 68",
+                  "chapter": 68,
+                  "subdivision": "Any other product from heading 6803",
+                  "min": "6803000000",
+                  "max": "6803999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 68",
+                  "chapter": 68,
+                  "subdivision": "Articles of stone, plaster, cement, asbestos, mica or similar materials",
+                  "min": "6804000000",
+                  "max": "6811999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -15135,6 +11374,48 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 68",
+                  "chapter": 68,
+                  "subdivision": "Any other product from heading 6812",
+                  "min": "6812000000",
+                  "max": "6812999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 68",
+                  "chapter": 68,
+                  "subdivision": "Articles of stone, plaster, cement, asbestos, mica or similar materials",
+                  "min": "6813000000",
+                  "max": "6813999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 6814",
                   "chapter": 68,
                   "subdivision": "Articles of mica, including agglomerated or reconstituted mica, on a support of paper, paperboard or other materials",
@@ -15145,6 +11426,48 @@
                               "rule": "Manufacture from worked mica (including agglomerated or reconstituted mica).",
                               "class": [
                                     "PRODUCTION FROM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 68",
+                  "chapter": 68,
+                  "subdivision": "Any other product from heading 6814",
+                  "min": "6814000000",
+                  "max": "6814999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 68",
+                  "chapter": 68,
+                  "subdivision": "Articles of stone, plaster, cement, asbestos, mica or similar materials",
+                  "min": "6815000000",
+                  "max": "6815999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -15177,31 +11500,10 @@
                   "valid": true
             },
             {
-                  "heading": "7001",
+                  "heading": "ex Chapter 70",
                   "chapter": 70,
                   "subdivision": "Glass and glassware",
                   "min": "7001000000",
-                  "max": "7001999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7002",
-                  "chapter": 70,
-                  "subdivision": "Glass and glassware",
-                  "min": "7002000000",
                   "max": "7002999999",
                   "rules": [
                         {
@@ -15240,9 +11542,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7003",
+                  "heading": "ex Chapter 70",
                   "chapter": 70,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7003",
                   "min": "7003000000",
                   "max": "7003999999",
                   "rules": [
@@ -15282,9 +11584,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7004",
+                  "heading": "ex Chapter 70",
                   "chapter": 70,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7004",
                   "min": "7004000000",
                   "max": "7004999999",
                   "rules": [
@@ -15324,9 +11626,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7005",
+                  "heading": "ex Chapter 70",
                   "chapter": 70,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7005",
                   "min": "7005000000",
                   "max": "7005999999",
                   "rules": [
@@ -15482,7 +11784,7 @@
                   "valid": true
             },
             {
-                  "heading": "7011",
+                  "heading": "ex Chapter 70",
                   "chapter": 70,
                   "subdivision": "Glass and glassware",
                   "min": "7011000000",
@@ -15546,94 +11848,10 @@
                   "valid": true
             },
             {
-                  "heading": "7014",
+                  "heading": "ex Chapter 70",
                   "chapter": 70,
                   "subdivision": "Glass and glassware",
                   "min": "7014000000",
-                  "max": "7014999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7015",
-                  "chapter": 70,
-                  "subdivision": "Glass and glassware",
-                  "min": "7015000000",
-                  "max": "7015999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7016",
-                  "chapter": 70,
-                  "subdivision": "Glass and glassware",
-                  "min": "7016000000",
-                  "max": "7016999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7017",
-                  "chapter": 70,
-                  "subdivision": "Glass and glassware",
-                  "min": "7017000000",
-                  "max": "7017999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7018",
-                  "chapter": 70,
-                  "subdivision": "Glass and glassware",
-                  "min": "7018000000",
                   "max": "7018999999",
                   "rules": [
                         {
@@ -15658,17 +11876,10 @@
                   "max": "7019999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Uncoloured slivers, rovings, yarn or chopped strands, or\n\nglass wool.",
-                              "class": [],
+                              "rule": "Manufacture from:\n\n- uncoloured slivers, rovings, yarn or chopped strands, *or*\n\n- glass wool.",
+                              "class": [
+                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM"
+                              ],
                               "footnotes": [],
                               "operator": null,
                               "quota": false,
@@ -15679,9 +11890,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7019",
+                  "heading": "ex Chapter 70",
                   "chapter": 70,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7019",
                   "min": "7019000000",
                   "max": "7019999999",
                   "rules": [
@@ -15700,7 +11911,7 @@
                   "valid": true
             },
             {
-                  "heading": "7020",
+                  "heading": "ex Chapter 70",
                   "chapter": 70,
                   "subdivision": "Glass and glassware",
                   "min": "7020000000",
@@ -15742,9 +11953,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7101",
+                  "heading": "ex Chapter 71",
                   "chapter": 71,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7101",
                   "min": "7101000000",
                   "max": "7101999999",
                   "rules": [
@@ -15784,9 +11995,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7102",
+                  "heading": "ex Chapter 71",
                   "chapter": 71,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7102",
                   "min": "7102000000",
                   "max": "7102999999",
                   "rules": [
@@ -15826,9 +12037,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7103",
+                  "heading": "ex Chapter 71",
                   "chapter": 71,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7103",
                   "min": "7103000000",
                   "max": "7103999999",
                   "rules": [
@@ -15868,9 +12079,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7104",
+                  "heading": "ex Chapter 71",
                   "chapter": 71,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7104",
                   "min": "7104000000",
                   "max": "7104999999",
                   "rules": [
@@ -15889,9 +12100,9 @@
                   "valid": true
             },
             {
-                  "heading": "7105",
+                  "heading": "ex Chapter 71",
                   "chapter": 71,
-                  "subdivision": "Natural or cultured pearls, precious or semi-precious stones, precious metals, metals clad with precious metal, and articles thereof; imitation jewellery; coin; except for;",
+                  "subdivision": "Natural or cultured pearls, precious or semi-precious stones, precious metals, metals clad with precious metal, and articles thereof; imitation jewellery; coin",
                   "min": "7105000000",
                   "max": "7105999999",
                   "rules": [
@@ -15926,17 +12137,7 @@
                               "quota": false,
                               "import": true,
                               "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7106",
-                  "chapter": 71,
-                  "subdivision": "",
-                  "min": "7106000000",
-                  "max": "7106999999",
-                  "rules": [
+                        },
                         {
                               "rule": "Electrolytic, thermal or chemical separation of precious metals of [heading&nbsp;7106](/headings/7106), [heading&nbsp;7108](/headings/7108) or [heading&nbsp;7110](/headings/7110).",
                               "class": [],
@@ -16001,9 +12202,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7107",
+                  "heading": "ex Chapter 71",
                   "chapter": 71,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7107",
                   "min": "7107000000",
                   "max": "7107999999",
                   "rules": [
@@ -16073,7 +12274,7 @@
             {
                   "heading": "7108",
                   "chapter": 71,
-                  "subdivision": "Precious metals; \u25b8 Semi-manufactured or in powder form",
+                  "subdivision": " \u25b8 Semi-manufactured or in powder form",
                   "min": "7108000000",
                   "max": "7108999999",
                   "rules": [
@@ -16113,9 +12314,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7109",
+                  "heading": "ex Chapter 71",
                   "chapter": 71,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7109",
                   "min": "7109000000",
                   "max": "7109999999",
                   "rules": [
@@ -16150,17 +12351,7 @@
                               "quota": false,
                               "import": true,
                               "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7110",
-                  "chapter": 71,
-                  "subdivision": "",
-                  "min": "7110000000",
-                  "max": "7110999999",
-                  "rules": [
+                        },
                         {
                               "rule": "Electrolytic, thermal or chemical separation of precious metals of [heading&nbsp;7106](/headings/7106), [heading&nbsp;7108](/headings/7108) or [heading&nbsp;7110](/headings/7110).",
                               "class": [],
@@ -16225,9 +12416,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7111",
+                  "heading": "ex Chapter 71",
                   "chapter": 71,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7111",
                   "min": "7111000000",
                   "max": "7111999999",
                   "rules": [
@@ -16246,73 +12437,10 @@
                   "valid": true
             },
             {
-                  "heading": "7112",
+                  "heading": "ex Chapter 71",
                   "chapter": 71,
-                  "subdivision": "Natural or cultured pearls, precious or semi-precious stones, precious metals, metals clad with precious metal, and articles thereof; imitation jewellery; coin; except for;",
+                  "subdivision": "Natural or cultured pearls, precious or semi-precious stones, precious metals, metals clad with precious metal, and articles thereof; imitation jewellery; coin",
                   "min": "7112000000",
-                  "max": "7112999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7113",
-                  "chapter": 71,
-                  "subdivision": "Natural or cultured pearls, precious or semi-precious stones, precious metals, metals clad with precious metal, and articles thereof; imitation jewellery; coin; except for;",
-                  "min": "7113000000",
-                  "max": "7113999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7114",
-                  "chapter": 71,
-                  "subdivision": "Natural or cultured pearls, precious or semi-precious stones, precious metals, metals clad with precious metal, and articles thereof; imitation jewellery; coin; except for;",
-                  "min": "7114000000",
-                  "max": "7114999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7115",
-                  "chapter": 71,
-                  "subdivision": "Natural or cultured pearls, precious or semi-precious stones, precious metals, metals clad with precious metal, and articles thereof; imitation jewellery; coin; except for;",
-                  "min": "7115000000",
                   "max": "7115999999",
                   "rules": [
                         {
@@ -16383,9 +12511,9 @@
                   "valid": true
             },
             {
-                  "heading": "7118",
+                  "heading": "ex Chapter 71",
                   "chapter": 71,
-                  "subdivision": "Natural or cultured pearls, precious or semi-precious stones, precious metals, metals clad with precious metal, and articles thereof; imitation jewellery; coin; except for;",
+                  "subdivision": "Natural or cultured pearls, precious or semi-precious stones, precious metals, metals clad with precious metal, and articles thereof; imitation jewellery; coin",
                   "min": "7118000000",
                   "max": "7118999999",
                   "rules": [
@@ -16408,133 +12536,7 @@
                   "chapter": 72,
                   "subdivision": "Iron and steel",
                   "min": "7201000000",
-                  "max": "7201999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7202000000",
-                  "max": "7202999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7203000000",
-                  "max": "7203999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7204000000",
-                  "max": "7204999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7205000000",
-                  "max": "7205999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7206000000",
                   "max": "7206999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7207000000",
-                  "max": "7207999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product.",
@@ -16572,394 +12574,16 @@
                   "valid": true
             },
             {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7208000000",
-                  "max": "7208999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7208-7216",
+                  "heading": "7208 to 7216",
                   "chapter": 72,
                   "subdivision": "Flat-rolled products, bars and rods, angles, shapes and sections of iron or non-alloy steel",
                   "min": "7208000000",
-                  "max": "7208999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from ingots or other primary forms or semi-finished materials of [heading&nbsp;7206](/headings/7206) or [heading&nbsp;7207](/headings/7207).",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7209000000",
-                  "max": "7209999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7208-7216",
-                  "chapter": 72,
-                  "subdivision": "Flat-rolled products, bars and rods, angles, shapes and sections of iron or non-alloy steel",
-                  "min": "7209000000",
-                  "max": "7209999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from ingots or other primary forms or semi-finished materials of [heading&nbsp;7206](/headings/7206) or [heading&nbsp;7207](/headings/7207).",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7210000000",
-                  "max": "7210999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7208-7216",
-                  "chapter": 72,
-                  "subdivision": "Flat-rolled products, bars and rods, angles, shapes and sections of iron or non-alloy steel",
-                  "min": "7210000000",
-                  "max": "7210999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from ingots or other primary forms or semi-finished materials of [heading&nbsp;7206](/headings/7206) or [heading&nbsp;7207](/headings/7207).",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7211000000",
-                  "max": "7211999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7208-7216",
-                  "chapter": 72,
-                  "subdivision": "Flat-rolled products, bars and rods, angles, shapes and sections of iron or non-alloy steel",
-                  "min": "7211000000",
-                  "max": "7211999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from ingots or other primary forms or semi-finished materials of [heading&nbsp;7206](/headings/7206) or [heading&nbsp;7207](/headings/7207).",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7212000000",
-                  "max": "7212999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7208-7216",
-                  "chapter": 72,
-                  "subdivision": "Flat-rolled products, bars and rods, angles, shapes and sections of iron or non-alloy steel",
-                  "min": "7212000000",
-                  "max": "7212999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from ingots or other primary forms or semi-finished materials of [heading&nbsp;7206](/headings/7206) or [heading&nbsp;7207](/headings/7207).",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7213000000",
-                  "max": "7213999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7208-7216",
-                  "chapter": 72,
-                  "subdivision": "Flat-rolled products, bars and rods, angles, shapes and sections of iron or non-alloy steel",
-                  "min": "7213000000",
-                  "max": "7213999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from ingots or other primary forms or semi-finished materials of [heading&nbsp;7206](/headings/7206) or [heading&nbsp;7207](/headings/7207).",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7214000000",
-                  "max": "7214999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7208-7216",
-                  "chapter": 72,
-                  "subdivision": "Flat-rolled products, bars and rods, angles, shapes and sections of iron or non-alloy steel",
-                  "min": "7214000000",
-                  "max": "7214999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from ingots or other primary forms or semi-finished materials of [heading&nbsp;7206](/headings/7206) or [heading&nbsp;7207](/headings/7207).",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7215000000",
-                  "max": "7215999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7208-7216",
-                  "chapter": 72,
-                  "subdivision": "Flat-rolled products, bars and rods, angles, shapes and sections of iron or non-alloy steel",
-                  "min": "7215000000",
-                  "max": "7215999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from ingots or other primary forms or semi-finished materials of [heading&nbsp;7206](/headings/7206) or [heading&nbsp;7207](/headings/7207).",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7216000000",
-                  "max": "7216999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7208-7216",
-                  "chapter": 72,
-                  "subdivision": "Flat-rolled products, bars and rods, angles, shapes and sections of iron or non-alloy steel",
-                  "min": "7216000000",
                   "max": "7216999999",
                   "rules": [
                         {
                               "rule": "Manufacture from ingots or other primary forms or semi-finished materials of [heading&nbsp;7206](/headings/7206) or [heading&nbsp;7207](/headings/7207).",
                               "class": [
                                     "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7217000000",
-                  "max": "7217999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -16992,48 +12616,6 @@
                   "valid": true
             },
             {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7218100000",
-                  "max": "7218199999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7218910000",
-                  "max": "7218919999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "ex 721891",
                   "chapter": 72,
                   "subdivision": "Semi-finished products",
@@ -17044,27 +12626,6 @@
                               "rule": "Manufacture from materials of [heading&nbsp;7201](/headings/7201), [heading&nbsp;7202](/headings/7202), [heading&nbsp;7203](/headings/7203), [heading&nbsp;7204](/headings/7204), [heading&nbsp;7205](/headings/7205) or 721810.",
                               "class": [
                                     "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7218990000",
-                  "max": "7218999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -17099,9 +12660,9 @@
             {
                   "heading": "ex Chapter 72",
                   "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7219000000",
-                  "max": "7219999999",
+                  "subdivision": "Any other product from heading 7218",
+                  "min": "7218000000",
+                  "max": "7218999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product.",
@@ -17118,163 +12679,16 @@
                   "valid": true
             },
             {
-                  "heading": "7219-7222",
+                  "heading": "7219 to 7222",
                   "chapter": 72,
                   "subdivision": "Flat-rolled products, bars and rods, angles, shapes and sections of stainless steel",
                   "min": "7219000000",
-                  "max": "7219999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from ingots or other primary forms or semi-finished materials of [heading&nbsp;7218](/headings/7218).",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7220000000",
-                  "max": "7220999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7219-7222",
-                  "chapter": 72,
-                  "subdivision": "Flat-rolled products, bars and rods, angles, shapes and sections of stainless steel",
-                  "min": "7220000000",
-                  "max": "7220999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from ingots or other primary forms or semi-finished materials of [heading&nbsp;7218](/headings/7218).",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7221000000",
-                  "max": "7221999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7219-7222",
-                  "chapter": 72,
-                  "subdivision": "Flat-rolled products, bars and rods, angles, shapes and sections of stainless steel",
-                  "min": "7221000000",
-                  "max": "7221999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from ingots or other primary forms or semi-finished materials of [heading&nbsp;7218](/headings/7218).",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7222000000",
-                  "max": "7222999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7219-7222",
-                  "chapter": 72,
-                  "subdivision": "Flat-rolled products, bars and rods, angles, shapes and sections of stainless steel",
-                  "min": "7222000000",
                   "max": "7222999999",
                   "rules": [
                         {
                               "rule": "Manufacture from ingots or other primary forms or semi-finished materials of [heading&nbsp;7218](/headings/7218).",
                               "class": [
                                     "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7223000000",
-                  "max": "7223999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -17307,53 +12721,11 @@
                   "valid": true
             },
             {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7224100000",
-                  "max": "7224199999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7224900000",
-                  "max": "7224999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "ex 722490",
                   "chapter": 72,
                   "subdivision": "Semi-finished products",
                   "min": "7224900000",
-                  "max": "7224999999",
+                  "max": "7224909999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of [heading&nbsp;7201](/headings/7201), [heading&nbsp;7202](/headings/7202), [heading&nbsp;7203](/headings/7203), [heading&nbsp;7204](/headings/7204), [heading&nbsp;7205](/headings/7205) or 722410.",
@@ -17372,9 +12744,9 @@
             {
                   "heading": "ex Chapter 72",
                   "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7225000000",
-                  "max": "7225999999",
+                  "subdivision": "Any other product from heading 7224",
+                  "min": "7224000000",
+                  "max": "7224999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product.",
@@ -17391,163 +12763,16 @@
                   "valid": true
             },
             {
-                  "heading": "7225-7228",
+                  "heading": "7225 to 7228",
                   "chapter": 72,
                   "subdivision": "Flat-rolled products, hot-rolled bars and rods, in irregularly wound coils; angles, shapes and sections, of other alloy steel; hollow drill bars and rods, of alloy or non-alloy steel",
                   "min": "7225000000",
-                  "max": "7225999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from ingots or other primary forms or semi-finished materials of [heading&nbsp;7206](/headings/7206), [heading&nbsp;7207](/headings/7207), [heading&nbsp;7218](/headings/7218) or [heading&nbsp;7224](/headings/7224).",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7226000000",
-                  "max": "7226999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7225-7228",
-                  "chapter": 72,
-                  "subdivision": "Flat-rolled products, hot-rolled bars and rods, in irregularly wound coils; angles, shapes and sections, of other alloy steel; hollow drill bars and rods, of alloy or non-alloy steel",
-                  "min": "7226000000",
-                  "max": "7226999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from ingots or other primary forms or semi-finished materials of [heading&nbsp;7206](/headings/7206), [heading&nbsp;7207](/headings/7207), [heading&nbsp;7218](/headings/7218) or [heading&nbsp;7224](/headings/7224).",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7227000000",
-                  "max": "7227999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7225-7228",
-                  "chapter": 72,
-                  "subdivision": "Flat-rolled products, hot-rolled bars and rods, in irregularly wound coils; angles, shapes and sections, of other alloy steel; hollow drill bars and rods, of alloy or non-alloy steel",
-                  "min": "7227000000",
-                  "max": "7227999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from ingots or other primary forms or semi-finished materials of [heading&nbsp;7206](/headings/7206), [heading&nbsp;7207](/headings/7207), [heading&nbsp;7218](/headings/7218) or [heading&nbsp;7224](/headings/7224).",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7228000000",
-                  "max": "7228999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7225-7228",
-                  "chapter": 72,
-                  "subdivision": "Flat-rolled products, hot-rolled bars and rods, in irregularly wound coils; angles, shapes and sections, of other alloy steel; hollow drill bars and rods, of alloy or non-alloy steel",
-                  "min": "7228000000",
                   "max": "7228999999",
                   "rules": [
                         {
                               "rule": "Manufacture from ingots or other primary forms or semi-finished materials of [heading&nbsp;7206](/headings/7206), [heading&nbsp;7207](/headings/7207), [heading&nbsp;7218](/headings/7218) or [heading&nbsp;7224](/headings/7224).",
                               "class": [
                                     "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "ex Chapter 72",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7229000000",
-                  "max": "7229999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -17601,9 +12826,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7301",
+                  "heading": "ex Chapter 73",
                   "chapter": 73,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7301",
                   "min": "7301000000",
                   "max": "7301999999",
                   "rules": [
@@ -17643,7 +12868,7 @@
                   "valid": true
             },
             {
-                  "heading": "7303",
+                  "heading": "ex Chapter 73",
                   "chapter": 73,
                   "subdivision": "Articles of iron or steel",
                   "min": "7303000000",
@@ -17664,7 +12889,7 @@
                   "valid": true
             },
             {
-                  "heading": "7304-7306",
+                  "heading": "7304 to 7306",
                   "chapter": 73,
                   "subdivision": "Tubes, pipes and hollow profiles, of iron (other than cast iron) or steel",
                   "min": "7304000000",
@@ -17707,9 +12932,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7307",
+                  "heading": "ex Chapter 73",
                   "chapter": 73,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7307",
                   "min": "7307000000",
                   "max": "7307999999",
                   "rules": [
@@ -17749,115 +12974,10 @@
                   "valid": true
             },
             {
-                  "heading": "7309",
+                  "heading": "ex Chapter 73",
                   "chapter": 73,
                   "subdivision": "Articles of iron or steel",
                   "min": "7309000000",
-                  "max": "7309999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7310",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7310000000",
-                  "max": "7310999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7311",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7311000000",
-                  "max": "7311999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7312",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7312000000",
-                  "max": "7312999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7313",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7313000000",
-                  "max": "7313999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7314",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7314000000",
                   "max": "7314999999",
                   "rules": [
                         {
@@ -17896,9 +13016,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7315",
+                  "heading": "ex Chapter 73",
                   "chapter": 73,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7315",
                   "min": "7315000000",
                   "max": "7315999999",
                   "rules": [
@@ -17917,220 +13037,10 @@
                   "valid": true
             },
             {
-                  "heading": "7316",
+                  "heading": "ex Chapter 73",
                   "chapter": 73,
                   "subdivision": "Articles of iron or steel",
                   "min": "7316000000",
-                  "max": "7316999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7317",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7317000000",
-                  "max": "7317999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7318",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7318000000",
-                  "max": "7318999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7319",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7319000000",
-                  "max": "7319999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7320",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7320000000",
-                  "max": "7320999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7321",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7321000000",
-                  "max": "7321999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7322",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7322000000",
-                  "max": "7322999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7323",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7323000000",
-                  "max": "7323999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7324",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7324000000",
-                  "max": "7324999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7325",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7325000000",
-                  "max": "7325999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7326",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7326000000",
                   "max": "7326999999",
                   "rules": [
                         {
@@ -18274,145 +13184,14 @@
                   "valid": true
             },
             {
-                  "heading": "7406",
+                  "heading": "ex Chapter 74",
+                  "chapter": 74,
                   "subdivision": "Copper and articles thereof",
                   "min": "7406000000",
-                  "max": "7406999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 74
-            },
-            {
-                  "heading": "7407",
-                  "subdivision": "Copper and articles thereof",
-                  "min": "7407000000",
-                  "max": "7407999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 74
-            },
-            {
-                  "heading": "7408",
-                  "subdivision": "Copper and articles thereof",
-                  "min": "7408000000",
-                  "max": "7408999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 74
-            },
-            {
-                  "heading": "7409",
-                  "subdivision": "Copper and articles thereof",
-                  "min": "7409000000",
-                  "max": "7409999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 74
-            },
-            {
-                  "heading": "7410",
-                  "subdivision": "Copper and articles thereof",
-                  "min": "7410000000",
-                  "max": "7410999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 74
-            },
-            {
-                  "heading": "7411",
-                  "subdivision": "Copper and articles thereof",
-                  "min": "7411000000",
-                  "max": "7411999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 74
-            },
-            {
-                  "heading": "7412",
-                  "subdivision": "Copper and articles thereof",
-                  "min": "7412000000",
                   "max": "7412999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture:\n\nfrom materials of any heading, except that of the product, *and*\n\nin which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM",
                                     "CTH"
@@ -18424,8 +13203,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 74
+                  "valid": true
             },
             {
                   "heading": "7413",
@@ -18449,57 +13227,14 @@
                   "valid": true
             },
             {
-                  "heading": "7415",
+                  "heading": "ex Chapter 74",
+                  "chapter": 74,
                   "subdivision": "Copper and articles thereof",
                   "min": "7415000000",
-                  "max": "7415999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 74
-            },
-            {
-                  "heading": "7418",
-                  "subdivision": "Copper and articles thereof",
-                  "min": "7418000000",
-                  "max": "7418999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 74
-            },
-            {
-                  "heading": "7419",
-                  "subdivision": "Copper and articles thereof",
-                  "min": "7419000000",
                   "max": "7419999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture:\n\nfrom materials of any heading, except that of the product, *and*\n\nin which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM",
                                     "CTH"
@@ -18511,11 +13246,10 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 74
+                  "valid": true
             },
             {
-                  "heading": "7501-7503",
+                  "heading": "7501 to 7503",
                   "chapter": 75,
                   "subdivision": "Nickel mattes, nickel oxide sinters and other intermediate products of nickel metallurgy; unwrought nickel; nickel waste and scrap",
                   "min": "7501000000",
@@ -18536,97 +13270,10 @@
                   "valid": true
             },
             {
-                  "heading": "7504",
+                  "heading": "ex Chapter 75",
+                  "chapter": 75,
                   "subdivision": "Nickel and articles thereof",
                   "min": "7504000000",
-                  "max": "7504999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 75
-            },
-            {
-                  "heading": "7505",
-                  "subdivision": "Nickel and articles thereof",
-                  "min": "7505000000",
-                  "max": "7505999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 75
-            },
-            {
-                  "heading": "7506",
-                  "subdivision": "Nickel and articles thereof",
-                  "min": "7506000000",
-                  "max": "7506999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 75
-            },
-            {
-                  "heading": "7507",
-                  "subdivision": "Nickel and articles thereof",
-                  "min": "7507000000",
-                  "max": "7507999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 75
-            },
-            {
-                  "heading": "7508",
-                  "subdivision": "Nickel and articles thereof",
-                  "min": "7508000000",
                   "max": "7508999999",
                   "rules": [
                         {
@@ -18642,8 +13289,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 75
+                  "valid": true
             },
             {
                   "heading": "7601",
@@ -18698,76 +13344,10 @@
                   "valid": true
             },
             {
-                  "heading": "7603",
+                  "heading": "ex Chapter 76",
                   "chapter": 76,
                   "subdivision": "Aluminium and articles thereof",
                   "min": "7603000000",
-                  "max": "7603999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7604",
-                  "chapter": 76,
-                  "subdivision": "Aluminium and articles thereof",
-                  "min": "7604000000",
-                  "max": "7604999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7605",
-                  "chapter": 76,
-                  "subdivision": "Aluminium and articles thereof",
-                  "min": "7605000000",
-                  "max": "7605999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7606",
-                  "chapter": 76,
-                  "subdivision": "Aluminium and articles thereof",
-                  "min": "7606000000",
                   "max": "7606999999",
                   "rules": [
                         {
@@ -18807,32 +13387,10 @@
                   "valid": true
             },
             {
-                  "heading": "7608",
+                  "heading": "ex Chapter 76",
                   "chapter": 76,
                   "subdivision": "Aluminium and articles thereof",
                   "min": "7608000000",
-                  "max": "7608999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7609",
-                  "chapter": 76,
-                  "subdivision": "Aluminium and articles thereof",
-                  "min": "7609000000",
                   "max": "7609999999",
                   "rules": [
                         {
@@ -18872,54 +13430,10 @@
                   "valid": true
             },
             {
-                  "heading": "7611",
+                  "heading": "ex Chapter 76",
                   "chapter": 76,
                   "subdivision": "Aluminium and articles thereof",
                   "min": "7611000000",
-                  "max": "7611999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7612",
-                  "chapter": 76,
-                  "subdivision": "Aluminium and articles thereof",
-                  "min": "7612000000",
-                  "max": "7612999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7613",
-                  "chapter": 76,
-                  "subdivision": "Aluminium and articles thereof",
-                  "min": "7613000000",
                   "max": "7613999999",
                   "rules": [
                         {
@@ -18959,7 +13473,7 @@
                   "valid": true
             },
             {
-                  "heading": "7615",
+                  "heading": "ex Chapter 76",
                   "chapter": 76,
                   "subdivision": "Aluminium and articles thereof",
                   "min": "7615000000",
@@ -18988,7 +13502,7 @@
                   "max": "7616999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product. \n\n- However, gauze, cloth, grill, netting, fencing, reinforcing fabric and similar materials (including endless bands) of aluminium wire, or expanded metal of aluminium may be used *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture from:\n\n- materials of any heading, except that of the product. However, gauze, cloth, grill, netting, fencing, reinforcing fabric and similar materials (including endless bands) of aluminium wire, or expanded metal of aluminium may be used, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM",
                                     "CTH TOLERANCE MAY BE USED"
@@ -19003,9 +13517,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7616",
+                  "heading": "ex Chapter 76",
                   "chapter": 76,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7616",
                   "min": "7616000000",
                   "max": "7616999999",
                   "rules": [
@@ -19088,31 +13602,10 @@
                   "valid": true
             },
             {
-                  "heading": "7804",
-                  "subdivision": "Lead and articles thereof; except for;",
+                  "heading": "ex Chapter 78",
+                  "chapter": 78,
+                  "subdivision": "Lead and articles thereof",
                   "min": "7804000000",
-                  "max": "7804999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 78
-            },
-            {
-                  "heading": "7806",
-                  "subdivision": "Lead and articles thereof; except for;",
-                  "min": "7806000000",
                   "max": "7806999999",
                   "rules": [
                         {
@@ -19128,8 +13621,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 78
+                  "valid": true
             },
             {
                   "heading": "7901",
@@ -19174,75 +13666,10 @@
                   "valid": true
             },
             {
-                  "heading": "7903",
+                  "heading": "ex Chapter 79",
+                  "chapter": 79,
                   "subdivision": "Zinc and articles thereof",
                   "min": "7903000000",
-                  "max": "7903999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 79
-            },
-            {
-                  "heading": "7904",
-                  "subdivision": "Zinc and articles thereof",
-                  "min": "7904000000",
-                  "max": "7904999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 79
-            },
-            {
-                  "heading": "7905",
-                  "subdivision": "Zinc and articles thereof",
-                  "min": "7905000000",
-                  "max": "7905999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 79
-            },
-            {
-                  "heading": "7907",
-                  "subdivision": "Zinc and articles thereof",
-                  "min": "7907000000",
                   "max": "7907999999",
                   "rules": [
                         {
@@ -19258,8 +13685,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 79
+                  "valid": true
             },
             {
                   "heading": "8001",
@@ -19304,8 +13730,9 @@
                   "valid": true
             },
             {
-                  "heading": "8003",
-                  "subdivision": "Tin and articles thereof; except for;",
+                  "heading": "ex Chapter 80",
+                  "chapter": 80,
+                  "subdivision": "Tin and articles thereof",
                   "min": "8003000000",
                   "max": "8003999999",
                   "rules": [
@@ -19322,8 +13749,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 80
+                  "valid": true
             },
             {
                   "heading": "8007",
@@ -19347,10 +13773,11 @@
                   "valid": true
             },
             {
-                  "heading": "8101",
+                  "heading": "Chapter 81",
+                  "chapter": 81,
                   "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8101000000",
-                  "max": "8101999999",
+                  "min": "8100000000",
+                  "max": "8199999999",
                   "rules": [
                         {
                               "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
@@ -19364,14 +13791,14 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 81
+                  "valid": true
             },
             {
-                  "heading": "8101",
+                  "heading": "Chapter 81",
+                  "chapter": 81,
                   "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other",
-                  "min": "8101000000",
-                  "max": "8101999999",
+                  "min": "8100000000",
+                  "max": "8199999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product.",
@@ -19385,560 +13812,13 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 81
+                  "valid": true
             },
             {
-                  "heading": "8102",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8102000000",
-                  "max": "8102999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8102",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other",
-                  "min": "8102000000",
-                  "max": "8102999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8103",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8103000000",
-                  "max": "8103999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8103",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other",
-                  "min": "8103000000",
-                  "max": "8103999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8104",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8104000000",
-                  "max": "8104999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8104",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other",
-                  "min": "8104000000",
-                  "max": "8104999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8105",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8105000000",
-                  "max": "8105999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8105",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other",
-                  "min": "8105000000",
-                  "max": "8105999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8106",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8106000000",
-                  "max": "8106999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8106",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other",
-                  "min": "8106000000",
-                  "max": "8106999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8108",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8108000000",
-                  "max": "8108999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8108",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other",
-                  "min": "8108000000",
-                  "max": "8108999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8109",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8109000000",
-                  "max": "8109999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8109",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other",
-                  "min": "8109000000",
-                  "max": "8109999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8110",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8110000000",
-                  "max": "8110999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8110",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other",
-                  "min": "8110000000",
-                  "max": "8110999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8111",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8111000000",
-                  "max": "8111999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8111",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other",
-                  "min": "8111000000",
-                  "max": "8111999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8112",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8112000000",
-                  "max": "8112999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8112",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other",
-                  "min": "8112000000",
-                  "max": "8112999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8113",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8113000000",
-                  "max": "8113999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8113",
-                  "subdivision": "Other base metals; cermets; articles thereof; \u25b8 Other",
-                  "min": "8113000000",
-                  "max": "8113999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8201",
+                  "heading": "ex Chapter 82",
                   "chapter": 82,
                   "subdivision": "Tools, implements, cutlery, spoons and forks, of base metal; parts thereof of base metal",
                   "min": "8201000000",
-                  "max": "8201999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8202",
-                  "chapter": 82,
-                  "subdivision": "Tools, implements, cutlery, spoons and forks, of base metal; parts thereof of base metal",
-                  "min": "8202000000",
-                  "max": "8202999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8203",
-                  "chapter": 82,
-                  "subdivision": "Tools, implements, cutlery, spoons and forks, of base metal; parts thereof of base metal",
-                  "min": "8203000000",
-                  "max": "8203999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8204",
-                  "chapter": 82,
-                  "subdivision": "Tools, implements, cutlery, spoons and forks, of base metal; parts thereof of base metal",
-                  "min": "8204000000",
-                  "max": "8204999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8205",
-                  "chapter": 82,
-                  "subdivision": "Tools, implements, cutlery, spoons and forks, of base metal; parts thereof of base metal",
-                  "min": "8205000000",
                   "max": "8205999999",
                   "rules": [
                         {
@@ -20022,31 +13902,10 @@
                   "valid": true
             },
             {
-                  "heading": "8209",
+                  "heading": "ex Chapter 82",
                   "chapter": 82,
                   "subdivision": "Tools, implements, cutlery, spoons and forks, of base metal; parts thereof of base metal",
                   "min": "8209000000",
-                  "max": "8209999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8210",
-                  "chapter": 82,
-                  "subdivision": "Tools, implements, cutlery, spoons and forks, of base metal; parts thereof of base metal",
-                  "min": "8210000000",
                   "max": "8210999999",
                   "rules": [
                         {
@@ -20085,9 +13944,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8211",
+                  "heading": "ex Chapter 82",
                   "chapter": 82,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8211",
                   "min": "8211000000",
                   "max": "8211999999",
                   "rules": [
@@ -20106,31 +13965,10 @@
                   "valid": true
             },
             {
-                  "heading": "8212",
+                  "heading": "ex Chapter 82",
                   "chapter": 82,
                   "subdivision": "Tools, implements, cutlery, spoons and forks, of base metal; parts thereof of base metal",
                   "min": "8212000000",
-                  "max": "8212999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8213",
-                  "chapter": 82,
-                  "subdivision": "Tools, implements, cutlery, spoons and forks, of base metal; parts thereof of base metal",
-                  "min": "8213000000",
                   "max": "8213999999",
                   "rules": [
                         {
@@ -20192,9 +14030,9 @@
             {
                   "heading": "ex Chapter 83",
                   "chapter": 83,
-                  "subdivision": "Miscellaneous articles of base metal; except for;",
-                  "min": "8300000000",
-                  "max": "8399999999",
+                  "subdivision": "Miscellaneous articles of base metal",
+                  "min": "8301000000",
+                  "max": "8301999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product.",
@@ -20233,6 +14071,48 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 83",
+                  "chapter": 83,
+                  "subdivision": "Any other product from heading 8302",
+                  "min": "8302000000",
+                  "max": "8302999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 83",
+                  "chapter": 83,
+                  "subdivision": "Miscellaneous articles of base metal",
+                  "min": "8303000000",
+                  "max": "8305999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 8306",
                   "chapter": 83,
                   "subdivision": "Statuettes and other ornaments, of base metal",
@@ -20244,6 +14124,48 @@
                               "class": [
                                     "MAXNOM",
                                     "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 83",
+                  "chapter": 83,
+                  "subdivision": "Any other product from heading 8306",
+                  "min": "8306000000",
+                  "max": "8306999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 83",
+                  "chapter": 83,
+                  "subdivision": "Miscellaneous articles of base metal",
+                  "min": "8307000000",
+                  "max": "8311999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -20287,9 +14209,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8401",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8401",
                   "min": "8401000000",
                   "max": "8401999999",
                   "rules": [
@@ -20406,9 +14328,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8404",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8404",
                   "min": "8404000000",
                   "max": "8404999999",
                   "rules": [
@@ -20428,7 +14350,7 @@
                   "valid": true
             },
             {
-                  "heading": "8405",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8405000000",
@@ -20534,7 +14456,7 @@
                   "valid": true
             },
             {
-                  "heading": "8410",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8410000000",
@@ -20643,9 +14565,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8413",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8413",
                   "min": "8413000000",
                   "max": "8413999999",
                   "rules": [
@@ -20698,9 +14620,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8414",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8414",
                   "min": "8414000000",
                   "max": "8414999999",
                   "rules": [
@@ -20741,32 +14663,10 @@
                   "valid": true
             },
             {
-                  "heading": "8416",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8416000000",
-                  "max": "8416999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8417",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8417000000",
                   "max": "8417999999",
                   "rules": [
                         {
@@ -20850,9 +14750,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8419",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8419",
                   "min": "8419000000",
                   "max": "8419999999",
                   "rules": [
@@ -20904,32 +14804,10 @@
                   "valid": true
             },
             {
-                  "heading": "8421",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8421000000",
-                  "max": "8421999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8422",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8422000000",
                   "max": "8422999999",
                   "rules": [
                         {
@@ -21012,7 +14890,7 @@
                   "valid": true
             },
             {
-                  "heading": "8425-8428",
+                  "heading": "8425 to 8428",
                   "chapter": 84,
                   "subdivision": "Lifting, handling, loading or unloading machinery",
                   "min": "8425000000",
@@ -21150,9 +15028,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8431",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8431",
                   "min": "8431000000",
                   "max": "8431999999",
                   "rules": [
@@ -21172,142 +15050,10 @@
                   "valid": true
             },
             {
-                  "heading": "8432",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8432000000",
-                  "max": "8432999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8433",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8433000000",
-                  "max": "8433999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8434",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8434000000",
-                  "max": "8434999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8435",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8435000000",
-                  "max": "8435999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8436",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8436000000",
-                  "max": "8436999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8437",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8437000000",
-                  "max": "8437999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8438",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8438000000",
                   "max": "8438999999",
                   "rules": [
                         {
@@ -21358,7 +15104,7 @@
                   "valid": true
             },
             {
-                  "heading": "8440",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8440000000",
@@ -21412,7 +15158,7 @@
                   "valid": true
             },
             {
-                  "heading": "8442",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8442000000",
@@ -21455,9 +15201,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8443",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8443",
                   "min": "8443000000",
                   "max": "8443999999",
                   "rules": [
@@ -21477,7 +15223,7 @@
                   "valid": true
             },
             {
-                  "heading": "8444-8447",
+                  "heading": "8444 to 8447",
                   "chapter": 84,
                   "subdivision": "Machines of these headings for use in the textile industry",
                   "min": "8444000000",
@@ -21519,9 +15265,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8448",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8448",
                   "min": "8448000000",
                   "max": "8448999999",
                   "rules": [
@@ -21541,54 +15287,10 @@
                   "valid": true
             },
             {
-                  "heading": "8449",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8449000000",
-                  "max": "8449999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8450",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8450000000",
-                  "max": "8450999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8451",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8451000000",
                   "max": "8451999999",
                   "rules": [
                         {
@@ -21651,54 +15353,10 @@
                   "valid": true
             },
             {
-                  "heading": "8453",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8453000000",
-                  "max": "8453999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8454",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8454000000",
-                  "max": "8454999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8455",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8455000000",
                   "max": "8455999999",
                   "rules": [
                         {
@@ -21717,7 +15375,7 @@
                   "valid": true
             },
             {
-                  "heading": "8456-8466",
+                  "heading": "8456 to 8466",
                   "chapter": 84,
                   "subdivision": "Machine-tools and machines and their parts and accessories of headings 8456 to 8466",
                   "min": "8456000000",
@@ -21738,32 +15396,10 @@
                   "valid": true
             },
             {
-                  "heading": "8467",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8467000000",
-                  "max": "8467999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8468",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8468000000",
                   "max": "8468999999",
                   "rules": [
                         {
@@ -21782,10 +15418,10 @@
                   "valid": true
             },
             {
-                  "heading": "8469-8472",
+                  "heading": "8470 to 8472",
                   "chapter": 84,
                   "subdivision": "Office machines (for example, typewriters, calculating machines, automatic data processing machines, duplicating machines, stapling machines)",
-                  "min": "8469000000",
+                  "min": "8470000000",
                   "max": "8472999999",
                   "rules": [
                         {
@@ -21803,142 +15439,10 @@
                   "valid": true
             },
             {
-                  "heading": "8473",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8473000000",
-                  "max": "8473999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8474",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8474000000",
-                  "max": "8474999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8475",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8475000000",
-                  "max": "8475999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8476",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8476000000",
-                  "max": "8476999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8477",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8477000000",
-                  "max": "8477999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8478",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8478000000",
-                  "max": "8478999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8479",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8479000000",
                   "max": "8479999999",
                   "rules": [
                         {
@@ -21978,7 +15482,7 @@
                   "valid": true
             },
             {
-                  "heading": "8481",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8481000000",
@@ -22033,7 +15537,7 @@
                   "valid": true
             },
             {
-                  "heading": "8483",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8483000000",
@@ -22076,7 +15580,7 @@
                   "valid": true
             },
             {
-                  "heading": "8485",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8485000000",
@@ -22121,7 +15625,7 @@
             {
                   "heading": "ex 8486",
                   "chapter": 84,
-                  "subdivision": "Sewing machines, other than book-sewing machines of heading 8440; furniture, bases and covers specially designed for sewing machines; sewing machine needles \u25b8 moulds, injection or compression types",
+                  "subdivision": "Machine tools for working any material by removal of material, by laser or other light or photon beam, ultrasonic, electrodischarge, electrochemical, electron beam, ionic-beam or plasma arc processes and parts and accessories thereof\nmachine tools (including presses) for working metal by bending, folding, straightening, flattening, and parts and accessories thereof\nmachine tools for working stone, ceramics, concrete, asbestos-cement or like mineral materials or for cold working glass and parts and accessories thereof\nmarking-out instruments which are pattern generating apparatus of a kind used for producing masks or reticles from photoresist coated substrates; parts and accessories thereof \u25b8 Moulds, injection or compression types",
                   "min": "8486000000",
                   "max": "8486999999",
                   "rules": [
@@ -22142,7 +15646,7 @@
             {
                   "heading": "ex 8486",
                   "chapter": 84,
-                  "subdivision": "Sewing machines, other than book-sewing machines of heading 8440; furniture, bases and covers specially designed for sewing machines; sewing machine needles \u25b8 lifting, handing, loading or unloading machinery",
+                  "subdivision": "Machine tools for working any material by removal of material, by laser or other light or photon beam, ultrasonic, electrodischarge, electrochemical, electron beam, ionic-beam or plasma arc processes and parts and accessories thereof\nmachine tools (including presses) for working metal by bending, folding, straightening, flattening, and parts and accessories thereof\nmachine tools for working stone, ceramics, concrete, asbestos-cement or like mineral materials or for cold working glass and parts and accessories thereof\nmarking-out instruments which are pattern generating apparatus of a kind used for producing masks or reticles from photoresist coated substrates; parts and accessories thereof \u25b8 Lifting, handing, loading or unloading machinery",
                   "min": "8486000000",
                   "max": "8486999999",
                   "rules": [
@@ -22172,9 +15676,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8486",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8486",
                   "min": "8486000000",
                   "max": "8486999999",
                   "rules": [
@@ -22222,7 +15726,7 @@
                   "max": "8501999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- the value of all the materials used does not exceed **40%** of the ex-works price of the product, *and*\n\n- within the above limit, the value of all the materials of [heading&nbsp;8503](/headings/8503) used does not exceed **10%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\nthe value of all the materials used does not exceed **40%** of the ex-works price of the product, *and*\n\nwithin the above limit, the value of all the materials of [heading&nbsp;8503](/headings/8503) used does not exceed **10%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -22254,7 +15758,7 @@
                   "max": "8502999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- the value of all the materials used does not exceed **40%** of the ex-works price of the product, *and*\n\n- within the above limit, the value of all the materials of [heading&nbsp;8501](/headings/8501) and [heading&nbsp;8503](/headings/8503) used does not exceed **10%** of the ex-works price of the product.",
+                              "rule": "Manufacture in which:\n\nthe value of all the materials used does not exceed **40%** of the ex-works price of the product, *and*\n\nwithin the above limit, the value of all the materials of [heading&nbsp;8501](/headings/8501) and [heading&nbsp;8503](/headings/8503) used does not exceed **10%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -22279,9 +15783,9 @@
                   "valid": true
             },
             {
-                  "heading": "8503",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles; except for;",
+                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
                   "min": "8503000000",
                   "max": "8503999999",
                   "rules": [
@@ -22333,9 +15837,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8504",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8504",
                   "min": "8504000000",
                   "max": "8504999999",
                   "rules": [
@@ -22366,9 +15870,9 @@
                   "valid": true
             },
             {
-                  "heading": "8505",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles; except for;",
+                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
                   "min": "8505000000",
                   "max": "8505999999",
                   "rules": [
@@ -22463,43 +15967,10 @@
                   "valid": true
             },
             {
-                  "heading": "8508",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles; except for;",
+                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
                   "min": "8508000000",
-                  "max": "8508999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8509",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles; except for;",
-                  "min": "8509000000",
                   "max": "8509999999",
                   "rules": [
                         {
@@ -22562,142 +16033,10 @@
                   "valid": true
             },
             {
-                  "heading": "8511",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles; except for;",
+                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
                   "min": "8511000000",
-                  "max": "8511999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8512",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles; except for;",
-                  "min": "8512000000",
-                  "max": "8512999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8513",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles; except for;",
-                  "min": "8513000000",
-                  "max": "8513999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8514",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles; except for;",
-                  "min": "8514000000",
-                  "max": "8514999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8515",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles; except for;",
-                  "min": "8515000000",
                   "max": "8515999999",
                   "rules": [
                         {
@@ -22793,9 +16132,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8517",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8517",
                   "min": "8517000000",
                   "max": "8517999999",
                   "rules": [
@@ -22859,9 +16198,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8518",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8518",
                   "min": "8518000000",
                   "max": "8518999999",
                   "rules": [
@@ -22981,7 +16320,7 @@
             {
                   "heading": "8523",
                   "chapter": 85,
-                  "subdivision": "Sewing machines, other than book-sewing machines of heading 8440; furniture, bases and covers specially designed for sewing machines; sewing machine needles \u25b8 Unrecorded discs, tapes, solid-state non-volatile storage devices and other media for the recording of sound or of other phenomena, but excluding products of Chapter 37",
+                  "subdivision": "Parts and accessories suitable for use solely or principally with the apparatus of headings 8519 to 8521 \u25b8 Unrecorded discs, tapes, solid-state non-volatile storage devices and other media for the recording of sound or of other phenomena, but excluding products of Chapter 37",
                   "min": "8523000000",
                   "max": "8523999999",
                   "rules": [
@@ -23002,7 +16341,7 @@
             {
                   "heading": "8523",
                   "chapter": 85,
-                  "subdivision": "Sewing machines, other than book-sewing machines of heading 8440; furniture, bases and covers specially designed for sewing machines; sewing machine needles \u25b8 recorded discs, tapes solid-state non-volatile storage devices and other media for the recording of sound or of other phenomena, but excluding products of Chapter 37",
+                  "subdivision": "Parts and accessories suitable for use solely or principally with the apparatus of headings 8519 to 8521 \u25b8 Recorded discs, tapes solid-state non-volatile storage devices and other media for the recording of sound or of other phenomena, but excluding products of Chapter 37",
                   "min": "8523000000",
                   "max": "8523999999",
                   "rules": [
@@ -23034,7 +16373,7 @@
             {
                   "heading": "8523",
                   "chapter": 85,
-                  "subdivision": "Sewing machines, other than book-sewing machines of heading 8440; furniture, bases and covers specially designed for sewing machines; sewing machine needles \u25b8 matrices and masters for the production of discs, but excluding products of Chapter 37",
+                  "subdivision": "Parts and accessories suitable for use solely or principally with the apparatus of headings 8519 to 8521 \u25b8 Matrices and masters for the production of discs, but excluding products of Chapter 37",
                   "min": "8523000000",
                   "max": "8523999999",
                   "rules": [
@@ -23066,7 +16405,7 @@
             {
                   "heading": "8523",
                   "chapter": 85,
-                  "subdivision": "Sewing machines, other than book-sewing machines of heading 8440; furniture, bases and covers specially designed for sewing machines; sewing machine needles \u25b8 proximity cards and \"smart cards\" with two or more electronic integrated circuits",
+                  "subdivision": "Parts and accessories suitable for use solely or principally with the apparatus of headings 8519 to 8521 \u25b8 Proximity cards and \"smart cards\" with two or more electronic integrated circuits",
                   "min": "8523000000",
                   "max": "8523999999",
                   "rules": [
@@ -23099,7 +16438,7 @@
             {
                   "heading": "8523",
                   "chapter": 85,
-                  "subdivision": "Sewing machines, other than book-sewing machines of heading 8440; furniture, bases and covers specially designed for sewing machines; sewing machine needles \u25b8 \"smart cards\" with one electronic integrated circuit",
+                  "subdivision": "Parts and accessories suitable for use solely or principally with the apparatus of headings 8519 to 8521 \u25b8 \"smart cards\" with one electronic integrated circuit",
                   "min": "8523000000",
                   "max": "8523999999",
                   "rules": [
@@ -23138,9 +16477,9 @@
                   "valid": true
             },
             {
-                  "heading": "8524",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles; except for;",
+                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
                   "min": "8524000000",
                   "max": "8524999999",
                   "rules": [
@@ -23272,7 +16611,7 @@
             {
                   "heading": "8528",
                   "chapter": 85,
-                  "subdivision": "Sewing machines, other than book-sewing machines of heading 8440; furniture, bases and covers specially designed for sewing machines; sewing machine needles \u25b8 Monitors and projectors, not incorporating television reception apparatus, of a kind solely or principally used in an automatic data- processing system of heading 8471",
+                  "subdivision": "Reception apparatus for radio-broadcasting, whether or not combined, in the same housing, with sound recording or reproducing apparatus or a clock \u25b8 Monitors and projectors, not incorporating television reception apparatus, of a kind solely or principally used in an automatic data- processing system of heading 8471",
                   "min": "8528000000",
                   "max": "8528999999",
                   "rules": [
@@ -23293,7 +16632,7 @@
             {
                   "heading": "8528",
                   "chapter": 85,
-                  "subdivision": "Sewing machines, other than book-sewing machines of heading 8440; furniture, bases and covers specially designed for sewing machines; sewing machine needles \u25b8 other monitors and projectors, not incorporating television reception apparatus; reception apparatus for television, whether or not incorporating radio broadcast receivers or sound or video recording or reproducing apparatus",
+                  "subdivision": "Reception apparatus for radio-broadcasting, whether or not combined, in the same housing, with sound recording or reproducing apparatus or a clock \u25b8 Other monitors and projectors, not incorporating television reception apparatus; reception apparatus for television, whether or not incorporating radio broadcast receivers or sound or video recording or reproducing apparatus",
                   "min": "8528000000",
                   "max": "8528999999",
                   "rules": [
@@ -23411,9 +16750,9 @@
                   "valid": true
             },
             {
-                  "heading": "8530",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles; except for;",
+                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
                   "min": "8530000000",
                   "max": "8530999999",
                   "rules": [
@@ -23476,76 +16815,10 @@
                   "valid": true
             },
             {
-                  "heading": "8532",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles; except for;",
+                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
                   "min": "8532000000",
-                  "max": "8532999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8533",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles; except for;",
-                  "min": "8533000000",
-                  "max": "8533999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8534",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles; except for;",
-                  "min": "8534000000",
                   "max": "8534999999",
                   "rules": [
                         {
@@ -23609,7 +16882,7 @@
             {
                   "heading": "8536",
                   "chapter": 85,
-                  "subdivision": "Parts suitable for use solely or principally with the apparatus of headings 8525 to 8528 \u25b8 Electrical apparatus for switching or protecting electrical circuits, or for making connections to or in electrical circuits for a voltage not exceeding\n1 000 V",
+                  "subdivision": "Electrical apparatus for switching or protecting electrical circuits, or for making connections to or in electrical circuits (for example, switches, fuses, lightning arresters, voltage limiters, surge suppressors, plugs and other connectors, junction boxes), for a voltage exceeding\n1 000 V \u25b8 Electrical apparatus for switching or protecting electrical circuits, or for making connections to or in electrical circuits for a voltage not exceeding\n1 000 V",
                   "min": "8536000000",
                   "max": "8536999999",
                   "rules": [
@@ -23641,7 +16914,7 @@
             {
                   "heading": "8536",
                   "chapter": 85,
-                  "subdivision": "Parts suitable for use solely or principally with the apparatus of headings 8525 to 8528 \u25b8 connectors for optical fibres, optical fibre bundles or cables \u25b8 of plastics",
+                  "subdivision": "Electrical apparatus for switching or protecting electrical circuits, or for making connections to or in electrical circuits (for example, switches, fuses, lightning arresters, voltage limiters, surge suppressors, plugs and other connectors, junction boxes), for a voltage exceeding\n1 000 V \u25b8 Of plastics",
                   "min": "8536000000",
                   "max": "8536999999",
                   "rules": [
@@ -23662,7 +16935,7 @@
             {
                   "heading": "8536",
                   "chapter": 85,
-                  "subdivision": "Parts suitable for use solely or principally with the apparatus of headings 8525 to 8528 \u25b8 connectors for optical fibres, optical fibre bundles or cables \u25b8 -of ceramics",
+                  "subdivision": "Of ceramics",
                   "min": "8536000000",
                   "max": "8536999999",
                   "rules": [
@@ -23683,7 +16956,7 @@
             {
                   "heading": "8536",
                   "chapter": 85,
-                  "subdivision": "Parts suitable for use solely or principally with the apparatus of headings 8525 to 8528 \u25b8 connectors for optical fibres, optical fibre bundles or cables \u25b8 -of copper",
+                  "subdivision": "Of copper",
                   "min": "8536000000",
                   "max": "8536999999",
                   "rules": [
@@ -23735,76 +17008,10 @@
                   "valid": true
             },
             {
-                  "heading": "8538",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles; except for;",
+                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
                   "min": "8538000000",
-                  "max": "8538999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8539",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles; except for;",
-                  "min": "8539000000",
-                  "max": "8539999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8540",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles; except for;",
-                  "min": "8540000000",
                   "max": "8540999999",
                   "rules": [
                         {
@@ -23867,9 +17074,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8541",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8541",
                   "min": "8541000000",
                   "max": "8541999999",
                   "rules": [
@@ -23994,9 +17201,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8542",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8542",
                   "min": "8542000000",
                   "max": "8542999999",
                   "rules": [
@@ -24027,9 +17234,9 @@
                   "valid": true
             },
             {
-                  "heading": "8543",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles; except for;",
+                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
                   "min": "8543000000",
                   "max": "8543999999",
                   "rules": [
@@ -24197,9 +17404,9 @@
                   "valid": true
             },
             {
-                  "heading": "8549",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles; except for;",
+                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
                   "min": "8549000000",
                   "max": "8549999999",
                   "rules": [
@@ -24230,135 +17437,10 @@
                   "valid": true
             },
             {
-                  "heading": "8601",
-                  "subdivision": "Railway or tramway locomotives, rolling- stock and parts thereof; railway or tramway track fixtures and fittings and parts thereof; mechanical (including electro-mechanical) traffic signalling equipment of all kinds; except for;",
+                  "heading": "ex Chapter 86",
+                  "chapter": 86,
+                  "subdivision": "Railway or tramway locomotives, rolling- stock and parts thereof; railway or tramway track fixtures and fittings and parts thereof; mechanical (including electro-mechanical) traffic signalling equipment of all kinds",
                   "min": "8601000000",
-                  "max": "8601999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 86
-            },
-            {
-                  "heading": "8602",
-                  "subdivision": "Railway or tramway locomotives, rolling- stock and parts thereof; railway or tramway track fixtures and fittings and parts thereof; mechanical (including electro-mechanical) traffic signalling equipment of all kinds; except for;",
-                  "min": "8602000000",
-                  "max": "8602999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 86
-            },
-            {
-                  "heading": "8603",
-                  "subdivision": "Railway or tramway locomotives, rolling- stock and parts thereof; railway or tramway track fixtures and fittings and parts thereof; mechanical (including electro-mechanical) traffic signalling equipment of all kinds; except for;",
-                  "min": "8603000000",
-                  "max": "8603999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 86
-            },
-            {
-                  "heading": "8604",
-                  "subdivision": "Railway or tramway locomotives, rolling- stock and parts thereof; railway or tramway track fixtures and fittings and parts thereof; mechanical (including electro-mechanical) traffic signalling equipment of all kinds; except for;",
-                  "min": "8604000000",
-                  "max": "8604999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 86
-            },
-            {
-                  "heading": "8605",
-                  "subdivision": "Railway or tramway locomotives, rolling- stock and parts thereof; railway or tramway track fixtures and fittings and parts thereof; mechanical (including electro-mechanical) traffic signalling equipment of all kinds; except for;",
-                  "min": "8605000000",
-                  "max": "8605999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 86
-            },
-            {
-                  "heading": "8606",
-                  "subdivision": "Railway or tramway locomotives, rolling- stock and parts thereof; railway or tramway track fixtures and fittings and parts thereof; mechanical (including electro-mechanical) traffic signalling equipment of all kinds; except for;",
-                  "min": "8606000000",
-                  "max": "8606999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 86
-            },
-            {
-                  "heading": "8607",
-                  "subdivision": "Railway or tramway locomotives, rolling- stock and parts thereof; railway or tramway track fixtures and fittings and parts thereof; mechanical (including electro-mechanical) traffic signalling equipment of all kinds; except for;",
-                  "min": "8607000000",
                   "max": "8607999999",
                   "rules": [
                         {
@@ -24373,8 +17455,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 86
+                  "valid": true
             },
             {
                   "heading": "8608",
@@ -24410,8 +17491,9 @@
                   "valid": true
             },
             {
-                  "heading": "8609",
-                  "subdivision": "Railway or tramway locomotives, rolling- stock and parts thereof; railway or tramway track fixtures and fittings and parts thereof; mechanical (including electro-mechanical) traffic signalling equipment of all kinds; except for;",
+                  "heading": "ex Chapter 86",
+                  "chapter": 86,
+                  "subdivision": "Railway or tramway locomotives, rolling- stock and parts thereof; railway or tramway track fixtures and fittings and parts thereof; mechanical (including electro-mechanical) traffic signalling equipment of all kinds",
                   "min": "8609000000",
                   "max": "8609999999",
                   "rules": [
@@ -24427,161 +17509,13 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 86
+                  "valid": true
             },
             {
-                  "heading": "8701",
+                  "heading": "ex Chapter 87",
                   "chapter": 87,
-                  "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof; except for;",
+                  "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof",
                   "min": "8701000000",
-                  "max": "8701999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8702",
-                  "chapter": 87,
-                  "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof; except for;",
-                  "min": "8702000000",
-                  "max": "8702999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8703",
-                  "chapter": 87,
-                  "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof; except for;",
-                  "min": "8703000000",
-                  "max": "8703999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8704",
-                  "chapter": 87,
-                  "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof; except for;",
-                  "min": "8704000000",
-                  "max": "8704999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8705",
-                  "chapter": 87,
-                  "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof; except for;",
-                  "min": "8705000000",
-                  "max": "8705999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8706",
-                  "chapter": 87,
-                  "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof; except for;",
-                  "min": "8706000000",
-                  "max": "8706999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8707",
-                  "chapter": 87,
-                  "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof; except for;",
-                  "min": "8707000000",
-                  "max": "8707999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8708",
-                  "chapter": 87,
-                  "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof; except for;",
-                  "min": "8708000000",
                   "max": "8708999999",
                   "rules": [
                         {
@@ -24639,7 +17573,7 @@
                   "max": "8710999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "rule": "Manufacture:\n\nfrom materials of any heading, except that of the product, *and*\n\nin which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM",
                                     "CTH"
@@ -24729,9 +17663,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8712",
+                  "heading": "ex Chapter 87",
                   "chapter": 87,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8712",
                   "min": "8712000000",
                   "max": "8712999999",
                   "rules": [
@@ -24750,31 +17684,10 @@
                   "valid": true
             },
             {
-                  "heading": "8713",
+                  "heading": "ex Chapter 87",
                   "chapter": 87,
-                  "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof; except for;",
+                  "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof",
                   "min": "8713000000",
-                  "max": "8713999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8714",
-                  "chapter": 87,
-                  "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof; except for;",
-                  "min": "8714000000",
                   "max": "8714999999",
                   "rules": [
                         {
@@ -24858,42 +17771,10 @@
                   "valid": true
             },
             {
-                  "heading": "8801",
+                  "heading": "ex Chapter 88",
                   "chapter": 88,
                   "subdivision": "Aircraft, spacecraft, and parts thereof",
                   "min": "8801000000",
-                  "max": "8801999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8802",
-                  "chapter": 88,
-                  "subdivision": "Aircraft, spacecraft, and parts thereof",
-                  "min": "8802000000",
                   "max": "8802999999",
                   "rules": [
                         {
@@ -24954,9 +17835,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8804",
+                  "heading": "ex Chapter 88",
                   "chapter": 88,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8804",
                   "min": "8804000000",
                   "max": "8804999999",
                   "rules": [
@@ -25018,42 +17899,10 @@
                   "valid": true
             },
             {
-                  "heading": "8806",
+                  "heading": "ex Chapter 88",
                   "chapter": 88,
                   "subdivision": "Aircraft, spacecraft, and parts thereof",
                   "min": "8806000000",
-                  "max": "8806999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8807",
-                  "chapter": 88,
-                  "subdivision": "Aircraft, spacecraft, and parts thereof",
-                  "min": "8807000000",
                   "max": "8807999999",
                   "rules": [
                         {
@@ -25156,7 +18005,7 @@
                   "valid": true
             },
             {
-                  "heading": "9003",
+                  "heading": "ex Chapter 90",
                   "chapter": 90,
                   "subdivision": "Optical, photographic, cinematographic, measuring, checking, precision, medical or surgical instruments and apparatus; parts and accessories thereof",
                   "min": "9003000000",
@@ -25212,7 +18061,7 @@
             {
                   "heading": "ex 9005",
                   "chapter": 90,
-                  "subdivision": "Binoculars, monoculars, other optical telescopes, and mountings therefor, except for astronomical refracting telescopes and mountings therefor",
+                  "subdivision": "Binoculars, monoculars, other optical telescopes, and mountings therefor astronomical refracting telescopes and mountings therefor",
                   "min": "9005000000",
                   "max": "9005999999",
                   "rules": [
@@ -25244,9 +18093,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9005",
+                  "heading": "ex Chapter 90",
                   "chapter": 90,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 9005",
                   "min": "9005000000",
                   "max": "9005999999",
                   "rules": [
@@ -25311,9 +18160,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9006",
+                  "heading": "ex Chapter 90",
                   "chapter": 90,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 9006",
                   "min": "9006000000",
                   "max": "9006999999",
                   "rules": [
@@ -25378,43 +18227,10 @@
                   "valid": true
             },
             {
-                  "heading": "9008",
+                  "heading": "ex Chapter 90",
                   "chapter": 90,
                   "subdivision": "Optical, photographic, cinematographic, measuring, checking, precision, medical or surgical instruments and apparatus; parts and accessories thereof",
                   "min": "9008000000",
-                  "max": "9008999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9010",
-                  "chapter": 90,
-                  "subdivision": "Optical, photographic, cinematographic, measuring, checking, precision, medical or surgical instruments and apparatus; parts and accessories thereof",
-                  "min": "9010000000",
                   "max": "9010999999",
                   "rules": [
                         {
@@ -25478,43 +18294,10 @@
                   "valid": true
             },
             {
-                  "heading": "9012",
+                  "heading": "ex Chapter 90",
                   "chapter": 90,
                   "subdivision": "Optical, photographic, cinematographic, measuring, checking, precision, medical or surgical instruments and apparatus; parts and accessories thereof",
                   "min": "9012000000",
-                  "max": "9012999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9013",
-                  "chapter": 90,
-                  "subdivision": "Optical, photographic, cinematographic, measuring, checking, precision, medical or surgical instruments and apparatus; parts and accessories thereof",
-                  "min": "9013000000",
                   "max": "9013999999",
                   "rules": [
                         {
@@ -25565,9 +18348,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9014",
+                  "heading": "ex Chapter 90",
                   "chapter": 90,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 9014",
                   "min": "9014000000",
                   "max": "9014999999",
                   "rules": [
@@ -25792,76 +18575,10 @@
                   "valid": true
             },
             {
-                  "heading": "9021",
+                  "heading": "ex Chapter 90",
                   "chapter": 90,
                   "subdivision": "Optical, photographic, cinematographic, measuring, checking, precision, medical or surgical instruments and apparatus; parts and accessories thereof",
                   "min": "9021000000",
-                  "max": "9021999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9022",
-                  "chapter": 90,
-                  "subdivision": "Optical, photographic, cinematographic, measuring, checking, precision, medical or surgical instruments and apparatus; parts and accessories thereof",
-                  "min": "9022000000",
-                  "max": "9022999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9023",
-                  "chapter": 90,
-                  "subdivision": "Optical, photographic, cinematographic, measuring, checking, precision, medical or surgical instruments and apparatus; parts and accessories thereof",
-                  "min": "9023000000",
                   "max": "9023999999",
                   "rules": [
                         {
@@ -26134,72 +18851,10 @@
                   "valid": true
             },
             {
-                  "heading": "9101",
-                  "subdivision": "Clocks and watches and parts thereof; except for;",
+                  "heading": "ex Chapter 91",
+                  "chapter": 91,
+                  "subdivision": "Clocks and watches and parts thereof",
                   "min": "9101000000",
-                  "max": "9101999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 91
-            },
-            {
-                  "heading": "9102",
-                  "subdivision": "Clocks and watches and parts thereof; except for;",
-                  "min": "9102000000",
-                  "max": "9102999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 91
-            },
-            {
-                  "heading": "9103",
-                  "subdivision": "Clocks and watches and parts thereof; except for;",
-                  "min": "9103000000",
-                  "max": "9103999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 91
-            },
-            {
-                  "heading": "9104",
-                  "subdivision": "Clocks and watches and parts thereof; except for;",
-                  "min": "9104000000",
                   "max": "9104999999",
                   "rules": [
                         {
@@ -26214,8 +18869,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 91
+                  "valid": true
             },
             {
                   "heading": "9105",
@@ -26251,51 +18905,10 @@
                   "valid": true
             },
             {
-                  "heading": "9106",
-                  "subdivision": "Clocks and watches and parts thereof; except for;",
+                  "heading": "ex Chapter 91",
+                  "chapter": 91,
+                  "subdivision": "Clocks and watches and parts thereof",
                   "min": "9106000000",
-                  "max": "9106999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 91
-            },
-            {
-                  "heading": "9107",
-                  "subdivision": "Clocks and watches and parts thereof; except for;",
-                  "min": "9107000000",
-                  "max": "9107999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 91
-            },
-            {
-                  "heading": "9108",
-                  "subdivision": "Clocks and watches and parts thereof; except for;",
-                  "min": "9108000000",
                   "max": "9108999999",
                   "rules": [
                         {
@@ -26310,8 +18923,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 91
+                  "valid": true
             },
             {
                   "heading": "9109",
@@ -26487,8 +19099,9 @@
                   "valid": true
             },
             {
-                  "heading": "9114",
-                  "subdivision": "Clocks and watches and parts thereof; except for;",
+                  "heading": "ex Chapter 91",
+                  "chapter": 91,
+                  "subdivision": "Clocks and watches and parts thereof",
                   "min": "9114000000",
                   "max": "9114999999",
                   "rules": [
@@ -26504,8 +19117,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 91
+                  "valid": true
             },
             {
                   "heading": "Chapter 92",
@@ -26593,9 +19205,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9401",
+                  "heading": "ex Chapter 94",
                   "chapter": 94,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 9401",
                   "min": "9401000000",
                   "max": "9401999999",
                   "rules": [
@@ -26625,7 +19237,7 @@
                   "valid": true
             },
             {
-                  "heading": "9402",
+                  "heading": "ex Chapter 94",
                   "chapter": 94,
                   "subdivision": "Furniture; bedding, mattresses, mattress supports, cushions and similar stuffed furnishings; lamps and lighting fittings, not elsewhere specified or included; illuminated signs, illuminated name-plates and the like; prefabricated buildings",
                   "min": "9402000000",
@@ -26700,9 +19312,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9403",
+                  "heading": "ex Chapter 94",
                   "chapter": 94,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 9403",
                   "min": "9403000000",
                   "max": "9403999999",
                   "rules": [
@@ -26732,7 +19344,7 @@
                   "valid": true
             },
             {
-                  "heading": "9404",
+                  "heading": "ex Chapter 94",
                   "chapter": 94,
                   "subdivision": "Furniture; bedding, mattresses, mattress supports, cushions and similar stuffed furnishings; lamps and lighting fittings, not elsewhere specified or included; illuminated signs, illuminated name-plates and the like; prefabricated buildings",
                   "min": "9404000000",
@@ -26817,11 +19429,33 @@
                   "valid": true
             },
             {
+                  "heading": "ex 9503",
+                  "chapter": 95,
+                  "subdivision": "Other toys; reduced-size (\"scale\") models and similar recreational models, working or not; puzzles of all kinds",
+                  "min": "9503000000",
+                  "max": "9503999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture:\n\nfrom materials of any heading, except that of the product, *and*\n\nin which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex Chapter 95",
                   "chapter": 95,
-                  "subdivision": "Toys, games and sports requisites; parts and accessories thereof",
-                  "min": "9500000000",
-                  "max": "9599999999",
+                  "subdivision": "Any other product from heading 9503",
+                  "min": "9503000000",
+                  "max": "9503999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product.",
@@ -26838,16 +19472,15 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9503",
+                  "heading": "ex Chapter 95",
                   "chapter": 95,
-                  "subdivision": "Other toys; reduced-size (\"scale\") models and similar recreational models, working or not; puzzles of all kinds",
-                  "min": "9503000000",
-                  "max": "9503999999",
+                  "subdivision": "Toys, games and sports requisites; parts and accessories thereof",
+                  "min": "9504000000",
+                  "max": "9505999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
                               "class": [
-                                    "MAXNOM",
                                     "CTH"
                               ],
                               "footnotes": [],
@@ -26881,6 +19514,48 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 95",
+                  "chapter": 95,
+                  "subdivision": "Any other product from heading 9506",
+                  "min": "9506000000",
+                  "max": "9506999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 95",
+                  "chapter": 95,
+                  "subdivision": "Toys, games and sports requisites; parts and accessories thereof",
+                  "min": "9507000000",
+                  "max": "9508999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 9601",
                   "chapter": 96,
                   "subdivision": "Articles of animal, vegetable or mineral carving materials",
@@ -26902,9 +19577,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9601",
+                  "heading": "ex Chapter 96",
                   "chapter": 96,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 9601",
                   "min": "9601000000",
                   "max": "9601999999",
                   "rules": [
@@ -26944,9 +19619,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9602",
+                  "heading": "ex Chapter 96",
                   "chapter": 96,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 9602",
                   "min": "9602000000",
                   "max": "9602999999",
                   "rules": [
@@ -26967,7 +19642,7 @@
             {
                   "heading": "ex 9603",
                   "chapter": 96,
-                  "subdivision": "Brooms and brushes (except for besoms and the like and brushes made from marten or squirrel hair), hand-operated mechanical floor sweepers, not motorized, paint pads and rollers, squeegees and mops",
+                  "subdivision": "Brooms and brushes (except for: besoms and the like and brushes made from marten or squirrel hair), hand-operated mechanical floor sweepers, not motorized, paint pads and rollers, squeegees and mops",
                   "min": "9603000000",
                   "max": "9603999999",
                   "rules": [
@@ -26986,9 +19661,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9603",
+                  "heading": "ex Chapter 96",
                   "chapter": 96,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 9603",
                   "min": "9603000000",
                   "max": "9603999999",
                   "rules": [
@@ -27007,7 +19682,7 @@
                   "valid": true
             },
             {
-                  "heading": "9604",
+                  "heading": "ex Chapter 96",
                   "chapter": 96,
                   "subdivision": "Miscellaneous manufactured articles",
                   "min": "9604000000",
@@ -27072,7 +19747,7 @@
                   "valid": true
             },
             {
-                  "heading": "9607",
+                  "heading": "ex Chapter 96",
                   "chapter": 96,
                   "subdivision": "Miscellaneous manufactured articles",
                   "min": "9607000000",
@@ -27135,31 +19810,10 @@
                   "valid": true
             },
             {
-                  "heading": "9610",
+                  "heading": "ex Chapter 96",
                   "chapter": 96,
                   "subdivision": "Miscellaneous manufactured articles",
                   "min": "9610000000",
-                  "max": "9610999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9611",
-                  "chapter": 96,
-                  "subdivision": "Miscellaneous manufactured articles",
-                  "min": "9611000000",
                   "max": "9611999999",
                   "rules": [
                         {
@@ -27220,9 +19874,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9613",
+                  "heading": "ex Chapter 96",
                   "chapter": 96,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 9613",
                   "min": "9613000000",
                   "max": "9613999999",
                   "rules": [
@@ -27262,9 +19916,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9614",
+                  "heading": "ex Chapter 96",
                   "chapter": 96,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 9614",
                   "min": "9614000000",
                   "max": "9614999999",
                   "rules": [
@@ -27283,115 +19937,10 @@
                   "valid": true
             },
             {
-                  "heading": "9615",
+                  "heading": "ex Chapter 96",
                   "chapter": 96,
                   "subdivision": "Miscellaneous manufactured articles",
                   "min": "9615000000",
-                  "max": "9615999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9616",
-                  "chapter": 96,
-                  "subdivision": "Miscellaneous manufactured articles",
-                  "min": "9616000000",
-                  "max": "9616999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9617",
-                  "chapter": 96,
-                  "subdivision": "Miscellaneous manufactured articles",
-                  "min": "9617000000",
-                  "max": "9617999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9618",
-                  "chapter": 96,
-                  "subdivision": "Miscellaneous manufactured articles",
-                  "min": "9618000000",
-                  "max": "9618999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9619",
-                  "chapter": 96,
-                  "subdivision": "Miscellaneous manufactured articles",
-                  "min": "9619000000",
-                  "max": "9619999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9620",
-                  "chapter": 96,
-                  "subdivision": "Miscellaneous manufactured articles",
-                  "min": "9620000000",
                   "max": "9620999999",
                   "rules": [
                         {


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4691

### What?

I have altered:

- [x] db/rules_of_origin/roo_schemes_uk/rule_sets/central-america.json


### Why?

I am doing this because:

- RoO PSRs for Central America are out of date

Testing on commodity 5909001000

BEFORE
![image](https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/99d5d45a-2353-40fb-9721-d1c0941207b8)

AFTER
![image](https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/ee647511-6db9-4a3b-bc9a-350ea846c3f9)
