### PR TITLE
OTT-212 Updated Iceland ORD Details

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk.json
+++ b/db/rules_of_origin/roo_schemes_uk.json
@@ -1962,8 +1962,8 @@
             },
             "ord": {
                 "ord_title": "Origin Reference Document implementing the Agreement between the United Kingdom of Great Britain and Northern Ireland, Iceland and the Kingdom of Norway on Trade in Goods, dated 8th July 2021 ('the Iceland Origin Reference Document')",
-                "ord_version": "1.1",
-                "ord_date": "28 December 2021",
+                "ord_version": "2.0",
+                "ord_date": "5 August 2022",
                 "ord_original": "050822_Iceland_Norway_ORD.odt"
             },
             "articles": {


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-212

### What?

I have added/removed/altered:

- [x] Updated Iceland ORD version and date Details

### Why?

I am doing this because:

- The Iceland ORD version and date details were out of date

BEFORE
<img width="297" alt="image" src="https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/f1eff055-2e93-4544-914b-0b3c66208e35">

AFTER
![image](https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/4495253a-4495-418d-a50b-104760938f69)
