### PR TITLE
HMRC-385 Enable tracing in Senty

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,8 +42,10 @@ gem 'nokogiri'
 gem 'omniauth-rails_csrf_protection'
 gem 'plek'
 gem 'sentry-rails'
+gem 'sentry-ruby'
 gem 'sentry-sidekiq'
 gem 'slack-notifier'
+gem 'stackprof'
 
 # API related
 gem 'ansi'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -471,6 +471,7 @@ GEM
       thor (~> 1.0)
       tilt (~> 2.0)
       yard (~> 0.9, >= 0.9.24)
+    stackprof (0.2.26)
     stringio (3.1.1)
     strscan (3.1.0)
     thor (1.3.2)
@@ -544,6 +545,7 @@ DEPENDENCIES
   rubocop-govuk
   rubyzip
   sentry-rails
+  sentry-ruby
   sentry-sidekiq
   sequel (= 5.84.0)
   sequel-rails
@@ -552,6 +554,7 @@ DEPENDENCIES
   simplecov
   slack-notifier
   solargraph
+  stackprof
   tilt
   webmock
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,5 @@
 Sentry.init do |config|
-  config.breadcrumbs_logger = [:active_support_logger]
+  config.breadcrumbs_logger = %i[active_support_logger http_logger]
 
   config.excluded_exceptions += %w[
     Sequel::Plugins::RailsExtensions::ModelNotFound
@@ -7,4 +7,8 @@ Sentry.init do |config|
     Sequel::RecordNotFound
     MaintenanceMode::MaintenanceModeActive
   ]
+
+  config.traces_sample_rate = 1.0
+
+  config.profiles_sample_rate = 1.0
 end


### PR DESCRIPTION
### Jira link

HMRC-385

### What?

It transpires that Sentry can do APM tracing so it's worth trying that first.  This PR enables that.