### PR TITLE
OTT-180 Use router to parse routes

### DIFF
--- a/app/controllers/api/v2/exchange_rates/files_controller.rb
+++ b/app/controllers/api/v2/exchange_rates/files_controller.rb
@@ -3,7 +3,10 @@ module Api
     module ExchangeRates
       class FilesController < ApiController
         def show
-          filename = ExchangeRateFile.filename_for_download(type, format, year, month)
+          filename = ExchangeRateFile.filename_for_download(params[:type],
+                                                            format,
+                                                            params[:year],
+                                                            params[:month])
 
           send_data(
             file_data,
@@ -13,23 +16,6 @@ module Api
         end
 
         private
-
-        def type
-          match_data = id.match(/^(monthly_csv_hmrc|monthly_csv|monthly_xml|average_csv|spot_csv)_/)
-          match_data[1] if match_data
-        end
-
-        def month
-          @month ||= params[:id].split('-').last
-        end
-
-        def year
-          @year ||= params[:id].split('-').first.split('_').last
-        end
-
-        def id
-          params[:id].to_s
-        end
 
         def format
           request.format.symbol
@@ -48,9 +34,9 @@ module Api
 
         def file
           @file ||= ExchangeRateFile.where(
-            type:,
-            period_year: year,
-            period_month: month,
+            type: params[:type],
+            period_year: params[:year],
+            period_month: params[:month],
             format: format.to_s,
           ).take
         end

--- a/app/models/exchange_rate_file.rb
+++ b/app/models/exchange_rate_file.rb
@@ -1,5 +1,6 @@
 class ExchangeRateFile < Sequel::Model
   APPLICABLE_TYPES = %w[monthly_csv monthly_xml spot_csv average_csv].freeze
+  HISTORIC_TYPES = %w[monthly_csv_hmrc].freeze
   OBJECT_KEY_PREFIX = 'data/exchange_rates'.freeze
 
   include ContentAddressableId
@@ -39,6 +40,10 @@ class ExchangeRateFile < Sequel::Model
   end
 
   class << self
+    def type_check_regexp
+      %r{(#{(HISTORIC_TYPES + APPLICABLE_TYPES).join('|')})}
+    end
+
     def filepath_for(type, format, year, month)
       object_key_prefix = "#{OBJECT_KEY_PREFIX}/#{year}/#{month}/"
       filename = filename_for(type, format, year, month)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,7 +100,14 @@ Rails.application.routes.draw do
 
       namespace :exchange_rates do
         get 'period_lists(/:year)', to: 'period_lists#show', as: :period_list
-        resources :files, only: [:show]
+
+        get 'files/(:type)_:year-:month', to: 'files#show',
+                                          as: :file,
+                                          constraints: {
+                                            type: ExchangeRateFile.type_check_regexp,
+                                            year: /20\d\d/,
+                                            month: /[01]?\d/,
+                                          }
       end
 
       resources :exchange_rates, only: [:show]

--- a/spec/requests/api/v2/exchange_rates/files_controller_spec.rb
+++ b/spec/requests/api/v2/exchange_rates/files_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Api::V2::ExchangeRates::FilesController, type: :request do
       let(:type) { 'monthly_csv' }
       let(:format) { 'csv' }
 
-      before { get api_exchange_rates_file_path("#{type}_#{year}-#{month}", format: :csv) }
+      before { get api_exchange_rates_file_path(type:, year:, month:, format: :csv) }
 
       it 'returns HTTP status :ok' do
         expect(response).to have_http_status(:ok)
@@ -37,7 +37,7 @@ RSpec.describe Api::V2::ExchangeRates::FilesController, type: :request do
       let(:type) { 'monthly_xml' }
       let(:format) { 'xml' }
 
-      before { get api_exchange_rates_file_path("#{type}_#{year}-#{month}", format: :xml) }
+      before { get api_exchange_rates_file_path(type:, year:, month:, format: :xml) }
 
       it 'returns HTTP status :ok' do
         expect(response).to have_http_status(:ok)
@@ -60,7 +60,7 @@ RSpec.describe Api::V2::ExchangeRates::FilesController, type: :request do
       let(:type) { 'monthly_csv_hmrc' }
       let(:format) { 'csv' }
 
-      before { get api_exchange_rates_file_path("#{type}_#{year}-#{month}", format: :csv) }
+      before { get api_exchange_rates_file_path(type:, year:, month:, format: :csv) }
 
       it 'returns HTTP status :ok' do
         expect(response).to have_http_status(:ok)
@@ -83,7 +83,7 @@ RSpec.describe Api::V2::ExchangeRates::FilesController, type: :request do
       let(:type) { 'non_existing_type' }
       let(:format) { 'csv' }
 
-      before { get api_exchange_rates_file_path("#{type}_#{year}-#{month}", format: :csv) }
+      before { get api_exchange_rates_file_path(type:, year:, month:, format: :csv) }
 
       it 'returns HTTP status :not_found' do
         expect(response).to have_http_status(:not_found)


### PR DESCRIPTION
Incorrectly formatted requests now return a 404

### Jira link

OTT-180

### What?

I have added/removed/altered:

- [x] Moved the logic for parsing the exchange rates params out into the router

### Why?

I am doing this because:

- Invalid `:id`'s were being passed to the controller but then could not be parsed because they did not follow the expected format
- This lets the router deal with parsing path params

### Deployment risks (optional)

- Notable, this is a simple change but it affects a crucial service so needs to be thoroughly checked prior to deployment
