### PR TITLE
GL-373 cache Category assessments endpoint

### DIFF
--- a/app/controllers/api/v2/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/api/v2/green_lanes/category_assessments_controller.rb
@@ -2,41 +2,66 @@ module Api
   module V2
     module GreenLanes
       class CategoryAssessmentsController < BaseController
+        TTL = 24.hours
+
         def index
-          category_assessments =
-            ::GreenLanes::CategoryAssessment
-              .eager(
-                theme: [],
-                base_regulation: [],
-                modification_regulation: [],
-                measure_type: %i[measure_type_description measure_type_series_description],
-                measures: {
-                  additional_code: :additional_code_descriptions,
-                  measure_conditions: { certificate: %i[certificate_descriptions exempting_certificate_override] },
-                  geographical_area: :geographical_area_descriptions,
-                  measure_excluded_geographical_areas: [],
-                  excluded_geographical_areas: :geographical_area_descriptions,
-                  measure_type: [],
-                },
-                green_lanes_measures: [],
-                exemptions: [],
-              )
-              .all
+          render json: cached_json
+        end
 
-          presented_assessments =
-            CategoryAssessmentPresenter.wrap(category_assessments)
+      private
 
-          serializer =
-            CategoryAssessmentSerializer
-              .new(presented_assessments,
-                   include: %w[geographical_area
-                               excluded_geographical_areas
-                               exemptions
-                               theme
-                               regulation
-                               measure_type])
+        def category_assessments
+          ::GreenLanes::CategoryAssessment
+            .eager(
+              theme: [],
+              base_regulation: [],
+              modification_regulation: [],
+              measure_type: %i[measure_type_description measure_type_series_description],
+              measures: {
+                additional_code: :additional_code_descriptions,
+                measure_conditions: { certificate: %i[certificate_descriptions exempting_certificate_override] },
+                geographical_area: :geographical_area_descriptions,
+                measure_excluded_geographical_areas: [],
+                excluded_geographical_areas: :geographical_area_descriptions,
+              },
+              green_lanes_measures: [],
+              exemptions: [],
+            )
+            .all
+        end
 
-          render json: serializer.serializable_hash
+        def presented_assessments
+          CategoryAssessmentPresenter.wrap(category_assessments)
+        end
+
+        def serializer
+          CategoryAssessmentSerializer
+            .new(presented_assessments,
+                 include: %w[geographical_area
+                             excluded_geographical_areas
+                             exemptions
+                             theme
+                             regulation
+                             measure_type])
+        end
+
+        def cached_json
+          Rails.cache.fetch(cache_key, expires_in: TTL) do
+            serializer.serializable_hash.to_json
+          end
+        end
+
+        def cache_key
+          [
+            'category-assessments-for',
+            actual_date.to_fs(:db),
+            'latest-assessment-on',
+            latest_assessment_update&.iso8601,
+          ].join('-')
+        end
+
+        def latest_assessment_update
+          ::GreenLanes::CategoryAssessment.latest&.updated_at
         end
       end
     end

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -4,6 +4,7 @@ module GreenLanes
     plugin :auto_validations, not_null: :presence
     plugin :association_pks
     plugin :association_dependencies
+    plugin :touch
 
     many_to_one :theme
     many_to_one :measure_type, class: :MeasureType

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -28,6 +28,12 @@ module GreenLanes
     many_to_many :exemptions, join_table: :green_lanes_category_assessments_exemptions
     add_association_dependencies exemptions: :nullify
 
+    dataset_module do
+      def latest
+        order(Sequel.desc(:updated_at)).first
+      end
+    end
+
     def validate
       super
 

--- a/app/models/green_lanes/exempting_certificate_override.rb
+++ b/app/models/green_lanes/exempting_certificate_override.rb
@@ -8,5 +8,28 @@ module GreenLanes
                              primary_key: %i[certificate_type_code certificate_code] do |ds|
       ds.with_actual(Certificate)
     end
+
+  private
+
+    def after_create
+      super
+      touch_all_category_assessments
+    end
+
+    # Touch all of the model's touched_associations when destroying the object.
+    def after_destroy
+      super
+      touch_all_category_assessments
+    end
+
+    # Touch all of the model's touched_associations when updating the object.
+    def after_update
+      super
+      touch_all_category_assessments
+    end
+
+    def touch_all_category_assessments
+      CategoryAssessment.dataset.update updated_at: Time.zone.now
+    end
   end
 end

--- a/app/models/green_lanes/exemption.rb
+++ b/app/models/green_lanes/exemption.rb
@@ -6,5 +6,6 @@ module GreenLanes
 
     many_to_many :category_assessments,
                  join_table: :green_lanes_category_assessments_exemptions
+    plugin :touch, associations: %i[category_assessments]
   end
 end

--- a/app/models/green_lanes/measure.rb
+++ b/app/models/green_lanes/measure.rb
@@ -4,6 +4,8 @@ module GreenLanes
     plugin :auto_validations, not_null: :presence
 
     many_to_one :category_assessment
+    plugin :touch, associations: %i[category_assessment]
+
     many_to_one :goods_nomenclature, class: 'GoodsNomenclature',
                                      primary_key: %i[goods_nomenclature_item_id producline_suffix],
                                      key: %i[goods_nomenclature_item_id productline_suffix]

--- a/app/models/green_lanes/theme.rb
+++ b/app/models/green_lanes/theme.rb
@@ -4,6 +4,7 @@ module GreenLanes
     plugin :auto_validations, not_null: :presence
 
     one_to_many :category_assessments
+    plugin :touch, associations: %i[category_assessments]
 
     def to_s
       "#{code}. #{description}"

--- a/db/migrate/20240530121653_add_index_to_category_assessments_updated_at.rb
+++ b/db/migrate/20240530121653_add_index_to_category_assessments_updated_at.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    add_index :green_lanes_category_assessments, :updated_at
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10724,6 +10724,13 @@ CREATE UNIQUE INDEX green_lanes_category_assessments_measure_type_id_regulation_
 
 
 --
+-- Name: green_lanes_category_assessments_updated_at_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX green_lanes_category_assessments_updated_at_index ON uk.green_lanes_category_assessments USING btree (updated_at);
+
+
+--
 -- Name: green_lanes_exempting_certificate_overrides_certificate_code_ce; Type: INDEX; Schema: uk; Owner: -
 --
 
@@ -12407,3 +12414,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20240429125446_change_titl
 INSERT INTO "schema_migrations" ("filename") VALUES ('20240429135110_create_green_lanes_exempting_certificate_overrides.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20240507140515_add_green_lanes_measures_tables.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20240610160146_update_quota_definitions_oplog_volume.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20240530121653_add_index_to_category_assessments_updated_at.rb');

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -290,4 +290,15 @@ RSpec.describe GreenLanes::CategoryAssessment do
       it { is_expected.to include green_lanes_measure }
     end
   end
+
+  describe '#latest' do
+    subject { described_class.latest }
+
+    before { older && newer }
+
+    let(:older) { create :category_assessment, updated_at: 20.minutes.ago }
+    let(:newer) { create :category_assessment, updated_at: 2.minutes.ago }
+
+    it { is_expected.to eq_pk newer }
+  end
 end

--- a/spec/models/green_lanes/exempting_certificate_override_spec.rb
+++ b/spec/models/green_lanes/exempting_certificate_override_spec.rb
@@ -44,4 +44,31 @@ RSpec.describe GreenLanes::ExemptingCertificateOverride do
       it { is_expected.to eq certificate }
     end
   end
+
+  describe 'category_assessment timestamps' do
+    subject { assessment.reload.updated_at }
+
+    before { override && assessment }
+
+    let(:override) { create :exempting_certificate_override }
+    let(:assessment) { create :category_assessment, updated_at: 20.minutes.ago }
+
+    context 'when creating an override' do
+      before { create :exempting_certificate_override }
+
+      it { is_expected.to be_within(1.minute).of Time.zone.now }
+    end
+
+    context 'when updating an override' do
+      before { override.update certificate_type_code: 'X' }
+
+      it { is_expected.to be_within(1.minute).of Time.zone.now }
+    end
+
+    context 'when removing an override' do
+      before { override.destroy }
+
+      it { is_expected.to be_within(1.minute).of Time.zone.now }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

GL-373

### What?

I have added/removed/altered:

- [x] Update time stamps on category assessments when their associated data changes
- [x] Use the above to cache the generated json into redis

### Why?

I am doing this because:

- This endpoint needs to load _a lot_ of data so can be slow to generate, caching avoids reprocessing all that on repeated calls throughout the day

### Deployment risks (optional)

- Some, adds a DB index as well as the caching changes
