### PR TITLE
GL-366: Add admin APIs to list out a page of overrides

### DIFF
--- a/app/controllers/api/admin/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/api/admin/green_lanes/category_assessments_controller.rb
@@ -3,6 +3,7 @@ module Api
     module GreenLanes
       class CategoryAssessmentsController < AdminController
         include Pageable
+        include XiOnly
 
         before_action :check_service, :authenticate_user!
 
@@ -74,12 +75,6 @@ module Api
 
         def serialize_errors(category_assessment)
           Api::Admin::ErrorSerializationService.new(category_assessment).call
-        end
-
-        def check_service
-          if TradeTariffBackend.uk?
-            raise ActionController::RoutingError, 'Invalid service'
-          end
         end
       end
     end

--- a/app/controllers/api/admin/green_lanes/exempting_certificate_overrides_controller.rb
+++ b/app/controllers/api/admin/green_lanes/exempting_certificate_overrides_controller.rb
@@ -29,20 +29,6 @@ module Api
           end
         end
 
-        def update
-          eco = ::GreenLanes::ExemptingCertificateOverride.with_pk!(params[:id])
-          eco.set eco_params
-
-          if eco.valid? && eco.save
-            render json: serialize(eco),
-                   location: api_admin_green_lanes_exempting_certificate_override_url(eco.id),
-                   status: :ok
-          else
-            render json: serialize_errors(eco),
-                   status: :unprocessable_entity
-          end
-        end
-
         def destroy
           eco = ::GreenLanes::ExemptingCertificateOverride.with_pk!(params[:id])
           eco.destroy

--- a/app/controllers/api/admin/green_lanes/exempting_certificate_overrides_controller.rb
+++ b/app/controllers/api/admin/green_lanes/exempting_certificate_overrides_controller.rb
@@ -1,0 +1,80 @@
+module Api
+  module Admin
+    module GreenLanes
+      class ExemptingCertificateOverridesController < AdminController
+        include Pageable
+        include XiOnly
+
+        before_action :check_service, :authenticate_user!
+
+        def index
+          render json: serialize(exempting_certificate_override.to_a, pagination_meta)
+        end
+
+        def show
+          eco = ::GreenLanes::ExemptingCertificateOverride.with_pk!(params[:id])
+          render json: serialize(eco)
+        end
+
+        def create
+          eco = ::GreenLanes::ExemptingCertificateOverride.new(eco_params)
+
+          if eco.valid? && eco.save
+            render json: serialize(eco),
+                   location: api_admin_green_lanes_exempting_certificate_override_url(eco.id),
+                   status: :created
+          else
+            render json: serialize_errors(eco),
+                   status: :unprocessable_entity
+          end
+        end
+
+        def update
+          eco = ::GreenLanes::ExemptingCertificateOverride.with_pk!(params[:id])
+          eco.set eco_params
+
+          if eco.valid? && eco.save
+            render json: serialize(eco),
+                   location: api_admin_green_lanes_exempting_certificate_override_url(eco.id),
+                   status: :ok
+          else
+            render json: serialize_errors(eco),
+                   status: :unprocessable_entity
+          end
+        end
+
+        def destroy
+          eco = ::GreenLanes::ExemptingCertificateOverride.with_pk!(params[:id])
+          eco.destroy
+
+          head :no_content
+        end
+
+        private
+
+        def eco_params
+          params.require(:data).require(:attributes).permit(
+            :certificate_type_code,
+            :certificate_code,
+          )
+        end
+
+        def record_count
+          @exempting_certificate_override.pagination_record_count
+        end
+
+        def exempting_certificate_override
+          @exempting_certificate_override ||= ::GreenLanes::ExemptingCertificateOverride.order(Sequel.asc(:certificate_type_code), Sequel.asc(:certificate_code)).paginate(current_page, per_page)
+        end
+
+        def serialize(*args)
+          Api::Admin::GreenLanes::ExemptingCertificateOverrideSerializer.new(*args).serializable_hash
+        end
+
+        def serialize_errors(exempting_certificate_override)
+          Api::Admin::ErrorSerializationService.new(exempting_certificate_override).call
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/green_lanes/themes_controller.rb
+++ b/app/controllers/api/admin/green_lanes/themes_controller.rb
@@ -2,6 +2,8 @@ module Api
   module Admin
     module GreenLanes
       class ThemesController < AdminController
+        include XiOnly
+
         before_action :check_service, :authenticate_user!
 
         def index
@@ -16,12 +18,6 @@ module Api
 
         def serialize(*args)
           Api::Admin::GreenLanes::ThemeSerializer.new(*args).serializable_hash
-        end
-
-        def check_service
-          if TradeTariffBackend.uk?
-            raise ActionController::RoutingError, 'Invalid service'
-          end
         end
       end
     end

--- a/app/controllers/concerns/xi_only.rb
+++ b/app/controllers/concerns/xi_only.rb
@@ -1,0 +1,11 @@
+module XiOnly
+  extend ActiveSupport::Concern
+
+  included do
+    def check_service
+      if TradeTariffBackend.uk?
+        raise ActionController::RoutingError, 'Invalid service'
+      end
+    end
+  end
+end

--- a/app/serializers/api/admin/green_lanes/exempting_certificate_override_serializer.rb
+++ b/app/serializers/api/admin/green_lanes/exempting_certificate_override_serializer.rb
@@ -1,0 +1,18 @@
+module Api
+  module Admin
+    module GreenLanes
+      class ExemptingCertificateOverrideSerializer
+        include JSONAPI::Serializer
+
+        set_type :exempting_certificate_override
+
+        set_id :id
+
+        attributes :certificate_type_code,
+                   :certificate_code,
+                   :created_at,
+                   :updated_at
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ Rails.application.routes.draw do
         namespace :green_lanes do
           resources :category_assessments, only: %i[index show create update destroy]
           resources :themes, only: %i[index]
+          resources :exempting_certificate_overrides, only: %i[index show create update destroy]
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,7 @@ Rails.application.routes.draw do
         namespace :green_lanes do
           resources :category_assessments, only: %i[index show create update destroy]
           resources :themes, only: %i[index]
-          resources :exempting_certificate_overrides, only: %i[index show create update destroy]
+          resources :exempting_certificate_overrides, only: %i[index show create destroy]
         end
       end
     end

--- a/spec/requests/api/admin/green_lanes/exempting_certificate_overrides_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/exempting_certificate_overrides_controller_spec.rb
@@ -83,45 +83,6 @@ RSpec.describe Api::Admin::GreenLanes::ExemptingCertificateOverridesController d
     end
   end
 
-  describe 'PATCH to #update' do
-    let(:id) { override.id }
-    let(:certificate_code) { '3' }
-
-    let(:make_request) do
-      authenticated_patch api_admin_green_lanes_exempting_certificate_override_path(id, format: :json), params: {
-        data: {
-          type: :exempting_certificate_override,
-          attributes: { certificate_code: },
-        },
-      }
-    end
-
-    context 'with valid params' do
-      it { is_expected.to have_http_status :success }
-      it { is_expected.to have_attributes location: api_admin_green_lanes_exempting_certificate_override_url(override.id) }
-      it { expect { page_response }.not_to change(override.reload, :certificate_code) }
-    end
-
-    context 'with invalid params' do
-      let(:certificate_code) { nil }
-
-      it { is_expected.to have_http_status :unprocessable_entity }
-
-      it 'returns errors for category assessment' do
-        expect(json_response).to include('errors')
-      end
-
-      it { expect { page_response }.not_to change(override.reload, :certificate_code) }
-    end
-
-    context 'with unknown category assessment' do
-      let(:id) { 9999 }
-
-      it { is_expected.to have_http_status :not_found }
-      it { expect { page_response }.not_to change(override.reload, :certificate_code) }
-    end
-  end
-
   describe 'DELETE to #destroy' do
     let :make_request do
       authenticated_delete api_admin_green_lanes_exempting_certificate_override_path(id, format: :json)

--- a/spec/requests/api/admin/green_lanes/exempting_certificate_overrides_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/exempting_certificate_overrides_controller_spec.rb
@@ -1,0 +1,144 @@
+RSpec.describe Api::Admin::GreenLanes::ExemptingCertificateOverridesController do
+  subject(:page_response) { make_request && response }
+
+  before do
+    allow(TradeTariffBackend).to receive(:service).and_return 'xi'
+  end
+
+  let(:json_response) { JSON.parse(page_response.body) }
+  let(:override) { create :exempting_certificate_override }
+
+  describe 'GET to #index' do
+    let(:make_request) do
+      authenticated_get api_admin_green_lanes_exempting_certificate_overrides_path(format: :json)
+    end
+
+    context 'with some overrides' do
+      before do
+        override
+      end
+
+      it { is_expected.to have_http_status :success }
+      it { expect(json_response).to include('data') }
+      it { expect(json_response).to include('meta') }
+    end
+
+    context 'without any overrides' do
+      it { is_expected.to have_http_status :success }
+      it { expect(json_response).to include('data' => []) }
+    end
+  end
+
+  describe 'GET to #show' do
+    let(:make_request) do
+      authenticated_get api_admin_green_lanes_exempting_certificate_override_path(id, format: :json)
+    end
+
+    context 'with existent override' do
+      let(:id) { override.id }
+
+      it { is_expected.to have_http_status :success }
+      it { expect(json_response).to include('data') }
+    end
+
+    context 'with non-existent overrides item' do
+      let(:id) { 1001 }
+
+      it { is_expected.to have_http_status :not_found }
+    end
+  end
+
+  describe 'POST to #create' do
+    let(:make_request) do
+      authenticated_post api_admin_green_lanes_exempting_certificate_overrides_path(format: :json), params: eco_data
+    end
+
+    let :eco_data do
+      {
+        data: {
+          type: :exempting_certificate_override,
+          attributes: eco_attrs,
+        },
+      }
+    end
+
+    context 'with valid params' do
+      let(:eco_attrs) { build(:exempting_certificate_override).to_hash }
+
+      it { is_expected.to have_http_status :created }
+      it { is_expected.to have_attributes location: api_admin_green_lanes_exempting_certificate_override_url(GreenLanes::ExemptingCertificateOverride.last.id) }
+      it { expect { page_response }.to change(GreenLanes::ExemptingCertificateOverride, :count).by(1) }
+    end
+
+    context 'with invalid params' do
+      let(:eco_attrs) { build(:exempting_certificate_override, certificate_code: nil).to_hash }
+
+      it { is_expected.to have_http_status :unprocessable_entity }
+
+      it 'returns errors for overrides' do
+        expect(json_response).to include('errors')
+      end
+
+      it { expect { page_response }.not_to change(GreenLanes::ExemptingCertificateOverride, :count) }
+    end
+  end
+
+  describe 'PATCH to #update' do
+    let(:id) { override.id }
+    let(:certificate_code) { '3' }
+
+    let(:make_request) do
+      authenticated_patch api_admin_green_lanes_exempting_certificate_override_path(id, format: :json), params: {
+        data: {
+          type: :exempting_certificate_override,
+          attributes: { certificate_code: },
+        },
+      }
+    end
+
+    context 'with valid params' do
+      it { is_expected.to have_http_status :success }
+      it { is_expected.to have_attributes location: api_admin_green_lanes_exempting_certificate_override_url(override.id) }
+      it { expect { page_response }.not_to change(override.reload, :certificate_code) }
+    end
+
+    context 'with invalid params' do
+      let(:certificate_code) { nil }
+
+      it { is_expected.to have_http_status :unprocessable_entity }
+
+      it 'returns errors for category assessment' do
+        expect(json_response).to include('errors')
+      end
+
+      it { expect { page_response }.not_to change(override.reload, :certificate_code) }
+    end
+
+    context 'with unknown category assessment' do
+      let(:id) { 9999 }
+
+      it { is_expected.to have_http_status :not_found }
+      it { expect { page_response }.not_to change(override.reload, :certificate_code) }
+    end
+  end
+
+  describe 'DELETE to #destroy' do
+    let :make_request do
+      authenticated_delete api_admin_green_lanes_exempting_certificate_override_path(id, format: :json)
+    end
+
+    context 'with known category assessment' do
+      let(:id) { override.id }
+
+      it { is_expected.to have_http_status :no_content }
+      it { expect { page_response }.to change(override, :exists?) }
+    end
+
+    context 'with unknown category assessment' do
+      let(:id) { 9999 }
+
+      it { is_expected.to have_http_status :not_found }
+      it { expect { page_response }.not_to change(GreenLanes::ExemptingCertificateOverride, :count) }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[GL-366](https://transformuk.atlassian.net/browse/GL-366)

### What?

I have added/removed/altered:

- [ ] Added admin APIs to list / create / edit / remove overrides

### Why?

I am doing this because:

- So that a screen in the Admin area can be built to manage exempting certificate overrides

