### PR TITLE
OTT-137 Endline report added with new flag

### DIFF
--- a/app/lib/reporting/differences.rb
+++ b/app/lib/reporting/differences.rb
@@ -129,6 +129,7 @@ module Reporting
         add_missing_from_uk_worksheet
         add_missing_from_xi_worksheet
         add_indentation_worksheet
+        add_endline_worksheet
         add_overview_worksheet
       ]
       # methods = %i[

--- a/app/lib/reporting/differences/endline.rb
+++ b/app/lib/reporting/differences/endline.rb
@@ -84,7 +84,7 @@ module Reporting
         matching_uk_goods_nomenclature = uk_goods_nomenclature_ids[matching]
         matching_xi_goods_nomenclature = xi_goods_nomenclature_ids[matching]
 
-        return nil if matching_uk_goods_nomenclature['End line'] != matching_xi_goods_nomenclature['End line']
+        return nil if matching_uk_goods_nomenclature['End line'] == matching_xi_goods_nomenclature['End line']
 
         item_id, pls = matching_uk_goods_nomenclature['ItemIDPlusPLS'].split('_')
         uk_endline_status = matching_uk_goods_nomenclature['End line'] == 'true' ? '1' : '0'

--- a/app/lib/reporting/differences/endline.rb
+++ b/app/lib/reporting/differences/endline.rb
@@ -93,8 +93,8 @@ module Reporting
         matching_uk_goods_nomenclature_for_comparison = uk_goods_nomenclature_ids_for_comparison[matching]
         matching_xi_goods_nomenclature_for_comparison = xi_goods_nomenclature_ids_for_comparison[matching]
 
-        new_issue = matching_uk_goods_nomenclature_for_comparison.nil? || matching_xi_goods_nomenclature_for_comparison.nil? || matching_uk_goods_nomenclature_for_comparison['End line'] != matching_xi_goods_nomenclature_for_comparison['End line']      
-        
+        new_issue = matching_uk_goods_nomenclature_for_comparison.nil? || matching_xi_goods_nomenclature_for_comparison.nil? || matching_uk_goods_nomenclature_for_comparison['End line'] != matching_xi_goods_nomenclature_for_comparison['End line']
+
         [
           "#{item_id} (#{pls})",
           uk_endline_status,

--- a/app/lib/reporting/differences/endline.rb
+++ b/app/lib/reporting/differences/endline.rb
@@ -93,11 +93,8 @@ module Reporting
         matching_uk_goods_nomenclature_for_comparison = uk_goods_nomenclature_ids_for_comparison[matching]
         matching_xi_goods_nomenclature_for_comparison = xi_goods_nomenclature_ids_for_comparison[matching]
 
-        new_issue = if matching_uk_goods_nomenclature_for_comparison.nil? || matching_xi_goods_nomenclature_for_comparison.nil?
-                      true
-                    else
-                      matching_uk_goods_nomenclature_for_comparison['End line'] == matching_xi_goods_nomenclature_for_comparison['End line']
-                    end
+        new_issue = matching_uk_goods_nomenclature_for_comparison.nil? || matching_xi_goods_nomenclature_for_comparison.nil? || matching_uk_goods_nomenclature_for_comparison['End line'] != matching_xi_goods_nomenclature_for_comparison['End line']      
+        
         [
           "#{item_id} (#{pls})",
           uk_endline_status,

--- a/app/lib/reporting/differences/endline.rb
+++ b/app/lib/reporting/differences/endline.rb
@@ -93,7 +93,7 @@ module Reporting
         matching_uk_goods_nomenclature_for_comparison = uk_goods_nomenclature_ids_for_comparison[matching]
         matching_xi_goods_nomenclature_for_comparison = xi_goods_nomenclature_ids_for_comparison[matching]
 
-        new_issue = matching_uk_goods_nomenclature_for_comparison.nil? || matching_xi_goods_nomenclature_for_comparison.nil? || matching_uk_goods_nomenclature_for_comparison['End line'] != matching_xi_goods_nomenclature_for_comparison['End line']
+        new_issue = matching_uk_goods_nomenclature_for_comparison.nil? || matching_xi_goods_nomenclature_for_comparison.nil? || matching_uk_goods_nomenclature_for_comparison['End line'] == matching_xi_goods_nomenclature_for_comparison['End line']
 
         [
           "#{item_id} (#{pls})",

--- a/app/lib/reporting/differences/endline.rb
+++ b/app/lib/reporting/differences/endline.rb
@@ -49,7 +49,7 @@ module Reporting
 
           rows.compact.each do |row|
             report.increment_count(name)
-            if @new_issue
+            if row.last # last value in a row array is new_issue
               report.increment_new_issue_count(name)
             end
             sheet.add_row(row, types: CELL_TYPES, style: regular_style)
@@ -90,13 +90,19 @@ module Reporting
         uk_endline_status = matching_uk_goods_nomenclature['End line'] == 'true' ? '1' : '0'
         eu_endline_status = matching_xi_goods_nomenclature['End line'] == 'true' ? '1' : '0'
 
-        @new_issue = !uk_goods_nomenclature_ids_for_comparison.include?(matching_uk_goods_nomenclature['ItemIDPlusPLS']) ||
-          !xi_goods_nomenclature_ids_for_comparison.include?(matching_xi_goods_nomenclature['ItemIDPlusPLS'])
+        matching_uk_goods_nomenclature_for_comparison = uk_goods_nomenclature_ids_for_comparison[matching]
+        matching_xi_goods_nomenclature_for_comparison = xi_goods_nomenclature_ids_for_comparison[matching]
+
+        new_issue = if matching_uk_goods_nomenclature_for_comparison.nil? || matching_xi_goods_nomenclature_for_comparison.nil?
+                      true
+                    else
+                      matching_uk_goods_nomenclature_for_comparison['End line'] == matching_xi_goods_nomenclature_for_comparison['End line']
+                    end
         [
           "#{item_id} (#{pls})",
           uk_endline_status,
           eu_endline_status,
-          @new_issue,
+          new_issue,
         ]
       end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-137

### What?

I have altered:

- [x] app/lib/reporting/differences/endline.rb

### Why?

I am doing this because:

- The differences report requires a 'New' tab for issues that have occurred in the past 7 days.

<img width="507" alt="image" src="https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/ed02d57a-a6a2-4cb0-8f95-de0c0bd71830">
<img width="1110" alt="image" src="https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/7592147b-2864-423c-980c-5e239699c6bf">
