### PR TITLE
OTT-138 Start Date report added with new flag

### DIFF
--- a/app/lib/reporting/differences.rb
+++ b/app/lib/reporting/differences.rb
@@ -129,6 +129,7 @@ module Reporting
         add_missing_from_uk_worksheet
         add_missing_from_xi_worksheet
         add_indentation_worksheet
+        add_start_date_worksheet
         add_overview_worksheet
       ]
       # methods = %i[

--- a/app/lib/reporting/differences/goods_nomenclature_start_date.rb
+++ b/app/lib/reporting/differences/goods_nomenclature_start_date.rb
@@ -33,8 +33,6 @@ module Reporting
 
       FROZEN_VIEW_STARTING_CELL = 'A2'.freeze
 
-      # @new_issue = false
-
       def initialize(report)
         @report = report
       end

--- a/app/lib/reporting/differences/goods_nomenclature_start_date.rb
+++ b/app/lib/reporting/differences/goods_nomenclature_start_date.rb
@@ -90,7 +90,7 @@ module Reporting
         matching_uk_goods_nomenclature_for_comparison = uk_goods_nomenclature_ids_for_comparison[matching]
         matching_xi_goods_nomenclature_for_comparison = xi_goods_nomenclature_ids_for_comparison[matching]
 
-        new_issue = matching_uk_goods_nomenclature_for_comparison.nil? || matching_xi_goods_nomenclature_for_comparison.nil? || matching_uk_goods_nomenclature_for_comparison['Start date'] != matching_xi_goods_nomenclature_for_comparison['Start date']
+        new_issue = matching_uk_goods_nomenclature_for_comparison.nil? || matching_xi_goods_nomenclature_for_comparison.nil? || matching_uk_goods_nomenclature_for_comparison['Start date'] == matching_xi_goods_nomenclature_for_comparison['Start date']
 
         [
           "#{item_id} (#{pls})",

--- a/app/lib/reporting/differences/goods_nomenclature_start_date.rb
+++ b/app/lib/reporting/differences/goods_nomenclature_start_date.rb
@@ -90,11 +90,7 @@ module Reporting
         matching_uk_goods_nomenclature_for_comparison = uk_goods_nomenclature_ids_for_comparison[matching]
         matching_xi_goods_nomenclature_for_comparison = xi_goods_nomenclature_ids_for_comparison[matching]
 
-        new_issue = if matching_uk_goods_nomenclature_for_comparison.nil? || matching_xi_goods_nomenclature_for_comparison.nil?
-                      true
-                    else
-                      matching_uk_goods_nomenclature_for_comparison['Start date'] == matching_xi_goods_nomenclature_for_comparison['Start date']
-                    end
+        new_issue = matching_uk_goods_nomenclature_for_comparison.nil? || matching_xi_goods_nomenclature_for_comparison.nil? || matching_uk_goods_nomenclature_for_comparison['Start date'] != matching_xi_goods_nomenclature_for_comparison['Start date']
 
         [
           "#{item_id} (#{pls})",

--- a/app/lib/reporting/differences/goods_nomenclature_start_date.rb
+++ b/app/lib/reporting/differences/goods_nomenclature_start_date.rb
@@ -90,7 +90,9 @@ module Reporting
         matching_uk_goods_nomenclature_for_comparison = uk_goods_nomenclature_ids_for_comparison[matching]
         matching_xi_goods_nomenclature_for_comparison = xi_goods_nomenclature_ids_for_comparison[matching]
 
-        new_issue = matching_uk_goods_nomenclature_for_comparison.nil? || matching_xi_goods_nomenclature_for_comparison.nil? || matching_uk_goods_nomenclature_for_comparison['Start date'] == matching_xi_goods_nomenclature_for_comparison['Start date']
+        new_issue = matching_uk_goods_nomenclature_for_comparison.present? &&
+          matching_xi_goods_nomenclature_for_comparison.present? &&
+          matching_uk_goods_nomenclature_for_comparison['Start date'] == matching_xi_goods_nomenclature_for_comparison['Start date']
 
         [
           "#{item_id} (#{pls})",


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-138

### What?

I have altered:

- [x] app/lib/reporting/differences/goods_nomenclature_start_date.rb

### Why?

I am doing this because:

- The differences report requires a 'New' tab for issues that have occurred in the past 7 days.

<img width="508" alt="image" src="https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/9f8a327a-8aec-478b-abc9-003fed51693f">

<img width="1130" alt="image" src="https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/58d793cb-1428-42a4-9a8f-cfc6f35f1592">
