### PR TITLE
BAU - Prevent duplicate logging in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -80,5 +80,5 @@ Rails.application.configure do
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
 
-  config.logger = SchemaQueryFilterLogger.new(ActiveSupport::Logger.new($stdout))
+  config.logger = SchemaQueryFilterLogger.new(Logger.new('/dev/null'))
 end


### PR DESCRIPTION
### Jira link

BAU

### What?

I have stopped the app from logging in duplicate in development which makes it harder to see what's going on.  This just helps keep the noise down.

### Why?

I am doing this because we don't need everything twice.

### Deployment risks (optional)

None