### PR TITLE
GL-539 Eager load geo area filtering

### DIFF
--- a/app/models/geographical_area.rb
+++ b/app/models/geographical_area.rb
@@ -103,6 +103,10 @@ class GeographicalArea < Sequel::Model
     GSP.include?(geographical_area_id) || DCTS.include?(geographical_area_id)
   end
 
+  def referenced_or_self
+    referenced.presence || self
+  end
+
   private
 
   def referenced_id

--- a/app/models/geographical_area.rb
+++ b/app/models/geographical_area.rb
@@ -24,6 +24,12 @@ class GeographicalArea < Sequel::Model
       .order(Sequel.desc(:geographical_area_description_periods__validity_start_date))
   end
 
+  many_to_one :referenced, class: 'GeographicalArea',
+                           primary_key: :geographical_area_id,
+                           key: :referenced_id do |ds|
+    ds.with_actual(GeographicalArea)
+  end
+
   def geographical_area_description
     geographical_area_descriptions.first
   end
@@ -54,10 +60,6 @@ class GeographicalArea < Sequel::Model
 
   def candidate_excluded_geographical_area_ids
     @candidate_excluded_geographical_area_ids ||= contained_geographical_area_ids << geographical_area_id
-  end
-
-  def referenced
-    self.class.where(geographical_area_id: referenced_id).actual.first
   end
 
   def contained_geographical_area_ids

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -660,15 +660,11 @@ class Measure < Sequel::Model
   end
 
   def measure_excluded_geographical_area_ids
-    excluded_geographical_areas = measure_excluded_geographical_areas_dataset
-      .eager(:geographical_area)
-      .map(&:geographical_area)
-
-    excluded_geographical_areas.each_with_object([]) do |geographical_area, acc|
-      actual_area = geographical_area.referenced.presence || geographical_area
-
-      acc.concat(actual_area.candidate_excluded_geographical_area_ids)
-    end
+    excluded_geographical_areas
+      .map(&:referenced_or_self)
+      .uniq
+      .flat_map(&:candidate_excluded_geographical_area_ids)
+      .uniq
   end
 
   def resolves_meursing_measures?

--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -49,6 +49,13 @@ class CachedCommodityService
     },
     { quota_order_number: { quota_definition: %i[quota_balance_events quota_suspension_periods quota_blocking_periods] } },
     { excluded_geographical_areas: :geographical_area_descriptions },
+    {
+      excluded_geographical_areas: [
+        :geographical_area_descriptions,
+        :contained_geographical_areas,
+        { referenced: :contained_geographical_areas },
+      ],
+    },
     { geographical_area: [:geographical_area_descriptions,
                           { contained_geographical_areas: :geographical_area_descriptions }] },
     { additional_code: :additional_code_descriptions },

--- a/app/services/heading_service/serialization/declarable_service.rb
+++ b/app/services/heading_service/serialization/declarable_service.rb
@@ -37,7 +37,13 @@ module HeadingService
           ],
         },
         { quota_order_number: :quota_definition },
-        { excluded_geographical_areas: :geographical_area_descriptions },
+        {
+          excluded_geographical_areas: [
+            :geographical_area_descriptions,
+            :contained_geographical_areas,
+            { referenced: :contained_geographical_areas },
+          ],
+        },
         :additional_code,
         :full_temporary_stop_regulations,
         :measure_partial_temporary_stops,

--- a/spec/models/geographical_area_spec.rb
+++ b/spec/models/geographical_area_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe GeographicalArea do
     it { is_expected.to eq(%w[RO 1011]) }
   end
 
-  describe '.referenced' do
+  describe '#referenced' do
     context 'when the geographical area is a reference area' do
       subject(:refeenced) { create(:geographical_area, geographical_area_id: 'EU').referenced }
 
@@ -28,6 +28,24 @@ RSpec.describe GeographicalArea do
       subject(:refeenced) { create(:geographical_area).referenced }
 
       it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#referenced_or_self' do
+    context 'with referenced' do
+      subject(:referencer) { create :geographical_area, geographical_area_id: 'EU' }
+
+      let(:reference) { create :geographical_area, geographical_area_id: '1013' }
+
+      it { is_expected.to have_attributes referenced: reference }
+      it { is_expected.to have_attributes referenced_or_self: referencer }
+    end
+
+    context 'without referenced' do
+      subject(:referencer) { create :geographical_area, geographical_area_id: 'FR' }
+
+      it { is_expected.to have_attributes referenced: nil }
+      it { is_expected.to have_attributes referenced_or_self: referencer }
     end
   end
 


### PR DESCRIPTION
### Jira link

GL-539

### What?

I have added/removed/altered:

- [x] Refactored measure exclusion areas work to allow for eager loading
- [x] Added eager loading for commodities and declarable headings

### Why?

I am doing this because:

- The existing implementation does its own queries, preventing eager loading
- This negatively impacts green lanes but its beneficial to add here, I found even without the eager load changes there was still a significant drop in queries with the existing eager loads already in place

### Deployment risks (optional)

- Some, this changes the internal implementation of key functionality
