### PR TITLE
GL-384: Add deleting pseudo measures

### DIFF
--- a/app/controllers/api/admin/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/api/admin/green_lanes/category_assessments_controller.rb
@@ -22,7 +22,7 @@ module Api
 
         def create
           ca = ::GreenLanes::CategoryAssessment.new(ca_params)
-          binding.pry
+
           if ca.valid? && ca.save
             render json: serialize(ca),
                    location: api_admin_green_lanes_category_assessment_url(ca.id),

--- a/app/controllers/api/admin/green_lanes/measures_controller.rb
+++ b/app/controllers/api/admin/green_lanes/measures_controller.rb
@@ -51,6 +51,13 @@ module Api
           end
         end
 
+        def destroy
+          measure = ::GreenLanes::Measure.with_pk!(params[:id])
+          measure.destroy
+
+          head :no_content
+        end
+
         private
 
         def measures

--- a/app/controllers/api/admin/green_lanes/measures_controller.rb
+++ b/app/controllers/api/admin/green_lanes/measures_controller.rb
@@ -27,7 +27,7 @@ module Api
         def create
           measure = ::GreenLanes::Measure.new(measure_params)
 
-          if measure.save
+          if measure.valid? && measure.save
             render json: serialize(measure),
                    location: api_admin_green_lanes_measure_url(measure.id),
                    status: :created
@@ -41,7 +41,7 @@ module Api
           measure = ::GreenLanes::Measure.with_pk!(params[:id])
           measure.set measure_params
 
-          if measure.save
+          if measure.valid? && measure.save
             render json: serialize(measure),
                    location: api_admin_green_lanes_measure_url(measure.id),
                    status: :ok

--- a/app/controllers/api/admin/green_lanes/measures_controller.rb
+++ b/app/controllers/api/admin/green_lanes/measures_controller.rb
@@ -20,8 +20,10 @@ module Api
         end
 
         def show
+          options = { is_collection: false }
+          options[:include] = %i[category_assessment]
           measure = ::GreenLanes::Measure.with_pk!(params[:id])
-          render json: serialize(measure)
+          render json: serialize(measure, options)
         end
 
         def create

--- a/app/controllers/api/admin/green_lanes/measures_controller.rb
+++ b/app/controllers/api/admin/green_lanes/measures_controller.rb
@@ -27,7 +27,7 @@ module Api
         def create
           measure = ::GreenLanes::Measure.new(measure_params)
 
-          if measure.valid? && measure.save
+          if measure.save
             render json: serialize(measure),
                    location: api_admin_green_lanes_measure_url(measure.id),
                    status: :created
@@ -41,7 +41,7 @@ module Api
           measure = ::GreenLanes::Measure.with_pk!(params[:id])
           measure.set measure_params
 
-          if measure.valid? && measure.save
+          if measure.save
             render json: serialize(measure),
                    location: api_admin_green_lanes_measure_url(measure.id),
                    status: :ok

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,7 +74,7 @@ Rails.application.routes.draw do
           resources :themes, only: %i[index]
           resources :exempting_certificate_overrides, only: %i[index show create destroy]
           resources :exemptions, only: %i[index show create update destroy]
-          resources :measures, only: %i[index show create update]
+          resources :measures, only: %i[index show create update destroy]
         end
       end
     end

--- a/spec/requests/api/admin/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/category_assessments_controller_spec.rb
@@ -136,8 +136,8 @@ RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentsController do
 
     let(:make_request) do
       authenticated_post exemptions_api_admin_green_lanes_category_assessment_path(id, format: :json), params: {
-        id: id,
-        exemption_id: exemption_id,
+        id:,
+        exemption_id:,
       }
     end
 

--- a/spec/requests/api/admin/green_lanes/measurers_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/measurers_controller_spec.rb
@@ -121,4 +121,24 @@ RSpec.describe Api::Admin::GreenLanes::MeasuresController do
       it { expect { page_response }.not_to change(measure.reload, :productline_suffix) }
     end
   end
+
+  describe 'DELETE to #destroy' do
+    let :make_request do
+      authenticated_delete api_admin_green_lanes_measure_path(id, format: :json)
+    end
+
+    context 'with known measure' do
+      let(:id) { measure.id }
+
+      it { is_expected.to have_http_status :no_content }
+      it { expect { page_response }.to change(measure, :exists?) }
+    end
+
+    context 'with unknown measure' do
+      let(:id) { 9999 }
+
+      it { is_expected.to have_http_status :not_found }
+      it { expect { page_response }.not_to change(GreenLanes::Measure, :count) }
+    end
+  end
 end

--- a/spec/requests/api/admin/green_lanes/measurers_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/measurers_controller_spec.rb
@@ -88,21 +88,34 @@ RSpec.describe Api::Admin::GreenLanes::MeasuresController do
       authenticated_patch api_admin_green_lanes_measure_path(id, format: :json), params: {
         data: {
           type: :green_lanes_measure,
-          attributes: { category_assessment_id: new_category_assessment.id },
+          attributes: { category_assessment_id: new_category_assessment_id },
         },
       }
     end
 
     context 'with valid params' do
       let(:id) { measure.id }
+      let(:new_category_assessment_id) { new_category_assessment.id }
 
       it { is_expected.to have_http_status :success }
       it { is_expected.to have_attributes location: api_admin_green_lanes_measure_url(measure.id) }
       it { expect { page_response }.not_to change(measure.reload, :productline_suffix) }
     end
 
+    context 'with invalid params' do
+      let(:id) { measure.id }
+      let(:new_category_assessment_id) { nil }
+
+      it { is_expected.to have_http_status :unprocessable_entity }
+
+      it 'returns errors for exemption' do
+        expect(json_response).to include('errors')
+      end
+    end
+
     context 'with unknown exemption' do
       let(:id) { 9999 }
+      let(:new_category_assessment_id) { new_category_assessment.id }
 
       it { is_expected.to have_http_status :not_found }
       it { expect { page_response }.not_to change(measure.reload, :productline_suffix) }

--- a/spec/requests/api/admin/green_lanes/measurers_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/measurers_controller_spec.rb
@@ -82,7 +82,6 @@ RSpec.describe Api::Admin::GreenLanes::MeasuresController do
   end
 
   describe 'PATCH to #update' do
-    let(:id) { measure.id }
     let(:new_category_assessment) { create :category_assessment }
 
     let(:make_request) do
@@ -95,6 +94,8 @@ RSpec.describe Api::Admin::GreenLanes::MeasuresController do
     end
 
     context 'with valid params' do
+      let(:id) { measure.id }
+
       it { is_expected.to have_http_status :success }
       it { is_expected.to have_attributes location: api_admin_green_lanes_measure_url(measure.id) }
       it { expect { page_response }.not_to change(measure.reload, :productline_suffix) }


### PR DESCRIPTION
### Jira link

[GL-384](https://transformuk.atlassian.net/browse/GL-384)

### What?

I have added/removed/altered:

- [ ] Added GL api to delete measures


### Why?

I am doing this because:

- Admin user should be able to manage GL measures
