### PR TITLE
OTT-326 error message encountered if user enters trade date of more than 6 digits

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,7 +24,10 @@ class ApplicationController < ActionController::API
   private
 
   def actual_date
-    Date.parse(params[:as_of].to_s)
+    date = Date.parse(params[:as_of].to_s)
+    raise ArgumentError, 'Invalid date' if date > 20.years.from_now || date < 20.years.ago
+
+    date
   rescue ArgumentError # empty as_of param means today
     Time.zone.today
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe ApplicationController, type: :controller do
+  controller do
+    def index
+      render(plain: actual_date.to_formatted_s(:db))
+    end
+  end
+
+  describe 'handling invalid dates' do
+    it 'overrides to today if date is out of range' do
+      response = get :index, params: { as_of: '2023000-01-01' }
+      expect(response.body).to eq(Time.zone.now.to_date.to_formatted_s(:db))
+    end
+
+    it 'respects the date if it is in range' do
+      response = get :index, params: { as_of: '2024-01-01' }
+      expect(response.body).to eq('2024-01-01')
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

OTT-326

### What?

Added a constraint around date params (as_of) that it must be inside 20 years either side of today

### Why?

Currently it's possible to pass a date from the frontend such as 202400000-01-01, which is a valid date, but one which is very far in the future.  We already have dates to check that the date is valid, but no check to determine if the date is _reasonable_.

Should the date be unreasonable, todays date is used (which is the same behaviour as an invalid date)