### PR TITLE
OTT-264 Origin Tab Update UX

### DIFF
--- a/app/models/rules_of_origin/query.rb
+++ b/app/models/rules_of_origin/query.rb
@@ -44,7 +44,7 @@ module RulesOfOrigin
     end
 
     def links
-      scheme_set.links + schemes.map(&:links).flatten
+      schemes.map(&:links).flatten
     end
 
     def scheme_rule_sets

--- a/app/models/rules_of_origin/scheme_set.rb
+++ b/app/models/rules_of_origin/scheme_set.rb
@@ -28,7 +28,6 @@ module RulesOfOrigin
       @base_path = base_path
       data = JSON.parse(source_data)
 
-      @links = build_links(data['links']).freeze
       @proof_urls = data['proof_urls'] || {}
       @_schemes = build_schemes(data['schemes']).freeze
       @_countries = build_countries_to_schemes_index.freeze
@@ -90,14 +89,6 @@ module RulesOfOrigin
           countries[country_code] << scheme_code
         end
       end
-    end
-
-    def build_links(links)
-      links.map(&method(:build_link)).compact
-    end
-
-    def build_link(link_data)
-      Link.new_with_check link_data.merge(source: 'scheme_set')
     end
 
     def build_schemes(schemes_data)

--- a/app/presenters/api/v2/rules_of_origin/scheme_presenter.rb
+++ b/app/presenters/api/v2/rules_of_origin/scheme_presenter.rb
@@ -20,7 +20,7 @@ module Api
           super(scheme)
           @scheme = scheme
           @rules = rules || []
-          @links = Array.wrap(scheme_set&.links) + @scheme.links
+          @links = @scheme.links
           @rule_sets = rule_sets || []
         end
 

--- a/db/rules_of_origin/roo_schemes_uk.json
+++ b/db/rules_of_origin/roo_schemes_uk.json
@@ -1,11 +1,6 @@
 {
     "scope": "uk",
-    "links": [
-        {
-            "text": "Check your goods meet the rules of origin",
-            "url": "https://www.gov.uk/guidance/check-your-goods-meet-the-rules-of-origin"
-        }
-    ],
+    "links": [],
     "schemes": [
         {
             "scheme_code": "eu",

--- a/spec/models/rules_of_origin/query_spec.rb
+++ b/spec/models/rules_of_origin/query_spec.rb
@@ -90,8 +90,7 @@ RSpec.describe RulesOfOrigin::Query do
     describe '#links' do
       subject { query.links }
 
-      it { is_expected.to have_attributes length: 3 }
-      it { is_expected.to include roo_data_set.scheme_set.links.first }
+      it { is_expected.to have_attributes length: 2 }
       it { is_expected.to include roo_scheme.links.first }
     end
 

--- a/spec/models/rules_of_origin/scheme_set_spec.rb
+++ b/spec/models/rules_of_origin/scheme_set_spec.rb
@@ -99,14 +99,6 @@ RSpec.describe RulesOfOrigin::SchemeSet do
     end
   end
 
-  describe '#links' do
-    subject { scheme_set.links }
-
-    it { is_expected.to have_attributes length: 1 }
-    it { is_expected.to all be_instance_of RulesOfOrigin::Link }
-    it { is_expected.to all have_attributes source: 'scheme_set' }
-  end
-
   describe '#read_referenced_file' do
     subject :read_file do
       scheme_set.read_referenced_file('fta_intro', file_name)

--- a/spec/presenters/api/v2/rules_of_origin/scheme_presenter_spec.rb
+++ b/spec/presenters/api/v2/rules_of_origin/scheme_presenter_spec.rb
@@ -54,11 +54,7 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemePresenter do
       let(:scheme_set) { build :rules_of_origin_scheme_set }
       let(:scheme) { build :rules_of_origin_scheme, :with_links, scheme_set: }
 
-      it { is_expected.to have_attributes length: 3 }
-
-      it 'includes links from scheme set' do
-        expect(presented_link_ids).to include scheme_set.links.first.id
-      end
+      it { is_expected.to have_attributes length: 2 }
 
       it 'includes links from scheme itself' do
         expect(presented_link_ids).to include scheme.links.first.id


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-264

### What?

I have removed

- [x] Check rules of origin links. 


### Why?

I am doing this because:

- This is no longer required following UX changes of Origin tab. The link was used at the bottom of the tab replaced by 'Further information on trade with `[_country_]`'
- 
Deployment risks
Requires frontend PR https://github.com/trade-tariff/trade-tariff-frontend/pull/1921

![image](https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/f57ae1d8-deba-4291-a8ce-b0fad7778ccf)

![image](https://github.com/trade-tariff/trade-tariff-backend/assets/127106895/c811ad04-5339-4e32-8879-93c2c856821e)