### PR TITLE
OTT-215 Updated South Korea ORD Details

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk.json
+++ b/db/rules_of_origin/roo_schemes_uk.json
@@ -3885,10 +3885,10 @@
                 }
             },
             "ord": {
-                "ord_title": "Origin Reference Document implementing the Free Trade Agreement between the United Kingdom of Great Britain and Northern Ireland, of the one part, and the Republic of  Korea, of the other part, signed on 22 August 2019 ('the Korea Origin Reference Document')",
-                "ord_version": "1.1",
-                "ord_date": "28th December 2021",
-                "ord_original": "211208_ORD_Korea__HS_UPDATE_.odt"
+                "ord_title": "Origin Reference Document implementing the Free Trade Agreement between the United Kingdom of Great Britain and Northern Ireland and the Republic of Korea, signed on 22 August 2019 ('the Korea Origin Reference Document')",
+                "ord_version": "1.2",
+                "ord_date": "7th November 2023",
+                "ord_original": "231107_ORD_Korea.docx"
             },
             "articles": {
                 "article 1": "definitions",

--- a/db/rules_of_origin/roo_schemes_uk/articles/south-korea/wholly-obtained.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/south-korea/wholly-obtained.md
@@ -8,10 +8,9 @@ For the purposes of Article 2(a), the following shall be considered as wholly ob
 
 4. **products from live animals** raised there;
 
-5. 
-   1. products obtained by hunting, trapping within the land territory or fishing, conducted within the land waters or within the territorial sea of a Party;
+5. i. products obtained by hunting, trapping within the land territory or fishing, conducted within the land waters or within the territorial sea of a Party;
 
-   2. Products of **aquaculture**, where the fish, crustaceans and mollusc are born and raised there;
+   ii. Products of **aquaculture**, where the fish, crustaceans and mollusc are born and raised there;
 
 6. products of **sea fishing and other products** taken from the sea outside the territorial sea of a Party by its vessels;
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-215

### What?

I have altered:

- [x]  South Korea ORD Details
- [x] Wholly Obtained Definitions to use roman numerals in line with govspeak markdown formatting.

### Why?

I am doing this because:

- The South Korea ORD was out of date and some of the details represented incorrectly.

BEFORE
![image](https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/46241399-f6cb-4341-ab63-b273f0d2b641)

![image](https://github.com/trade-tariff/trade-tariff-frontend/assets/127106895/b8a5241e-7ff5-428e-9276-479912ca762c)


AFTER
![image](https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/0b85fd5d-e0d0-45ef-9811-8fa305d06120)

![image](https://github.com/trade-tariff/trade-tariff-frontend/assets/127106895/52d95cdc-ab02-4fb6-a6f6-99fb5cca854c)