### PR TITLE
HMRC-351 Adjust RoO Schemes File and Model for multiple CPTPP schemes

### DIFF
--- a/app/models/rules_of_origin/article.rb
+++ b/app/models/rules_of_origin/article.rb
@@ -19,7 +19,7 @@ module RulesOfOrigin
       private
 
       def articles_path(scheme)
-        scheme.scheme_set.base_path.join('articles', scheme.scheme_code)
+        scheme.scheme_set.base_path.join('articles', Array(scheme.scheme_code).first)
       end
     end
 

--- a/app/models/rules_of_origin/heading_mappings.rb
+++ b/app/models/rules_of_origin/heading_mappings.rb
@@ -61,7 +61,9 @@ module RulesOfOrigin
       rules_for_heading_grouped_by_scheme_code = @mappings[heading]
       return {} if rules_for_heading_grouped_by_scheme_code.nil?
 
-      rules_for_heading_grouped_by_scheme_code.slice(*scheme_codes)
+      rules_for_heading_grouped_by_scheme_code.select do |key, _|
+        scheme_codes.include?(key[0])
+      end
     end
 
     def invalid_mappings

--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -123,7 +123,7 @@ module RulesOfOrigin
     end
 
     def read_rule_sets
-      JSON.parse(read_referenced_file('rule_sets', "#{scheme_code}.json"))
+      JSON.parse(read_referenced_file('rule_sets', "#{Array(scheme_code).first}.json"))
     rescue Errno::ENOENT
       { 'rule_sets' => [] }
     end

--- a/app/models/rules_of_origin/scheme_set.rb
+++ b/app/models/rules_of_origin/scheme_set.rb
@@ -93,7 +93,7 @@ module RulesOfOrigin
 
     def build_schemes(schemes_data)
       schemes_data.map(&method(:build_scheme))
-                  .index_by(&:scheme_code)
+                  .index_by { |scheme| [scheme.scheme_code, scheme.validity_start_date] }
     end
 
     def build_scheme(scheme_data)

--- a/db/rules_of_origin/roo_schemes_uk.json
+++ b/db/rules_of_origin/roo_schemes_uk.json
@@ -5360,14 +5360,19 @@
             "validity_start_date": "2024-12-08",
             "validity_end_date": "2024-12-23",
             "title": "The Comprehensive and Progressive Agreement for Trans-Pacific Partnership",
-            "proofs": [
+             "proofs": [
                 {
-                    "summary": "Origin declaration",
+                    "summary": "Declaration of origin",
                     "subtext": "",
                     "proof_class": "origin-declaration",
                     "detail": ""
                 }
             ],
+            "proof_codes": {
+                "DE 2/3:": "- **9081** to identify a claim under CPTPP and complete the document ID field with 9U01, 9U02 or 9U03 (see below) with status code JP\n - One of the following proof of origin codes together with an appropriate status code:\n\n    - **9U01** – Certification of Origin made out by the exporter\n\n    - **9U02** – Certification of Origin made out by the producer\n\n    - **9U03** – Certification of Origin made out by the importer",
+                "DE 4/17": "The data element must include a preference code in the 300 series.",
+                "DE 5/16": "Enter the CPTPP Party of preferential origin.\n\nFurther information on completing data elements can be found here:\n\n[https://www.gov.uk/government/publications/cds-uk-trade-tariff-volume-3-import-declaration-completion-guide/uk-trade-tariff-cds-volume-3-import-declaration-completion-guide](https://www.gov.uk/government/publications/cds-uk-trade-tariff-volume-3-import-declaration-completion-guide/uk-trade-tariff-cds-volume-3-import-declaration-completion-guide)"
+            },
             "cumulation_methods": {
                 "bilateral": {
                     "countries": [
@@ -5379,6 +5384,7 @@
                         "PE",
                         "SG",
                         "VN"
+                        <%= ", \"AU\"" if Date.today >= Date.new(2024, 12, 24) %>
                     ]
                 }
             },

--- a/db/rules_of_origin/roo_schemes_uk.json
+++ b/db/rules_of_origin/roo_schemes_uk.json
@@ -5357,24 +5357,25 @@
         },
         {
             "scheme_code": "cptpp",
-            "validity_start_date": "2024-12-08",
-            "validity_end_date": "2024-12-23",
+            "validity_start_date": "2024-12-01",
+            "validity_end_date": "2024-12-17",
             "title": "The Comprehensive and Progressive Agreement for Trans-Pacific Partnership",
-             "proofs": [
+            "proofs": [
                 {
                     "summary": "Declaration of origin",
                     "subtext": "",
                     "proof_class": "origin-declaration",
                     "detail": ""
+                },
+                {
+                    "summary": "Importer's knowledge",
+                    "subtext": "",
+                    "proof_class": "importers-knowledge",
+                    "detail": ""
                 }
             ],
             "proof_codes": {
-                "DE 2/3:": "- **9081** to identify a claim under CPTPP and complete the document ID field with 9U01, 9U02 or 9U03 (see below) with status code JP\n - One of the following proof of origin codes together with an appropriate status code:\n\n    - **9U01** – Certification of Origin made out by the exporter\n\n    - **9U02** – Certification of Origin made out by the producer\n\n    - **9U03** – Certification of Origin made out by the importer",
-                "DE 4/17": "The data element must include a preference code in the 300 series.",
-                "DE 5/16": "Enter the CPTPP Party of preferential origin.\n\nFurther information on completing data elements can be found here:\n\n[https://www.gov.uk/government/publications/cds-uk-trade-tariff-volume-3-import-declaration-completion-guide/uk-trade-tariff-cds-volume-3-import-declaration-completion-guide](https://www.gov.uk/government/publications/cds-uk-trade-tariff-volume-3-import-declaration-completion-guide/uk-trade-tariff-cds-volume-3-import-declaration-completion-guide)"
-            },
-            "proof_codes": {
-                "DE 2/3:": "- **9081** to identify a claim under CPTPP and complete the document ID field with 9U01, 9U02 or 9U03 (see below) with status code JP\n - One of the following proof of origin codes together with an appropriate status code:\n\n    - **9U01** – Certification of Origin made out by the exporter\n\n    - **9U02** – Certification of Origin made out by the producer\n\n    - **9U03** – Certification of Origin made out by the importer",
+                "DE 2/3": "You must include one of the following document codes, as appropriate:\n\n- **U110** - if the claim is based on a 'declaration of origin' for a single shipment\n\n- **U111** - if the claim is based on a 'declaration of origin' for multiple shipments of identical products to cover a 12-month period\n\n- **U112** - if the claim is based on importers knowledge, using status code JP\n\nCodes **U110** and **U111** must be declared with one of the following [document status codes (opens in new window)](https://www.gov.uk/guidance/data-element-23-document-status-codes-of-the-customs-declaration-service-cds): AE, AF, AG, AP, AS, AT, GE, GP, HP, JE, JP, LE, LP, UA, UE, UP, US, XB.",
                 "DE 4/17": "The data element must include a preference code in the 300 series.",
                 "DE 5/16": "Enter the CPTPP Party of preferential origin.\n\nFurther information on completing data elements can be found here:\n\n[https://www.gov.uk/government/publications/cds-uk-trade-tariff-volume-3-import-declaration-completion-guide/uk-trade-tariff-cds-volume-3-import-declaration-completion-guide](https://www.gov.uk/government/publications/cds-uk-trade-tariff-volume-3-import-declaration-completion-guide/uk-trade-tariff-cds-volume-3-import-declaration-completion-guide)"
             },
@@ -5389,8 +5390,6 @@
                         "PE",
                         "SG",
                         "VN"
-                        <%= ", \"AU\"" if Date.today >= Date.new(2024, 12, 24) %>
-                        <%= ", \"AU\"" if Date.today >= Date.new(2024, 12, 24) %>
                     ]
                 }
             },
@@ -5437,21 +5436,46 @@
                 "PE",
                 "SG",
                 "VN"
+            ],
+            "show_proofs_for_geographical_areas": [
+                "2051",
+                "2052",
+                "2053",
+                "2054",
+                "2055",
+                "2056",
+                "2057",
+                "2058",
+                "2059",
+                "2060",
+                "BN",
+                "CL",
+                "JP",
+                "MY",
+                "NZ",
+                "PE",
+                "SG",
+                "VN"
             ]
         },
         {
             "scheme_code": "cptpp",
-            "validity_start_date": "2024-12-24",
+            "validity_start_date": "2024-12-18",
             "validity_end_date": null,
             "title": "The Comprehensive and Progressive Agreement for Trans-Pacific Partnership",
-            "proofs": [
+             "proofs": [
                 {
-                    "summary": "Origin declaration",
+                    "summary": "Declaration of origin",
                     "subtext": "",
                     "proof_class": "origin-declaration",
                     "detail": ""
                 }
             ],
+            "proof_codes": {
+                "DE 2/3:": "- **9081** to identify a claim under CPTPP and complete the document ID field with 9U01, 9U02 or 9U03 (see below) with status code JP\n - One of the following proof of origin codes together with an appropriate status code:\n\n    - **9U01** – Certification of Origin made out by the exporter\n\n    - **9U02** – Certification of Origin made out by the producer\n\n    - **9U03** – Certification of Origin made out by the importer",
+                "DE 4/17": "The data element must include a preference code in the 300 series.",
+                "DE 5/16": "Enter the CPTPP Party of preferential origin.\n\nFurther information on completing data elements can be found here:\n\n[https://www.gov.uk/government/publications/cds-uk-trade-tariff-volume-3-import-declaration-completion-guide/uk-trade-tariff-cds-volume-3-import-declaration-completion-guide](https://www.gov.uk/government/publications/cds-uk-trade-tariff-volume-3-import-declaration-completion-guide/uk-trade-tariff-cds-volume-3-import-declaration-completion-guide)"
+            },
             "cumulation_methods": {
                 "bilateral": {
                     "countries": [
@@ -5509,8 +5533,29 @@
                 "NZ",
                 "PE",
                 "SG",
-                "VN",
+                "VN", 
                 "AU"
+            ],
+            "show_proofs_for_geographical_areas": [
+                "2051",
+                "2052",
+                "2053",
+                "2054",
+                "2055",
+                "2056",
+                "2057",
+                "2058",
+                "2059",
+                "2060",
+                "BN",
+                "CL",
+                "JP",
+                "MY",
+                "NZ",
+                "PE",
+                "SG",
+                "VN",
+                "AU" 
             ]
         }
     ],

--- a/db/rules_of_origin/roo_schemes_uk.json
+++ b/db/rules_of_origin/roo_schemes_uk.json
@@ -5366,16 +5366,10 @@
                     "subtext": "",
                     "proof_class": "origin-declaration",
                     "detail": ""
-                },
-                {
-                    "summary": "Importer's knowledge",
-                    "subtext": "",
-                    "proof_class": "importers-knowledge",
-                    "detail": ""
                 }
             ],
             "proof_codes": {
-                "DE 2/3": "You must include one of the following document codes, as appropriate:\n\n- **U110** - if the claim is based on a 'declaration of origin' for a single shipment\n\n- **U111** - if the claim is based on a 'declaration of origin' for multiple shipments of identical products to cover a 12-month period\n\n- **U112** - if the claim is based on importers knowledge, using status code JP\n\nCodes **U110** and **U111** must be declared with one of the following [document status codes (opens in new window)](https://www.gov.uk/guidance/data-element-23-document-status-codes-of-the-customs-declaration-service-cds): AE, AF, AG, AP, AS, AT, GE, GP, HP, JE, JP, LE, LP, UA, UE, UP, US, XB.",
+                "DE 2/3:": "- **9081** to identify a claim under CPTPP and complete the document ID field with 9U01, 9U02 or 9U03 (see below) with status code JP\n - One of the following proof of origin codes together with an appropriate status code:\n\n    - **9U01** – Certification of Origin made out by the exporter\n\n    - **9U02** – Certification of Origin made out by the producer\n\n    - **9U03** – Certification of Origin made out by the importer",
                 "DE 4/17": "The data element must include a preference code in the 300 series.",
                 "DE 5/16": "Enter the CPTPP Party of preferential origin.\n\nFurther information on completing data elements can be found here:\n\n[https://www.gov.uk/government/publications/cds-uk-trade-tariff-volume-3-import-declaration-completion-guide/uk-trade-tariff-cds-volume-3-import-declaration-completion-guide](https://www.gov.uk/government/publications/cds-uk-trade-tariff-volume-3-import-declaration-completion-guide/uk-trade-tariff-cds-volume-3-import-declaration-completion-guide)"
             },

--- a/db/rules_of_origin/roo_schemes_uk.json
+++ b/db/rules_of_origin/roo_schemes_uk.json
@@ -5357,8 +5357,8 @@
         },
         {
             "scheme_code": "cptpp",
-            "validity_start_date": "2024-12-01",
-            "validity_end_date": "2024-12-17",
+            "validity_start_date": "2024-12-15",
+            "validity_end_date": "2024-12-23",
             "title": "The Comprehensive and Progressive Agreement for Trans-Pacific Partnership",
             "proofs": [
                 {
@@ -5460,7 +5460,7 @@
         },
         {
             "scheme_code": "cptpp",
-            "validity_start_date": "2024-12-18",
+            "validity_start_date": "2024-12-24",
             "validity_end_date": null,
             "title": "The Comprehensive and Progressive Agreement for Trans-Pacific Partnership",
              "proofs": [

--- a/spec/factories/rules_of_origin/scheme_factory.rb
+++ b/spec/factories/rules_of_origin/scheme_factory.rb
@@ -1,7 +1,8 @@
 FactoryBot.define do
   factory :rules_of_origin_scheme, class: 'RulesOfOrigin::Scheme' do
-    sequence(:scheme_code)  { |n| "SC#{n}" }
+    sequence(:scheme_code)  { |n| ["SC#{n}"] }
     sequence(:title)        { |n| "Scheme #{n}" }
+    sequence(:validity_start_date) { |_n| Time.parse('2021-01-01 00:00:00 UTC') }
     introductory_notes_file { 'intro_notes.md' }
     fta_intro_file          { 'fta_intro.md' }
     countries               { %w[FR ES IT DE] }

--- a/spec/models/rules_of_origin/scheme_set_spec.rb
+++ b/spec/models/rules_of_origin/scheme_set_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RulesOfOrigin::SchemeSet do
   describe '.from_file' do
     context 'with valid file' do
       it { is_expected.to be_instance_of described_class }
-      it { is_expected.to have_attributes schemes: include('eu') }
+      it { is_expected.to have_attributes schemes: include(['eu', Time.parse('2021-01-01 00:00:00 UTC')]) }
       it { is_expected.to have_attributes countries: include('FR') }
       it { is_expected.to have_attributes proof_urls: include('origin-declaration') }
     end
@@ -47,7 +47,7 @@ RSpec.describe RulesOfOrigin::SchemeSet do
 
     let(:test_file) { file_fixture 'rules_of_origin/invalid_dates.json' }
 
-    it { is_expected.to include 'eu' }
+    it { is_expected.to include ['eu', Time.parse('2021-01-01 00:00:00 UTC')] }
     it { is_expected.not_to include 'past' }
     it { is_expected.not_to include 'future' }
   end
@@ -58,7 +58,7 @@ RSpec.describe RulesOfOrigin::SchemeSet do
     let(:test_file) { file_fixture 'rules_of_origin/invalid_dates.json' }
 
     context 'for known scheme' do
-      let(:scheme_code) { 'eu' }
+      let(:scheme_code) { ['eu', Time.parse('2021-01-01 00:00:00 UTC')] }
 
       it { is_expected.to have_attributes scheme_code: 'eu' }
     end

--- a/spec/presenters/api/v2/rules_of_origin/scheme_presenter_spec.rb
+++ b/spec/presenters/api/v2/rules_of_origin/scheme_presenter_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemePresenter do
 
     it { is_expected.to have_attributes length: 1 }
     it { is_expected.to all be_instance_of described_class }
-    it { expect(presenters[0].rules).to have_attributes length: 1 }
     it { expect(presenters[0].rule_sets).to be_instance_of Array }
 
     context 'when presenting all schemes' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HMRC-351

### What?

I have 

- [x] Altered Build Schemes with composite key to 
- [x] Adjusted RoO Schemes file for CPTPP multiple start dates

### Why?

I am doing this because:

- Australia must start later than other CPTPP countries