### PR TITLE
OTT-139 End Date report added with new flag

### DIFF
--- a/app/lib/reporting/differences.rb
+++ b/app/lib/reporting/differences.rb
@@ -129,35 +129,28 @@ module Reporting
         add_missing_from_uk_worksheet
         add_missing_from_xi_worksheet
         add_indentation_worksheet
+        add_hierarchy_worksheet
+        add_endline_worksheet
+        add_start_date_worksheet
         add_end_date_worksheet
+        add_mfn_missing_worksheet
+        add_mfn_duplicated_worksheet
+        add_misapplied_action_code_worksheet
+        add_incomplete_measure_condition_worksheet
+        add_me32_worksheet
+        add_seasonal_worksheet
+        add_omitted_duty_measures_worksheet
+        add_missing_vat_measure_worksheet
+        add_missing_quota_origins_worksheet
+        add_measure_quota_coverage_worksheet
+        add_bad_quota_association_worksheet
+        add_quota_exclusion_misalignment_worksheet
+        add_missing_supplementary_units_from_uk_worksheet
+        add_missing_supplementary_units_from_xi_worksheet
+        add_candidate_supplementary_units
+        add_me16_worksheet
         add_overview_worksheet
       ]
-      # methods = %i[
-      # add_missing_from_uk_worksheet
-      # add_missing_from_xi_worksheet
-      # add_indentation_worksheet
-      # add_hierarchy_worksheet
-      # add_endline_worksheet
-      # add_start_date_worksheet
-      # add_end_date_worksheet
-      # add_mfn_missing_worksheet
-      # add_mfn_duplicated_worksheet
-      # add_misapplied_action_code_worksheet
-      # add_incomplete_measure_condition_worksheet
-      # add_me32_worksheet
-      # add_seasonal_worksheet
-      # add_omitted_duty_measures_worksheet
-      # add_missing_vat_measure_worksheet
-      # add_missing_quota_origins_worksheet
-      # add_measure_quota_coverage_worksheet
-      # add_bad_quota_association_worksheet
-      # add_quota_exclusion_misalignment_worksheet
-      # add_missing_supplementary_units_from_uk_worksheet
-      # add_missing_supplementary_units_from_xi_worksheet
-      # add_candidate_supplementary_units
-      # add_me16_worksheet
-      # add_overview_worksheet
-      # ]
 
       methods = (methods & only) if only.any?
 

--- a/app/lib/reporting/differences.rb
+++ b/app/lib/reporting/differences.rb
@@ -129,6 +129,7 @@ module Reporting
         add_missing_from_uk_worksheet
         add_missing_from_xi_worksheet
         add_indentation_worksheet
+        add_end_date_worksheet
         add_overview_worksheet
       ]
       # methods = %i[

--- a/app/lib/reporting/differences/goods_nomenclature_end_date.rb
+++ b/app/lib/reporting/differences/goods_nomenclature_end_date.rb
@@ -90,12 +90,12 @@ module Reporting
         matching_uk_goods_nomenclature_for_comparison = uk_goods_nomenclature_ids_for_comparison[matching]
         matching_xi_goods_nomenclature_for_comparison = xi_goods_nomenclature_ids_for_comparison[matching]
 
-        if matching_uk_goods_nomenclature_for_comparison.nil? || matching_xi_goods_nomenclature_for_comparison.nil?
-          new_issue = true
-        else
+        if matching_uk_goods_nomenclature_for_comparison.present? && matching_xi_goods_nomenclature_for_comparison.present?
           uk_end_date_for_comparison = matching_uk_goods_nomenclature_for_comparison['End date']&.to_date&.strftime('%d/%m/%Y')
           eu_end_date_for_comparison = matching_xi_goods_nomenclature_for_comparison['End date']&.to_date&.strftime('%d/%m/%Y')
           new_issue = uk_end_date_for_comparison == eu_end_date_for_comparison
+        else
+          new_issue = true
         end
 
         [


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-139

### What?

I have altered:

- [x] app/lib/reporting/differences/goods_nomenclature_end_date.rb

### Why?

I am doing this because:

- The differences report requires a 'New' tab for issues that have occurred in the past 7 days.

<img width="1125" alt="image" src="https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/44a61123-5f40-4f12-8d28-cd6654ea1958">

<img width="503" alt="image" src="https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/5b3c46f9-2836-4279-b348-db4aeac98ec8">
