### PR TITLE
HMRC-351 - Updated Articles Legislative Lists with Asterisks

### DIFF
--- a/db/rules_of_origin/roo_schemes_uk.json
+++ b/db/rules_of_origin/roo_schemes_uk.json
@@ -5362,7 +5362,7 @@
             "title": "UK-Comprehensive and Progressive Agreement for Trans-Pacific Partnership Agreement (CPTPP)",
             "proofs": [
                 {
-                    "summary": "Declaration of origin",
+                    "summary": "Certification of origin",
                     "subtext": "",
                     "proof_class": "origin-declaration",
                     "detail": ""

--- a/db/rules_of_origin/roo_schemes_uk.json
+++ b/db/rules_of_origin/roo_schemes_uk.json
@@ -5359,7 +5359,7 @@
             "scheme_code": "cptpp",
             "validity_start_date": "2024-12-15",
             "validity_end_date": "2024-12-23",
-            "title": "The Comprehensive and Progressive Agreement for Trans-Pacific Partnership",
+            "title": "UK-Comprehensive and Progressive Agreement for Trans-Pacific Partnership Agreement (CPTPP)",
             "proofs": [
                 {
                     "summary": "Declaration of origin",

--- a/db/rules_of_origin/roo_schemes_uk/articles/cptpp/accessories.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/cptpp/accessories.md
@@ -1,15 +1,15 @@
 For the purpose of determining whether a good is wholly obtained, or satisfies a process or change in tariff classification requirement as set out in Annex II (Product-Specific Rules of Origin), accessories, spare parts, tools or instructional or other information materials, as described in paragraph 4, shall be disregarded; and
 
 $LegislativeList
-2. For the purpose of determining whether a good meets a regional value content requirement, the value of the accessories, spare parts, tools or instructional or other information materials, as described in paragraph 4, shall be taken into account as originating or non-originating materials, as the case may be, in calculating the regional value content of the good.
+* 2. For the purpose of determining whether a good meets a regional value content requirement, the value of the accessories, spare parts, tools or instructional or other information materials, as described in paragraph 4, shall be taken into account as originating or non-originating materials, as the case may be, in calculating the regional value content of the good.
 
-3. A good’s accessories, spare parts, tools or instructional or other information materials, as described in paragraph 4, shall be deemed to have the originating status of the good with which they are delivered.
+* 3. A good’s accessories, spare parts, tools or instructional or other information materials, as described in paragraph 4, shall be deemed to have the originating status of the good with which they are delivered.
 
-4. For the purposes of this Article, accessories, spare parts, tools, and instructional or other information materials are covered when:
+* 4. For the purposes of this Article, accessories, spare parts, tools, and instructional or other information materials are covered when:
 
-  a. the accessories, spare parts, tools and instructional or other information materials are classified with, delivered with but not invoiced separately from the good; and
+  * a. the accessories, spare parts, tools and instructional or other information materials are classified with, delivered with but not invoiced separately from the good; and
 
-  b. the types, quantities, and value of the accessories, spare parts, tools and instructional or other information materials are customary for that good.
+  * b. the types, quantities, and value of the accessories, spare parts, tools and instructional or other information materials are customary for that good.
 $EndLegislativeList
 
 {{Article 13}}

--- a/db/rules_of_origin/roo_schemes_uk/articles/cptpp/cumulation-export.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/cptpp/cumulation-export.md
@@ -1,11 +1,11 @@
 ***Cumulation in the United Kingdom***
 
 $LegislativeList
-1. A good is regarded as originating if the good is produced in the territory of one or more of the Parties by one or more producers, provided that the good satisfies the requirements in Article 2 (Originating Goods) and all other applicable requirements in this Origin Reference Document. 
+* 1. A good is regarded as originating if the good is produced in the territory of one or more of the Parties by one or more producers, provided that the good satisfies the requirements in Article 2 (Originating Goods) and all other applicable requirements in this Origin Reference Document. 
 
-2. An originating good or material of one or more of the Parties that is used in the production of another good in the territory of another Party is considered as originating in the territory of the other Party.
+* 2. An originating good or material of one or more of the Parties that is used in the production of another good in the territory of another Party is considered as originating in the territory of the other Party.
 
-3. Production undertaken on a non-originating material in the territory of one or more of the Parties by one or more producers may contribute toward the originating content of a good for the purpose of determining its origin, regardless of whether that production was sufficient to confer originating status to the material itself.
+* 3. Production undertaken on a non-originating material in the territory of one or more of the Parties by one or more producers may contribute toward the originating content of a good for the purpose of determining its origin, regardless of whether that production was sufficient to confer originating status to the material itself.
 $EndLegislativeList
 
 {{Article 10}}

--- a/db/rules_of_origin/roo_schemes_uk/articles/cptpp/cumulation-import.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/cptpp/cumulation-import.md
@@ -1,11 +1,11 @@
 ***Cumulation in CPTPP states***
 
 $LegislativeList
-1. A good is regarded as originating if the good is produced in the territory of one or more of the Parties by one or more producers, provided that the good satisfies the requirements in Article 2 (Originating Goods) and all other applicable requirements in this Origin Reference Document. 
+* 1. A good is regarded as originating if the good is produced in the territory of one or more of the Parties by one or more producers, provided that the good satisfies the requirements in Article 2 (Originating Goods) and all other applicable requirements in this Origin Reference Document. 
 
-2. An originating good or material of one or more of the Parties that is used in the production of another good in the territory of another Party is considered as originating in the territory of the other Party.
+* 2. An originating good or material of one or more of the Parties that is used in the production of another good in the territory of another Party is considered as originating in the territory of the other Party.
 
-3. Production undertaken on a non-originating material in the territory of one or more of the Parties by one or more producers may contribute toward the originating content of a good for the purpose of determining its origin, regardless of whether that production was sufficient to confer originating status to the material itself.
+* 3. Production undertaken on a non-originating material in the territory of one or more of the Parties by one or more producers may contribute toward the originating content of a good for the purpose of determining its origin, regardless of whether that production was sufficient to confer originating status to the material itself.
 $EndLegislativeList
 
 {{Article 10}}

--- a/db/rules_of_origin/roo_schemes_uk/articles/cptpp/direct-transport.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/cptpp/direct-transport.md
@@ -1,11 +1,11 @@
 $LegislativeList
-1. An originating good shall retain its originating status if the good has been transported to the importing Party without passing through the territory of a non-Party.
+* 1. An originating good shall retain its originating status if the good has been transported to the importing Party without passing through the territory of a non-Party.
 
-2. If an originating good is transported through the territory of one or more non-Parties, the good shall retain its originating status provided that the good:
+* 2. If an originating good is transported through the territory of one or more non-Parties, the good shall retain its originating status provided that the good:
 
-  a. does not undergo any operation outside the territories of the Parties other than: unloading; reloading; separation from a bulk shipment; storing; labelling or marking required by the importing Party; or any other operation necessary to preserve it in good condition or to transport the good to the territory of the importing Party; and
+  * a. does not undergo any operation outside the territories of the Parties other than: unloading; reloading; separation from a bulk shipment; storing; labelling or marking required by the importing Party; or any other operation necessary to preserve it in good condition or to transport the good to the territory of the importing Party; and
 
-  b. remains under the control of the customs administration in the territory of a non-Party.
+  * b. remains under the control of the customs administration in the territory of a non-Party.
 $EndLegislativeList
 
 {{Article 18}}

--- a/db/rules_of_origin/roo_schemes_uk/articles/cptpp/insufficient-processing.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/cptpp/insufficient-processing.md
@@ -1,4 +1,4 @@
-Non-originating goods/materials must be processed to meet the PSRs. 
+Non-originating goods/materials must be processed to meet the PSRs, except in the case of short supply goods listed in Annex IV, provided that meet the conditions set out in that Annex.
  
 Except as otherwise provided in a Party’s Tariff Schedule, where an importing Party applies a different preferential tariff under CPTTP to other Parties for the same originating good and more than one Party is involved in the production, for the correct tariff to be applied the preferential origin must be declared as the Party where the last production process occurred with the exception of the following:
 

--- a/db/rules_of_origin/roo_schemes_uk/articles/cptpp/insufficient-processing.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/cptpp/insufficient-processing.md
@@ -3,13 +3,13 @@ Non-originating goods/materials must be processed to meet the PSRs.
 Except as otherwise provided in a Party’s Tariff Schedule, where an importing Party applies a different preferential tariff under CPTTP to other Parties for the same originating good and more than one Party is involved in the production, for the correct tariff to be applied the preferential origin must be declared as the Party where the last production process occurred with the exception of the following:
 
 $LegislativeList
-a. an operation to ensure the preservation of a good in good condition for the purposes of transport and storage
+* a. an operation to ensure the preservation of a good in good condition for the purposes of transport and storage
 
-b. packaging, re-packaging, breaking up of consignments or putting up a good for retail sale, including placing a good in bottles, cans, flasks, bags, cases or boxes
+* b. packaging, re-packaging, breaking up of consignments or putting up a good for retail sale, including placing a good in bottles, cans, flasks, bags, cases or boxes
 
-c. mere dilution with water or another substance that does not materially alter the characteristics of the good
+* c. mere dilution with water or another substance that does not materially alter the characteristics of the good
 
-d. collection of goods intended to form sets, assortments, kits or composite goods; and
+* d. collection of goods intended to form sets, assortments, kits or composite goods; and
 
-e. any combination of operations referred to in subparagraphs (a) through (d).
+* e. any combination of operations referred to in subparagraphs (a) through (d).
 $EndLegislativeList

--- a/db/rules_of_origin/roo_schemes_uk/articles/cptpp/neutral-elements.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/cptpp/neutral-elements.md
@@ -1,19 +1,19 @@
 “indirect material” means a material used in the production, testing or inspection of a good but not physically incorporated into the good; or a material used in the maintenance of buildings or the operation of equipment, associated with the production of a good, including:
 
 $LegislativeList
-i. fuel, energy, catalysts and solvents;
+* i. fuel, energy, catalysts and solvents;
 
-ii. equipment, devices and supplies used to test or inspect the good;
+* ii. equipment, devices and supplies used to test or inspect the good;
 
-iii. gloves, glasses, footwear, clothing, safety equipment and supplies;
+* iii. gloves, glasses, footwear, clothing, safety equipment and supplies;
 
-iv. tools, dies and moulds;
+* iv. tools, dies and moulds;
 
-v. spare parts and materials used in the maintenance of equipment and buildings;
+* v. spare parts and materials used in the maintenance of equipment and buildings;
 
-vi. lubricants, greases, compounding materials and other materials used in production or used to operate equipment and buildings; and
+* vi. lubricants, greases, compounding materials and other materials used in production or used to operate equipment and buildings; and
 
-vii. any other material that is not incorporated into the good but the use of which in the production of the good can reasonably be demonstrated to be a part of that production.
+* vii. any other material that is not incorporated into the good but the use of which in the production of the good can reasonably be demonstrated to be a part of that production.
 $EndLegislativeList
 
 An indirect material shall be considered to be originating without regard to where it is produced.

--- a/db/rules_of_origin/roo_schemes_uk/articles/cptpp/origin_processes.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/cptpp/origin_processes.md
@@ -1,47 +1,47 @@
 ## Article 20 - Claims for Preferential Tariff Treatment
 
 $LegislativeList
-1. An importer may make a claim for preferential tariff treatment, based on a certification of origin completed by the exporter, producer or importer, or issued by an issuing authority in accordance with Annex 3-A (Other Arrangements) of the CPTPP Agreement.
+* 1. An importer may make a claim for preferential tariff treatment, based on a certification of origin completed by the exporter, producer or importer, or issued by an issuing authority in accordance with Annex 3-A (Other Arrangements) of the CPTPP Agreement.
 
-2. A certification of origin:
+* 2. A certification of origin:
 
-  a. need not follow a prescribed format;
+  * a. need not follow a prescribed format;
 
-  b. must be in writing, including electronic format;
+  * b. must be in writing, including electronic format;
 
-  c. must specify that the good is both originating and meets the requirements of this Origin Reference Document; and
+  * c. must specify that the good is both originating and meets the requirements of this Origin Reference Document; and
 
-  d. must contain a set of minimum data requirements as set out in Annex I (Minimum Data Requirements).
+  * d. must contain a set of minimum data requirements as set out in Annex I (Minimum Data Requirements).
 
-3. certification of origin may apply to:
+* 3. certification of origin may apply to:
 
-  a. a single shipment of a good into the territory of a Party; or
+  * a. a single shipment of a good into the territory of a Party; or
 
-  b. multiple shipments of identical goods within any period specified in the certification of origin, but not exceeding 12 months.
+  * b. multiple shipments of identical goods within any period specified in the certification of origin, but not exceeding 12 months.
 
-4. certification of origin shall be valid for two years after the date that it was issued.
+* 4. certification of origin shall be valid for two years after the date that it was issued.
 
-5. An importer may submit a certification of origin in English. If the certification of origin is not in English, the importing Party may require the importer to submit a translation in the language of the importing Party.
+* 5. An importer may submit a certification of origin in English. If the certification of origin is not in English, the importing Party may require the importer to submit a translation in the language of the importing Party.
 $EndLegislativeList
 
 ## Article 21 - Basis of a Certification of Origin
 
 $LegislativeList
-1. If a producer certifies the origin of a good, the certification of origin shall be completed on the basis of the producer having information that the good is originating.
+* 1. If a producer certifies the origin of a good, the certification of origin shall be completed on the basis of the producer having information that the good is originating.
 
-2. If the exporter is not the producer of the good, a certification of origin may be completed by the exporter of the good on the basis of:
+* 2. If the exporter is not the producer of the good, a certification of origin may be completed by the exporter of the good on the basis of:
 
-  a. the exporter having information that the good is originating; or
+  * a. the exporter having information that the good is originating; or
 
-  b. reasonable reliance on the producer’s information that the good is originating.
+  * b. reasonable reliance on the producer’s information that the good is originating.
 
-3. A certification of origin may be completed by the importer of the good on the basis of:
+* 3. A certification of origin may be completed by the importer of the good on the basis of:
 
-  a. the importer having documentation that the good is originating; or
+  * a. the importer having documentation that the good is originating; or
 
-  b. reasonable reliance on supporting documentation provided by the exporter or producer that the good is originating.
+  * b. reasonable reliance on supporting documentation provided by the exporter or producer that the good is originating.
 
-4. For greater certainty, nothing in paragraph 1 or 2 shall be construed to allow a Party to require an exporter or producer to complete a certification of origin or provide a certification of origin to another person.
+* 4. For greater certainty, nothing in paragraph 1 or 2 shall be construed to allow a Party to require an exporter or producer to complete a certification of origin or provide a certification of origin to another person.
 $EndLegislativeList
 
 ## Article 22 - Discrepancies
@@ -63,41 +63,41 @@ provided that the importation does not form part of a series of importations car
 #  Article 24 - Obligations Relating to Importation
 
 $LegislativeList
-1. Except as otherwise provided for in this Origin Reference Document, for the purpose of claiming preferential tariff treatment, the importer shall:
+* 1. Except as otherwise provided for in this Origin Reference Document, for the purpose of claiming preferential tariff treatment, the importer shall:
 
-  a. make a declaration that the good qualifies as an originating good;
+  * a. make a declaration that the good qualifies as an originating good;
 
-  b. have a valid certification of origin in its possession at the time the declaration referred to in subparagraph (a) is made;
+  * b. have a valid certification of origin in its possession at the time the declaration referred to in subparagraph (a) is made;
 
-  c. provide a copy of the certification of origin to the importing Party if required by the Party; and
+  * c. provide a copy of the certification of origin to the importing Party if required by the Party; and
 
-  d. if required by a Party to demonstrate that the requirements in Article 18 (Transit and Transhipment) have been satisfied, provide relevant documents, such as transport documents, and in the case of storage, storage or customs documents.
+  * d. if required by a Party to demonstrate that the requirements in Article 18 (Transit and Transhipment) have been satisfied, provide relevant documents, such as transport documents, and in the case of storage, storage or customs documents.
 
-2. If the importer has reason to believe that the certification of origin is based on incorrect information that could affect the accuracy or validity of the certification of origin, the importer shall correct the importation document and pay any customs duty and, if applicable, penalties owed.
+* 2. If the importer has reason to believe that the certification of origin is based on incorrect information that could affect the accuracy or validity of the certification of origin, the importer shall correct the importation document and pay any customs duty and, if applicable, penalties owed.
 
-3. No importing Party shall subject an importer to a penalty for making an invalid claim for preferential tariff treatment if the importer, on becoming aware that such a claim is not valid and prior to discovery of the error by that Party, voluntarily corrects the claim and pays any applicable customs duty under the circumstances provided for in the Party’s law.
+* 3. No importing Party shall subject an importer to a penalty for making an invalid claim for preferential tariff treatment if the importer, on becoming aware that such a claim is not valid and prior to discovery of the error by that Party, voluntarily corrects the claim and pays any applicable customs duty under the circumstances provided for in the Party’s law.
 $EndLegislativeList
 
 ## Article 25 - Obligations Relating to Exportation
 
 $LegislativeList
-1. An exporter or producer that completes a certification of origin shall submit a copy of that certification of origin to the exporting Party, on its request.
+* 1. An exporter or producer that completes a certification of origin shall submit a copy of that certification of origin to the exporting Party, on its request.
 
-2. A false certification of origin or other false information provided by an exporter or a producer to support a claim that a good exported to the territory of another Party is originating may have the same legal consequences, with appropriate modifications, as those that would apply to an importer in its territory that makes a false statement or representation in connection with an importation.
+* 2. A false certification of origin or other false information provided by an exporter or a producer to support a claim that a good exported to the territory of another Party is originating may have the same legal consequences, with appropriate modifications, as those that would apply to an importer in its territory that makes a false statement or representation in connection with an importation.
 
-3. If an exporter or a producer has provided a certification of origin and has reason to believe that it contains or is based on incorrect information, the exporter or producer shall promptly notify, in writing, every person and every Party to whom the exporter or producer provided the certification of origin of any change that could affect the accuracy or validity of the certification of origin.
+* 3. If an exporter or a producer has provided a certification of origin and has reason to believe that it contains or is based on incorrect information, the exporter or producer shall promptly notify, in writing, every person and every Party to whom the exporter or producer provided the certification of origin of any change that could affect the accuracy or validity of the certification of origin.
 $EndLegislativeList
 
 ## Article 26 - Record Keeping Requirements
 
 $LegislativeList
-1. An importer claiming preferential tariff treatment for a good imported into the territory of a Party shall maintain, for a period of no less than five years from the date of importation of the good:
+* 1. An importer claiming preferential tariff treatment for a good imported into the territory of a Party shall maintain, for a period of no less than five years from the date of importation of the good:
 
-  a. the documentation related to the importation, including the certification of origin that served as the basis for the claim; and
+  * a. the documentation related to the importation, including the certification of origin that served as the basis for the claim; and
 
-  b. all records necessary to demonstrate that the good is originating and qualified for preferential tariff treatment, if the claim was based on a certification of origin completed by the importer.
+  * b. all records necessary to demonstrate that the good is originating and qualified for preferential tariff treatment, if the claim was based on a certification of origin completed by the importer.
 
-2. A producer or exporter that provides a certification of origin shall maintain, for a period of no less than five years from the date the certification of origin was issued, all records necessary to demonstrate that a good for which the exporter or producer provided a certification of origin is originating. 
+* 2. A producer or exporter that provides a certification of origin shall maintain, for a period of no less than five years from the date the certification of origin was issued, all records necessary to demonstrate that a good for which the exporter or producer provided a certification of origin is originating. 
 
-3. An importer, exporter or producer may choose to maintain the records specified in paragraphs 1 and 2 in any medium that allows for prompt retrieval, including electronic, optical, magnetic or written form in accordance with a Party’s laws and regulations.
+* 3. An importer, exporter or producer may choose to maintain the records specified in paragraphs 1 and 2 in any medium that allows for prompt retrieval, including electronic, optical, magnetic or written form in accordance with a Party’s laws and regulations.
 $EndLegislativeList

--- a/db/rules_of_origin/roo_schemes_uk/articles/cptpp/packaging_retail.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/cptpp/packaging_retail.md
@@ -1,5 +1,5 @@
 $LegislativeList
-1. Packaging materials and containers in which a good is packaged for retail sale, if classified with the good, shall be disregarded in determining whether all the non-originating materials used in the production of the good have satisfied the applicable process or change in tariff classification requirement set out in Annex II (Product-Specific Rules of Origin) or whether the good is wholly obtained or produced.
+* 1. Packaging materials and containers in which a good is packaged for retail sale, if classified with the good, shall be disregarded in determining whether all the non-originating materials used in the production of the good have satisfied the applicable process or change in tariff classification requirement set out in Annex II (Product-Specific Rules of Origin) or whether the good is wholly obtained or produced.
 
-2. If a good is subject to a regional value content requirement, the value of the packaging materials and containers in which the good is packaged for retail sale, if classified with the good, shall be taken into account as originating or non-originating, as the case may be, in calculating the regional value content of the good.
+* 2. If a good is subject to a regional value content requirement, the value of the packaging materials and containers in which the good is packaged for retail sale, if classified with the good, shall be taken into account as originating or non-originating, as the case may be, in calculating the regional value content of the good.
 $EndLegislativeList

--- a/db/rules_of_origin/roo_schemes_uk/articles/cptpp/sets.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/cptpp/sets.md
@@ -1,17 +1,17 @@
 $LegislativeList
-1. For a set classified as a result of the application of Rule 3(a) or (b) of the General Rules for the Interpretation of the Harmonized System, the originating status of the set shall be determined in accordance with the product-specific rule of origin that applies to the set.
+* 1. For a set classified as a result of the application of Rule 3(a) or (b) of the General Rules for the Interpretation of the Harmonized System, the originating status of the set shall be determined in accordance with the product-specific rule of origin that applies to the set.
 
-2. For a set classified as a result of the application of Rule 3(c) of the General Rules for the Interpretation of the Harmonized System, the set shall be originating only if each good in the set is originating and both the set and the goods meet the other applicable requirements of this Origin Reference Document.
+* 2. For a set classified as a result of the application of Rule 3(c) of the General Rules for the Interpretation of the Harmonized System, the set shall be originating only if each good in the set is originating and both the set and the goods meet the other applicable requirements of this Origin Reference Document.
 
-3. Notwithstanding paragraph 2, for a set classified as a result of the application of Rule 3(c) of the General Rules for the Interpretation of the Harmonized System, the set shall be originating if the value of all the non-originating goods in the set does not exceed 10 per cent of the value of the set.
+* 3. Notwithstanding paragraph 2, for a set classified as a result of the application of Rule 3(c) of the General Rules for the Interpretation of the Harmonized System, the set shall be originating if the value of all the non-originating goods in the set does not exceed 10 per cent of the value of the set.
 
-4. Notwithstanding paragraphs 1 through 3, and the textile and apparel product-specific rules of origin set out in Annex II (Product-Specific Rules of Origin), textile and apparel goods put up in sets for retail sale, classified as a result of the application of Rule 3 of the General Rules for the Interpretation of the Harmonized System, shall not be regarded as originating goods unless each of the goods in the set is an originating good or the total value of the non-originating goods in the set does not exceed 10 per cent of the value of the set.
+* 4. Notwithstanding paragraphs 1 through 3, and the textile and apparel product-specific rules of origin set out in Annex II (Product-Specific Rules of Origin), textile and apparel goods put up in sets for retail sale, classified as a result of the application of Rule 3 of the General Rules for the Interpretation of the Harmonized System, shall not be regarded as originating goods unless each of the goods in the set is an originating good or the total value of the non-originating goods in the set does not exceed 10 per cent of the value of the set.
 
-5. For the purposes of paragraph 3 and 4:
+* 5. For the purposes of paragraph 3 and 4:
 
-  a. the value of non-originating goods in the set shall be calculated in the same manner as the value of non-originating materials in this Origin Reference Document; and
+  * a. the value of non-originating goods in the set shall be calculated in the same manner as the value of non-originating materials in this Origin Reference Document; and
 
-  b. the value of the set shall be calculated in the same manner as the value of the good in this Origin Reference Document.
+  * b. the value of the set shall be calculated in the same manner as the value of the good in this Origin Reference Document.
 $EndLegislativeList
 
 {{Article 17}}

--- a/db/rules_of_origin/roo_schemes_uk/articles/cptpp/tolerances.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/cptpp/tolerances.md
@@ -1,40 +1,40 @@
 $LegislativeList
-1. Except as provided in paragraphs 4 to 7, a good that contains non-originating materials that do not satisfy the applicable change in tariff classification requirement specified in Annex II (Product-Specific Rules of Origin) for the good shall nonetheless be regarded as an originating good if the value of all those materials does not exceed 10 per cent of the value of the good, as defined under Article 1 (Definitions), and the good meets all the other applicable requirements of this Origin Reference Document.
+* 1. Except as provided in paragraphs 4 to 7, a good that contains non-originating materials that do not satisfy the applicable change in tariff classification requirement specified in Annex II (Product-Specific Rules of Origin) for the good shall nonetheless be regarded as an originating good if the value of all those materials does not exceed 10 per cent of the value of the good, as defined under Article 1 (Definitions), and the good meets all the other applicable requirements of this Origin Reference Document.
 
-2. Paragraph 1 applies only when using a non-originating material in the production of another good.
+* 2. Paragraph 1 applies only when using a non-originating material in the production of another good.
 
-3. If a good described in paragraph 1 is also subject to a regional value content requirement, the value of those non-originating materials shall be included in the value of non-originating materials for the applicable regional value content requirement.
+* 3. If a good described in paragraph 1 is also subject to a regional value content requirement, the value of those non-originating materials shall be included in the value of non-originating materials for the applicable regional value content requirement.
 
-4. A textile or apparel good classified outside of Chapters 61 through 63 of the Harmonized System 2012 that contains non-originating materials that do not satisfy the applicable change in tariff classification requirement specified in Annex II (Product-Specific Rules of Origin), shall nonetheless be considered to be an originating good if the total weight of all those materials is not more than 10 per cent of the total weight of the good and the good meets all the other applicable requirements of this Origin Reference Document.
+* 4. A textile or apparel good classified outside of Chapters 61 through 63 of the Harmonized System 2012 that contains non-originating materials that do not satisfy the applicable change in tariff classification requirement specified in Annex II (Product-Specific Rules of Origin), shall nonetheless be considered to be an originating good if the total weight of all those materials is not more than 10 per cent of the total weight of the good and the good meets all the other applicable requirements of this Origin Reference Document.
 
-5. A textile or apparel good classified in Chapters 61 through 63 of the Harmonized System 2012 that contains non-originating fibres or yarns in the component of the good that determines the tariff classification of the good that do not satisfy the applicable change in tariff classification set out in Annex II (Product-Specific Rules of Origin), shall nonetheless be considered to be an originating good if the total weight of all those fibres or yarns is not more than 10 per cent of the total weight of that component and the good meets all the other applicable requirements of this Origin Reference Document.
+* 5. A textile or apparel good classified in Chapters 61 through 63 of the Harmonized System 2012 that contains non-originating fibres or yarns in the component of the good that determines the tariff classification of the good that do not satisfy the applicable change in tariff classification set out in Annex II (Product-Specific Rules of Origin), shall nonetheless be considered to be an originating good if the total weight of all those fibres or yarns is not more than 10 per cent of the total weight of that component and the good meets all the other applicable requirements of this Origin Reference Document.
 
-6. Notwithstanding paragraphs 4 and 5, a good described in paragraph 4 containing elastomeric yarn or a good described in paragraph 5 containing elastomeric yarn in the component of the good that determines the tariff classification of the good shall be considered to be an originating good only if such yarns are wholly formed in the territory of one or more of the Parties. (footnote: For greater certainty, this paragraph shall not be construed to require a material listed in Annex IV (Short Supply List of Products) to be produced from elastomeric yarns wholly formed in the territory of one or more of the Parties.
+* 6. Notwithstanding paragraphs 4 and 5, a good described in paragraph 4 containing elastomeric yarn or a good described in paragraph 5 containing elastomeric yarn in the component of the good that determines the tariff classification of the good shall be considered to be an originating good only if such yarns are wholly formed in the territory of one or more of the Parties. (footnote: For greater certainty, this paragraph shall not be construed to require a material listed in Annex IV (Short Supply List of Products) to be produced from elastomeric yarns wholly formed in the territory of one or more of the Parties.
 For the purposes of this paragraph, “wholly formed” means all production processes and finishing operations, beginning with the extrusion of filaments, strips, film or sheet, and including drawing to fully orient a filament or slitting a film or sheet into strip, or the spinning of all fibres into yarn, or both, and ending with a finished yarn or plied yarn.)
 
-7. This article shall not apply to:
+* 7. This article shall not apply to:
 
-  a. non-originating materials of HS 2012 heading 04.01 through 04.06, or non-originating dairy preparations containing over 10 per cent by dry weight of milk solids of subheading 1901.90 or 2106.90, used in the production of a good of heading 04.01 through 04.06 other than a good of subheading 0402.10 through 0402.29 or 0406.30 (footenote: For greater certainty, milk powder of HS 2012 subheading 0402.10 through 0402.29, and processed cheese of subheading 0406.30, that is originating as a result of the application of the 10 per cent de minimis allowance in Article 11 (De Minimis), shall be an originating material when used in the production of any good of heading 04.01 through 04.06 as referred to in subparagraph (a) or the goods listed in subparagraph (b))
+  * a. non-originating materials of HS 2012 heading 04.01 through 04.06, or non-originating dairy preparations containing over 10 per cent by dry weight of milk solids of subheading 1901.90 or 2106.90, used in the production of a good of heading 04.01 through 04.06 other than a good of subheading 0402.10 through 0402.29 or 0406.30 (footenote: For greater certainty, milk powder of HS 2012 subheading 0402.10 through 0402.29, and processed cheese of subheading 0406.30, that is originating as a result of the application of the 10 per cent de minimis allowance in Article 11 (De Minimis), shall be an originating material when used in the production of any good of heading 04.01 through 04.06 as referred to in subparagraph (a) or the goods listed in subparagraph (b))
 
-  b. non-originating materials of HS 2012 heading 04.01 through 04.06, or non-originating dairy preparations containing over 10 per cent by dry weight of milk solids of subheading 1901.90, used in the production of the following goods:
+  * b. non-originating materials of HS 2012 heading 04.01 through 04.06, or non-originating dairy preparations containing over 10 per cent by dry weight of milk solids of subheading 1901.90, used in the production of the following goods:
 
-    i. infant preparations containing over 10 per cent by dry weight of milk solids of subheading 1901.10;
+    * i. infant preparations containing over 10 per cent by dry weight of milk solids of subheading 1901.10;
 
-    ii. mixes and doughs, containing over 25 per cent by dry weight of butterfat, not put up for retail sale of subheading 1901.20;
+    * ii. mixes and doughs, containing over 25 per cent by dry weight of butterfat, not put up for retail sale of subheading 1901.20;
 
-    iii. dairy preparations containing over 10 per cent by dry weight of milk solids of subheading 1901.90 or 2106.90;
+    * iii. dairy preparations containing over 10 per cent by dry weight of milk solids of subheading 1901.90 or 2106.90;
 
-    iv. goods of heading 21.05;
+    * iv. goods of heading 21.05;
 
-    v. beverages containing milk of subheading 2202.90; or
+    * v. beverages containing milk of subheading 2202.90; or
 
-    vi. animal feeds containing over 10 per cent by dry weight of milk solids of subheading 2309.90;
+    * vi. animal feeds containing over 10 per cent by dry weight of milk solids of subheading 2309.90;
 
-  c. non-originating materials of HS 2012 heading 08.05 or subheading 2009.11 through 2009.39, used in the production of a good of subheading 2009.11 through 2009.39 or a fruit or vegetable juice of any single fruit or vegetable, fortified with minerals or vitamins, concentrated or unconcentrated, of subheading 2106.90 or 2202.90;
+  * c. non-originating materials of HS 2012 heading 08.05 or subheading 2009.11 through 2009.39, used in the production of a good of subheading 2009.11 through 2009.39 or a fruit or vegetable juice of any single fruit or vegetable, fortified with minerals or vitamins, concentrated or unconcentrated, of subheading 2106.90 or 2202.90;
 
-  d. non-originating materials of Chapter 15 of the Harmonized System 2012, used in the production of a good of headings 15.07, 15.08, 15.12, or 15.14; or
+  * d. non-originating materials of Chapter 15 of the Harmonized System 2012, used in the production of a good of headings 15.07, 15.08, 15.12, or 15.14; or
 
-  e. non-originating peaches, pears or apricots of Chapter 8 or 20 of the Harmonized System 2012, used in the production of a good of heading 20.08.
+  * e. non-originating peaches, pears or apricots of Chapter 8 or 20 of the Harmonized System 2012, used in the production of a good of heading 20.08.
 $EndLegislativeList
 
 {{Article 11}}

--- a/db/rules_of_origin/roo_schemes_uk/articles/cptpp/verification.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/cptpp/verification.md
@@ -1,25 +1,25 @@
 ## Verification of proofs of origin
 
 $LegislativeList
-1. An importer may be denied a claim for preferential tariff treatment if:
+* 1. An importer may be denied a claim for preferential tariff treatment if:
 
-  a. the importing Party determines that the good does not qualify for preferential treatment;
+  * a. the importing Party determines that the good does not qualify for preferential treatment;
 
-  b. pursuant to a verification under Article 3.27 (Verification of Origin) of the CPTPP Agreement, the importing Party has not received sufficient information to determine that the good qualifies as originating;
+  * b. pursuant to a verification under Article 3.27 (Verification of Origin) of the CPTPP Agreement, the importing Party has not received sufficient information to determine that the good qualifies as originating;
 
-  c. the exporter, producer or importer fails to respond to a written request for information in accordance with Article 3.27 (Verification of Origin) of the CPTPP Agreement;
+  * c. the exporter, producer or importer fails to respond to a written request for information in accordance with Article 3.27 (Verification of Origin) of the CPTPP Agreement;
 
-  d. after receipt of a written notification for a verification visit, the exporter or producer does not provide its written consent in accordance with Article 3.27 (Verification of Origin) of the CPTPP Agreement; 
+  * d. after receipt of a written notification for a verification visit, the exporter or producer does not provide its written consent in accordance with Article 3.27 (Verification of Origin) of the CPTPP Agreement; 
 
-  e. the importer, exporter or producer fails to comply with the requirements of this Origin Reference Document; or
+  * e. the importer, exporter or producer fails to comply with the requirements of this Origin Reference Document; or
 
-  f. for a textile and apparel good, if, pursuant to a verification under Chapter 4 of the CPTPP Agreement, access or permission for the visit is denied, the importing Party is prevented from completing the visit on the proposed date, and the exporter or producer does not provide an alternative date acceptable to the importing Party, or the exporter or producer does not provide access to the relevant records or facilities during a visit.
+  * f. for a textile and apparel good, if, pursuant to a verification under Chapter 4 of the CPTPP Agreement, access or permission for the visit is denied, the importing Party is prevented from completing the visit on the proposed date, and the exporter or producer does not provide an alternative date acceptable to the importing Party, or the exporter or producer does not provide access to the relevant records or facilities during a visit.
 
-2. If an importer is denied a claim for preferential tariff treatment, they shall be issued with a determination that includes the reasons for the determination.
+* 2. If an importer is denied a claim for preferential tariff treatment, they shall be issued with a determination that includes the reasons for the determination.
 
-3. A claim for preferential tariff treatment shall not be rejected for the sole reason that the invoice was issued in a non-Party. If an invoice is issued in a non-Party, the certification of origin shall be separate from the invoice.
+* 3. A claim for preferential tariff treatment shall not be rejected for the sole reason that the invoice was issued in a non-Party. If an invoice is issued in a non-Party, the certification of origin shall be separate from the invoice.
 
-4. If the competent authority that issued the certification of origin fails to respond to a verification request, the importing Party may deny the claim for preferential tariff treatment.
+* 4. If the competent authority that issued the certification of origin fails to respond to a verification request, the importing Party may deny the claim for preferential tariff treatment.
 $EndLegislativeList
 
 {{Article 27}}

--- a/db/rules_of_origin/roo_schemes_uk/articles/cptpp/wholly-obtained.md
+++ b/db/rules_of_origin/roo_schemes_uk/articles/cptpp/wholly-obtained.md
@@ -1,30 +1,31 @@
 For the purposes of Article 2 (Originating Goods), a good is wholly obtained or produced entirely in the territory of one or more of the Parties if it is:
 
 $LegislativeList
-a. a plant or plant good, grown, cultivated, harvested, picked or gathered there;
+* a. a plant or plant good, grown, cultivated, harvested, picked or gathered there;
 
-b. a live animal born and raised there;
+* b. a live animal born and raised there;
 
-c. a good obtained from a live animal there;
-dan animal obtained by hunting, trapping, fishing, gathering or capturing there;
+* c. a good obtained from a live animal there;
 
-e. a good obtained from aquaculture there;
+* d. an animal obtained by hunting, trapping, fishing, gathering or capturing there;
 
-f. a mineral or other naturally occurring substance, not included in subparagraphs (a) through (e), extracted or taken from there;
+* e. a good obtained from aquaculture there;
 
-g. fish, shellfish and other marine life taken from the sea, seabed or subsoil outside the territories of the Parties and, in accordance with international law, outside the territorial sea of non-Parties by vessels that are registered, listed or recorded with a Party and entitled to fly the flag of that Party;
+* f. a mineral or other naturally occurring substance, not included in subparagraphs (a) through (e), extracted or taken from there;
 
-h. a good produced from goods referred to in subparagraph (g) on board a factory ship that is registered, listed or recorded with a Party and entitled to fly the flag of that Party;
+* g. fish, shellfish and other marine life taken from the sea, seabed or subsoil outside the territories of the Parties and, in accordance with international law, outside the territorial sea of non-Parties by vessels that are registered, listed or recorded with a Party and entitled to fly the flag of that Party;
 
-i. a good other than fish, shellfish and other marine life taken by a Party or a person of a Party from the seabed or subsoil outside the territories of the Parties, and beyond areas over which non-Parties exercise jurisdiction provided that Party or person of that Party has the right to exploit that seabed or subsoil in accordance with international law;
+* h. a good produced from goods referred to in subparagraph (g) on board a factory ship that is registered, listed or recorded with a Party and entitled to fly the flag of that Party;
 
-j. a good that is:
+* i. a good other than fish, shellfish and other marine life taken by a Party or a person of a Party from the seabed or subsoil outside the territories of the Parties, and beyond areas over which non-Parties exercise jurisdiction provided that Party or person of that Party has the right to exploit that seabed or subsoil in accordance with international law;
 
-  i. waste or scrap derived from production there; or
+* j. a good that is:
 
-  ii. waste or scrap derived from used goods collected there, provided that those goods are fit only for the recovery of raw materials; and
+  * i. waste or scrap derived from production there; or
 
-k. a good produced there, exclusively from goods referred to in subparagraphs (a) through (j), or from their derivatives.
+  * ii. waste or scrap derived from used goods collected there, provided that those goods are fit only for the recovery of raw materials; and
+
+* k. a good produced there, exclusively from goods referred to in subparagraphs (a) through (j), or from their derivatives.
 $EndLegislativeList
 
 {{Article 3}}

--- a/db/rules_of_origin/roo_schemes_uk/introductory_notes/cptpp_intro.md
+++ b/db/rules_of_origin/roo_schemes_uk/introductory_notes/cptpp_intro.md
@@ -1,37 +1,36 @@
 $LegislativeList
-1. For the purposes of interpreting the product specific rules of origin set out in this Annex, the following definitions apply:
+* 1. For the purposes of interpreting the product specific rules of origin set out in this Annex, the following definitions apply:
 
-  a. “section" means a section of the Harmonized System 2012 (HS 2012);  	
+  * a. “section" means a section of the Harmonized System 2012 (HS 2012);  	
 
-  b. “chapter” means a chapter of the Harmonized System 2012 (HS 2012);
+  * b. “chapter” means a chapter of the Harmonized System 2012 (HS 2012);
 
-  c. “heading” means the first four digits of the tariff classification number under the Harmonized System 2012 (HS 2012);
-and
+  * c. “heading” means the first four digits of the tariff classification number under the Harmonized System 2012 (HS 2012); and
 
-  d. “sub-heading” means the first six digits of the tariff classification number under the Harmonized System 2012 (HS 2012).
+  * d. “sub-heading” means the first six digits of the tariff classification number under the Harmonized System 2012 (HS 2012).
 
 
-2. Under this Annex, a good is an originating good if it is produced entirely in the territory of one or more of the Parties by one or more producers using non-originating materials, and:
+* 2. Under this Annex, a good is an originating good if it is produced entirely in the territory of one or more of the Parties by one or more producers using non-originating materials, and:
 
-  a. each of the non-originating materials used in the production of the good satisfies any applicable change in tariff classification requirement, or the good otherwise satisfies the production process requirement, regional value content requirement, or any other requirement specified in this Annex; and
+  * a. each of the non-originating materials used in the production of the good satisfies any applicable change in tariff classification requirement, or the good otherwise satisfies the production process requirement, regional value content requirement, or any other requirement specified in this Annex; and
 
-  b. the good satisfies all other applicable requirements of this Origin Reference Document
+  * b. the good satisfies all other applicable requirements of this Origin Reference Document
 
-3. For the purposes of interpreting the product-specific rules of origin set out in this Annex:
+* 3. For the purposes of interpreting the product-specific rules of origin set out in this Annex:
 
-  a. the specific rule, or specific set of rules, that applies to a particular heading, subheading or group of headings or subheadings is set out immediately adjacent to the heading, subheading or group of headings or subheadings;
+  * a. the specific rule, or specific set of rules, that applies to a particular heading, subheading or group of headings or subheadings is set out immediately adjacent to the heading, subheading or group of headings or subheadings;
 
-  b. section, chapter or heading notes, where applicable, are found at the beginning of each section or chapter, and are read in conjunction with the product-specific rules of origin and may impose further conditions on, or provide an alternative to the product-specific rules of origin;
+  * b. section, chapter or heading notes, where applicable, are found at the beginning of each section or chapter, and are read in conjunction with the product-specific rules of origin and may impose further conditions on, or provide an alternative to the product-specific rules of origin;
 
-  c. the requirement of a change in tariff classification shall apply only to non-originating materials;
+  * c. the requirement of a change in tariff classification shall apply only to non-originating materials;
 
-  d. if a product-specific rule of origin excludes certain materials of the Harmonized System, it shall be construed to mean that the product specific rule of origin requires that the excluded materials be originating for the good to be originating;
+  * d. if a product-specific rule of origin excludes certain materials of the Harmonized System, it shall be construed to mean that the product specific rule of origin requires that the excluded materials be originating for the good to be originating;
 
-  e. if a good is subject to alternative product-specific rules of origin, the good shall be originating if it satisfies one of the alternatives;
+  * e. if a good is subject to alternative product-specific rules of origin, the good shall be originating if it satisfies one of the alternatives;
 
-  f. if a good is subject to a product-specific rule of origin that includes multiple requirements, the good shall be originating only if it satisfies all of the requirements; and
+  * f. if a good is subject to a product-specific rule of origin that includes multiple requirements, the good shall be originating only if it satisfies all of the requirements; and
 
-  g. if a single product-specific rule of origin applies to a group of headings or subheadings and that rule of origin specifies a change of heading or subheading, it shall be understood that the change in heading or subheading may occur from any other heading or subheading, as the case may be, including from any other heading or subheading within the group.
+  * g. if a single product-specific rule of origin applies to a group of headings or subheadings and that rule of origin specifies a change of heading or subheading, it shall be understood that the change in heading or subheading may occur from any other heading or subheading, as the case may be, including from any other heading or subheading within the group.
 
-4. For goods of chapters 84 and 87 marked with a symbol ( † ), an optional methodology for satisfying the regional value content requirement of the product specific rule of origin shall apply. This methodology is contained in Annex III (Provisions Related to the Product-Specific Rules of Origin for Certain Vehicles and Parts of Vehicles).
+* 4. For goods of chapters 84 and 87 marked with a symbol ( † ), an optional methodology for satisfying the regional value content requirement of the product specific rule of origin shall apply. This methodology is contained in Annex III (Provisions Related to the Product-Specific Rules of Origin for Certain Vehicles and Parts of Vehicles).
 $EndLegislativeList

--- a/db/rules_of_origin/roo_schemes_uk/proofs/cptpp/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/cptpp/origin-declaration.md
@@ -1,7 +1,31 @@
-The origin declaration is provided on an invoice or any other commercial document that describes the originating product in sufficient detail to enable its identification.
+The certification of origin may be issued by the exporter, producer or importer, or issued by an issuing authority in accordance with Annex 3-A (Other arrangements) of the CPTPP agreement.
 
-The text of the origin declaration is set out in Annex 2 of the [origin document]({ord_url}).
+A certification of origin:
 
-In the UK, the exporter’s reference number will be the EORI number. If you do not have one, you can [apply for an EORI number](https://www.gov.uk/eori). 
+1. need not follow a prescribed format;
+2. must be in writing, including electronic format;
+3. must specify that the good is originating ; and
+4. must contain a set of minimum data requirements as set out in Annex I (Minimum Data Requirements) of the CPTPP ORD
 
-Find out more about using [origin declarations](https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration).
+A certification of origin may apply to:
+
+1. a single shipment of a good into the territory of a party
+2. multiple shipments of identical goods within any period specified in the certification of origin, but not exceeding 12 months.
+
+A certification of origin shall be valid for 2 years after the date it was issued.
+
+1. If a producer certifies the origin of a good, the certification of origin shall be completed on the basis of the producer having information that the good is originating.
+
+2. If the exporter is not the producer of the good, a certification of origin may be completed by the exporter of the good on the basis of:
+
+    a.  the exporter having information that the good is originating; or
+
+    b.  reasonable reliance on the producer's information that the good is originating.
+
+3. A certification of origin may be completed by the importer of the good on the basis of:
+
+    a. the importer having documentation that the good is originating; or
+
+    b. reasonable reliance on supporting documentation provided by the exporter or producer that the good is originating.
+
+4. For greater certainty, nothing in paragraph 1 or 2 shall be construed to allow a Party to require an exporter or producer to complete a certification of origin or provide a certification of origin to another person.

--- a/db/rules_of_origin/roo_schemes_uk/proofs/cptpp/origin-declaration.md
+++ b/db/rules_of_origin/roo_schemes_uk/proofs/cptpp/origin-declaration.md
@@ -2,15 +2,19 @@ The certification of origin may be issued by the exporter, producer or importer,
 
 A certification of origin:
 
-1. need not follow a prescribed format;
-2. must be in writing, including electronic format;
-3. must specify that the good is originating ; and
-4. must contain a set of minimum data requirements as set out in Annex I (Minimum Data Requirements) of the CPTPP ORD
+$LegislativeList
+- a. need not follow a prescribed format;
+- b. must be in writing, including electronic format;
+- c. must specify that the good is originating ; and
+- d. must contain a set of minimum data requirements as set out in Annex I (Minimum Data Requirements) of the CPTPP ORD
+$EndLegislativeList
 
 A certification of origin may apply to:
 
-1. a single shipment of a good into the territory of a party
-2. multiple shipments of identical goods within any period specified in the certification of origin, but not exceeding 12 months.
+$LegislativeList
+- a. a single shipment of a good into the territory of a party
+- b. multiple shipments of identical goods within any period specified in the certification of origin, but not exceeding 12 months.
+$EndLegislativeList
 
 A certification of origin shall be valid for 2 years after the date it was issued.
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HMRC-351

### What?

I have added asterisks to legislativelists in markdown docs and updated the scheme name in the schemes file

### Why?

I am doing this because:

- the formatting was incorrect and the scheme name was wrong

Example:

BEFORE:
<img width="519" alt="image" src="https://github.com/user-attachments/assets/8c1e7b8c-7c86-42a4-8a53-b10911c20e8d" />

AFTER:
<img width="530" alt="image" src="https://github.com/user-attachments/assets/2fd8532e-6fb2-49df-8482-b89013997c0c" />
