### PR TITLE
GL-909: Extend categorisation function to account for GB specific measures

### DIFF
--- a/app/services/green_lanes/find_category_assessments_service.rb
+++ b/app/services/green_lanes/find_category_assessments_service.rb
@@ -42,7 +42,7 @@ module GreenLanes
     def filter_by_geographical_area(measure)
       return true if @geographical_area_id.blank?
 
-      measure.relevant_for_country? @geographical_area_id
+      measure.relevant_for_country?(@geographical_area_id) || measure.relevant_for_country?('GB')
     end
   end
 end

--- a/spec/services/green_lanes/find_category_assessments_service_spec.rb
+++ b/spec/services/green_lanes/find_category_assessments_service_spec.rb
@@ -102,5 +102,41 @@ RSpec.describe GreenLanes::FindCategoryAssessmentsService do
         end
       end
     end
+
+    context 'with default GB measures for category assessments' do
+      before do
+        gb = create(:geographical_area, geographical_area_id: 'GB')
+
+        gbm = create(:measure,
+                     :with_base_regulation,
+                     goods_nomenclature:,
+                     for_geo_area: gb)
+        measures << gbm
+
+        category_assessments << create(:category_assessment, measure: gbm)
+      end
+
+      let(:geographical_area_id) { countries[:switzerland].geographical_area_id }
+
+      it { is_expected.to have_attributes length: 4 }
+
+      context 'for swiss assessment' do
+        subject { presented_assessments[category_assessments[0].id].first }
+
+        it { is_expected.to have_attributes measure_ids: [measures[0].measure_sid] }
+      end
+
+      context 'for erga omnes assessment' do
+        subject { presented_assessments[category_assessments[2].id].first }
+
+        it { is_expected.to have_attributes measure_ids: [measures[2].measure_sid] }
+      end
+
+      context 'for gb assessment' do
+        subject { presented_assessments[category_assessments[3].id].first }
+
+        it { is_expected.to have_attributes measure_ids: [measures[3].measure_sid] }
+      end
+    end
   end
 end


### PR DESCRIPTION
### Jira link

[GL-909](https://transformuk.atlassian.net/browse/GL-909)

### What?

I have added/removed/altered:

- [ ] Added condition to include GB spesific measures to categorisation for  geographical_area filtered requests.

### Why?

I am doing this because:

- Trade movements related to GL are always from GB to NI regradless of country of origin of the trade comoddity. So the GB related measures are always applicable for GL categorisation. 