### PR TITLE
Remove csv gem deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'opensearch-ruby'
 # Helpers
 gem 'bootsnap', require: false
 gem 'caxlsx'
+gem 'csv'
 gem 'gds-sso'
 gem 'hashie'
 gem 'holidays'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
+    csv (3.3.0)
     database_cleaner-core (2.0.1)
     database_cleaner-sequel (2.0.2)
       database_cleaner-core (~> 2.0.0)
@@ -479,6 +480,7 @@ DEPENDENCIES
   brakeman
   caxlsx
   connection_pool
+  csv
   database_cleaner-sequel
   dotenv-rails
   factory_bot_rails


### PR DESCRIPTION
BAU: `csv` is being removed from stdlib as of Ruby 3.4.0.  This change removes the deprecation warning.
