### PR TITLE
BAU: Disable smoke-test-staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,14 +422,14 @@ workflows:
           context: trade-tariff-terraform-aws-staging
           <<: *filter-main
 
-      - tariff/smoketests:
-          name: smoketest-staging
-          context: trade-tariff-testing
-          url: https://staging.trade-tariff.service.gov.uk
-          yarn_run: staging-tariff-backend-smoketests
-          requires:
-            - apply-terraform-staging
-          <<: *filter-main
+      # - tariff/smoketests:
+      #     name: smoketest-staging
+      #     context: trade-tariff-testing
+      #     url: https://staging.trade-tariff.service.gov.uk
+      #     yarn_run: staging-tariff-backend-smoketests
+      #     requires:
+      #       - apply-terraform-staging
+      #     <<: *filter-main
 
   deploy-to-production:
     jobs:


### PR DESCRIPTION
### Jira link

BAU: Disable the `smoke-test-staging` test suite

### Why?

This suite runs on every `deploy-to-staging` aka merge.  However it is clearly adding no value whatsoever as it has been failing on multiple tests at a rate of 65% yet there are no apparent negative side effects.  This suite has also been failing at 100% rate 

Before reinstating the test suite needs review as to:
a) why it's failing
b) if it's even useful given the world has kept spinning even with it failing two times out of three.