### PR TITLE
GL-359 Add pseudo measures models

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -120,6 +120,11 @@ class GoodsNomenclature < Sequel::Model
                           foreign_key: :goods_nomenclature_sid,
                           order: Sequel.desc(:created_at)
 
+  one_to_many :green_lanes_measures, class: 'Measure',
+                                     class_namespace: 'GreenLanes',
+                                     key: %i[goods_nomenclature_item_id productline_suffix],
+                                     primary_key: %i[goods_nomenclature_item_id producline_suffix]
+
   dataset_module do
     def non_hidden
       filter(Sequel.~(goods_nomenclatures__goods_nomenclature_item_id: HiddenGoodsNomenclature.codes))

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -2,6 +2,7 @@ module GreenLanes
   class CategoryAssessment < Sequel::Model(:green_lanes_category_assessments)
     plugin :timestamps, update_on_create: true
     plugin :auto_validations, not_null: :presence
+    plugin :association_pks
 
     many_to_one :theme
     many_to_one :measure_type, class: :MeasureType
@@ -15,9 +16,12 @@ module GreenLanes
                            key: %i[measure_type_id
                                    measure_generating_regulation_id
                                    measure_generating_regulation_role] do |ds|
-      ds.with_actual(Measure)
+      ds.with_actual(::Measure)
         .with_regulation_dates_query
     end
+
+    one_to_many :green_lanes_measures, class: 'Measure', class_namespace: 'GreenLanes'
+    many_to_many :exemptions, join_table: :green_lanes_category_assessments_exemptions
 
     def validate
       super
@@ -37,7 +41,7 @@ module GreenLanes
     def regulation
       case regulation_role
       when nil then nil
-      when Measure::MODIFICATION_REGULATION_ROLE then modification_regulation
+      when ::Measure::MODIFICATION_REGULATION_ROLE then modification_regulation
       else base_regulation
       end
     end

--- a/app/models/green_lanes/exemption.rb
+++ b/app/models/green_lanes/exemption.rb
@@ -1,0 +1,10 @@
+module GreenLanes
+  class Exemption < Sequel::Model(:green_lanes_exemptions)
+    plugin :timestamps, update_on_create: true
+    plugin :auto_validations, not_null: :presence
+    plugin :association_pks
+
+    many_to_many :category_assessments,
+                 join_table: :green_lanes_category_assessments_exemptions
+  end
+end

--- a/app/models/green_lanes/measure.rb
+++ b/app/models/green_lanes/measure.rb
@@ -1,0 +1,11 @@
+module GreenLanes
+  class Measure < Sequel::Model(:green_lanes_measures)
+    plugin :timestamps, update_on_create: true
+    plugin :auto_validations, not_null: :presence
+
+    many_to_one :category_assessment
+    many_to_one :goods_nomenclature, class: 'GoodsNomenclature',
+                                     primary_key: %i[goods_nomenclature_item_id producline_suffix],
+                                     key: %i[goods_nomenclature_item_id productline_suffix]
+  end
+end

--- a/spec/factories/green_lanes/category_assessment_factory.rb
+++ b/spec/factories/green_lanes/category_assessment_factory.rb
@@ -3,11 +3,13 @@ FactoryBot.define do
     transient do
       measures_count { 1 }
       measure { nil }
+      exemptions { [] }
     end
 
     regulation { measure&.generating_regulation || create(:base_regulation) }
     measure_type { measure&.measure_type || create(:measure_type) }
     theme { create :green_lanes_theme }
+    exemption_pks { exemptions.map(&:pk) }
 
     trait :category1 do
       theme { create :green_lanes_theme, :category1 }

--- a/spec/factories/green_lanes/exemption_factory.rb
+++ b/spec/factories/green_lanes/exemption_factory.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :green_lanes_exemption, class: 'GreenLanes::Exemption' do
+    transient do
+      category_assessments { [] }
+    end
+
+    sequence(:code) { |n| sprintf '%04d', n }
+    description { Forgery(:basic).text }
+    category_assessment_pks { category_assessments.map(&:pk) }
+  end
+end

--- a/spec/factories/green_lanes/measure_factory.rb
+++ b/spec/factories/green_lanes/measure_factory.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :green_lanes_measure, class: 'GreenLanes::Measure' do
+    transient do
+      category_assessment { create :category_assessment }
+      goods_nomenclature { create :commodity }
+    end
+
+    category_assessment_id { category_assessment.id }
+    goods_nomenclature_item_id { goods_nomenclature.goods_nomenclature_item_id }
+    productline_suffix { goods_nomenclature.producline_suffix }
+  end
+end

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -488,4 +488,16 @@ RSpec.describe GoodsNomenclature do
       it { expect(dataset.pluck(:footnote_type_id)).to eq %w[Y N] }
     end
   end
+
+  describe '#green_lanes_measures' do
+    subject { goods_nomenclature.green_lanes_measures }
+
+    let :goods_nomenclature do
+      create(:commodity).tap do |gn|
+        create :green_lanes_measure, goods_nomenclature: gn
+      end
+    end
+
+    it { is_expected.to include instance_of GreenLanes::Measure }
+  end
 end

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -149,6 +149,45 @@ RSpec.describe GreenLanes::CategoryAssessment do
         it { is_expected.to be_empty }
       end
     end
+
+    describe '#green_lanes_measures' do
+      subject { assessment.green_lanes_measures }
+
+      let :assessment do
+        create(:category_assessment).tap do |ca|
+          create :green_lanes_measure, category_assessment_id: ca.id
+        end
+      end
+
+      it { is_expected.to include instance_of GreenLanes::Measure }
+    end
+
+    describe '#exemptions' do
+      subject { assessment.reload.exemptions }
+
+      let :assessment do
+        create(:category_assessment).tap do |ca|
+          ca.add_exemption create(:green_lanes_exemption)
+        end
+      end
+
+      it { is_expected.to include instance_of GreenLanes::Exemption }
+    end
+
+    describe '#exemption_ids' do
+      subject { assessment.reload.exemption_pks }
+
+      let :assessment do
+        create(:category_assessment).tap do |ca|
+          ca.exemption_pks = exemptions.map(&:pk)
+          ca.save
+        end
+      end
+
+      let(:exemptions) { create_list :green_lanes_exemption, 1 }
+
+      it { is_expected.to match_array exemptions.map(&:id) }
+    end
   end
 
   describe '#regulation' do

--- a/spec/models/green_lanes/exemption_spec.rb
+++ b/spec/models/green_lanes/exemption_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe GreenLanes::Exemption do
+  describe 'attributes' do
+    it { is_expected.to respond_to :id }
+    it { is_expected.to respond_to :code }
+    it { is_expected.to respond_to :description }
+    it { is_expected.to respond_to :created_at }
+    it { is_expected.to respond_to :updated_at }
+  end
+
+  describe 'validations' do
+    subject(:errors) { instance.tap(&:valid?).errors }
+
+    let(:instance) { described_class.new }
+
+    it { is_expected.to include code: ['is not present'] }
+    it { is_expected.to include description: ['is not present'] }
+
+    context 'with duplicate code' do
+      let(:existing) { create :green_lanes_exemption }
+      let(:instance) { build :green_lanes_exemption, code: existing.code }
+
+      it { is_expected.to include code: ['is already taken'] }
+    end
+  end
+
+  describe '#associations' do
+    describe '#category_assessments' do
+      subject { exemption.reload.category_assessments }
+
+      let :exemption do
+        create(:green_lanes_exemption).tap do |exempt|
+          exempt.add_category_assessment create(:category_assessment)
+        end
+      end
+
+      it { is_expected.to include instance_of GreenLanes::CategoryAssessment }
+    end
+
+    describe '#category_assessments_pks' do
+      subject { exemption.reload.category_assessment_pks }
+
+      let :exemption do
+        create(:green_lanes_exemption).tap do |exempt|
+          exempt.category_assessment_pks = assessments.map(&:pk)
+          exempt.save
+        end
+      end
+
+      let(:assessments) { create_list :category_assessment, 1 }
+
+      it { is_expected.to match_array assessments.map(&:id) }
+    end
+  end
+end

--- a/spec/models/green_lanes/measure_spec.rb
+++ b/spec/models/green_lanes/measure_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe GreenLanes::Measure do
+  describe 'attributes' do
+    it { is_expected.to respond_to :id }
+    it { is_expected.to respond_to :category_assessment_id }
+    it { is_expected.to respond_to :goods_nomenclature_item_id }
+    it { is_expected.to respond_to :productline_suffix }
+    it { is_expected.to respond_to :created_at }
+    it { is_expected.to respond_to :updated_at }
+  end
+
+  describe 'validations' do
+    subject(:errors) { instance.tap(&:valid?).errors }
+
+    let(:instance) { described_class.new }
+
+    it { is_expected.to include category_assessment_id: ['is not present'] }
+    it { is_expected.to include goods_nomenclature_item_id: ['is not present'] }
+    it { is_expected.to include productline_suffix: ['is not present'] }
+
+    context 'with duplicate associations' do
+      let(:existing) { create :green_lanes_measure }
+
+      let :instance do
+        build :green_lanes_measure,
+              category_assessment_id: existing.category_assessment_id,
+              goods_nomenclature_item_id: existing.goods_nomenclature_item_id,
+              productline_suffix: existing.productline_suffix
+      end
+
+      let :uniqueness_key do
+        %i[category_assessment_id goods_nomenclature_item_id productline_suffix]
+      end
+
+      it { is_expected.to include uniqueness_key => ['is already taken'] }
+    end
+  end
+
+  describe 'associations' do
+    describe '#category_assessment' do
+      subject { measure.category_assessment }
+
+      let(:measure) { create :green_lanes_measure, category_assessment_id: ca.id }
+      let(:ca) { create :category_assessment }
+
+      it { is_expected.to be_instance_of GreenLanes::CategoryAssessment }
+    end
+
+    describe '#goods_nomenclature' do
+      subject { measure.goods_nomenclature }
+
+      let :measure do
+        create :green_lanes_measure,
+               goods_nomenclature_item_id: gn.goods_nomenclature_item_id,
+               productline_suffix: gn.producline_suffix
+      end
+
+      let(:gn) { create :commodity }
+
+      it { is_expected.to be_instance_of Commodity }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

GL-359

### What?

I have added/removed/altered:

- [x] Added GreenLanes::Measure and GreenLanes::Exemption models
- [x] Added relationships between GoodsNomenclatures and GreenLanes::Measures
- [x] Added relationships between GreenLanes::Measures and GreenLanes::CategoryAssessments
- [x] Added relationships between GreenLanes::CategoryAssessments and GreenLanes::Exemptions

### Why?

I am doing this because:

- We need to manually associate certain category assessments with certain goods nomenclatures
- We need to manually add exemptions to certain category assessments

### Deployment risks (optional)

- Low, primarily impacts green lanes models
