### PR TITLE
GL-913: Create secret & inject in the env of the app

### DIFF
--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -262,6 +262,10 @@ module TradeTariffBackend
       ENV['GREEN_LANES_API_TOKENS']
     end
 
+    def green_lanes_api_keys
+      ENV['GREEN_LANES_API_KEYS']
+    end
+
     def excise_alcohol_coercian_starts_from
       @excise_alcohol_coercian_starts_from ||= Date.parse(
         ENV.fetch(

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -51,6 +51,7 @@ Terraform to deploy the service into AWS.
 | [aws_secretsmanager_secret.database_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.database_readonly_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.differences_to_emails](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
+| [aws_secretsmanager_secret.green_lanes_api_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.green_lanes_api_tokens](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.oauth_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.oauth_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -119,6 +119,10 @@ data "aws_secretsmanager_secret" "green_lanes_api_tokens" {
   name = "backend-green-lanes-api-tokens"
 }
 
+data "aws_secretsmanager_secret" "green_lanes_api_keys" {
+  name = "backend-green-lanes-api-keys"
+}
+
 data "aws_s3_bucket" "spelling_corrector" {
   bucket = "trade-tariff-search-configuration-${local.account_id}"
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -12,6 +12,7 @@ data "aws_iam_policy_document" "secrets" {
       data.aws_secretsmanager_secret.database_readonly_connection_string.arn,
       data.aws_secretsmanager_secret.differences_to_emails.arn,
       data.aws_secretsmanager_secret.green_lanes_api_tokens.arn,
+      data.aws_secretsmanager_secret.green_lanes_api_keys.arn,
       data.aws_secretsmanager_secret.oauth_id.arn,
       data.aws_secretsmanager_secret.oauth_secret.arn,
       data.aws_secretsmanager_secret.redis_frontend_connection_string.arn,

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -205,6 +205,10 @@ locals {
       valueFrom = data.aws_secretsmanager_secret.green_lanes_api_tokens.arn
     },
     {
+      name      = "GREEN_LANES_API_KEYS"
+      valueFrom = data.aws_secretsmanager_secret.green_lanes_api_keys.arn
+    },
+    {
       name      = "SENTRY_DSN"
       valueFrom = data.aws_secretsmanager_secret.sentry_dsn.arn
     },


### PR DESCRIPTION
### Jira link

[GL-913](https://transformuk.atlassian.net/browse/GL-913)

### What?

I have added/removed/altered:

- [ ] Added env variable to fetch and store valid api keys from aws secret store
- [ ] Added authentication by X-Api-Key header value


### Why?

I am doing this because:

- We need to enable clients that send X-Api-Key header in their request by validating against Api key provided to them.
- Autherisation header validation also still available for backward compatibility.
- This is tempory solution and api-key validation will be handed over to api-gateway in the future
