### PR TITLE
GL-338 Only include exemption certificates

### DIFF
--- a/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
@@ -74,7 +74,7 @@ module Api
         end
 
         def certificates
-          measure_conditions.select(&:certificate).map(&:certificate)
+          measure_conditions.select(&:exemption_class?).map(&:certificate)
         end
 
         def additional_codes

--- a/app/services/green_lanes/permutation_calculator_service.rb
+++ b/app/services/green_lanes/permutation_calculator_service.rb
@@ -19,7 +19,7 @@ module GreenLanes
         measure.measure_excluded_geographical_areas.map(&:excluded_geographical_area).sort.uniq.join('|'),
         measure.additional_code_type_id,
         measure.additional_code_id,
-        measure.measure_conditions.map(&:document_code).reject(&:blank?).sort.uniq.join('|'),
+        measure.measure_conditions.select(&:exemption_class?).map(&:document_code).sort.uniq.join('|'),
       ]
     end
   end

--- a/spec/factories/certificate_factory.rb
+++ b/spec/factories/certificate_factory.rb
@@ -51,8 +51,11 @@ FactoryBot.define do
     end
 
     trait :exemption do
-      certificate_code { '005' }
       certificate_type_code { 'Y' }
+    end
+
+    trait :license do
+      certificate_type_code { 'L' }
     end
   end
 

--- a/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
@@ -40,15 +40,34 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentPresenter do
     it { expect(measures.map(&:measure_sid)).to eq assessment.measures.map(&:measure_sid) }
   end
 
+  describe '#certificates' do
+    subject { presented.certificates }
+
+    before do
+      create :measure_condition, measure: assessment.measures.first, certificate:
+    end
+
+    context 'with exemption certificate' do
+      let(:certificate) { create :certificate, :exemption }
+
+      it { is_expected.to include certificate }
+    end
+
+    context 'with license certificate' do
+      let(:certificate) { create :certificate, :license }
+
+      it { is_expected.not_to include certificate }
+    end
+  end
+
   describe '#exemptions' do
     subject { presented.exemptions }
 
     let :certificates do
-      create_pair(:certificate).each do |cert|
+      create_pair(:certificate, :exemption).each do |certificate|
         create :measure_condition,
-               measure_sid: assessment.measures.first.measure_sid,
-               certificate_type_code: cert.certificate_type_code,
-               certificate_code: cert.certificate_code
+               measure: assessment.measures.first,
+               certificate:
       end
     end
 

--- a/spec/services/green_lanes/permutation_calculator_service_spec.rb
+++ b/spec/services/green_lanes/permutation_calculator_service_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe GreenLanes::PermutationCalculatorService do
       it_behaves_like 'two segregated lists'
     end
 
-    context 'with different certificates' do
+    context 'with different exemption certificates' do
       let :measures do
         [
           measure,
@@ -90,6 +90,23 @@ RSpec.describe GreenLanes::PermutationCalculatorService do
       end
 
       it_behaves_like 'two segregated lists'
+    end
+
+    context 'with non exemption certificates' do
+      let :measures do
+        [
+          measure,
+          create(:measure, :with_measure_conditions,
+                 generating_regulation: measure.generating_regulation,
+                 measure_type_id: measure.measure_type_id,
+                 geographical_area_id: measure.geographical_area_id,
+                 certificate_type_code: 'L',
+                 certificate_code: '123'),
+        ]
+      end
+
+      it { is_expected.to have_attributes length: 1 }
+      it { expect(permutations[0]).to eq_pk measures }
     end
 
     context 'with different geographical area' do


### PR DESCRIPTION
### Jira link

HOTT-388

### What?

I have added/removed/altered:

- [x] Only use exemption certs in permutations calculation
- [x] Only include exemption certs in exemptions list on CAs

### Why?

I am doing this because:

- We should not be included other certificate types such as licenses

### Deployment risks (optional)

- Low
