### PR TITLE
GL-1065: Implement Sorting Functionality on Category Assessments Page

### DIFF
--- a/spec/requests/api/admin/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/category_assessments_controller_spec.rb
@@ -47,6 +47,34 @@ RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentsController do
       it { expect(json_response['data'].first['attributes']['measure_type_id']).to include(category.measure_type_id.to_s) }
     end
 
+    context 'with some category assessments, sort by parameter present' do
+      before do
+        category
+      end
+
+      let(:make_request) do
+        authenticated_get api_admin_green_lanes_category_assessments_path(format: :json), params: search_data
+      end
+
+      let :search_data do
+        {
+          query: {
+            sort: 'regulation_id',
+            direction: 'desc',
+            page: 1,
+          },
+        }
+      end
+
+      let :regulation_ids do
+        json_response['data'].map { |assessment| assessment['attributes']['regulation_id'] }
+      end
+
+      it { is_expected.to have_http_status :success }
+
+      it { expect(regulation_ids).to eq(regulation_ids.sort.reverse) }
+    end
+
     context 'without any category assessments' do
       it { is_expected.to have_http_status :success }
       it { expect(json_response).to include('data' => []) }

--- a/spec/requests/api/admin/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/category_assessments_controller_spec.rb
@@ -44,7 +44,10 @@ RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentsController do
       it { is_expected.to have_http_status :success }
       it { expect(json_response).to include('data') }
       it { expect(json_response).to include('meta') }
-      it { expect(json_response['data'].first['attributes']['measure_type_id']).to include(category.measure_type_id.to_s) }
+      it 'expects measure_type_id to be in the json response' do
+        measure_type_ids = json_response['data'].map { |item| item['attributes']['measure_type_id'] }
+        expect(measure_type_ids).to include(category.measure_type_id.to_s)
+      end
     end
 
     context 'with some category assessments, sort by parameter present' do

--- a/spec/requests/api/admin/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/category_assessments_controller_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentsController do
       it { is_expected.to have_http_status :success }
       it { expect(json_response).to include('data') }
       it { expect(json_response).to include('meta') }
+
       it 'expects measure_type_id to be in the json response' do
         measure_type_ids = json_response['data'].map { |item| item['attributes']['measure_type_id'] }
         expect(measure_type_ids).to include(category.measure_type_id.to_s)


### PR DESCRIPTION
### Jira link

[GL-1065](https://transformuk.atlassian.net/browse/GL-1065)

### What?

I have added/removed/altered:

- [ ] Sorting functionality to Category Assessment tables


### Why?

I am doing this because:

- User needs to sort the result table by different attributes

