### PR TITLE
OTT-307 Updated the way Legal Basis Links are generated from BaseRegulation

### DIFF
--- a/app/services/measure_service/council_regulation_url_generator.rb
+++ b/app/services/measure_service/council_regulation_url_generator.rb
@@ -1,15 +1,6 @@
-#
-# This service generates search url for http://eur-lex.europa.eu service
-#
-# We are using 2 approaches of search for regulation details:
-#
-# APPROACH 1: If regulation have official journal page
-#             then we are using seach by Official Journal parameters
-#
-# APPROACH 2: If regulation doens't have official joirnal page
-#             then we are using search by celex number
-#
-
+# Get the CELEX link using instructions here:
+# https://eur-lex.europa.eu/content/help/data-reuse/linking.html
+# https://eur-lex.europa.eu/content/help/eurlex-content/celex-number.html
 module MeasureService
   class CouncilRegulationUrlGenerator
     attr_accessor :target_regulation
@@ -19,45 +10,10 @@ module MeasureService
     end
 
     def generate
-      if target_regulation.officialjournal_page.present?
-        published_journal_search_type_url
-      else
-        celex_number_search_type_url
-      end
-    end
-
-    private
-
-    def published_journal_search_type_url
-      oj_seria, oj_number = target_regulation.officialjournal_number
-                                             .split(' ')
-
-      oj_page = target_regulation.officialjournal_page
-                                 .to_s
-                                 .rjust(4, '0')
-
-      url_ops = if target_regulation.is_a?(MeasurePartialTemporaryStop) || target_regulation.published_date.nil?
-                  #
-                  # If MeasurePartialTemporaryStop, we do not pass year into the search params
-                  # as there are no published_date for partial stop
-                  #
-                  "whOJ=NO_OJ%3D#{oj_number},PAGE_FIRST%3D#{oj_page}&DB_COLL_OJ=oj-#{oj_seria.downcase}&type=advanced&lang=en"
-                else
-                  #
-                  # If general regulation or FullTemporaryStopRegulation, then
-                  # we are providing 'published_date' year to the search parameters
-                  #
-                  oj_year = target_regulation.published_date.year
-                  "whOJ=NO_OJ%3D#{oj_number},YEAR_OJ%3D#{oj_year},PAGE_FIRST%3D#{oj_page}&DB_COLL_OJ=oj-#{oj_seria.downcase}&type=advanced&lang=en"
-                end
-
-      "http://eur-lex.europa.eu/search.html?#{url_ops}"
-    end
-
-    def celex_number_search_type_url
-      regulation_code = regulation_id
+      regulation_code = target_regulation.regulation_id
 
       year = regulation_code[1..2]
+
       # When we get to 2071 assume that we don't care about the 1900's
       # or the EU has a better way to search
       full_year = if year.to_i > 70
@@ -67,11 +23,7 @@ module MeasureService
                   end
 
       code = "3#{full_year}#{regulation_code.first}#{regulation_code[3..6]}"
-      "http://eur-lex.europa.eu/search.html?instInvStatus=ALL&or0=DN%3D#{code}*,DN-old%3D#{code}*&DTC=false&type=advanced"
-    end
-
-    def regulation_id
-      target_regulation.regulation_id
+      "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A#{code}"
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ApplicationHelper do
         end
 
         it 'generates council regulation url' do
-          expect(regulation_url(measure.generating_regulation)).to eql('http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D353,YEAR_OJ%3D2017,PAGE_FIRST%3D0019&DB_COLL_OJ=oj-c&type=advanced&lang=en')
+          expect(regulation_url(measure.generating_regulation)).to eql('https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32017I0353')
         end
       end
 
@@ -45,78 +45,19 @@ RSpec.describe ApplicationHelper do
         end
 
         it 'generates council regulation url' do
-          expect(regulation_url(measure.generating_regulation)).to eql('http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D138,YEAR_OJ%3D2017,PAGE_FIRST%3D0057&DB_COLL_OJ=oj-l&type=advanced&lang=en')
+          expect(regulation_url(measure.generating_regulation)).to eql('https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32017R0892')
         end
       end
     end
 
-    context 'for suspending_regulation' do
-      context 'for FullTemporaryStopRegulation' do
-        before do
-          create(:fts_regulation, full_temporary_stop_regulation_id: 'R9528150',
-                                  full_temporary_stop_regulation_role: 8,
-                                  published_date: Date.new(1995, 12, 9),
-                                  officialjournal_number: 'L 297',
-                                  officialjournal_page: 1)
-          create(:fts_regulation_action, fts_regulation_role: 8,
-                                         fts_regulation_id: 'R9528150',
-                                         stopped_regulation_role: 1,
-                                         stopped_regulation_id: 'R9309900')
-          measure.reload
-        end
-
-        let!(:measure) do
-          create(:measure, goods_nomenclature_item_id: '0100000000',
-                           measure_generating_regulation_id: 'R9309900')
-        end
-
-        it 'generates council regulation url' do
-          expect(regulation_url(measure.suspending_regulation)).to eql(
-            'http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D297,YEAR_OJ%3D1995,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-l&type=advanced&lang=en',
-          )
-        end
+    describe '#regulation_code' do
+      let(:measure) do
+        create :measure, generating_regulation: create(:base_regulation, base_regulation_id: '1234567')
       end
 
-      context 'for MeasurePartialTemporaryStop' do
-        before do
-          create(:measure_partial_temporary_stop, measure_sid: measure.measure_sid,
-                                                  partial_temporary_stop_regulation_id: 'R0912150',
-                                                  validity_start_date: Time.parse('2010-01-04T00:00:00.000Z'),
-                                                  officialjournal_number: 'L 328',
-                                                  officialjournal_page: 6)
-          measure.reload
-        end
-
-        let(:base_regulation) do
-          create(:base_regulation, base_regulation_id: 'R0912150',
-                                   base_regulation_role: 1,
-                                   published_date: Date.new(2009, 12, 15),
-                                   officialjournal_number: 'L 328',
-                                   officialjournal_page: 1)
-        end
-
-        let!(:measure) do
-          create(:measure, goods_nomenclature_item_id: '2823000000',
-                           measure_generating_regulation_id: 'R0912150',
-                           base_regulation:)
-        end
-
-        it 'generates council regulation url' do
-          expect(regulation_url(measure.suspending_regulation)).to eql(
-            'http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D328,PAGE_FIRST%3D0006&DB_COLL_OJ=oj-l&type=advanced&lang=en',
-          )
-        end
+      it 'returns generating regulation code in TARIC format' do
+        expect(regulation_code(measure.generating_regulation)).to eq '14567/23'
       end
-    end
-  end
-
-  describe '#regulation_code' do
-    let(:measure) do
-      create :measure, generating_regulation: create(:base_regulation, base_regulation_id: '1234567')
-    end
-
-    it 'returns generating regulation code in TARIC format' do
-      expect(regulation_code(measure.generating_regulation)).to eq '14567/23'
     end
   end
 end

--- a/spec/presenters/api/v2/green_lanes/regulation_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/regulation_presenter_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe Api::V2::GreenLanes::RegulationPresenter do
   it { is_expected.to have_attributes base_regulation_id: regulation.base_regulation_id }
   it { is_expected.to have_attributes published_date: regulation.published_date }
   it { is_expected.to have_attributes regulation_code: %r{[A-Z0-9]{5}/[A-Z0-9]{2}} }
-  it { is_expected.to have_attributes regulation_url: %r{http://eur-lex.} }
+  it { is_expected.to have_attributes regulation_url: %r{https://eur-lex.} }
   it { is_expected.to have_attributes description: be_present }
 end

--- a/spec/presenters/api/v2/measures/measure_legal_act_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_legal_act_presenter_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::V2::Measures::MeasureLegalActPresenter do
   let(:eu_regulation) do
     {
       code: '14567/23',
-      url: 'http://eur-lex.europa.eu/search.html?',
+      url: 'https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A3202314567',
       description: 'This is some explanatory information text',
     }
   end

--- a/spec/services/measure_service/council_regulation_url_generator_spec.rb
+++ b/spec/services/measure_service/council_regulation_url_generator_spec.rb
@@ -1,34 +1,17 @@
 RSpec.describe MeasureService::CouncilRegulationUrlGenerator do
-  let(:target_regulation) { create(:measure_partial_temporary_stop) }
+  let(:target_regulation) { create(:measure_partial_temporary_stop, partial_temporary_stop_regulation_id: 'A09CDEF') }
   let(:service) { described_class.new(target_regulation) }
 
   describe '#generate' do
     it 'returns external regulation url' do
-      expect(service.generate).to start_with('http://eur-lex.europa.eu/search.html')
-    end
-  end
-
-  describe '#regulation_id' do
-    context 'for measure_partial_temporary_stop' do
-      it 'return regulation_id for target regulation' do
-        expect(service.send(:regulation_id)).to eq(target_regulation.partial_temporary_stop_regulation_id)
-      end
+      code = '32009ACDEF'
+      expect(service.generate).to eq("https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A#{code}")
     end
 
-    context 'for full_temporary_stop_regulation' do
-      let(:target_regulation) { create(:fts_regulation) }
-
-      it 'return regulation_id for target regulation' do
-        expect(service.send(:regulation_id)).to eq(target_regulation.full_temporary_stop_regulation_id)
-      end
-    end
-
-    context 'for base_regulation' do
-      let(:target_regulation) { create(:base_regulation) }
-
-      it 'return regulation_id for target regulation' do
-        expect(service.send(:regulation_id)).to eq(target_regulation.base_regulation_id)
-      end
+    it 'handles years that are greater than 2071' do
+      target_regulation.partial_temporary_stop_regulation_id = 'A72CDEF'
+      code = '31972ACDEF'
+      expect(service.generate).to eq("https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A#{code}")
     end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-307

### What?

I have 

- [x] Updated the way Legal Basis Links are generated from BaseRegulation, an explicit CELEX link is now used instead of using the unstable explicit OJ links and searches based on whether a journal page is given.

### Why?

I am doing this because:

- Links using existing methods were not working

More info on generating links here:

https://eur-lex.europa.eu/content/help/data-reuse/linking.html
https://eur-lex.europa.eu/content/help/eurlex-content/celex-number.html

