### PR TITLE
GL-138 Convert GreenLanes GoodsNomenclature API to use database

### DIFF
--- a/app/controllers/api/v2/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/api/v2/green_lanes/category_assessments_controller.rb
@@ -8,12 +8,11 @@ module Api
               .eager(
                 theme: [],
                 measures: {
-                  additional_code: [],
-                  measure_conditions: :certificate,
+                  additional_code: :additional_code_descriptions,
+                  measure_conditions: { certificate: :certificate_descriptions },
                   geographical_area: :geographical_area_descriptions,
-                  measure_excluded_geographical_areas: {
-                    geographical_area: :geographical_area_descriptions,
-                  },
+                  measure_excluded_geographical_areas: [],
+                  excluded_geographical_areas: :geographical_area_descriptions,
                 },
               )
               .all

--- a/app/models/green_lanes/theme.rb
+++ b/app/models/green_lanes/theme.rb
@@ -4,5 +4,9 @@ module GreenLanes
     plugin :auto_validations, not_null: :presence
 
     one_to_many :category_assessments
+
+    def to_s
+      "#{section}.#{subsection}. #{description}"
+    end
   end
 end

--- a/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
@@ -16,7 +16,8 @@ module Api
         delegate :geographical_area_id,
                  :geographical_area,
                  :excluded_geographical_areas,
-                 :exemptions,
+                 :measure_conditions,
+                 :additional_code,
                  to: :first_measure
 
         content_addressable_fields do |ca|
@@ -66,6 +67,18 @@ module Api
 
         def excluded_geographical_area_ids
           excluded_geographical_areas.map(&:geographical_area_id)
+        end
+
+        def exemptions
+          certificates + additional_codes
+        end
+
+        def certificates
+          measure_conditions.select(&:certificate).map(&:certificate)
+        end
+
+        def additional_codes
+          Array.wrap(additional_code)
         end
 
       private

--- a/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
@@ -61,6 +61,10 @@ module Api
           @category_assessment.theme.category
         end
 
+        def category_assessment_id
+          @category_assessment.id
+        end
+
         def excluded_geographical_areas
           [] # ignore for now to match existing api behaviour
         end

--- a/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
@@ -15,7 +15,6 @@ module Api
 
         delegate :geographical_area_id,
                  :geographical_area,
-                 :excluded_geographical_area_ids,
                  :excluded_geographical_areas,
                  :exemptions,
                  to: :first_measure
@@ -54,23 +53,19 @@ module Api
         end
 
         def theme
-          @category_assessment.theme.theme
+          @category_assessment.theme.to_s
         end
 
         def category
-          @category_assessment.theme.category
+          @category_assessment.theme.category.to_s
         end
 
         def category_assessment_id
           @category_assessment.id
         end
 
-        def excluded_geographical_areas
-          [] # ignore for now to match existing api behaviour
-        end
-
         def excluded_geographical_area_ids
-          [] # ignore for now to match existing api behaviour
+          excluded_geographical_areas.map(&:geographical_area_id)
         end
 
       private

--- a/app/services/green_lanes/fetch_goods_nomenclature_service.rb
+++ b/app/services/green_lanes/fetch_goods_nomenclature_service.rb
@@ -1,6 +1,27 @@
 module GreenLanes
   class FetchGoodsNomenclatureService
     ITEM_ID_LENGTH = 10
+
+    MEASURES_EAGER = {
+      additional_code: :additional_code_descriptions,
+      goods_nomenclature: %i[goods_nomenclature_indents goods_nomenclature_descriptions],
+      footnotes: :footnote_descriptions,
+      geographical_area: %i[geographical_area_descriptions contained_geographical_areas],
+      measure_excluded_geographical_areas: [],
+      excluded_geographical_areas: :geographical_area_descriptions,
+      measure_conditions: { certificate: :certificate_descriptions },
+      category_assessment: :theme,
+    }.freeze
+
+    EAGER_LOAD = {
+      ancestors: {
+        measures: MEASURES_EAGER,
+        goods_nomenclature_descriptions: [],
+      },
+      measures: MEASURES_EAGER,
+      goods_nomenclature_descriptions: [],
+    }.freeze
+
     def initialize(goods_nomenclature_item_id)
       @goods_nomenclature_item_id = goods_nomenclature_item_id
     end
@@ -8,6 +29,7 @@ module GreenLanes
     def call
       GoodsNomenclature
         .actual
+        .eager(EAGER_LOAD)
         .where(goods_nomenclature_item_id: length_adjusted_digit_id, producline_suffix: '80')
         .take
     end

--- a/spec/factories/green_lanes/category_assessment_factory.rb
+++ b/spec/factories/green_lanes/category_assessment_factory.rb
@@ -2,10 +2,11 @@ FactoryBot.define do
   factory :category_assessment, class: 'GreenLanes::CategoryAssessment' do
     transient do
       measures_count { 1 }
+      measure { nil }
     end
 
-    regulation { create(:base_regulation) }
-    measure_type { create(:measure_type) }
+    regulation { measure&.generating_regulation || create(:base_regulation) }
+    measure_type { measure&.measure_type || create(:measure_type) }
     theme { create :green_lanes_theme }
 
     trait :category1 do

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
       default_start_date { 3.years.ago.beginning_of_day }
       additional_code { nil }
       goods_nomenclature { nil }
+      for_geo_area { nil }
     end
 
     filename { build(:cds_update, issue_date: operation_date || validity_start_date).filename }
@@ -35,8 +36,8 @@ FactoryBot.define do
     additional_code_type_id { additional_code&.additional_code_type_id || '1' }
     goods_nomenclature_sid { goods_nomenclature&.goods_nomenclature_sid || generate(:goods_nomenclature_sid) }
     goods_nomenclature_item_id { goods_nomenclature&.goods_nomenclature_item_id || 10.times.map { Random.rand(9) }.join }
-    geographical_area_sid { generate(:geographical_area_sid) }
-    geographical_area_id { generate(:geographical_area_id) }
+    geographical_area_sid { for_geo_area&.geographical_area_sid || generate(:geographical_area_sid) }
+    geographical_area_id { for_geo_area&.geographical_area_id || generate(:geographical_area_id) }
     validity_start_date { default_start_date }
     validity_end_date   { nil }
     reduction_indicator { 1 }
@@ -51,7 +52,7 @@ FactoryBot.define do
     end
 
     geographical_area do
-      create(
+      for_geo_area || create(
         :geographical_area,
         :with_description,
         geographical_area_sid:,

--- a/spec/models/green_lanes/theme_spec.rb
+++ b/spec/models/green_lanes/theme_spec.rb
@@ -65,4 +65,16 @@ RSpec.describe GreenLanes::Theme do
       end
     end
   end
+
+  describe '#to_s' do
+    subject do
+      described_class.create(section: 1,
+                             subsection: 2,
+                             category: 1,
+                             theme: 'Short desc',
+                             description: 'Long description').to_s
+    end
+
+    it { is_expected.to eq '1.2. Long description' }
+  end
 end

--- a/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
@@ -25,6 +25,12 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentPresenter do
       it { is_expected.to have_attributes id: /^[0-9a-f]{32}$/ }
       it { is_expected.to have_attributes measure_ids: assessment.measures.map(&:measure_sid) }
     end
+
+    context 'with no measures' do
+      let(:assessment) { create :category_assessment }
+
+      it { is_expected.to be_empty }
+    end
   end
 
   describe '#measures' do
@@ -32,5 +38,46 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentPresenter do
 
     it { is_expected.to all be_instance_of Api::V2::GreenLanes::MeasurePresenter }
     it { expect(measures.map(&:measure_sid)).to eq assessment.measures.map(&:measure_sid) }
+  end
+
+  describe '#exemptions' do
+    subject { presented.exemptions }
+
+    let :certificates do
+      create_pair(:certificate).each do |cert|
+        create :measure_condition,
+               measure_sid: assessment.measures.first.measure_sid,
+               certificate_type_code: cert.certificate_type_code,
+               certificate_code: cert.certificate_code
+      end
+    end
+
+    let :additional_code do
+      create(:additional_code).tap do |ad_code|
+        assessment.measures.first.update additional_code: ad_code
+      end
+    end
+
+    context 'with certificates' do
+      before { certificates }
+
+      it { is_expected.to match_array certificates }
+    end
+
+    context 'with additional code' do
+      before { additional_code }
+
+      it { is_expected.to match_array [additional_code] }
+    end
+
+    context 'with certificates and additional code' do
+      before { certificates && additional_code }
+
+      it { is_expected.to match_array certificates << additional_code }
+    end
+
+    context 'with neither' do
+      it { is_expected.to be_empty }
+    end
   end
 end

--- a/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentPresenter do
   end
 
   it { is_expected.to have_attributes id: /^[0-9a-f]{32}$/ }
+  it { is_expected.to have_attributes category_assessment_id: assessment.id }
   it { is_expected.to have_attributes measure_ids: assessment.measures.map(&:measure_sid) }
 
   describe '.wrap' do

--- a/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentPresenter do
   it { is_expected.to have_attributes id: /^[0-9a-f]{32}$/ }
   it { is_expected.to have_attributes category_assessment_id: assessment.id }
   it { is_expected.to have_attributes measure_ids: assessment.measures.map(&:measure_sid) }
+  it { is_expected.to have_attributes category: /\d+/ }
+  it { is_expected.to have_attributes theme: /\d+\.\d+\. \w+/ }
 
   describe '.wrap' do
     subject(:wrapped) { described_class.wrap [assessment] }

--- a/spec/serializers/api/v2/green_lanes/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/goods_nomenclature_serializer_spec.rb
@@ -1,9 +1,5 @@
 RSpec.describe Api::V2::GreenLanes::GoodsNomenclatureSerializer do
   subject(:serialized) do
-    presented_assessments = [
-      ::Api::V2::GreenLanes::CategoryAssessmentPresenter.new(category_assessment, [first_measure]),
-    ]
-
     gn_presenter = \
       Api::V2::GreenLanes::GoodsNomenclaturePresenter.new(subheading, presented_assessments)
 
@@ -14,8 +10,15 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclatureSerializer do
     ).serializable_hash
   end
 
-  before do
-    allow(GreenLanes::CategoryAssessmentJson).to receive(:all).and_return([category_assessment])
+  let(:subheading) { create :subheading, :with_measures }
+  let(:assessment) { create :category_assessment, measure: subheading.measures.first }
+
+  let :permutations do
+    GreenLanes::PermutationCalculatorService.new(subheading.applicable_measures).call
+  end
+
+  let :presented_assessments do
+    [Api::V2::GreenLanes::CategoryAssessmentPresenter.new(assessment, *permutations.first)]
   end
 
   let(:expected_pattern) do
@@ -34,7 +37,7 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclatureSerializer do
         "relationships": {
           "applicable_category_assessments": {
             "data": [{
-              "id": GreenLanes::CategoryAssessmentJson.all[0].id,
+              "id": presented_assessments[0].id,
               type: eq(:category_assessment),
             }],
           },
@@ -42,17 +45,17 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclatureSerializer do
       },
       included: [
         {
-          id: '1000',
+          id: subheading.measures.first.geographical_area_id,
           type: eq(:geographical_area),
         },
         {
-          id: GreenLanes::CategoryAssessmentJson.all[0].id,
+          id: presented_assessments[0].id,
           type: eq(:category_assessment),
           relationships: {
             measures: {
               data: [
                 {
-                  id: first_measure.measure_sid.to_s,
+                  id: subheading.measures.first.measure_sid.to_s,
                   type: eq(:measure),
                 },
               ],
@@ -61,17 +64,6 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclatureSerializer do
         },
       ],
     }
-  end
-
-  let(:subheading) { create :subheading, :with_measures }
-  let(:first_measure) { subheading.applicable_measures.first }
-
-  let :category_assessment do
-    build :category_assessment_json, measure: first_measure, geographical_area:
-  end
-
-  let :geographical_area do
-    create(:geographical_area, :with_reference_group_and_members, :with_description, geographical_area_id: '1000')
   end
 
   it { is_expected.to include_json(expected_pattern) }


### PR DESCRIPTION
### Jira link

GL-138

### What?

I have added/removed/altered:

- [x] Look up category assessments from the database
- [x] Ensure correct measures are being returned for Category Assessments
- [x] Ensure data is eager loaded
- [x] Adds support for measure excluded GeographicalAreas and GeographicalArea groups
- [x] Corrects the format of the theme data to match the existing API output

### Why?

I am doing this because:

- We want to rely on the database for the Category Assessments data and their measures
- This will allow managing the Category Assessments an api consumer sees

### Deployment risks (optional)

- Low, should only be changing GreenLanes APIs
