### PR TITLE
GL-361: Add admin API to list out pseudo measures

### DIFF
--- a/app/controllers/api/admin/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/api/admin/green_lanes/category_assessments_controller.rb
@@ -12,8 +12,12 @@ module Api
         end
 
         def show
+          options = { is_collection: false }
+          options[:include] = %i[green_lanes_measures green_lanes_measures.goods_nomenclature exemptions]
+          options[:params] = { with_measures: true, with_exemptions: true }
           ca = ::GreenLanes::CategoryAssessment.with_pk!(params[:id])
-          render json: serialize(ca)
+
+          render json: serialize(ca, options)
         end
 
         def create

--- a/app/controllers/api/admin/green_lanes/exemptions_controller.rb
+++ b/app/controllers/api/admin/green_lanes/exemptions_controller.rb
@@ -2,12 +2,13 @@ module Api
   module Admin
     module GreenLanes
       class ExemptionsController < AdminController
+        include Pageable
         include XiOnly
 
         before_action :check_service, :authenticate_user!
 
         def index
-          render json: serialize(exemptions.to_a)
+          render json: serialize(exemptions.to_a, pagination_meta)
         end
 
         def show
@@ -58,8 +59,12 @@ module Api
           )
         end
 
+        def record_count
+          @exemptions.pagination_record_count
+        end
+
         def exemptions
-          @exemptions ||= ::GreenLanes::Exemption.order(Sequel.asc(:code))
+          @exemptions ||= ::GreenLanes::Exemption.order(Sequel.asc(:code)).paginate(current_page, per_page)
         end
 
         def serialize(*args)

--- a/app/controllers/api/admin/green_lanes/measures_controller.rb
+++ b/app/controllers/api/admin/green_lanes/measures_controller.rb
@@ -1,0 +1,25 @@
+module Api
+  module Admin
+    module GreenLanes
+      class MeasuresController < AdminController
+        include XiOnly
+
+        before_action :check_service, :authenticate_user!
+
+        def index
+          render json: serialize(measures.to_a)
+        end
+
+        private
+
+        def measures
+          @measures ||= ::GreenLanes::Measure.order(Sequel.asc(:id))
+        end
+
+        def serialize(*args)
+          Api::Admin::GreenLanes::MeasureSerializer.new(*args).serializable_hash
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/green_lanes/measures_controller.rb
+++ b/app/controllers/api/admin/green_lanes/measures_controller.rb
@@ -4,16 +4,23 @@ module Api
       class MeasuresController < AdminController
         include XiOnly
 
+        MEASURE_EAGER_GRAPH = {
+          category_assessment: :theme,
+          goods_nomenclature: :goods_nomenclature_descriptions,
+        }.freeze
+
         before_action :check_service, :authenticate_user!
 
         def index
-          render json: serialize(measures.to_a)
+          options = { is_collection: true }
+          options[:include] = %i[category_assessment category_assessment.theme goods_nomenclature]
+          render json: serialize(measures.to_a, options)
         end
 
         private
 
         def measures
-          @measures ||= ::GreenLanes::Measure.order(Sequel.asc(:id))
+          @measures ||= ::GreenLanes::Measure.eager(MEASURE_EAGER_GRAPH).all
         end
 
         def serialize(*args)

--- a/app/controllers/api/admin/green_lanes/measures_controller.rb
+++ b/app/controllers/api/admin/green_lanes/measures_controller.rb
@@ -2,6 +2,7 @@ module Api
   module Admin
     module GreenLanes
       class MeasuresController < AdminController
+        include Pageable
         include XiOnly
 
         MEASURE_EAGER_GRAPH = {
@@ -14,17 +15,32 @@ module Api
         def index
           options = { is_collection: true }
           options[:include] = %i[category_assessment category_assessment.theme goods_nomenclature]
+          options[:meta] = pagination_meta(measures)
           render json: serialize(measures.to_a, options)
         end
 
         private
 
         def measures
-          @measures ||= ::GreenLanes::Measure.eager(MEASURE_EAGER_GRAPH).all
+          @measures ||= ::GreenLanes::Measure.eager(MEASURE_EAGER_GRAPH).order.paginate(current_page, per_page)
+        end
+
+        def record_count
+          @measures.pagination_record_count
         end
 
         def serialize(*args)
           Api::Admin::GreenLanes::MeasureSerializer.new(*args).serializable_hash
+        end
+
+        def pagination_meta(data_set)
+          {
+            pagination: {
+              page: current_page,
+              per_page:,
+              total_count: data_set.pagination_record_count,
+            },
+          }
         end
       end
     end

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -3,6 +3,7 @@ module GreenLanes
     plugin :timestamps, update_on_create: true
     plugin :auto_validations, not_null: :presence
     plugin :association_pks
+    plugin :association_dependencies
 
     many_to_one :theme
     many_to_one :measure_type, class: :MeasureType
@@ -21,7 +22,10 @@ module GreenLanes
     end
 
     one_to_many :green_lanes_measures, class: 'Measure', class_namespace: 'GreenLanes'
+    add_association_dependencies green_lanes_measures: :delete
+
     many_to_many :exemptions, join_table: :green_lanes_category_assessments_exemptions
+    add_association_dependencies exemptions: :nullify
 
     def validate
       super

--- a/app/models/green_lanes/measure.rb
+++ b/app/models/green_lanes/measure.rb
@@ -7,8 +7,6 @@ module GreenLanes
     many_to_one :goods_nomenclature, class: 'GoodsNomenclature',
                                      primary_key: %i[goods_nomenclature_item_id producline_suffix],
                                      key: %i[goods_nomenclature_item_id productline_suffix]
-    def goods_nomenclature_id
-      goods_nomenclature_item_id
-    end
+    delegate :goods_nomenclature_sid, to: :goods_nomenclature
   end
 end

--- a/app/models/green_lanes/measure.rb
+++ b/app/models/green_lanes/measure.rb
@@ -7,5 +7,8 @@ module GreenLanes
     many_to_one :goods_nomenclature, class: 'GoodsNomenclature',
                                      primary_key: %i[goods_nomenclature_item_id producline_suffix],
                                      key: %i[goods_nomenclature_item_id productline_suffix]
+    def goods_nomenclature_id
+      goods_nomenclature_item_id
+    end
   end
 end

--- a/app/serializers/api/admin/green_lanes/category_assessment_serializer.rb
+++ b/app/serializers/api/admin/green_lanes/category_assessment_serializer.rb
@@ -10,7 +10,8 @@ module Api
 
         attributes :measure_type_id,
                    :regulation_id,
-                   :regulation_role
+                   :regulation_role,
+                   :theme_id
 
         has_one :theme, serializer: ThemeSerializer
       end

--- a/app/serializers/api/admin/green_lanes/category_assessment_serializer.rb
+++ b/app/serializers/api/admin/green_lanes/category_assessment_serializer.rb
@@ -10,8 +10,7 @@ module Api
 
         attributes :measure_type_id,
                    :regulation_id,
-                   :regulation_role,
-                   :theme_id
+                   :regulation_role
 
         has_one :theme, serializer: ThemeSerializer
       end

--- a/app/serializers/api/admin/green_lanes/category_assessment_serializer.rb
+++ b/app/serializers/api/admin/green_lanes/category_assessment_serializer.rb
@@ -14,6 +14,8 @@ module Api
                    :theme_id
 
         has_one :theme, serializer: ThemeSerializer
+        has_many :green_lanes_measures, serializer: MeasureSerializer, if: ->(_record, params) { params[:with_measures] }, id_method_name: :green_lanes_measure_pks
+        has_many :exemptions, serializer: ExemptionSerializer, if: ->(_record, params) { params[:with_exemptions] }, id_method_name: :exemption_pks
       end
     end
   end

--- a/app/serializers/api/admin/green_lanes/category_assessment_serializer.rb
+++ b/app/serializers/api/admin/green_lanes/category_assessment_serializer.rb
@@ -11,9 +11,9 @@ module Api
         attributes :measure_type_id,
                    :regulation_id,
                    :regulation_role,
-                   :theme_id,
-                   :created_at,
-                   :updated_at
+                   :theme_id
+
+        has_one :theme, serializer: ThemeSerializer
       end
     end
   end

--- a/app/serializers/api/admin/green_lanes/goods_nomenclature_serializer.rb
+++ b/app/serializers/api/admin/green_lanes/goods_nomenclature_serializer.rb
@@ -1,0 +1,16 @@
+module Api
+  module Admin
+    module GreenLanes
+      class GoodsNomenclatureSerializer
+        include JSONAPI::Serializer
+
+        set_type :green_lanes_goods_nomenclature
+
+        set_id :goods_nomenclature_item_id
+
+        attributes :description, :goods_nomenclature_item_id
+
+      end
+    end
+  end
+end

--- a/app/serializers/api/admin/green_lanes/goods_nomenclature_serializer.rb
+++ b/app/serializers/api/admin/green_lanes/goods_nomenclature_serializer.rb
@@ -6,9 +6,9 @@ module Api
 
         set_type :green_lanes_goods_nomenclature
 
-        set_id :goods_nomenclature_item_id
+        set_id :goods_nomenclature_sid
 
-        attributes :description, :goods_nomenclature_item_id
+        attributes :description, :goods_nomenclature_sid
       end
     end
   end

--- a/app/serializers/api/admin/green_lanes/goods_nomenclature_serializer.rb
+++ b/app/serializers/api/admin/green_lanes/goods_nomenclature_serializer.rb
@@ -8,7 +8,7 @@ module Api
 
         set_id :goods_nomenclature_sid
 
-        attributes :description, :goods_nomenclature_sid
+        attributes :description, :goods_nomenclature_sid, :goods_nomenclature_item_id
       end
     end
   end

--- a/app/serializers/api/admin/green_lanes/goods_nomenclature_serializer.rb
+++ b/app/serializers/api/admin/green_lanes/goods_nomenclature_serializer.rb
@@ -9,7 +9,6 @@ module Api
         set_id :goods_nomenclature_item_id
 
         attributes :description, :goods_nomenclature_item_id
-
       end
     end
   end

--- a/app/serializers/api/admin/green_lanes/measure_serializer.rb
+++ b/app/serializers/api/admin/green_lanes/measure_serializer.rb
@@ -11,7 +11,7 @@ module Api
         attribute :productline_suffix
 
         has_one :category_assessment, serializer: CategoryAssessmentSerializer
-        has_one :goods_nomenclature, serializer: GoodsNomenclatureSerializer
+        has_one :goods_nomenclature, serializer: GoodsNomenclatureSerializer, id_method_name: :goods_nomenclature_sid
       end
     end
   end

--- a/app/serializers/api/admin/green_lanes/measure_serializer.rb
+++ b/app/serializers/api/admin/green_lanes/measure_serializer.rb
@@ -1,0 +1,18 @@
+module Api
+  module Admin
+    module GreenLanes
+      class MeasureSerializer
+        include JSONAPI::Serializer
+
+        set_type :green_lanes_measure
+
+        set_id :id
+
+        attribute :productline_suffix
+
+        has_one :category_assessment, serializer: CategoryAssessmentSerializer
+        has_one :goods_nomenclature, serializer: GoodsNomenclatureSerializer
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,7 @@ Rails.application.routes.draw do
           resources :themes, only: %i[index]
           resources :exempting_certificate_overrides, only: %i[index show create destroy]
           resources :exemptions, only: %i[index show create update destroy]
+          resources :measures, only: %i[index]
         end
       end
     end

--- a/spec/factories/green_lanes/category_assessment_factory.rb
+++ b/spec/factories/green_lanes/category_assessment_factory.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     transient do
       measures_count { 1 }
       measure { nil }
+      green_lanes_measures { [] }
       exemptions { [] }
     end
 
@@ -10,6 +11,7 @@ FactoryBot.define do
     measure_type { measure&.measure_type || create(:measure_type) }
     theme { create :green_lanes_theme }
     exemption_pks { exemptions.map(&:pk) }
+    green_lanes_measure_pks { green_lanes_measures.map(&:pk) }
 
     trait :category1 do
       theme { create :green_lanes_theme, :category1 }
@@ -33,6 +35,14 @@ FactoryBot.define do
 
     trait :without_regulation do
       regulation { nil }
+    end
+
+    trait :with_green_lanes_measure do
+      green_lanes_measures { create_list :green_lanes_measure, 2 }
+    end
+
+    trait :with_exemption do
+      exemptions { create_list :green_lanes_exemption, 2 }
     end
   end
 end

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe GreenLanes::CategoryAssessment do
     it { is_expected.to respond_to :theme_id }
     it { is_expected.to respond_to :created_at }
     it { is_expected.to respond_to :updated_at }
+    it { is_expected.to respond_to :green_lanes_measure_pks }
+    it { is_expected.to respond_to :exemption_pks }
   end
 
   describe 'validations' do
@@ -154,7 +156,7 @@ RSpec.describe GreenLanes::CategoryAssessment do
       subject { assessment.green_lanes_measures }
 
       let :assessment do
-        create(:category_assessment).tap do |ca|
+        create(:category_assessment, :with_green_lanes_measure).tap do |ca|
           create :green_lanes_measure, category_assessment_id: ca.id
         end
       end

--- a/spec/models/green_lanes/measure_spec.rb
+++ b/spec/models/green_lanes/measure_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe GreenLanes::Measure do
     it { is_expected.to respond_to :productline_suffix }
     it { is_expected.to respond_to :created_at }
     it { is_expected.to respond_to :updated_at }
+    it { is_expected.to respond_to :goods_nomenclature_sid }
   end
 
   describe 'validations' do

--- a/spec/requests/api/admin/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/category_assessments_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentsController do
   end
 
   let(:json_response) { JSON.parse(page_response.body) }
-  let(:category) { create :category_assessment }
+  let(:category) { create :category_assessment, :with_green_lanes_measure, :with_exemption }
 
   describe 'GET to #index' do
     let(:make_request) do
@@ -39,6 +39,12 @@ RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentsController do
 
       it { is_expected.to have_http_status :success }
       it { expect(json_response).to include('data') }
+
+      it 'only contains green_lanes_measure or green_lanes_exemption types' do
+        json_response['included'].each do |json_object|
+          expect(json_object['type']).to(satisfy { |type| %w[green_lanes_measure green_lanes_exemption green_lanes_goods_nomenclature].include?(type) })
+        end
+      end
     end
 
     context 'with non-existent category assessments item' do

--- a/spec/requests/api/admin/green_lanes/measurers_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/measurers_controller_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe Api::Admin::GreenLanes::MeasuresController do
+  subject(:page_response) { make_request && response }
+
+  before do
+    allow(TradeTariffBackend).to receive(:service).and_return 'xi'
+  end
+
+  let(:json_response) { JSON.parse(page_response.body) }
+  let(:measure) { create :green_lanes_measure }
+
+  describe 'GET to #index' do
+    let(:make_request) do
+      authenticated_get api_admin_green_lanes_measures_path(format: :json)
+    end
+
+    context 'with some measures' do
+      before { measure }
+
+      it { is_expected.to have_http_status :success }
+      it { expect(json_response).to include('data') }
+      it { expect(json_response['data'].first['type']).to include('green_lanes_measure') }
+    end
+
+    context 'without any measures' do
+      it { is_expected.to have_http_status :success }
+      it { expect(json_response).to include('data' => []) }
+    end
+  end
+end

--- a/spec/serializers/api/admin/green_lanes/category_assessment_serializer_spec.rb
+++ b/spec/serializers/api/admin/green_lanes/category_assessment_serializer_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentSerializer do
           measure_type_id: category.measure_type_id,
           regulation_id: category.regulation_id,
           regulation_role: category.regulation_role,
-          theme_id: category.theme_id,
         },
         relationships: {
           theme: {

--- a/spec/serializers/api/admin/green_lanes/category_assessment_serializer_spec.rb
+++ b/spec/serializers/api/admin/green_lanes/category_assessment_serializer_spec.rb
@@ -1,7 +1,5 @@
 RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentSerializer do
-  subject(:serialized) do
-    described_class.new(category).serializable_hash
-  end
+  subject { described_class.new(category).serializable_hash.as_json }
 
   let(:category) { create :category_assessment }
 
@@ -9,22 +7,21 @@ RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentSerializer do
     {
       data: {
         id: category.id.to_s,
-        type: :category_assessment,
+        type: 'category_assessment',
         attributes: {
           measure_type_id: category.measure_type_id,
           regulation_id: category.regulation_id,
           regulation_role: category.regulation_role,
           theme_id: category.theme_id,
-          created_at: category.created_at,
-          updated_at: category.updated_at,
+        },
+        relationships: {
+          theme: {
+            data: { id: category.theme_id.to_s, type: 'theme' },
+          },
         },
       },
     }
   end
 
-  describe '#serializable_hash' do
-    it 'matches the expected hash' do
-      expect(serialized).to eq(expected)
-    end
-  end
+  it { is_expected.to include_json(expected) }
 end

--- a/spec/serializers/api/admin/green_lanes/category_assessment_serializer_spec.rb
+++ b/spec/serializers/api/admin/green_lanes/category_assessment_serializer_spec.rb
@@ -1,7 +1,11 @@
 RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentSerializer do
-  subject { described_class.new(category).serializable_hash.as_json }
+  subject do
+    described_class.new(category,
+                        params: { with_measures: true, with_exemptions: true },
+                        include: %w[green_lanes_measures exemptions]).serializable_hash.as_json
+  end
 
-  let(:category) { create :category_assessment }
+  let(:category) { create :category_assessment, :with_green_lanes_measure, :with_exemption }
 
   let :expected do
     {
@@ -16,6 +20,18 @@ RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentSerializer do
         relationships: {
           theme: {
             data: { id: category.theme_id.to_s, type: 'theme' },
+          },
+          green_lanes_measures: {
+            data: [
+              { id: /\A\d+\z/, type: 'green_lanes_measure' },
+              { id: /\A\d+\z/, type: 'green_lanes_measure' },
+            ],
+          },
+          exemptions: {
+            data: [
+              { id: /\A\d+\z/, type: 'green_lanes_exemption' },
+              { id: /\A\d+\z/, type: 'green_lanes_exemption' },
+            ],
           },
         },
       },

--- a/spec/serializers/api/admin/green_lanes/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/api/admin/green_lanes/goods_nomenclature_serializer_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Api::Admin::GreenLanes::GoodsNomenclatureSerializer do
   let(:expected) do
     {
       data: {
-        id: serializable.goods_nomenclature_item_id,
+        id: serializable.goods_nomenclature_sid.to_s,
         type: :green_lanes_goods_nomenclature,
         attributes: {
           description: serializable.description,
-          goods_nomenclature_item_id: serializable.goods_nomenclature_item_id,
+          goods_nomenclature_sid: serializable.goods_nomenclature_sid,
         },
       },
     }

--- a/spec/serializers/api/admin/green_lanes/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/api/admin/green_lanes/goods_nomenclature_serializer_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Api::Admin::GreenLanes::GoodsNomenclatureSerializer do
         attributes: {
           description: serializable.description,
           goods_nomenclature_sid: serializable.goods_nomenclature_sid,
+          goods_nomenclature_item_id: serializable.goods_nomenclature_item_id,
         },
       },
     }

--- a/spec/serializers/api/admin/green_lanes/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/api/admin/green_lanes/goods_nomenclature_serializer_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe Api::Admin::GreenLanes::GoodsNomenclatureSerializer do
+  subject(:serialized) { described_class.new(serializable).serializable_hash }
+
+  let(:serializable) { create(:commodity) }
+
+  let(:expected) do
+    {
+      data: {
+        id: serializable.goods_nomenclature_item_id,
+        type: :green_lanes_goods_nomenclature,
+        attributes: {
+          description: serializable.description,
+          goods_nomenclature_item_id: serializable.goods_nomenclature_item_id,
+        },
+      },
+    }
+  end
+
+  describe '#serializable_hash' do
+    it { expect(serialized).to eq(expected) }
+  end
+end

--- a/spec/serializers/api/admin/green_lanes/measure_serializer_spec.rb
+++ b/spec/serializers/api/admin/green_lanes/measure_serializer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Api::Admin::GreenLanes::MeasureSerializer do
             data: { id: measure.category_assessment.id.to_s, type: 'category_assessment' },
           },
           goods_nomenclature: {
-            data: { id: measure.goods_nomenclature.goods_nomenclature_item_id.to_s, type: 'green_lanes_goods_nomenclature' },
+            data: { id: measure.goods_nomenclature.goods_nomenclature_sid.to_s, type: 'green_lanes_goods_nomenclature' },
           },
         },
       },

--- a/spec/serializers/api/admin/green_lanes/measure_serializer_spec.rb
+++ b/spec/serializers/api/admin/green_lanes/measure_serializer_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe Api::Admin::GreenLanes::MeasureSerializer do
+  subject { described_class.new(measure).serializable_hash.as_json }
+
+  let(:measure) { create :green_lanes_measure }
+
+  let :expected_pattern do
+    {
+      data: {
+        id: measure.id.to_s,
+        type: 'green_lanes_measure',
+        attributes: {
+          productline_suffix: measure.productline_suffix,
+        },
+        relationships: {
+          category_assessment: {
+            data: { id: measure.category_assessment.id.to_s, type: 'category_assessment' },
+          },
+          goods_nomenclature: {
+            data: { id: measure.goods_nomenclature.goods_nomenclature_item_id.to_s, type: 'green_lanes_goods_nomenclature' },
+          },
+        },
+      },
+    }
+  end
+
+  it { is_expected.to include_json(expected_pattern) }
+end


### PR DESCRIPTION
### Jira link

[GL-361](https://transformuk.atlassian.net/browse/GL-361)

### What?

I have added/removed/altered:

- [ ] Added admin api endpoint to list green lanes measurs
- [ ] Updated admin category_assessment api response to include them information

### Why?

I am doing this because:

- User should be able to manage measures in admin UI