### PR TITLE
OTT-502 Remove item counts and rely on Excel

### DIFF
--- a/app/lib/reporting.rb
+++ b/app/lib/reporting.rb
@@ -2,19 +2,19 @@ module Reporting
   extend Reportable
 
   def self.get(object_key)
-    # if Rails.env.production?
-    #   object(object_key).get.body.read
-    # else
+    if Rails.env.production?
+      object(object_key).get.body.read
+    else
 
-    File.open(object_key)
-    # end
+      File.open(object_key)
+    end
   end
 
   def self.get_link(object_key)
-    # if Rails.env.production?
-    #   File.join(TradeTariffBackend.reporting_cdn_host, object_key)
-    # else
-    object_key
-    # end
+    if Rails.env.production?
+      File.join(TradeTariffBackend.reporting_cdn_host, object_key)
+    else
+      object_key
+    end
   end
 end

--- a/app/lib/reporting.rb
+++ b/app/lib/reporting.rb
@@ -2,19 +2,19 @@ module Reporting
   extend Reportable
 
   def self.get(object_key)
-    if Rails.env.production?
-      object(object_key).get.body.read
-    else
+    # if Rails.env.production?
+    #   object(object_key).get.body.read
+    # else
 
-      File.open(object_key)
-    end
+    File.open(object_key)
+    # end
   end
 
   def self.get_link(object_key)
-    if Rails.env.production?
-      File.join(TradeTariffBackend.reporting_cdn_host, object_key)
-    else
-      object_key
-    end
+    # if Rails.env.production?
+    #   File.join(TradeTariffBackend.reporting_cdn_host, object_key)
+    # else
+    object_key
+    # end
   end
 end

--- a/app/lib/reporting/differences.rb
+++ b/app/lib/reporting/differences.rb
@@ -77,8 +77,7 @@ module Reporting
                 :bold_style,
                 :centered_style,
                 :print_style,
-                :as_of,
-                :overview_counts
+                :as_of
 
     def initialize
       @package = Axlsx::Package.new
@@ -117,15 +116,12 @@ module Reporting
         sz: 11,
       )
       @as_of = Time.zone.today.iso8601
-      @overview_counts = Hash.new(0)
     end
 
     def generate(only: [])
       total_start = Time.zone.now
 
       methods = %i[
-
-        add_measure_quota_coverage_worksheet
         add_missing_from_uk_worksheet
         add_missing_from_xi_worksheet
         add_indentation_worksheet
@@ -142,6 +138,7 @@ module Reporting
         add_omitted_duty_measures_worksheet
         add_missing_vat_measure_worksheet
         add_missing_quota_origins_worksheet
+        add_measure_quota_coverage_worksheet
         add_bad_quota_association_worksheet
         add_quota_exclusion_misalignment_worksheet
         add_missing_supplementary_units_from_uk_worksheet
@@ -300,10 +297,6 @@ module Reporting
       CSV.parse(csv, headers: true).map(&:to_h)
     end
 
-    def increment_count(worksheet_name)
-      overview_counts[worksheet_name] += 1
-    end
-
     def sections
       Reporting::Differences::Renderers::Overview::OVERVIEW_SECTION_CONFIG.keys.map do |section|
         worksheets = Reporting::Differences::Renderers::Overview::OVERVIEW_SECTION_CONFIG.dig(section, :worksheets).map do |worksheet, config|
@@ -311,7 +304,6 @@ module Reporting
             worksheet:,
             worksheet_name: config[:worksheet_name],
             subtext: config[:description].sub('as_of', as_of.to_date.to_fs(:govuk)),
-            issue_count: overview_counts[config[:worksheet_name]],
           )
         end
 

--- a/app/lib/reporting/differences/renderers/bad_quota_association.rb
+++ b/app/lib/reporting/differences/renderers/bad_quota_association.rb
@@ -49,7 +49,6 @@ module Reporting
             end
 
             (rows || []).compact.each do |row|
-              report.increment_count(name)
               sheet.add_row(row, types: CELL_TYPES, style: regular_style)
             end
 

--- a/app/lib/reporting/differences/renderers/candidate_supplementary_unit.rb
+++ b/app/lib/reporting/differences/renderers/candidate_supplementary_unit.rb
@@ -57,7 +57,6 @@ module Reporting
             end
 
             (rows || []).each do |row|
-              report.increment_count(name)
               sheet.add_row(row, types: CELL_TYPES, style: regular_style)
               sheet.rows.last[1].style = centered_style
             end

--- a/app/lib/reporting/differences/renderers/endline.rb
+++ b/app/lib/reporting/differences/renderers/endline.rb
@@ -49,7 +49,6 @@ module Reporting
             end
 
             (rows || []).compact.each do |row|
-              report.increment_count(name)
               sheet.add_row(row, types: CELL_TYPES, style: regular_style)
               sheet.rows.last.tap do |last_row|
                 last_row.cells[1].style = centered_style # UK endline status

--- a/app/lib/reporting/differences/renderers/goods_nomenclature.rb
+++ b/app/lib/reporting/differences/renderers/goods_nomenclature.rb
@@ -61,7 +61,6 @@ module Reporting
             end
 
             (rows || []).each do |row|
-              report.increment_count(name)
               sheet.add_row(row, types: CELL_TYPES, style: regular_style)
               sheet.rows.last.tap do |last_row|
                 last_row.cells[5].style = centered_style # Indentation

--- a/app/lib/reporting/differences/renderers/goods_nomenclature_end_date.rb
+++ b/app/lib/reporting/differences/renderers/goods_nomenclature_end_date.rb
@@ -47,7 +47,6 @@ module Reporting
             end
 
             (rows || []).compact.each do |row|
-              report.increment_count(name)
               sheet.add_row(row, types: CELL_TYPES, style: regular_style)
             end
 

--- a/app/lib/reporting/differences/renderers/goods_nomenclature_start_date.rb
+++ b/app/lib/reporting/differences/renderers/goods_nomenclature_start_date.rb
@@ -49,7 +49,6 @@ module Reporting
             end
 
             (rows || []).compact.each do |row|
-              report.increment_count(name)
               sheet.add_row(row, types: CELL_TYPES, style: regular_style)
             end
 

--- a/app/lib/reporting/differences/renderers/hierarchy.rb
+++ b/app/lib/reporting/differences/renderers/hierarchy.rb
@@ -44,7 +44,6 @@ module Reporting
             end
 
             (rows || []).compact.each do |row|
-              report.increment_count(name)
               sheet.add_row(row, types: CELL_TYPES, style: regular_style)
             end
 

--- a/app/lib/reporting/differences/renderers/incomplete_measure_condition.rb
+++ b/app/lib/reporting/differences/renderers/incomplete_measure_condition.rb
@@ -47,7 +47,6 @@ module Reporting
             end
 
             (rows || []).compact.each do |row|
-              report.increment_count(name)
               sheet.add_row(row, types: CELL_TYPES, style: regular_style)
             end
 

--- a/app/lib/reporting/differences/renderers/indentation.rb
+++ b/app/lib/reporting/differences/renderers/indentation.rb
@@ -47,7 +47,6 @@ module Reporting
             end
 
             (rows || []).compact.each do |row|
-              report.increment_count(name)
               sheet.add_row(row, types: CELL_TYPES, style: regular_style)
               sheet.rows.last.tap do |last_row|
                 last_row.cells[1].style = centered_style # UK indentation

--- a/app/lib/reporting/differences/renderers/me16.rb
+++ b/app/lib/reporting/differences/renderers/me16.rb
@@ -57,7 +57,6 @@ module Reporting
             end
 
             (rows || []).compact.each do |row|
-              report.increment_count(name)
               sheet.add_row(row, types: CELL_TYPES, style: regular_style)
             end
 

--- a/app/lib/reporting/differences/renderers/me32.rb
+++ b/app/lib/reporting/differences/renderers/me32.rb
@@ -65,7 +65,6 @@ module Reporting
             end
 
             (rows || []).compact.each do |row|
-              report.increment_count(name)
               sheet.add_row(row, types: CELL_TYPES, style: regular_style)
             end
 

--- a/app/lib/reporting/differences/renderers/measure_quota_coverage.rb
+++ b/app/lib/reporting/differences/renderers/measure_quota_coverage.rb
@@ -39,7 +39,6 @@ module Reporting
             end
 
             (rows || []).each do |row|
-              report.increment_count(name)
               sheet.add_row(
                 row,
                 types: CELL_TYPES,

--- a/app/lib/reporting/differences/renderers/mfn_duplicated.rb
+++ b/app/lib/reporting/differences/renderers/mfn_duplicated.rb
@@ -58,7 +58,6 @@ module Reporting
             end
 
             (rows || []).compact.each do |row|
-              report.increment_count(name)
               sheet.add_row(row, types: CELL_TYPES, style: regular_style)
             end
 

--- a/app/lib/reporting/differences/renderers/mfn_missing.rb
+++ b/app/lib/reporting/differences/renderers/mfn_missing.rb
@@ -43,7 +43,6 @@ module Reporting
             end
 
             (rows || []).compact.each do |row|
-              report.increment_count(name)
               sheet.add_row(row, types: CELL_TYPES, style: regular_style)
             end
 

--- a/app/lib/reporting/differences/renderers/misapplied_action_code.rb
+++ b/app/lib/reporting/differences/renderers/misapplied_action_code.rb
@@ -49,7 +49,6 @@ module Reporting
             end
 
             (rows || []).compact.each do |row|
-              report.increment_count(name)
               sheet.add_row(row, types: CELL_TYPES, style: regular_style)
             end
 

--- a/app/lib/reporting/differences/renderers/missing_vat_measure.rb
+++ b/app/lib/reporting/differences/renderers/missing_vat_measure.rb
@@ -48,7 +48,6 @@ module Reporting
             end
 
             (rows || []).each do |row|
-              report.increment_count(name)
               sheet.add_row(row, types: CELL_TYPES, style: regular_style)
             end
 

--- a/app/lib/reporting/differences/renderers/omitted_duty_measures.rb
+++ b/app/lib/reporting/differences/renderers/omitted_duty_measures.rb
@@ -54,7 +54,6 @@ module Reporting
             end
 
             (rows || []).compact.each do |row|
-              report.increment_count(name)
               sheet.add_row(row, types: CELL_TYPES, style: regular_style)
             end
 

--- a/app/lib/reporting/differences/renderers/overview.rb
+++ b/app/lib/reporting/differences/renderers/overview.rb
@@ -96,7 +96,7 @@ module Reporting
             worksheets: {
               'Missing VAT rates' => {
                 description: 'Commodities, as of as_of, where there is no VAT rate.',
-                worksheet_name: 'VAT-related anomalies',
+                worksheet_name: 'VAT missing',
                 new_items_formula: "=COUNTIF('VAT missing'!C:C, \"Yes\")",
               },
             },
@@ -253,7 +253,7 @@ module Reporting
                   [
                     nil,
                     worksheet,
-                    report.overview_counts[worksheet_name],
+                    "=COUNTA('#{worksheet_name}'!A2:A1048576)",
                     worksheet_config.fetch(:new_items_formula, nil),
                     worksheet_description,
                     'View issues',

--- a/app/lib/reporting/differences/renderers/quota_missing_origin.rb
+++ b/app/lib/reporting/differences/renderers/quota_missing_origin.rb
@@ -37,7 +37,6 @@ module Reporting
             end
 
             (rows || []).each do |row|
-              report.increment_count(name)
               sheet.add_row(row, types: CELL_TYPES, style: regular_style)
             end
 

--- a/app/lib/reporting/differences/renderers/seasonal.rb
+++ b/app/lib/reporting/differences/renderers/seasonal.rb
@@ -59,7 +59,6 @@ module Reporting
             end
 
             (rows || []).compact.each do |row|
-              report.increment_count(name)
               sheet.add_row(row, types: CELL_TYPES, style: regular_style)
             end
 

--- a/app/lib/reporting/differences/renderers/supplementary_unit.rb
+++ b/app/lib/reporting/differences/renderers/supplementary_unit.rb
@@ -71,7 +71,6 @@ module Reporting
             end
 
             (rows || []).each do |row|
-              report.increment_count(name)
               sheet.add_row(row, types: CELL_TYPES, style: centered_style)
               sheet.rows.last.tap do |last_row|
                 last_row.cells[0].style = regular_style # Commodity code


### PR DESCRIPTION
### Jira link

OTT-502

### What?

This removes the manual counting of items in the Excel spreadsheet, and replaces them with Excel functions meaning that the numbers will always correlate with the contents of each sheet.

### Why?

Previously it was wrong
