### PR TITLE
GL-407 Add missing themes entities

### DIFF
--- a/app/controllers/api/v2/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/api/v2/green_lanes/category_assessments_controller.rb
@@ -23,7 +23,7 @@ module Api
           serializer =
             CategoryAssessmentSerializer
               .new(presented_assessments,
-                   include: %w[geographical_area excluded_geographical_areas])
+                   include: %w[geographical_area excluded_geographical_areas theme])
 
           render json: serializer.serializable_hash
         end

--- a/app/controllers/api/v2/green_lanes/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/green_lanes/goods_nomenclatures_controller.rb
@@ -29,6 +29,7 @@ module Api
               applicable_category_assessments.measures.measure_types
               applicable_category_assessments.measures.footnotes
               applicable_category_assessments.measures.additional_codes
+              applicable_category_assessments.theme
               descendant_category_assessments
               descendant_category_assessments.exemptions
               descendant_category_assessments.geographical_area
@@ -37,6 +38,7 @@ module Api
               descendant_category_assessments.measures.measure_types
               descendant_category_assessments.measures.footnotes
               descendant_category_assessments.measures.additional_codes
+              descendant_category_assessments.theme
               ancestors
               ancestors.measures
               ancestors.measures.measure_types


### PR DESCRIPTION
### Jira link

GL-407

### What?

I have added/removed/altered:

- [ ] Include the Themes entities in the api response

### Why?

I am doing this because:

- This got missed when I switch to a dedicated entity type

### Deployment risks (optional)

- Low
