### PR TITLE
Add bin/dev to allow dev web+workers

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,3 @@
+web: bin/rails server -p 3000
+worker1: bundle exec sidekiq -C ./config/sidekiq.yml
+worker2: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,2 @@
 web: bin/rails server -p 3000
-worker1: bundle exec sidekiq -C ./config/sidekiq.yml
-worker2: bundle exec sidekiq -C ./config/sidekiq.yml
+worker: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ These can be configured by running `docker-compose up` or by manual installation
       Sidekiq is started to build the search indexes - once the jobs have all
       finished (10 `[done]` jobs, one after the other), hit `Ctrl-C` to exit
       sidekiq.
-4. Start the app with `bin/rails s`.
+4. Start the app with `bin/rails s`. If you want to run rails plus the sidekiq worker, run `bin/dev`.
 
 ### Database
 

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+# install foreman if needed — https://github.com/ddollar/foreman
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+# run foreman and point it to our Procfile.dev, and pass through any arguments we've added
+# learn more from the foreman docs — https://ddollar.github.io/foreman/
+exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
### Jira link

BAU: Dev cleanup

### What?

I have added `bin/dev` which will use `Procfile.dev` to spin up web + workers as an option.  Currently the README only demonstrates how to start Rails on it's own.