### PR TITLE
GL-465 Integrate pseudo exemptions

### DIFF
--- a/app/controllers/api/v2/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/api/v2/green_lanes/category_assessments_controller.rb
@@ -28,6 +28,7 @@ module Api
               .new(presented_assessments,
                    include: %w[geographical_area
                                excluded_geographical_areas
+                               exemptions
                                theme
                                regulation
                                measure_type])

--- a/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
@@ -66,7 +66,7 @@ module Api
         end
 
         def exemptions
-          certificates + additional_codes
+          @exemptions ||= (certificates + additional_codes + pseudo_exemptions)
         end
 
         def certificates
@@ -75,6 +75,10 @@ module Api
 
         def additional_codes
           Array.wrap(additional_code)
+        end
+
+        def pseudo_exemptions
+          ExemptionPresenter.wrap(@category_assessment.exemptions)
         end
 
         def regulation

--- a/app/presenters/api/v2/green_lanes/exemption_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/exemption_presenter.rb
@@ -1,0 +1,15 @@
+module Api
+  module V2
+    module GreenLanes
+      class ExemptionPresenter < WrapDelegator
+        def id
+          code
+        end
+
+        def formatted_description
+          description
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/v2/green_lanes/category_assessment_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/category_assessment_serializer.rb
@@ -5,7 +5,6 @@ module Api
         include JSONAPI::Serializer
 
         set_type :category_assessment
-
         set_id :id
 
         has_many :exemptions, serializer: lambda { |record, _params|
@@ -14,6 +13,8 @@ module Api
             GreenLanes::CertificateSerializer
           when AdditionalCode
             AdditionalCodeSerializer
+          when ExemptionPresenter
+            GreenLanes::ExemptionSerializer
           else
             raise 'Unknown type'
           end

--- a/app/serializers/api/v2/green_lanes/exemption_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/exemption_serializer.rb
@@ -1,0 +1,15 @@
+module Api
+  module V2
+    module GreenLanes
+      class ExemptionSerializer
+        include JSONAPI::Serializer
+
+        set_id :code
+
+        attributes :code,
+                   :description,
+                   :formatted_description
+      end
+    end
+  end
+end

--- a/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
@@ -106,7 +106,13 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentPresenter do
       it { is_expected.to match_array certificates << additional_code }
     end
 
-    context 'with neither' do
+    context 'with pseudo exemption' do
+      before { assessment.add_exemption create(:green_lanes_exemption) }
+
+      it { is_expected.to include instance_of Api::V2::GreenLanes::ExemptionPresenter }
+    end
+
+    context 'with no exemptions' do
       it { is_expected.to be_empty }
     end
   end

--- a/spec/presenters/api/v2/green_lanes/exemption_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/exemption_presenter_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Api::V2::GreenLanes::ExemptionPresenter do
+  subject { described_class.new(exemption) }
+
+  let(:exemption) { create :green_lanes_exemption }
+
+  it { is_expected.to have_attributes id: exemption.code }
+  it { is_expected.to have_attributes code: exemption.code }
+  it { is_expected.to have_attributes description: exemption.description }
+  it { is_expected.to have_attributes formatted_description: exemption.description }
+end

--- a/spec/serializers/api/v2/green_lanes/category_assessment_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/category_assessment_serializer_spec.rb
@@ -7,9 +7,12 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentSerializer do
     ).serializable_hash.as_json
   end
 
+  before { category_assessment.add_exemption exemption }
+
   let(:category_assessment) { create :category_assessment, measure: }
   let(:certificate) { create :certificate, :exemption, :with_certificate_type, :with_description }
   let(:measure) { create :measure, :with_additional_code, :with_base_regulation, certificate: }
+  let(:exemption) { create :green_lanes_exemption }
 
   let :presented do
     Api::V2::GreenLanes::CategoryAssessmentPresenter.wrap(category_assessment).first
@@ -28,6 +31,7 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentSerializer do
             data: [
               { id: certificate.id, type: 'certificate' },
               { id: measure.additional_code.id.to_s, type: 'additional_code' },
+              { id: exemption.code, type: 'exemption' },
             ],
           },
           geographical_area: {
@@ -72,6 +76,15 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentSerializer do
           type: 'additional_code',
           attributes: {
             code: measure.additional_code.code,
+            description: be_a(String),
+            formatted_description: be_a(String),
+          },
+        },
+        {
+          id: exemption.code,
+          type: 'exemption',
+          attributes: {
+            code: exemption.code,
             description: be_a(String),
             formatted_description: be_a(String),
           },

--- a/spec/serializers/api/v2/green_lanes/exemption_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/exemption_serializer_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe Api::V2::GreenLanes::ExemptionSerializer do
+  subject { described_class.new(presented).serializable_hash.as_json }
+
+  let(:exemption) { create :green_lanes_exemption }
+  let(:presented) { Api::V2::GreenLanes::ExemptionPresenter.new exemption }
+
+  let(:expected_pattern) do
+    {
+      data: {
+        id: exemption.code,
+        type: 'exemption',
+        attributes: {
+          code: exemption.code,
+          description: exemption.description,
+          formatted_description: exemption.description,
+        },
+      },
+    }
+  end
+
+  it { is_expected.to include_json(expected_pattern) }
+end

--- a/spec/services/green_lanes/permutation_calculator_service_spec.rb
+++ b/spec/services/green_lanes/permutation_calculator_service_spec.rb
@@ -17,6 +17,26 @@ RSpec.describe GreenLanes::PermutationCalculatorService do
       it { is_expected.to eq(measures.map { |m| [m] }) }
     end
 
+    context 'with related measures' do
+      let(:measures) { [measure, measure2] }
+
+      let :measure do
+        create :measure, :with_additional_code, :with_measure_type, :with_base_regulation
+      end
+
+      let :measure2 do
+        create :measure, measure_type_id: measure.measure_type_id,
+                         generating_regulation: measure.generating_regulation,
+                         additional_code_sid: measure.additional_code_sid,
+                         additional_code_id: measure.additional_code_id,
+                         additional_code_type_id: measure.additional_code_type_id,
+                         geographical_area_id: measure.geographical_area_id
+      end
+
+      it { is_expected.to have_attributes length: 1 }
+      it { expect(permutations[0]).to eq_pk measures }
+    end
+
     context 'with mixture of related and unrelated' do
       let :measures do
         measures = create_list(:measure, 2, :with_measure_type, :with_base_regulation)


### PR DESCRIPTION
### Jira link

GL-465

### What?

I have added/removed/altered:

- [x] Integrate Pseudo Exemptions into Green Lanes Goods Nomenclature endpoint
- [x] Integrate Pseudo Exemptions into Green Lanes Category Assessment endpoint

### Why?

I am doing this because:

- We want to expose pseudo exemptions to our api consumers in a manner consistent with other types of exemptions

### Deployment risks (optional)

- Low, currently targets and epic branch
