### PR TITLE
GL-935: Extend API to allow categorization of 4 digit commodities that are end leaves-bug fix

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -227,7 +227,7 @@ Rails.application.routes.draw do
       get 'goods_nomenclatures/heading/:heading_id', to: 'goods_nomenclatures#show_by_heading', constraints: { heading_id: /\d{4}/ }
 
       namespace :green_lanes do
-        resources :goods_nomenclatures, only: %i[show], constraints: { id: /\d{6,10}/ }
+        resources :goods_nomenclatures, only: %i[show], constraints: { id: /\d{4,10}/ }
 
         resources :category_assessments, only: %i[index]
 


### PR DESCRIPTION
### Jira link

[GL-935](https://transformuk.atlassian.net/browse/GL-935)

### What?

I have added/removed/altered:

- [x] Updated CC validation in GN api to allow 4 digit declarables.

### Why?

I am doing this because:

- To remove the restriction in route file that check CC to min 6 digits

