### PR TITLE
OTT-274 Changed wholly-obtained to use legislative list

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk/articles/turkey/wholly-obtained.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/turkey/wholly-obtained.md
@@ -1,27 +1,29 @@
-The following products shall be considered as wholly obtained in a Party:
+$LegislativeList
+* 1. The following products shall be considered as wholly obtained in a Party:
 
-1. **mineral products** extracted or taken from its soil or from its seabed;
+    * a. **mineral products** extracted or taken from its soil or from its seabed;
 
-2. **plants and vegetable products** grown or harvested there;
+    * b. **plants and vegetable products** grown or harvested there;
 
-3. **live animals** born and raised there;
+    * c. **live animals** born and raised there;
 
-4. products **obtained from live animals** raised there;
+    * d. products **obtained from live animals** raised there;
 
-5. products obtained from **slaughtered animals** born and raised there;
+    * e. products obtained from **slaughtered animals** born and raised there;
 
-6. products obtained by **hunting or fishing** conducted there;
+    * f. products obtained by **hunting or fishing** conducted there;
 
-7. products obtained from **aquaculture** there if aquatic organisms, including fish, molluscs, crustaceans, other aquatic invertebrates and aquatic plants are born or raised from seed stock such as eggs, roes, fry, fingerlings, larvae, parr, smolts or other immature fish at a post-larval stage by intervention in the rearing or growth processes to enhance production such as regular stocking, feeding or protection from predators;
+    * g. products obtained from **aquaculture** there if aquatic organisms, including fish, molluscs, crustaceans, other aquatic invertebrates and aquatic plants are born or raised from seed stock such as eggs, roes, fry, fingerlings, larvae, parr, smolts or other immature fish at a post-larval stage by intervention in the rearing or growth processes to enhance production such as regular stocking, feeding or protection from predators;
 
-8. products of **sea fishing and other products** taken from the sea outside any territorial sea by a vessel of a Party;
+    * h. products of **sea fishing and other products** taken from the sea outside any territorial sea by a vessel of a Party;
 
-9. products made aboard of a factory ship of a Party exclusively from products referred to in sub-paragraph (h);
+    * i. products made aboard of a factory ship of a Party exclusively from products referred to in sub-paragraph (h);
 
-10. products extracted from the **seabed or subsoil** outside any territorial sea provided that they have rights to exploit or work such seabed or subsoil;
+    * j. products extracted from the **seabed or subsoil** outside any territorial sea provided that they have rights to exploit or work such seabed or subsoil;
 
-11. **waste and scrap** resulting from production operations conducted there; waste and scrap derived from **used products** collected there, provided that those products are fit only for the **recovery of raw materials**;
+    * k. **waste and scrap** resulting from production operations conducted there; waste and scrap derived from **used products** collected there, provided that those products are fit only for the **recovery of raw materials**;
 
-12. products produced there exclusively from the products specified in sub-paragraphs (a) to (k).
+    * l. products produced there exclusively from the products specified in sub-paragraphs (a) to (k).
 
 {{ Article 4 }}
+$EndLegislativeList


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-274

### What?

I have altered:

- [x] Turkey Wholly Obtained FTA RoO definition to use `Govspeak LegislativeList`

### Why?

I am doing this because:

- The numbering and lettering was incorrect

BEFORE
![image](https://github.com/user-attachments/assets/62220ffd-3527-4fa2-9498-e009e0a6359f)

AFTER
![image](https://github.com/user-attachments/assets/620292ed-efc3-41d5-9f3e-3e0c23d00fce)

