### PR TITLE
GL-914: Consume secret in controller & auth with secret in controller

### DIFF
--- a/app/controllers/api/v2/green_lanes/base_controller.rb
+++ b/app/controllers/api/v2/green_lanes/base_controller.rb
@@ -17,16 +17,54 @@ module Api
         end
 
         def authenticate
-          unless Rails.env.development? && TradeTariffBackend.green_lanes_api_tokens.blank?
-            authenticate_or_request_with_http_token do |provided_token, _options|
-              Rails.logger.debug provided_token
-              api_tokens.any? { |token| ActiveSupport::SecurityUtils.secure_compare(provided_token, token) }
-            end
+          unless Rails.env.development? && TradeTariffBackend.green_lanes_api_keys.blank?
+            authenticated = authenticate_with_api_keys
           end
+
+          unless Rails.env.development? && TradeTariffBackend.green_lanes_api_tokens.blank?
+            authenticated ||= authenticate_with_api_tokens
+          end
+
+          unless authenticated || (Rails.env.development? && TradeTariffBackend.green_lanes_api_keys.blank?)
+            render json: { error: 'Invalid API Key' }, status: :bad_request
+          end
+        end
+
+        def authenticate_with_api_tokens
+          authenticate_or_request_with_http_token do |provided_token, _options|
+            Rails.logger.debug "Provided token: #{provided_token}"
+            api_tokens.any? { |token| ActiveSupport::SecurityUtils.secure_compare(provided_token, token) }
+          end
+
+          true
+        end
+
+        def authenticate_with_api_keys
+          provided_key = request.headers['X-Api-Key']
+          return false if provided_key.blank?
+
+          Rails.logger.debug "Provided key: #{provided_key}"
+
+          return false unless api_keys.any? { |api_key| ActiveSupport::SecurityUtils.secure_compare(provided_key, api_key) }
+
+          true
         end
 
         def api_tokens
           @api_tokens ||= read_tokens
+        end
+
+        def api_keys
+          @api_keys ||= read_api_keys
+        end
+
+        def read_api_keys
+          api_key_hash = JSON.parse(TradeTariffBackend.green_lanes_api_keys)
+          if api_key_hash.any?
+            api_key_hash['api_keys'].keys
+          else
+            []
+          end
         end
 
         def read_tokens


### PR DESCRIPTION
### Jira link

[GL-914](https://transformuk.atlassian.net/browse/GL-914)

### What?

I have added/removed/altered:

- [ ] Added authentication by X-Api-Key header value

### Why?

I am doing this because:

- We need to enable clients that send X-Api-Key header in their request by validating against Api key provided to them.  
- Autherisation header validation also still available for backward compatibility.
- This is tempory solution and api-key validation will be handed over to api-gateway in the future

