### PR TITLE
BAU: Handle development uk-only routes better

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,7 @@ Rails.application.routes.draw do
 
       # avoid admin named routes clashing with public api named routes
       namespace :admin, path: '' do
-        if TradeTariffBackend.uk? && !Rails.env.development?
+        if Rails.env.development? || TradeTariffBackend.uk?
           namespace :news do
             resources :items, only: %i[index show create update destroy]
             resources :collections, only: %i[index show create update]
@@ -197,7 +197,7 @@ Rails.application.routes.draw do
             as: :product_specific_rules
       end
 
-      if TradeTariffBackend.uk? && !Rails.env.development?
+      if Rails.env.development? || TradeTariffBackend.uk?
         namespace :news do
           resources :items, only: %i[index show]
           resources :years, only: %i[index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,7 @@ Rails.application.routes.draw do
 
       # avoid admin named routes clashing with public api named routes
       namespace :admin, path: '' do
-        if TradeTariffBackend.uk?
+        if TradeTariffBackend.uk? && !Rails.env.development?
           namespace :news do
             resources :items, only: %i[index show create update destroy]
             resources :collections, only: %i[index show create update]
@@ -197,7 +197,7 @@ Rails.application.routes.draw do
             as: :product_specific_rules
       end
 
-      if TradeTariffBackend.uk?
+      if TradeTariffBackend.uk? && !Rails.env.development?
         namespace :news do
           resources :items, only: %i[index show]
           resources :years, only: %i[index]


### PR DESCRIPTION
### Jira link

BAU

The frontend application needs these routes to be available since it
doesn't have access to both a UK and an XI service running locally on
separate configurations.

We had choices:

1. Run a separate XI/UK service locally and plumb together the routes in
   the frontend to point at these running on individual ports
2. Just preserve the current setup for XI runs of the backend but mount
   the routes that the frontend service depends on in development
3. Just remove the defensive route conditional and let clients decide

I'm opting for 2 since this has significantly less overhead in terms of
local configuration.

### What?

I have added/removed/altered:

- [x] Altered routes to mount uk routes in development regardless of the service configuration

### Why?

I am doing this because:

- This makes working with the frontend using the xi service locally (e.g. with green lanes) just work
