### PR TITLE
Monkey patch for allowing ZWL rate only be saved as ZIG

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -521,7 +521,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 3.2.2p53
+   ruby 3.2.3p157
 
 BUNDLED WITH
    2.3.8

--- a/app/services/exchange_rates/update_currency_rates_service.rb
+++ b/app/services/exchange_rates/update_currency_rates_service.rb
@@ -13,16 +13,25 @@ module ExchangeRates
       response = @xe_api.get_all_historic_rates
 
       ExchangeRateCurrencyRate.db.transaction do
-        rates = build_rates(response)
-        # This will only get rates for the current live rates so you cant pull historic data
-        included_rates = @type == ExchangeRateCurrencyRate::MONTHLY_RATE_TYPE ? ExchangeRateCountryCurrency.live_currency_codes : ExchangeRateCountryCurrency::SPOT_RATE_CURRENCY_CODES
-        rates = rates.select { |rate| included_rates.include?(rate.currency_code) }
-
+        rates = build_rates(response).select { |rate| included_rates.include?(rate.currency_code) }
         upsert_rates(rates)
       end
     end
 
     private
+
+    def monthly_rate_type?
+      @type == ExchangeRateCurrencyRate::MONTHLY_RATE_TYPE
+    end
+
+    def included_rates
+      # This will only get rates for the current live rates so you cant pull historic data
+      if monthly_rate_type?
+        ExchangeRateCountryCurrency.live_currency_codes
+      else
+        ExchangeRateCountryCurrency::SPOT_RATE_CURRENCY_CODES
+      end
+    end
 
     def build_rates(response)
       response['to'].map do |currency_data|
@@ -41,16 +50,24 @@ module ExchangeRates
       currency_code = currency_data['quotecurrency']
       rate = currency_data['mid']
 
-      validity_start_date = @type == ExchangeRateCurrencyRate::MONTHLY_RATE_TYPE ? @date.beginning_of_month : @date.end_of_month
+      validity_start_date = monthly_rate_type? ? @date.beginning_of_month : @date.end_of_month
       validity_end_date = @date.end_of_month
 
       ExchangeRateCurrencyRate.new(
-        currency_code:,
+        currency_code: currency_overide(currency_code),
         validity_start_date:,
         validity_end_date:,
         rate:,
         rate_type: @type,
       )
+    end
+
+    def currency_overide(currency_code)
+      currency_overides = { 'ZWL' => 'ZIG' }
+
+      return currency_code unless currency_overides.keys.include?(currency_code)
+
+      currency_overides[currency_code]
     end
   end
 end

--- a/db/data_migrations/20240606125159_add_new_zimbabwe_gold.rb
+++ b/db/data_migrations/20240606125159_add_new_zimbabwe_gold.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    if TradeTariffBackend.uk?
+      new_zimbabwe_country_currency = ExchangeRateCountryCurrency.where(country_description: 'Zimbabwe',
+                                                                        currency_code: 'ZIG',
+                                                                        country_code:'ZW').first
+
+      zimbabwe_country_currency.update(country_description: 'Zimbabwe Gold')
+    end
+  end
+
+  down do
+    # We don't want to rollback to incorrect Zimbabwe rates.
+  end
+end


### PR DESCRIPTION
### Jira link

OTT-309

### What?

I have added/removed/altered:

- [ ] Ensured we the correct currency description for the new ZIG currency
- [ ] Added tests to demo when we get provided with either the wrong currency code for Zimbabwe or both

### Why?

I am doing this because:

- XE are supplying us with the ZIG rate under the ZWL code
