### PR TITLE
GL-151 Add Theme entity

### DIFF
--- a/app/models/green_lanes/theme.rb
+++ b/app/models/green_lanes/theme.rb
@@ -6,7 +6,11 @@ module GreenLanes
     one_to_many :category_assessments
 
     def to_s
-      "#{section}.#{subsection}. #{description}"
+      "#{code}. #{description}"
+    end
+
+    def code
+      "#{section}.#{subsection}"
     end
   end
 end

--- a/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
@@ -49,16 +49,12 @@ module Api
           @measures = MeasurePresenter.wrap(measures)
         end
 
+        def theme_id
+          theme&.code
+        end
+
         def measure_ids
           @measure_ids = measures.map(&:measure_sid)
-        end
-
-        def theme
-          @category_assessment.theme.to_s
-        end
-
-        def category
-          @category_assessment.theme.category.to_s
         end
 
         def category_assessment_id

--- a/app/serializers/api/v2/green_lanes/category_assessment_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/category_assessment_serializer.rb
@@ -8,9 +8,6 @@ module Api
 
         set_id :id
 
-        attributes :category,
-                   :theme
-
         has_many :exemptions, serializer: lambda { |record, _params|
           case record
           when Certificate
@@ -22,6 +19,7 @@ module Api
           end
         }
 
+        has_one :theme, serializer: ThemeSerializer
         has_one :geographical_area, serializer: GeographicalAreaSerializer
         has_many :excluded_geographical_areas, serializer: GeographicalAreaSerializer
         has_many :measures, serializer: GreenLanes::MeasureSerializer,

--- a/app/serializers/api/v2/green_lanes/theme_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/theme_serializer.rb
@@ -1,0 +1,15 @@
+module Api
+  module V2
+    module GreenLanes
+      class ThemeSerializer
+        include JSONAPI::Serializer
+
+        set_id :code
+
+        attribute :id, &:code
+        attribute :theme, &:description
+        attribute :category
+      end
+    end
+  end
+end

--- a/spec/models/green_lanes/theme_spec.rb
+++ b/spec/models/green_lanes/theme_spec.rb
@@ -77,4 +77,10 @@ RSpec.describe GreenLanes::Theme do
 
     it { is_expected.to eq '1.2. Long description' }
   end
+
+  describe '#code' do
+    subject { create(:green_lanes_theme, section: 2, subsection: 3).code }
+
+    it { is_expected.to eq '2.3' }
+  end
 end

--- a/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentPresenter do
   it { is_expected.to have_attributes id: /^[0-9a-f]{32}$/ }
   it { is_expected.to have_attributes category_assessment_id: assessment.id }
   it { is_expected.to have_attributes measure_ids: assessment.measures.map(&:measure_sid) }
-  it { is_expected.to have_attributes category: /\d+/ }
-  it { is_expected.to have_attributes theme: /\d+\.\d+\. \w+/ }
+  it { is_expected.to have_attributes theme_id: /\d+\.\d+/ }
 
   describe '.wrap' do
     subject(:wrapped) { described_class.wrap [assessment] }

--- a/spec/serializers/api/v2/green_lanes/category_assessment_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/category_assessment_serializer_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentSerializer do
   subject(:serialized) do
     described_class.new(
       presented,
-      include: %w[exemptions geographical_area excluded_geographical_areas],
+      include: %w[theme exemptions geographical_area excluded_geographical_areas],
     ).serializable_hash.as_json
   end
 
@@ -19,11 +19,10 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentSerializer do
       data: {
         id: be_a(String),
         type: 'category_assessment',
-        attributes: {
-          category: category_assessment.theme.category.to_s,
-          theme: category_assessment.theme.to_s,
-        },
         relationships: {
+          theme: {
+            data: { id: category_assessment.theme.code, type: 'theme' },
+          },
           exemptions: {
             data: [
               { id: certificate.id, type: 'certificate' },
@@ -42,6 +41,15 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentSerializer do
         },
       },
       included: [
+        {
+          id: category_assessment.theme.code,
+          type: 'theme',
+          attributes: {
+            id: category_assessment.theme.code,
+            theme: category_assessment.theme.description,
+            category: category_assessment.theme.category,
+          },
+        },
         {
           id: certificate.id,
           type: 'certificate',

--- a/spec/serializers/api/v2/green_lanes/theme_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/theme_serializer_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Api::V2::GreenLanes::ThemeSerializer do
+  subject { described_class.new(theme).serializable_hash.as_json }
+
+  let(:theme) { create :green_lanes_theme }
+
+  let :expected_pattern do
+    {
+      data: {
+        id: theme.code,
+        type: 'theme',
+        attributes: {
+          id: theme.code,
+          theme: theme.description,
+          category: theme.category,
+        },
+      },
+    }
+  end
+
+  it { is_expected.to include_json(expected_pattern) }
+end


### PR DESCRIPTION
### Jira link

GL-151

### What?

I have added/removed/altered:

- [x] Added a Theme entity

### Why?

I am doing this because:

- It brings us inline with the upstream API design
- Gives us some where to attach further theme information in the future if so required

### Have you? (optional)

- [x] Added documentation for new apis

### Deployment risks (optional)

- Low, only changes GL APIs
