### PR TITLE
GL-574 Handle pseudo measures against expired goods nomenclatures

### DIFF
--- a/app/controllers/api/v2/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/api/v2/green_lanes/category_assessments_controller.rb
@@ -24,7 +24,7 @@ module Api
                 measure_excluded_geographical_areas: [],
                 excluded_geographical_areas: :geographical_area_descriptions,
               },
-              green_lanes_measures: [],
+              green_lanes_measures: :goods_nomenclature,
               exemptions: [],
             )
             .all

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -123,7 +123,8 @@ class GoodsNomenclature < Sequel::Model
   one_to_many :green_lanes_measures, class: 'Measure',
                                      class_namespace: 'GreenLanes',
                                      key: %i[goods_nomenclature_item_id productline_suffix],
-                                     primary_key: %i[goods_nomenclature_item_id producline_suffix]
+                                     primary_key: %i[goods_nomenclature_item_id producline_suffix],
+                                     reciprocal: :goods_nomenclature
 
   dataset_module do
     def non_hidden

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -22,7 +22,9 @@ module GreenLanes
         .with_regulation_dates_query
     end
 
-    one_to_many :green_lanes_measures, class: 'Measure', class_namespace: 'GreenLanes'
+    one_to_many :green_lanes_measures, class: 'Measure',
+                                       class_namespace: 'GreenLanes',
+                                       reciprocal: :category_assessment
     add_association_dependencies green_lanes_measures: :delete
 
     many_to_many :exemptions, join_table: :green_lanes_category_assessments_exemptions
@@ -71,7 +73,11 @@ module GreenLanes
     end
 
     def combined_measures
-      measures.select(&:import) + green_lanes_measures
+      measures.select(&:import) + active_green_lanes_measures
+    end
+
+    def active_green_lanes_measures
+      green_lanes_measures.select(&:goods_nomenclature)
     end
   end
 end

--- a/app/models/green_lanes/measure.rb
+++ b/app/models/green_lanes/measure.rb
@@ -8,8 +8,10 @@ module GreenLanes
 
     many_to_one :goods_nomenclature, class: 'GoodsNomenclature',
                                      primary_key: %i[goods_nomenclature_item_id producline_suffix],
-                                     key: %i[goods_nomenclature_item_id productline_suffix]
-    delegate :goods_nomenclature_sid, to: :goods_nomenclature
+                                     key: %i[goods_nomenclature_item_id productline_suffix] do |ds|
+      ds.with_actual(::GoodsNomenclature)
+    end
+    delegate :goods_nomenclature_sid, to: :goods_nomenclature, allow_nil: true
 
     many_to_one :geographical_area, class: 'GeographicalArea',
                                     primary_key: :geographical_area_id,

--- a/app/models/green_lanes/measure.rb
+++ b/app/models/green_lanes/measure.rb
@@ -3,12 +3,13 @@ module GreenLanes
     plugin :timestamps, update_on_create: true
     plugin :auto_validations, not_null: :presence
 
-    many_to_one :category_assessment
+    many_to_one :category_assessment, reciprocal: :green_lanes_measures
     plugin :touch, associations: %i[category_assessment]
 
     many_to_one :goods_nomenclature, class: 'GoodsNomenclature',
                                      primary_key: %i[goods_nomenclature_item_id producline_suffix],
-                                     key: %i[goods_nomenclature_item_id productline_suffix] do |ds|
+                                     key: %i[goods_nomenclature_item_id productline_suffix],
+                                     reciprocal: :green_lanes_measures do |ds|
       ds.with_actual(::GoodsNomenclature)
     end
     delegate :goods_nomenclature_sid, to: :goods_nomenclature, allow_nil: true

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -289,6 +289,38 @@ RSpec.describe GreenLanes::CategoryAssessment do
       it { is_expected.to include tariff_measure }
       it { is_expected.to include green_lanes_measure }
     end
+
+    context 'with expired goods_nomenclature' do
+      before { green_lanes_measure.goods_nomenclature.update validity_end_date: 2.days.ago }
+
+      let(:green_lanes_measure) { create :green_lanes_measure, category_assessment: }
+
+      it { is_expected.to include tariff_measure }
+      it { is_expected.not_to include green_lanes_measure }
+    end
+  end
+
+  describe '#active_green_lanes_measures' do
+    subject { assessment.active_green_lanes_measures }
+
+    let :assessment do
+      create(:category_assessment, :with_green_lanes_measure).tap do |ca|
+        create :green_lanes_measure, category_assessment_id: ca.id
+      end
+    end
+
+    let(:gl_measure) { assessment.green_lanes_measures.first }
+
+    it { is_expected.to include gl_measure }
+
+    context 'with expired goods_nomenclature' do
+      before do
+        gl_measure.goods_nomenclature.update validity_end_date: 2.days.ago
+        assessment.reload
+      end
+
+      it { is_expected.not_to include gl_measure }
+    end
   end
 
   describe '#latest' do

--- a/spec/models/green_lanes/measure_spec.rb
+++ b/spec/models/green_lanes/measure_spec.rb
@@ -58,6 +58,12 @@ RSpec.describe GreenLanes::Measure do
       let(:gn) { create :commodity }
 
       it { is_expected.to be_instance_of Commodity }
+
+      context 'with expired goods_nomenclature' do
+        before { gn.update(validity_end_date: 2.days.ago) }
+
+        it { is_expected.to be_nil }
+      end
     end
 
     describe '#geographical_area' do
@@ -86,8 +92,9 @@ RSpec.describe GreenLanes::Measure do
   end
 
   describe 'tariff measure emulation' do
-    subject { create :green_lanes_measure, category_assessment: assessment }
+    subject { gl_measure }
 
+    let(:gl_measure) { create :green_lanes_measure, category_assessment: assessment }
     let(:assessment) { create :category_assessment }
 
     it { is_expected.to have_attributes measure_sid: /gl\d{6}/ }
@@ -95,6 +102,7 @@ RSpec.describe GreenLanes::Measure do
     it { is_expected.to have_attributes measure_generating_regulation_role: assessment.regulation_role }
     it { is_expected.to have_attributes generating_regulation: assessment.regulation }
     it { is_expected.to have_attributes geographical_area_id: GeographicalArea::ERGA_OMNES_ID }
+    it { is_expected.to have_attributes goods_nomenclature_sid: gl_measure.goods_nomenclature.goods_nomenclature_sid }
     it { is_expected.to have_attributes measure_excluded_geographical_areas: [] }
     it { is_expected.to have_attributes excluded_geographical_areas: [] }
     it { is_expected.to have_attributes additional_code_id: nil }
@@ -102,5 +110,13 @@ RSpec.describe GreenLanes::Measure do
     it { is_expected.to have_attributes additional_code: nil }
     it { is_expected.to have_attributes measure_conditions: [] }
     it { is_expected.to have_attributes footnotes: [] }
+
+    context 'with expired goods_nomenclature' do
+      subject { gl_measure.reload }
+
+      before { gl_measure.goods_nomenclature.update validity_end_date: 2.days.ago }
+
+      it { is_expected.to have_attributes goods_nomenclature_sid: nil }
+    end
   end
 end


### PR DESCRIPTION
### Jira link

GL-574

### What?

I have added/removed/altered:

- [x] Use TimeMachine for GoodsNomenclature relationship on pseudo measures
- [x] Exclude pseudo measures against expired GoodsNomenclatures in APIs
- [x] Fixed `reciprocal` configuration for pseudo measures relationship

### Why?

I am doing this because:

- We should ignore measures (and their associated CAs) when the GN they attach to is not valid for the requested date

### Deployment risks (optional)

- Low, only affects GL APIs
