### PR TITLE
GL-935: Extend API to allow categorization of 4 digit commodities that are end leaves

### DIFF
--- a/app/services/green_lanes/fetch_goods_nomenclature_service.rb
+++ b/app/services/green_lanes/fetch_goods_nomenclature_service.rb
@@ -68,7 +68,7 @@ module GreenLanes
     private
 
     def invalid_id(id)
-      id.blank? || !is_id_length_greater(id,2)
+      id.blank? || !is_id_length_greater(id, 2)
     end
 
     def is_id_length_greater(id, length)

--- a/app/services/green_lanes/fetch_goods_nomenclature_service.rb
+++ b/app/services/green_lanes/fetch_goods_nomenclature_service.rb
@@ -54,7 +54,7 @@ module GreenLanes
              .order(Sequel[:goods_nomenclatures][:producline_suffix], Sequel[:goods_nomenclature_indents][:number_indents])
              .first
 
-      if gn.present?
+      if gn.present? && (is_id_length_greater(@goods_nomenclature_item_id, 4) || gn.declarable?)
         GoodsNomenclature
           .actual
           .eager(EAGER_LOAD)
@@ -68,7 +68,11 @@ module GreenLanes
     private
 
     def invalid_id(id)
-      id.blank? || id.length <= 4 || id[4..].each_char.all? { |char| char == '0' }
+      id.blank? || !is_id_length_greater(id,2)
+    end
+
+    def is_id_length_greater(id, length)
+      id.length > length && id[length..].each_char.any? { |char| char != '0' }
     end
 
     def length_adjusted_digit_id

--- a/spec/services/green_lanes/fetch_goods_nomenclature_service_spec.rb
+++ b/spec/services/green_lanes/fetch_goods_nomenclature_service_spec.rb
@@ -6,6 +6,28 @@ RSpec.describe GreenLanes::FetchGoodsNomenclatureService do
       create(:goods_nomenclature, goods_nomenclature_item_id: '0101210000')
       create(:goods_nomenclature, goods_nomenclature_item_id: '0101214200')
       create(:goods_nomenclature, goods_nomenclature_item_id: '0101214264')
+      create(:goods_nomenclature, :without_descendants, :non_grouping, goods_nomenclature_item_id: '4909000000')
+      create(:goods_nomenclature, :with_descendants, goods_nomenclature_item_id: '0202000000')
+    end
+
+    context 'when the ID is 4-digit and declarable' do
+      let(:id) { '4909' }
+
+      it { expect(service.call).to be_a(GoodsNomenclature) }
+
+      it 'return the correct goods nomenclature item id' do
+        goods_nomenclature = service.call
+
+        expect(goods_nomenclature.goods_nomenclature_item_id).to eq('4909000000')
+      end
+    end
+
+    context 'when the ID is 4-digit and non declarable' do
+      let(:id) { '0202' }
+
+      it 'raises record not found exception' do
+        expect { described_class.new(id).call }.to raise_error Sequel::RecordNotFound
+      end
     end
 
     context 'when the ID is 6-digit' do


### PR DESCRIPTION
### Jira link

[GL-935](https://transformuk.atlassian.net/browse/GL-935)

### What?

I have added/removed/altered:

- [x] Updated CC validation in GN api to allow 4 digit declarables.

### Why?

I am doing this because:

- As current validation block 4 digit declarables but they need to be allowed for categorisation
-
-

### Have you? (optional)

- [x] Added documentation for new apis
