### PR TITLE
HMRC-142: Implement Filtering Options on Category Assessments Page

### DIFF
--- a/app/controllers/api/admin/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/api/admin/green_lanes/category_assessments_controller.rb
@@ -106,6 +106,10 @@ module Api
 
         def category_assessments
           exemption_code = params.dig(:query, :filters, :exemption_code) || ''
+          measure_type_id = params.dig(:query, :filters, :measure_type_id) || ''
+          regulation_id = params.dig(:query, :filters, :regulation_id) || ''
+          regulation_role = params.dig(:query, :filters, :regulation_role) || ''
+          theme_id = params.dig(:query, :filters, :theme_id) || ''
           sort_by = params.dig(:query, :sort) || 'id'
           sort_order = params.dig(:query, :direction) || 'asc'
 
@@ -115,25 +119,34 @@ module Api
                          Sequel.asc(Sequel[:green_lanes_category_assessments][sort_by.to_sym])
                        end
 
-          @category_assessments ||= search_category_assessments(exemption_code, order_expr)
+          @category_assessments ||= search_category_assessments(exemption_code, measure_type_id, regulation_id, regulation_role, theme_id, order_expr)
         end
 
-        def search_category_assessments(exemption_code, order_expr)
+        def search_category_assessments(exemption_code, measure_type_id, regulation_id, regulation_role, theme_id, order_expr)
+          conditions = {}
+          conditions[Sequel[:green_lanes_category_assessments][:measure_type_id]] = measure_type_id if measure_type_id.present?
+          conditions[Sequel[:green_lanes_category_assessments][:regulation_id]] = regulation_id if regulation_id.present?
+          conditions[Sequel[:green_lanes_category_assessments][:regulation_role]] = regulation_role if regulation_role.present?
+          conditions[Sequel[:green_lanes_category_assessments][:theme_id]] = theme_id if theme_id.present?
+
           if exemption_code.blank?
-            return ::GreenLanes::CategoryAssessment.eager(:theme).order(order_expr)
-                                                   .paginate(ca_current_page, per_page)
+            query = ::GreenLanes::CategoryAssessment.eager(:theme).order(order_expr)
+            query = query.where(Sequel.|(conditions)) unless conditions.empty?
+            query = query.paginate(ca_current_page, per_page)
+            return query
           end
+
+          conditions[Sequel[:exemptions][:code]] = exemption_code
 
           ::GreenLanes::CategoryAssessment
             .association_join(:exemptions)
-            .where(
-              Sequel.|(
-                { Sequel[:exemptions][:code] => exemption_code },
-              ),
-            )
+            .where(Sequel.|(conditions))
             .select_all(:green_lanes_category_assessments)
-            .eager(:theme).order(order_expr).paginate(ca_current_page, per_page)
+            .eager(:theme)
+            .order(order_expr)
+            .paginate(ca_current_page, per_page)
         end
+
 
         def green_lanes_measures(category_assessment)
           category_assessment.green_lanes_measures_dataset.paginate(current_page, per_page)

--- a/spec/requests/api/admin/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/category_assessments_controller_spec.rb
@@ -8,30 +8,28 @@ RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentsController do
   let(:json_response) { JSON.parse(page_response.body) }
   let(:category) { create :category_assessment, :with_green_lanes_measure, :with_exemption }
 
-  describe 'GET to #index' do
-    let(:make_request) do
-      authenticated_get api_admin_green_lanes_category_assessments_path(format: :json)
+  shared_examples_for 'search category assessment response' do
+    it { is_expected.to have_http_status :success }
+    it { expect(json_response).to include('data') }
+    it { expect(json_response).to include('meta') }
+
+    it 'expects measure_type_id to be in the json response' do
+      measure_type_ids = json_response['data'].map { |item| item['attributes']['measure_type_id'] }
+      expect(measure_type_ids).to include(category.measure_type_id.to_s)
+    end
+  end
+
+
+  describe 'GET to #index search' do
+    before do
+      category
     end
 
-    context 'with some category assessments' do
-      before do
-        category
-      end
-
-      it { is_expected.to have_http_status :success }
-      it { expect(json_response).to include('data') }
-      it { expect(json_response).to include('meta') }
+    let(:make_request) do
+      authenticated_get api_admin_green_lanes_category_assessments_path(format: :json), params: search_data
     end
 
     context 'with some category assessments, search by exemption code' do
-      before do
-        category
-      end
-
-      let(:make_request) do
-        authenticated_get api_admin_green_lanes_category_assessments_path(format: :json), params: search_data
-      end
-
       let :search_data do
         {
           query: {
@@ -41,25 +39,62 @@ RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentsController do
         }
       end
 
-      it { is_expected.to have_http_status :success }
-      it { expect(json_response).to include('data') }
-      it { expect(json_response).to include('meta') }
+      it_behaves_like 'search category assessment response'
+    end
 
-      it 'expects measure_type_id to be in the json response' do
-        measure_type_ids = json_response['data'].map { |item| item['attributes']['measure_type_id'] }
-        expect(measure_type_ids).to include(category.measure_type_id.to_s)
+    context 'with some category assessments, search by measure type id' do
+      let :search_data do
+        {
+          query: {
+            measure_type_id: category.measure_type_id.to_s,
+            page: 1,
+          },
+        }
       end
+
+      it_behaves_like 'search category assessment response'
+    end
+
+    context 'with some category assessments, search by regulation id' do
+      let :search_data do
+        {
+          query: {
+            regulation_id: category.regulation_id.to_s,
+            page: 1,
+          },
+        }
+      end
+
+      it_behaves_like 'search category assessment response'
+    end
+
+    context 'with some category assessments, search by regulation role' do
+      let :search_data do
+        {
+          query: {
+            regulation_role: category.regulation_role,
+            page: 1,
+          },
+        }
+      end
+
+      it_behaves_like 'search category assessment response'
+    end
+
+    context 'with some category assessments, search by theme id' do
+      let :search_data do
+        {
+          query: {
+            theme_id: category.theme_id.to_s,
+            page: 1,
+          },
+        }
+      end
+
+      it_behaves_like 'search category assessment response'
     end
 
     context 'with some category assessments, sort by parameter present' do
-      before do
-        category
-      end
-
-      let(:make_request) do
-        authenticated_get api_admin_green_lanes_category_assessments_path(format: :json), params: search_data
-      end
-
       let :search_data do
         {
           query: {
@@ -77,6 +112,22 @@ RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentsController do
       it { is_expected.to have_http_status :success }
 
       it { expect(regulation_ids).to eq(regulation_ids.sort.reverse) }
+    end
+  end
+
+  describe 'GET to #index' do
+    let(:make_request) do
+      authenticated_get api_admin_green_lanes_category_assessments_path(format: :json)
+    end
+
+    context 'with some category assessments' do
+      before do
+        category
+      end
+
+      it { is_expected.to have_http_status :success }
+      it { expect(json_response).to include('data') }
+      it { expect(json_response).to include('meta') }
     end
 
     context 'without any category assessments' do


### PR DESCRIPTION
### Jira link

[HMRC-142](https://transformuk.atlassian.net/browse/HMRC-142)

### What?

I have added/removed/altered:

- [ ] Added 'Regulation ID', 'Measure Type', 'Theme', and 'Regulation Role' filters to CA search


### Why?

I am doing this because:

- Admin users need to filter the CA list by these fields

