### PR TITLE
GL-921: Change how CAs uniqueness is calculated to factor in theme

### DIFF
--- a/db/migrate/20240808113431_update_green_lanes_category_assessments_index.rb
+++ b/db/migrate/20240808113431_update_green_lanes_category_assessments_index.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table :green_lanes_category_assessments do
+      drop_index %i[measure_type_id regulation_id regulation_role]
+      add_index %i[measure_type_id regulation_id regulation_role theme_id], unique: true
+    end
+  end
+
+  down do
+    alter_table :green_lanes_category_assessments do
+      drop_index %i[measure_type_id regulation_id regulation_role theme_id]
+      add_index %i[measure_type_id regulation_id regulation_role], unique: true
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10792,7 +10792,7 @@ CREATE INDEX green_lanes_category_assessments_exemptions_exemption_id_catego ON 
 -- Name: green_lanes_category_assessments_measure_type_id_regulation_id_; Type: INDEX; Schema: uk; Owner: -
 --
 
-CREATE UNIQUE INDEX green_lanes_category_assessments_measure_type_id_regulation_id_ ON uk.green_lanes_category_assessments USING btree (measure_type_id, regulation_id, regulation_role);
+CREATE UNIQUE INDEX green_lanes_category_assessments_measure_type_id_regulation_id_ ON uk.green_lanes_category_assessments USING btree (measure_type_id, regulation_id, regulation_role, theme_id);
 
 
 --
@@ -12496,3 +12496,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20240610160146_update_quot
 INSERT INTO "schema_migrations" ("filename") VALUES ('20240530121653_add_index_to_category_assessments_updated_at.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20240627113028_create_green_lanes_exempting_additional_code_overrides.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20240723112213_create_green_lanes_update_notifications.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20240808113431_update_green_lanes_category_assessments_index.rb');

--- a/lib/tasks/green_lanes.rake
+++ b/lib/tasks/green_lanes.rake
@@ -239,6 +239,5 @@ namespace :green_lanes do
 
       assessments[key] = assessment
     end
-
   end
 end

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -22,16 +22,17 @@ RSpec.describe GreenLanes::CategoryAssessment do
     it { is_expected.to include regulation_role: ['is not present'] }
     it { is_expected.to include theme_id: ['is not present'] }
 
-    context 'with duplicate measure_type_id and regulation_id' do
+    context 'with duplicate measure_type_id, regulation_id and theme_id' do
       let(:existing) { create :category_assessment }
 
       let :instance do
         described_class.new measure_type_id: existing.measure_type_id,
                             regulation_id: existing.regulation_id,
-                            regulation_role: existing.regulation_role
+                            regulation_role: existing.regulation_role,
+                            theme_id: existing.theme_id
       end
 
-      it { is_expected.to include %i[measure_type_id regulation_id regulation_role] => ['is already taken'] }
+      it { is_expected.to include %i[measure_type_id regulation_id regulation_role theme_id] => ['is already taken'] }
     end
   end
 


### PR DESCRIPTION
### Jira link

[GL-921](https://transformuk.atlassian.net/browse/GL-921)

### What?

I have added/removed/altered:

- [ ] Updated unique index of category_assessment table add them_id into the index


### Why?

I am doing this because:

- We need to add two different CA for same measure_type and regulation quotable and non-quotable items. These CAs created for different category but enforced by same measure type and regulation.
