### PR TITLE
GL-735: Admin UI: Paginate pseudo measures in CA edit page

### DIFF
--- a/app/presenters/api/admin/green_lanes/category_assessment_presenter.rb
+++ b/app/presenters/api/admin/green_lanes/category_assessment_presenter.rb
@@ -1,0 +1,19 @@
+module Api
+  module Admin
+    module GreenLanes
+      class CategoryAssessmentPresenter < SimpleDelegator
+        attr_reader :green_lanes_measures
+
+        def initialize(ca, measures)
+          @green_lanes_measures = measures
+
+          super(ca)
+        end
+
+        def green_lanes_measure_ids
+          @green_lanes_measure_ids ||= @green_lanes_measures.map(&:id)
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/admin/green_lanes/category_assessment_serializer.rb
+++ b/app/serializers/api/admin/green_lanes/category_assessment_serializer.rb
@@ -13,6 +13,16 @@ module Api
                    :regulation_role,
                    :theme_id
 
+        attribute :measure_pagination do |object, params|
+          if params[:with_measures]
+            {
+              :id => 1,
+              :type => 'measure_pagination',
+              :attributes=> params[:measure_pagination]
+            }
+          end
+        end
+
         has_one :theme, serializer: ThemeSerializer
         has_many :green_lanes_measures, serializer: MeasureSerializer, if: ->(_record, params) { params[:with_measures] }, id_method_name: :green_lanes_measure_pks
         has_many :exemptions, serializer: ExemptionSerializer, if: ->(_record, params) { params[:with_exemptions] }, id_method_name: :exemption_pks

--- a/spec/serializers/api/admin/green_lanes/category_assessment_serializer_spec.rb
+++ b/spec/serializers/api/admin/green_lanes/category_assessment_serializer_spec.rb
@@ -1,10 +1,17 @@
 RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentSerializer do
   subject do
     described_class.new(category,
-                        params: { with_measures: true, with_exemptions: true },
+                        params: { with_measures: true, with_exemptions: true, measure_pagination: measure_pagination },
                         include: %w[green_lanes_measures exemptions]).serializable_hash.as_json
   end
 
+  let(:measure_pagination) {
+    {
+      current_page: 1,
+      limit_value: 20,
+      total_pages: 2
+    }
+  }
   let(:category) { create :category_assessment, :with_green_lanes_measure, :with_exemption }
 
   let :expected do
@@ -16,6 +23,7 @@ RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentSerializer do
           measure_type_id: category.measure_type_id,
           regulation_id: category.regulation_id,
           regulation_role: category.regulation_role,
+          measure_pagination: {id: 1, type: 'measure_pagination', attributes: { current_page: 1, limit_value: 20, total_pages: 2 }},
         },
         relationships: {
           theme: {


### PR DESCRIPTION
### Jira link

[GL-735](https://transformuk.atlassian.net/browse/GL-735)

### What?

I have added/removed/altered:

- [ ] Added pagination to list of pseudo measures in category assessment edit page

### Why?

I am doing this because:

- Number of measure records cannot be handle without pagination
