### PR TITLE
Allow News endpoints from XI in local dev

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -190,7 +190,7 @@ Rails.application.routes.draw do
             as: :product_specific_rules
       end
 
-      if TradeTariffBackend.uk?
+      if TradeTariffBackend.uk? || Rails.env.development?
         namespace :news do
           resources :items, only: %i[index show]
           resources :years, only: %i[index]


### PR DESCRIPTION

### Jira link

HOTT-???

### What?

I have added/removed/altered:

- [x] Allow access to news when doing local development on XI service

### Why?

I am doing this because:

- We only run one backend in local dev and if that backend is XI then then news endpoints are not available, blocking the frontend from working

### Deployment risks (optional)

- Low, should only impact local development
