### PR TITLE
BAU: Fixes differences report after lint

### DIFF
--- a/app/lib/reporting/differences/omitted_duty_measures.rb
+++ b/app/lib/reporting/differences/omitted_duty_measures.rb
@@ -101,9 +101,11 @@ module Reporting
 
           next if current_measures.nil?
 
-          past_measures.each_key do |past_measure|
+          # rubocop:disable Style/HashEachMethods
+          past_measures.each do |past_measure, _|
             non_continuous_measures << past_measure unless current_measures.include?(past_measure)
           end
+          # rubocop:enable Style/HashEachMethods
         end
 
         non_continuous_measures.each { |measure| yield build_row_for(measure) }


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Fixes differences report

### Why?

I am doing this because:

- This is required to make sure we're sending these reports out
- This was broken after an upgrade of the rubocop gem
