### PR TITLE
Allow development to use localstack over AWS

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -31,3 +31,9 @@ XE_API_PASSWORD=pass
 XE_API_URL=url
 XE_API_USERNAME=user
 GREEN_LANES_UPDATE_EMAIL=hmrc@example.com
+## LOCALSTACK SETUP
+# Uncomment the following lines to use localstack
+# AWS_ENDPOINT=http://s3.localhost.localstack.cloud:4566
+# AWS_REGION=eu-west-2
+# AWS_SECRET_ACCESS_KEY=test
+# AWS_ACCESS_KEY_ID=test

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ TARIFF_SYNC_USERNAME
 GREEN_LANES_UPDATE_EMAIL
 ```
 
+## Localstack
+
+This project uses [localstack](https://github.com/localstack/localstack) to simulate AWS services locally should you choose to. To use localstack, you will need to install it and run it locally. You can find instructions on how to do this [here](https://github.com/localstack/localstack#installation).
+
+Once you have installed localstack, you will need to configure it to use the correct AWS region and credentials.  This can be done by uncommenting the relevant lines in the `.env.development` file and setting the appropriate values.
+
 ## Licence
 
 Trade Tariff is licenced under the [MIT licence](https://github.com/trade-tariff/trade-tariff-backend/blob/main/LICENCE.txt)

--- a/config/initializers/persistence_bucket.rb
+++ b/config/initializers/persistence_bucket.rb
@@ -2,7 +2,12 @@ s3_bucket_name = ENV['AWS_BUCKET_NAME']
 running_in_aws = ENV['ECS_AGENT_URI'].present?
 credentials_loaded = ENV['AWS_PROFILE'].present? || (ENV['AWS_SECRET_ACCESS_KEY'].present? && ENV['AWS_ACCESS_KEY_ID'].present?)
 
-s3_bucket = if Rails.env.test?
+s3_bucket = if Rails.env.development? && ENV.key?('AWS_ENDPOINT')
+              unless Aws::S3::Resource.new(endpoint: ENV['AWS_ENDPOINT']).bucket(s3_bucket_name).exists?
+                Aws::S3::Resource.new(endpoint: ENV['AWS_ENDPOINT']).create_bucket({ bucket: s3_bucket_name })
+              end
+              Aws::S3::Resource.new(endpoint: ENV['AWS_ENDPOINT']).bucket(s3_bucket_name)
+            elsif Rails.env.test?
               Aws::S3::Resource.new(stub_responses: true).bucket(s3_bucket_name)
             elsif s3_bucket_name && (credentials_loaded || running_in_aws)
               Aws::S3::Resource.new.bucket(s3_bucket_name)

--- a/config/initializers/spelling_corrector_bucket.rb
+++ b/config/initializers/spelling_corrector_bucket.rb
@@ -2,14 +2,19 @@ s3_bucket_name = ENV['SPELLING_CORRECTOR_BUCKET_NAME']
 running_in_aws = ENV['ECS_AGENT_URI'].present?
 credentials_loaded = ENV['AWS_PROFILE'].present? || (ENV['AWS_SECRET_ACCESS_KEY'].present? && ENV['AWS_ACCESS_KEY_ID'])
 
-if Rails.env.test?
-  s3_bucket = Aws::S3::Resource.new(stub_responses: true).bucket(s3_bucket_name)
-elsif s3_bucket_name
-  if running_in_aws || credentials_loaded
+if s3_bucket_name.present?
+  if Rails.env.development? && ENV.key?('AWS_ENDPOINT')
+    unless Aws::S3::Resource.new(endpoint: ENV['AWS_ENDPOINT']).bucket(s3_bucket_name).exists?
+      Aws::S3::Resource.new(endpoint: ENV['AWS_ENDPOINT']).create_bucket({ bucket: s3_bucket_name })
+    end
+    Aws::S3::Resource.new(endpoint: ENV['AWS_ENDPOINT']).bucket(s3_bucket_name)
+  elsif Rails.env.test?
+    s3_bucket = Aws::S3::Resource.new(stub_responses: true).bucket(s3_bucket_name)
+  elsif running_in_aws || credentials_loaded
     s3_bucket = Aws::S3::Resource.new.bucket(s3_bucket_name)
   else
     Rails.logger.warn 'AWS credentials missing, or not running on AWS.'
   end
-end
 
-Rails.application.config.spelling_corrector_s3_bucket = s3_bucket
+  Rails.application.config.spelling_corrector_s3_bucket = s3_bucket
+end


### PR DESCRIPTION
### Jira link

BAU / Experiment.  

### What?

This PR allows local development to use [localstack](https://github.com/localstack/localstack) over AWS for development purposes.  This allows developers to work offline, or seperated from other developers in a non-shared environment.

Note this PR only covers S3 usage rather than other services.

Fails-safe to the current way of working so localstack is an opt-in change