### PR TITLE
GL-618: Validate green lanes measures against invalid goods nomenclature codes

### DIFF
--- a/app/controllers/api/admin/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/api/admin/green_lanes/category_assessments_controller.rb
@@ -101,7 +101,7 @@ module Api
         end
 
         def category_assessments
-          @category_assessments ||= ::GreenLanes::CategoryAssessment.eager(:theme).order(:theme_id).paginate(current_page, per_page)
+          @category_assessments ||= ::GreenLanes::CategoryAssessment.eager(:theme).order(:id).paginate(current_page, per_page)
         end
 
         def serialize(*args)

--- a/app/controllers/api/admin/green_lanes/measures_controller.rb
+++ b/app/controllers/api/admin/green_lanes/measures_controller.rb
@@ -27,15 +27,22 @@ module Api
         end
 
         def create
-          measure = ::GreenLanes::Measure.new(measure_params)
+          gn = GoodsNomenclature.actual.where(goods_nomenclature_item_id: measure_params[:goods_nomenclature_item_id],
+                                              producline_suffix: measure_params[:productline_suffix])
 
-          if measure.valid? && measure.save
-            render json: serialize(measure),
-                   location: api_admin_green_lanes_measure_url(measure.id),
-                   status: :created
+          if gn.present?
+            measure = ::GreenLanes::Measure.new(measure_params)
+
+            if gn.present? && measure.valid? && measure.save
+              render json: serialize(measure),
+                     location: api_admin_green_lanes_measure_url(measure.id),
+                     status: :created
+            else
+              render json: serialize_errors(measure),
+                     status: :unprocessable_entity
+            end
           else
-            render json: serialize_errors(measure),
-                   status: :unprocessable_entity
+            raise Sequel::RecordNotFound
           end
         end
 

--- a/app/models/green_lanes/exemption.rb
+++ b/app/models/green_lanes/exemption.rb
@@ -3,9 +3,11 @@ module GreenLanes
     plugin :timestamps, update_on_create: true
     plugin :auto_validations, not_null: :presence
     plugin :association_pks
+    plugin :association_dependencies
 
     many_to_many :category_assessments,
                  join_table: :green_lanes_category_assessments_exemptions
+    add_association_dependencies category_assessments: :nullify
     plugin :touch, associations: %i[category_assessments]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,7 @@ Rails.application.routes.draw do
           resources :category_assessments, only: %i[index show create update destroy] do
             member do
               post 'exemptions', to: 'category_assessments#add_exemption'
+              delete 'exemptions', to: 'category_assessments#remove_exemption'
             end
           end
           resources :themes, only: %i[index]


### PR DESCRIPTION
### Jira link

[GL-618](https://transformuk.atlassian.net/browse/GL-618)

### What?

I have added/removed/altered:

- [ ] Added validation to pseudo measures against invalid goods nomenclature

### Why?

I am doing this because:

- Since there are no forign key constrains in gl data, we need to manually validate pseudo mesures against invalid GN
