### PR TITLE
BAU: Removes redundant reports endpoint

### DIFF
--- a/app/controllers/api/admin/commodities_controller.rb
+++ b/app/controllers/api/admin/commodities_controller.rb
@@ -8,18 +8,6 @@ module Api
         render json: Api::Admin::Commodities::CommoditySerializer.new(@commodity).serializable_hash
       end
 
-      def index
-        respond_to do |format|
-          format.csv do
-            send_data(
-              serialized_csv,
-              type: 'text/csv; charset=utf-8; header=present',
-              disposition: "attachment; filename=#{TradeTariffBackend.service}-commodities-#{actual_date.iso8601}.csv",
-            )
-          end
-        end
-      end
-
       private
 
       def find_commodity
@@ -41,10 +29,6 @@ module Api
 
       def productline_suffix
         params[:id].split('-', 2)[1] || '80'
-      end
-
-      def serialized_csv
-        Reporting::Commodities.get_today
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
           end
         end
 
-        resources :commodities, only: %i[show index] do
+        resources :commodities, only: %i[show] do
           scope module: 'commodities' do
             resources :search_references, only: %i[show index destroy create update]
           end

--- a/spec/requests/api/admin/commodities_controller_spec.rb
+++ b/spec/requests/api/admin/commodities_controller_spec.rb
@@ -41,30 +41,4 @@ RSpec.describe Api::Admin::CommoditiesController, type: :request do
       end
     end
   end
-
-  describe 'GET #index' do
-    subject(:do_request) do
-      authenticated_get api_commodities_path(format: :csv)
-      response.body
-    end
-
-    before do
-      allow(Reporting::Commodities).to receive(:get_today).and_return(StringIO.new("foo,bar\nqux,qul"))
-    end
-
-    it 'gets the csv' do
-      do_request
-
-      expect(Reporting::Commodities).to have_received(:get_today)
-    end
-
-    it_behaves_like 'a successful csv response' do
-      let(:make_request) { authenticated_get '/admin/commodities.csv' }
-      let(:expected_filename) { "uk-commodities-#{Time.zone.today.iso8601}.csv" }
-
-      before do
-        create(:commodity)
-      end
-    end
-  end
 end


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Removes redundant reports endpoint

### Why?

I am doing this because:

- This has been replaced by the static site hosted in s3
