### PR TITLE
HMRC-337 FIx key for supp units report

### DIFF
--- a/app/lib/reporting/differences/loaders/supplementary_unit.rb
+++ b/app/lib/reporting/differences/loaders/supplementary_unit.rb
@@ -13,6 +13,10 @@ module Reporting
           @report = report
         end
 
+        def key
+          [self.class.name, source, target].join('_')
+        end
+
         private
 
         attr_reader :source, :target, :report


### PR DESCRIPTION
### Jira link

HMRC-337

### What?

Added a missing key for the supplementary units reports as it was not overridden correctly to include the `uk` and `xi` params