### PR TITLE
OTT-217 Updated Cote d'Ivoire ORD Details

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk/articles/cotedivoire/wholly-obtained.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/cotedivoire/wholly-obtained.md
@@ -8,8 +8,7 @@ The following shall be considered as wholly obtained in Côte d'Ivoire or in the
 
 4. **products from live animals** raised there;
 
-5. 
-   1. products obtained by **hunting or fishing** conducted there;
+5. 1. products obtained by **hunting or fishing** conducted there;
 
    2. products of **aquaculture**, including mariculture, where the animals are raised from eggs, spawn, larvae or fry;
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-217

### What?

I have added/removed/altered:

- [x] Updated Cote D'Ivoire Wholly Obtained Definition

### Why?

I am doing this because:

- The Cote D'Ivoire ORD  Wholly Obtained Definition was badly numbered at paragraph (e) 

BEFORE
![image](https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/35831d00-3751-4917-8d70-7ca38a702015)

AFTER
![image](https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/a464dc85-b609-4266-bc35-f1aaa37b983c)