### PR TITLE
HMRC-351 Adjust CPTPP to exclude Australia

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk.json
+++ b/db/rules_of_origin/roo_schemes_uk.json
@@ -5357,17 +5357,22 @@
         },
         {
             "scheme_code": "cptpp",
-            "validity_start_date": "2024-12-08",
+            "validity_start_date": "2024-12-15",
             "validity_end_date": "2024-12-23",
             "title": "The Comprehensive and Progressive Agreement for Trans-Pacific Partnership",
             "proofs": [
                 {
-                    "summary": "Origin declaration",
+                    "summary": "Declaration of origin",
                     "subtext": "",
                     "proof_class": "origin-declaration",
                     "detail": ""
                 }
             ],
+            "proof_codes": {
+                "DE 2/3:": "- **9081** to identify a claim under CPTPP and complete the document ID field with 9U01, 9U02 or 9U03 (see below) with status code JP\n - One of the following proof of origin codes together with an appropriate status code:\n\n    - **9U01** – Certification of Origin made out by the exporter\n\n    - **9U02** – Certification of Origin made out by the producer\n\n    - **9U03** – Certification of Origin made out by the importer",
+                "DE 4/17": "The data element must include a preference code in the 300 series.",
+                "DE 5/16": "Enter the CPTPP Party of preferential origin.\n\nFurther information on completing data elements can be found here:\n\n[https://www.gov.uk/government/publications/cds-uk-trade-tariff-volume-3-import-declaration-completion-guide/uk-trade-tariff-cds-volume-3-import-declaration-completion-guide](https://www.gov.uk/government/publications/cds-uk-trade-tariff-volume-3-import-declaration-completion-guide/uk-trade-tariff-cds-volume-3-import-declaration-completion-guide)"
+            },
             "cumulation_methods": {
                 "bilateral": {
                     "countries": [
@@ -5425,71 +5430,18 @@
                 "PE",
                 "SG",
                 "VN"
-            ]
-        },
-        {
-            "scheme_code": "cptpp",
-            "validity_start_date": "2024-12-24",
-            "validity_end_date": null,
-            "title": "The Comprehensive and Progressive Agreement for Trans-Pacific Partnership",
-            "proofs": [
-                {
-                    "summary": "Origin declaration",
-                    "subtext": "",
-                    "proof_class": "origin-declaration",
-                    "detail": ""
-                }
             ],
-            "cumulation_methods": {
-                "bilateral": {
-                    "countries": [
-                        "BN",
-                        "CL",
-                        "JP",
-                        "MY",
-                        "NZ",
-                        "PE",
-                        "SG",
-                        "VN",
-                        "AU"
-                    ]
-                }
-            },
-            "ord": {
-                "ord_title": "The CPTPP Origin Reference Document, version 1.1, dated 30 September 2024",
-                "ord_version": "1.1",
-                "ord_date": "30 September 2024",
-                "ord_original": "240924_ORD_CPTPP_v1.1.docx"
-            },
-            "articles": {
-                "article 1": "neutral-elements",
-                "article 3": "wholly obtained",
-                "article 10": "cumulation",
-                "article 11": "tolerances",
-                "article 13": "accessories",
-                "article 14": "packing materials - retail",
-                "article 15": "packing materials - shipment",
-                "article 17": "sets",
-                "article 18": "direct-transport",
-                "article 27": "verification",
-                "Annex II": "insufficient-processing"
-              
-            },
-            "features": {
-                "absorption": true,
-                "tolerances": false,
-                "sets": true,
-                "cumulation": true,
-                "drawback": false
-            },
-            "introductory_notes_file": "cptpp_intro.md",
-            "links": [
-                {
-                    "text": "The UK and the Comprehensive and Progressive Agreement for Trans-Pacific Partnership (CPTPP)",
-                    "url": "https://www.gov.uk/government/collections/the-uk-and-the-comprehensive-and-progressive-agreement-for-trans-pacific-partnershipcptpp"
-                }
-            ],
-            "countries": [
+            "show_proofs_for_geographical_areas": [
+                "2051",
+                "2052",
+                "2053",
+                "2054",
+                "2055",
+                "2056",
+                "2057",
+                "2058",
+                "2059",
+                "2060",
                 "BN",
                 "CL",
                 "JP",
@@ -5497,8 +5449,7 @@
                 "NZ",
                 "PE",
                 "SG",
-                "VN",
-                "AU"
+                "VN"
             ]
         }
     ],


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HMRC-351

### What?

I have:

- [x] Removed duplicate CPTPP node for Australia from origin schemes file
- [x] Adjusted start date for CPTPP FTA in origin schemes file

### Why?

I am doing this because:

- CPTPP FTA needs to be active for all ratified countries bar Australia.
