### PR TITLE
GL-402 Ignore export measures

### DIFF
--- a/app/controllers/api/v2/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/api/v2/green_lanes/category_assessments_controller.rb
@@ -12,10 +12,11 @@ module Api
                 measure_type: %i[measure_type_description measure_type_series_description],
                 measures: {
                   additional_code: :additional_code_descriptions,
-                  measure_conditions: { certificate: :certificate_descriptions },
+                  measure_conditions: { certificate: %i[certificate_descriptions exempting_certificate_override] },
                   geographical_area: :geographical_area_descriptions,
                   measure_excluded_geographical_areas: [],
                   excluded_geographical_areas: :geographical_area_descriptions,
+                  measure_type: [],
                 },
                 green_lanes_measures: [],
                 exemptions: [],

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -64,7 +64,7 @@ module GreenLanes
     end
 
     def combined_measures
-      measures + green_lanes_measures
+      measures.select(&:import) + green_lanes_measures
     end
   end
 end

--- a/app/presenters/api/v2/green_lanes/goods_nomenclature_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/goods_nomenclature_presenter.rb
@@ -47,12 +47,12 @@ module Api
       private
 
         def combined_descendant_measures
-          descendants.flat_map(&:measures) +
+          descendants.flat_map(&:measures).select(&:import) +
             descendants.flat_map(&:green_lanes_measures)
         end
 
         def combined_applicable_measures
-          applicable_measures +
+          applicable_measures.select(&:import) +
             green_lanes_measures +
             ancestors.flat_map(&:green_lanes_measures)
         end

--- a/app/presenters/api/v2/green_lanes/referenced_goods_nomenclature_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/referenced_goods_nomenclature_presenter.rb
@@ -39,7 +39,8 @@ module Api
 
         def area_relevant_applicable_measures
           @area_relevant_applicable_measures ||=
-            applicable_measures.select do |measure|
+            applicable_measures.select(&:import)
+                               .select do |measure|
               measure.relevant_for_country?(requested_geo_area_with_fallback)
             end
         end

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -582,6 +582,7 @@ FactoryBot.define do
     validity_end_date      { nil }
     measure_explosion_level { 10 }
     order_number_capture_code { 10 }
+    trade_movement_code { 0 }
 
     trait :export do
       trade_movement_code { 1 }

--- a/spec/presenters/api/v2/green_lanes/goods_nomenclature_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/goods_nomenclature_presenter_spec.rb
@@ -191,6 +191,12 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclaturePresenter do
 
       it { is_expected.to have_attributes supplementary_measure_unit: /\w+ \(\w+\)/ }
     end
+
+    context 'with export measure' do
+      before { MeasureType::Operation.dataset.update trade_movement_code: 1 }
+
+      it { is_expected.to have_attributes supplementary_measure_unit: nil }
+    end
   end
 
   describe '#licences' do
@@ -242,6 +248,12 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclaturePresenter do
       subject(:presented) { described_class.new(gn.descendants.first, requested_geo_area) }
 
       it { is_expected.to have_attributes licences: [certificate] }
+    end
+
+    context 'with export measure' do
+      before { MeasureType::Operation.dataset.update trade_movement_code: 1 }
+
+      it { is_expected.to have_attributes licences: [] }
     end
   end
 end

--- a/spec/presenters/api/v2/green_lanes/referenced_goods_nomenclature_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/referenced_goods_nomenclature_presenter_spec.rb
@@ -51,6 +51,12 @@ RSpec.describe Api::V2::GreenLanes::ReferencedGoodsNomenclaturePresenter do
 
       it { is_expected.to have_attributes supplementary_measure_unit: /\w+ \(\w+\)/ }
     end
+
+    context 'with export measure' do
+      before { MeasureType::Operation.dataset.update trade_movement_code: 1 }
+
+      it { is_expected.to have_attributes supplementary_measure_unit: nil }
+    end
   end
 
   describe '#licences' do
@@ -104,6 +110,12 @@ RSpec.describe Api::V2::GreenLanes::ReferencedGoodsNomenclaturePresenter do
       let(:child) { create :goods_nomenclature, parent: gn }
 
       it { is_expected.to have_attributes licences: [certificate] }
+    end
+
+    context 'with export measure' do
+      before { MeasureType::Operation.dataset.update trade_movement_code: 1 }
+
+      it { is_expected.to have_attributes licences: [] }
     end
   end
 end


### PR DESCRIPTION
### Jira link

GL-402

### What?

I have added/removed/altered:

- [x] Only include export measures in green lanes APIs
- [x] Fix missing eager load on category assessments endpoint

### Why?

I am doing this because:

- Whilst export measures shouldn't be matched unless we have bad data, we can trivially ensure that they are not

### Deployment risks (optional)

- Low, only affects GL APIs
