### PR TITLE
GL-142 descendant category assessments

### DIFF
--- a/app/controllers/api/v2/green_lanes/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/green_lanes/goods_nomenclatures_controller.rb
@@ -25,6 +25,13 @@ module Api
             applicable_category_assessments.measures
             applicable_category_assessments.measures.measure_types
             applicable_category_assessments.measures.footnotes
+            descendant_category_assessments
+            descendant_category_assessments.exemptions
+            descendant_category_assessments.geographical_area
+            descendant_category_assessments.excluded_geographical_areas
+            descendant_category_assessments.measures
+            descendant_category_assessments.measures.measure_types
+            descendant_category_assessments.measures.footnotes
             ancestors
             ancestors.measures
             ancestors.measures.measure_types

--- a/app/presenters/api/v2/green_lanes/goods_nomenclature_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/goods_nomenclature_presenter.rb
@@ -24,6 +24,17 @@ module Api
               @geographical_area_id
         end
 
+        def descendant_category_assessment_ids
+          @descendant_category_assessment_ids ||= descendant_category_assessments.map(&:id)
+        end
+
+        def descendant_category_assessments
+          @descendant_category_assessments ||=
+            ::GreenLanes::FindCategoryAssessmentsService.call \
+              all_descendant_measures,
+              @geographical_area_id
+        end
+
         def ancestor_ids
           @ancestor_ids ||= ancestors.map(&:goods_nomenclature_sid)
         end
@@ -59,6 +70,10 @@ module Api
           unfiltered_measures.select do |measure|
             measure.relevant_for_country? @geographical_area_id
           end
+        end
+
+        def all_descendant_measures
+          descendants.flat_map(&:measures)
         end
       end
     end

--- a/app/presenters/api/v2/green_lanes/goods_nomenclature_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/goods_nomenclature_presenter.rb
@@ -20,8 +20,8 @@ module Api
         def applicable_category_assessments
           @applicable_category_assessments ||=
             ::GreenLanes::FindCategoryAssessmentsService.call \
-              goods_nomenclature: self,
-              geographical_area_id: @geographical_area_id
+              applicable_measures,
+              @geographical_area_id
         end
 
         def ancestor_ids

--- a/app/serializers/api/v2/green_lanes/goods_nomenclature_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/goods_nomenclature_serializer.rb
@@ -19,6 +19,7 @@ module Api
                    :parent_sid
 
         has_many :applicable_category_assessments, serializer: CategoryAssessmentSerializer
+        has_many :descendant_category_assessments, serializer: CategoryAssessmentSerializer
         has_many :ancestors, serializer: GreenLanes::ReferencedGoodsNomenclatureSerializer
         has_many :descendants, serializer: GreenLanes::ReferencedGoodsNomenclatureSerializer
         has_many :measures, serializer: GreenLanes::MeasureSerializer

--- a/app/services/green_lanes/find_category_assessments_service.rb
+++ b/app/services/green_lanes/find_category_assessments_service.rb
@@ -1,19 +1,18 @@
 module GreenLanes
   class FindCategoryAssessmentsService
     class << self
-      def call(goods_nomenclature:, geographical_area_id: nil)
-        new(goods_nomenclature, geographical_area_id).call
+      def call(measures, geographical_area_id = nil)
+        new(measures, geographical_area_id).call
       end
     end
 
-    def initialize(goods_nomenclature, geographical_area_id)
-      @goods_nomenclature = goods_nomenclature
+    def initialize(measures, geographical_area_id = nil)
+      @measures = measures
       @geographical_area_id = geographical_area_id
     end
 
     def call
-      @goods_nomenclature
-        .applicable_measures
+      @measures
         .select(&:category_assessment)
         .select(&method(:filter_by_geographical_area))
         .group_by(&:category_assessment)
@@ -24,15 +23,15 @@ module GreenLanes
 
   private
 
-    def compute_assessment_permutations(assessment, applicable_measures)
-      permutations_for_assessment(applicable_measures)
+    def compute_assessment_permutations(assessment, assessment_measures)
+      permutations_for_assessment(assessment_measures)
         .map do |key, permutation|
           present_assessment(assessment, key, permutation)
         end
     end
 
-    def permutations_for_assessment(applicable_measures)
-      PermutationCalculatorService.new(applicable_measures).call
+    def permutations_for_assessment(assessment_measures)
+      PermutationCalculatorService.new(assessment_measures).call
     end
 
     def present_assessment(assessment, key, permutation)

--- a/spec/requests/api/v2/green_lanes/goods_nomenclatures_controller_spec.rb
+++ b/spec/requests/api/v2/green_lanes/goods_nomenclatures_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclaturesController do
 
         expect(GreenLanes::FindCategoryAssessmentsService)
           .to have_received(:call)
-          .with hash_including(geographical_area_id: 'AU')
+          .with(gn.applicable_measures, 'AU')
       end
     end
   end

--- a/spec/serializers/api/v2/green_lanes/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/goods_nomenclature_serializer_spec.rb
@@ -1,7 +1,13 @@
 RSpec.describe Api::V2::GreenLanes::GoodsNomenclatureSerializer do
   subject { described_class.new(presented).serializable_hash }
 
-  before { create :category_assessment, measure: subheading.measures.first }
+  before do
+    measure = subheading.measures.first
+    create(:category_assessment, measure:)
+    create(:measure, goods_nomenclature: subheading.children.first,
+                     measure_type_id: measure.measure_type_id,
+                     generating_regulation: measure.generating_regulation)
+  end
 
   let(:subheading) { create :goods_nomenclature, :with_ancestors, :with_children, :with_measures }
   let(:presented) { Api::V2::GreenLanes::GoodsNomenclaturePresenter.new(subheading) }
@@ -22,6 +28,12 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclatureSerializer do
         },
         relationships: {
           applicable_category_assessments: {
+            data: [{
+              id: /^[a-f0-9]{32}$/,
+              type: eq(:category_assessment),
+            }],
+          },
+          descendant_category_assessments: {
             data: [{
               id: /^[a-f0-9]{32}$/,
               type: eq(:category_assessment),

--- a/spec/services/green_lanes/find_category_assessments_service_spec.rb
+++ b/spec/services/green_lanes/find_category_assessments_service_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe GreenLanes::FindCategoryAssessmentsService do
   describe '#call' do
     subject :presented_assessments do
-      described_class.call(goods_nomenclature:, geographical_area_id:)
+      described_class.call(goods_nomenclature.applicable_measures, geographical_area_id)
                      .group_by(&:category_assessment_id)
     end
 


### PR DESCRIPTION
### Jira link

GL-142

### What?

I have added/removed/altered:

- [x] Added descendant category assessments to GL GN API

### Why?

I am doing this because:

- We want to expose the 'MIGHT' category assessments which apply to goods nomenclatures below the requested GN

### Have you? (optional)

- [x] Added documentation for new apis

### Deployment risks (optional)

- Low, only impacts GL GN API
