### PR TITLE
HOTT-5071: Drop old exchange rate tables with no backing models

### DIFF
--- a/db/migrate/20240314140653_drop_exchange_rate_tables.rb
+++ b/db/migrate/20240314140653_drop_exchange_rate_tables.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    drop_table :exchange_rate_countries
+    drop_table :exchange_rate_currencies
+  end
+
+  down do
+    # No reverting
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-5071

### What?

I have added/removed/altered:

- [x] Added migration to drop unused tables

### Why?

I am doing this because:

- We migrated to an event log style table where a history of country/currency descriptions and their associations is now recorded so these are no longer needed.
