### PR TITLE
BAU: Include the category assessment id in the serialized output

### DIFF
--- a/app/serializers/api/v2/green_lanes/category_assessment_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/category_assessment_serializer.rb
@@ -7,7 +7,7 @@ module Api
         set_type :category_assessment
         set_id :id
 
-        attribute :category_assessment_id if Rails.env.development?
+        attribute :category_assessment_id
 
         has_many :exemptions, serializer: lambda { |record, _params|
           case record

--- a/spec/serializers/api/v2/green_lanes/category_assessment_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/category_assessment_serializer_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentSerializer do
       data: {
         id: be_a(String),
         type: 'category_assessment',
+        attributes: { category_assessment_id: be_a(Integer) },
         relationships: {
           theme: {
             data: { id: category_assessment.theme.code, type: 'theme' },


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Fixes missing serialized attribute in live environments

### Why?

I am doing this because:

- This is needed by the frontend
