### PR TITLE
OTT-272 Iceland RoO Lettering Fix

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk/articles/iceland-norway/wholly-obtained.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/iceland-norway/wholly-obtained.md
@@ -25,7 +25,7 @@ fingerlings, larvae, parr, or smolts by intervention in the rearing or growth pr
 
 12. products extracted from the seabed or below the seabed which is situated outside its territorial sea but where it has exclusive exploitation rights; and
 
-13. goods produced there exclusively from the products specified in points 1 to 12
+13. goods produced there exclusively from the products specified in points a to l
 
 {{ Article 3 }}
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-272

### What?

I have altered:

- [x] Iceland/Norway RoO Wholly Obtained Definition markdown point referencing.

### Why?

I am doing this because:

- Govspeak and lettered-list class transforms numbers to letters but numbers were being used in point M.

Before (https://www.trade-tariff.service.gov.uk/rules_of_origin/0409000010/IS/wholly_obtained_definition)
<img width="518" alt="image" src="https://github.com/user-attachments/assets/067d9982-8a35-4149-b079-fa32d85d3b8a">

After

<img width="504" alt="image" src="https://github.com/user-attachments/assets/b55f39d0-1de5-4647-938c-ff7cf39fcd0b">
