### PR TITLE
HMRC-423 Fix 20 Year Problem

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,13 +24,25 @@ class ApplicationController < ActionController::API
   private
 
   def actual_date
-    date = Date.parse(params[:as_of].to_s)
-    raise ArgumentError, 'Invalid date' if date > 20.years.from_now || date < 20.years.ago
+    as_of_param = params[:as_of].to_s
 
-    date
-  rescue ArgumentError # empty as_of param means today
+    # Validate the format of the date using regex
+    unless as_of_param.match?(/\A\d{4}-\d{2}-\d{2}\z/)
+      return Time.zone.today
+    end
+
+    date = Date.parse(as_of_param)
+
+    # Ensure the date is within a 20-year range
+    if date > 20.years.from_now
+      Time.zone.today
+    else
+      date
+    end
+  rescue ArgumentError
     Time.zone.today
   end
+
   helper_method :actual_date
 
   def configure_time_machine(&block)


### PR DESCRIPTION
Added regex check for correct date format, returns today if date is completely wrong

### Jira link

https://transformuk.atlassian.net/browse/HMRC-423

### What?

I have altered:

- [x] Application_Controller>Actual_Date to check for correct date format or return today's date.  

### Why?

I am doing this because:

- returning a date >20 years in the past caused a bug in the front end making a commodity look active when it isn't
- Dates thousands of years in the future are unacceptable however we don't want the app to error as trade dates can be in the future
- possible UX constraint for front end required to restrict date input

