### PR TITLE
OTT-85 and OTT-132: Fixed preference codes bug on commodities and declarable headings pages/API

### DIFF
--- a/app/models/preference_code.rb
+++ b/app/models/preference_code.rb
@@ -16,10 +16,10 @@ class PreferenceCode
     MEASURE_TYPE_ID_PREFERENCE_CODE_MAPPING['117'] = ->(_, _) { '140' }
     MEASURE_TYPE_ID_PREFERENCE_CODE_MAPPING['119'] = ->(_, _) { '119' }
     MEASURE_TYPE_ID_PREFERENCE_CODE_MAPPING['123'] = ->(_, _) { '123' }
-    MEASURE_TYPE_ID_PREFERENCE_CODE_MAPPING['103'] = lambda do |presented_declarable, _measure|
+    MEASURE_TYPE_ID_PREFERENCE_CODE_MAPPING['103'] = lambda do |presented_declarable, measure|
       if presented_declarable.authorised_use_provisions_submission?
         '140'
-      elsif presented_declarable.special_nature?
+      elsif presented_declarable.special_nature?(measure)
         '150'
       else
         '100'
@@ -29,7 +29,7 @@ class PreferenceCode
       measure.authorised_use? ? '115' : '110'
     end
     MEASURE_TYPE_ID_PREFERENCE_CODE_MAPPING['122'] = lambda do |presented_declarable, measure|
-      if presented_declarable.special_nature?
+      if presented_declarable.special_nature?(measure)
         '125'
       elsif measure.authorised_use?
         '123'
@@ -49,14 +49,14 @@ class PreferenceCode
     end
     MEASURE_TYPE_ID_PREFERENCE_CODE_MAPPING['143'] = lambda do |presented_declarable, measure|
       if measure.gsp_or_dcts?
-        if presented_declarable.special_nature?
+        if presented_declarable.special_nature?(measure)
           '255'
         elsif measure.authorised_use?
           '223'
         else
           '220'
         end
-      elsif presented_declarable.special_nature?
+      elsif presented_declarable.special_nature?(measure)
         '325'
       elsif measure.authorised_use?
         '323'

--- a/app/presenters/api/v2/commodities/commodity_presenter.rb
+++ b/app/presenters/api/v2/commodities/commodity_presenter.rb
@@ -101,8 +101,14 @@ module Api
           ImportTradeSummary.build(import_measures)
         end
 
-        def special_nature?
-          @special_nature ||= import_measures.any?(&:special_nature?)
+        def special_nature?(presented_measure)
+          if @filtering_by_country
+            @special_nature ||= import_measures.any?(&:special_nature?)
+          else
+            filtered_measures = import_measures.reject { |measure| measure.geographical_area_id != presented_measure.geographical_area_id && measure.geographical_area_id != GeographicalArea::ERGA_OMNES_ID }
+
+            @special_nature ||= filtered_measures.any?(&:special_nature?)
+          end
         end
 
         def authorised_use_provisions_submission?

--- a/app/presenters/api/v2/commodities/commodity_presenter.rb
+++ b/app/presenters/api/v2/commodities/commodity_presenter.rb
@@ -2,6 +2,8 @@ module Api
   module V2
     module Commodities
       class CommodityPresenter < SimpleDelegator
+        include SpecialNature
+
         attr_reader :commodity,
                     :footnotes,
                     :import_measures,
@@ -99,16 +101,6 @@ module Api
 
         def import_trade_summary
           ImportTradeSummary.build(import_measures)
-        end
-
-        def special_nature?(presented_measure)
-          if @filtering_by_country
-            @special_nature ||= import_measures.any?(&:special_nature?)
-          else
-            filtered_measures = import_measures.reject { |measure| measure.geographical_area_id != presented_measure.geographical_area_id && measure.geographical_area_id != GeographicalArea::ERGA_OMNES_ID }
-
-            @special_nature ||= filtered_measures.any?(&:special_nature?)
-          end
         end
 
         def authorised_use_provisions_submission?

--- a/app/presenters/api/v2/headings/declarable_heading_presenter.rb
+++ b/app/presenters/api/v2/headings/declarable_heading_presenter.rb
@@ -81,7 +81,7 @@ module Api
           ImportTradeSummary.build(import_measures)
         end
 
-        def special_nature?(_presented_measure = nil) #temporary fix
+        def special_nature?(_presented_measure = nil)
           @special_nature ||= import_measures.any?(&:special_nature?)
         end
 

--- a/app/presenters/api/v2/headings/declarable_heading_presenter.rb
+++ b/app/presenters/api/v2/headings/declarable_heading_presenter.rb
@@ -81,7 +81,7 @@ module Api
           ImportTradeSummary.build(import_measures)
         end
 
-        def special_nature?
+        def special_nature?(_presented_measure = nil) #temporary fix
           @special_nature ||= import_measures.any?(&:special_nature?)
         end
 

--- a/app/presenters/api/v2/headings/declarable_heading_presenter.rb
+++ b/app/presenters/api/v2/headings/declarable_heading_presenter.rb
@@ -2,6 +2,8 @@ module Api
   module V2
     module Headings
       class DeclarableHeadingPresenter < SimpleDelegator
+        include SpecialNature
+
         attr_reader :heading,
                     :import_measures,
                     :export_measures,
@@ -79,10 +81,6 @@ module Api
 
         def import_trade_summary
           ImportTradeSummary.build(import_measures)
-        end
-
-        def special_nature?(_presented_measure = nil)
-          @special_nature ||= import_measures.any?(&:special_nature?)
         end
 
         def authorised_use_provisions_submission?

--- a/app/presenters/api/v2/special_nature.rb
+++ b/app/presenters/api/v2/special_nature.rb
@@ -1,0 +1,15 @@
+module Api
+  module V2
+    module SpecialNature
+      def special_nature?(presented_measure)
+        if !@filtering_by_country && presented_measure.geographical_area_id.match?(/^\D+$/)
+          filtered_measures = import_measures.reject { |measure| measure.geographical_area_id != presented_measure.geographical_area_id && measure.geographical_area_id != GeographicalArea::ERGA_OMNES_ID }
+
+          @special_nature = filtered_measures.any?(&:special_nature?)
+        else
+          @special_nature = import_measures.any?(&:special_nature?)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/preference_code_spec.rb
+++ b/spec/models/preference_code_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe PreferenceCode do
               :with_measure_conditions,
               :with_special_nature,
               goods_nomenclature_sid: declarable.goods_nomenclature_sid,
+              geographical_area_id: measure.geographical_area_id,
             )
 
             [measure, special_nature_measure]
@@ -121,6 +122,7 @@ RSpec.describe PreferenceCode do
               :with_measure_conditions,
               :with_special_nature,
               goods_nomenclature_sid: declarable.goods_nomenclature_sid,
+              geographical_area_id: measure.geographical_area_id,
             )
 
             [measure, special_nature_measure]

--- a/spec/presenters/api/v2/commodities/commodity_presenter_spec.rb
+++ b/spec/presenters/api/v2/commodities/commodity_presenter_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Api::V2::Commodities::CommodityPresenter do
           create_list(
             :measure, 1,
             :with_measure_conditions,
-            goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+            goods_nomenclature_sid: commodity.goods_nomenclature_sid
           )
         end
 

--- a/spec/presenters/api/v2/commodities/commodity_presenter_spec.rb
+++ b/spec/presenters/api/v2/commodities/commodity_presenter_spec.rb
@@ -89,25 +89,87 @@ RSpec.describe Api::V2::Commodities::CommodityPresenter do
   end
 
   describe '#special_nature?' do
-    context 'when commodity has at least one measure condition containing special nature certificate' do
-      let(:measures) do
-        create_list(
-          :measure, 1,
-          :with_measure_conditions,
-          :with_special_nature,
-          goods_nomenclature_sid: commodity.goods_nomenclature_sid
-        )
+    let(:presenter) { described_class.new(commodity.reload, measure_collection) }
+
+    context 'when filtering by country' do
+      let(:measure_collection) { MeasureCollection.new measures, geographical_area_id: 'CN' }
+
+      context 'when commodity has at least one measure condition containing special nature certificate' do
+        let(:measures) do
+          create_list(
+            :measure, 1,
+            :with_measure_conditions,
+            :with_special_nature,
+            goods_nomenclature_sid: commodity.goods_nomenclature_sid
+          )
+        end
+
+        it { expect(presenter.special_nature?(measures.first)).to eq(true) }
       end
 
-      it { is_expected.to be_special_nature }
+      context 'when commodity does not have any measure conditions containing special nature certificate' do
+        let(:measures) do
+          create_list(:measure, 1, goods_nomenclature_sid: commodity.goods_nomenclature_sid)
+        end
+
+        it { expect(presenter.special_nature?(measures.first)).to eq(false) }
+      end
     end
 
-    context 'when commodity does not have any measure conditions containing special nature certificate' do
-      let(:measures) do
-        create_list(:measure, 1, goods_nomenclature_sid: commodity.goods_nomenclature_sid)
+    context 'when not filtering by country' do
+      context 'when commodity has at least one measure condition containing special nature certificate' do
+        let(:measure_collection) { MeasureCollection.new measures }
+
+        let(:measures) do
+          create_list(
+            :measure, 1,
+            :with_measure_conditions,
+            :with_special_nature,
+            goods_nomenclature_sid: commodity.goods_nomenclature_sid
+          )
+        end
+
+        it { expect(presenter.special_nature?(measures.first)).to eq(true) }
       end
 
-      it { is_expected.not_to be_special_nature }
+      context 'when commodity does not have any measure conditions containing special nature certificate' do
+        let(:measure_collection) { MeasureCollection.new measures }
+
+        let(:measures) do
+          create_list(
+            :measure, 1,
+            :with_measure_conditions,
+            goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+          )
+        end
+
+        it { expect(presenter.special_nature?(measures.first)).to eq(false) }
+      end
+
+      context 'when commodity has some measure conditions containing special nature certificate' do
+        let(:measure_collection) { MeasureCollection.new measures_not_special_nature + measures_special_nature }
+
+        let(:measures_special_nature) do
+          create_list(
+            :measure, 1,
+            :with_measure_conditions,
+            :with_special_nature,
+            goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+            geographical_area_id: 'PK'
+          )
+        end
+
+        let(:measures_not_special_nature) do
+          create_list(
+            :measure, 1,
+            :with_measure_conditions,
+            goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+            geographical_area_id: 'CN'
+          )
+        end
+
+        it { expect(presenter.special_nature?(measures_not_special_nature.first)).to eq(false) }
+      end
     end
   end
 

--- a/spec/presenters/api/v2/commodities/commodity_presenter_spec.rb
+++ b/spec/presenters/api/v2/commodities/commodity_presenter_spec.rb
@@ -91,65 +91,48 @@ RSpec.describe Api::V2::Commodities::CommodityPresenter do
   describe '#special_nature?' do
     let(:presenter) { described_class.new(commodity.reload, measure_collection) }
 
+    let(:measures_special_nature) do
+      create_list(
+        :measure, 1,
+        :with_measure_conditions,
+        :with_special_nature,
+        goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+        geographical_area_id: 'PK'
+      )
+    end
+
+    let(:measures_not_special_nature) do
+      create_list(
+        :measure, 1,
+        :with_measure_conditions,
+        goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+        geographical_area_id: 'CN'
+      )
+    end
+
     context 'when filtering by country' do
-      let(:measure_collection) { MeasureCollection.new measures, geographical_area_id: 'CN' }
+      let(:geographical_area_id) { 'CN' }
 
       context 'when commodity has at least one measure condition containing special nature certificate' do
-        let(:measures) do
-          create_list(
-            :measure, 1,
-            :with_measure_conditions,
-            :with_special_nature,
-            goods_nomenclature_sid: commodity.goods_nomenclature_sid
-          )
-        end
+        let(:measure_collection) { MeasureCollection.new measures_special_nature, geographical_area_id: }
 
-        it { expect(presenter.special_nature?(measures.first)).to eq(true) }
+        it { expect(presenter.special_nature?(measures_special_nature.first)).to eq(true) }
       end
 
       context 'when commodity does not have any measure conditions containing special nature certificate' do
-        let(:measures) do
-          create_list(:measure, 1, goods_nomenclature_sid: commodity.goods_nomenclature_sid)
-        end
+        let(:measure_collection) { MeasureCollection.new measures_not_special_nature, geographical_area_id: }
 
-        it { expect(presenter.special_nature?(measures.first)).to eq(false) }
+        it { expect(presenter.special_nature?(measures_not_special_nature.first)).to eq(false) }
       end
     end
 
     context 'when not filtering by country' do
+      let(:geographical_area_id) { nil }
+
       context 'when commodity has at least one measure condition containing special nature certificate' do
-        let(:measure_collection) { MeasureCollection.new measures }
+        let(:measure_collection) { MeasureCollection.new measures, geographical_area_id: }
 
         let(:measures) do
-          create_list(
-            :measure, 1,
-            :with_measure_conditions,
-            :with_special_nature,
-            goods_nomenclature_sid: commodity.goods_nomenclature_sid
-          )
-        end
-
-        it { expect(presenter.special_nature?(measures.first)).to eq(true) }
-      end
-
-      context 'when commodity does not have any measure conditions containing special nature certificate' do
-        let(:measure_collection) { MeasureCollection.new measures }
-
-        let(:measures) do
-          create_list(
-            :measure, 1,
-            :with_measure_conditions,
-            goods_nomenclature_sid: commodity.goods_nomenclature_sid
-          )
-        end
-
-        it { expect(presenter.special_nature?(measures.first)).to eq(false) }
-      end
-
-      context 'when commodity has some measure conditions containing special nature certificate' do
-        let(:measure_collection) { MeasureCollection.new measures_not_special_nature + measures_special_nature }
-
-        let(:measures_special_nature) do
           create_list(
             :measure, 1,
             :with_measure_conditions,
@@ -159,16 +142,34 @@ RSpec.describe Api::V2::Commodities::CommodityPresenter do
           )
         end
 
-        let(:measures_not_special_nature) do
+        it { expect(presenter.special_nature?(measures.first)).to eq(true) }
+      end
+
+      context 'when commodity does not have any measure conditions containing special nature certificate' do
+        let(:measure_collection) { MeasureCollection.new measures, geographical_area_id: }
+
+        let(:measures) do
           create_list(
             :measure, 1,
             :with_measure_conditions,
             goods_nomenclature_sid: commodity.goods_nomenclature_sid,
-            geographical_area_id: 'CN'
+            geographical_area_id: 'PK'
           )
         end
 
+        it { expect(presenter.special_nature?(measures.first)).to eq(false) }
+      end
+
+      context 'when commodity has some non country specific measure conditions containing special nature certificate' do
+        let(:measure_collection) { MeasureCollection.new measures_not_special_nature + measures_special_nature, geographical_area_id: }
+
         it { expect(presenter.special_nature?(measures_not_special_nature.first)).to eq(false) }
+      end
+
+      context 'when commodity has some country specific measure conditions containing special nature certificate' do
+        let(:measure_collection) { MeasureCollection.new measures_not_special_nature + measures_special_nature, geographical_area_id: }
+
+        it { expect(presenter.special_nature?(measures_special_nature.first)).to eq(true) }
       end
     end
   end

--- a/spec/presenters/api/v2/headings/declarable_headings_presenter_spec.rb
+++ b/spec/presenters/api/v2/headings/declarable_headings_presenter_spec.rb
@@ -149,20 +149,88 @@ RSpec.describe Api::V2::Headings::DeclarableHeadingPresenter do
   end
 
   describe '#special_nature?' do
-    context 'when heading has at least one measure condition containing special nature certificate' do
-      let(:measures) do
-        create_list(:measure, 1, :with_measure_conditions, :with_special_nature, goods_nomenclature_sid: heading.goods_nomenclature_sid)
-      end
+    let(:presenter) { described_class.new(heading.reload, measure_collection) }
 
-      it { is_expected.to be_special_nature }
+    let(:measures_special_nature) do
+      create_list(
+        :measure, 1,
+        :with_measure_conditions,
+        :with_special_nature,
+        goods_nomenclature_sid: heading.goods_nomenclature_sid,
+        geographical_area_id: 'PK'
+      )
     end
 
-    context 'when heading does not have any measure conditions containing special nature certificate' do
-      let(:measures) do
-        create_list(:measure, 1, goods_nomenclature_sid: heading.goods_nomenclature_sid)
+    let(:measures_not_special_nature) do
+      create_list(
+        :measure, 1,
+        :with_measure_conditions,
+        goods_nomenclature_sid: heading.goods_nomenclature_sid,
+        geographical_area_id: 'CN'
+      )
+    end
+
+    context 'when filtering by country' do
+      let(:geographical_area_id) { 'CN' }
+
+      context 'when heading has at least one measure condition containing special nature certificate' do
+        let(:measure_collection) { MeasureCollection.new measures_special_nature, geographical_area_id: }
+
+        it { expect(presenter.special_nature?(measures_special_nature.first)).to eq(true) }
       end
 
-      it { is_expected.not_to be_special_nature }
+      context 'when heading does not have any measure conditions containing special nature certificate' do
+        let(:measure_collection) { MeasureCollection.new measures_not_special_nature, geographical_area_id: }
+
+        it { expect(presenter.special_nature?(measures_not_special_nature.first)).to eq(false) }
+      end
+    end
+
+    context 'when not filtering by country' do
+      let(:geographical_area_id) { nil }
+
+      context 'when heading has at least one measure condition containing special nature certificate' do
+        let(:measure_collection) { MeasureCollection.new measures, geographical_area_id: }
+
+        let(:measures) do
+          create_list(
+            :measure, 1,
+            :with_measure_conditions,
+            :with_special_nature,
+            goods_nomenclature_sid: heading.goods_nomenclature_sid,
+            geographical_area_id: 'PK'
+          )
+        end
+
+        it { expect(presenter.special_nature?(measures.first)).to eq(true) }
+      end
+
+      context 'when heading does not have any measure conditions containing special nature certificate' do
+        let(:measure_collection) { MeasureCollection.new measures, geographical_area_id: }
+
+        let(:measures) do
+          create_list(
+            :measure, 1,
+            :with_measure_conditions,
+            goods_nomenclature_sid: heading.goods_nomenclature_sid,
+            geographical_area_id: 'PK'
+          )
+        end
+
+        it { expect(presenter.special_nature?(measures.first)).to eq(false) }
+      end
+
+      context 'when heading has some non country specific measure conditions containing special nature certificate' do
+        let(:measure_collection) { MeasureCollection.new measures_not_special_nature + measures_special_nature, geographical_area_id: }
+
+        it { expect(presenter.special_nature?(measures_not_special_nature.first)).to eq(false) }
+      end
+
+      context 'when heading has some country specific measure conditions containing special nature certificate' do
+        let(:measure_collection) { MeasureCollection.new measures_not_special_nature + measures_special_nature, geographical_area_id: }
+
+        it { expect(presenter.special_nature?(measures_special_nature.first)).to eq(true) }
+      end
     end
   end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-85
https://transformuk.atlassian.net/browse/OTT-132

### What?

I have added/removed/altered:

- [ ] Fixed preference codes bug on commodities and declarable headings pages/API

### Why?

I am doing this because:

- The preference codes displayed were wrong

<img width="998" alt="Screenshot 2024-04-03 at 14 53 41" src="https://github.com/trade-tariff/trade-tariff-backend/assets/12201130/f68682c4-0b99-4f16-aabf-07c83a51128d">
<img width="957" alt="Screenshot 2024-04-03 at 14 53 58" src="https://github.com/trade-tariff/trade-tariff-backend/assets/12201130/72165cd0-d82a-469a-8c88-0fff673eb03b">

<img width="1052" alt="Screenshot 2024-04-03 at 14 54 23" src="https://github.com/trade-tariff/trade-tariff-backend/assets/12201130/2af3bd3d-4e2d-4e61-8209-d87656343627">

<img width="1065" alt="Screenshot 2024-04-03 at 14 55 07" src="https://github.com/trade-tariff/trade-tariff-backend/assets/12201130/92e2e58a-f9e9-4dc2-b9a4-ce4e3eeb9639">
