### PR TITLE
GL-102: Add Admin API to backend for CRUD of categorisation data

### DIFF
--- a/app/controllers/api/admin/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/api/admin/green_lanes/category_assessments_controller.rb
@@ -10,7 +10,55 @@ module Api
           render json: serialize(category_assessments.to_a, pagination_meta)
         end
 
+        def show
+          ca = ::GreenLanes::CategoryAssessment.with_pk!(params[:id])
+          render json: serialize(ca)
+        end
+
+        def create
+          ca = ::GreenLanes::CategoryAssessment.new(ca_params)
+
+          if ca.valid? && ca.save
+            render json: serialize(ca),
+                   location: api_admin_category_assessment_url(ca.id),
+                   status: :created
+          else
+            render json: serialize_errors(ca),
+                   status: :unprocessable_entity
+          end
+        end
+
+        def update
+          ca = ::GreenLanes::CategoryAssessment.with_pk!(params[:id])
+          ca.set ca_params
+
+          if ca.valid? && ca.save
+            render json: serialize(ca),
+                   location: api_admin_category_assessment_url(ca.id),
+                   status: :ok
+          else
+            render json: serialize_errors(ca),
+                   status: :unprocessable_entity
+          end
+        end
+
+        def destroy
+          ca = ::GreenLanes::CategoryAssessment.with_pk!(params[:id])
+          ca.destroy
+
+          head :no_content
+        end
+
         private
+
+        def ca_params
+          params.require(:data).require(:attributes).permit(
+            :regulation_id,
+            :regulation_role,
+            :measure_type_id,
+            :theme_id,
+            )
+        end
 
         def record_count
           @category_assessments.pagination_record_count
@@ -22,6 +70,10 @@ module Api
 
         def serialize(*args)
           Api::Admin::GreenLanes::CategoryAssessmentSerializer.new(*args).serializable_hash
+        end
+
+        def serialize_errors(ca)
+          Api::Admin::ErrorSerializationService.new(ca).call
         end
 
         def check_service

--- a/app/controllers/api/admin/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/api/admin/green_lanes/category_assessments_controller.rb
@@ -57,7 +57,7 @@ module Api
             :regulation_role,
             :measure_type_id,
             :theme_id,
-            )
+          )
         end
 
         def record_count
@@ -72,8 +72,8 @@ module Api
           Api::Admin::GreenLanes::CategoryAssessmentSerializer.new(*args).serializable_hash
         end
 
-        def serialize_errors(ca)
-          Api::Admin::ErrorSerializationService.new(ca).call
+        def serialize_errors(category_assessment)
+          Api::Admin::ErrorSerializationService.new(category_assessment).call
         end
 
         def check_service

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,7 +64,7 @@ Rails.application.routes.draw do
                                controller: 'news/items'
       end
 
-      resources :category_assessments, module: 'green_lanes', only: %i[index]
+      resources :category_assessments, module: 'green_lanes', only: %i[index show create update destroy]
     end
   end
 

--- a/spec/requests/api/admin/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/category_assessments_controller_spec.rb
@@ -28,4 +28,117 @@ RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentsController do
       it { expect(json_response).to include('data' => []) }
     end
   end
+
+  describe 'GET to #show' do
+    let(:make_request) do
+      authenticated_get api_admin_category_assessment_path(id, format: :json)
+    end
+
+    context 'with existent category assessment' do
+      let(:id) { category.id }
+
+      it { is_expected.to have_http_status :success }
+      it { expect(json_response).to include('data') }
+    end
+
+    context 'with non-existent category assessments item' do
+      let(:id) { 1001 }
+
+      it { is_expected.to have_http_status :not_found }
+    end
+  end
+
+  describe 'POST to #create' do
+    let(:make_request) do
+      authenticated_post api_admin_category_assessments_path(format: :json), params: ca_data
+    end
+
+    let :ca_data do
+      {
+        data: {
+          type: :category_assessment,
+          attributes: ca_attrs,
+        },
+      }
+    end
+
+    context 'with valid params' do
+      let(:ca_attrs) { build(:category_assessment).to_hash }
+
+      it { is_expected.to have_http_status :created }
+      it { is_expected.to have_attributes location: api_admin_category_assessment_url(GreenLanes::CategoryAssessment.last.id) }
+      it { expect { page_response }.to change(GreenLanes::CategoryAssessment, :count).by(1) }
+    end
+
+    context 'with invalid params' do
+      let(:ca_attrs) { build(:category_assessment, regulation_role: nil).to_hash }
+
+      it { is_expected.to have_http_status :unprocessable_entity }
+
+      it 'returns errors for category assessment' do
+        expect(json_response).to include('errors')
+      end
+
+      it { expect { page_response }.not_to change(GreenLanes::CategoryAssessment, :count) }
+    end
+  end
+
+  describe 'PATCH to #update' do
+    let(:id) { category.id }
+    let(:updated_regulation) { '3' }
+
+    let(:make_request) do
+      authenticated_patch api_admin_category_assessment_path(id, format: :json), params: {
+        data: {
+          type: :category_assessment,
+          attributes: { regulation_role: updated_regulation },
+        },
+      }
+    end
+
+    context 'with valid params' do
+      it { is_expected.to have_http_status :success }
+      it { is_expected.to have_attributes location: api_admin_category_assessment_url(category.id) }
+      it { expect { page_response }.not_to change(category.reload, :regulation_role) }
+    end
+
+    context 'with invalid params' do
+      let(:updated_regulation) { nil }
+
+      it { is_expected.to have_http_status :unprocessable_entity }
+
+      it 'returns errors for category assessment' do
+        expect(json_response).to include('errors')
+      end
+
+      it { expect { page_response }.not_to change(category.reload, :regulation_role) }
+    end
+
+    context 'with unknown category assessment' do
+      let(:id) { 9999 }
+
+      it { is_expected.to have_http_status :not_found }
+      it { expect { page_response }.not_to change(category.reload, :regulation_role) }
+    end
+  end
+
+  describe 'DELETE to #destroy' do
+    let :make_request do
+      authenticated_delete api_admin_category_assessment_path(id, format: :json)
+    end
+
+    context 'with known category assessment' do
+      let(:id) { category.id }
+
+      it { is_expected.to have_http_status :no_content }
+      it { expect { page_response }.to change(category, :exists?) }
+    end
+
+    context 'with unknown category assessment' do
+      let(:id) { 9999 }
+
+      it { is_expected.to have_http_status :not_found }
+      it { expect { page_response }.not_to change(GreenLanes::CategoryAssessment, :count) }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

[GL-102](https://transformuk.atlassian.net/browse/GL-102)

### What?

I have added/removed/altered:

- [ ] Added an admin API which will allow performing Create/Read/Update/Delete operations on the Green Lanes categorisation data

### Why?

I am doing this because:

- We need to  build a Green Lanes admin interface to manage green lanes category assessments

### Have you? (optional)

- [ ] Added documentation for new apis
- [ ] Added new environment variables with correct values to all apps in all spaces

