### PR TITLE
HMRC-434 Changed Changes process for Staging for TGP

### DIFF
--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -269,8 +269,8 @@ module TradeTariffBackend
       ENV['GREEN_LANES_NOTIFY_MEASURE_UPDATES'].to_s == 'true'
     end
 
-    def execute_clean_up_changes_table?
-      ENV.fetch('EXECUTE_CLEAN_UP_CHANGES_TABLE', 'true') == 'true'
+    def process_extra_changes_for_tgp?
+      ENV.fetch('PROCESS_EXTRA_CHANGES_FOR_TGP', 'false') == 'true'
     end
   end
 end

--- a/app/workers/populate_changes_table_worker.rb
+++ b/app/workers/populate_changes_table_worker.rb
@@ -4,11 +4,15 @@ class PopulateChangesTableWorker
   sidekiq_options queue: :sync, retry: false
 
   def perform
-    ChangesTablePopulator.populate
-    if TradeTariffBackend.execute_clean_up_changes_table?
+    if TradeTariffBackend.process_extra_changes_for_tgp?
       ChangesTablePopulator.cleanup_outdated
+      ChangesTablePopulator.populate
+      logger.info 'Populating changes for TGP for 1-Jan-2022 & 1-Jan-2024, see env_var PROCESS_EXTRA_CHANGES_FOR_TGP'
+      ChangesTablePopulator.populate(day: Time.zone.parse('2024-01-01'))
+      ChangesTablePopulator.populate(day: Time.zone.parse('2022-01-01'))
     else
-      logger.info 'Skipping cleanup of outdated changes, see env_var CLEAN_UP_CHANGES_TABLE'
+      ChangesTablePopulator.populate
+      ChangesTablePopulator.cleanup_outdated
     end
   end
 end

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -92,7 +92,7 @@ Terraform to deploy the service into AWS.
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Largest number of tasks the service can scale-out to. | `number` | `5` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory to allocate in MB. Powers of 2 only. | `number` | n/a | yes |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | Smallest number of tasks the service can scale-in to. | `number` | `1` | no |
-| <a name="input_process_extra_changes_for_tgp"></a> [process\_extra\_changes\_for\_tgp](#input\_process\_extra\_changes\_for\_tgp) | Defaults to false except in STAGING only for TGP testing (HMRC-434). | `bool` | `true` | no |
+| <a name="input_process_extra_changes_for_tgp"></a> [process\_extra\_changes\_for\_tgp](#input\_process\_extra\_changes\_for\_tgp) | Defaults to false except in STAGING only for TGP testing (HMRC-434). | `bool` | `false` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region to use. | `string` | n/a | yes |
 | <a name="input_service_count"></a> [service\_count](#input\_service\_count) | Number of services to use. | `number` | `2` | no |
 | <a name="input_stemming_exclusion_reference_analyzer"></a> [stemming\_exclusion\_reference\_analyzer](#input\_stemming\_exclusion\_reference\_analyzer) | Stemmer package file path in opensearch | `string` | n/a | yes |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -84,7 +84,6 @@ Terraform to deploy the service into AWS.
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |
-| <a name="input_execute_clean_up_changes_table"></a> [execute\_clean\_up\_changes\_table](#input\_execute\_clean\_up\_changes\_table) | Defaults to true except in STAGING only to stop daily cleanup of the Changes table for TGP testing (HMRC-434). | `bool` | `true` | no |
 | <a name="input_frontend_base_domain"></a> [frontend\_base\_domain](#input\_frontend\_base\_domain) | Host address of the frontend service. | `string` | n/a | yes |
 | <a name="input_green_lanes_notify_measure_updates"></a> [green\_lanes\_notify\_measure\_updates](#input\_green\_lanes\_notify\_measure\_updates) | Flag to indicate if updated or expired measure records should be included in green lanes update email. | `bool` | n/a | yes |
 | <a name="input_green_lanes_update_email"></a> [green\_lanes\_update\_email](#input\_green\_lanes\_update\_email) | Email address for the green lanes policy team. | `string` | n/a | yes |
@@ -93,6 +92,7 @@ Terraform to deploy the service into AWS.
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Largest number of tasks the service can scale-out to. | `number` | `5` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory to allocate in MB. Powers of 2 only. | `number` | n/a | yes |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | Smallest number of tasks the service can scale-in to. | `number` | `1` | no |
+| <a name="input_process_extra_changes_for_tgp"></a> [process\_extra\_changes\_for\_tgp](#input\_process\_extra\_changes\_for\_tgp) | Defaults to false except in STAGING only for TGP testing (HMRC-434). | `bool` | `true` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region to use. | `string` | n/a | yes |
 | <a name="input_service_count"></a> [service\_count](#input\_service\_count) | Number of services to use. | `number` | `2` | no |
 | <a name="input_stemming_exclusion_reference_analyzer"></a> [stemming\_exclusion\_reference\_analyzer](#input\_stemming\_exclusion\_reference\_analyzer) | Stemmer package file path in opensearch | `string` | n/a | yes |

--- a/terraform/config_staging.tfvars
+++ b/terraform/config_staging.tfvars
@@ -14,4 +14,4 @@ management_email                      = "hmrc-trade-tariff-support-g@digital.hmr
 green_lanes_update_email              = ""
 green_lanes_notify_measure_updates    = false
 legacy_search_enhancements_enabled    = true
-execute_clean_up_changes_table        = false
+process_extra_changes_for_tgp         = false

--- a/terraform/config_staging.tfvars
+++ b/terraform/config_staging.tfvars
@@ -14,4 +14,4 @@ management_email                      = "hmrc-trade-tariff-support-g@digital.hmr
 green_lanes_update_email              = ""
 green_lanes_notify_measure_updates    = false
 legacy_search_enhancements_enabled    = true
-process_extra_changes_for_tgp         = false
+process_extra_changes_for_tgp         = true

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -115,8 +115,8 @@ locals {
       value = var.green_lanes_notify_measure_updates
     },
     {
-      name  = "EXECUTE_CLEAN_UP_CHANGES_TABLE"
-      value = var.execute_clean_up_changes_table
+      name  = "PROCESS_EXTRA_CHANGES_FOR_TGP"
+      value = var.process_extra_changes_for_tgp
     }
   ]
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -87,8 +87,8 @@ variable "green_lanes_notify_measure_updates" {
   type        = bool
 }
 
-variable "execute_clean_up_changes_table" {
-  description = "Defaults to true except in STAGING only to stop daily cleanup of the Changes table for TGP testing (HMRC-434)."
+variable "process_extra_changes_for_tgp" {
+  description = "Defaults to false except in STAGING only for TGP testing (HMRC-434)."
   type        = bool
   default     = true
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -90,5 +90,5 @@ variable "green_lanes_notify_measure_updates" {
 variable "process_extra_changes_for_tgp" {
   description = "Defaults to false except in STAGING only for TGP testing (HMRC-434)."
   type        = bool
-  default     = true
+  default     = false
 }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HMRC-434

### What?
I have added

- [x] Env Var PROCESS_EXTRA_CHANGES_FOR_TGP to add extra changes for TGP in populate_changes_table_worker

### Why?

I am doing this because:

- TGP have requested adhoc Change data to be added for 1-1-2022 and 1-1-2024 to staging and want to test it over a period of days.
- When the staging daily DB refresh occurs and when populate changes Cron runs as normal that data would be deleted and we want to retain it for TGP in staging
- Note Terraform files have the env var set to false in all environments other than staging
- This change will be reverted following TGP successful testing

### Have you? (optional)

- [x] Added new environment variables with correct values to all apps in all spaces

### Deployment risks (optional)

- [x] Includes non-destructive actions which may effect performance
- [x] Changes an api that is used in production
