### PR TITLE
GL-295 Update certificate serialization

### DIFF
--- a/app/serializers/api/v2/green_lanes/certificate_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/certificate_serializer.rb
@@ -6,6 +6,8 @@ module Api
 
         set_id :id
 
+        attribute :code, &:id
+
         attributes :certificate_type_code,
                    :certificate_code,
                    :description,

--- a/spec/serializers/api/v2/green_lanes/certificate_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/certificate_serializer_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Api::V2::GreenLanes::CertificateSerializer do
         id: certificate.id,
         type: 'certificate',
         attributes: {
+          code: certificate.id,
           certificate_type_code: certificate.certificate_type_code,
           certificate_code: certificate.certificate_code,
           description: certificate.description,


### PR DESCRIPTION
### Jira link

GL-295

### What?

I have added/removed/altered:

- [x] Added a `#code` attribute to the certificate serialization

### Why?

I am doing this because:

- It standardises the format of exemptions - simplifying things for clients. Both Certificate and AdditionalCode exemptions can be stored by just the `code` and the `description`/`formatted_description`

### Have you? (optional)

- [x] Added documentation for new apis

### Deployment risks (optional)

- Low, only affects green lanes