### PR TITLE
BAU: Update Bundler to 2.5.17

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -527,4 +527,4 @@ RUBY VERSION
    ruby 3.3.4p94
 
 BUNDLED WITH
-   2.3.8
+   2.5.17


### PR DESCRIPTION
### Jira link

BAU

### What?

Updated Bundler as our version here is over 2.5 years old

### Why?

I am doing this because:

- It being this out of date is fairly risky

### Deployment risks (optional)

- There could potentially be an issue where the target wants to stick to the old version but from what I can see everything should update.
