### PR TITLE
BAU - prevent double logging in local development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -79,6 +79,4 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
-
-  config.logger = SchemaQueryFilterLogger.new(ActiveSupport::Logger.new($stdout))
 end


### PR DESCRIPTION

### Jira link

OTT-BAU

### What?

I have added/removed/altered:

- [x] Prevent double log entries in local development

### Why?

I am doing this because:

- I'd added a workaround for Sequel-Rails not creating its logs after the Rails 7.1 upgrade - at some point this has started working in Sequel-Rails resulting in double log entries

### Deployment risks (optional)

- None, local dev environment
