### PR TITLE
GL-296: Hide Cat 3 CAs

### DIFF
--- a/app/models/green_lanes/category_assessment_json.rb
+++ b/app/models/green_lanes/category_assessment_json.rb
@@ -64,7 +64,8 @@ module GreenLanes
       end
     end
 
-    def match?(regulation_id:, measure_type_id:, geographical_area: nil)
+    def match?(regulation_id:, measure_type_id:, geographical_area: nil, filtered_category: nil)
+      (filtered_category == nil || self.category.in?(filtered_category)) &&
       regulation_id == self.regulation_id &&
         measure_type_id == self.measure_type_id &&
         (geographical_area == geographical_area_id ||

--- a/app/models/green_lanes/category_assessment_json.rb
+++ b/app/models/green_lanes/category_assessment_json.rb
@@ -65,8 +65,8 @@ module GreenLanes
     end
 
     def match?(regulation_id:, measure_type_id:, geographical_area: nil, filtered_category: nil)
-      (filtered_category == nil || self.category.in?(filtered_category)) &&
-      regulation_id == self.regulation_id &&
+      (filtered_category.nil? || category.in?(filtered_category)) &&
+        regulation_id == self.regulation_id &&
         measure_type_id == self.measure_type_id &&
         (geographical_area == geographical_area_id ||
           geographical_area.blank? ||

--- a/app/services/green_lanes/find_category_assessments_service.rb
+++ b/app/services/green_lanes/find_category_assessments_service.rb
@@ -1,6 +1,5 @@
 module GreenLanes
   class FindCategoryAssessmentsService
-
     FILTERED_CATEGORY = Set.new([1, 2]).freeze
     class << self
       def call(goods_nomenclature:, geographical_area_id: nil)

--- a/app/services/green_lanes/find_category_assessments_service.rb
+++ b/app/services/green_lanes/find_category_assessments_service.rb
@@ -1,5 +1,7 @@
 module GreenLanes
   class FindCategoryAssessmentsService
+
+    FILTERED_CATEGORY = Set.new([1, 2]).freeze
     class << self
       def call(goods_nomenclature:, geographical_area_id: nil)
         new(goods_nomenclature, geographical_area_id).call
@@ -22,7 +24,8 @@ module GreenLanes
     def assessment_matches_measure?(category_assessment, measure)
       category_assessment.match?(regulation_id: measure.measure_generating_regulation_id,
                                  measure_type_id: measure.measure_type_id,
-                                 geographical_area: @geographical_area_id)
+                                 geographical_area: @geographical_area_id,
+                                 filtered_category: FILTERED_CATEGORY)
     end
 
     def matching_measures(category_assessment)

--- a/spec/models/green_lanes/category_assessment_json_spec.rb
+++ b/spec/models/green_lanes/category_assessment_json_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe GreenLanes::CategoryAssessmentJson do
 
   describe '#match?' do
     subject(:categorisation) do
-      described_class.new regulation_id: 'D000004', measure_type_id: '430', geographical_area_id:
+      described_class.new category: 1, regulation_id: 'D000004', measure_type_id: '430', geographical_area_id:
     end
 
     let(:geographical_area_id) { 'US' }
@@ -207,11 +207,12 @@ RSpec.describe GreenLanes::CategoryAssessmentJson do
       it do
         expect(categorisation.match?(regulation_id: 'D000004',
                                      measure_type_id: '430',
-                                     geographical_area: 'US')).to be true
+                                     geographical_area: 'US',
+                                     filtered_category: Set.new([1]).freeze)).to be true
       end
     end
 
-    context 'when the attributes match and geographical_area is NOT specified' do
+    context 'when the attributes match and geographical_area and category are NOT specified' do
       it do
         expect(categorisation.match?(regulation_id: 'D000004', measure_type_id: '430')).to be true
       end
@@ -248,6 +249,15 @@ RSpec.describe GreenLanes::CategoryAssessmentJson do
         expect(categorisation.match?(regulation_id: 'D000004',
                                      measure_type_id: '430',
                                      geographical_area: 'XXX')).to be false
+      end
+    end
+
+    context 'when the category filter does NOT match' do
+      it do
+        expect(categorisation.match?(regulation_id: 'D000004',
+                                     measure_type_id: '430',
+                                     geographical_area: 'US',
+                                     filtered_category: Set.new([2]).freeze)).to be false
       end
     end
   end

--- a/spec/services/green_lanes/find_category_assessments_service_spec.rb
+++ b/spec/services/green_lanes/find_category_assessments_service_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe GreenLanes::FindCategoryAssessmentsService do
                                          measure_type_id: '713',
                                          geographical_area_id: '1011'),
         build(:category_assessment_json, :category3,
-                                          regulation_id: 'D0000004',
-                                          measure_type_id: '800',
-                                          geographical_area_id: 'NK'),
+              regulation_id: 'D0000004',
+              measure_type_id: '800',
+              geographical_area_id: 'NK'),
       ]
     end
 

--- a/spec/services/green_lanes/find_category_assessments_service_spec.rb
+++ b/spec/services/green_lanes/find_category_assessments_service_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe GreenLanes::FindCategoryAssessmentsService do
         create(:measure, measure_generating_regulation_id: 'D0000001', measure_type_id: '400'),
         create(:measure, measure_generating_regulation_id: 'D0000002', measure_type_id: '500'),
         create(:measure, measure_generating_regulation_id: 'D0000003', measure_type_id: '713'),
+        create(:measure, measure_generating_regulation_id: 'D0000004', measure_type_id: '800'),
       ]
     end
 
@@ -32,6 +33,10 @@ RSpec.describe GreenLanes::FindCategoryAssessmentsService do
         build(:category_assessment_json, regulation_id: 'D0000003',
                                          measure_type_id: '713',
                                          geographical_area_id: '1011'),
+        build(:category_assessment_json, :category3,
+                                          regulation_id: 'D0000004',
+                                          measure_type_id: '800',
+                                          geographical_area_id: 'NK'),
       ]
     end
 


### PR DESCRIPTION
### Jira link

[GL-296](https://transformuk.atlassian.net/browse/GL-296)

### What?

I have added/removed/altered:

- [ ] Added a filter to filter out category 3 assessments from goods_nomenclature response


### Why?

I am doing this because:

- We only need to show category 1 and 2 in categorisation response

