### PR TITLE
GL-360 Integrate pseudo measures

### DIFF
--- a/app/controllers/api/v2/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/api/v2/green_lanes/category_assessments_controller.rb
@@ -9,7 +9,7 @@ module Api
                 theme: [],
                 base_regulation: [],
                 modification_regulation: [],
-                measure_type: :measure_type_description,
+                measure_type: %i[measure_type_description measure_type_series_description],
                 measures: {
                   additional_code: :additional_code_descriptions,
                   measure_conditions: { certificate: :certificate_descriptions },
@@ -17,6 +17,8 @@ module Api
                   measure_excluded_geographical_areas: [],
                   excluded_geographical_areas: :geographical_area_descriptions,
                 },
+                green_lanes_measures: [],
+                exemptions: [],
               )
               .all
 

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -58,5 +58,9 @@ module GreenLanes
         self.base_regulation = regulation
       end
     end
+
+    def combined_measures
+      measures + green_lanes_measures
+    end
   end
 end

--- a/app/models/green_lanes/measure.rb
+++ b/app/models/green_lanes/measure.rb
@@ -7,5 +7,73 @@ module GreenLanes
     many_to_one :goods_nomenclature, class: 'GoodsNomenclature',
                                      primary_key: %i[goods_nomenclature_item_id producline_suffix],
                                      key: %i[goods_nomenclature_item_id productline_suffix]
+
+    many_to_one :geographical_area, class: 'GeographicalArea',
+                                    primary_key: :geographical_area_id,
+                                    key: :geographical_area_id do |ds|
+      ds.with_actual(::GeographicalArea)
+    end
+
+    delegate :measure_type_id, :measure_type, to: :category_assessment
+
+    alias_method :effective_start_date, :created_at
+
+    # simulate the filtering interface on tariff measures
+    # true because GL measures always apply to all regions
+    def relevant_for_country?(_geographical_area_id)
+      true
+    end
+
+    def measure_generating_regulation_id
+      category_assessment.regulation_id
+    end
+
+    def measure_generating_regulation_role
+      category_assessment.regulation_role
+    end
+
+    def generating_regulation
+      category_assessment.regulation
+    end
+
+    def geographical_area_id
+      GeographicalArea::ERGA_OMNES_ID
+    end
+
+    def measure_excluded_geographical_areas
+      []
+    end
+
+    def excluded_geographical_areas
+      []
+    end
+
+    def additional_code_type_id
+      nil
+    end
+
+    def additional_code_id
+      nil
+    end
+
+    def additional_code
+      nil
+    end
+
+    def measure_conditions
+      []
+    end
+
+    def footnotes
+      []
+    end
+
+    def measure_sid
+      @measure_sid ||= sprintf('gl%06d', id)
+    end
+
+    def effective_end_date
+      nil
+    end
   end
 end

--- a/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
@@ -37,7 +37,7 @@ module Api
 
           def permutations(assessment)
             ::GreenLanes::PermutationCalculatorService
-              .new(assessment.measures)
+              .new(assessment.combined_measures)
               .call
           end
         end

--- a/app/presenters/api/v2/green_lanes/goods_nomenclature_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/goods_nomenclature_presenter.rb
@@ -20,7 +20,7 @@ module Api
         def applicable_category_assessments
           @applicable_category_assessments ||=
             ::GreenLanes::FindCategoryAssessmentsService.call \
-              applicable_measures,
+              combined_applicable_measures,
               @geographical_area_id
         end
 
@@ -31,7 +31,7 @@ module Api
         def descendant_category_assessments
           @descendant_category_assessments ||=
             ::GreenLanes::FindCategoryAssessmentsService.call \
-              all_descendant_measures,
+              combined_descendant_measures,
               @geographical_area_id
         end
 
@@ -72,8 +72,15 @@ module Api
           end
         end
 
-        def all_descendant_measures
-          descendants.flat_map(&:measures)
+        def combined_descendant_measures
+          descendants.flat_map(&:measures) +
+            descendants.flat_map(&:green_lanes_measures)
+        end
+
+        def combined_applicable_measures
+          applicable_measures +
+            green_lanes_measures +
+            ancestors.flat_map(&:green_lanes_measures)
         end
       end
     end

--- a/app/serializers/api/v2/green_lanes/category_assessment_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/category_assessment_serializer.rb
@@ -7,6 +7,8 @@ module Api
         set_type :category_assessment
         set_id :id
 
+        attribute :category_assessment_id if Rails.env.development?
+
         has_many :exemptions, serializer: lambda { |record, _params|
           case record
           when Certificate

--- a/app/services/green_lanes/fetch_goods_nomenclature_service.rb
+++ b/app/services/green_lanes/fetch_goods_nomenclature_service.rb
@@ -2,30 +2,32 @@ module GreenLanes
   class FetchGoodsNomenclatureService
     ITEM_ID_LENGTH = 10
 
-    MEASURES_EAGER = {
-      additional_code: :additional_code_descriptions,
-      goods_nomenclature: %i[goods_nomenclature_indents goods_nomenclature_descriptions],
-      footnotes: :footnote_descriptions,
-      geographical_area: %i[geographical_area_descriptions contained_geographical_areas],
-      measure_excluded_geographical_areas: [],
-      excluded_geographical_areas: :geographical_area_descriptions,
-      measure_conditions: { certificate: %i[certificate_descriptions exempting_certificate_override] },
-      category_assessment: (%i[theme base_regulation modification_regulation] +
-                            [{ measure_type: :measure_type_description }]),
+    ASSESSMENT_EAGER = [
+      :theme,
+      :base_regulation,
+      :modification_regulation,
+      :exemptions,
+      { measure_type: %i[measure_type_description measure_type_series_description] },
+    ].freeze
+
+    GN_EAGER_LOAD = {
+      measures: {
+        additional_code: :additional_code_descriptions,
+        footnotes: :footnote_descriptions,
+        geographical_area: %i[geographical_area_descriptions contained_geographical_areas],
+        measure_excluded_geographical_areas: [],
+        excluded_geographical_areas: :geographical_area_descriptions,
+        measure_conditions: { certificate: %i[certificate_descriptions exempting_certificate_override] },
+        category_assessment: ASSESSMENT_EAGER,
+      },
+      green_lanes_measures: { category_assessment: ASSESSMENT_EAGER },
+      goods_nomenclature_descriptions: [],
     }.freeze
 
     EAGER_LOAD = {
-      ancestors: {
-        measures: MEASURES_EAGER,
-        goods_nomenclature_descriptions: [],
-      },
-      descendants: {
-        measures: MEASURES_EAGER,
-        goods_nomenclature_descriptions: [],
-      },
-      measures: MEASURES_EAGER,
-      goods_nomenclature_descriptions: [],
-    }.freeze
+      ancestors: GN_EAGER_LOAD,
+      descendants: GN_EAGER_LOAD,
+    }.merge(GN_EAGER_LOAD).freeze
 
     def initialize(goods_nomenclature_item_id)
       @goods_nomenclature_item_id = goods_nomenclature_item_id

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -34,7 +34,7 @@ FactoryBot.define do
     measure_generating_regulation_role { generating_regulation&.role || Measure::BASE_REGULATION_ROLE }
     additional_code_id { additional_code&.additional_code }
     additional_code_sid { additional_code&.additional_code_sid }
-    additional_code_type_id { additional_code&.additional_code_type_id || '1' }
+    additional_code_type_id { additional_code&.additional_code_type_id }
     goods_nomenclature_sid { goods_nomenclature&.goods_nomenclature_sid || generate(:goods_nomenclature_sid) }
     goods_nomenclature_item_id { goods_nomenclature&.goods_nomenclature_item_id || 10.times.map { Random.rand(9) }.join }
     geographical_area_sid { for_geo_area&.geographical_area_sid || generate(:geographical_area_sid) }

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -259,4 +259,33 @@ RSpec.describe GreenLanes::CategoryAssessment do
       end
     end
   end
+
+  describe '#combined_measures' do
+    subject { category_assessment.combined_measures }
+
+    let(:tariff_measure) { create :measure, :with_base_regulation }
+    let(:category_assessment) { create :category_assessment, measure: tariff_measure }
+
+    context 'with tariff measure' do
+      it { is_expected.to include tariff_measure }
+    end
+
+    context 'with green lanes measure' do
+      before { green_lanes_measure }
+
+      let(:green_lanes_measure) { create :green_lanes_measure, category_assessment: }
+      let(:category_assessment) { create :category_assessment }
+
+      it { is_expected.to include green_lanes_measure }
+    end
+
+    context 'with both types of measure' do
+      before { green_lanes_measure }
+
+      let(:green_lanes_measure) { create :green_lanes_measure, category_assessment: }
+
+      it { is_expected.to include tariff_measure }
+      it { is_expected.to include green_lanes_measure }
+    end
+  end
 end

--- a/spec/models/green_lanes/measure_spec.rb
+++ b/spec/models/green_lanes/measure_spec.rb
@@ -58,5 +58,48 @@ RSpec.describe GreenLanes::Measure do
 
       it { is_expected.to be_instance_of Commodity }
     end
+
+    describe '#geographical_area' do
+      subject { measure.geographical_area }
+
+      before { erga_omnes }
+
+      let(:erga_omnes) { create :geographical_area, :erga_omnes }
+      let(:measure) { create :green_lanes_measure }
+
+      it { is_expected.to eq_pk erga_omnes }
+
+      context 'with eager loading' do
+        subject do
+          GoodsNomenclature.actual
+                           .where(goods_nomenclature_item_id: measure.goods_nomenclature_item_id)
+                           .eager(green_lanes_measures: :geographical_area)
+                           .take
+                           .green_lanes_measures
+                           .map(&:geographical_area)
+        end
+
+        it { is_expected.to all eq_pk erga_omnes }
+      end
+    end
+  end
+
+  describe 'tariff measure emulation' do
+    subject { create :green_lanes_measure, category_assessment: assessment }
+
+    let(:assessment) { create :category_assessment }
+
+    it { is_expected.to have_attributes measure_sid: /gl\d{6}/ }
+    it { is_expected.to have_attributes measure_generating_regulation_id: assessment.regulation_id }
+    it { is_expected.to have_attributes measure_generating_regulation_role: assessment.regulation_role }
+    it { is_expected.to have_attributes generating_regulation: assessment.regulation }
+    it { is_expected.to have_attributes geographical_area_id: GeographicalArea::ERGA_OMNES_ID }
+    it { is_expected.to have_attributes measure_excluded_geographical_areas: [] }
+    it { is_expected.to have_attributes excluded_geographical_areas: [] }
+    it { is_expected.to have_attributes additional_code_id: nil }
+    it { is_expected.to have_attributes additional_code_type_id: nil }
+    it { is_expected.to have_attributes additional_code: nil }
+    it { is_expected.to have_attributes measure_conditions: [] }
+    it { is_expected.to have_attributes footnotes: [] }
   end
 end

--- a/spec/serializers/api/v2/green_lanes/category_assessment_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/category_assessment_serializer_spec.rb
@@ -116,6 +116,21 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentSerializer do
       it { is_expected.to include 'measures' }
     end
 
+    context 'with green lanes measures' do
+      subject(:relationships) do
+        described_class.new(presented, params: { with_measures: true })
+                       .serializable_hash
+                       .as_json['data']['relationships']
+      end
+
+      before { create :green_lanes_measure, category_assessment: }
+
+      let(:category_assessment) { create :category_assessment }
+
+      it { is_expected.to include 'measures' }
+      it { expect(relationships['measures']['data'].pluck('id')).to include %r{gl\d+} }
+    end
+
     context 'without measures' do
       subject { serialized['data']['relationships'] }
 

--- a/spec/services/green_lanes/permutation_calculator_service_spec.rb
+++ b/spec/services/green_lanes/permutation_calculator_service_spec.rb
@@ -3,12 +3,17 @@ RSpec.describe GreenLanes::PermutationCalculatorService do
 
   describe '.call' do
     let(:measures) { create_list :measure, 1 }
-    let(:measure) { create :measure, :with_measure_type, :with_base_regulation }
+    let(:measure) { create :measure, :with_measure_type, :with_base_regulation, :erga_omnes }
 
     shared_examples 'two segregated lists' do
       it { is_expected.to have_attributes length: 2 }
       it { expect(permutations[0]).to eq_pk [measures[0]] }
       it { expect(permutations[1]).to eq_pk [measures[1]] }
+    end
+
+    shared_examples 'a single list' do
+      it { is_expected.to have_attributes length: 1 }
+      it { expect(permutations[0]).to eq_pk measures }
     end
 
     context 'with unrelated measures' do
@@ -33,8 +38,7 @@ RSpec.describe GreenLanes::PermutationCalculatorService do
                          geographical_area_id: measure.geographical_area_id
       end
 
-      it { is_expected.to have_attributes length: 1 }
-      it { expect(permutations[0]).to eq_pk measures }
+      it_behaves_like 'a single list'
     end
 
     context 'with mixture of related and unrelated' do
@@ -190,6 +194,14 @@ RSpec.describe GreenLanes::PermutationCalculatorService do
       end
 
       it_behaves_like 'two segregated lists'
+    end
+
+    context 'with green lanes measures' do
+      let(:measures) { [measure, gl_measure] }
+      let(:gl_measure) { create(:green_lanes_measure, category_assessment:) }
+      let(:category_assessment) { create :category_assessment, measure: }
+
+      it_behaves_like 'a single list'
     end
   end
 end


### PR DESCRIPTION
### Jira link

GL-360

### What?

I have added/removed/altered:

- [x] Integrated pseudo measures into greenlanes api output
- [x] Corrected eager loading to remove duplicated queries

### Why?

I am doing this because:

- We want to use pseudo measures to apply certain category assessments to certain goods nomenclatures in a manner not represented within the tariff

### Deployment risks (optional)

- Low, changes a private API and only impacts an epic branch for now
