### PR TITLE
GL-705: Remove add code from permutation key

### DIFF
--- a/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
@@ -17,7 +17,6 @@ module Api
                  :geographical_area,
                  :excluded_geographical_areas,
                  :measure_conditions,
-                 :additional_code,
                  to: :first_measure
 
         content_addressable_fields do |ca|
@@ -77,7 +76,8 @@ module Api
         end
 
         def additional_codes
-          Array.wrap(additional_code)
+          additional_codes = measures.map(&:additional_code).compact
+          additional_codes.empty? ? [] : additional_codes
         end
 
         def pseudo_exemptions

--- a/app/services/green_lanes/find_category_assessments_service.rb
+++ b/app/services/green_lanes/find_category_assessments_service.rb
@@ -25,8 +25,8 @@ module GreenLanes
 
     def compute_assessment_permutations(assessment, assessment_measures)
       permutations_for_assessment(assessment_measures)
-        .map do |key, permutation|
-          present_assessment(assessment, key, permutation)
+        .map do |key, measure_permutation|
+          present_assessment(assessment, key, measure_permutation)
         end
     end
 
@@ -34,9 +34,9 @@ module GreenLanes
       PermutationCalculatorService.new(assessment_measures).call
     end
 
-    def present_assessment(assessment, key, permutation)
+    def present_assessment(assessment, key, measure_permutation)
       ::Api::V2::GreenLanes::CategoryAssessmentPresenter
-        .new(assessment, key, permutation)
+        .new(assessment, key, measure_permutation)
     end
 
     def filter_by_geographical_area(measure)

--- a/app/services/green_lanes/permutation_calculator_service.rb
+++ b/app/services/green_lanes/permutation_calculator_service.rb
@@ -17,8 +17,6 @@ module GreenLanes
         measure.measure_generating_regulation_role,
         measure.geographical_area_id,
         measure.measure_excluded_geographical_areas.map(&:excluded_geographical_area).sort.uniq.join('|'),
-        measure.additional_code_type_id,
-        measure.additional_code_id,
         measure.measure_conditions.select(&:is_exempting_with_certificate_overridden?).map(&:document_code).sort.uniq.join('|'),
       ]
     end

--- a/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Api::V2::GreenLanes::CategoryAssessmentPresenter do
-  subject(:presented) { described_class.new(assessment, *permutations.first) }
+  subject(:presented) { described_class.new(assessment, permutations.first, assessment.measures) }
 
-  let(:assessment) { create :category_assessment, :with_measures }
+  let(:assessment) { create :category_assessment, :with_measures, measures_count: 2}
 
   let :permutations do
     GreenLanes::PermutationCalculatorService.new(assessment.measures).call
@@ -15,14 +15,14 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentPresenter do
   describe '.wrap' do
     subject(:wrapped) { described_class.wrap [assessment] }
 
-    it { is_expected.to have_attributes length: 1 }
+    it { is_expected.to have_attributes length: 2 }
     it { is_expected.to all be_instance_of described_class }
 
     context 'with first presented category assessment' do
       subject { wrapped.first }
 
       it { is_expected.to have_attributes id: /^[0-9a-f]{32}$/ }
-      it { is_expected.to have_attributes measure_ids: assessment.measures.map(&:measure_sid) }
+      it { is_expected.to have_attributes measure_ids: [assessment.measures.map(&:measure_sid).first] }
     end
 
     context 'with no measures' do
@@ -82,10 +82,11 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentPresenter do
       end
     end
 
-    let :additional_code do
-      create(:additional_code).tap do |ad_code|
-        assessment.measures.first.update additional_code: ad_code
-      end
+    let :additional_codes do
+      additional_codes = create_list(:additional_code, 2)
+      assessment.measures[0].update additional_code: additional_codes[0]
+      assessment.measures[1].update additional_code: additional_codes[1]
+      additional_codes
     end
 
     context 'with certificates' do
@@ -110,15 +111,15 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentPresenter do
     end
 
     context 'with additional code' do
-      before { additional_code }
+      before { additional_codes }
 
-      it { is_expected.to match_array [additional_code] }
+      it { is_expected.to match_array additional_codes }
     end
 
     context 'with certificates and additional code' do
-      before { certificates && additional_code }
+      before { certificates && additional_codes }
 
-      it { is_expected.to match_array certificates << additional_code }
+      it { is_expected.to match_array certificates + additional_codes }
     end
 
     context 'with pseudo exemption' do

--- a/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/category_assessment_presenter_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Api::V2::GreenLanes::CategoryAssessmentPresenter do
   subject(:presented) { described_class.new(assessment, permutations.first, assessment.measures) }
 
-  let(:assessment) { create :category_assessment, :with_measures, measures_count: 2}
+  let(:assessment) { create :category_assessment, :with_measures, measures_count: 2 }
 
   let :permutations do
     GreenLanes::PermutationCalculatorService.new(assessment.measures).call

--- a/spec/services/green_lanes/permutation_calculator_service_spec.rb
+++ b/spec/services/green_lanes/permutation_calculator_service_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe GreenLanes::PermutationCalculatorService do
         ]
       end
 
-      it_behaves_like 'two segregated lists'
+      it_behaves_like 'a single list'
     end
 
     context 'with different exemption certificates' do


### PR DESCRIPTION
### Jira link

[GL-705](https://transformuk.atlassian.net/browse/GL-705)

### What?

I have added/removed/altered:

- [ ] Removed additional code key from the permutation key

### Why?

I am doing this because:

- We don't need to create separate CA for each additional codes. Instead, we need to group them into a one CA