### PR TITLE
GL-1067: Implement Search Functionality for Exemptions on Category As…

### DIFF
--- a/spec/requests/api/admin/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/category_assessments_controller_spec.rb
@@ -23,6 +23,29 @@ RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentsController do
       it { expect(json_response).to include('meta') }
     end
 
+    context 'with some category assessments, search by exemption code' do
+      before do
+        category
+      end
+
+      let(:make_request) do
+        authenticated_get api_admin_green_lanes_category_assessments_path(format: :json), params: search_data
+      end
+
+      let :search_data do
+        {
+          query: {
+            exemption_code: category.exemptions[1].code,
+            page: 1,
+          },
+        }
+      end
+      it { is_expected.to have_http_status :success }
+      it { expect(json_response).to include('data') }
+      it { expect(json_response).to include('meta') }
+      it { expect(json_response['data'].first['attributes']['measure_type_id']).to include(category.measure_type_id.to_s) }
+    end
+
     context 'without any category assessments' do
       it { is_expected.to have_http_status :success }
       it { expect(json_response).to include('data' => []) }


### PR DESCRIPTION
### Jira link

[GL-1067](https://transformuk.atlassian.net/browse/GL-1067)

### What?

I have added/removed/altered:

- [ ] Added search parameter to green lanes admin category assessment controler index endpoint


### Why?

I am doing this because:

- User need to search CA by green lanes exemption code
