### PR TITLE
GL-379 Drop measures from category assessments endpoint

### DIFF
--- a/app/controllers/api/v2/green_lanes/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/green_lanes/goods_nomenclatures_controller.rb
@@ -17,38 +17,41 @@ module Api
         end
 
         def serializer_for(goods_nomenclature)
-          GreenLanes::GoodsNomenclatureSerializer.new(goods_nomenclature, include: %w[
-            applicable_category_assessments
-            applicable_category_assessments.exemptions
-            applicable_category_assessments.geographical_area
-            applicable_category_assessments.excluded_geographical_areas
-            applicable_category_assessments.measures
-            applicable_category_assessments.measures.measure_types
-            applicable_category_assessments.measures.footnotes
-            applicable_category_assessments.measures.additional_codes
-            descendant_category_assessments
-            descendant_category_assessments.exemptions
-            descendant_category_assessments.geographical_area
-            descendant_category_assessments.excluded_geographical_areas
-            descendant_category_assessments.measures
-            descendant_category_assessments.measures.measure_types
-            descendant_category_assessments.measures.footnotes
-            descendant_category_assessments.measures.additional_codes
-            ancestors
-            ancestors.measures
-            ancestors.measures.measure_types
-            ancestors.measures.footnotes
-            ancestors.measures.additional_codes
-            measures
-            measures.measure_types
-            measures.footnotes
-            measures.additional_codes
-            descendants
-            descendants.measures
-            descendants.measures.measure_types
-            descendants.measures.footnotes
-            descendants.measures.additional_codes
-          ])
+          GreenLanes::GoodsNomenclatureSerializer.new \
+            goods_nomenclature,
+            params: { with_measures: true },
+            include: %w[
+              applicable_category_assessments
+              applicable_category_assessments.exemptions
+              applicable_category_assessments.geographical_area
+              applicable_category_assessments.excluded_geographical_areas
+              applicable_category_assessments.measures
+              applicable_category_assessments.measures.measure_types
+              applicable_category_assessments.measures.footnotes
+              applicable_category_assessments.measures.additional_codes
+              descendant_category_assessments
+              descendant_category_assessments.exemptions
+              descendant_category_assessments.geographical_area
+              descendant_category_assessments.excluded_geographical_areas
+              descendant_category_assessments.measures
+              descendant_category_assessments.measures.measure_types
+              descendant_category_assessments.measures.footnotes
+              descendant_category_assessments.measures.additional_codes
+              ancestors
+              ancestors.measures
+              ancestors.measures.measure_types
+              ancestors.measures.footnotes
+              ancestors.measures.additional_codes
+              measures
+              measures.measure_types
+              measures.footnotes
+              measures.additional_codes
+              descendants
+              descendants.measures
+              descendants.measures.measure_types
+              descendants.measures.footnotes
+              descendants.measures.additional_codes
+            ]
         end
       end
     end

--- a/app/serializers/api/v2/green_lanes/category_assessment_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/category_assessment_serializer.rb
@@ -23,7 +23,7 @@ module Api
         has_one :geographical_area, serializer: GeographicalAreaSerializer
         has_many :excluded_geographical_areas, serializer: GeographicalAreaSerializer
         has_many :measures, serializer: GreenLanes::MeasureSerializer,
-                            if: ->(record) { record.is_a? CategoryAssessmentPresenter }
+                            if: ->(_record, params) { params[:with_measures] }
       end
     end
   end

--- a/spec/serializers/api/v2/green_lanes/category_assessment_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/category_assessment_serializer_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentSerializer do
   subject(:serialized) do
     described_class.new(
       presented,
+      params: {},
       include: %w[theme exemptions geographical_area excluded_geographical_areas],
     ).serializable_hash.as_json
   end
@@ -84,4 +85,22 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentSerializer do
   end
 
   it { is_expected.to include_json(expected_pattern) }
+
+  describe 'measures relationship' do
+    context 'with measures' do
+      subject do
+        described_class.new(presented, params: { with_measures: true })
+                       .serializable_hash
+                       .as_json['data']['relationships']
+      end
+
+      it { is_expected.to include 'measures' }
+    end
+
+    context 'without measures' do
+      subject { serialized['data']['relationships'] }
+
+      it { is_expected.not_to include 'measures' }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

GL-379

### What?

I have added/removed/altered:

- [x] Removed measures from category assessments endpoint

### Why?

I am doing this because:

- It will end up as a very long list of measure ids, particularly if we implement regulation-less category assessments

### Deployment risks (optional)

- Low, impacts epic branch
