### PR TITLE
Ignore default 'undefined' resource_id in search to used in sql query.

### DIFF
--- a/app/lib/custom_regex.rb
+++ b/app/lib/custom_regex.rb
@@ -10,10 +10,12 @@ module CustomRegex
   end
 
   def cus_number_regex
+    # Seven digits, followed by a hyphen, followed by one digit.
     /\A\d{7}-\d\z/
   end
 
   def no_alpha_regex
+    # entire strings that do not contain any alphabetic characters
     /^(?!.*[A-Za-z]+).*$/
   end
 

--- a/app/services/search_service/exact_search.rb
+++ b/app/services/search_service/exact_search.rb
@@ -34,7 +34,7 @@ class SearchService
 
     def find_search_suggestion(query)
       filter = { value: singular_and_plural(query) }
-      if resource_id.present?
+      if resource_id.present? && resource_id != "undefined"
         filter[:id] = resource_id
       end
 

--- a/app/services/search_service/exact_search.rb
+++ b/app/services/search_service/exact_search.rb
@@ -34,7 +34,7 @@ class SearchService
 
     def find_search_suggestion(query)
       filter = { value: singular_and_plural(query) }
-      if resource_id.present? && resource_id != "undefined"
+      if resource_id.present? && resource_id != 'undefined'
         filter[:id] = resource_id
       end
 


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [ ] Removed default resource_id filter from search query

### Why?

I am doing this because: Parameter is populated with "undiefined" when the param is empty.