### PR TITLE
GL-365: Use exempting_certificate_override table to control whether a certificate is treated as an exemption

### DIFF
--- a/app/controllers/api/admin/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/api/admin/green_lanes/category_assessments_controller.rb
@@ -3,6 +3,7 @@ module Api
     module GreenLanes
       class CategoryAssessmentsController < AdminController
         include Pageable
+        include XiOnly
 
         before_action :check_service, :authenticate_user!
 
@@ -74,12 +75,6 @@ module Api
 
         def serialize_errors(category_assessment)
           Api::Admin::ErrorSerializationService.new(category_assessment).call
-        end
-
-        def check_service
-          if TradeTariffBackend.uk?
-            raise ActionController::RoutingError, 'Invalid service'
-          end
         end
       end
     end

--- a/app/controllers/api/admin/green_lanes/exempting_certificate_overrides_controller.rb
+++ b/app/controllers/api/admin/green_lanes/exempting_certificate_overrides_controller.rb
@@ -29,20 +29,6 @@ module Api
           end
         end
 
-        def update
-          eco = ::GreenLanes::ExemptingCertificateOverride.with_pk!(params[:id])
-          eco.set eco_params
-
-          if eco.valid? && eco.save
-            render json: serialize(eco),
-                   location: api_admin_green_lanes_exempting_certificate_override_url(eco.id),
-                   status: :ok
-          else
-            render json: serialize_errors(eco),
-                   status: :unprocessable_entity
-          end
-        end
-
         def destroy
           eco = ::GreenLanes::ExemptingCertificateOverride.with_pk!(params[:id])
           eco.destroy

--- a/app/controllers/api/admin/green_lanes/exempting_certificate_overrides_controller.rb
+++ b/app/controllers/api/admin/green_lanes/exempting_certificate_overrides_controller.rb
@@ -1,0 +1,80 @@
+module Api
+  module Admin
+    module GreenLanes
+      class ExemptingCertificateOverridesController < AdminController
+        include Pageable
+        include XiOnly
+
+        before_action :check_service, :authenticate_user!
+
+        def index
+          render json: serialize(exempting_certificate_override.to_a, pagination_meta)
+        end
+
+        def show
+          eco = ::GreenLanes::ExemptingCertificateOverride.with_pk!(params[:id])
+          render json: serialize(eco)
+        end
+
+        def create
+          eco = ::GreenLanes::ExemptingCertificateOverride.new(eco_params)
+
+          if eco.valid? && eco.save
+            render json: serialize(eco),
+                   location: api_admin_green_lanes_exempting_certificate_override_url(eco.id),
+                   status: :created
+          else
+            render json: serialize_errors(eco),
+                   status: :unprocessable_entity
+          end
+        end
+
+        def update
+          eco = ::GreenLanes::ExemptingCertificateOverride.with_pk!(params[:id])
+          eco.set eco_params
+
+          if eco.valid? && eco.save
+            render json: serialize(eco),
+                   location: api_admin_green_lanes_exempting_certificate_override_url(eco.id),
+                   status: :ok
+          else
+            render json: serialize_errors(eco),
+                   status: :unprocessable_entity
+          end
+        end
+
+        def destroy
+          eco = ::GreenLanes::ExemptingCertificateOverride.with_pk!(params[:id])
+          eco.destroy
+
+          head :no_content
+        end
+
+        private
+
+        def eco_params
+          params.require(:data).require(:attributes).permit(
+            :certificate_type_code,
+            :certificate_code,
+          )
+        end
+
+        def record_count
+          @exempting_certificate_override.pagination_record_count
+        end
+
+        def exempting_certificate_override
+          @exempting_certificate_override ||= ::GreenLanes::ExemptingCertificateOverride.order(Sequel.asc(:certificate_type_code), Sequel.asc(:certificate_code)).paginate(current_page, per_page)
+        end
+
+        def serialize(*args)
+          Api::Admin::GreenLanes::ExemptingCertificateOverrideSerializer.new(*args).serializable_hash
+        end
+
+        def serialize_errors(exempting_certificate_override)
+          Api::Admin::ErrorSerializationService.new(exempting_certificate_override).call
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/green_lanes/themes_controller.rb
+++ b/app/controllers/api/admin/green_lanes/themes_controller.rb
@@ -2,6 +2,8 @@ module Api
   module Admin
     module GreenLanes
       class ThemesController < AdminController
+        include XiOnly
+
         before_action :check_service, :authenticate_user!
 
         def index
@@ -16,12 +18,6 @@ module Api
 
         def serialize(*args)
           Api::Admin::GreenLanes::ThemeSerializer.new(*args).serializable_hash
-        end
-
-        def check_service
-          if TradeTariffBackend.uk?
-            raise ActionController::RoutingError, 'Invalid service'
-          end
         end
       end
     end

--- a/app/controllers/concerns/xi_only.rb
+++ b/app/controllers/concerns/xi_only.rb
@@ -1,0 +1,11 @@
+module XiOnly
+  extend ActiveSupport::Concern
+
+  included do
+    def check_service
+      if TradeTariffBackend.uk?
+        raise ActionController::RoutingError, 'Invalid service'
+      end
+    end
+  end
+end

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -188,6 +188,10 @@ class MeasureCondition < Sequel::Model
     document_code.blank?
   end
 
+  def is_exempting_with_certificate_overridden?
+    (exemption_class? && !is_exempting_certificate_overridden?) || (!exemption_class? && is_exempting_certificate_overridden?)
+  end
+
   private
 
   def is_threshold?
@@ -216,5 +220,9 @@ class MeasureCondition < Sequel::Model
 
   def is_eps_condition?
     entry_price_system? && is_price_condition? && is_weight_condition?
+  end
+
+  def is_exempting_certificate_overridden?
+    certificate.present? && certificate.exempting_certificate_override.present?
   end
 end

--- a/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
@@ -70,7 +70,7 @@ module Api
         end
 
         def certificates
-          measure_conditions.select(&:exemption_class?).map(&:certificate)
+          measure_conditions.select(&:is_exempting_with_certificate_overridden?).map(&:certificate)
         end
 
         def additional_codes

--- a/app/serializers/api/admin/green_lanes/exempting_certificate_override_serializer.rb
+++ b/app/serializers/api/admin/green_lanes/exempting_certificate_override_serializer.rb
@@ -1,0 +1,18 @@
+module Api
+  module Admin
+    module GreenLanes
+      class ExemptingCertificateOverrideSerializer
+        include JSONAPI::Serializer
+
+        set_type :exempting_certificate_override
+
+        set_id :id
+
+        attributes :certificate_type_code,
+                   :certificate_code,
+                   :created_at,
+                   :updated_at
+      end
+    end
+  end
+end

--- a/app/services/green_lanes/fetch_goods_nomenclature_service.rb
+++ b/app/services/green_lanes/fetch_goods_nomenclature_service.rb
@@ -9,7 +9,7 @@ module GreenLanes
       geographical_area: %i[geographical_area_descriptions contained_geographical_areas],
       measure_excluded_geographical_areas: [],
       excluded_geographical_areas: :geographical_area_descriptions,
-      measure_conditions: { certificate: :certificate_descriptions },
+      measure_conditions: { certificate: %i[certificate_descriptions exempting_certificate_override] },
       category_assessment: (%i[theme base_regulation modification_regulation] +
                             [{ measure_type: :measure_type_description }]),
     }.freeze

--- a/app/services/green_lanes/permutation_calculator_service.rb
+++ b/app/services/green_lanes/permutation_calculator_service.rb
@@ -19,7 +19,7 @@ module GreenLanes
         measure.measure_excluded_geographical_areas.map(&:excluded_geographical_area).sort.uniq.join('|'),
         measure.additional_code_type_id,
         measure.additional_code_id,
-        measure.measure_conditions.select(&:exemption_class?).map(&:document_code).sort.uniq.join('|'),
+        measure.measure_conditions.select(&:is_exempting_with_certificate_overridden?).map(&:document_code).sort.uniq.join('|'),
       ]
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ Rails.application.routes.draw do
         namespace :green_lanes do
           resources :category_assessments, only: %i[index show create update destroy]
           resources :themes, only: %i[index]
+          resources :exempting_certificate_overrides, only: %i[index show create update destroy]
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,7 @@ Rails.application.routes.draw do
         namespace :green_lanes do
           resources :category_assessments, only: %i[index show create update destroy]
           resources :themes, only: %i[index]
-          resources :exempting_certificate_overrides, only: %i[index show create update destroy]
+          resources :exempting_certificate_overrides, only: %i[index show create destroy]
         end
       end
     end

--- a/spec/factories/certificate_factory.rb
+++ b/spec/factories/certificate_factory.rb
@@ -5,12 +5,21 @@ FactoryBot.define do
   factory :certificate do
     transient do
       description { Forgery(:basic).text }
+      exempting_certificate_override { false }
     end
 
     certificate_type_code { generate(:certificate_type_code) }
     certificate_code      { Forgery(:basic).text(exactly: 3) }
     validity_start_date   { 2.years.ago.beginning_of_day }
     validity_end_date     { nil }
+
+    after(:build) do |certificate, evaluator|
+      if evaluator.exempting_certificate_override
+        create(:exempting_certificate_override,
+               certificate_type_code: certificate.certificate_type_code,
+               certificate_code: certificate.certificate_code)
+      end
+    end
 
     trait :with_description do
       after(:create) do |certificate, _evaluator|

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -370,6 +370,7 @@ FactoryBot.define do
         condition_code { 'B' }
         certificate_type_code { nil }
         certificate_code { nil }
+        exempting_certificate_override { false }
       end
 
       after(:build) do |measure, evaluator|
@@ -415,6 +416,7 @@ FactoryBot.define do
             :certificate,
             certificate_type_code: evaluator.certificate_type_code,
             certificate_code: evaluator.certificate_code,
+            exempting_certificate_override: evaluator.exempting_certificate_override,
           )
         end
       end

--- a/spec/models/measure_condition_spec.rb
+++ b/spec/models/measure_condition_spec.rb
@@ -295,4 +295,40 @@ RSpec.describe MeasureCondition do
       it { expect(measure_condition.threshold_unit_type).to eq nil }
     end
   end
+
+  describe '#is_exempting_with_certificate_overridden?' do
+    context 'when the condition is exemption class and certificate has not been overridden' do
+      subject(:measure_condition) { create :measure_condition, certificate: }
+
+      let(:certificate) { create(:certificate, certificate_code: '005', certificate_type_code: 'Y') }
+
+      it { is_expected.to be_is_exempting_with_certificate_overridden }
+    end
+
+    context 'when the condition is exemption class and certificate has been overridden' do
+      subject(:measure_condition) { create :measure_condition, certificate: }
+
+      let(:certificate) { create(:certificate, certificate_code: '005', certificate_type_code: 'Y', exempting_certificate_override:) }
+      let(:exempting_certificate_override) { create :exempting_certificate_override }
+
+      it { is_expected.not_to be_is_exempting_with_certificate_overridden }
+    end
+
+    context 'when the condition is not exemption class and certificate has not been overridden' do
+      subject(:measure_condition) { create :measure_condition, certificate: }
+
+      let(:certificate) { create(:certificate, certificate_code: '005', certificate_type_code: 'C') }
+
+      it { is_expected.not_to be_is_exempting_with_certificate_overridden }
+    end
+
+    context 'when the condition is not exemption class and certificate has been overridden' do
+      subject(:measure_condition) { create :measure_condition, certificate: }
+
+      let(:certificate) { create(:certificate, certificate_code: '005', certificate_type_code: 'C', exempting_certificate_override:) }
+      let(:exempting_certificate_override) { create :exempting_certificate_override }
+
+      it { is_expected.to be_is_exempting_with_certificate_overridden }
+    end
+  end
 end

--- a/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
@@ -52,10 +52,22 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentPresenter do
       it { is_expected.to include certificate }
     end
 
+    context 'with exemption certificate and overridden' do
+      let(:certificate) { create :certificate, :exemption, exempting_certificate_override: true }
+
+      it { is_expected.not_to include certificate }
+    end
+
     context 'with license certificate' do
       let(:certificate) { create :certificate, :license }
 
       it { is_expected.not_to include certificate }
+    end
+
+    context 'with license certificate and overridden' do
+      let(:certificate) { create :certificate, :license, exempting_certificate_override: true }
+
+      it { is_expected.to include certificate }
     end
   end
 

--- a/spec/requests/api/admin/green_lanes/exempting_certificate_overrides_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/exempting_certificate_overrides_controller_spec.rb
@@ -83,45 +83,6 @@ RSpec.describe Api::Admin::GreenLanes::ExemptingCertificateOverridesController d
     end
   end
 
-  describe 'PATCH to #update' do
-    let(:id) { override.id }
-    let(:certificate_code) { '3' }
-
-    let(:make_request) do
-      authenticated_patch api_admin_green_lanes_exempting_certificate_override_path(id, format: :json), params: {
-        data: {
-          type: :exempting_certificate_override,
-          attributes: { certificate_code: },
-        },
-      }
-    end
-
-    context 'with valid params' do
-      it { is_expected.to have_http_status :success }
-      it { is_expected.to have_attributes location: api_admin_green_lanes_exempting_certificate_override_url(override.id) }
-      it { expect { page_response }.not_to change(override.reload, :certificate_code) }
-    end
-
-    context 'with invalid params' do
-      let(:certificate_code) { nil }
-
-      it { is_expected.to have_http_status :unprocessable_entity }
-
-      it 'returns errors for category assessment' do
-        expect(json_response).to include('errors')
-      end
-
-      it { expect { page_response }.not_to change(override.reload, :certificate_code) }
-    end
-
-    context 'with unknown category assessment' do
-      let(:id) { 9999 }
-
-      it { is_expected.to have_http_status :not_found }
-      it { expect { page_response }.not_to change(override.reload, :certificate_code) }
-    end
-  end
-
   describe 'DELETE to #destroy' do
     let :make_request do
       authenticated_delete api_admin_green_lanes_exempting_certificate_override_path(id, format: :json)

--- a/spec/requests/api/admin/green_lanes/exempting_certificate_overrides_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/exempting_certificate_overrides_controller_spec.rb
@@ -1,0 +1,144 @@
+RSpec.describe Api::Admin::GreenLanes::ExemptingCertificateOverridesController do
+  subject(:page_response) { make_request && response }
+
+  before do
+    allow(TradeTariffBackend).to receive(:service).and_return 'xi'
+  end
+
+  let(:json_response) { JSON.parse(page_response.body) }
+  let(:override) { create :exempting_certificate_override }
+
+  describe 'GET to #index' do
+    let(:make_request) do
+      authenticated_get api_admin_green_lanes_exempting_certificate_overrides_path(format: :json)
+    end
+
+    context 'with some overrides' do
+      before do
+        override
+      end
+
+      it { is_expected.to have_http_status :success }
+      it { expect(json_response).to include('data') }
+      it { expect(json_response).to include('meta') }
+    end
+
+    context 'without any overrides' do
+      it { is_expected.to have_http_status :success }
+      it { expect(json_response).to include('data' => []) }
+    end
+  end
+
+  describe 'GET to #show' do
+    let(:make_request) do
+      authenticated_get api_admin_green_lanes_exempting_certificate_override_path(id, format: :json)
+    end
+
+    context 'with existent override' do
+      let(:id) { override.id }
+
+      it { is_expected.to have_http_status :success }
+      it { expect(json_response).to include('data') }
+    end
+
+    context 'with non-existent overrides item' do
+      let(:id) { 1001 }
+
+      it { is_expected.to have_http_status :not_found }
+    end
+  end
+
+  describe 'POST to #create' do
+    let(:make_request) do
+      authenticated_post api_admin_green_lanes_exempting_certificate_overrides_path(format: :json), params: eco_data
+    end
+
+    let :eco_data do
+      {
+        data: {
+          type: :exempting_certificate_override,
+          attributes: eco_attrs,
+        },
+      }
+    end
+
+    context 'with valid params' do
+      let(:eco_attrs) { build(:exempting_certificate_override).to_hash }
+
+      it { is_expected.to have_http_status :created }
+      it { is_expected.to have_attributes location: api_admin_green_lanes_exempting_certificate_override_url(GreenLanes::ExemptingCertificateOverride.last.id) }
+      it { expect { page_response }.to change(GreenLanes::ExemptingCertificateOverride, :count).by(1) }
+    end
+
+    context 'with invalid params' do
+      let(:eco_attrs) { build(:exempting_certificate_override, certificate_code: nil).to_hash }
+
+      it { is_expected.to have_http_status :unprocessable_entity }
+
+      it 'returns errors for overrides' do
+        expect(json_response).to include('errors')
+      end
+
+      it { expect { page_response }.not_to change(GreenLanes::ExemptingCertificateOverride, :count) }
+    end
+  end
+
+  describe 'PATCH to #update' do
+    let(:id) { override.id }
+    let(:certificate_code) { '3' }
+
+    let(:make_request) do
+      authenticated_patch api_admin_green_lanes_exempting_certificate_override_path(id, format: :json), params: {
+        data: {
+          type: :exempting_certificate_override,
+          attributes: { certificate_code: },
+        },
+      }
+    end
+
+    context 'with valid params' do
+      it { is_expected.to have_http_status :success }
+      it { is_expected.to have_attributes location: api_admin_green_lanes_exempting_certificate_override_url(override.id) }
+      it { expect { page_response }.not_to change(override.reload, :certificate_code) }
+    end
+
+    context 'with invalid params' do
+      let(:certificate_code) { nil }
+
+      it { is_expected.to have_http_status :unprocessable_entity }
+
+      it 'returns errors for category assessment' do
+        expect(json_response).to include('errors')
+      end
+
+      it { expect { page_response }.not_to change(override.reload, :certificate_code) }
+    end
+
+    context 'with unknown category assessment' do
+      let(:id) { 9999 }
+
+      it { is_expected.to have_http_status :not_found }
+      it { expect { page_response }.not_to change(override.reload, :certificate_code) }
+    end
+  end
+
+  describe 'DELETE to #destroy' do
+    let :make_request do
+      authenticated_delete api_admin_green_lanes_exempting_certificate_override_path(id, format: :json)
+    end
+
+    context 'with known category assessment' do
+      let(:id) { override.id }
+
+      it { is_expected.to have_http_status :no_content }
+      it { expect { page_response }.to change(override, :exists?) }
+    end
+
+    context 'with unknown category assessment' do
+      let(:id) { 9999 }
+
+      it { is_expected.to have_http_status :not_found }
+      it { expect { page_response }.not_to change(GreenLanes::ExemptingCertificateOverride, :count) }
+    end
+  end
+end

--- a/spec/services/green_lanes/permutation_calculator_service_spec.rb
+++ b/spec/services/green_lanes/permutation_calculator_service_spec.rb
@@ -92,6 +92,24 @@ RSpec.describe GreenLanes::PermutationCalculatorService do
       it_behaves_like 'two segregated lists'
     end
 
+    context 'with different exemption certificates and certificate is overridden' do
+      let :measures do
+        [
+          measure,
+          create(:measure, :with_measure_conditions,
+                 generating_regulation: measure.generating_regulation,
+                 measure_type_id: measure.measure_type_id,
+                 geographical_area_id: measure.geographical_area_id,
+                 certificate_type_code: 'Y',
+                 certificate_code: '123',
+                 exempting_certificate_override: true),
+        ]
+      end
+
+      it { is_expected.to have_attributes length: 1 }
+      it { expect(permutations[0]).to eq_pk measures }
+    end
+
     context 'with non exemption certificates' do
       let :measures do
         [
@@ -107,6 +125,23 @@ RSpec.describe GreenLanes::PermutationCalculatorService do
 
       it { is_expected.to have_attributes length: 1 }
       it { expect(permutations[0]).to eq_pk measures }
+    end
+
+    context 'with non exemption certificates and certificate is overridden' do
+      let :measures do
+        [
+          measure,
+          create(:measure, :with_measure_conditions,
+                 generating_regulation: measure.generating_regulation,
+                 measure_type_id: measure.measure_type_id,
+                 geographical_area_id: measure.geographical_area_id,
+                 certificate_type_code: 'L',
+                 certificate_code: '123',
+                 exempting_certificate_override: true),
+        ]
+      end
+
+      it_behaves_like 'two segregated lists'
     end
 
     context 'with different geographical area' do


### PR DESCRIPTION
### Jira link

[GL-365](https://transformuk.atlassian.net/browse/GL-365)

### What?

I have added/removed/altered:

- [ ] Changed GL permutation calculator to check exempting_certificate_override table to detemine if certificate is an exemption
- [ ] Changed GL Category Assessment presenter to check exempting_certificate_override to load exemption certificates

### Why?

I am doing this because:

- We want to override the default exemption behaviour of certificates.

