### PR TITLE
BAU: Use the patched downloader

### DIFF
--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -56,6 +56,10 @@ module "worker_xi" {
         value = "tariff-xi-worker-${var.environment}.apps.internal" # This is necessary for a GOVUK gem we're not using
       },
       {
+        name  = "PATCH_BROKEN_TARIC_DOWNLOADS",
+        value = "true"
+      },
+      {
         name  = "SERVICE"
         value = "xi"
       },


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added a feature flag to worker_xi.tf to enable the patched downloader

### Why?

I am doing this because:

- This is required because the HMRC API is broken
