### PR TITLE
GL-601 Fix priorisation of regulations for category assessment imports

### DIFF
--- a/lib/tasks/green_lanes.rake
+++ b/lib/tasks/green_lanes.rake
@@ -84,8 +84,8 @@ namespace :green_lanes do
           assessment.measure_type_id = json_ca.measure_type_id
           assessment.regulation_id = json_ca.regulation_id
 
-          regulation = BaseRegulation.actual.where(base_regulation_id: json_ca.regulation_id).all.last
-          regulation ||= ModificationRegulation.actual.where(base_regulation_id: json_ca.regulation_id).all.last
+          regulation = ModificationRegulation.actual.where(modification_regulation_id: json_ca.regulation_id).all.last
+          regulation ||= BaseRegulation.actual.where(base_regulation_id: json_ca.regulation_id).all.last
 
           assessment.regulation_role = regulation&.role || 1
           assessments[key] = assessment


### PR DESCRIPTION
### Jira link

GL-601

### What?

I have added/removed/altered:

- [x] Changed priorisation of Regulation Lookup

### Why?

I am doing this because:

- We should favour ModificationRegulations over BaseRegulations

### Deployment risks (optional)

- Low, means we'll be importing slightly different data into production than staging
