### PR TITLE
GL-1079: Validation for only allowing declarable commodities is not working

### DIFF
--- a/app/controllers/api/v2/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/goods_nomenclatures_controller.rb
@@ -16,11 +16,14 @@ module Api
       end
 
       def show
-        gn = GoodsNomenclature.actual
-                              .eager(:ancestors,
-                                     :descendants)
-                              .where(goods_nomenclature_item_id: params[:id])
-                              .take
+        gn = GoodsNomenclature
+               .actual
+               .association_join(:goods_nomenclature_indents)
+               .where(Sequel[:goods_nomenclatures][:goods_nomenclature_item_id] => params[:id])
+               .order(Sequel[:goods_nomenclatures][:producline_suffix], Sequel[:goods_nomenclature_indents][:number_indents])
+               .last
+
+        raise Sequel::RecordNotFound if gn.blank?
 
         render json: Api::V2::GoodsNomenclatures::GoodsNomenclatureExtendedSerializer.new(gn).serializable_hash
       end

--- a/app/controllers/api/v2/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/goods_nomenclatures_controller.rb
@@ -15,6 +15,16 @@ module Api
         respond_with(commodities)
       end
 
+      def show
+        gn = GoodsNomenclature.actual
+                              .eager(:ancestors,
+                                     :descendants)
+                              .where(goods_nomenclature_item_id: params[:id])
+                              .take
+
+        render json: Api::V2::GoodsNomenclatures::GoodsNomenclatureExtendedSerializer.new(gn).serializable_hash
+      end
+
       def show_by_section
         section  = Section.where(position: params[:position]).take
         chapters = section.chapters_dataset

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -223,6 +223,7 @@ Rails.application.routes.draw do
       get 'goods_nomenclatures/section/:position', to: 'goods_nomenclatures#show_by_section', constraints: { position: /\d+/ }
       get 'goods_nomenclatures/chapter/:chapter_id', to: 'goods_nomenclatures#show_by_chapter', constraints: { chapter_id: /\d{2}/ }
       get 'goods_nomenclatures/heading/:heading_id', to: 'goods_nomenclatures#show_by_heading', constraints: { heading_id: /\d{4}/ }
+      get 'goods_nomenclatures/:id', to: 'goods_nomenclatures#show', constraints: { id: /\d{4,10}/ }
 
       namespace :green_lanes do
         resources :goods_nomenclatures, only: %i[show], constraints: { id: /\d{4,10}/ }

--- a/spec/controllers/api/v2/goods_nomenclatures_controller_spec.rb
+++ b/spec/controllers/api/v2/goods_nomenclatures_controller_spec.rb
@@ -88,6 +88,21 @@ RSpec.describe Api::V2::GoodsNomenclaturesController do
     end
   end
 
+  context 'when GNs for a id is requested' do
+    it 'returns rendered record of the GN' do
+      get :show, params: { id: commodity.goods_nomenclature_item_id },
+          format: :json
+
+      expect(response_json['id']).to eq commodity.goods_nomenclature_sid.to_s
+    end
+
+    context 'with an incorrect short code' do
+      before { get :show, params: { id: '9922' }, format: :json }
+
+      it { is_expected.to have_http_status :not_found }
+    end
+  end
+
   context 'when GNs for a heading are requested as CSV' do
     it 'returns rendered record of GNs in the heading as CSV' do
       get :show_by_heading, params: { heading_id: commodity.heading.short_code },

--- a/spec/controllers/api/v2/goods_nomenclatures_controller_spec.rb
+++ b/spec/controllers/api/v2/goods_nomenclatures_controller_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Api::V2::GoodsNomenclaturesController do
   context 'when GNs for a id is requested' do
     it 'returns rendered record of the GN' do
       get :show, params: { id: commodity.goods_nomenclature_item_id },
-          format: :json
+                 format: :json
 
       expect(response_json['id']).to eq commodity.goods_nomenclature_sid.to_s
     end


### PR DESCRIPTION
### Jira link

[GL-1079](https://transformuk.atlassian.net/browse/GL-1079)

### What?

I have added/removed/altered:

- [ ] Added an api to return basic gn information for given comodity code


### Why?

I am doing this because:

- Front end GL screen need to validate if given GN is a declarable 
