### PR TITLE
HOTT-5215: Add filtering the Goods Nomenclature page by geo area

### DIFF
--- a/app/models/green_lanes/category_assessment_json.rb
+++ b/app/models/green_lanes/category_assessment_json.rb
@@ -69,6 +69,7 @@ module GreenLanes
         measure_type_id == self.measure_type_id &&
         (geographical_area == geographical_area_id ||
           geographical_area.nil? ||
+          geographical_area.empty? ||
           geographical_area_id == GeographicalArea::ERGA_OMNES_ID)
     end
 

--- a/spec/models/green_lanes/category_assessment_json_spec.rb
+++ b/spec/models/green_lanes/category_assessment_json_spec.rb
@@ -217,6 +217,14 @@ RSpec.describe GreenLanes::CategoryAssessmentJson do
       end
     end
 
+    context 'when the attributes match and geographical_area is empty' do
+      it do
+        expect(categorisation.match?(regulation_id: 'D000004',
+                                     measure_type_id: '430',
+                                     geographical_area: '')).to be true
+      end
+    end
+
     context 'when the attributes match and geographical_area is ERGA OMNES' do
       let(:geographical_area_id) { GeographicalArea::ERGA_OMNES_ID }
 


### PR DESCRIPTION
### Jira link

[HOTT-5215](https://transformuk.atlassian.net/browse/HOTT-5215)

### What?

I have added/removed/altered:

- [ ] Added empty geographical area filter into category_assessment model
- [ ] Removed baz

### Why?

I am doing this because:

- When front end sends api request to green lanes api, it sends country='' paramter for default All Country option in country drop down.


### Have you? (optional)

- [ ] Added documentation for new apis
- [ ] Added new environment variables with correct values to all apps in all spaces