### PR TITLE
BAU: Tidy up broken release notes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,16 +292,6 @@ jobs:
           command: |
             bin/sync-opensearch-packages << parameters.space >> << parameters.bucket >>
 
-  notify-production-deployment:
-    docker:
-      - image: cimg/ruby:3.3.4
-    steps:
-      - checkout
-      - tariff/notify-production-release:
-          app-name: Backend
-          slack-channel: trade_tariff
-          release-tag: $CIRCLE_TAG
-
 workflows:
   version: 2
 
@@ -487,10 +477,4 @@ workflows:
           environment: production
           requires:
             - write-docker-tag-prod-release
-          <<: *filter-release
-
-      - notify-production-deployment:
-          context: trade-tariff-releases
-          requires:
-            - apply-terraform-prod
           <<: *filter-release


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Tidy up broken release notes

### Why?

I am doing this because:

- These fail and duplicate the other release notes we generate
