### PR TITLE
HOTT-4697 Updated Faroe Islands RoO PSRs

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk/rule_sets/faroe-islands.json
+++ b/db/rules_of_origin/roo_schemes_uk/rule_sets/faroe-islands.json
@@ -64,30 +64,10 @@
                   "valid": true
             },
             {
-                  "heading": "0401",
+                  "heading": "ex Chapter 4",
+                  "chapter": 4,
                   "subdivision": "Dairy produce; birds' eggs; natural honey; edible products of animal origin, not elsewhere specified or included",
                   "min": "0401000000",
-                  "max": "0401999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 4
-            },
-            {
-                  "heading": "0402",
-                  "subdivision": "Dairy produce; birds' eggs; natural honey; edible products of animal origin, not elsewhere specified or included",
-                  "min": "0402000000",
                   "max": "0402999999",
                   "rules": [
                         {
@@ -102,8 +82,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 4
+                  "valid": true
             },
             {
                   "heading": "0403",
@@ -129,135 +108,10 @@
                   "valid": true
             },
             {
-                  "heading": "0404",
+                  "heading": "ex Chapter 4",
+                  "chapter": 4,
                   "subdivision": "Dairy produce; birds' eggs; natural honey; edible products of animal origin, not elsewhere specified or included",
                   "min": "0404000000",
-                  "max": "0404999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 4
-            },
-            {
-                  "heading": "0405",
-                  "subdivision": "Dairy produce; birds' eggs; natural honey; edible products of animal origin, not elsewhere specified or included",
-                  "min": "0405000000",
-                  "max": "0405999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 4
-            },
-            {
-                  "heading": "0406",
-                  "subdivision": "Dairy produce; birds' eggs; natural honey; edible products of animal origin, not elsewhere specified or included",
-                  "min": "0406000000",
-                  "max": "0406999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 4
-            },
-            {
-                  "heading": "0407",
-                  "subdivision": "Dairy produce; birds' eggs; natural honey; edible products of animal origin, not elsewhere specified or included",
-                  "min": "0407000000",
-                  "max": "0407999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 4
-            },
-            {
-                  "heading": "0408",
-                  "subdivision": "Dairy produce; birds' eggs; natural honey; edible products of animal origin, not elsewhere specified or included",
-                  "min": "0408000000",
-                  "max": "0408999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 4
-            },
-            {
-                  "heading": "0409",
-                  "subdivision": "Dairy produce; birds' eggs; natural honey; edible products of animal origin, not elsewhere specified or included",
-                  "min": "0409000000",
-                  "max": "0409999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;4](/chapters/04) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 4
-            },
-            {
-                  "heading": "0410",
-                  "subdivision": "Dairy produce; birds' eggs; natural honey; edible products of animal origin, not elsewhere specified or included",
-                  "min": "0410000000",
                   "max": "0410999999",
                   "rules": [
                         {
@@ -272,15 +126,14 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 4
+                  "valid": true
             },
             {
                   "heading": "ex Chapter 5",
                   "chapter": 5,
                   "subdivision": "Products of animal origin, not elsewhere specified or included",
-                  "min": "0500000000",
-                  "max": "0599999999",
+                  "min": "0501000000",
+                  "max": "0501999999",
                   "rules": [
                         {
                               "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
@@ -307,6 +160,48 @@
                               "rule": "Cleaning, disinfecting, sorting and straightening of bristles and hair.",
                               "class": [
                                     "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 5",
+                  "chapter": 5,
+                  "subdivision": "Any other product from heading 0502",
+                  "min": "0502000000",
+                  "max": "0502999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
+                              "class": [
+                                    "WO"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 5",
+                  "chapter": 5,
+                  "subdivision": "Products of animal origin, not elsewhere specified or included",
+                  "min": "0504000000",
+                  "max": "0511999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture in which all the materials of [chapter&nbsp;5](/chapters/05) used are wholly obtained.",
+                              "class": [
+                                    "WO"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -425,136 +320,10 @@
                   "valid": true
             },
             {
-                  "heading": "0903",
+                  "heading": "ex Chapter 9",
                   "chapter": 9,
                   "subdivision": "Coffee, tea, mat\u00e9 and spices",
                   "min": "0903000000",
-                  "max": "0903999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "0904",
-                  "chapter": 9,
-                  "subdivision": "Coffee, tea, mat\u00e9 and spices",
-                  "min": "0904000000",
-                  "max": "0904999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "0905",
-                  "chapter": 9,
-                  "subdivision": "Coffee, tea, mat\u00e9 and spices",
-                  "min": "0905000000",
-                  "max": "0905999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "0906",
-                  "chapter": 9,
-                  "subdivision": "Coffee, tea, mat\u00e9 and spices",
-                  "min": "0906000000",
-                  "max": "0906999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "0907",
-                  "chapter": 9,
-                  "subdivision": "Coffee, tea, mat\u00e9 and spices",
-                  "min": "0907000000",
-                  "max": "0907999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "0908",
-                  "chapter": 9,
-                  "subdivision": "Coffee, tea, mat\u00e9 and spices",
-                  "min": "0908000000",
-                  "max": "0908999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the materials of [chapter&nbsp;9](/chapters/09) used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "0909",
-                  "chapter": 9,
-                  "subdivision": "Coffee, tea, mat\u00e9 and spices",
-                  "min": "0909000000",
                   "max": "0909999999",
                   "rules": [
                         {
@@ -593,9 +362,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 0910",
+                  "heading": "ex Chapter 9",
                   "chapter": 9,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 0910",
                   "min": "0910000000",
                   "max": "0910999999",
                   "rules": [
@@ -638,8 +407,8 @@
                   "heading": "ex Chapter 11",
                   "chapter": 11,
                   "subdivision": "Products of the milling industry; malt; starches; inulin; wheat gluten",
-                  "min": "1100000000",
-                  "max": "1199999999",
+                  "min": "1101000000",
+                  "max": "1105999999",
                   "rules": [
                         {
                               "rule": "Manufacture in which all the cereals, edible vegetables, roots and tubers of [heading&nbsp;0714](/headings/0714) or fruit used are wholly obtained.",
@@ -666,6 +435,48 @@
                               "rule": "Drying and milling of leguminous vegetables of [heading&nbsp;0708](/headings/0708).",
                               "class": [
                                     "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 11",
+                  "chapter": 11,
+                  "subdivision": "Any other product from heading 1106",
+                  "min": "1106000000",
+                  "max": "1106999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture in which all the cereals, edible vegetables, roots and tubers of [heading&nbsp;0714](/headings/0714) or fruit used are wholly obtained.",
+                              "class": [
+                                    "WO"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 11",
+                  "chapter": 11,
+                  "subdivision": "Products of the milling industry; malt; starches; inulin; wheat gluten",
+                  "min": "1107000000",
+                  "max": "1109999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture in which all the cereals, edible vegetables, roots and tubers of [heading&nbsp;0714](/headings/0714) or fruit used are wholly obtained.",
+                              "class": [
+                                    "WO"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -866,7 +677,7 @@
                   "valid": true
             },
             {
-                  "heading": "1503",
+                  "heading": "ex Chapter 15",
                   "chapter": 15,
                   "subdivision": "Animal or vegetable fats and oils and their cleavage products; prepared edible fats; animal or vegetable waxes",
                   "min": "1503000000",
@@ -950,9 +761,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 1505",
+                  "heading": "ex Chapter 15",
                   "chapter": 15,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 1505",
                   "min": "1505000000",
                   "max": "1505999999",
                   "rules": [
@@ -1013,7 +824,7 @@
                   "valid": true
             },
             {
-                  "heading": "1507-1515",
+                  "heading": "1507 to 1515",
                   "chapter": 15,
                   "subdivision": "Vegetable oils and their fractions \u25b8 Soya, ground nut, palm, copra, palm kernel, babassu, tung and oiticica oil, myrtle wax and Japan wax, fractions of jojoba oil and oils for technical or industrial uses other than the manufacture of foodstuffs for human consumption",
                   "min": "1507000000",
@@ -1034,9 +845,9 @@
                   "valid": true
             },
             {
-                  "heading": "1507-1515",
+                  "heading": "1507 to 1515",
                   "chapter": 15,
-                  "subdivision": "Vegetable oils and their fractions \u25b8 Solid fractions, except for that of jojoba oil",
+                  "subdivision": "Vegetable oils and their fractions \u25b8 Solid fractions that of jojoba oil",
                   "min": "1507000000",
                   "max": "1515999999",
                   "rules": [
@@ -1055,7 +866,7 @@
                   "valid": true
             },
             {
-                  "heading": "1507-1515",
+                  "heading": "1507 to 1515",
                   "chapter": 15,
                   "subdivision": "Vegetable oils and their fractions \u25b8 Other",
                   "min": "1507000000",
@@ -1120,73 +931,10 @@
                   "valid": true
             },
             {
-                  "heading": "1518",
+                  "heading": "ex Chapter 15",
                   "chapter": 15,
                   "subdivision": "Animal or vegetable fats and oils and their cleavage products; prepared edible fats; animal or vegetable waxes",
                   "min": "1518000000",
-                  "max": "1518999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "1520",
-                  "chapter": 15,
-                  "subdivision": "Animal or vegetable fats and oils and their cleavage products; prepared edible fats; animal or vegetable waxes",
-                  "min": "1520000000",
-                  "max": "1520999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "1521",
-                  "chapter": 15,
-                  "subdivision": "Animal or vegetable fats and oils and their cleavage products; prepared edible fats; animal or vegetable waxes",
-                  "min": "1521000000",
-                  "max": "1521999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "1522",
-                  "chapter": 15,
-                  "subdivision": "Animal or vegetable fats and oils and their cleavage products; prepared edible fats; animal or vegetable waxes",
-                  "min": "1522000000",
                   "max": "1522999999",
                   "rules": [
                         {
@@ -1247,9 +995,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 1701",
+                  "heading": "ex Chapter 17",
                   "chapter": 17,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 1701",
                   "min": "1701000000",
                   "max": "1701999999",
                   "rules": [
@@ -1352,9 +1100,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 1703",
+                  "heading": "ex Chapter 17",
                   "chapter": 17,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 1703",
                   "min": "1703000000",
                   "max": "1703999999",
                   "rules": [
@@ -1588,9 +1336,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2001",
+                  "heading": "ex Chapter 20",
                   "chapter": 20,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2001",
                   "min": "2001000000",
                   "max": "2001999999",
                   "rules": [
@@ -1609,31 +1357,10 @@
                   "valid": true
             },
             {
-                  "heading": "2002",
+                  "heading": "ex Chapter 20",
                   "chapter": 20,
                   "subdivision": "Preparations of vegetables, fruit, nuts or other parts of plants",
                   "min": "2002000000",
-                  "max": "2002999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which all the fruit, nuts or vegetables used are wholly obtained.",
-                              "class": [
-                                    "WO"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2003",
-                  "chapter": 20,
-                  "subdivision": "Preparations of vegetables, fruit, nuts or other parts of plants",
-                  "min": "2003000000",
                   "max": "2003999999",
                   "rules": [
                         {
@@ -1672,9 +1399,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2004",
+                  "heading": "ex Chapter 20",
                   "chapter": 20,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2004",
                   "min": "2004000000",
                   "max": "2004999999",
                   "rules": [
@@ -1714,9 +1441,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2005",
+                  "heading": "ex Chapter 20",
                   "chapter": 20,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2005",
                   "min": "2005000000",
                   "max": "2005999999",
                   "rules": [
@@ -1780,7 +1507,7 @@
             {
                   "heading": "ex 2008",
                   "chapter": 20,
-                  "subdivision": "Pasta, whether or not cooked or stuffed (with meat or other substances) or otherwise prepared, such as spaghetti, macaroni, noodles, lasagne, gnocchi, ravioli, cannelloni; couscous, whether or not prepared \u25b8 Nuts, not containing added sugar or spirits",
+                  "subdivision": "Jams, fruit jellies, marmalades, fruit or nut pur\u00e9e and fruit or nut pastes, obtained by cooking, whether or not containing added sugar or other sweetening matter \u25b8 Nuts, not containing added sugar or spirits",
                   "min": "2008000000",
                   "max": "2008999999",
                   "rules": [
@@ -1802,7 +1529,7 @@
             {
                   "heading": "ex 2008",
                   "chapter": 20,
-                  "subdivision": "Pasta, whether or not cooked or stuffed (with meat or other substances) or otherwise prepared, such as spaghetti, macaroni, noodles, lasagne, gnocchi, ravioli, cannelloni; couscous, whether or not prepared \u25b8 Peanut butter; mixtures based on cereals; palm hearts; maize (corn)",
+                  "subdivision": "Jams, fruit jellies, marmalades, fruit or nut pur\u00e9e and fruit or nut pastes, obtained by cooking, whether or not containing added sugar or other sweetening matter \u25b8 Peanut butter; mixtures based on cereals; palm hearts; maize (corn)",
                   "min": "2008000000",
                   "max": "2008999999",
                   "rules": [
@@ -1823,7 +1550,7 @@
             {
                   "heading": "ex 2008",
                   "chapter": 20,
-                  "subdivision": "Pasta, whether or not cooked or stuffed (with meat or other substances) or otherwise prepared, such as spaghetti, macaroni, noodles, lasagne, gnocchi, ravioli, cannelloni; couscous, whether or not prepared \u25b8 Other except for fruit and nuts cooked otherwise than by steaming or boiling in water, not containing added sugar, frozen",
+                  "subdivision": "Jams, fruit jellies, marmalades, fruit or nut pur\u00e9e and fruit or nut pastes, obtained by cooking, whether or not containing added sugar or other sweetening matter \u25b8 Other except for: fruit and nuts cooked otherwise than by steaming or boiling in water, not containing added sugar, frozen",
                   "min": "2008000000",
                   "max": "2008999999",
                   "rules": [
@@ -1843,9 +1570,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2008",
+                  "heading": "ex Chapter 20",
                   "chapter": 20,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2008",
                   "min": "2008000000",
                   "max": "2008999999",
                   "rules": [
@@ -1908,7 +1635,7 @@
                   "valid": true
             },
             {
-                  "heading": "2102",
+                  "heading": "ex Chapter 21",
                   "chapter": 21,
                   "subdivision": "Miscellaneous edible preparations",
                   "min": "2102000000",
@@ -1992,9 +1719,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2104",
+                  "heading": "ex Chapter 21",
                   "chapter": 21,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2104",
                   "min": "2104000000",
                   "max": "2104999999",
                   "rules": [
@@ -2013,7 +1740,7 @@
                   "valid": true
             },
             {
-                  "heading": "2105",
+                  "heading": "ex Chapter 21",
                   "chapter": 21,
                   "subdivision": "Miscellaneous edible preparations",
                   "min": "2105000000",
@@ -2056,7 +1783,8 @@
                   "valid": true
             },
             {
-                  "heading": "2201",
+                  "heading": "ex Chapter 22",
+                  "chapter": 22,
                   "subdivision": "Beverages, spirits and vinegar",
                   "min": "2201000000",
                   "max": "2201999999",
@@ -2074,8 +1802,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 22
+                  "valid": true
             },
             {
                   "heading": "2202",
@@ -2101,75 +1828,10 @@
                   "valid": true
             },
             {
-                  "heading": "2203",
+                  "heading": "ex Chapter 22",
+                  "chapter": 22,
                   "subdivision": "Beverages, spirits and vinegar",
                   "min": "2203000000",
-                  "max": "2203999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which all the grapes or materials derived from grapes used are wholly obtained.",
-                              "class": [
-                                    "WO",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 22
-            },
-            {
-                  "heading": "2204",
-                  "subdivision": "Beverages, spirits and vinegar",
-                  "min": "2204000000",
-                  "max": "2204999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which all the grapes or materials derived from grapes used are wholly obtained.",
-                              "class": [
-                                    "WO",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 22
-            },
-            {
-                  "heading": "2205",
-                  "subdivision": "Beverages, spirits and vinegar",
-                  "min": "2205000000",
-                  "max": "2205999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which all the grapes or materials derived from grapes used are wholly obtained.",
-                              "class": [
-                                    "WO",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 22
-            },
-            {
-                  "heading": "2206",
-                  "subdivision": "Beverages, spirits and vinegar",
-                  "min": "2206000000",
                   "max": "2206999999",
                   "rules": [
                         {
@@ -2185,8 +1847,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 22
+                  "valid": true
             },
             {
                   "heading": "2207",
@@ -2235,7 +1896,8 @@
                   "valid": true
             },
             {
-                  "heading": "2209",
+                  "heading": "ex Chapter 22",
+                  "chapter": 22,
                   "subdivision": "Beverages, spirits and vinegar",
                   "min": "2209000000",
                   "max": "2209999999",
@@ -2253,8 +1915,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 22
+                  "valid": true
             },
             {
                   "heading": "ex 2301",
@@ -2278,9 +1939,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2301",
+                  "heading": "ex Chapter 23",
                   "chapter": 23,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2301",
                   "min": "2301000000",
                   "max": "2301999999",
                   "rules": [
@@ -2299,7 +1960,7 @@
                   "valid": true
             },
             {
-                  "heading": "2302",
+                  "heading": "ex Chapter 23",
                   "chapter": 23,
                   "subdivision": "Residues and waste from the food industries; prepared animal fodder",
                   "min": "2302000000",
@@ -2341,9 +2002,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2303",
+                  "heading": "ex Chapter 23",
                   "chapter": 23,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2303",
                   "min": "2303000000",
                   "max": "2303999999",
                   "rules": [
@@ -2362,31 +2023,10 @@
                   "valid": true
             },
             {
-                  "heading": "2304",
+                  "heading": "ex Chapter 23",
                   "chapter": 23,
                   "subdivision": "Residues and waste from the food industries; prepared animal fodder",
                   "min": "2304000000",
-                  "max": "2304999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2305",
-                  "chapter": 23,
-                  "subdivision": "Residues and waste from the food industries; prepared animal fodder",
-                  "min": "2305000000",
                   "max": "2305999999",
                   "rules": [
                         {
@@ -2425,9 +2065,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2306",
+                  "heading": "ex Chapter 23",
                   "chapter": 23,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2306",
                   "min": "2306000000",
                   "max": "2306999999",
                   "rules": [
@@ -2446,31 +2086,10 @@
                   "valid": true
             },
             {
-                  "heading": "2307",
+                  "heading": "ex Chapter 23",
                   "chapter": 23,
                   "subdivision": "Residues and waste from the food industries; prepared animal fodder",
                   "min": "2307000000",
-                  "max": "2307999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2308",
-                  "chapter": 23,
-                  "subdivision": "Residues and waste from the food industries; prepared animal fodder",
-                  "min": "2308000000",
                   "max": "2308999999",
                   "rules": [
                         {
@@ -2510,7 +2129,7 @@
                   "valid": true
             },
             {
-                  "heading": "2401",
+                  "heading": "ex Chapter 24",
                   "chapter": 24,
                   "subdivision": "Tobacco and manufactured tobacco substitutes",
                   "min": "2401000000",
@@ -2573,9 +2192,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2403",
+                  "heading": "ex Chapter 24",
                   "chapter": 24,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2403",
                   "min": "2403000000",
                   "max": "2403999999",
                   "rules": [
@@ -2594,7 +2213,7 @@
                   "valid": true
             },
             {
-                  "heading": "2404",
+                  "heading": "ex Chapter 24",
                   "chapter": 24,
                   "subdivision": "Tobacco and manufactured tobacco substitutes",
                   "min": "2404000000",
@@ -2618,8 +2237,8 @@
                   "heading": "ex Chapter 25",
                   "chapter": 25,
                   "subdivision": "Salt; sulphur; earths and stone; plastering materials, lime and cement",
-                  "min": "2500000000",
-                  "max": "2599999999",
+                  "min": "2501000000",
+                  "max": "2503999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product.",
@@ -2657,6 +2276,48 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Any other product from heading 2504",
+                  "min": "2504000000",
+                  "max": "2504999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Salt; sulphur; earths and stone; plastering materials, lime and cement",
+                  "min": "2505000000",
+                  "max": "2514999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 2515",
                   "chapter": 25,
                   "subdivision": "Marble, merely cut, by sawing or otherwise, into blocks or slabs of a rectangular (including square) shape, of a thickness not exceeding 25 cm",
@@ -2666,6 +2327,27 @@
                         {
                               "rule": "Cutting, by sawing or otherwise, of marble (even if already sawn) of a thickness exceeding 25&nbsp;cm.",
                               "class": [],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Any other product from heading 2515",
+                  "min": "2515000000",
+                  "max": "2515999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
                               "footnotes": [],
                               "operator": null,
                               "quota": false,
@@ -2695,6 +2377,48 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Any other product from heading 2516",
+                  "min": "2516000000",
+                  "max": "2516999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Salt; sulphur; earths and stone; plastering materials, lime and cement",
+                  "min": "2517000000",
+                  "max": "2517999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 2518",
                   "chapter": 25,
                   "subdivision": "Calcined dolomite",
@@ -2705,6 +2429,27 @@
                               "rule": "Calcination of dolomite not calcined.",
                               "class": [
                                     "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Any other product from heading 2518",
+                  "min": "2518000000",
+                  "max": "2518999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -2737,6 +2482,27 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Any other product from heading 2519",
+                  "min": "2519000000",
+                  "max": "2519999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 2520",
                   "chapter": 25,
                   "subdivision": "Plasters specially prepared for dentistry",
@@ -2747,6 +2513,48 @@
                               "rule": "Manufacture in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Any other product from heading 2520",
+                  "min": "2520000000",
+                  "max": "2520999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Salt; sulphur; earths and stone; plastering materials, lime and cement",
+                  "min": "2521000000",
+                  "max": "2523999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -2779,6 +2587,27 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Any other product from heading 2524",
+                  "min": "2524000000",
+                  "max": "2524999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 2525",
                   "chapter": 25,
                   "subdivision": "Mica powder",
@@ -2789,6 +2618,48 @@
                               "rule": "Grinding of mica or mica waste.",
                               "class": [
                                     "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Any other product from heading 2525",
+                  "min": "2525000000",
+                  "max": "2525999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Salt; sulphur; earths and stone; plastering materials, lime and cement",
+                  "min": "2526000000",
+                  "max": "2529999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -2821,6 +2692,27 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 25",
+                  "chapter": 25,
+                  "subdivision": "Any other product from heading 2530",
+                  "min": "2530000000",
+                  "max": "2530999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "Chapter 26",
                   "chapter": 26,
                   "subdivision": "Ores, slag and ash",
@@ -2842,115 +2734,10 @@
                   "valid": true
             },
             {
-                  "heading": "2701",
+                  "heading": "ex Chapter 27",
                   "chapter": 27,
                   "subdivision": "Mineral fuels, mineral oils and products of their distillation; bituminous substances; mineral waxes",
                   "min": "2701000000",
-                  "max": "2701999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2702",
-                  "chapter": 27,
-                  "subdivision": "Mineral fuels, mineral oils and products of their distillation; bituminous substances; mineral waxes",
-                  "min": "2702000000",
-                  "max": "2702999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2703",
-                  "chapter": 27,
-                  "subdivision": "Mineral fuels, mineral oils and products of their distillation; bituminous substances; mineral waxes",
-                  "min": "2703000000",
-                  "max": "2703999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2704",
-                  "chapter": 27,
-                  "subdivision": "Mineral fuels, mineral oils and products of their distillation; bituminous substances; mineral waxes",
-                  "min": "2704000000",
-                  "max": "2704999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2705",
-                  "chapter": 27,
-                  "subdivision": "Mineral fuels, mineral oils and products of their distillation; bituminous substances; mineral waxes",
-                  "min": "2705000000",
-                  "max": "2705999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2706",
-                  "chapter": 27,
-                  "subdivision": "Mineral fuels, mineral oils and products of their distillation; bituminous substances; mineral waxes",
-                  "min": "2706000000",
                   "max": "2706999999",
                   "rules": [
                         {
@@ -3000,9 +2787,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2707",
+                  "heading": "ex Chapter 27",
                   "chapter": 27,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2707",
                   "min": "2707000000",
                   "max": "2707999999",
                   "rules": [
@@ -3021,7 +2808,7 @@
                   "valid": true
             },
             {
-                  "heading": "2708",
+                  "heading": "ex Chapter 27",
                   "chapter": 27,
                   "subdivision": "Mineral fuels, mineral oils and products of their distillation; bituminous substances; mineral waxes",
                   "min": "2708000000",
@@ -3063,9 +2850,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2709",
+                  "heading": "ex Chapter 27",
                   "chapter": 27,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2709",
                   "min": "2709000000",
                   "max": "2709999999",
                   "rules": [
@@ -3276,7 +3063,7 @@
                   "valid": true
             },
             {
-                  "heading": "2716",
+                  "heading": "ex Chapter 27",
                   "chapter": 27,
                   "subdivision": "Mineral fuels, mineral oils and products of their distillation; bituminous substances; mineral waxes",
                   "min": "2716000000",
@@ -3300,8 +3087,8 @@
                   "heading": "ex Chapter 28",
                   "chapter": 28,
                   "subdivision": "Inorganic chemicals; organic or inorganic compounds of precious metals, of rare-earth metals, of radioactive elements or of isotopes",
-                  "min": "2800000000",
-                  "max": "2899999999",
+                  "min": "2801000000",
+                  "max": "2804999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
@@ -3352,6 +3139,72 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 28",
+                  "chapter": 28,
+                  "subdivision": "Any other product from heading 2805",
+                  "min": "2805000000",
+                  "max": "2805999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 28",
+                  "chapter": 28,
+                  "subdivision": "Inorganic chemicals; organic or inorganic compounds of precious metals, of rare-earth metals, of radioactive elements or of isotopes",
+                  "min": "2806000000",
+                  "max": "2810999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 2811",
                   "chapter": 28,
                   "subdivision": "Sulphur trioxide",
@@ -3362,6 +3215,72 @@
                               "rule": "Manufacture from sulphur dioxide.",
                               "class": [
                                     "PRODUCTION FROM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 28",
+                  "chapter": 28,
+                  "subdivision": "Any other product from heading 2811",
+                  "min": "2811000000",
+                  "max": "2811999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 28",
+                  "chapter": 28,
+                  "subdivision": "Inorganic chemicals; organic or inorganic compounds of precious metals, of rare-earth metals, of radioactive elements or of isotopes",
+                  "min": "2812000000",
+                  "max": "2832999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -3405,6 +3324,72 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 28",
+                  "chapter": 28,
+                  "subdivision": "Any other product from heading 2833",
+                  "min": "2833000000",
+                  "max": "2833999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 28",
+                  "chapter": 28,
+                  "subdivision": "Inorganic chemicals; organic or inorganic compounds of precious metals, of rare-earth metals, of radioactive elements or of isotopes",
+                  "min": "2834000000",
+                  "max": "2839999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 2840",
                   "chapter": 28,
                   "subdivision": "Sodium perborate",
@@ -3437,9 +3422,75 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 28",
+                  "chapter": 28,
+                  "subdivision": "Any other product from heading 2840",
+                  "min": "2840000000",
+                  "max": "2840999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 28",
+                  "chapter": 28,
+                  "subdivision": "Inorganic chemicals; organic or inorganic compounds of precious metals, of rare-earth metals, of radioactive elements or of isotopes",
+                  "min": "2841000000",
+                  "max": "2850999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 2852",
                   "chapter": 28,
-                  "subdivision": "Sauces and preparations therefor; mixed condiments and mixed seasonings; mustard flour and meal and prepared mustard \u25b8 Mercury compounds of internal ethers and their halogenated, sulphonated, nitrated or nitrosated derivatives",
+                  "subdivision": "Sodium perborate \u25b8 Mercury compounds of internal ethers and their halogenated, sulphonated, nitrated or nitrosated derivatives",
                   "min": "2852000000",
                   "max": "2852999999",
                   "rules": [
@@ -3471,7 +3522,7 @@
             {
                   "heading": "ex 2852",
                   "chapter": 28,
-                  "subdivision": "Sauces and preparations therefor; mixed condiments and mixed seasonings; mustard flour and meal and prepared mustard \u25b8 Mercury compounds of nucleic acids and their salts, whether or not chemically defined; other heterocyclic compounds",
+                  "subdivision": "Sodium perborate \u25b8 Mercury compounds of nucleic acids and their salts, whether or not chemically defined; other heterocyclic compounds",
                   "min": "2852000000",
                   "max": "2852999999",
                   "rules": [
@@ -3479,6 +3530,72 @@
                               "rule": "Manufacture from materials of any heading. However, the value of all the materials of [heading&nbsp;2852](/headings/2852), [heading&nbsp;2932](/headings/2932), [heading&nbsp;2933](/headings/2933) and [heading&nbsp;2934](/headings/2934) used must not exceed **20%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 28",
+                  "chapter": 28,
+                  "subdivision": "Any other product from heading 2852",
+                  "min": "2852000000",
+                  "max": "2852999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 28",
+                  "chapter": 28,
+                  "subdivision": "Inorganic chemicals; organic or inorganic compounds of precious metals, of rare-earth metals, of radioactive elements or of isotopes",
+                  "min": "2853000000",
+                  "max": "2853999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -3533,9 +3650,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2901",
+                  "heading": "ex Chapter 29",
                   "chapter": 29,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2901",
                   "min": "2901000000",
                   "max": "2901999999",
                   "rules": [
@@ -3598,9 +3715,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2902",
+                  "heading": "ex Chapter 29",
                   "chapter": 29,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2902",
                   "min": "2902000000",
                   "max": "2902999999",
                   "rules": [
@@ -3631,43 +3748,10 @@
                   "valid": true
             },
             {
-                  "heading": "2903",
+                  "heading": "ex Chapter 29",
                   "chapter": 29,
                   "subdivision": "Organic chemicals",
                   "min": "2903000000",
-                  "max": "2903999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2904",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2904000000",
                   "max": "2904999999",
                   "rules": [
                         {
@@ -3730,9 +3814,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2905",
+                  "heading": "ex Chapter 29",
                   "chapter": 29,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2905",
                   "min": "2905000000",
                   "max": "2905999999",
                   "rules": [
@@ -3763,274 +3847,10 @@
                   "valid": true
             },
             {
-                  "heading": "2906",
+                  "heading": "ex Chapter 29",
                   "chapter": 29,
                   "subdivision": "Organic chemicals",
                   "min": "2906000000",
-                  "max": "2906999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2907",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2907000000",
-                  "max": "2907999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2908",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2908000000",
-                  "max": "2908999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2909",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2909000000",
-                  "max": "2909999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2910",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2910000000",
-                  "max": "2910999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2911",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2911000000",
-                  "max": "2911999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2912",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2912000000",
-                  "max": "2912999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2913",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2913000000",
-                  "max": "2913999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2914",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2914000000",
                   "max": "2914999999",
                   "rules": [
                         {
@@ -4092,505 +3912,10 @@
                   "valid": true
             },
             {
-                  "heading": "2916",
+                  "heading": "ex Chapter 29",
                   "chapter": 29,
                   "subdivision": "Organic chemicals",
                   "min": "2916000000",
-                  "max": "2916999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2917",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2917000000",
-                  "max": "2917999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2918",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2918000000",
-                  "max": "2918999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2919",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2919000000",
-                  "max": "2919999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2920",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2920000000",
-                  "max": "2920999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2921",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2921000000",
-                  "max": "2921999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2922",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2922000000",
-                  "max": "2922999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2923",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2923000000",
-                  "max": "2923999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2924",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2924000000",
-                  "max": "2924999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2925",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2925000000",
-                  "max": "2925999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2926",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2926000000",
-                  "max": "2926999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2927",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2927000000",
-                  "max": "2927999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2928",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2928000000",
-                  "max": "2928999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2929",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2929000000",
-                  "max": "2929999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2930",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2930000000",
-                  "max": "2930999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2931",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2931000000",
                   "max": "2931999999",
                   "rules": [
                         {
@@ -4622,7 +3947,7 @@
             {
                   "heading": "ex 2932",
                   "chapter": 29,
-                  "subdivision": "Sauces and preparations therefor; mixed condiments and mixed seasonings; mustard flour and meal and prepared mustard \u25b8 Internal ethers and their halogenated, sulphonated, nitrated or nitrosated derivatives",
+                  "subdivision": "Saturated acyclic monocarboxylic acids and their anhydrides, halides, peroxides and peroxyacids; their halogenated, sulphonated, nitrated or nitrosated derivatives \u25b8 Internal ethers and their halogenated, sulphonated, nitrated or nitrosated derivatives",
                   "min": "2932000000",
                   "max": "2932999999",
                   "rules": [
@@ -4654,7 +3979,7 @@
             {
                   "heading": "ex 2932",
                   "chapter": 29,
-                  "subdivision": "Sauces and preparations therefor; mixed condiments and mixed seasonings; mustard flour and meal and prepared mustard \u25b8 Cyclic acetals and internal hemiacetals and their halogenated, sulphonated, nitrated or nitrosated derivatives",
+                  "subdivision": "Saturated acyclic monocarboxylic acids and their anhydrides, halides, peroxides and peroxyacids; their halogenated, sulphonated, nitrated or nitrosated derivatives \u25b8 Cyclic acetals and internal hemiacetals and their halogenated, sulphonated, nitrated or nitrosated derivatives",
                   "min": "2932000000",
                   "max": "2932999999",
                   "rules": [
@@ -4684,9 +4009,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2932",
+                  "heading": "ex Chapter 29",
                   "chapter": 29,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2932",
                   "min": "2932000000",
                   "max": "2932999999",
                   "rules": [
@@ -4781,109 +4106,10 @@
                   "valid": true
             },
             {
-                  "heading": "2935",
+                  "heading": "ex Chapter 29",
                   "chapter": 29,
                   "subdivision": "Organic chemicals",
                   "min": "2935000000",
-                  "max": "2935999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2936",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2936000000",
-                  "max": "2936999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2937",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2937000000",
-                  "max": "2937999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2938",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2938000000",
                   "max": "2938999999",
                   "rules": [
                         {
@@ -4934,9 +4160,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 2939",
+                  "heading": "ex Chapter 29",
                   "chapter": 29,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 2939",
                   "min": "2939000000",
                   "max": "2939999999",
                   "rules": [
@@ -4967,76 +4193,10 @@
                   "valid": true
             },
             {
-                  "heading": "2940",
+                  "heading": "ex Chapter 29",
                   "chapter": 29,
                   "subdivision": "Organic chemicals",
                   "min": "2940000000",
-                  "max": "2940999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2941",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2941000000",
-                  "max": "2941999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "2942",
-                  "chapter": 29,
-                  "subdivision": "Organic chemicals",
-                  "min": "2942000000",
                   "max": "2942999999",
                   "rules": [
                         {
@@ -5066,7 +4226,7 @@
                   "valid": true
             },
             {
-                  "heading": "3001",
+                  "heading": "ex Chapter 30",
                   "chapter": 30,
                   "subdivision": "Pharmaceutical products",
                   "min": "3001000000",
@@ -5112,7 +4272,7 @@
             {
                   "heading": "3002",
                   "chapter": 30,
-                  "subdivision": "Human blood; animal blood prepared for therapeutic, prophylactic or diagnostic uses; antisera and other blood fractions and modified immunological products, whether or not obtained by means of biotechnological processes; vaccines, toxins, cultures of micro-organisms (excluding yeasts) and similar products \u25b8 Other \u25b8 - Human blood",
+                  "subdivision": "Human blood; animal blood prepared for therapeutic, prophylactic or diagnostic uses; antisera and other blood fractions and modified immunological products, whether or not obtained by means of biotechnological processes; vaccines, toxins, cultures of micro-organisms (excluding yeasts) and similar products \u25b8 Other \u25b8 Human blood",
                   "min": "3002000000",
                   "max": "3002999999",
                   "rules": [
@@ -5134,7 +4294,7 @@
             {
                   "heading": "3002",
                   "chapter": 30,
-                  "subdivision": "Human blood; animal blood prepared for therapeutic, prophylactic or diagnostic uses; antisera and other blood fractions and modified immunological products, whether or not obtained by means of biotechnological processes; vaccines, toxins, cultures of micro-organisms (excluding yeasts) and similar products \u25b8 Other \u25b8 - Animal blood prepared for therapeutic or prophylactic uses",
+                  "subdivision": "Human blood; animal blood prepared for therapeutic, prophylactic or diagnostic uses; antisera and other blood fractions and modified immunological products, whether or not obtained by means of biotechnological processes; vaccines, toxins, cultures of micro-organisms (excluding yeasts) and similar products \u25b8 Other \u25b8 Animal blood prepared for therapeutic or prophylactic uses",
                   "min": "3002000000",
                   "max": "3002999999",
                   "rules": [
@@ -5156,7 +4316,7 @@
             {
                   "heading": "3002",
                   "chapter": 30,
-                  "subdivision": "Human blood; animal blood prepared for therapeutic, prophylactic or diagnostic uses; antisera and other blood fractions and modified immunological products, whether or not obtained by means of biotechnological processes; vaccines, toxins, cultures of micro-organisms (excluding yeasts) and similar products \u25b8 Other \u25b8 - Blood fractions other than antisera, haemoglobin, blood globulins and serum globulins",
+                  "subdivision": "Human blood; animal blood prepared for therapeutic, prophylactic or diagnostic uses; antisera and other blood fractions and modified immunological products, whether or not obtained by means of biotechnological processes; vaccines, toxins, cultures of micro-organisms (excluding yeasts) and similar products \u25b8 Other \u25b8 Blood fractions other than antisera, haemoglobin, blood globulins and serum globulins",
                   "min": "3002000000",
                   "max": "3002999999",
                   "rules": [
@@ -5178,7 +4338,7 @@
             {
                   "heading": "3002",
                   "chapter": 30,
-                  "subdivision": "Human blood; animal blood prepared for therapeutic, prophylactic or diagnostic uses; antisera and other blood fractions and modified immunological products, whether or not obtained by means of biotechnological processes; vaccines, toxins, cultures of micro-organisms (excluding yeasts) and similar products \u25b8 Other \u25b8 - Haemoglobin, blood globulins and serum globulins",
+                  "subdivision": "Human blood; animal blood prepared for therapeutic, prophylactic or diagnostic uses; antisera and other blood fractions and modified immunological products, whether or not obtained by means of biotechnological processes; vaccines, toxins, cultures of micro-organisms (excluding yeasts) and similar products \u25b8 Other \u25b8 Haemoglobin, blood globulins and serum globulins",
                   "min": "3002000000",
                   "max": "3002999999",
                   "rules": [
@@ -5200,7 +4360,7 @@
             {
                   "heading": "3002",
                   "chapter": 30,
-                  "subdivision": "Human blood; animal blood prepared for therapeutic, prophylactic or diagnostic uses; antisera and other blood fractions and modified immunological products, whether or not obtained by means of biotechnological processes; vaccines, toxins, cultures of micro-organisms (excluding yeasts) and similar products \u25b8 Other \u25b8 - Other",
+                  "subdivision": "Human blood; animal blood prepared for therapeutic, prophylactic or diagnostic uses; antisera and other blood fractions and modified immunological products, whether or not obtained by means of biotechnological processes; vaccines, toxins, cultures of micro-organisms (excluding yeasts) and similar products \u25b8 Other \u25b8 Other",
                   "min": "3002000000",
                   "max": "3002999999",
                   "rules": [
@@ -5220,7 +4380,7 @@
                   "valid": true
             },
             {
-                  "heading": "3003-3004",
+                  "heading": "3003 to 3004",
                   "chapter": 30,
                   "subdivision": "Medicaments (excluding goods of heading 3002, 3005 or 3006) \u25b8 Obtained from amikacin of heading 2941",
                   "min": "3003000000",
@@ -5242,7 +4402,7 @@
                   "valid": true
             },
             {
-                  "heading": "3003-3004",
+                  "heading": "3003 to 3004",
                   "chapter": 30,
                   "subdivision": "Medicaments (excluding goods of heading 3002, 3005 or 3006) \u25b8 Other",
                   "min": "3003000000",
@@ -5264,7 +4424,7 @@
                   "valid": true
             },
             {
-                  "heading": "3005",
+                  "heading": "ex Chapter 30",
                   "chapter": 30,
                   "subdivision": "Pharmaceutical products",
                   "min": "3005000000",
@@ -5309,7 +4469,7 @@
             {
                   "heading": "ex 3006",
                   "chapter": 30,
-                  "subdivision": "Medicaments (excluding goods of heading 3002, 3005 or 3006) \u25b8 Sterile surgical or dental adhesion barriers, whether or not absorbable \u25b8 - made of plastics",
+                  "subdivision": "Medicaments (excluding goods of heading 3002, 3005 or 3006) \u25b8 Sterile surgical or dental adhesion barriers, whether or not absorbable \u25b8 Made of plastics",
                   "min": "3006000000",
                   "max": "3006999999",
                   "rules": [
@@ -5341,24 +4501,17 @@
             {
                   "heading": "ex 3006",
                   "chapter": 30,
-                  "subdivision": "Medicaments (excluding goods of heading 3002, 3005 or 3006) \u25b8 Sterile surgical or dental adhesion barriers, whether or not absorbable \u25b8 - made of fabrics",
+                  "subdivision": "Medicaments (excluding goods of heading 3002, 3005 or 3006) \u25b8 Sterile surgical or dental adhesion barriers, whether or not absorbable \u25b8 Made of fabrics",
                   "min": "3006000000",
                   "max": "3006999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- natural fibres\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning,",
-                              "class": [],
+                              "rule": "Manufacture from:\n\n- natural fibres\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, *or*\n\n- chemical materials or textile pulp.",
+                              "class": [
+                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
+                              ],
                               "footnotes": [],
                               "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "- chemical materials or textile pulp.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
                               "quota": false,
                               "import": true,
                               "export": true
@@ -5369,7 +4522,7 @@
             {
                   "heading": "ex 3006",
                   "chapter": 30,
-                  "subdivision": "Medicaments (excluding goods of heading 3002, 3005 or 3006) \u25b8 Sterile surgical or dental adhesion barriers, whether or not absorbable \u25b8 Appliances identifiable for ostomy use",
+                  "subdivision": "Medicaments (excluding goods of heading 3002, 3005 or 3006) \u25b8 Appliances identifiable for ostomy use",
                   "min": "3006000000",
                   "max": "3006999999",
                   "rules": [
@@ -5388,9 +4541,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3006",
+                  "heading": "ex Chapter 30",
                   "chapter": 30,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 3006",
                   "min": "3006000000",
                   "max": "3006999999",
                   "rules": [
@@ -5413,8 +4566,8 @@
                   "heading": "ex Chapter 31",
                   "chapter": 31,
                   "subdivision": "Fertilizers",
-                  "min": "3100000000",
-                  "max": "3199999999",
+                  "min": "3101000000",
+                  "max": "3104999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
@@ -5445,12 +4598,45 @@
             {
                   "heading": "ex 3105",
                   "chapter": 31,
-                  "subdivision": "Mineral or chemical fertilizers containing two or three of the fertilizing elements nitrogen, phosphorous and potassium; other fertilizers; goods of this chapter, in tablets or similar forms or in packages of a gross weight not exceeding 10 kg, except for:\n - sodium nitrate\n - calcium cyanamide\n - potassium sulphate\n - magnesium potassium sulphate",
+                  "subdivision": "Mineral or chemical fertilizers containing two or three of the fertilizing elements nitrogen, phosphorous and potassium; other fertilizers; goods of this chapter, in tablets or similar forms or in packages of a gross weight not exceeding 10 kg\n - sodium nitrate\n - calcium cyanamide\n - potassium sulphate\n - magnesium potassium sulphate",
                   "min": "3105000000",
                   "max": "3105999999",
                   "rules": [
                         {
                               "rule": "Manufacture:\n\n- from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 31",
+                  "chapter": 31,
+                  "subdivision": "Any other product from heading 3105",
+                  "min": "3105000000",
+                  "max": "3105999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM",
                                     "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
@@ -5508,9 +4694,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3201",
+                  "heading": "ex Chapter 32",
                   "chapter": 32,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 3201",
                   "min": "3201000000",
                   "max": "3201999999",
                   "rules": [
@@ -5541,76 +4727,10 @@
                   "valid": true
             },
             {
-                  "heading": "3202",
+                  "heading": "ex Chapter 32",
                   "chapter": 32,
                   "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
                   "min": "3202000000",
-                  "max": "3202999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3203",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3203000000",
-                  "max": "3203999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3204",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3204000000",
                   "max": "3204999999",
                   "rules": [
                         {
@@ -5673,307 +4793,10 @@
                   "valid": true
             },
             {
-                  "heading": "3206",
+                  "heading": "ex Chapter 32",
                   "chapter": 32,
                   "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
                   "min": "3206000000",
-                  "max": "3206999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3207",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3207000000",
-                  "max": "3207999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3208",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3208000000",
-                  "max": "3208999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3209",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3209000000",
-                  "max": "3209999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3210",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3210000000",
-                  "max": "3210999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3211",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3211000000",
-                  "max": "3211999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3212",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3212000000",
-                  "max": "3212999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3213",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3213000000",
-                  "max": "3213999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3214",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3214000000",
-                  "max": "3214999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3215",
-                  "chapter": 32,
-                  "subdivision": "Tanning or dyeing extracts; tannins and their derivatives; dyes, pigments and other colouring matter; paints and varnishes; putty and other mastics; inks",
-                  "min": "3215000000",
                   "max": "3215999999",
                   "rules": [
                         {
@@ -6036,209 +4859,11 @@
                   "valid": true
             },
             {
-                  "heading": "3302",
+                  "heading": "ex Chapter 33",
+                  "chapter": 33,
                   "subdivision": "Essential oils and resinoids; perfumery, cosmetic or toilet preparations",
                   "min": "3302000000",
-                  "max": "3302999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 33
-            },
-            {
-                  "heading": "3303",
-                  "subdivision": "Essential oils and resinoids; perfumery, cosmetic or toilet preparations",
-                  "min": "3303000000",
-                  "max": "3303999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 33
-            },
-            {
-                  "heading": "3304",
-                  "subdivision": "Essential oils and resinoids; perfumery, cosmetic or toilet preparations",
-                  "min": "3304000000",
-                  "max": "3304999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 33
-            },
-            {
-                  "heading": "3305",
-                  "subdivision": "Essential oils and resinoids; perfumery, cosmetic or toilet preparations",
-                  "min": "3305000000",
-                  "max": "3305999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 33
-            },
-            {
-                  "heading": "3306",
-                  "subdivision": "Essential oils and resinoids; perfumery, cosmetic or toilet preparations",
-                  "min": "3306000000",
-                  "max": "3306999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 33
-            },
-            {
-                  "heading": "3307",
-                  "subdivision": "Essential oils and resinoids; perfumery, cosmetic or toilet preparations",
-                  "min": "3307000000",
                   "max": "3307999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 33
-            },
-            {
-                  "heading": "3401",
-                  "chapter": 34,
-                  "subdivision": "Soap, organic surface-active agents, washing preparations, lubricating preparations, artificial waxes, prepared waxes, polishing or scouring preparations, candles and similar articles, modelling pastes, 'dental waxes' and dental preparations with a basis of plaster",
-                  "min": "3401000000",
-                  "max": "3401999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
@@ -6267,10 +4892,10 @@
                   "valid": true
             },
             {
-                  "heading": "3402",
+                  "heading": "ex Chapter 34",
                   "chapter": 34,
                   "subdivision": "Soap, organic surface-active agents, washing preparations, lubricating preparations, artificial waxes, prepared waxes, polishing or scouring preparations, candles and similar articles, modelling pastes, 'dental waxes' and dental preparations with a basis of plaster",
-                  "min": "3402000000",
+                  "min": "3401000000",
                   "max": "3402999999",
                   "rules": [
                         {
@@ -6332,9 +4957,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3403",
+                  "heading": "ex Chapter 34",
                   "chapter": 34,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 3403",
                   "min": "3403000000",
                   "max": "3403999999",
                   "rules": [
@@ -6394,7 +5019,7 @@
                   "max": "3404999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from materials of any heading, except:\n\n- hydrogenated oils having the character of waxes of [heading&nbsp;1516](/headings/1516),\n\n- fatty acids not chemically defined or industrial fatty alcohols having the character of waxes of [heading&nbsp;3823](/headings/3823), *and*\n\n- materials of heading&nbsp;3404\n\nHowever, these materials may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
+                              "rule": "Manufacture from materials of any heading, except:\n\n- hydrogenated oils having the character of waxes of [heading&nbsp;1516](/headings/1516),\n\n- fatty acids not chemically defined or industrial fatty alcohols having the character of waxes of [heading&nbsp;3823](/headings/3823), *and*\n\n- materials of [heading&nbsp;3404](/headings/3404).\n\nHowever, these materials may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM",
                                     "AH EXCEPT TOLERANCE MAY BE USED RESTRICTION MAXNOM"
@@ -6420,76 +5045,10 @@
                   "valid": true
             },
             {
-                  "heading": "3405",
+                  "heading": "ex Chapter 34",
                   "chapter": 34,
                   "subdivision": "Soap, organic surface-active agents, washing preparations, lubricating preparations, artificial waxes, prepared waxes, polishing or scouring preparations, candles and similar articles, modelling pastes, 'dental waxes' and dental preparations with a basis of plaster",
                   "min": "3405000000",
-                  "max": "3405999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3406",
-                  "chapter": 34,
-                  "subdivision": "Soap, organic surface-active agents, washing preparations, lubricating preparations, artificial waxes, prepared waxes, polishing or scouring preparations, candles and similar articles, modelling pastes, 'dental waxes' and dental preparations with a basis of plaster",
-                  "min": "3406000000",
-                  "max": "3406999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3407",
-                  "chapter": 34,
-                  "subdivision": "Soap, organic surface-active agents, washing preparations, lubricating preparations, artificial waxes, prepared waxes, polishing or scouring preparations, candles and similar articles, modelling pastes, 'dental waxes' and dental preparations with a basis of plaster",
-                  "min": "3407000000",
                   "max": "3407999999",
                   "rules": [
                         {
@@ -6519,109 +5078,10 @@
                   "valid": true
             },
             {
-                  "heading": "3501",
+                  "heading": "ex Chapter 35",
                   "chapter": 35,
                   "subdivision": "Albuminoidal substances; modified starches; glues; enzymes",
                   "min": "3501000000",
-                  "max": "3501999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3502",
-                  "chapter": 35,
-                  "subdivision": "Albuminoidal substances; modified starches; glues; enzymes",
-                  "min": "3502000000",
-                  "max": "3502999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3503",
-                  "chapter": 35,
-                  "subdivision": "Albuminoidal substances; modified starches; glues; enzymes",
-                  "min": "3503000000",
-                  "max": "3503999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3504",
-                  "chapter": 35,
-                  "subdivision": "Albuminoidal substances; modified starches; glues; enzymes",
-                  "min": "3504000000",
                   "max": "3504999999",
                   "rules": [
                         {
@@ -6715,7 +5175,7 @@
                   "valid": true
             },
             {
-                  "heading": "3506",
+                  "heading": "ex Chapter 35",
                   "chapter": 35,
                   "subdivision": "Albuminoidal substances; modified starches; glues; enzymes",
                   "min": "3506000000",
@@ -6769,9 +5229,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3507",
+                  "heading": "ex Chapter 35",
                   "chapter": 35,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 3507",
                   "min": "3507000000",
                   "max": "3507999999",
                   "rules": [
@@ -6933,7 +5393,8 @@
                   "valid": true
             },
             {
-                  "heading": "3703",
+                  "heading": "ex Chapter 37",
+                  "chapter": 37,
                   "subdivision": "Photographic or cinematographic goods",
                   "min": "3703000000",
                   "max": "3703999999",
@@ -6962,8 +5423,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 37
+                  "valid": true
             },
             {
                   "heading": "3704",
@@ -6998,75 +5458,10 @@
                   "valid": true
             },
             {
-                  "heading": "3705",
+                  "heading": "ex Chapter 37",
+                  "chapter": 37,
                   "subdivision": "Photographic or cinematographic goods",
                   "min": "3705000000",
-                  "max": "3705999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 37
-            },
-            {
-                  "heading": "3706",
-                  "subdivision": "Photographic or cinematographic goods",
-                  "min": "3706000000",
-                  "max": "3706999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 37
-            },
-            {
-                  "heading": "3707",
-                  "subdivision": "Photographic or cinematographic goods",
-                  "min": "3707000000",
                   "max": "3707999999",
                   "rules": [
                         {
@@ -7093,13 +5488,12 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 37
+                  "valid": true
             },
             {
                   "heading": "ex 3801",
                   "chapter": 38,
-                  "subdivision": "Photographic plates and film in the flat, sensitised, unexposed, of any material other than paper, paperboard or textiles; instant print film in the flat, sensitised, unexposed, whether or not in packs \u25b8 Colloidal graphite in suspension in oil and semi-colloidal graphite; carbonaceous pastes for electrodes",
+                  "subdivision": "Miscellaneous chemical products \u25b8 Colloidal graphite in suspension in oil and semi-colloidal graphite; carbonaceous pastes for electrodes",
                   "min": "3801000000",
                   "max": "3801999999",
                   "rules": [
@@ -7120,7 +5514,7 @@
             {
                   "heading": "ex 3801",
                   "chapter": 38,
-                  "subdivision": "Photographic plates and film in the flat, sensitised, unexposed, of any material other than paper, paperboard or textiles; instant print film in the flat, sensitised, unexposed, whether or not in packs \u25b8 Graphite in paste form, being a mixture of more than 30% by weight of graphite with mineral oils",
+                  "subdivision": "Miscellaneous chemical products \u25b8 Graphite in paste form, being a mixture of more than 30% by weight of graphite with mineral oils",
                   "min": "3801000000",
                   "max": "3801999999",
                   "rules": [
@@ -7150,9 +5544,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3801",
+                  "heading": "ex Chapter 38",
                   "chapter": 38,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 3801",
                   "min": "3801000000",
                   "max": "3801999999",
                   "rules": [
@@ -7183,7 +5577,7 @@
                   "valid": true
             },
             {
-                  "heading": "3802",
+                  "heading": "ex Chapter 38",
                   "chapter": 38,
                   "subdivision": "Miscellaneous chemical products",
                   "min": "3802000000",
@@ -7248,9 +5642,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3803",
+                  "heading": "ex Chapter 38",
                   "chapter": 38,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 3803",
                   "min": "3803000000",
                   "max": "3803999999",
                   "rules": [
@@ -7281,7 +5675,7 @@
                   "valid": true
             },
             {
-                  "heading": "3804",
+                  "heading": "ex Chapter 38",
                   "chapter": 38,
                   "subdivision": "Miscellaneous chemical products",
                   "min": "3804000000",
@@ -7346,9 +5740,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3805",
+                  "heading": "ex Chapter 38",
                   "chapter": 38,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 3805",
                   "min": "3805000000",
                   "max": "3805999999",
                   "rules": [
@@ -7411,9 +5805,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3806",
+                  "heading": "ex Chapter 38",
                   "chapter": 38,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 3806",
                   "min": "3806000000",
                   "max": "3806999999",
                   "rules": [
@@ -7476,9 +5870,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3807",
+                  "heading": "ex Chapter 38",
                   "chapter": 38,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 3807",
                   "min": "3807000000",
                   "max": "3807999999",
                   "rules": [
@@ -7677,76 +6071,10 @@
                   "valid": true
             },
             {
-                  "heading": "3815",
+                  "heading": "ex Chapter 38",
                   "chapter": 38,
                   "subdivision": "Miscellaneous chemical products",
                   "min": "3815000000",
-                  "max": "3815999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3816",
-                  "chapter": 38,
-                  "subdivision": "Miscellaneous chemical products",
-                  "min": "3816000000",
-                  "max": "3816999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3817",
-                  "chapter": 38,
-                  "subdivision": "Miscellaneous chemical products",
-                  "min": "3817000000",
                   "max": "3817999999",
                   "rules": [
                         {
@@ -7860,9 +6188,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3821",
+                  "heading": "ex Chapter 38",
                   "chapter": 38,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 3821",
                   "min": "3821000000",
                   "max": "3821999999",
                   "rules": [
@@ -8010,76 +6338,10 @@
                   "valid": true
             },
             {
-                  "heading": "3825",
+                  "heading": "ex Chapter 38",
                   "chapter": 38,
                   "subdivision": "Miscellaneous chemical products",
                   "min": "3825000000",
-                  "max": "3825999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3826",
-                  "chapter": 38,
-                  "subdivision": "Miscellaneous chemical products",
-                  "min": "3826000000",
-                  "max": "3826999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product. However, materials of the same heading as the product may be used, provided that their total value does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3827",
-                  "chapter": 38,
-                  "subdivision": "Miscellaneous chemical products",
-                  "min": "3827000000",
                   "max": "3827999999",
                   "rules": [
                         {
@@ -8109,73 +6371,9 @@
                   "valid": true
             },
             {
-                  "heading": "3901-3915",
-                  "chapter": 39,
-                  "subdivision": "Plastics in primary forms, waste, parings and scrap, of plastic; except for headings ex 3907 and 3912 for which the rules are set out below \u25b8 Addition homopolymerisation products in which a single monomer contributes more than 99% by weight to the total polymer content",
-                  "min": "3901000000",
-                  "max": "3915999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which:\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product, *and*\n\n- within the above limit, the value of all the materials of [chapter&nbsp;39](/chapters/39) used does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **25%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3901-3915",
-                  "chapter": 39,
-                  "subdivision": "Plastics in primary forms, waste, parings and scrap, of plastic; except for headings ex 3907 and 3912 for which the rules are set out below \u25b8 Other",
-                  "min": "3901000000",
-                  "max": "3915999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of [chapter&nbsp;39](/chapters/39) used does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **25%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
                   "heading": "ex 3907",
                   "chapter": 39,
-                  "subdivision": "Plastics in primary forms, waste, parings and scrap, of plastic; except for headings ex 3907 and 3912 for which the rules are set out below \u25b8 Copolymer, made from polycarbonate and acrylonitrile-butadiene-styrene copolymer (ABS)",
+                  "subdivision": "Plastics in primary forms, waste, parings and scrap, of plastic headings ex 3907 and 3912 for which the rules are set out below \u25b8 Copolymer, made from polycarbonate and acrylonitrile-butadiene-styrene copolymer (ABS)",
                   "min": "3907000000",
                   "max": "3907999999",
                   "rules": [
@@ -8197,7 +6395,7 @@
             {
                   "heading": "ex 3907",
                   "chapter": 39,
-                  "subdivision": "Plastics in primary forms, waste, parings and scrap, of plastic; except for headings ex 3907 and 3912 for which the rules are set out below \u25b8 Polyester",
+                  "subdivision": "Plastics in primary forms, waste, parings and scrap, of plastic headings ex 3907 and 3912 for which the rules are set out below \u25b8 Polyester",
                   "min": "3907000000",
                   "max": "3907999999",
                   "rules": [
@@ -8237,75 +6435,11 @@
                   "valid": true
             },
             {
-                  "heading": "ex 3916",
+                  "heading": "3901 to 3915",
                   "chapter": 39,
-                  "subdivision": "Profile shapes and tubes",
-                  "min": "3916000000",
-                  "max": "3916999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which:\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product, *and*\n\n- within the above limit, the value of all the materials of the same heading as the product used does not exceed **20%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **25%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3916-3921",
-                  "chapter": 39,
-                  "subdivision": "Semi-manufactures and articles of plastics; except for headings ex 3916, ex 3917, ex 3920 and ex 3921, for which the rules are set out below \u25b8 Flat products, further worked than only surface-worked or cut into forms other than rectangular (including square); other products, further worked than only surface-worked",
-                  "min": "3916000000",
-                  "max": "3921999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of [chapter&nbsp;39](/chapters/39) used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **25%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "3916-3921",
-                  "chapter": 39,
-                  "subdivision": "Semi-manufactures and articles of plastics; except for headings ex 3916, ex 3917, ex 3920 and ex 3921, for which the rules are set out below \u25b8 Other \u25b8 - Addition homopolymerisation products in which a single monomer contributes more than 99% by weight to the total polymer content",
-                  "min": "3916000000",
-                  "max": "3921999999",
+                  "subdivision": "Plastics in primary forms, waste, parings and scrap, of plastic headings ex 3907 and 3912 for which the rules are set out below \u25b8 Addition homopolymerisation products in which a single monomer contributes more than 99% by weight to the total polymer content",
+                  "min": "3901000000",
+                  "max": "3915999999",
                   "rules": [
                         {
                               "rule": "Manufacture in which:\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product, *and*\n\n- within the above limit, the value of all the materials of [chapter&nbsp;39](/chapters/39) used does not exceed **20%** of the ex-works price of the product.",
@@ -8333,14 +6467,46 @@
                   "valid": true
             },
             {
-                  "heading": "3916-3921",
+                  "heading": "3901 to 3915",
                   "chapter": 39,
-                  "subdivision": "Semi-manufactures and articles of plastics; except for headings ex 3916, ex 3917, ex 3920 and ex 3921, for which the rules are set out below \u25b8 Other \u25b8 - Other",
-                  "min": "3916000000",
-                  "max": "3921999999",
+                  "subdivision": "Plastics in primary forms, waste, parings and scrap, of plastic headings ex 3907 and 3912 for which the rules are set out below \u25b8 Other",
+                  "min": "3901000000",
+                  "max": "3915999999",
                   "rules": [
                         {
                               "rule": "Manufacture in which the value of all the materials of [chapter&nbsp;39](/chapters/39) used does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **25%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex 3916",
+                  "chapter": 39,
+                  "subdivision": "Profile shapes and tubes",
+                  "min": "3916000000",
+                  "max": "3916999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture in which:\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product, *and*\n\n- within the above limit, the value of all the materials of the same heading as the product used does not exceed **20%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
@@ -8399,7 +6565,7 @@
             {
                   "heading": "ex 3920",
                   "chapter": 39,
-                  "subdivision": "Semi-manufactures and articles of plastics; except for headings ex 3916, ex 3917, ex 3920 and ex 3921, for which the rules are set out below \u25b8 Other \u25b8 Ionomer sheet or film",
+                  "subdivision": "Profile shapes and tubes \u25b8 Ionomer sheet or film",
                   "min": "3920000000",
                   "max": "3920999999",
                   "rules": [
@@ -8431,7 +6597,7 @@
             {
                   "heading": "ex 3920",
                   "chapter": 39,
-                  "subdivision": "Semi-manufactures and articles of plastics; except for headings ex 3916, ex 3917, ex 3920 and ex 3921, for which the rules are set out below \u25b8 Other \u25b8 Sheets of regenerated cellulose, polyamides or polyethylene",
+                  "subdivision": "Profile shapes and tubes \u25b8 Sheets of regenerated cellulose, polyamides or polyethylene",
                   "min": "3920000000",
                   "max": "3920999999",
                   "rules": [
@@ -8442,6 +6608,102 @@
                               ],
                               "footnotes": [],
                               "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "3916 to 3921",
+                  "chapter": 39,
+                  "subdivision": "Semi-manufactures and articles of plastics headings ex 3916, ex 3917, ex 3920 and ex 3921, for which the rules are set out below \u25b8 Flat products, further worked than only surface-worked or cut into forms other than rectangular (including square); other products, further worked than only surface-worked",
+                  "min": "3916000000",
+                  "max": "3921999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture in which the value of all the materials of [chapter&nbsp;39](/chapters/39) used does not exceed **50%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **25%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "3916 to 3921",
+                  "chapter": 39,
+                  "subdivision": "Semi-manufactures and articles of plastics headings ex 3916, ex 3917, ex 3920 and ex 3921, for which the rules are set out below \u25b8 Other \u25b8 Addition homopolymerisation products in which a single monomer contributes more than 99% by weight to the total polymer content",
+                  "min": "3916000000",
+                  "max": "3921999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture in which:\n\n- the value of all the materials used does not exceed **50%** of the ex-works price of the product, *and*\n\n- within the above limit, the value of all the materials of [chapter&nbsp;39](/chapters/39) used does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **25%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "3916 to 3921",
+                  "chapter": 39,
+                  "subdivision": "Semi-manufactures and articles of plastics headings ex 3916, ex 3917, ex 3920 and ex 3921, for which the rules are set out below \u25b8 Other \u25b8 Other",
+                  "min": "3916000000",
+                  "max": "3921999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture in which the value of all the materials of [chapter&nbsp;39](/chapters/39) used does not exceed **20%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture in which the value of all the materials used does not exceed **25%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM"
+                              ],
+                              "footnotes": [],
+                              "operator": "or",
                               "quota": false,
                               "import": true,
                               "export": true
@@ -8482,7 +6744,7 @@
                   "valid": true
             },
             {
-                  "heading": "3922-3926",
+                  "heading": "3922 to 3926",
                   "chapter": 39,
                   "subdivision": "Articles of plastics",
                   "min": "3922000000",
@@ -8524,9 +6786,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 4001",
+                  "heading": "ex Chapter 40",
                   "chapter": 40,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 4001",
                   "min": "4001000000",
                   "max": "4001999999",
                   "rules": [
@@ -8545,52 +6807,10 @@
                   "valid": true
             },
             {
-                  "heading": "4002",
+                  "heading": "ex Chapter 40",
                   "chapter": 40,
                   "subdivision": "Rubber and articles thereof",
                   "min": "4002000000",
-                  "max": "4002999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4003",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof",
-                  "min": "4003000000",
-                  "max": "4003999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4004",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof",
-                  "min": "4004000000",
                   "max": "4004999999",
                   "rules": [
                         {
@@ -8629,115 +6849,10 @@
                   "valid": true
             },
             {
-                  "heading": "4006",
+                  "heading": "ex Chapter 40",
                   "chapter": 40,
                   "subdivision": "Rubber and articles thereof",
                   "min": "4006000000",
-                  "max": "4006999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4007",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof",
-                  "min": "4007000000",
-                  "max": "4007999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4008",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof",
-                  "min": "4008000000",
-                  "max": "4008999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4009",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof",
-                  "min": "4009000000",
-                  "max": "4009999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4010",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof",
-                  "min": "4010000000",
-                  "max": "4010999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4011",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof",
-                  "min": "4011000000",
                   "max": "4011999999",
                   "rules": [
                         {
@@ -8797,73 +6912,10 @@
                   "valid": true
             },
             {
-                  "heading": "4013",
+                  "heading": "ex Chapter 40",
                   "chapter": 40,
                   "subdivision": "Rubber and articles thereof",
                   "min": "4013000000",
-                  "max": "4013999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4014",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof",
-                  "min": "4014000000",
-                  "max": "4014999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4015",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof",
-                  "min": "4015000000",
-                  "max": "4015999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4016",
-                  "chapter": 40,
-                  "subdivision": "Rubber and articles thereof",
-                  "min": "4016000000",
                   "max": "4016999999",
                   "rules": [
                         {
@@ -8902,9 +6954,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 4017",
+                  "heading": "ex Chapter 40",
                   "chapter": 40,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 4017",
                   "min": "4017000000",
                   "max": "4017999999",
                   "rules": [
@@ -8923,7 +6975,7 @@
                   "valid": true
             },
             {
-                  "heading": "4101",
+                  "heading": "ex Chapter 41",
                   "chapter": 41,
                   "subdivision": "Raw hides and skins (other than furskins) and leather",
                   "min": "4101000000",
@@ -8965,9 +7017,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 4102",
+                  "heading": "ex Chapter 41",
                   "chapter": 41,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 4102",
                   "min": "4102000000",
                   "max": "4102999999",
                   "rules": [
@@ -8986,7 +7038,7 @@
                   "valid": true
             },
             {
-                  "heading": "4103",
+                  "heading": "ex Chapter 41",
                   "chapter": 41,
                   "subdivision": "Raw hides and skins (other than furskins) and leather",
                   "min": "4103000000",
@@ -9007,7 +7059,7 @@
                   "valid": true
             },
             {
-                  "heading": "4104-4106",
+                  "heading": "4104 to 4106",
                   "chapter": 41,
                   "subdivision": "Tanned or crust hides and skins, without wool or hair on, whether or not split, but not further prepared",
                   "min": "4104000000",
@@ -9060,7 +7112,7 @@
                   "valid": true
             },
             {
-                  "heading": "4112-4113",
+                  "heading": "4112 to 4113",
                   "chapter": 41,
                   "subdivision": "Leather further prepared after tanning or crusting, including parchment-dressed leather, without wool or hair on, whether or not split, other than leather of heading 4114",
                   "min": "4112000000",
@@ -9103,9 +7155,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 4114",
+                  "heading": "ex Chapter 41",
                   "chapter": 41,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 4114",
                   "min": "4114000000",
                   "max": "4114999999",
                   "rules": [
@@ -9124,7 +7176,7 @@
                   "valid": true
             },
             {
-                  "heading": "4115",
+                  "heading": "ex Chapter 41",
                   "chapter": 41,
                   "subdivision": "Raw hides and skins (other than furskins) and leather",
                   "min": "4115000000",
@@ -9166,7 +7218,7 @@
                   "valid": true
             },
             {
-                  "heading": "4301",
+                  "heading": "ex Chapter 43",
                   "chapter": 43,
                   "subdivision": "Furskins and artificial fur; manufactures thereof",
                   "min": "4301000000",
@@ -9229,9 +7281,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 4302",
+                  "heading": "ex Chapter 43",
                   "chapter": 43,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 4302",
                   "min": "4302000000",
                   "max": "4302999999",
                   "rules": [
@@ -9271,7 +7323,7 @@
                   "valid": true
             },
             {
-                  "heading": "4304",
+                  "heading": "ex Chapter 43",
                   "chapter": 43,
                   "subdivision": "Furskins and artificial fur; manufactures thereof",
                   "min": "4304000000",
@@ -9295,8 +7347,8 @@
                   "heading": "ex Chapter 44",
                   "chapter": 44,
                   "subdivision": "Wood and articles of wood; wood charcoal",
-                  "min": "4400000000",
-                  "max": "4499999999",
+                  "min": "4401000000",
+                  "max": "4402999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product.",
@@ -9334,6 +7386,48 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4403",
+                  "min": "4403000000",
+                  "max": "4403999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Wood and articles of wood; wood charcoal",
+                  "min": "4404000000",
+                  "max": "4406999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 4407",
                   "chapter": 44,
                   "subdivision": "Wood sawn or chipped lengthwise, sliced or peeled, of a thickness exceeding 6 mm, planed, sanded or end-jointed",
@@ -9355,6 +7449,27 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4407",
+                  "min": "4407000000",
+                  "max": "4407999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 4408",
                   "chapter": 44,
                   "subdivision": "Sheets for veneering (including those obtained by slicing laminated wood) and for plywood, of a thickness not exceeding 6 mm, spliced, and other wood sawn lengthwise, sliced or peeled of a thickness not exceeding 6 mm, planed, sanded or end-jointed",
@@ -9365,6 +7480,27 @@
                               "rule": "Splicing, planing, sanding or end-jointing.",
                               "class": [
                                     "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4408",
+                  "min": "4408000000",
+                  "max": "4408999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -9418,6 +7554,27 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4409",
+                  "min": "4409000000",
+                  "max": "4409999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 4410",
                   "chapter": 44,
                   "subdivision": "Beadings and mouldings, including moulded skirting and other moulded boards",
@@ -9428,6 +7585,27 @@
                               "rule": "Beading or moulding.",
                               "class": [
                                     "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4410",
+                  "min": "4410000000",
+                  "max": "4410999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -9460,6 +7638,27 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4411",
+                  "min": "4411000000",
+                  "max": "4411999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 4412",
                   "chapter": 44,
                   "subdivision": "Beadings and mouldings, including moulded skirting and other moulded boards",
@@ -9470,6 +7669,27 @@
                               "rule": "Beading or moulding.",
                               "class": [
                                     "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4412",
+                  "min": "4412000000",
+                  "max": "4412999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -9502,6 +7722,48 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4413",
+                  "min": "4413000000",
+                  "max": "4413999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Wood and articles of wood; wood charcoal",
+                  "min": "4414000000",
+                  "max": "4414999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 4415",
                   "chapter": 44,
                   "subdivision": "Packing cases, boxes, crates, drums and similar packings, of wood",
@@ -9512,6 +7774,27 @@
                               "rule": "Manufacture from boards not cut to size.",
                               "class": [
                                     "PRODUCTION FROM"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4415",
+                  "min": "4415000000",
+                  "max": "4415999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -9544,9 +7827,51 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4416",
+                  "min": "4416000000",
+                  "max": "4416999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Wood and articles of wood; wood charcoal",
+                  "min": "4417000000",
+                  "max": "4417999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 4418",
                   "chapter": 44,
-                  "subdivision": "Wood continuously shaped along any of its edges, ends or faces, whether or not planed, sanded or end-jointed \u25b8 Builders' joinery and carpentry of wood",
+                  "subdivision": "Casks, barrels, vats, tubs and other coopers' products and parts thereof, of wood \u25b8 Builders' joinery and carpentry of wood",
                   "min": "4418000000",
                   "max": "4418999999",
                   "rules": [
@@ -9567,7 +7892,7 @@
             {
                   "heading": "ex 4418",
                   "chapter": 44,
-                  "subdivision": "Wood continuously shaped along any of its edges, ends or faces, whether or not planed, sanded or end-jointed \u25b8 Beadings and mouldings",
+                  "subdivision": "Casks, barrels, vats, tubs and other coopers' products and parts thereof, of wood \u25b8 Beadings and mouldings",
                   "min": "4418000000",
                   "max": "4418999999",
                   "rules": [
@@ -9575,6 +7900,48 @@
                               "rule": "Beading or moulding.",
                               "class": [
                                     "PROCESSING"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4418",
+                  "min": "4418000000",
+                  "max": "4418999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Wood and articles of wood; wood charcoal",
+                  "min": "4419000000",
+                  "max": "4420999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -9607,10 +7974,11 @@
                   "valid": true
             },
             {
-                  "heading": "4501",
-                  "subdivision": "Cork and articles of cork",
-                  "min": "4501000000",
-                  "max": "4501999999",
+                  "heading": "ex Chapter 44",
+                  "chapter": 44,
+                  "subdivision": "Any other product from heading 4421",
+                  "min": "4421000000",
+                  "max": "4421999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product.",
@@ -9624,13 +7992,13 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 45
+                  "valid": true
             },
             {
-                  "heading": "4502",
+                  "heading": "ex Chapter 45",
+                  "chapter": 45,
                   "subdivision": "Cork and articles of cork",
-                  "min": "4502000000",
+                  "min": "4501000000",
                   "max": "4502999999",
                   "rules": [
                         {
@@ -9645,8 +8013,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 45
+                  "valid": true
             },
             {
                   "heading": "4503",
@@ -9670,7 +8037,8 @@
                   "valid": true
             },
             {
-                  "heading": "4504",
+                  "heading": "ex Chapter 45",
+                  "chapter": 45,
                   "subdivision": "Cork and articles of cork",
                   "min": "4504000000",
                   "max": "4504999999",
@@ -9687,8 +8055,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 45
+                  "valid": true
             },
             {
                   "heading": "Chapter 46",
@@ -9733,199 +8100,10 @@
                   "valid": true
             },
             {
-                  "heading": "4801",
+                  "heading": "ex Chapter 48",
                   "chapter": 48,
                   "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
                   "min": "4801000000",
-                  "max": "4801999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4802",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4802000000",
-                  "max": "4802999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4803",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4803000000",
-                  "max": "4803999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4804",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4804000000",
-                  "max": "4804999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4805",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4805000000",
-                  "max": "4805999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4806",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4806000000",
-                  "max": "4806999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4807",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4807000000",
-                  "max": "4807999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4808",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4808000000",
-                  "max": "4808999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4809",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4809000000",
-                  "max": "4809999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4810",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4810000000",
                   "max": "4810999999",
                   "rules": [
                         {
@@ -9964,9 +8142,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 4811",
+                  "heading": "ex Chapter 48",
                   "chapter": 48,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 4811",
                   "min": "4811000000",
                   "max": "4811999999",
                   "rules": [
@@ -9985,52 +8163,10 @@
                   "valid": true
             },
             {
-                  "heading": "4812",
+                  "heading": "ex Chapter 48",
                   "chapter": 48,
                   "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
                   "min": "4812000000",
-                  "max": "4812999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4813",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4813000000",
-                  "max": "4813999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4814",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4814000000",
                   "max": "4814999999",
                   "rules": [
                         {
@@ -10112,9 +8248,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 4818",
+                  "heading": "ex Chapter 48",
                   "chapter": 48,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 4818",
                   "min": "4818000000",
                   "max": "4818999999",
                   "rules": [
@@ -10155,9 +8291,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 4819",
+                  "heading": "ex Chapter 48",
                   "chapter": 48,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 4819",
                   "min": "4819000000",
                   "max": "4819999999",
                   "rules": [
@@ -10197,9 +8333,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 4820",
+                  "heading": "ex Chapter 48",
                   "chapter": 48,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 4820",
                   "min": "4820000000",
                   "max": "4820999999",
                   "rules": [
@@ -10218,31 +8354,10 @@
                   "valid": true
             },
             {
-                  "heading": "4821",
+                  "heading": "ex Chapter 48",
                   "chapter": 48,
                   "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
                   "min": "4821000000",
-                  "max": "4821999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "4822",
-                  "chapter": 48,
-                  "subdivision": "Paper and paperboard; articles of paper pulp, of paper or of paperboard",
-                  "min": "4822000000",
                   "max": "4822999999",
                   "rules": [
                         {
@@ -10281,9 +8396,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 4823",
+                  "heading": "ex Chapter 48",
                   "chapter": 48,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 4823",
                   "min": "4823000000",
                   "max": "4823999999",
                   "rules": [
@@ -10302,156 +8417,10 @@
                   "valid": true
             },
             {
-                  "heading": "4901",
+                  "heading": "ex Chapter 49",
+                  "chapter": 49,
                   "subdivision": "Printed books, newspapers, pictures and other products of the printing industry; manuscripts, typescripts and plans",
                   "min": "4901000000",
-                  "max": "4901999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 49
-            },
-            {
-                  "heading": "4902",
-                  "subdivision": "Printed books, newspapers, pictures and other products of the printing industry; manuscripts, typescripts and plans",
-                  "min": "4902000000",
-                  "max": "4902999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 49
-            },
-            {
-                  "heading": "4903",
-                  "subdivision": "Printed books, newspapers, pictures and other products of the printing industry; manuscripts, typescripts and plans",
-                  "min": "4903000000",
-                  "max": "4903999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 49
-            },
-            {
-                  "heading": "4904",
-                  "subdivision": "Printed books, newspapers, pictures and other products of the printing industry; manuscripts, typescripts and plans",
-                  "min": "4904000000",
-                  "max": "4904999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 49
-            },
-            {
-                  "heading": "4905",
-                  "subdivision": "Printed books, newspapers, pictures and other products of the printing industry; manuscripts, typescripts and plans",
-                  "min": "4905000000",
-                  "max": "4905999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 49
-            },
-            {
-                  "heading": "4906",
-                  "subdivision": "Printed books, newspapers, pictures and other products of the printing industry; manuscripts, typescripts and plans",
-                  "min": "4906000000",
-                  "max": "4906999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 49
-            },
-            {
-                  "heading": "4907",
-                  "subdivision": "Printed books, newspapers, pictures and other products of the printing industry; manuscripts, typescripts and plans",
-                  "min": "4907000000",
-                  "max": "4907999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 49
-            },
-            {
-                  "heading": "4908",
-                  "subdivision": "Printed books, newspapers, pictures and other products of the printing industry; manuscripts, typescripts and plans",
-                  "min": "4908000000",
                   "max": "4908999999",
                   "rules": [
                         {
@@ -10466,8 +8435,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 49
+                  "valid": true
             },
             {
                   "heading": "4909",
@@ -10534,7 +8502,8 @@
                   "valid": true
             },
             {
-                  "heading": "4911",
+                  "heading": "ex Chapter 49",
+                  "chapter": 49,
                   "subdivision": "Printed books, newspapers, pictures and other products of the printing industry; manuscripts, typescripts and plans",
                   "min": "4911000000",
                   "max": "4911999999",
@@ -10551,35 +8520,13 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 49
-            },
-            {
-                  "heading": "5001",
-                  "chapter": 50,
-                  "subdivision": "Silk",
-                  "min": "5001000000",
-                  "max": "5001999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
                   "valid": true
             },
             {
-                  "heading": "5002",
+                  "heading": "ex Chapter 50",
                   "chapter": 50,
                   "subdivision": "Silk",
-                  "min": "5002000000",
+                  "min": "5001000000",
                   "max": "5002999999",
                   "rules": [
                         {
@@ -10618,9 +8565,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 5003",
+                  "heading": "ex Chapter 50",
                   "chapter": 50,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 5003",
                   "min": "5003000000",
                   "max": "5003999999",
                   "rules": [
@@ -10639,14 +8586,14 @@
                   "valid": true
             },
             {
-                  "heading": "5004-5005",
+                  "heading": "5004 to 5005",
                   "chapter": 50,
                   "subdivision": "Silk yarn and yarn spun from silk waste",
                   "min": "5004000000",
                   "max": "5005999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- other natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- other natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -10667,7 +8614,7 @@
                   "max": "5006999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- other natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- other natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -10681,9 +8628,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 5006",
+                  "heading": "ex Chapter 50",
                   "chapter": 50,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 5006",
                   "min": "5006000000",
                   "max": "5006999999",
                   "rules": [
@@ -10730,7 +8677,7 @@
                   "max": "5007999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n coir yarn,\n\n natural fibres,\n\nman-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\nchemical materials or textile pulp, or\n\npaper.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -10753,93 +8700,10 @@
                   "valid": true
             },
             {
-                  "heading": "5101",
+                  "heading": "ex Chapter 51",
+                  "chapter": 51,
                   "subdivision": "Wool, fine or coarse animal hair; horsehair yarn and woven fabric",
                   "min": "5101000000",
-                  "max": "5101999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 51
-            },
-            {
-                  "heading": "5102",
-                  "subdivision": "Wool, fine or coarse animal hair; horsehair yarn and woven fabric",
-                  "min": "5102000000",
-                  "max": "5102999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 51
-            },
-            {
-                  "heading": "5103",
-                  "subdivision": "Wool, fine or coarse animal hair; horsehair yarn and woven fabric",
-                  "min": "5103000000",
-                  "max": "5103999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 51
-            },
-            {
-                  "heading": "5104",
-                  "subdivision": "Wool, fine or coarse animal hair; horsehair yarn and woven fabric",
-                  "min": "5104000000",
-                  "max": "5104999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 51
-            },
-            {
-                  "heading": "5105",
-                  "subdivision": "Wool, fine or coarse animal hair; horsehair yarn and woven fabric",
-                  "min": "5105000000",
                   "max": "5105999999",
                   "rules": [
                         {
@@ -10854,18 +8718,17 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 51
+                  "valid": true
             },
             {
-                  "heading": "5106-5110",
+                  "heading": "5106 to 5110",
                   "chapter": 51,
                   "subdivision": "Yarn of wool, of fine or coarse animal hair or of horsehair",
                   "min": "5106000000",
                   "max": "5110999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -10879,7 +8742,7 @@
                   "valid": true
             },
             {
-                  "heading": "5111-5113",
+                  "heading": "5111 to 5113",
                   "chapter": 51,
                   "subdivision": "Woven fabrics of wool, of fine or coarse animal hair or of horsehair \u25b8 Incorporating rubber thread",
                   "min": "5111000000",
@@ -10900,14 +8763,14 @@
                   "valid": true
             },
             {
-                  "heading": "5111-5113",
+                  "heading": "5111 to 5113",
                   "chapter": 51,
                   "subdivision": "Woven fabrics of wool, of fine or coarse animal hair or of horsehair \u25b8 Other",
                   "min": "5111000000",
                   "max": "5113999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\ncoir yarn,\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\nchemical materials or textile pulp, or\n\npaper.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -10930,51 +8793,10 @@
                   "valid": true
             },
             {
-                  "heading": "5201",
+                  "heading": "ex Chapter 52",
+                  "chapter": 52,
                   "subdivision": "Cotton",
                   "min": "5201000000",
-                  "max": "5201999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 52
-            },
-            {
-                  "heading": "5202",
-                  "subdivision": "Cotton",
-                  "min": "5202000000",
-                  "max": "5202999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 52
-            },
-            {
-                  "heading": "5203",
-                  "subdivision": "Cotton",
-                  "min": "5203000000",
                   "max": "5203999999",
                   "rules": [
                         {
@@ -10989,18 +8811,17 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 52
+                  "valid": true
             },
             {
-                  "heading": "5204-5207",
+                  "heading": "5204 to 5207",
                   "chapter": 52,
                   "subdivision": "Yarn and thread of cotton",
                   "min": "5204000000",
                   "max": "5207999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11014,7 +8835,7 @@
                   "valid": true
             },
             {
-                  "heading": "5208-5212",
+                  "heading": "5208 to 5212",
                   "chapter": 52,
                   "subdivision": "Woven fabrics of cotton \u25b8 Incorporating rubber thread",
                   "min": "5208000000",
@@ -11035,14 +8856,14 @@
                   "valid": true
             },
             {
-                  "heading": "5208-5212",
+                  "heading": "5208 to 5212",
                   "chapter": 52,
                   "subdivision": "Woven fabrics of cotton \u25b8 Other",
                   "min": "5208000000",
                   "max": "5212999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\ncoir yarn,\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\nchemical materials or textile pulp, or\n\npaper.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11065,72 +8886,10 @@
                   "valid": true
             },
             {
-                  "heading": "5301",
+                  "heading": "ex Chapter 53",
+                  "chapter": 53,
                   "subdivision": "Other vegetable textile fibres; paper yarn and woven fabrics of paper yarn",
                   "min": "5301000000",
-                  "max": "5301999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 53
-            },
-            {
-                  "heading": "5302",
-                  "subdivision": "Other vegetable textile fibres; paper yarn and woven fabrics of paper yarn",
-                  "min": "5302000000",
-                  "max": "5302999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 53
-            },
-            {
-                  "heading": "5303",
-                  "subdivision": "Other vegetable textile fibres; paper yarn and woven fabrics of paper yarn",
-                  "min": "5303000000",
-                  "max": "5303999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 53
-            },
-            {
-                  "heading": "5305",
-                  "subdivision": "Other vegetable textile fibres; paper yarn and woven fabrics of paper yarn",
-                  "min": "5305000000",
                   "max": "5305999999",
                   "rules": [
                         {
@@ -11145,18 +8904,17 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 53
+                  "valid": true
             },
             {
-                  "heading": "5306-5308",
+                  "heading": "5306 to 5308",
                   "chapter": 53,
                   "subdivision": "Yarn of other vegetable textile fibres; paper yarn",
                   "min": "5306000000",
                   "max": "5308999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11170,7 +8928,7 @@
                   "valid": true
             },
             {
-                  "heading": "5309-5311",
+                  "heading": "5309 to 5311",
                   "chapter": 53,
                   "subdivision": "Woven fabrics of other vegetable textile fibres; woven fabrics of paper yarn \u25b8 Incorporating rubber thread",
                   "min": "5309000000",
@@ -11191,14 +8949,14 @@
                   "valid": true
             },
             {
-                  "heading": "5309-5311",
+                  "heading": "5309 to 5311",
                   "chapter": 53,
                   "subdivision": "Woven fabrics of other vegetable textile fibres; woven fabrics of paper yarn \u25b8 Other",
                   "min": "5309000000",
                   "max": "5311999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\ncoir yarn,\n\njute yarn,\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\nchemical materials or textile pulp, or\n\npaper.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- jute yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11221,14 +8979,14 @@
                   "valid": true
             },
             {
-                  "heading": "5401-5406",
+                  "heading": "5401 to 5406",
                   "chapter": 54,
                   "subdivision": "Yarn, monofilament and thread of man-made filaments",
                   "min": "5401000000",
                   "max": "5406999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11242,7 +9000,7 @@
                   "valid": true
             },
             {
-                  "heading": "5407-5408",
+                  "heading": "5407 to 5408",
                   "chapter": 54,
                   "subdivision": "Woven fabrics of man-made filament yarn \u25b8 Incorporating rubber thread",
                   "min": "5407000000",
@@ -11263,14 +9021,14 @@
                   "valid": true
             },
             {
-                  "heading": "5407-5408",
+                  "heading": "5407 to 5408",
                   "chapter": 54,
                   "subdivision": "Woven fabrics of man-made filament yarn \u25b8 Other",
                   "min": "5407000000",
                   "max": "5408999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\ncoir yarn,\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\nchemical materials or textile pulp, or\n\npaper.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11293,7 +9051,7 @@
                   "valid": true
             },
             {
-                  "heading": "5501-5507",
+                  "heading": "5501 to 5507",
                   "chapter": 55,
                   "subdivision": "Man-made staple fibres",
                   "min": "5501000000",
@@ -11314,14 +9072,14 @@
                   "valid": true
             },
             {
-                  "heading": "5508-5511",
+                  "heading": "5508 to 5511",
                   "chapter": 55,
                   "subdivision": "Yarn and sewing thread of man-made staple fibres",
                   "min": "5508000000",
                   "max": "5511999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- raw silk or silk waste, carded or combed or otherwise prepared for spinning,\n\n- natural fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11335,7 +9093,7 @@
                   "valid": true
             },
             {
-                  "heading": "5512-5516",
+                  "heading": "5512 to 5516",
                   "chapter": 55,
                   "subdivision": "Woven fabrics of man-made staple fibres \u25b8 Incorporating rubber thread",
                   "min": "5512000000",
@@ -11356,14 +9114,14 @@
                   "valid": true
             },
             {
-                  "heading": "5512-5516",
+                  "heading": "5512 to 5516",
                   "chapter": 55,
                   "subdivision": "Woven fabrics of man-made staple fibres \u25b8 Other",
                   "min": "5512000000",
                   "max": "5516999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\ncoir yarn,\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\nchemical materials or textile pulp, or\n\npaper.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise prepared for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11386,13 +9144,14 @@
                   "valid": true
             },
             {
-                  "heading": "5601",
+                  "heading": "ex Chapter 56",
+                  "chapter": 56,
                   "subdivision": "Wadding, felt and non-wovens; special yarns; twine, cordage, ropes and cables and articles thereof",
                   "min": "5601000000",
                   "max": "5601999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\ncoir yarn,\n\nnatural fibres,\n\nchemical materials or textile pulp, or\n\npaper-making materials.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11403,8 +9162,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 56
+                  "valid": true
             },
             {
                   "heading": "5602",
@@ -11414,7 +9172,7 @@
                   "max": "5602999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\nnatural fibres, or\n\nchemical materials or textile pulp\n\nHowever:\n\npolypropylene filament of [heading&nbsp;5402](/headings/5402),\n\npolypropylene fibres of [heading&nbsp;5503](/headings/5503) or [heading&nbsp;5506](/headings/5506), or\n\npolypropylene filament tow of [heading&nbsp;5501](/headings/5501),\n\nof which the denomination in all cases of a single filament or fibre is less than 9 decitex, may be used, provided that their total value does not exceed **40%** of the ex-works price of the product.",
+                              "rule": "Manufacture from:\n\n- natural fibres, *or*\n\n- chemical materials or textile pulp\n\nHowever:\n\n- polypropylene filament of [heading&nbsp;5402](/headings/5402),\n\n- polypropylene fibres of [heading&nbsp;5503](/headings/5503) or [heading&nbsp;5506](/headings/5506), *or*\n\n- polypropylene filament tow of [heading&nbsp;5501](/headings/5501),\n\nof which the denomination in all cases of a single filament or fibre is less than 9 decitex, may be used, provided that their total value does not exceed **40%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM",
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM TOLERANCE MAY BE USED RESTRICTION MAXNOM"
@@ -11436,7 +9194,7 @@
                   "max": "5602999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres made from casein, or\n\nchemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres made from casein, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11450,13 +9208,14 @@
                   "valid": true
             },
             {
-                  "heading": "5603",
+                  "heading": "ex Chapter 56",
+                  "chapter": 56,
                   "subdivision": "Wadding, felt and non-wovens; special yarns; twine, cordage, ropes and cables and articles thereof",
                   "min": "5603000000",
                   "max": "5603999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\ncoir yarn,\n\nnatural fibres,\n\nchemical materials or textile pulp, or\n\npaper-making materials.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11467,8 +9226,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 56
+                  "valid": true
             },
             {
                   "heading": "5604",
@@ -11499,7 +9257,7 @@
                   "max": "5604999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- natural fibres, not carded or combed or otherwise processed for spinning,\n\n- chemical materials or textile pulp, or\n\n- paper-making materials.",
+                              "rule": "Manufacture from:\n\n- natural fibres, not carded or combed or otherwise processed for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11520,7 +9278,7 @@
                   "max": "5605999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning,\n\nchemical materials or textile pulp, or\n\npaper-making materials.",
+                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11541,7 +9299,7 @@
                   "max": "5606999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning,\n\nchemical materials or textile pulp, or\n\npaper-making materials.",
+                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11555,55 +9313,14 @@
                   "valid": true
             },
             {
-                  "heading": "5607",
+                  "heading": "ex Chapter 56",
+                  "chapter": 56,
                   "subdivision": "Wadding, felt and non-wovens; special yarns; twine, cordage, ropes and cables and articles thereof",
                   "min": "5607000000",
-                  "max": "5607999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\ncoir yarn,\n\nnatural fibres,\n\nchemical materials or textile pulp, or\n\npaper-making materials.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 56
-            },
-            {
-                  "heading": "5608",
-                  "subdivision": "Wadding, felt and non-wovens; special yarns; twine, cordage, ropes and cables and articles thereof",
-                  "min": "5608000000",
-                  "max": "5608999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\ncoir yarn,\n\nnatural fibres,\n\nchemical materials or textile pulp, or\n\npaper-making materials.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 56
-            },
-            {
-                  "heading": "5609",
-                  "subdivision": "Wadding, felt and non-wovens; special yarns; twine, cordage, ropes and cables and articles thereof",
-                  "min": "5609000000",
                   "max": "5609999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\ncoir yarn,\n\nnatural fibres,\n\nchemical materials or textile pulp, or\n\npaper-making materials.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- chemical materials or textile pulp, *or*\n\n- paper-making materials.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11614,17 +9331,17 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 56
+                  "valid": true
             },
             {
-                  "heading": "5701",
+                  "heading": "Chapter 57",
+                  "chapter": 57,
                   "subdivision": "Carpets and other textile floor coverings \u25b8 Of needleloom felt",
-                  "min": "5701000000",
-                  "max": "5701999999",
+                  "min": "5700000000",
+                  "max": "5799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- natural fibres, or\n\n- chemical materials or textile pulp\n\nHowever:\n\n- polypropylene filament of [heading&nbsp;5402](/headings/5402),\n\n- polypropylene fibres of [heading&nbsp;5503](/headings/5503) or [heading&nbsp;5506](/headings/5506), or\n\n- polypropylene filament tow of [heading&nbsp;5501](/headings/5501),\n\nof which the denomination in all cases of a single filament or fibre is less than 9 decitex, may be used, provided that their total value does not exceed **40%** of the ex-works price of the product\n\nJute fabric may be used as a backing.",
+                              "rule": "Manufacture from:\n\n- natural fibres, *or*\n\n- chemical materials or textile pulp\n\nHowever:\n\n- polypropylene filament of [heading&nbsp;5402](/headings/5402),\n\n- polypropylene fibres of [heading&nbsp;5503](/headings/5503) or [heading&nbsp;5506](/headings/5506), *or*\n\n- polypropylene filament tow of [heading&nbsp;5501](/headings/5501),\n\nof which the denomination in all cases of a single filament or fibre is less than 9 decitex, may be used, provided that their total value does not exceed **40%** of the ex-works price of the product\n\nJute fabric may be used as a backing.",
                               "class": [
                                     "MAXNOM",
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM TOLERANCE MAY BE USED RESTRICTION MAXNOM"
@@ -11636,17 +9353,17 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 57
+                  "valid": true
             },
             {
-                  "heading": "5701",
+                  "heading": "Chapter 57",
+                  "chapter": 57,
                   "subdivision": "Carpets and other textile floor coverings \u25b8 Of other felt",
-                  "min": "5701000000",
-                  "max": "5701999999",
+                  "min": "5700000000",
+                  "max": "5799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- natural fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- natural fibres, not carded or combed or otherwise processed for spinning, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11657,17 +9374,17 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 57
+                  "valid": true
             },
             {
-                  "heading": "5701",
+                  "heading": "Chapter 57",
+                  "chapter": 57,
                   "subdivision": "Carpets and other textile floor coverings \u25b8 Other",
-                  "min": "5701000000",
-                  "max": "5701999999",
+                  "min": "5700000000",
+                  "max": "5799999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- coir yarn or jute yarn,\n\n- synthetic or artificial filament yarn,\n\n- natural fibres, or\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning\n\nJute fabric may be used as a backing.",
+                              "rule": "Manufacture from:\n\n- coir yarn or jute yarn,\n\n- synthetic or artificial filament yarn,\n\n- natural fibres, *or*\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning\n\nJute fabric may be used as a backing.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11678,270 +9395,14 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 57
+                  "valid": true
             },
             {
-                  "heading": "5702",
-                  "subdivision": "Carpets and other textile floor coverings \u25b8 Of needleloom felt",
-                  "min": "5702000000",
-                  "max": "5702999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres, or\n\n- chemical materials or textile pulp\n\nHowever:\n\n- polypropylene filament of [heading&nbsp;5402](/headings/5402),\n\n- polypropylene fibres of [heading&nbsp;5503](/headings/5503) or [heading&nbsp;5506](/headings/5506), or\n\n- polypropylene filament tow of [heading&nbsp;5501](/headings/5501),\n\nof which the denomination in all cases of a single filament or fibre is less than 9 decitex, may be used, provided that their total value does not exceed **40%** of the ex-works price of the product\n\nJute fabric may be used as a backing.",
-                              "class": [
-                                    "MAXNOM",
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5702",
-                  "subdivision": "Carpets and other textile floor coverings \u25b8 Of other felt",
-                  "min": "5702000000",
-                  "max": "5702999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5702",
-                  "subdivision": "Carpets and other textile floor coverings \u25b8 Other",
-                  "min": "5702000000",
-                  "max": "5702999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- coir yarn or jute yarn,\n\n- synthetic or artificial filament yarn,\n\n- natural fibres, or\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning\n\nJute fabric may be used as a backing.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5703",
-                  "subdivision": "Carpets and other textile floor coverings \u25b8 Of needleloom felt",
-                  "min": "5703000000",
-                  "max": "5703999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres, or\n\n- chemical materials or textile pulp\n\nHowever:\n\n- polypropylene filament of [heading&nbsp;5402](/headings/5402),\n\n- polypropylene fibres of [heading&nbsp;5503](/headings/5503) or [heading&nbsp;5506](/headings/5506), or\n\n- polypropylene filament tow of [heading&nbsp;5501](/headings/5501),\n\nof which the denomination in all cases of a single filament or fibre is less than 9 decitex, may be used, provided that their total value does not exceed **40%** of the ex-works price of the product\n\nJute fabric may be used as a backing.",
-                              "class": [
-                                    "MAXNOM",
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5703",
-                  "subdivision": "Carpets and other textile floor coverings \u25b8 Of other felt",
-                  "min": "5703000000",
-                  "max": "5703999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5703",
-                  "subdivision": "Carpets and other textile floor coverings \u25b8 Other",
-                  "min": "5703000000",
-                  "max": "5703999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- coir yarn or jute yarn,\n\n- synthetic or artificial filament yarn,\n\n- natural fibres, or\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning\n\nJute fabric may be used as a backing.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5704",
-                  "subdivision": "Carpets and other textile floor coverings \u25b8 Of needleloom felt",
-                  "min": "5704000000",
-                  "max": "5704999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres, or\n\n- chemical materials or textile pulp\n\nHowever:\n\n- polypropylene filament of [heading&nbsp;5402](/headings/5402),\n\n- polypropylene fibres of [heading&nbsp;5503](/headings/5503) or [heading&nbsp;5506](/headings/5506), or\n\n- polypropylene filament tow of [heading&nbsp;5501](/headings/5501),\n\nof which the denomination in all cases of a single filament or fibre is less than 9 decitex, may be used, provided that their total value does not exceed **40%** of the ex-works price of the product\n\nJute fabric may be used as a backing.",
-                              "class": [
-                                    "MAXNOM",
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5704",
-                  "subdivision": "Carpets and other textile floor coverings \u25b8 Of other felt",
-                  "min": "5704000000",
-                  "max": "5704999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5704",
-                  "subdivision": "Carpets and other textile floor coverings \u25b8 Other",
-                  "min": "5704000000",
-                  "max": "5704999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- coir yarn or jute yarn,\n\n- synthetic or artificial filament yarn,\n\n- natural fibres, or\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning\n\nJute fabric may be used as a backing.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5705",
-                  "subdivision": "Carpets and other textile floor coverings \u25b8 Of needleloom felt",
-                  "min": "5705000000",
-                  "max": "5705999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres, or\n\n- chemical materials or textile pulp\n\nHowever:\n\n- polypropylene filament of [heading&nbsp;5402](/headings/5402),\n\n- polypropylene fibres of [heading&nbsp;5503](/headings/5503) or [heading&nbsp;5506](/headings/5506), or\n\n- polypropylene filament tow of [heading&nbsp;5501](/headings/5501),\n\nof which the denomination in all cases of a single filament or fibre is less than 9 decitex, may be used, provided that their total value does not exceed **40%** of the ex-works price of the product\n\nJute fabric may be used as a backing.",
-                              "class": [
-                                    "MAXNOM",
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM TOLERANCE MAY BE USED RESTRICTION MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5705",
-                  "subdivision": "Carpets and other textile floor coverings \u25b8 Of other felt",
-                  "min": "5705000000",
-                  "max": "5705999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5705",
-                  "subdivision": "Carpets and other textile floor coverings \u25b8 Other",
-                  "min": "5705000000",
-                  "max": "5705999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- coir yarn or jute yarn,\n\n- synthetic or artificial filament yarn,\n\n- natural fibres, or\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning\n\nJute fabric may be used as a backing.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 57
-            },
-            {
-                  "heading": "5801",
+                  "heading": "ex Chapter 58",
+                  "chapter": 58,
                   "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery \u25b8 Combined with rubber thread",
                   "min": "5801000000",
-                  "max": "5801999999",
+                  "max": "5811999999",
                   "rules": [
                         {
                               "rule": "Manufacture from single yarn.",
@@ -11955,17 +9416,17 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 58
+                  "valid": true
             },
             {
-                  "heading": "5801",
+                  "heading": "ex Chapter 58",
+                  "chapter": 58,
                   "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery \u25b8 Other",
                   "min": "5801000000",
-                  "max": "5801999999",
+                  "max": "5811999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -11985,161 +9446,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5802",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery \u25b8 Combined with rubber thread",
-                  "min": "5802000000",
-                  "max": "5802999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from single yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5802",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery \u25b8 Other",
-                  "min": "5802000000",
-                  "max": "5802999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the ex-works price of the product.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5803",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery \u25b8 Combined with rubber thread",
-                  "min": "5803000000",
-                  "max": "5803999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from single yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5803",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery \u25b8 Other",
-                  "min": "5803000000",
-                  "max": "5803999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the ex-works price of the product.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5804",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery \u25b8 Combined with rubber thread",
-                  "min": "5804000000",
-                  "max": "5804999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from single yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5804",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery \u25b8 Other",
-                  "min": "5804000000",
-                  "max": "5804999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the ex-works price of the product.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
+                  "valid": true
             },
             {
                   "heading": "5805",
@@ -12163,210 +9470,6 @@
                   "valid": true
             },
             {
-                  "heading": "5806",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery \u25b8 Combined with rubber thread",
-                  "min": "5806000000",
-                  "max": "5806999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from single yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5806",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery \u25b8 Other",
-                  "min": "5806000000",
-                  "max": "5806999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the ex-works price of the product.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5807",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery \u25b8 Combined with rubber thread",
-                  "min": "5807000000",
-                  "max": "5807999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from single yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5807",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery \u25b8 Other",
-                  "min": "5807000000",
-                  "max": "5807999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the ex-works price of the product.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5808",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery \u25b8 Combined with rubber thread",
-                  "min": "5808000000",
-                  "max": "5808999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from single yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5808",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery \u25b8 Other",
-                  "min": "5808000000",
-                  "max": "5808999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the ex-works price of the product.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5809",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery \u25b8 Combined with rubber thread",
-                  "min": "5809000000",
-                  "max": "5809999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from single yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5809",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery \u25b8 Other",
-                  "min": "5809000000",
-                  "max": "5809999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the ex-works price of the product.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
                   "heading": "5810",
                   "chapter": 58,
                   "subdivision": "Embroidery in the piece, in strips or in motifs",
@@ -12387,57 +9490,6 @@
                         }
                   ],
                   "valid": true
-            },
-            {
-                  "heading": "5811",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery \u25b8 Combined with rubber thread",
-                  "min": "5811000000",
-                  "max": "5811999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from single yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
-            },
-            {
-                  "heading": "5811",
-                  "subdivision": "Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery \u25b8 Other",
-                  "min": "5811000000",
-                  "max": "5811999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling), provided that the value of the unprinted fabric used does not exceed **47.5%** of the ex-works price of the product.",
-                              "class": [],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 58
             },
             {
                   "heading": "5901",
@@ -12582,7 +9634,7 @@
                   "max": "5905999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -12612,7 +9664,7 @@
                   "max": "5906999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -12740,7 +9792,7 @@
                   "valid": true
             },
             {
-                  "heading": "5909-5911",
+                  "heading": "5909 to 5911",
                   "chapter": 59,
                   "subdivision": "Textile articles of a kind suitable for industrial use \u25b8 Polishing discs or rings other than of felt of heading 5911",
                   "min": "5909000000",
@@ -12761,14 +9813,14 @@
                   "valid": true
             },
             {
-                  "heading": "5909-5911",
+                  "heading": "5909 to 5911",
                   "chapter": 59,
                   "subdivision": "Textile articles of a kind suitable for industrial use \u25b8 Woven fabrics, of a kind commonly used in papermaking or other technical uses, felted or not, whether or not impregnated or coated, tubular or endless with single or multiple warp and/or weft, or flat woven with multiple warp and/or weft of heading 5911",
                   "min": "5909000000",
                   "max": "5911999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- the following materials:\n\n- yarn of polytetrafluoroethylene,\n\n- yarn, multiple, of polyamide, coated impregnated or covered with a phenolic resin,\n\n- yarn of synthetic textile fibres of aromatic polyamides, obtained by polycondensation of m-phenylenediamine and isophthalic acid,\n\n- monofil of polytetrafluoroethylene,\n\n- yarn of synthetic textile fibres of poly(p-phenylene terephthalamide),\n\n- glass fibre yarn, coated with phenol resin and gimped with acrylic yarn,\n\n- copolyester monofilaments of a polyester and a resin of terephthalic acid and 1,4-cyclohexanediethanol and isophthalic acid,\n\n- natural fibres,\n\n- man-made staple fibres not carded or combed or otherwise processed for spinning, or\n\n- chemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- the following materials:\n\n- yarn of polytetrafluoroethylene,\n\n- yarn, multiple, of polyamide, coated impregnated or covered with a phenolic resin,\n\n- yarn of synthetic textile fibres of aromatic polyamides, obtained by polycondensation of m-phenylenediamine and isophthalic acid,\n\n- monofil of polytetrafluoroethylene,\n\n- yarn of synthetic textile fibres of poly(p-phenylene terephthalamide),\n\n- glass fibre yarn, coated with phenol resin and gimped with acrylic yarn,\n\n- copolyester monofilaments of a polyester and a resin of terephthalic acid and 1,4-cyclohexanediethanol and isophthalic acid,\n\n- natural fibres,\n\n- man-made staple fibres not carded or combed or otherwise processed for spinning, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -12782,14 +9834,14 @@
                   "valid": true
             },
             {
-                  "heading": "5909-5911",
+                  "heading": "5909 to 5911",
                   "chapter": 59,
                   "subdivision": "Textile articles of a kind suitable for industrial use \u25b8 Other",
                   "min": "5909000000",
                   "max": "5911999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\ncoir yarn,\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- coir yarn,\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -12810,7 +9862,7 @@
                   "max": "6099999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -12824,10 +9876,11 @@
                   "valid": true
             },
             {
-                  "heading": "6101",
+                  "heading": "Chapter 61",
+                  "chapter": 61,
                   "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6101000000",
-                  "max": "6101999999",
+                  "min": "6100000000",
+                  "max": "6199999999",
                   "rules": [
                         {
                               "rule": "Manufacture from yarn.",
@@ -12841,17 +9894,17 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 61
+                  "valid": true
             },
             {
-                  "heading": "6101",
+                  "heading": "Chapter 61",
+                  "chapter": 61,
                   "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6101000000",
-                  "max": "6101999999",
+                  "min": "6100000000",
+                  "max": "6199999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -12862,683 +9915,10 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 61
+                  "valid": true
             },
             {
-                  "heading": "6102",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6102000000",
-                  "max": "6102999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6102",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6102000000",
-                  "max": "6102999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6103",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6103000000",
-                  "max": "6103999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6103",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6103000000",
-                  "max": "6103999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6104",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6104000000",
-                  "max": "6104999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6104",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6104000000",
-                  "max": "6104999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6105",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6105000000",
-                  "max": "6105999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6105",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6105000000",
-                  "max": "6105999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6106",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6106000000",
-                  "max": "6106999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6106",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6106000000",
-                  "max": "6106999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6107",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6107000000",
-                  "max": "6107999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6107",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6107000000",
-                  "max": "6107999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6108",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6108000000",
-                  "max": "6108999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6108",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6108000000",
-                  "max": "6108999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6109",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6109000000",
-                  "max": "6109999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6109",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6109000000",
-                  "max": "6109999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6110",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6110000000",
-                  "max": "6110999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6110",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6110000000",
-                  "max": "6110999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6111",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6111000000",
-                  "max": "6111999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6111",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6111000000",
-                  "max": "6111999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6112",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6112000000",
-                  "max": "6112999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6112",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6112000000",
-                  "max": "6112999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6113",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6113000000",
-                  "max": "6113999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6113",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6113000000",
-                  "max": "6113999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6114",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6114000000",
-                  "max": "6114999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6114",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6114000000",
-                  "max": "6114999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6115",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6115000000",
-                  "max": "6115999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6115",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6115000000",
-                  "max": "6115999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6116",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6116000000",
-                  "max": "6116999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6116",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6116000000",
-                  "max": "6116999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6117",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Obtained by sewing together or otherwise assembling, two or more pieces of knitted or crocheted fabric which have been either cut to form or obtained directly to form",
-                  "min": "6117000000",
-                  "max": "6117999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6117",
-                  "subdivision": "Articles of apparel and clothing accessories, knitted or crocheted \u25b8 Other",
-                  "min": "6117000000",
-                  "max": "6117999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
-                              "class": [
-                                    "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 61
-            },
-            {
-                  "heading": "6201",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
                   "subdivision": "Articles of apparel and clothing accessories, not knitted or crocheted",
                   "min": "6201000000",
@@ -13591,9 +9971,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 6202",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 6202",
                   "min": "6202000000",
                   "max": "6202999999",
                   "rules": [
@@ -13612,7 +9992,7 @@
                   "valid": true
             },
             {
-                  "heading": "6203",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
                   "subdivision": "Articles of apparel and clothing accessories, not knitted or crocheted",
                   "min": "6203000000",
@@ -13665,9 +10045,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 6204",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 6204",
                   "min": "6204000000",
                   "max": "6204999999",
                   "rules": [
@@ -13686,7 +10066,7 @@
                   "valid": true
             },
             {
-                  "heading": "6205",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
                   "subdivision": "Articles of apparel and clothing accessories, not knitted or crocheted",
                   "min": "6205000000",
@@ -13739,9 +10119,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 6206",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 6206",
                   "min": "6206000000",
                   "max": "6206999999",
                   "rules": [
@@ -13760,31 +10140,10 @@
                   "valid": true
             },
             {
-                  "heading": "6207",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
                   "subdivision": "Articles of apparel and clothing accessories, not knitted or crocheted",
                   "min": "6207000000",
-                  "max": "6207999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from yarn.",
-                              "class": [
-                                    "PRODUCTION FROM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "6208",
-                  "chapter": 62,
-                  "subdivision": "Articles of apparel and clothing accessories, not knitted or crocheted",
-                  "min": "6208000000",
                   "max": "6208999999",
                   "rules": [
                         {
@@ -13834,9 +10193,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 6209",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 6209",
                   "min": "6209000000",
                   "max": "6209999999",
                   "rules": [
@@ -13887,9 +10246,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 6210",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 6210",
                   "min": "6210000000",
                   "max": "6210999999",
                   "rules": [
@@ -13940,9 +10299,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 6211",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 6211",
                   "min": "6211000000",
                   "max": "6211999999",
                   "rules": [
@@ -13961,7 +10320,7 @@
                   "valid": true
             },
             {
-                  "heading": "6212",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
                   "subdivision": "Articles of apparel and clothing accessories, not knitted or crocheted",
                   "min": "6212000000",
@@ -13982,7 +10341,7 @@
                   "valid": true
             },
             {
-                  "heading": "6213-6214",
+                  "heading": "6213 to 6214",
                   "chapter": 62,
                   "subdivision": "Handkerchiefs, shawls, scarves, mufflers, mantillas, veils and the like \u25b8 Embroidered",
                   "min": "6213000000",
@@ -14014,7 +10373,7 @@
                   "valid": true
             },
             {
-                  "heading": "6213-6214",
+                  "heading": "6213 to 6214",
                   "chapter": 62,
                   "subdivision": "Handkerchiefs, shawls, scarves, mufflers, mantillas, veils and the like \u25b8 Other",
                   "min": "6213000000",
@@ -14044,7 +10403,7 @@
                   "valid": true
             },
             {
-                  "heading": "6215",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
                   "subdivision": "Articles of apparel and clothing accessories, not knitted or crocheted",
                   "min": "6215000000",
@@ -14097,9 +10456,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 6216",
+                  "heading": "ex Chapter 62",
                   "chapter": 62,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 6216",
                   "min": "6216000000",
                   "max": "6216999999",
                   "rules": [
@@ -14225,14 +10584,14 @@
                   "valid": true
             },
             {
-                  "heading": "6301-6304",
+                  "heading": "6301 to 6304",
                   "chapter": 63,
                   "subdivision": "Blankets, travelling rugs, bed linen etc.; curtains etc.; other furnishing articles \u25b8 Of felt, of non-wovens",
                   "min": "6301000000",
                   "max": "6304999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\nnatural fibres, or\n\nchemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- natural fibres, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -14246,9 +10605,9 @@
                   "valid": true
             },
             {
-                  "heading": "6301-6304",
+                  "heading": "6301 to 6304",
                   "chapter": 63,
-                  "subdivision": "Blankets, travelling rugs, bed linen etc.; curtains etc.; other furnishing articles \u25b8 Other \u25b8 - Embroidered",
+                  "subdivision": "Blankets, travelling rugs, bed linen etc.; curtains etc.; other furnishing articles \u25b8 Other \u25b8 Embroidered",
                   "min": "6301000000",
                   "max": "6304999999",
                   "rules": [
@@ -14278,9 +10637,9 @@
                   "valid": true
             },
             {
-                  "heading": "6301-6304",
+                  "heading": "6301 to 6304",
                   "chapter": 63,
-                  "subdivision": "Blankets, travelling rugs, bed linen etc.; curtains etc.; other furnishing articles \u25b8 Other \u25b8 - Other",
+                  "subdivision": "Blankets, travelling rugs, bed linen etc.; curtains etc.; other furnishing articles \u25b8 Other \u25b8 Other",
                   "min": "6301000000",
                   "max": "6304999999",
                   "rules": [
@@ -14306,7 +10665,7 @@
                   "max": "6305999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\nnatural fibres,\n\nman-made staple fibres, not carded or combed or otherwise processed for spinning, or\n\nchemical materials or textile pulp.",
+                              "rule": "Manufacture from:\n\n- natural fibres,\n\n- man-made staple fibres, not carded or combed or otherwise processed for spinning, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -14327,7 +10686,7 @@
                   "max": "6306999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from :\n\nnatural fibres, or\n\nchemical materials or textile pulp.",
+                              "rule": "Manufacture from :\n\n- natural fibres, *or*\n\n- chemical materials or textile pulp.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -14405,30 +10764,10 @@
                   "valid": true
             },
             {
-                  "heading": "6309",
+                  "heading": "ex Chapter 63",
+                  "chapter": 63,
                   "subdivision": "Other made-up textile articles; sets; worn clothing and worn textile articles; rags",
                   "min": "6309000000",
-                  "max": "6309999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 63
-            },
-            {
-                  "heading": "6310",
-                  "subdivision": "Other made-up textile articles; sets; worn clothing and worn textile articles; rags",
-                  "min": "6310000000",
                   "max": "6310999999",
                   "rules": [
                         {
@@ -14443,97 +10782,13 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 63
+                  "valid": true
             },
             {
-                  "heading": "6401",
+                  "heading": "ex Chapter 64",
+                  "chapter": 64,
                   "subdivision": "Footwear, gaiters and the like; parts of such articles",
                   "min": "6401000000",
-                  "max": "6401999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except from assemblies of uppers affixed to inner soles or to other sole components of [heading&nbsp;6406](/headings/6406).",
-                              "class": [
-                                    "AH EXCEPT"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 64
-            },
-            {
-                  "heading": "6402",
-                  "subdivision": "Footwear, gaiters and the like; parts of such articles",
-                  "min": "6402000000",
-                  "max": "6402999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except from assemblies of uppers affixed to inner soles or to other sole components of [heading&nbsp;6406](/headings/6406).",
-                              "class": [
-                                    "AH EXCEPT"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 64
-            },
-            {
-                  "heading": "6403",
-                  "subdivision": "Footwear, gaiters and the like; parts of such articles",
-                  "min": "6403000000",
-                  "max": "6403999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except from assemblies of uppers affixed to inner soles or to other sole components of [heading&nbsp;6406](/headings/6406).",
-                              "class": [
-                                    "AH EXCEPT"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 64
-            },
-            {
-                  "heading": "6404",
-                  "subdivision": "Footwear, gaiters and the like; parts of such articles",
-                  "min": "6404000000",
-                  "max": "6404999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except from assemblies of uppers affixed to inner soles or to other sole components of [heading&nbsp;6406](/headings/6406).",
-                              "class": [
-                                    "AH EXCEPT"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 64
-            },
-            {
-                  "heading": "6405",
-                  "subdivision": "Footwear, gaiters and the like; parts of such articles",
-                  "min": "6405000000",
                   "max": "6405999999",
                   "rules": [
                         {
@@ -14548,8 +10803,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 64
+                  "valid": true
             },
             {
                   "heading": "6406",
@@ -14573,51 +10827,10 @@
                   "valid": true
             },
             {
-                  "heading": "6501",
+                  "heading": "ex Chapter 65",
+                  "chapter": 65,
                   "subdivision": "Headgear and parts thereof",
                   "min": "6501000000",
-                  "max": "6501999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 65
-            },
-            {
-                  "heading": "6502",
-                  "subdivision": "Headgear and parts thereof",
-                  "min": "6502000000",
-                  "max": "6502999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 65
-            },
-            {
-                  "heading": "6504",
-                  "subdivision": "Headgear and parts thereof",
-                  "min": "6504000000",
                   "max": "6504999999",
                   "rules": [
                         {
@@ -14632,8 +10845,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 65
+                  "valid": true
             },
             {
                   "heading": "6505",
@@ -14657,30 +10869,10 @@
                   "valid": true
             },
             {
-                  "heading": "6506",
+                  "heading": "ex Chapter 65",
+                  "chapter": 65,
                   "subdivision": "Headgear and parts thereof",
                   "min": "6506000000",
-                  "max": "6506999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 65
-            },
-            {
-                  "heading": "6507",
-                  "subdivision": "Headgear and parts thereof",
-                  "min": "6507000000",
                   "max": "6507999999",
                   "rules": [
                         {
@@ -14695,8 +10887,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 65
+                  "valid": true
             },
             {
                   "heading": "6601",
@@ -14720,30 +10911,10 @@
                   "valid": true
             },
             {
-                  "heading": "6602",
+                  "heading": "ex Chapter 66",
+                  "chapter": 66,
                   "subdivision": "Umbrellas, sun umbrellas, walking-sticks, seat-sticks, whips, riding-crops, and parts thereof",
                   "min": "6602000000",
-                  "max": "6602999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 66
-            },
-            {
-                  "heading": "6603",
-                  "subdivision": "Umbrellas, sun umbrellas, walking-sticks, seat-sticks, whips, riding-crops, and parts thereof",
-                  "min": "6603000000",
                   "max": "6603999999",
                   "rules": [
                         {
@@ -14758,8 +10929,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 66
+                  "valid": true
             },
             {
                   "heading": "Chapter 67",
@@ -14786,8 +10956,8 @@
                   "heading": "ex Chapter 68",
                   "chapter": 68,
                   "subdivision": "Articles of stone, plaster, cement, asbestos, mica or similar materials",
-                  "min": "6800000000",
-                  "max": "6899999999",
+                  "min": "6801000000",
+                  "max": "6802999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product.",
@@ -14825,6 +10995,48 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 68",
+                  "chapter": 68,
+                  "subdivision": "Any other product from heading 6803",
+                  "min": "6803000000",
+                  "max": "6803999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 68",
+                  "chapter": 68,
+                  "subdivision": "Articles of stone, plaster, cement, asbestos, mica or similar materials",
+                  "min": "6804000000",
+                  "max": "6811999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 6812",
                   "chapter": 68,
                   "subdivision": "Articles of asbestos; articles of mixtures with a basis of asbestos or of mixtures with a basis of asbestos and magnesium carbonate",
@@ -14835,6 +11047,48 @@
                               "rule": "Manufacture from materials of any heading.",
                               "class": [
                                     "AH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 68",
+                  "chapter": 68,
+                  "subdivision": "Any other product from heading 6812",
+                  "min": "6812000000",
+                  "max": "6812999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 68",
+                  "chapter": 68,
+                  "subdivision": "Articles of stone, plaster, cement, asbestos, mica or similar materials",
+                  "min": "6813000000",
+                  "max": "6813999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
@@ -14867,6 +11121,48 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 68",
+                  "chapter": 68,
+                  "subdivision": "Any other product from heading 6814",
+                  "min": "6814000000",
+                  "max": "6814999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 68",
+                  "chapter": 68,
+                  "subdivision": "Articles of stone, plaster, cement, asbestos, mica or similar materials",
+                  "min": "6815000000",
+                  "max": "6815999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "Chapter 69",
                   "chapter": 69,
                   "subdivision": "Ceramic products",
@@ -14888,31 +11184,10 @@
                   "valid": true
             },
             {
-                  "heading": "7001",
+                  "heading": "ex Chapter 70",
                   "chapter": 70,
                   "subdivision": "Glass and glassware",
                   "min": "7001000000",
-                  "max": "7001999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7002",
-                  "chapter": 70,
-                  "subdivision": "Glass and glassware",
-                  "min": "7002000000",
                   "max": "7002999999",
                   "rules": [
                         {
@@ -14951,9 +11226,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7003",
+                  "heading": "ex Chapter 70",
                   "chapter": 70,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7003",
                   "min": "7003000000",
                   "max": "7003999999",
                   "rules": [
@@ -14993,9 +11268,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7004",
+                  "heading": "ex Chapter 70",
                   "chapter": 70,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7004",
                   "min": "7004000000",
                   "max": "7004999999",
                   "rules": [
@@ -15035,9 +11310,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7005",
+                  "heading": "ex Chapter 70",
                   "chapter": 70,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7005",
                   "min": "7005000000",
                   "max": "7005999999",
                   "rules": [
@@ -15193,7 +11468,7 @@
                   "valid": true
             },
             {
-                  "heading": "7011",
+                  "heading": "ex Chapter 70",
                   "chapter": 70,
                   "subdivision": "Glass and glassware",
                   "min": "7011000000",
@@ -15257,94 +11532,10 @@
                   "valid": true
             },
             {
-                  "heading": "7014",
+                  "heading": "ex Chapter 70",
                   "chapter": 70,
                   "subdivision": "Glass and glassware",
                   "min": "7014000000",
-                  "max": "7014999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7015",
-                  "chapter": 70,
-                  "subdivision": "Glass and glassware",
-                  "min": "7015000000",
-                  "max": "7015999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7016",
-                  "chapter": 70,
-                  "subdivision": "Glass and glassware",
-                  "min": "7016000000",
-                  "max": "7016999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7017",
-                  "chapter": 70,
-                  "subdivision": "Glass and glassware",
-                  "min": "7017000000",
-                  "max": "7017999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7018",
-                  "chapter": 70,
-                  "subdivision": "Glass and glassware",
-                  "min": "7018000000",
                   "max": "7018999999",
                   "rules": [
                         {
@@ -15369,7 +11560,7 @@
                   "max": "7019999999",
                   "rules": [
                         {
-                              "rule": "Manufacture from:\n\nuncoloured slivers, rovings, yarn or chopped strands, or\n\nglass wool.",
+                              "rule": "Manufacture from:\n\n- uncoloured slivers, rovings, yarn or chopped strands, *or*\n\n- glass wool.",
                               "class": [
                                     "PRODUCTION FROM OR_ENUM PRODUCTION FROM"
                               ],
@@ -15383,9 +11574,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7019",
+                  "heading": "ex Chapter 70",
                   "chapter": 70,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7019",
                   "min": "7019000000",
                   "max": "7019999999",
                   "rules": [
@@ -15404,7 +11595,7 @@
                   "valid": true
             },
             {
-                  "heading": "7020",
+                  "heading": "ex Chapter 70",
                   "chapter": 70,
                   "subdivision": "Glass and glassware",
                   "min": "7020000000",
@@ -15446,9 +11637,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7101",
+                  "heading": "ex Chapter 71",
                   "chapter": 71,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7101",
                   "min": "7101000000",
                   "max": "7101999999",
                   "rules": [
@@ -15488,9 +11679,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7102",
+                  "heading": "ex Chapter 71",
                   "chapter": 71,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7102",
                   "min": "7102000000",
                   "max": "7102999999",
                   "rules": [
@@ -15530,9 +11721,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7103",
+                  "heading": "ex Chapter 71",
                   "chapter": 71,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7103",
                   "min": "7103000000",
                   "max": "7103999999",
                   "rules": [
@@ -15572,9 +11763,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7104",
+                  "heading": "ex Chapter 71",
                   "chapter": 71,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7104",
                   "min": "7104000000",
                   "max": "7104999999",
                   "rules": [
@@ -15593,7 +11784,7 @@
                   "valid": true
             },
             {
-                  "heading": "7105",
+                  "heading": "ex Chapter 71",
                   "chapter": 71,
                   "subdivision": "Natural or cultured pearls, precious or semi-precious stones, precious metals, metals clad with precious metal, and articles thereof; imitation jewellery; coin",
                   "min": "7105000000",
@@ -15695,9 +11886,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7107",
+                  "heading": "ex Chapter 71",
                   "chapter": 71,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7107",
                   "min": "7107000000",
                   "max": "7107999999",
                   "rules": [
@@ -15797,9 +11988,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7109",
+                  "heading": "ex Chapter 71",
                   "chapter": 71,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7109",
                   "min": "7109000000",
                   "max": "7109999999",
                   "rules": [
@@ -15899,9 +12090,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7111",
+                  "heading": "ex Chapter 71",
                   "chapter": 71,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7111",
                   "min": "7111000000",
                   "max": "7111999999",
                   "rules": [
@@ -15920,73 +12111,10 @@
                   "valid": true
             },
             {
-                  "heading": "7112",
+                  "heading": "ex Chapter 71",
                   "chapter": 71,
                   "subdivision": "Natural or cultured pearls, precious or semi-precious stones, precious metals, metals clad with precious metal, and articles thereof; imitation jewellery; coin",
                   "min": "7112000000",
-                  "max": "7112999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7113",
-                  "chapter": 71,
-                  "subdivision": "Natural or cultured pearls, precious or semi-precious stones, precious metals, metals clad with precious metal, and articles thereof; imitation jewellery; coin",
-                  "min": "7113000000",
-                  "max": "7113999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7114",
-                  "chapter": 71,
-                  "subdivision": "Natural or cultured pearls, precious or semi-precious stones, precious metals, metals clad with precious metal, and articles thereof; imitation jewellery; coin",
-                  "min": "7114000000",
-                  "max": "7114999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7115",
-                  "chapter": 71,
-                  "subdivision": "Natural or cultured pearls, precious or semi-precious stones, precious metals, metals clad with precious metal, and articles thereof; imitation jewellery; coin",
-                  "min": "7115000000",
                   "max": "7115999999",
                   "rules": [
                         {
@@ -16057,7 +12185,7 @@
                   "valid": true
             },
             {
-                  "heading": "7118",
+                  "heading": "ex Chapter 71",
                   "chapter": 71,
                   "subdivision": "Natural or cultured pearls, precious or semi-precious stones, precious metals, metals clad with precious metal, and articles thereof; imitation jewellery; coin",
                   "min": "7118000000",
@@ -16078,115 +12206,10 @@
                   "valid": true
             },
             {
-                  "heading": "7201",
+                  "heading": "ex Chapter 72",
                   "chapter": 72,
                   "subdivision": "Iron and steel",
                   "min": "7201000000",
-                  "max": "7201999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7202",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7202000000",
-                  "max": "7202999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7203",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7203000000",
-                  "max": "7203999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7204",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7204000000",
-                  "max": "7204999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7205",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7205000000",
-                  "max": "7205999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7206",
-                  "chapter": 72,
-                  "subdivision": "Iron and steel",
-                  "min": "7206000000",
                   "max": "7206999999",
                   "rules": [
                         {
@@ -16225,7 +12248,7 @@
                   "valid": true
             },
             {
-                  "heading": "7208-7216",
+                  "heading": "7208 to 7216",
                   "chapter": 72,
                   "subdivision": "Flat-rolled products, bars and rods, angles, shapes and sections of iron or non-alloy steel",
                   "min": "7208000000",
@@ -16288,9 +12311,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7218",
+                  "heading": "ex Chapter 72",
                   "chapter": 72,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7218",
                   "min": "7218000000",
                   "max": "7218999999",
                   "rules": [
@@ -16309,7 +12332,7 @@
                   "valid": true
             },
             {
-                  "heading": "7219-7222",
+                  "heading": "7219 to 7222",
                   "chapter": 72,
                   "subdivision": "Semi-finished products, flat-rolled products, bars and rods, angles, shapes and sections of stainless steel",
                   "min": "7219000000",
@@ -16372,9 +12395,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7224",
+                  "heading": "ex Chapter 72",
                   "chapter": 72,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7224",
                   "min": "7224000000",
                   "max": "7224999999",
                   "rules": [
@@ -16393,7 +12416,7 @@
                   "valid": true
             },
             {
-                  "heading": "7225-7228",
+                  "heading": "7225 to 7228",
                   "chapter": 72,
                   "subdivision": "Semi-finished products, flat-rolled products, hot-rolled bars and rods, in irregularly wound coils; angles, shapes and sections, of other alloy steel; hollow drill bars and rods, of alloy or non-alloy steel",
                   "min": "7225000000",
@@ -16456,9 +12479,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7301",
+                  "heading": "ex Chapter 73",
                   "chapter": 73,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7301",
                   "min": "7301000000",
                   "max": "7301999999",
                   "rules": [
@@ -16498,7 +12521,7 @@
                   "valid": true
             },
             {
-                  "heading": "7303",
+                  "heading": "ex Chapter 73",
                   "chapter": 73,
                   "subdivision": "Articles of iron or steel",
                   "min": "7303000000",
@@ -16519,7 +12542,7 @@
                   "valid": true
             },
             {
-                  "heading": "7304-7306",
+                  "heading": "7304 to 7306",
                   "chapter": 73,
                   "subdivision": "Tubes, pipes and hollow profiles, of iron (other than cast iron) or steel",
                   "min": "7304000000",
@@ -16562,9 +12585,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7307",
+                  "heading": "ex Chapter 73",
                   "chapter": 73,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7307",
                   "min": "7307000000",
                   "max": "7307999999",
                   "rules": [
@@ -16604,115 +12627,10 @@
                   "valid": true
             },
             {
-                  "heading": "7309",
+                  "heading": "ex Chapter 73",
                   "chapter": 73,
                   "subdivision": "Articles of iron or steel",
                   "min": "7309000000",
-                  "max": "7309999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7310",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7310000000",
-                  "max": "7310999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7311",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7311000000",
-                  "max": "7311999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7312",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7312000000",
-                  "max": "7312999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7313",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7313000000",
-                  "max": "7313999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7314",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7314000000",
                   "max": "7314999999",
                   "rules": [
                         {
@@ -16751,9 +12669,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7315",
+                  "heading": "ex Chapter 73",
                   "chapter": 73,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7315",
                   "min": "7315000000",
                   "max": "7315999999",
                   "rules": [
@@ -16772,220 +12690,10 @@
                   "valid": true
             },
             {
-                  "heading": "7316",
+                  "heading": "ex Chapter 73",
                   "chapter": 73,
                   "subdivision": "Articles of iron or steel",
                   "min": "7316000000",
-                  "max": "7316999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7317",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7317000000",
-                  "max": "7317999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7318",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7318000000",
-                  "max": "7318999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7319",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7319000000",
-                  "max": "7319999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7320",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7320000000",
-                  "max": "7320999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7321",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7321000000",
-                  "max": "7321999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7322",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7322000000",
-                  "max": "7322999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7323",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7323000000",
-                  "max": "7323999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7324",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7324000000",
-                  "max": "7324999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7325",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7325000000",
-                  "max": "7325999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7326",
-                  "chapter": 73,
-                  "subdivision": "Articles of iron or steel",
-                  "min": "7326000000",
                   "max": "7326999999",
                   "rules": [
                         {
@@ -17129,229 +12837,10 @@
                   "valid": true
             },
             {
-                  "heading": "7406",
+                  "heading": "ex Chapter 74",
+                  "chapter": 74,
                   "subdivision": "Copper and articles thereof",
                   "min": "7406000000",
-                  "max": "7406999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 74
-            },
-            {
-                  "heading": "7407",
-                  "subdivision": "Copper and articles thereof",
-                  "min": "7407000000",
-                  "max": "7407999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 74
-            },
-            {
-                  "heading": "7408",
-                  "subdivision": "Copper and articles thereof",
-                  "min": "7408000000",
-                  "max": "7408999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 74
-            },
-            {
-                  "heading": "7409",
-                  "subdivision": "Copper and articles thereof",
-                  "min": "7409000000",
-                  "max": "7409999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 74
-            },
-            {
-                  "heading": "7410",
-                  "subdivision": "Copper and articles thereof",
-                  "min": "7410000000",
-                  "max": "7410999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 74
-            },
-            {
-                  "heading": "7411",
-                  "subdivision": "Copper and articles thereof",
-                  "min": "7411000000",
-                  "max": "7411999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 74
-            },
-            {
-                  "heading": "7412",
-                  "subdivision": "Copper and articles thereof",
-                  "min": "7412000000",
-                  "max": "7412999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 74
-            },
-            {
-                  "heading": "7413",
-                  "subdivision": "Copper and articles thereof",
-                  "min": "7413000000",
-                  "max": "7413999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 74
-            },
-            {
-                  "heading": "7415",
-                  "subdivision": "Copper and articles thereof",
-                  "min": "7415000000",
-                  "max": "7415999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 74
-            },
-            {
-                  "heading": "7418",
-                  "subdivision": "Copper and articles thereof",
-                  "min": "7418000000",
-                  "max": "7418999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 74
-            },
-            {
-                  "heading": "7419",
-                  "subdivision": "Copper and articles thereof",
-                  "min": "7419000000",
                   "max": "7419999999",
                   "rules": [
                         {
@@ -17367,11 +12856,10 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 74
+                  "valid": true
             },
             {
-                  "heading": "7501-7503",
+                  "heading": "7501 to 7503",
                   "chapter": 75,
                   "subdivision": "Nickel mattes, nickel oxide sinters and other intermediate products of nickel metallurgy; unwrought nickel; nickel waste and scrap",
                   "min": "7501000000",
@@ -17392,97 +12880,10 @@
                   "valid": true
             },
             {
-                  "heading": "7504",
+                  "heading": "ex Chapter 75",
+                  "chapter": 75,
                   "subdivision": "Nickel and articles thereof",
                   "min": "7504000000",
-                  "max": "7504999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 75
-            },
-            {
-                  "heading": "7505",
-                  "subdivision": "Nickel and articles thereof",
-                  "min": "7505000000",
-                  "max": "7505999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 75
-            },
-            {
-                  "heading": "7506",
-                  "subdivision": "Nickel and articles thereof",
-                  "min": "7506000000",
-                  "max": "7506999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 75
-            },
-            {
-                  "heading": "7507",
-                  "subdivision": "Nickel and articles thereof",
-                  "min": "7507000000",
-                  "max": "7507999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 75
-            },
-            {
-                  "heading": "7508",
-                  "subdivision": "Nickel and articles thereof",
-                  "min": "7508000000",
                   "max": "7508999999",
                   "rules": [
                         {
@@ -17498,8 +12899,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 75
+                  "valid": true
             },
             {
                   "heading": "7601",
@@ -17509,12 +12909,22 @@
                   "max": "7601999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product\n\n- or\n\n- Manufacture by thermal or electrolytic treatment from unalloyed aluminium or waste and scrap of aluminium.",
+                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
                               "class": [
-                                    "MAXNOM"
+                                    "MAXNOM",
+                                    "CTH"
                               ],
                               "footnotes": [],
                               "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "Manufacture by thermal or electrolytic treatment from unalloyed aluminium or waste and scrap of aluminium.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
                               "quota": false,
                               "import": true,
                               "export": true
@@ -17544,274 +12954,10 @@
                   "valid": true
             },
             {
-                  "heading": "7603",
+                  "heading": "ex Chapter 76",
                   "chapter": 76,
                   "subdivision": "Aluminium and articles thereof",
                   "min": "7603000000",
-                  "max": "7603999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7604",
-                  "chapter": 76,
-                  "subdivision": "Aluminium and articles thereof",
-                  "min": "7604000000",
-                  "max": "7604999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7605",
-                  "chapter": 76,
-                  "subdivision": "Aluminium and articles thereof",
-                  "min": "7605000000",
-                  "max": "7605999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7606",
-                  "chapter": 76,
-                  "subdivision": "Aluminium and articles thereof",
-                  "min": "7606000000",
-                  "max": "7606999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7607",
-                  "chapter": 76,
-                  "subdivision": "Aluminium and articles thereof",
-                  "min": "7607000000",
-                  "max": "7607999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7608",
-                  "chapter": 76,
-                  "subdivision": "Aluminium and articles thereof",
-                  "min": "7608000000",
-                  "max": "7608999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7609",
-                  "chapter": 76,
-                  "subdivision": "Aluminium and articles thereof",
-                  "min": "7609000000",
-                  "max": "7609999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7610",
-                  "chapter": 76,
-                  "subdivision": "Aluminium and articles thereof",
-                  "min": "7610000000",
-                  "max": "7610999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7611",
-                  "chapter": 76,
-                  "subdivision": "Aluminium and articles thereof",
-                  "min": "7611000000",
-                  "max": "7611999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7612",
-                  "chapter": 76,
-                  "subdivision": "Aluminium and articles thereof",
-                  "min": "7612000000",
-                  "max": "7612999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7613",
-                  "chapter": 76,
-                  "subdivision": "Aluminium and articles thereof",
-                  "min": "7613000000",
-                  "max": "7613999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7614",
-                  "chapter": 76,
-                  "subdivision": "Aluminium and articles thereof",
-                  "min": "7614000000",
-                  "max": "7614999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "7615",
-                  "chapter": 76,
-                  "subdivision": "Aluminium and articles thereof",
-                  "min": "7615000000",
                   "max": "7615999999",
                   "rules": [
                         {
@@ -17852,9 +12998,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 7616",
+                  "heading": "ex Chapter 76",
                   "chapter": 76,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 7616",
                   "min": "7616000000",
                   "max": "7616999999",
                   "rules": [
@@ -17937,31 +13083,10 @@
                   "valid": true
             },
             {
-                  "heading": "7804",
+                  "heading": "ex Chapter 78",
+                  "chapter": 78,
                   "subdivision": "Lead and articles thereof",
                   "min": "7804000000",
-                  "max": "7804999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 78
-            },
-            {
-                  "heading": "7806",
-                  "subdivision": "Lead and articles thereof",
-                  "min": "7806000000",
                   "max": "7806999999",
                   "rules": [
                         {
@@ -17977,8 +13102,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 78
+                  "valid": true
             },
             {
                   "heading": "7901",
@@ -18023,75 +13147,10 @@
                   "valid": true
             },
             {
-                  "heading": "7903",
+                  "heading": "ex Chapter 79",
+                  "chapter": 79,
                   "subdivision": "Zinc and articles thereof",
                   "min": "7903000000",
-                  "max": "7903999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 79
-            },
-            {
-                  "heading": "7904",
-                  "subdivision": "Zinc and articles thereof",
-                  "min": "7904000000",
-                  "max": "7904999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 79
-            },
-            {
-                  "heading": "7905",
-                  "subdivision": "Zinc and articles thereof",
-                  "min": "7905000000",
-                  "max": "7905999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 79
-            },
-            {
-                  "heading": "7907",
-                  "subdivision": "Zinc and articles thereof",
-                  "min": "7907000000",
                   "max": "7907999999",
                   "rules": [
                         {
@@ -18107,8 +13166,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 79
+                  "valid": true
             },
             {
                   "heading": "8001",
@@ -18153,7 +13211,8 @@
                   "valid": true
             },
             {
-                  "heading": "8003",
+                  "heading": "ex Chapter 80",
+                  "chapter": 80,
                   "subdivision": "Tin and articles thereof",
                   "min": "8003000000",
                   "max": "8003999999",
@@ -18171,8 +13230,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 80
+                  "valid": true
             },
             {
                   "heading": "8007",
@@ -18196,10 +13254,11 @@
                   "valid": true
             },
             {
-                  "heading": "8101",
+                  "heading": "Chapter 81",
+                  "chapter": 81,
                   "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8101000000",
-                  "max": "8101999999",
+                  "min": "8100000000",
+                  "max": "8199999999",
                   "rules": [
                         {
                               "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
@@ -18213,14 +13272,14 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 81
+                  "valid": true
             },
             {
-                  "heading": "8101",
+                  "heading": "Chapter 81",
+                  "chapter": 81,
                   "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other",
-                  "min": "8101000000",
-                  "max": "8101999999",
+                  "min": "8100000000",
+                  "max": "8199999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product.",
@@ -18234,560 +13293,13 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 81
+                  "valid": true
             },
             {
-                  "heading": "8102",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8102000000",
-                  "max": "8102999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8102",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other",
-                  "min": "8102000000",
-                  "max": "8102999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8103",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8103000000",
-                  "max": "8103999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8103",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other",
-                  "min": "8103000000",
-                  "max": "8103999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8104",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8104000000",
-                  "max": "8104999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8104",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other",
-                  "min": "8104000000",
-                  "max": "8104999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8105",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8105000000",
-                  "max": "8105999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8105",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other",
-                  "min": "8105000000",
-                  "max": "8105999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8106",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8106000000",
-                  "max": "8106999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8106",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other",
-                  "min": "8106000000",
-                  "max": "8106999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8108",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8108000000",
-                  "max": "8108999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8108",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other",
-                  "min": "8108000000",
-                  "max": "8108999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8109",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8109000000",
-                  "max": "8109999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8109",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other",
-                  "min": "8109000000",
-                  "max": "8109999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8110",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8110000000",
-                  "max": "8110999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8110",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other",
-                  "min": "8110000000",
-                  "max": "8110999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8111",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8111000000",
-                  "max": "8111999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8111",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other",
-                  "min": "8111000000",
-                  "max": "8111999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8112",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8112000000",
-                  "max": "8112999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8112",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other",
-                  "min": "8112000000",
-                  "max": "8112999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8113",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other base metals, wrought; articles thereof",
-                  "min": "8113000000",
-                  "max": "8113999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials of the same heading as the product used does not exceed **50%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8113",
-                  "subdivision": "Other base metals; cermets; articles thereof \u25b8 Other",
-                  "min": "8113000000",
-                  "max": "8113999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 81
-            },
-            {
-                  "heading": "8201",
+                  "heading": "ex Chapter 82",
                   "chapter": 82,
                   "subdivision": "Tools, implements, cutlery, spoons and forks, of base metal; parts thereof of base metal",
                   "min": "8201000000",
-                  "max": "8201999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8202",
-                  "chapter": 82,
-                  "subdivision": "Tools, implements, cutlery, spoons and forks, of base metal; parts thereof of base metal",
-                  "min": "8202000000",
-                  "max": "8202999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8203",
-                  "chapter": 82,
-                  "subdivision": "Tools, implements, cutlery, spoons and forks, of base metal; parts thereof of base metal",
-                  "min": "8203000000",
-                  "max": "8203999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8204",
-                  "chapter": 82,
-                  "subdivision": "Tools, implements, cutlery, spoons and forks, of base metal; parts thereof of base metal",
-                  "min": "8204000000",
-                  "max": "8204999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8205",
-                  "chapter": 82,
-                  "subdivision": "Tools, implements, cutlery, spoons and forks, of base metal; parts thereof of base metal",
-                  "min": "8205000000",
                   "max": "8205999999",
                   "rules": [
                         {
@@ -18871,31 +13383,10 @@
                   "valid": true
             },
             {
-                  "heading": "8209",
+                  "heading": "ex Chapter 82",
                   "chapter": 82,
                   "subdivision": "Tools, implements, cutlery, spoons and forks, of base metal; parts thereof of base metal",
                   "min": "8209000000",
-                  "max": "8209999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8210",
-                  "chapter": 82,
-                  "subdivision": "Tools, implements, cutlery, spoons and forks, of base metal; parts thereof of base metal",
-                  "min": "8210000000",
                   "max": "8210999999",
                   "rules": [
                         {
@@ -18934,9 +13425,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8211",
+                  "heading": "ex Chapter 82",
                   "chapter": 82,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8211",
                   "min": "8211000000",
                   "max": "8211999999",
                   "rules": [
@@ -18955,31 +13446,10 @@
                   "valid": true
             },
             {
-                  "heading": "8212",
+                  "heading": "ex Chapter 82",
                   "chapter": 82,
                   "subdivision": "Tools, implements, cutlery, spoons and forks, of base metal; parts thereof of base metal",
                   "min": "8212000000",
-                  "max": "8212999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8213",
-                  "chapter": 82,
-                  "subdivision": "Tools, implements, cutlery, spoons and forks, of base metal; parts thereof of base metal",
-                  "min": "8213000000",
                   "max": "8213999999",
                   "rules": [
                         {
@@ -19042,8 +13512,8 @@
                   "heading": "ex Chapter 83",
                   "chapter": 83,
                   "subdivision": "Miscellaneous articles of base metal",
-                  "min": "8300000000",
-                  "max": "8399999999",
+                  "min": "8301000000",
+                  "max": "8301999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product.",
@@ -19082,6 +13552,48 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 83",
+                  "chapter": 83,
+                  "subdivision": "Any other product from heading 8302",
+                  "min": "8302000000",
+                  "max": "8302999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 83",
+                  "chapter": 83,
+                  "subdivision": "Miscellaneous articles of base metal",
+                  "min": "8303000000",
+                  "max": "8305999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 8306",
                   "chapter": 83,
                   "subdivision": "Statuettes and other ornaments, of base metal",
@@ -19104,7 +13616,49 @@
                   "valid": true
             },
             {
-                  "heading": "8401",
+                  "heading": "ex Chapter 83",
+                  "chapter": 83,
+                  "subdivision": "Any other product from heading 8306",
+                  "min": "8306000000",
+                  "max": "8306999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 83",
+                  "chapter": 83,
+                  "subdivision": "Miscellaneous articles of base metal",
+                  "min": "8307000000",
+                  "max": "8311999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8401000000",
@@ -19234,9 +13788,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8404",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8404",
                   "min": "8404000000",
                   "max": "8404999999",
                   "rules": [
@@ -19267,7 +13821,7 @@
                   "valid": true
             },
             {
-                  "heading": "8405",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8405000000",
@@ -19384,7 +13938,7 @@
                   "valid": true
             },
             {
-                  "heading": "8410",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8410000000",
@@ -19504,9 +14058,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8413",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8413",
                   "min": "8413000000",
                   "max": "8413999999",
                   "rules": [
@@ -19570,9 +14124,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8414",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8414",
                   "min": "8414000000",
                   "max": "8414999999",
                   "rules": [
@@ -19624,43 +14178,10 @@
                   "valid": true
             },
             {
-                  "heading": "8416",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8416000000",
-                  "max": "8416999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8417",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8417000000",
                   "max": "8417999999",
                   "rules": [
                         {
@@ -19756,9 +14277,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8419",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8419",
                   "min": "8419000000",
                   "max": "8419999999",
                   "rules": [
@@ -19821,43 +14342,10 @@
                   "valid": true
             },
             {
-                  "heading": "8421",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8421000000",
-                  "max": "8421999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8422",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8422000000",
                   "max": "8422999999",
                   "rules": [
                         {
@@ -19920,7 +14408,7 @@
                   "valid": true
             },
             {
-                  "heading": "8424",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8424000000",
@@ -19953,7 +14441,7 @@
                   "valid": true
             },
             {
-                  "heading": "8425-8428",
+                  "heading": "8425 to 8428",
                   "chapter": 84,
                   "subdivision": "Lifting, handling, loading or unloading machinery",
                   "min": "8425000000",
@@ -20091,9 +14579,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8431",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8431",
                   "min": "8431000000",
                   "max": "8431999999",
                   "rules": [
@@ -20124,208 +14612,10 @@
                   "valid": true
             },
             {
-                  "heading": "8432",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8432000000",
-                  "max": "8432999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8433",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8433000000",
-                  "max": "8433999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8434",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8434000000",
-                  "max": "8434999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8435",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8435000000",
-                  "max": "8435999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8436",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8436000000",
-                  "max": "8436999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8437",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8437000000",
-                  "max": "8437999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8438",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8438000000",
                   "max": "8438999999",
                   "rules": [
                         {
@@ -20387,7 +14677,7 @@
                   "valid": true
             },
             {
-                  "heading": "8440",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8440000000",
@@ -20452,7 +14742,7 @@
                   "valid": true
             },
             {
-                  "heading": "8442",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8442000000",
@@ -20506,9 +14796,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8443",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8443",
                   "min": "8443000000",
                   "max": "8443999999",
                   "rules": [
@@ -20539,7 +14829,7 @@
                   "valid": true
             },
             {
-                  "heading": "8444-8447",
+                  "heading": "8444 to 8447",
                   "chapter": 84,
                   "subdivision": "Machines of these headings for use in the textile industry",
                   "min": "8444000000",
@@ -20581,9 +14871,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8448",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8448",
                   "min": "8448000000",
                   "max": "8448999999",
                   "rules": [
@@ -20614,76 +14904,10 @@
                   "valid": true
             },
             {
-                  "heading": "8449",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8449000000",
-                  "max": "8449999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8450",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8450000000",
-                  "max": "8450999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8451",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8451000000",
                   "max": "8451999999",
                   "rules": [
                         {
@@ -20757,76 +14981,10 @@
                   "valid": true
             },
             {
-                  "heading": "8453",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8453000000",
-                  "max": "8453999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8454",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8454000000",
-                  "max": "8454999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8455",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8455000000",
                   "max": "8455999999",
                   "rules": [
                         {
@@ -20856,7 +15014,7 @@
                   "valid": true
             },
             {
-                  "heading": "8456-8466",
+                  "heading": "8456 to 8466",
                   "chapter": 84,
                   "subdivision": "Machine-tools and machines and their parts and accessories of headings 8456 to 8466",
                   "min": "8456000000",
@@ -20877,43 +15035,10 @@
                   "valid": true
             },
             {
-                  "heading": "8467",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8467000000",
-                  "max": "8467999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8468",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8468000000",
                   "max": "8468999999",
                   "rules": [
                         {
@@ -20943,10 +15068,10 @@
                   "valid": true
             },
             {
-                  "heading": "8469-8472",
+                  "heading": "8470 to 8472",
                   "chapter": 84,
                   "subdivision": "Office machines (for example, typewriters, calculating machines, automatic data processing machines, duplicating machines, stapling machines)",
-                  "min": "8469000000",
+                  "min": "8470000000",
                   "max": "8472999999",
                   "rules": [
                         {
@@ -20964,208 +15089,10 @@
                   "valid": true
             },
             {
-                  "heading": "8473",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8473000000",
-                  "max": "8473999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8474",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8474000000",
-                  "max": "8474999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8475",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8475000000",
-                  "max": "8475999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8476",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8476000000",
-                  "max": "8476999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8477",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8477000000",
-                  "max": "8477999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8478",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8478000000",
-                  "max": "8478999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8479",
-                  "chapter": 84,
-                  "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
-                  "min": "8479000000",
                   "max": "8479999999",
                   "rules": [
                         {
@@ -21216,7 +15143,7 @@
                   "valid": true
             },
             {
-                  "heading": "8481",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8481000000",
@@ -21282,7 +15209,7 @@
                   "valid": true
             },
             {
-                  "heading": "8483",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8483000000",
@@ -21336,7 +15263,7 @@
                   "valid": true
             },
             {
-                  "heading": "8485",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
                   "subdivision": "Nuclear reactors, boilers, machinery and mechanical appliances; parts thereof",
                   "min": "8485000000",
@@ -21371,7 +15298,7 @@
             {
                   "heading": "ex 8486",
                   "chapter": 84,
-                  "subdivision": "Sewing machines, other than book-sewing machines of heading 8440; furniture, bases and covers specially designed for sewing machines; sewing machine needles \u25b8 Machine tools for working any material by removal of material, by laser or other light or photon beam, ultrasonic, electrodischarge, electrochemical, electron beam, ionic-beam or plasma arc processes and parts and accessories thereof",
+                  "subdivision": "Gaskets and similar joints of metal sheeting combined with other material or of two or more layers of metal; sets or assortments of gaskets and similar joints, dissimilar in composition, put up in pouches, envelopes or similar packings; mechanical seals \u25b8 Machine tools for working any material by removal of material, by laser or other light or photon beam, ultrasonic, electrodischarge, electrochemical, electron beam, ionic-beam or plasma arc processes and parts and accessories thereof",
                   "min": "8486000000",
                   "max": "8486999999",
                   "rules": [
@@ -21392,7 +15319,7 @@
             {
                   "heading": "ex 8486",
                   "chapter": 84,
-                  "subdivision": "Sewing machines, other than book-sewing machines of heading 8440; furniture, bases and covers specially designed for sewing machines; sewing machine needles \u25b8 machine tools (including presses) for working metal by bending, folding, straightening, flattening, and parts and accessories thereof \u25b8 machine tools for working stone, ceramics, concrete, asbestos-cement or like mineral materials or for cold working glass and parts and accessories thereof \u25b8 marking-out instruments which are pattern generating apparatus of a kind used for producing masks or reticles from photoresist coated substrates; parts and accessories thereof \u25b8 moulds, injection or compression types",
+                  "subdivision": "Gaskets and similar joints of metal sheeting combined with other material or of two or more layers of metal; sets or assortments of gaskets and similar joints, dissimilar in composition, put up in pouches, envelopes or similar packings; mechanical seals \u25b8 Moulds, injection or compression types",
                   "min": "8486000000",
                   "max": "8486999999",
                   "rules": [
@@ -21413,7 +15340,7 @@
             {
                   "heading": "ex 8486",
                   "chapter": 84,
-                  "subdivision": "Sewing machines, other than book-sewing machines of heading 8440; furniture, bases and covers specially designed for sewing machines; sewing machine needles \u25b8 machine tools (including presses) for working metal by bending, folding, straightening, flattening, and parts and accessories thereof \u25b8 machine tools for working stone, ceramics, concrete, asbestos-cement or like mineral materials or for cold working glass and parts and accessories thereof \u25b8 marking-out instruments which are pattern generating apparatus of a kind used for producing masks or reticles from photoresist coated substrates; parts and accessories thereof \u25b8 lifting, handing, loading or unloading machinery",
+                  "subdivision": "Gaskets and similar joints of metal sheeting combined with other material or of two or more layers of metal; sets or assortments of gaskets and similar joints, dissimilar in composition, put up in pouches, envelopes or similar packings; mechanical seals \u25b8 Lifting, handing, loading or unloading machinery",
                   "min": "8486000000",
                   "max": "8486999999",
                   "rules": [
@@ -21443,9 +15370,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8486",
+                  "heading": "ex Chapter 84",
                   "chapter": 84,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8486",
                   "min": "8486000000",
                   "max": "8486999999",
                   "rules": [
@@ -21561,7 +15488,7 @@
                   "valid": true
             },
             {
-                  "heading": "8503",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
                   "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
                   "min": "8503000000",
@@ -21615,9 +15542,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8504",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8504",
                   "min": "8504000000",
                   "max": "8504999999",
                   "rules": [
@@ -21648,373 +15575,10 @@
                   "valid": true
             },
             {
-                  "heading": "8505",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
                   "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
                   "min": "8505000000",
-                  "max": "8505999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8506",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
-                  "min": "8506000000",
-                  "max": "8506999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8507",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
-                  "min": "8507000000",
-                  "max": "8507999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8508",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
-                  "min": "8508000000",
-                  "max": "8508999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8509",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
-                  "min": "8509000000",
-                  "max": "8509999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8510",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
-                  "min": "8510000000",
-                  "max": "8510999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8511",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
-                  "min": "8511000000",
-                  "max": "8511999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8512",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
-                  "min": "8512000000",
-                  "max": "8512999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8513",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
-                  "min": "8513000000",
-                  "max": "8513999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8514",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
-                  "min": "8514000000",
-                  "max": "8514999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8515",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
-                  "min": "8515000000",
-                  "max": "8515999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8516",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
-                  "min": "8516000000",
                   "max": "8516999999",
                   "rules": [
                         {
@@ -22077,9 +15641,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8517",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8517",
                   "min": "8517000000",
                   "max": "8517999999",
                   "rules": [
@@ -22143,9 +15707,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8518",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8518",
                   "min": "8518000000",
                   "max": "8518999999",
                   "rules": [
@@ -22388,12 +15952,21 @@
                   "max": "8523999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- the value of all the materials used does not exceed **40%** of the ex-works price of the product, *and*\n\n- within the above limit, the value of all the materials of [heading&nbsp;8541](/headings/8541) and [heading&nbsp;8542](/headings/8542) used does not exceed **10%** of the ex-works price of the product\n\n- or\n\n- The operation of diffusion, in which integrated circuits are formed on a semi-conductor substrate by the selective introduction of an appropriate dopant, whether or not assembled and&nbsp;/&nbsp;or tested in a country other than those specified in Article 3.",
+                              "rule": "Manufacture in which:\n\n- the value of all the materials used does not exceed **40%** of the ex-works price of the product, *and*\n\n- within the above limit, the value of all the materials of [heading&nbsp;8541](/headings/8541) and [heading&nbsp;8542](/headings/8542) used does not exceed **10%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "The operation of diffusion, in which integrated circuits are formed on a semi-conductor substrate by the selective introduction of an appropriate dopant, whether or not assembled and&nbsp;/&nbsp;or tested in a country other than those specified in Article 3.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
                               "quota": false,
                               "import": true,
                               "export": true
@@ -22413,7 +15986,7 @@
                   "valid": true
             },
             {
-                  "heading": "8524",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
                   "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
                   "min": "8524000000",
@@ -22686,142 +16259,10 @@
                   "valid": true
             },
             {
-                  "heading": "8530",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
                   "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
                   "min": "8530000000",
-                  "max": "8530999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8531",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
-                  "min": "8531000000",
-                  "max": "8531999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8532",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
-                  "min": "8532000000",
-                  "max": "8532999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8533",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
-                  "min": "8533000000",
-                  "max": "8533999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8534",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
-                  "min": "8534000000",
                   "max": "8534999999",
                   "rules": [
                         {
@@ -22917,7 +16358,7 @@
             {
                   "heading": "8536",
                   "chapter": 85,
-                  "subdivision": "Electrical apparatus for switching or protecting electrical circuits, or for making connections to or in electrical circuits for a voltage not exceeding 1 000 V; connectors for optical fibres, optical fibre bundles or cables \u25b8 Connectors for optical fibres, optical fibre bundles or cables \u25b8 - of plastics",
+                  "subdivision": "Electrical apparatus for switching or protecting electrical circuits, or for making connections to or in electrical circuits for a voltage not exceeding 1 000 V; connectors for optical fibres, optical fibre bundles or cables \u25b8 Connectors for optical fibres, optical fibre bundles or cables \u25b8 Of plastics",
                   "min": "8536000000",
                   "max": "8536999999",
                   "rules": [
@@ -22938,7 +16379,7 @@
             {
                   "heading": "8536",
                   "chapter": 85,
-                  "subdivision": "Electrical apparatus for switching or protecting electrical circuits, or for making connections to or in electrical circuits for a voltage not exceeding 1 000 V; connectors for optical fibres, optical fibre bundles or cables \u25b8 Connectors for optical fibres, optical fibre bundles or cables \u25b8 - of ceramics",
+                  "subdivision": "Electrical apparatus for switching or protecting electrical circuits, or for making connections to or in electrical circuits for a voltage not exceeding 1 000 V; connectors for optical fibres, optical fibre bundles or cables \u25b8 Connectors for optical fibres, optical fibre bundles or cables \u25b8 Of ceramics",
                   "min": "8536000000",
                   "max": "8536999999",
                   "rules": [
@@ -22959,7 +16400,7 @@
             {
                   "heading": "8536",
                   "chapter": 85,
-                  "subdivision": "Electrical apparatus for switching or protecting electrical circuits, or for making connections to or in electrical circuits for a voltage not exceeding 1 000 V; connectors for optical fibres, optical fibre bundles or cables \u25b8 Connectors for optical fibres, optical fibre bundles or cables \u25b8 - of copper",
+                  "subdivision": "Electrical apparatus for switching or protecting electrical circuits, or for making connections to or in electrical circuits for a voltage not exceeding 1 000 V; connectors for optical fibres, optical fibre bundles or cables \u25b8 Connectors for optical fibres, optical fibre bundles or cables \u25b8 Of copper",
                   "min": "8536000000",
                   "max": "8536999999",
                   "rules": [
@@ -23011,76 +16452,10 @@
                   "valid": true
             },
             {
-                  "heading": "8538",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
                   "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
                   "min": "8538000000",
-                  "max": "8538999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8539",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
-                  "min": "8539000000",
-                  "max": "8539999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8540",
-                  "chapter": 85,
-                  "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
-                  "min": "8540000000",
                   "max": "8540999999",
                   "rules": [
                         {
@@ -23143,9 +16518,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8541",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8541",
                   "min": "8541000000",
                   "max": "8541999999",
                   "rules": [
@@ -23183,12 +16558,21 @@
                   "max": "8542999999",
                   "rules": [
                         {
-                              "rule": "Manufacture in which:\n\n- the value of all the materials used does not exceed **40%** of the ex-works price of the product, *and*\n\n- within the above limit, the value of all the materials of [heading&nbsp;8541](/headings/8541) and [heading&nbsp;8542](/headings/8542) used does not exceed **10%** of the ex-works price of the product\n\n- or\n\n- The operation of diffusion, in which integrated circuits are formed on a semi-conductor substrate by the selective introduction of an appropriate dopant, whether or not assembled and&nbsp;/&nbsp;or tested in a country other than those specified in Article 3.",
+                              "rule": "Manufacture in which:\n\n- the value of all the materials used does not exceed **40%** of the ex-works price of the product, *and*\n\n- within the above limit, the value of all the materials of [heading&nbsp;8541](/headings/8541) and [heading&nbsp;8542](/headings/8542) used does not exceed **10%** of the ex-works price of the product.",
                               "class": [
                                     "MAXNOM"
                               ],
                               "footnotes": [],
                               "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        },
+                        {
+                              "rule": "The operation of diffusion, in which integrated circuits are formed on a semi-conductor substrate by the selective introduction of an appropriate dopant, whether or not assembled and&nbsp;/&nbsp;or tested in a country other than those specified in Article 3.",
+                              "class": [],
+                              "footnotes": [],
+                              "operator": "or",
                               "quota": false,
                               "import": true,
                               "export": true
@@ -23261,7 +16645,7 @@
                   "valid": true
             },
             {
-                  "heading": "8543",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
                   "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
                   "min": "8543000000",
@@ -23431,7 +16815,7 @@
                   "valid": true
             },
             {
-                  "heading": "8549",
+                  "heading": "ex Chapter 85",
                   "chapter": 85,
                   "subdivision": "Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles",
                   "min": "8549000000",
@@ -23464,135 +16848,10 @@
                   "valid": true
             },
             {
-                  "heading": "8601",
+                  "heading": "ex Chapter 86",
+                  "chapter": 86,
                   "subdivision": "Railway or tramway locomotives, rolling-stock and parts thereof; railway or tramway track fixtures and fittings and parts thereof; mechanical (including electro-mechanical) traffic signalling equipment of all kinds",
                   "min": "8601000000",
-                  "max": "8601999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 86
-            },
-            {
-                  "heading": "8602",
-                  "subdivision": "Railway or tramway locomotives, rolling-stock and parts thereof; railway or tramway track fixtures and fittings and parts thereof; mechanical (including electro-mechanical) traffic signalling equipment of all kinds",
-                  "min": "8602000000",
-                  "max": "8602999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 86
-            },
-            {
-                  "heading": "8603",
-                  "subdivision": "Railway or tramway locomotives, rolling-stock and parts thereof; railway or tramway track fixtures and fittings and parts thereof; mechanical (including electro-mechanical) traffic signalling equipment of all kinds",
-                  "min": "8603000000",
-                  "max": "8603999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 86
-            },
-            {
-                  "heading": "8604",
-                  "subdivision": "Railway or tramway locomotives, rolling-stock and parts thereof; railway or tramway track fixtures and fittings and parts thereof; mechanical (including electro-mechanical) traffic signalling equipment of all kinds",
-                  "min": "8604000000",
-                  "max": "8604999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 86
-            },
-            {
-                  "heading": "8605",
-                  "subdivision": "Railway or tramway locomotives, rolling-stock and parts thereof; railway or tramway track fixtures and fittings and parts thereof; mechanical (including electro-mechanical) traffic signalling equipment of all kinds",
-                  "min": "8605000000",
-                  "max": "8605999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 86
-            },
-            {
-                  "heading": "8606",
-                  "subdivision": "Railway or tramway locomotives, rolling-stock and parts thereof; railway or tramway track fixtures and fittings and parts thereof; mechanical (including electro-mechanical) traffic signalling equipment of all kinds",
-                  "min": "8606000000",
-                  "max": "8606999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 86
-            },
-            {
-                  "heading": "8607",
-                  "subdivision": "Railway or tramway locomotives, rolling-stock and parts thereof; railway or tramway track fixtures and fittings and parts thereof; mechanical (including electro-mechanical) traffic signalling equipment of all kinds",
-                  "min": "8607000000",
                   "max": "8607999999",
                   "rules": [
                         {
@@ -23607,8 +16866,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 86
+                  "valid": true
             },
             {
                   "heading": "8608",
@@ -23644,7 +16902,8 @@
                   "valid": true
             },
             {
-                  "heading": "8609",
+                  "heading": "ex Chapter 86",
+                  "chapter": 86,
                   "subdivision": "Railway or tramway locomotives, rolling-stock and parts thereof; railway or tramway track fixtures and fittings and parts thereof; mechanical (including electro-mechanical) traffic signalling equipment of all kinds",
                   "min": "8609000000",
                   "max": "8609999999",
@@ -23661,161 +16920,13 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 86
+                  "valid": true
             },
             {
-                  "heading": "8701",
+                  "heading": "ex Chapter 87",
                   "chapter": 87,
                   "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof",
                   "min": "8701000000",
-                  "max": "8701999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8702",
-                  "chapter": 87,
-                  "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof",
-                  "min": "8702000000",
-                  "max": "8702999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8703",
-                  "chapter": 87,
-                  "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof",
-                  "min": "8703000000",
-                  "max": "8703999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8704",
-                  "chapter": 87,
-                  "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof",
-                  "min": "8704000000",
-                  "max": "8704999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8705",
-                  "chapter": 87,
-                  "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof",
-                  "min": "8705000000",
-                  "max": "8705999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8706",
-                  "chapter": 87,
-                  "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof",
-                  "min": "8706000000",
-                  "max": "8706999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8707",
-                  "chapter": 87,
-                  "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof",
-                  "min": "8707000000",
-                  "max": "8707999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8708",
-                  "chapter": 87,
-                  "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof",
-                  "min": "8708000000",
                   "max": "8708999999",
                   "rules": [
                         {
@@ -23901,7 +17012,7 @@
             {
                   "heading": "8711",
                   "chapter": 87,
-                  "subdivision": "Motorcycles (including mopeds) and cycles fitted with an auxiliary motor, with or without side-cars; side-cars \u25b8 With reciprocating internal combustion piston engine of a cylinder capacity \u25b8 - Not exceeding 50 cm3",
+                  "subdivision": "Motorcycles (including mopeds) and cycles fitted with an auxiliary motor, with or without side-cars; side-cars \u25b8 With reciprocating internal combustion piston engine of a cylinder capacity \u25b8 Not exceeding 50 cm3",
                   "min": "8711000000",
                   "max": "8711999999",
                   "rules": [
@@ -23934,7 +17045,7 @@
             {
                   "heading": "8711",
                   "chapter": 87,
-                  "subdivision": "Motorcycles (including mopeds) and cycles fitted with an auxiliary motor, with or without side-cars; side-cars \u25b8 With reciprocating internal combustion piston engine of a cylinder capacity \u25b8 - Exceeding 50 cm3",
+                  "subdivision": "Motorcycles (including mopeds) and cycles fitted with an auxiliary motor, with or without side-cars; side-cars \u25b8 With reciprocating internal combustion piston engine of a cylinder capacity \u25b8 Exceeding 50 cm3",
                   "min": "8711000000",
                   "max": "8711999999",
                   "rules": [
@@ -23967,7 +17078,7 @@
             {
                   "heading": "8711",
                   "chapter": 87,
-                  "subdivision": "Motorcycles (including mopeds) and cycles fitted with an auxiliary motor, with or without side-cars; side-cars \u25b8 With reciprocating internal combustion piston engine of a cylinder capacity \u25b8 Other",
+                  "subdivision": "Motorcycles (including mopeds) and cycles fitted with an auxiliary motor, with or without side-cars; side-cars \u25b8 Other",
                   "min": "8711000000",
                   "max": "8711999999",
                   "rules": [
@@ -24030,9 +17141,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8712",
+                  "heading": "ex Chapter 87",
                   "chapter": 87,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8712",
                   "min": "8712000000",
                   "max": "8712999999",
                   "rules": [
@@ -24051,31 +17162,10 @@
                   "valid": true
             },
             {
-                  "heading": "8713",
+                  "heading": "ex Chapter 87",
                   "chapter": 87,
                   "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof",
                   "min": "8713000000",
-                  "max": "8713999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8714",
-                  "chapter": 87,
-                  "subdivision": "Vehicles other than railway or tramway rolling-stock, and parts and accessories thereof",
-                  "min": "8714000000",
                   "max": "8714999999",
                   "rules": [
                         {
@@ -24159,42 +17249,10 @@
                   "valid": true
             },
             {
-                  "heading": "8801",
+                  "heading": "ex Chapter 88",
                   "chapter": 88,
                   "subdivision": "Aircraft, spacecraft, and parts thereof",
                   "min": "8801000000",
-                  "max": "8801999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8802",
-                  "chapter": 88,
-                  "subdivision": "Aircraft, spacecraft, and parts thereof",
-                  "min": "8802000000",
                   "max": "8802999999",
                   "rules": [
                         {
@@ -24255,9 +17313,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 8804",
+                  "heading": "ex Chapter 88",
                   "chapter": 88,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 8804",
                   "min": "8804000000",
                   "max": "8804999999",
                   "rules": [
@@ -24319,42 +17377,10 @@
                   "valid": true
             },
             {
-                  "heading": "8806",
+                  "heading": "ex Chapter 88",
                   "chapter": 88,
                   "subdivision": "Aircraft, spacecraft, and parts thereof",
                   "min": "8806000000",
-                  "max": "8806999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "8807",
-                  "chapter": 88,
-                  "subdivision": "Aircraft, spacecraft, and parts thereof",
-                  "min": "8807000000",
                   "max": "8807999999",
                   "rules": [
                         {
@@ -24457,7 +17483,7 @@
                   "valid": true
             },
             {
-                  "heading": "9003",
+                  "heading": "ex Chapter 90",
                   "chapter": 90,
                   "subdivision": "Optical, photographic, cinematographic, measuring, checking, precision, medical or surgical instruments and apparatus; parts and accessories thereof",
                   "min": "9003000000",
@@ -24513,7 +17539,7 @@
             {
                   "heading": "ex 9005",
                   "chapter": 90,
-                  "subdivision": "Binoculars, monoculars, other optical telescopes, and mountings therefor, except for astronomical refracting telescopes and mountings therefor",
+                  "subdivision": "Binoculars, monoculars, other optical telescopes, and mountings therefor astronomical refracting telescopes and mountings therefor",
                   "min": "9005000000",
                   "max": "9005999999",
                   "rules": [
@@ -24545,9 +17571,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9005",
+                  "heading": "ex Chapter 90",
                   "chapter": 90,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 9005",
                   "min": "9005000000",
                   "max": "9005999999",
                   "rules": [
@@ -24612,9 +17638,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9006",
+                  "heading": "ex Chapter 90",
                   "chapter": 90,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 9006",
                   "min": "9006000000",
                   "max": "9006999999",
                   "rules": [
@@ -24679,43 +17705,10 @@
                   "valid": true
             },
             {
-                  "heading": "9008",
+                  "heading": "ex Chapter 90",
                   "chapter": 90,
                   "subdivision": "Optical, photographic, cinematographic, measuring, checking, precision, medical or surgical instruments and apparatus; parts and accessories thereof",
                   "min": "9008000000",
-                  "max": "9008999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9010",
-                  "chapter": 90,
-                  "subdivision": "Optical, photographic, cinematographic, measuring, checking, precision, medical or surgical instruments and apparatus; parts and accessories thereof",
-                  "min": "9010000000",
                   "max": "9010999999",
                   "rules": [
                         {
@@ -24779,43 +17772,10 @@
                   "valid": true
             },
             {
-                  "heading": "9012",
+                  "heading": "ex Chapter 90",
                   "chapter": 90,
                   "subdivision": "Optical, photographic, cinematographic, measuring, checking, precision, medical or surgical instruments and apparatus; parts and accessories thereof",
                   "min": "9012000000",
-                  "max": "9012999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9013",
-                  "chapter": 90,
-                  "subdivision": "Optical, photographic, cinematographic, measuring, checking, precision, medical or surgical instruments and apparatus; parts and accessories thereof",
-                  "min": "9013000000",
                   "max": "9013999999",
                   "rules": [
                         {
@@ -24866,9 +17826,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9014",
+                  "heading": "ex Chapter 90",
                   "chapter": 90,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 9014",
                   "min": "9014000000",
                   "max": "9014999999",
                   "rules": [
@@ -25093,76 +18053,10 @@
                   "valid": true
             },
             {
-                  "heading": "9021",
+                  "heading": "ex Chapter 90",
                   "chapter": 90,
                   "subdivision": "Optical, photographic, cinematographic, measuring, checking, precision, medical or surgical instruments and apparatus; parts and accessories thereof",
                   "min": "9021000000",
-                  "max": "9021999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9022",
-                  "chapter": 90,
-                  "subdivision": "Optical, photographic, cinematographic, measuring, checking, precision, medical or surgical instruments and apparatus; parts and accessories thereof",
-                  "min": "9022000000",
-                  "max": "9022999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM",
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        },
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **30%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": "or",
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9023",
-                  "chapter": 90,
-                  "subdivision": "Optical, photographic, cinematographic, measuring, checking, precision, medical or surgical instruments and apparatus; parts and accessories thereof",
-                  "min": "9023000000",
                   "max": "9023999999",
                   "rules": [
                         {
@@ -25435,72 +18329,10 @@
                   "valid": true
             },
             {
-                  "heading": "9101",
+                  "heading": "ex Chapter 91",
+                  "chapter": 91,
                   "subdivision": "Clocks and watches and parts thereof",
                   "min": "9101000000",
-                  "max": "9101999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 91
-            },
-            {
-                  "heading": "9102",
-                  "subdivision": "Clocks and watches and parts thereof",
-                  "min": "9102000000",
-                  "max": "9102999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 91
-            },
-            {
-                  "heading": "9103",
-                  "subdivision": "Clocks and watches and parts thereof",
-                  "min": "9103000000",
-                  "max": "9103999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 91
-            },
-            {
-                  "heading": "9104",
-                  "subdivision": "Clocks and watches and parts thereof",
-                  "min": "9104000000",
                   "max": "9104999999",
                   "rules": [
                         {
@@ -25515,8 +18347,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 91
+                  "valid": true
             },
             {
                   "heading": "9105",
@@ -25552,51 +18383,10 @@
                   "valid": true
             },
             {
-                  "heading": "9106",
+                  "heading": "ex Chapter 91",
+                  "chapter": 91,
                   "subdivision": "Clocks and watches and parts thereof",
                   "min": "9106000000",
-                  "max": "9106999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 91
-            },
-            {
-                  "heading": "9107",
-                  "subdivision": "Clocks and watches and parts thereof",
-                  "min": "9107000000",
-                  "max": "9107999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture in which the value of all the materials used does not exceed **40%** of the ex-works price of the product.",
-                              "class": [
-                                    "MAXNOM"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true,
-                  "chapter": 91
-            },
-            {
-                  "heading": "9108",
-                  "subdivision": "Clocks and watches and parts thereof",
-                  "min": "9108000000",
                   "max": "9108999999",
                   "rules": [
                         {
@@ -25611,8 +18401,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 91
+                  "valid": true
             },
             {
                   "heading": "9109",
@@ -25788,7 +18577,8 @@
                   "valid": true
             },
             {
-                  "heading": "9114",
+                  "heading": "ex Chapter 91",
+                  "chapter": 91,
                   "subdivision": "Clocks and watches and parts thereof",
                   "min": "9114000000",
                   "max": "9114999999",
@@ -25805,8 +18595,7 @@
                               "export": true
                         }
                   ],
-                  "valid": true,
-                  "chapter": 91
+                  "valid": true
             },
             {
                   "heading": "Chapter 92",
@@ -25894,9 +18683,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9401",
+                  "heading": "ex Chapter 94",
                   "chapter": 94,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 9401",
                   "min": "9401000000",
                   "max": "9401999999",
                   "rules": [
@@ -25926,7 +18715,7 @@
                   "valid": true
             },
             {
-                  "heading": "9402",
+                  "heading": "ex Chapter 94",
                   "chapter": 94,
                   "subdivision": "Furniture; bedding, mattresses, mattress supports, cushions and similar stuffed furnishings; lamps and lighting fittings, not elsewhere specified or included; illuminated signs, illuminated name-plates and the like; prefabricated buildings",
                   "min": "9402000000",
@@ -26001,9 +18790,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9403",
+                  "heading": "ex Chapter 94",
                   "chapter": 94,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 9403",
                   "min": "9403000000",
                   "max": "9403999999",
                   "rules": [
@@ -26033,7 +18822,7 @@
                   "valid": true
             },
             {
-                  "heading": "9404",
+                  "heading": "ex Chapter 94",
                   "chapter": 94,
                   "subdivision": "Furniture; bedding, mattresses, mattress supports, cushions and similar stuffed furnishings; lamps and lighting fittings, not elsewhere specified or included; illuminated signs, illuminated name-plates and the like; prefabricated buildings",
                   "min": "9404000000",
@@ -26107,11 +18896,33 @@
                   "valid": true
             },
             {
+                  "heading": "ex 9503",
+                  "chapter": 95,
+                  "subdivision": "Other toys; reduced-size ('scale') models and similar recreational models, working or not; puzzles of all kinds",
+                  "min": "9503000000",
+                  "max": "9503999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "class": [
+                                    "MAXNOM",
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex Chapter 95",
                   "chapter": 95,
-                  "subdivision": "Toys, games and sports requisites; parts and accessories thereof",
-                  "min": "9500000000",
-                  "max": "9599999999",
+                  "subdivision": "Any other product from heading 9503",
+                  "min": "9503000000",
+                  "max": "9503999999",
                   "rules": [
                         {
                               "rule": "Manufacture from materials of any heading, except that of the product.",
@@ -26128,16 +18939,15 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9503",
+                  "heading": "ex Chapter 95",
                   "chapter": 95,
-                  "subdivision": "Other toys; reduced-size ('scale') models and similar recreational models, working or not; puzzles of all kinds",
-                  "min": "9503000000",
-                  "max": "9503999999",
+                  "subdivision": "Toys, games and sports requisites; parts and accessories thereof",
+                  "min": "9504000000",
+                  "max": "9505999999",
                   "rules": [
                         {
-                              "rule": "Manufacture:\n\n- from materials of any heading, except that of the product, *and*\n\n- in which the value of all the materials used does not exceed **50%** of the ex-works price of the product.",
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
                               "class": [
-                                    "MAXNOM",
                                     "CTH"
                               ],
                               "footnotes": [],
@@ -26171,6 +18981,48 @@
                   "valid": true
             },
             {
+                  "heading": "ex Chapter 95",
+                  "chapter": 95,
+                  "subdivision": "Any other product from heading 9506",
+                  "min": "9506000000",
+                  "max": "9506999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
+                  "heading": "ex Chapter 95",
+                  "chapter": 95,
+                  "subdivision": "Toys, games and sports requisites; parts and accessories thereof",
+                  "min": "9507000000",
+                  "max": "9508999999",
+                  "rules": [
+                        {
+                              "rule": "Manufacture from materials of any heading, except that of the product.",
+                              "class": [
+                                    "CTH"
+                              ],
+                              "footnotes": [],
+                              "operator": null,
+                              "quota": false,
+                              "import": true,
+                              "export": true
+                        }
+                  ],
+                  "valid": true
+            },
+            {
                   "heading": "ex 9601",
                   "chapter": 96,
                   "subdivision": "Articles of animal, vegetable or mineral carving materials",
@@ -26192,9 +19044,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9601",
+                  "heading": "ex Chapter 96",
                   "chapter": 96,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 9601",
                   "min": "9601000000",
                   "max": "9601999999",
                   "rules": [
@@ -26234,9 +19086,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9602",
+                  "heading": "ex Chapter 96",
                   "chapter": 96,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 9602",
                   "min": "9602000000",
                   "max": "9602999999",
                   "rules": [
@@ -26257,7 +19109,7 @@
             {
                   "heading": "ex 9603",
                   "chapter": 96,
-                  "subdivision": "Brooms and brushes (except for besoms and the like and brushes made from marten or squirrel hair), hand-operated mechanical floor sweepers, not motorized, paint pads and rollers, squeegees and mops",
+                  "subdivision": "Brooms and brushes (except for: besoms and the like and brushes made from marten or squirrel hair), hand-operated mechanical floor sweepers, not motorized, paint pads and rollers, squeegees and mops",
                   "min": "9603000000",
                   "max": "9603999999",
                   "rules": [
@@ -26276,9 +19128,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9603",
+                  "heading": "ex Chapter 96",
                   "chapter": 96,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 9603",
                   "min": "9603000000",
                   "max": "9603999999",
                   "rules": [
@@ -26297,7 +19149,7 @@
                   "valid": true
             },
             {
-                  "heading": "9604",
+                  "heading": "ex Chapter 96",
                   "chapter": 96,
                   "subdivision": "Miscellaneous manufactured articles",
                   "min": "9604000000",
@@ -26362,7 +19214,7 @@
                   "valid": true
             },
             {
-                  "heading": "9607",
+                  "heading": "ex Chapter 96",
                   "chapter": 96,
                   "subdivision": "Miscellaneous manufactured articles",
                   "min": "9607000000",
@@ -26404,52 +19256,10 @@
                   "valid": true
             },
             {
-                  "heading": "9609",
+                  "heading": "ex Chapter 96",
                   "chapter": 96,
                   "subdivision": "Miscellaneous manufactured articles",
                   "min": "9609000000",
-                  "max": "9609999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9610",
-                  "chapter": 96,
-                  "subdivision": "Miscellaneous manufactured articles",
-                  "min": "9610000000",
-                  "max": "9610999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9611",
-                  "chapter": 96,
-                  "subdivision": "Miscellaneous manufactured articles",
-                  "min": "9611000000",
                   "max": "9611999999",
                   "rules": [
                         {
@@ -26510,9 +19320,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9613",
+                  "heading": "ex Chapter 96",
                   "chapter": 96,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 9613",
                   "min": "9613000000",
                   "max": "9613999999",
                   "rules": [
@@ -26552,9 +19362,9 @@
                   "valid": true
             },
             {
-                  "heading": "ex 9614",
+                  "heading": "ex Chapter 96",
                   "chapter": 96,
-                  "subdivision": "Any other product",
+                  "subdivision": "Any other product from heading 9614",
                   "min": "9614000000",
                   "max": "9614999999",
                   "rules": [
@@ -26573,115 +19383,10 @@
                   "valid": true
             },
             {
-                  "heading": "9615",
+                  "heading": "ex Chapter 96",
                   "chapter": 96,
                   "subdivision": "Miscellaneous manufactured articles",
                   "min": "9615000000",
-                  "max": "9615999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9616",
-                  "chapter": 96,
-                  "subdivision": "Miscellaneous manufactured articles",
-                  "min": "9616000000",
-                  "max": "9616999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9617",
-                  "chapter": 96,
-                  "subdivision": "Miscellaneous manufactured articles",
-                  "min": "9617000000",
-                  "max": "9617999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9618",
-                  "chapter": 96,
-                  "subdivision": "Miscellaneous manufactured articles",
-                  "min": "9618000000",
-                  "max": "9618999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9619",
-                  "chapter": 96,
-                  "subdivision": "Miscellaneous manufactured articles",
-                  "min": "9619000000",
-                  "max": "9619999999",
-                  "rules": [
-                        {
-                              "rule": "Manufacture from materials of any heading, except that of the product.",
-                              "class": [
-                                    "CTH"
-                              ],
-                              "footnotes": [],
-                              "operator": null,
-                              "quota": false,
-                              "import": true,
-                              "export": true
-                        }
-                  ],
-                  "valid": true
-            },
-            {
-                  "heading": "9620",
-                  "chapter": 96,
-                  "subdivision": "Miscellaneous manufactured articles",
-                  "min": "9620000000",
                   "max": "9620999999",
                   "rules": [
                         {


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4697

### What?

I have altered:

- [x] db/rules_of_origin/roo_schemes_uk/rule_sets/faroe-islands.json

### Why?

I am doing this because:

- The Rules of Origin Product Specific Rules for the Faroe Islands are not in line with the Origin Reference Document

Test results against commodity 5007100010

BEFORE
![image](https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/baf4633f-3b00-4156-88d4-31a6794e1c05)

AFTER
![image](https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/60b10fe1-be65-4756-a8c7-30b1cc69c32e)
