### PR TITLE
BAU: Don't run differences check outside production

### DIFF
--- a/app/workers/differences_report_check_worker.rb
+++ b/app/workers/differences_report_check_worker.rb
@@ -4,6 +4,8 @@ class DifferencesReportCheckWorker
   sidekiq_options retry: 1, retry_in: 1.hour
 
   def perform
+    return unless Rails.env.production?
+
     last_log = DifferencesLog.max(:date)
     notify_failure if last_log < 7.days.ago
   end

--- a/spec/workers/differences_report_check_worker_spec.rb
+++ b/spec/workers/differences_report_check_worker_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe DifferencesReportCheckWorker, type: :worker do
     end
 
     it 'is unhappy if the differences report has not run this week' do
+      allow(Rails.env).to receive(:production?).and_return(true)
       DifferencesLog.create(date: 10.days.ago, key: 'foo', value: 'foo')
       worker.perform
       expect(SlackNotifierService).to have_received(:call)


### PR DESCRIPTION
### Jira link

BAU

### What?

We check if the differences report has run, but we don't need to do it outside prod as that's giving us false alarms.  This fixes that.