### PR TITLE
BAU: Stop caching potentially broken list responses

### DIFF
--- a/app/lib/tariff_synchronizer/cds_update_downloader.rb
+++ b/app/lib/tariff_synchronizer/cds_update_downloader.rb
@@ -36,7 +36,7 @@ module TariffSynchronizer
     #   "fileSize"=>478 }
     # downloadURL contains gzip file with an xml file inside.
     def response
-      @response = Rails.cache.fetch('cds-updates-list', expires_in: 2.hours) do
+      @response = begin
         uri = URI.join(ENV['HMRC_API_HOST'], '/bulk-data-download/list/TARIFF-DAILY')
         https = Net::HTTP.new(uri.host, uri.port)
         https.use_ssl = true


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Removes arbitrary caching of list responses in CDS download process

### Why?

I am doing this because:

- These were caching failures that got fixed and add little value, really, since this is not a slow api
