### PR TITLE
GL-442 remove measures for now

### DIFF
--- a/app/controllers/api/v2/green_lanes/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/green_lanes/goods_nomenclatures_controller.rb
@@ -42,19 +42,7 @@ module Api
               descendant_category_assessments.measures.additional_codes
               descendant_category_assessments.theme
               ancestors
-              ancestors.measures
-              ancestors.measures.measure_types
-              ancestors.measures.footnotes
-              ancestors.measures.additional_codes
-              measures
-              measures.measure_types
-              measures.footnotes
-              measures.additional_codes
               descendants
-              descendants.measures
-              descendants.measures.measure_types
-              descendants.measures.footnotes
-              descendants.measures.additional_codes
             ]
         end
       end

--- a/app/serializers/api/v2/green_lanes/goods_nomenclature_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/goods_nomenclature_serializer.rb
@@ -22,7 +22,6 @@ module Api
         has_many :descendant_category_assessments, serializer: CategoryAssessmentSerializer
         has_many :ancestors, serializer: GreenLanes::ReferencedGoodsNomenclatureSerializer
         has_many :descendants, serializer: GreenLanes::ReferencedGoodsNomenclatureSerializer
-        has_many :measures, serializer: GreenLanes::MeasureSerializer
       end
     end
   end

--- a/app/serializers/api/v2/green_lanes/referenced_goods_nomenclature_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/referenced_goods_nomenclature_serializer.rb
@@ -16,8 +16,6 @@ module Api
                    :validity_start_date,
                    :validity_end_date,
                    :parent_sid
-
-        has_many :measures, serializer: GreenLanes::MeasureSerializer
       end
     end
   end

--- a/spec/serializers/api/v2/green_lanes/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/goods_nomenclature_serializer_spec.rb
@@ -51,14 +51,6 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclatureSerializer do
               },
             ],
           },
-          measures: {
-            data: [
-              {
-                id: subheading.measures.first.measure_sid.to_s,
-                type: eq(:measure),
-              },
-            ],
-          },
           descendants: {
             data: [
               {

--- a/spec/serializers/api/v2/green_lanes/referenced_goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/referenced_goods_nomenclature_serializer_spec.rb
@@ -21,13 +21,6 @@ RSpec.describe Api::V2::GreenLanes::ReferencedGoodsNomenclatureSerializer do
           validity_end_date: nil,
           parent_sid: nil,
         },
-        relationships: {
-          measures: {
-            data: [
-              { type: 'measure', id: subheading.measures.first.id.to_s },
-            ],
-          },
-        },
       },
     }
   end


### PR DESCRIPTION
### Jira link

GL-442

### What?

I have added/removed/altered:

- [x] Removed the measures entities from the requested GN, its ancestors and its descendants

### Why?

I am doing this because:

- There is still some ambiguity around how this information is presented but it is not yet required
- The rest of GL-308 is ready to release and is needed by our partners to make progress
- Removing this allows us to present and updated format to our partners

### Deployment risks (optional)

- Low, for now directly affects epic branch
