### PR TITLE
GL-356 pseudo measures epic

### DIFF
--- a/app/controllers/api/v2/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/api/v2/green_lanes/category_assessments_controller.rb
@@ -28,6 +28,7 @@ module Api
               .new(presented_assessments,
                    include: %w[geographical_area
                                excluded_geographical_areas
+                               exemptions
                                theme
                                regulation
                                measure_type])

--- a/app/controllers/api/v2/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/api/v2/green_lanes/category_assessments_controller.rb
@@ -9,7 +9,7 @@ module Api
                 theme: [],
                 base_regulation: [],
                 modification_regulation: [],
-                measure_type: :measure_type_description,
+                measure_type: %i[measure_type_description measure_type_series_description],
                 measures: {
                   additional_code: :additional_code_descriptions,
                   measure_conditions: { certificate: :certificate_descriptions },
@@ -17,6 +17,8 @@ module Api
                   measure_excluded_geographical_areas: [],
                   excluded_geographical_areas: :geographical_area_descriptions,
                 },
+                green_lanes_measures: [],
+                exemptions: [],
               )
               .all
 

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -120,6 +120,11 @@ class GoodsNomenclature < Sequel::Model
                           foreign_key: :goods_nomenclature_sid,
                           order: Sequel.desc(:created_at)
 
+  one_to_many :green_lanes_measures, class: 'Measure',
+                                     class_namespace: 'GreenLanes',
+                                     key: %i[goods_nomenclature_item_id productline_suffix],
+                                     primary_key: %i[goods_nomenclature_item_id producline_suffix]
+
   dataset_module do
     def non_hidden
       filter(Sequel.~(goods_nomenclatures__goods_nomenclature_item_id: HiddenGoodsNomenclature.codes))

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -2,6 +2,7 @@ module GreenLanes
   class CategoryAssessment < Sequel::Model(:green_lanes_category_assessments)
     plugin :timestamps, update_on_create: true
     plugin :auto_validations, not_null: :presence
+    plugin :association_pks
 
     many_to_one :theme
     many_to_one :measure_type, class: :MeasureType
@@ -15,9 +16,12 @@ module GreenLanes
                            key: %i[measure_type_id
                                    measure_generating_regulation_id
                                    measure_generating_regulation_role] do |ds|
-      ds.with_actual(Measure)
+      ds.with_actual(::Measure)
         .with_regulation_dates_query
     end
+
+    one_to_many :green_lanes_measures, class: 'Measure', class_namespace: 'GreenLanes'
+    many_to_many :exemptions, join_table: :green_lanes_category_assessments_exemptions
 
     def validate
       super
@@ -37,7 +41,7 @@ module GreenLanes
     def regulation
       case regulation_role
       when nil then nil
-      when Measure::MODIFICATION_REGULATION_ROLE then modification_regulation
+      when ::Measure::MODIFICATION_REGULATION_ROLE then modification_regulation
       else base_regulation
       end
     end

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -58,5 +58,9 @@ module GreenLanes
         self.base_regulation = regulation
       end
     end
+
+    def combined_measures
+      measures + green_lanes_measures
+    end
   end
 end

--- a/app/models/green_lanes/exemption.rb
+++ b/app/models/green_lanes/exemption.rb
@@ -1,0 +1,10 @@
+module GreenLanes
+  class Exemption < Sequel::Model(:green_lanes_exemptions)
+    plugin :timestamps, update_on_create: true
+    plugin :auto_validations, not_null: :presence
+    plugin :association_pks
+
+    many_to_many :category_assessments,
+                 join_table: :green_lanes_category_assessments_exemptions
+  end
+end

--- a/app/models/green_lanes/measure.rb
+++ b/app/models/green_lanes/measure.rb
@@ -1,0 +1,11 @@
+module GreenLanes
+  class Measure < Sequel::Model(:green_lanes_measures)
+    plugin :timestamps, update_on_create: true
+    plugin :auto_validations, not_null: :presence
+
+    many_to_one :category_assessment
+    many_to_one :goods_nomenclature, class: 'GoodsNomenclature',
+                                     primary_key: %i[goods_nomenclature_item_id producline_suffix],
+                                     key: %i[goods_nomenclature_item_id productline_suffix]
+  end
+end

--- a/app/models/green_lanes/measure.rb
+++ b/app/models/green_lanes/measure.rb
@@ -7,5 +7,73 @@ module GreenLanes
     many_to_one :goods_nomenclature, class: 'GoodsNomenclature',
                                      primary_key: %i[goods_nomenclature_item_id producline_suffix],
                                      key: %i[goods_nomenclature_item_id productline_suffix]
+
+    many_to_one :geographical_area, class: 'GeographicalArea',
+                                    primary_key: :geographical_area_id,
+                                    key: :geographical_area_id do |ds|
+      ds.with_actual(::GeographicalArea)
+    end
+
+    delegate :measure_type_id, :measure_type, to: :category_assessment
+
+    alias_method :effective_start_date, :created_at
+
+    # simulate the filtering interface on tariff measures
+    # true because GL measures always apply to all regions
+    def relevant_for_country?(_geographical_area_id)
+      true
+    end
+
+    def measure_generating_regulation_id
+      category_assessment.regulation_id
+    end
+
+    def measure_generating_regulation_role
+      category_assessment.regulation_role
+    end
+
+    def generating_regulation
+      category_assessment.regulation
+    end
+
+    def geographical_area_id
+      GeographicalArea::ERGA_OMNES_ID
+    end
+
+    def measure_excluded_geographical_areas
+      []
+    end
+
+    def excluded_geographical_areas
+      []
+    end
+
+    def additional_code_type_id
+      nil
+    end
+
+    def additional_code_id
+      nil
+    end
+
+    def additional_code
+      nil
+    end
+
+    def measure_conditions
+      []
+    end
+
+    def footnotes
+      []
+    end
+
+    def measure_sid
+      @measure_sid ||= sprintf('gl%06d', id)
+    end
+
+    def effective_end_date
+      nil
+    end
   end
 end

--- a/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
@@ -66,7 +66,7 @@ module Api
         end
 
         def exemptions
-          certificates + additional_codes
+          @exemptions ||= (certificates + additional_codes + pseudo_exemptions)
         end
 
         def certificates
@@ -75,6 +75,10 @@ module Api
 
         def additional_codes
           Array.wrap(additional_code)
+        end
+
+        def pseudo_exemptions
+          ExemptionPresenter.wrap(@category_assessment.exemptions)
         end
 
         def regulation

--- a/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
@@ -37,7 +37,7 @@ module Api
 
           def permutations(assessment)
             ::GreenLanes::PermutationCalculatorService
-              .new(assessment.measures)
+              .new(assessment.combined_measures)
               .call
           end
         end

--- a/app/presenters/api/v2/green_lanes/exemption_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/exemption_presenter.rb
@@ -1,0 +1,15 @@
+module Api
+  module V2
+    module GreenLanes
+      class ExemptionPresenter < WrapDelegator
+        def id
+          code
+        end
+
+        def formatted_description
+          description
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/api/v2/green_lanes/goods_nomenclature_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/goods_nomenclature_presenter.rb
@@ -20,7 +20,7 @@ module Api
         def applicable_category_assessments
           @applicable_category_assessments ||=
             ::GreenLanes::FindCategoryAssessmentsService.call \
-              applicable_measures,
+              combined_applicable_measures,
               @geographical_area_id
         end
 
@@ -31,7 +31,7 @@ module Api
         def descendant_category_assessments
           @descendant_category_assessments ||=
             ::GreenLanes::FindCategoryAssessmentsService.call \
-              all_descendant_measures,
+              combined_descendant_measures,
               @geographical_area_id
         end
 
@@ -72,8 +72,15 @@ module Api
           end
         end
 
-        def all_descendant_measures
-          descendants.flat_map(&:measures)
+        def combined_descendant_measures
+          descendants.flat_map(&:measures) +
+            descendants.flat_map(&:green_lanes_measures)
+        end
+
+        def combined_applicable_measures
+          applicable_measures +
+            green_lanes_measures +
+            ancestors.flat_map(&:green_lanes_measures)
         end
       end
     end

--- a/app/serializers/api/v2/green_lanes/category_assessment_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/category_assessment_serializer.rb
@@ -5,7 +5,6 @@ module Api
         include JSONAPI::Serializer
 
         set_type :category_assessment
-
         set_id :id
 
         has_many :exemptions, serializer: lambda { |record, _params|
@@ -14,6 +13,8 @@ module Api
             GreenLanes::CertificateSerializer
           when AdditionalCode
             AdditionalCodeSerializer
+          when ExemptionPresenter
+            GreenLanes::ExemptionSerializer
           else
             raise 'Unknown type'
           end

--- a/app/serializers/api/v2/green_lanes/category_assessment_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/category_assessment_serializer.rb
@@ -7,6 +7,8 @@ module Api
         set_type :category_assessment
         set_id :id
 
+        attribute :category_assessment_id if Rails.env.development?
+
         has_many :exemptions, serializer: lambda { |record, _params|
           case record
           when Certificate

--- a/app/serializers/api/v2/green_lanes/exemption_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/exemption_serializer.rb
@@ -1,0 +1,15 @@
+module Api
+  module V2
+    module GreenLanes
+      class ExemptionSerializer
+        include JSONAPI::Serializer
+
+        set_id :code
+
+        attributes :code,
+                   :description,
+                   :formatted_description
+      end
+    end
+  end
+end

--- a/app/services/green_lanes/fetch_goods_nomenclature_service.rb
+++ b/app/services/green_lanes/fetch_goods_nomenclature_service.rb
@@ -2,30 +2,32 @@ module GreenLanes
   class FetchGoodsNomenclatureService
     ITEM_ID_LENGTH = 10
 
-    MEASURES_EAGER = {
-      additional_code: :additional_code_descriptions,
-      goods_nomenclature: %i[goods_nomenclature_indents goods_nomenclature_descriptions],
-      footnotes: :footnote_descriptions,
-      geographical_area: %i[geographical_area_descriptions contained_geographical_areas],
-      measure_excluded_geographical_areas: [],
-      excluded_geographical_areas: :geographical_area_descriptions,
-      measure_conditions: { certificate: %i[certificate_descriptions exempting_certificate_override] },
-      category_assessment: (%i[theme base_regulation modification_regulation] +
-                            [{ measure_type: :measure_type_description }]),
+    ASSESSMENT_EAGER = [
+      :theme,
+      :base_regulation,
+      :modification_regulation,
+      :exemptions,
+      { measure_type: %i[measure_type_description measure_type_series_description] },
+    ].freeze
+
+    GN_EAGER_LOAD = {
+      measures: {
+        additional_code: :additional_code_descriptions,
+        footnotes: :footnote_descriptions,
+        geographical_area: %i[geographical_area_descriptions contained_geographical_areas],
+        measure_excluded_geographical_areas: [],
+        excluded_geographical_areas: :geographical_area_descriptions,
+        measure_conditions: { certificate: %i[certificate_descriptions exempting_certificate_override] },
+        category_assessment: ASSESSMENT_EAGER,
+      },
+      green_lanes_measures: { category_assessment: ASSESSMENT_EAGER },
+      goods_nomenclature_descriptions: [],
     }.freeze
 
     EAGER_LOAD = {
-      ancestors: {
-        measures: MEASURES_EAGER,
-        goods_nomenclature_descriptions: [],
-      },
-      descendants: {
-        measures: MEASURES_EAGER,
-        goods_nomenclature_descriptions: [],
-      },
-      measures: MEASURES_EAGER,
-      goods_nomenclature_descriptions: [],
-    }.freeze
+      ancestors: GN_EAGER_LOAD,
+      descendants: GN_EAGER_LOAD,
+    }.merge(GN_EAGER_LOAD).freeze
 
     def initialize(goods_nomenclature_item_id)
       @goods_nomenclature_item_id = goods_nomenclature_item_id

--- a/spec/factories/green_lanes/category_assessment_factory.rb
+++ b/spec/factories/green_lanes/category_assessment_factory.rb
@@ -3,11 +3,13 @@ FactoryBot.define do
     transient do
       measures_count { 1 }
       measure { nil }
+      exemptions { [] }
     end
 
     regulation { measure&.generating_regulation || create(:base_regulation) }
     measure_type { measure&.measure_type || create(:measure_type) }
     theme { create :green_lanes_theme }
+    exemption_pks { exemptions.map(&:pk) }
 
     trait :category1 do
       theme { create :green_lanes_theme, :category1 }

--- a/spec/factories/green_lanes/exemption_factory.rb
+++ b/spec/factories/green_lanes/exemption_factory.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :green_lanes_exemption, class: 'GreenLanes::Exemption' do
+    transient do
+      category_assessments { [] }
+    end
+
+    sequence(:code) { |n| sprintf '%04d', n }
+    description { Forgery(:basic).text }
+    category_assessment_pks { category_assessments.map(&:pk) }
+  end
+end

--- a/spec/factories/green_lanes/measure_factory.rb
+++ b/spec/factories/green_lanes/measure_factory.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :green_lanes_measure, class: 'GreenLanes::Measure' do
+    transient do
+      category_assessment { create :category_assessment }
+      goods_nomenclature { create :commodity }
+    end
+
+    category_assessment_id { category_assessment.id }
+    goods_nomenclature_item_id { goods_nomenclature.goods_nomenclature_item_id }
+    productline_suffix { goods_nomenclature.producline_suffix }
+  end
+end

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -34,7 +34,7 @@ FactoryBot.define do
     measure_generating_regulation_role { generating_regulation&.role || Measure::BASE_REGULATION_ROLE }
     additional_code_id { additional_code&.additional_code }
     additional_code_sid { additional_code&.additional_code_sid }
-    additional_code_type_id { additional_code&.additional_code_type_id || '1' }
+    additional_code_type_id { additional_code&.additional_code_type_id }
     goods_nomenclature_sid { goods_nomenclature&.goods_nomenclature_sid || generate(:goods_nomenclature_sid) }
     goods_nomenclature_item_id { goods_nomenclature&.goods_nomenclature_item_id || 10.times.map { Random.rand(9) }.join }
     geographical_area_sid { for_geo_area&.geographical_area_sid || generate(:geographical_area_sid) }

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -488,4 +488,16 @@ RSpec.describe GoodsNomenclature do
       it { expect(dataset.pluck(:footnote_type_id)).to eq %w[Y N] }
     end
   end
+
+  describe '#green_lanes_measures' do
+    subject { goods_nomenclature.green_lanes_measures }
+
+    let :goods_nomenclature do
+      create(:commodity).tap do |gn|
+        create :green_lanes_measure, goods_nomenclature: gn
+      end
+    end
+
+    it { is_expected.to include instance_of GreenLanes::Measure }
+  end
 end

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -259,4 +259,33 @@ RSpec.describe GreenLanes::CategoryAssessment do
       end
     end
   end
+
+  describe '#combined_measures' do
+    subject { category_assessment.combined_measures }
+
+    let(:tariff_measure) { create :measure, :with_base_regulation }
+    let(:category_assessment) { create :category_assessment, measure: tariff_measure }
+
+    context 'with tariff measure' do
+      it { is_expected.to include tariff_measure }
+    end
+
+    context 'with green lanes measure' do
+      before { green_lanes_measure }
+
+      let(:green_lanes_measure) { create :green_lanes_measure, category_assessment: }
+      let(:category_assessment) { create :category_assessment }
+
+      it { is_expected.to include green_lanes_measure }
+    end
+
+    context 'with both types of measure' do
+      before { green_lanes_measure }
+
+      let(:green_lanes_measure) { create :green_lanes_measure, category_assessment: }
+
+      it { is_expected.to include tariff_measure }
+      it { is_expected.to include green_lanes_measure }
+    end
+  end
 end

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -149,6 +149,45 @@ RSpec.describe GreenLanes::CategoryAssessment do
         it { is_expected.to be_empty }
       end
     end
+
+    describe '#green_lanes_measures' do
+      subject { assessment.green_lanes_measures }
+
+      let :assessment do
+        create(:category_assessment).tap do |ca|
+          create :green_lanes_measure, category_assessment_id: ca.id
+        end
+      end
+
+      it { is_expected.to include instance_of GreenLanes::Measure }
+    end
+
+    describe '#exemptions' do
+      subject { assessment.reload.exemptions }
+
+      let :assessment do
+        create(:category_assessment).tap do |ca|
+          ca.add_exemption create(:green_lanes_exemption)
+        end
+      end
+
+      it { is_expected.to include instance_of GreenLanes::Exemption }
+    end
+
+    describe '#exemption_ids' do
+      subject { assessment.reload.exemption_pks }
+
+      let :assessment do
+        create(:category_assessment).tap do |ca|
+          ca.exemption_pks = exemptions.map(&:pk)
+          ca.save
+        end
+      end
+
+      let(:exemptions) { create_list :green_lanes_exemption, 1 }
+
+      it { is_expected.to match_array exemptions.map(&:id) }
+    end
   end
 
   describe '#regulation' do

--- a/spec/models/green_lanes/exemption_spec.rb
+++ b/spec/models/green_lanes/exemption_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe GreenLanes::Exemption do
+  describe 'attributes' do
+    it { is_expected.to respond_to :id }
+    it { is_expected.to respond_to :code }
+    it { is_expected.to respond_to :description }
+    it { is_expected.to respond_to :created_at }
+    it { is_expected.to respond_to :updated_at }
+  end
+
+  describe 'validations' do
+    subject(:errors) { instance.tap(&:valid?).errors }
+
+    let(:instance) { described_class.new }
+
+    it { is_expected.to include code: ['is not present'] }
+    it { is_expected.to include description: ['is not present'] }
+
+    context 'with duplicate code' do
+      let(:existing) { create :green_lanes_exemption }
+      let(:instance) { build :green_lanes_exemption, code: existing.code }
+
+      it { is_expected.to include code: ['is already taken'] }
+    end
+  end
+
+  describe '#associations' do
+    describe '#category_assessments' do
+      subject { exemption.reload.category_assessments }
+
+      let :exemption do
+        create(:green_lanes_exemption).tap do |exempt|
+          exempt.add_category_assessment create(:category_assessment)
+        end
+      end
+
+      it { is_expected.to include instance_of GreenLanes::CategoryAssessment }
+    end
+
+    describe '#category_assessments_pks' do
+      subject { exemption.reload.category_assessment_pks }
+
+      let :exemption do
+        create(:green_lanes_exemption).tap do |exempt|
+          exempt.category_assessment_pks = assessments.map(&:pk)
+          exempt.save
+        end
+      end
+
+      let(:assessments) { create_list :category_assessment, 1 }
+
+      it { is_expected.to match_array assessments.map(&:id) }
+    end
+  end
+end

--- a/spec/models/green_lanes/measure_spec.rb
+++ b/spec/models/green_lanes/measure_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe GreenLanes::Measure do
+  describe 'attributes' do
+    it { is_expected.to respond_to :id }
+    it { is_expected.to respond_to :category_assessment_id }
+    it { is_expected.to respond_to :goods_nomenclature_item_id }
+    it { is_expected.to respond_to :productline_suffix }
+    it { is_expected.to respond_to :created_at }
+    it { is_expected.to respond_to :updated_at }
+  end
+
+  describe 'validations' do
+    subject(:errors) { instance.tap(&:valid?).errors }
+
+    let(:instance) { described_class.new }
+
+    it { is_expected.to include category_assessment_id: ['is not present'] }
+    it { is_expected.to include goods_nomenclature_item_id: ['is not present'] }
+    it { is_expected.to include productline_suffix: ['is not present'] }
+
+    context 'with duplicate associations' do
+      let(:existing) { create :green_lanes_measure }
+
+      let :instance do
+        build :green_lanes_measure,
+              category_assessment_id: existing.category_assessment_id,
+              goods_nomenclature_item_id: existing.goods_nomenclature_item_id,
+              productline_suffix: existing.productline_suffix
+      end
+
+      let :uniqueness_key do
+        %i[category_assessment_id goods_nomenclature_item_id productline_suffix]
+      end
+
+      it { is_expected.to include uniqueness_key => ['is already taken'] }
+    end
+  end
+
+  describe 'associations' do
+    describe '#category_assessment' do
+      subject { measure.category_assessment }
+
+      let(:measure) { create :green_lanes_measure, category_assessment_id: ca.id }
+      let(:ca) { create :category_assessment }
+
+      it { is_expected.to be_instance_of GreenLanes::CategoryAssessment }
+    end
+
+    describe '#goods_nomenclature' do
+      subject { measure.goods_nomenclature }
+
+      let :measure do
+        create :green_lanes_measure,
+               goods_nomenclature_item_id: gn.goods_nomenclature_item_id,
+               productline_suffix: gn.producline_suffix
+      end
+
+      let(:gn) { create :commodity }
+
+      it { is_expected.to be_instance_of Commodity }
+    end
+  end
+end

--- a/spec/models/green_lanes/measure_spec.rb
+++ b/spec/models/green_lanes/measure_spec.rb
@@ -58,5 +58,48 @@ RSpec.describe GreenLanes::Measure do
 
       it { is_expected.to be_instance_of Commodity }
     end
+
+    describe '#geographical_area' do
+      subject { measure.geographical_area }
+
+      before { erga_omnes }
+
+      let(:erga_omnes) { create :geographical_area, :erga_omnes }
+      let(:measure) { create :green_lanes_measure }
+
+      it { is_expected.to eq_pk erga_omnes }
+
+      context 'with eager loading' do
+        subject do
+          GoodsNomenclature.actual
+                           .where(goods_nomenclature_item_id: measure.goods_nomenclature_item_id)
+                           .eager(green_lanes_measures: :geographical_area)
+                           .take
+                           .green_lanes_measures
+                           .map(&:geographical_area)
+        end
+
+        it { is_expected.to all eq_pk erga_omnes }
+      end
+    end
+  end
+
+  describe 'tariff measure emulation' do
+    subject { create :green_lanes_measure, category_assessment: assessment }
+
+    let(:assessment) { create :category_assessment }
+
+    it { is_expected.to have_attributes measure_sid: /gl\d{6}/ }
+    it { is_expected.to have_attributes measure_generating_regulation_id: assessment.regulation_id }
+    it { is_expected.to have_attributes measure_generating_regulation_role: assessment.regulation_role }
+    it { is_expected.to have_attributes generating_regulation: assessment.regulation }
+    it { is_expected.to have_attributes geographical_area_id: GeographicalArea::ERGA_OMNES_ID }
+    it { is_expected.to have_attributes measure_excluded_geographical_areas: [] }
+    it { is_expected.to have_attributes excluded_geographical_areas: [] }
+    it { is_expected.to have_attributes additional_code_id: nil }
+    it { is_expected.to have_attributes additional_code_type_id: nil }
+    it { is_expected.to have_attributes additional_code: nil }
+    it { is_expected.to have_attributes measure_conditions: [] }
+    it { is_expected.to have_attributes footnotes: [] }
   end
 end

--- a/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
@@ -106,7 +106,13 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentPresenter do
       it { is_expected.to match_array certificates << additional_code }
     end
 
-    context 'with neither' do
+    context 'with pseudo exemption' do
+      before { assessment.add_exemption create(:green_lanes_exemption) }
+
+      it { is_expected.to include instance_of Api::V2::GreenLanes::ExemptionPresenter }
+    end
+
+    context 'with no exemptions' do
       it { is_expected.to be_empty }
     end
   end

--- a/spec/presenters/api/v2/green_lanes/exemption_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/exemption_presenter_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Api::V2::GreenLanes::ExemptionPresenter do
+  subject { described_class.new(exemption) }
+
+  let(:exemption) { create :green_lanes_exemption }
+
+  it { is_expected.to have_attributes id: exemption.code }
+  it { is_expected.to have_attributes code: exemption.code }
+  it { is_expected.to have_attributes description: exemption.description }
+  it { is_expected.to have_attributes formatted_description: exemption.description }
+end

--- a/spec/serializers/api/v2/green_lanes/category_assessment_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/category_assessment_serializer_spec.rb
@@ -7,9 +7,12 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentSerializer do
     ).serializable_hash.as_json
   end
 
+  before { category_assessment.add_exemption exemption }
+
   let(:category_assessment) { create :category_assessment, measure: }
   let(:certificate) { create :certificate, :exemption, :with_certificate_type, :with_description }
   let(:measure) { create :measure, :with_additional_code, :with_base_regulation, certificate: }
+  let(:exemption) { create :green_lanes_exemption }
 
   let :presented do
     Api::V2::GreenLanes::CategoryAssessmentPresenter.wrap(category_assessment).first
@@ -28,6 +31,7 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentSerializer do
             data: [
               { id: certificate.id, type: 'certificate' },
               { id: measure.additional_code.id.to_s, type: 'additional_code' },
+              { id: exemption.code, type: 'exemption' },
             ],
           },
           geographical_area: {
@@ -72,6 +76,15 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentSerializer do
           type: 'additional_code',
           attributes: {
             code: measure.additional_code.code,
+            description: be_a(String),
+            formatted_description: be_a(String),
+          },
+        },
+        {
+          id: exemption.code,
+          type: 'exemption',
+          attributes: {
+            code: exemption.code,
             description: be_a(String),
             formatted_description: be_a(String),
           },

--- a/spec/serializers/api/v2/green_lanes/category_assessment_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/category_assessment_serializer_spec.rb
@@ -116,6 +116,21 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentSerializer do
       it { is_expected.to include 'measures' }
     end
 
+    context 'with green lanes measures' do
+      subject(:relationships) do
+        described_class.new(presented, params: { with_measures: true })
+                       .serializable_hash
+                       .as_json['data']['relationships']
+      end
+
+      before { create :green_lanes_measure, category_assessment: }
+
+      let(:category_assessment) { create :category_assessment }
+
+      it { is_expected.to include 'measures' }
+      it { expect(relationships['measures']['data'].pluck('id')).to include %r{gl\d+} }
+    end
+
     context 'without measures' do
       subject { serialized['data']['relationships'] }
 

--- a/spec/serializers/api/v2/green_lanes/exemption_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/exemption_serializer_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe Api::V2::GreenLanes::ExemptionSerializer do
+  subject { described_class.new(presented).serializable_hash.as_json }
+
+  let(:exemption) { create :green_lanes_exemption }
+  let(:presented) { Api::V2::GreenLanes::ExemptionPresenter.new exemption }
+
+  let(:expected_pattern) do
+    {
+      data: {
+        id: exemption.code,
+        type: 'exemption',
+        attributes: {
+          code: exemption.code,
+          description: exemption.description,
+          formatted_description: exemption.description,
+        },
+      },
+    }
+  end
+
+  it { is_expected.to include_json(expected_pattern) }
+end

--- a/spec/services/green_lanes/permutation_calculator_service_spec.rb
+++ b/spec/services/green_lanes/permutation_calculator_service_spec.rb
@@ -17,6 +17,26 @@ RSpec.describe GreenLanes::PermutationCalculatorService do
       it { is_expected.to eq(measures.map { |m| [m] }) }
     end
 
+    context 'with related measures' do
+      let(:measures) { [measure, measure2] }
+
+      let :measure do
+        create :measure, :with_additional_code, :with_measure_type, :with_base_regulation
+      end
+
+      let :measure2 do
+        create :measure, measure_type_id: measure.measure_type_id,
+                         generating_regulation: measure.generating_regulation,
+                         additional_code_sid: measure.additional_code_sid,
+                         additional_code_id: measure.additional_code_id,
+                         additional_code_type_id: measure.additional_code_type_id,
+                         geographical_area_id: measure.geographical_area_id
+      end
+
+      it { is_expected.to have_attributes length: 1 }
+      it { expect(permutations[0]).to eq_pk measures }
+    end
+
     context 'with mixture of related and unrelated' do
       let :measures do
         measures = create_list(:measure, 2, :with_measure_type, :with_base_regulation)

--- a/spec/services/green_lanes/permutation_calculator_service_spec.rb
+++ b/spec/services/green_lanes/permutation_calculator_service_spec.rb
@@ -3,12 +3,17 @@ RSpec.describe GreenLanes::PermutationCalculatorService do
 
   describe '.call' do
     let(:measures) { create_list :measure, 1 }
-    let(:measure) { create :measure, :with_measure_type, :with_base_regulation }
+    let(:measure) { create :measure, :with_measure_type, :with_base_regulation, :erga_omnes }
 
     shared_examples 'two segregated lists' do
       it { is_expected.to have_attributes length: 2 }
       it { expect(permutations[0]).to eq_pk [measures[0]] }
       it { expect(permutations[1]).to eq_pk [measures[1]] }
+    end
+
+    shared_examples 'a single list' do
+      it { is_expected.to have_attributes length: 1 }
+      it { expect(permutations[0]).to eq_pk measures }
     end
 
     context 'with unrelated measures' do
@@ -33,8 +38,7 @@ RSpec.describe GreenLanes::PermutationCalculatorService do
                          geographical_area_id: measure.geographical_area_id
       end
 
-      it { is_expected.to have_attributes length: 1 }
-      it { expect(permutations[0]).to eq_pk measures }
+      it_behaves_like 'a single list'
     end
 
     context 'with mixture of related and unrelated' do
@@ -190,6 +194,14 @@ RSpec.describe GreenLanes::PermutationCalculatorService do
       end
 
       it_behaves_like 'two segregated lists'
+    end
+
+    context 'with green lanes measures' do
+      let(:measures) { [measure, gl_measure] }
+      let(:gl_measure) { create(:green_lanes_measure, category_assessment:) }
+      let(:category_assessment) { create :category_assessment, measure: }
+
+      it_behaves_like 'a single list'
     end
   end
 end


### PR DESCRIPTION
### Jira link

GL-356

### What?

I have added/removed/altered:

- [x] Added Pseudo Measures and Pseudo Exemption models
- [x] Include Pseudo Exemptions in the GL GN API output
- [x] Incorporate Pseudo Measures in the GL GN API output

### Why?

I am doing this because:

- We need pseudo measures to handle certain special cases in our API output

### Deployment risks (optional)

- Low, only affects Green Lanes APIs which are currently private
