### PR TITLE
GL-562 Uniq certificates to avoid duplicate certs

### DIFF
--- a/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
@@ -70,7 +70,10 @@ module Api
         end
 
         def certificates
-          measure_conditions.select(&:is_exempting_with_certificate_overridden?).map(&:certificate)
+          measure_conditions
+            .select(&:is_exempting_with_certificate_overridden?)
+            .map(&:certificate)
+            .uniq
         end
 
         def additional_codes

--- a/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
@@ -94,6 +94,21 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentPresenter do
       it { is_expected.to match_array certificates }
     end
 
+    context 'with duplicate conditions pointing to same certificate' do
+      before { certificates }
+
+      let(:measure) { assessment.measures.first }
+
+      let :certificates do
+        create_list(:certificate, 1, :exemption).each do |certificate|
+          create(:measure_condition, measure:, certificate:)
+          create(:measure_condition, measure:, certificate:)
+        end
+      end
+
+      it { is_expected.to eq_pk certificates }
+    end
+
     context 'with additional code' do
       before { additional_code }
 


### PR DESCRIPTION
### Jira link

GL-562

### What?

I have added/removed/altered:

- [x] Remove list of duplicate certificates from the exemptions list

### Why?

I am doing this because:

- We were getting duplicate certificates when there was duplicate measure conditions pointing to the same certificate

### Deployment risks (optional)

- Low, small bugfix
