### PR TITLE
OTT-342: Support Zimbabwe Gold

### DIFF
--- a/app/services/exchange_rates/update_currency_rates_service.rb
+++ b/app/services/exchange_rates/update_currency_rates_service.rb
@@ -54,20 +54,12 @@ module ExchangeRates
       validity_end_date = @date.end_of_month
 
       ExchangeRateCurrencyRate.new(
-        currency_code: currency_overide(currency_code),
+        currency_code:,
         validity_start_date:,
         validity_end_date:,
         rate:,
         rate_type: @type,
       )
-    end
-
-    def currency_overide(currency_code)
-      currency_overides = { 'ZWL' => 'ZIG' }
-
-      return currency_code unless currency_overides.keys.include?(currency_code)
-
-      currency_overides[currency_code]
     end
   end
 end

--- a/spec/services/exchange_rates/update_currency_rates_service_spec.rb
+++ b/spec/services/exchange_rates/update_currency_rates_service_spec.rb
@@ -75,69 +75,6 @@ RSpec.describe ExchangeRates::UpdateCurrencyRatesService do
 
         expect(new_rates).to include_json(expected_rates)
       end
-
-      # Below test is in place to protect us against XE
-      # not porviding ZIG currnecy even though its accepted across over 90% banks in Zimbabwe
-      context 'when XE provides ZWL and ZIG' do
-        let(:response) do
-          {
-            'to' => [
-              { 'quotecurrency' => 'ZWL', 'mid' => 16.8567 },
-              { 'quotecurrency' => 'ZIG', 'mid' => 16.8567 },
-            ],
-          }
-        end
-
-        let(:expected_rates) do
-          [
-            {
-              currency_code: 'ZIG',
-              validity_start_date: date.beginning_of_month,
-              validity_end_date: date.end_of_month,
-              rate: 16.8567,
-              rate_type: ExchangeRateCurrencyRate::MONTHLY_RATE_TYPE,
-            },
-          ].as_json
-        end
-
-        it 'will create a ZIG rate' do
-          service.call
-
-          new_rates = ExchangeRateCurrencyRate.all.map(&:values).as_json
-
-          expect(new_rates).to include_json(expected_rates)
-        end
-      end
-
-      context 'when XE provides ZWL' do
-        let(:response) do
-          {
-            'to' => [
-              { 'quotecurrency' => 'ZWL', 'mid' => 16.8567 },
-            ],
-          }
-        end
-
-        let(:expected_rates) do
-          [
-            {
-              currency_code: 'ZIG',
-              validity_start_date: date.beginning_of_month,
-              validity_end_date: date.end_of_month,
-              rate: 16.8567,
-              rate_type: ExchangeRateCurrencyRate::MONTHLY_RATE_TYPE,
-            },
-          ].as_json
-        end
-
-        it 'will create a ZIG rate' do
-          service.call
-
-          new_rates = ExchangeRateCurrencyRate.all.map(&:values).as_json
-
-          expect(new_rates).to include_json(expected_rates)
-        end
-      end
     end
 
     context 'when type is SPOT_RATE_TYPE' do


### PR DESCRIPTION
### Jira link

OTT-342

### What?

I have added/removed/altered:

- [x] Removed overrides for ZIG
- [ ] Added a migration to add a new country currency for ZWG (Zimbabwe Gold)
- [ ] Added a migration to end date the ZIG country currency

### Why?

I am doing this because:

- This is required because XE.com are going to be publishing ZWG rates for this months rates and have moved away from ZWL and ZIG rates
