### PR TITLE
OTT-129: Quota suspensions and blocking periods bug fix

### DIFF
--- a/app/models/quota_blocking_period.rb
+++ b/app/models/quota_blocking_period.rb
@@ -4,4 +4,8 @@ class QuotaBlockingPeriod < Sequel::Model
   plugin :time_machine, period_start_column: :blocking_start_date, period_end_column: :blocking_end_date
 
   set_primary_key [:quota_blocking_period_sid]
+
+  def self.status
+    'Blocked'
+  end
 end

--- a/app/models/quota_suspension_period.rb
+++ b/app/models/quota_suspension_period.rb
@@ -4,4 +4,8 @@ class QuotaSuspensionPeriod < Sequel::Model
   plugin :oplog, primary_key: :quota_suspension_period_sid
 
   set_primary_key [:quota_suspension_period_sid]
+
+  def self.status
+    'Suspended'
+  end
 end

--- a/spec/factories/quota_factory.rb
+++ b/spec/factories/quota_factory.rb
@@ -109,6 +109,24 @@ FactoryBot.define do
       end
     end
 
+    trait :with_expired_quota_suspension_period do
+      after(:create) do |quota_definition, _evaluator|
+        create(:quota_suspension_period, quota_definition_sid: quota_definition.quota_definition_sid, suspension_end_date: 1.year.ago.beginning_of_day)
+      end
+    end
+
+    trait :with_quota_blocking_period do
+      after(:create) do |quota_definition, _evaluator|
+        create(:quota_blocking_period, quota_definition_sid: quota_definition.quota_definition_sid)
+      end
+    end
+
+    trait :with_expired_quota_blocking_period do
+      after(:create) do |quota_definition, _evaluator|
+        create(:quota_blocking_period, quota_definition_sid: quota_definition.quota_definition_sid, blocking_end_date: 1.year.ago.beginning_of_day)
+      end
+    end
+
     trait :xml do
       validity_start_date             { 3.years.ago.beginning_of_day }
       validity_end_date               { 1.year.ago.beginning_of_day }
@@ -268,7 +286,7 @@ FactoryBot.define do
     quota_blocking_period_sid  { Forgery(:basic).number }
     quota_definition_sid       { Forgery(:basic).number }
     blocking_start_date        { 1.year.ago.beginning_of_day }
-    blocking_end_date          { 1.year.ago.beginning_of_day }
+    blocking_end_date          { 1.year.from_now.beginning_of_day }
     blocking_period_type       { Forgery(:basic).number }
     description                { Forgery(:lorem_ipsum).sentence }
   end
@@ -327,7 +345,7 @@ FactoryBot.define do
     quota_suspension_period_sid  { generate(:sid) }
     quota_definition_sid         { generate(:sid) }
     suspension_start_date        { 1.year.ago.beginning_of_day }
-    suspension_end_date          { 1.year.ago.beginning_of_day }
+    suspension_end_date          { 1.year.from_now.beginning_of_day }
     description                  { Forgery(:lorem_ipsum).sentence }
   end
 

--- a/spec/models/quota_blocking_period_spec.rb
+++ b/spec/models/quota_blocking_period_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe QuotaBlockingPeriod do
+  describe '.status' do
+    it "returns 'Blocked' string" do
+      expect(described_class.status).to eq('Blocked')
+    end
+  end
+end

--- a/spec/models/quota_definition_spec.rb
+++ b/spec/models/quota_definition_spec.rb
@@ -59,6 +59,36 @@ RSpec.describe QuotaDefinition do
 
       it { is_expected.to eq 'Open' }
     end
+
+    context 'when there is a valid suspension period it doenst overide the quota exausted status' do
+      subject(:status) { create(:quota_definition, :with_quota_exhaustion_events, :with_quota_suspension_period).reload.status }
+
+      it { is_expected.to eq 'Exhausted' }
+    end
+
+    context 'when there is a valid suspension period' do
+      subject(:status) { create(:quota_definition, :with_quota_suspension_period).reload.status }
+
+      it { is_expected.to eq 'Suspended' }
+    end
+
+    context 'when there is a expired suspension period' do
+      subject(:status) { create(:quota_definition, :with_expired_quota_suspension_period).reload.status }
+
+      it { is_expected.to eq 'Open' }
+    end
+
+    context 'when there is a valid blocking period' do
+      subject(:status) { create(:quota_definition, :with_quota_blocking_period).reload.status }
+
+      it { is_expected.to eq 'Blocked' }
+    end
+
+    context 'when there is a expired blocking period' do
+      subject(:status) { create(:quota_definition, :with_expired_quota_blocking_period).reload.status }
+
+      it { is_expected.to eq 'Open' }
+    end
   end
 
   describe '#quota_balance_event_ids' do

--- a/spec/models/quota_suspension_period_spec.rb
+++ b/spec/models/quota_suspension_period_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe QuotaSuspensionPeriod do
+  describe '.status' do
+    it "returns 'Suspended' string" do
+      expect(described_class.status).to eq('Suspended')
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-129

### What?

I have added/removed/altered:

- [ ] Quota suspensions and blocking periods bug fix

### Why?

I am doing this because:

- We need to handle suspended and blocked quota statuses

<img width="573" alt="Screenshot 2024-04-15 at 11 03 02" src="https://github.com/trade-tariff/trade-tariff-backend/assets/12201130/411b6042-9ab4-44da-9a26-ac8338180165">
<img width="566" alt="Screenshot 2024-04-15 at 11 02 33" src="https://github.com/trade-tariff/trade-tariff-backend/assets/12201130/5cfcd425-7abf-4a3e-ac21-79f892de7d3b">

