### PR TITLE
HMRC-511 - Revert HMRC-434-Toggle-Delete-Changes

### DIFF
--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -268,9 +268,5 @@ module TradeTariffBackend
     def green_lanes_notify_measure_updates
       ENV['GREEN_LANES_NOTIFY_MEASURE_UPDATES'].to_s == 'true'
     end
-
-    def execute_clean_up_changes_table?
-      ENV.fetch('EXECUTE_CLEAN_UP_CHANGES_TABLE', 'true') == 'true'
-    end
   end
 end

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -269,8 +269,8 @@ module TradeTariffBackend
       ENV['GREEN_LANES_NOTIFY_MEASURE_UPDATES'].to_s == 'true'
     end
 
-    def process_extra_changes_for_tgp?
-      ENV.fetch('PROCESS_EXTRA_CHANGES_FOR_TGP', 'false') == 'true'
+    def execute_clean_up_changes_table?
+      ENV.fetch('EXECUTE_CLEAN_UP_CHANGES_TABLE', 'true') == 'true'
     end
   end
 end

--- a/app/workers/populate_changes_table_worker.rb
+++ b/app/workers/populate_changes_table_worker.rb
@@ -4,15 +4,11 @@ class PopulateChangesTableWorker
   sidekiq_options queue: :sync, retry: false
 
   def perform
-    if TradeTariffBackend.process_extra_changes_for_tgp?
+    ChangesTablePopulator.populate
+    if TradeTariffBackend.execute_clean_up_changes_table?
       ChangesTablePopulator.cleanup_outdated
-      ChangesTablePopulator.populate
-      logger.info 'Populating changes for TGP for 1-Jan-2022 & 1-Jan-2024, see env_var PROCESS_EXTRA_CHANGES_FOR_TGP'
-      ChangesTablePopulator.populate(day: Time.zone.parse('2024-01-01'))
-      ChangesTablePopulator.populate(day: Time.zone.parse('2022-01-01'))
     else
-      ChangesTablePopulator.populate
-      ChangesTablePopulator.cleanup_outdated
+      logger.info 'Skipping cleanup of outdated changes, see env_var CLEAN_UP_CHANGES_TABLE'
     end
   end
 end

--- a/app/workers/populate_changes_table_worker.rb
+++ b/app/workers/populate_changes_table_worker.rb
@@ -5,10 +5,6 @@ class PopulateChangesTableWorker
 
   def perform
     ChangesTablePopulator.populate
-    if TradeTariffBackend.execute_clean_up_changes_table?
-      ChangesTablePopulator.cleanup_outdated
-    else
-      logger.info 'Skipping cleanup of outdated changes, see env_var CLEAN_UP_CHANGES_TABLE'
-    end
+    ChangesTablePopulator.cleanup_outdated
   end
 end

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -84,7 +84,6 @@ Terraform to deploy the service into AWS.
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |
-| <a name="input_execute_clean_up_changes_table"></a> [execute\_clean\_up\_changes\_table](#input\_execute\_clean\_up\_changes\_table) | Defaults to true except in STAGING only to stop daily cleanup of the Changes table for TGP testing (HMRC-434). | `bool` | `true` | no |
 | <a name="input_frontend_base_domain"></a> [frontend\_base\_domain](#input\_frontend\_base\_domain) | Host address of the frontend service. | `string` | n/a | yes |
 | <a name="input_green_lanes_notify_measure_updates"></a> [green\_lanes\_notify\_measure\_updates](#input\_green\_lanes\_notify\_measure\_updates) | Flag to indicate if updated or expired measure records should be included in green lanes update email. | `bool` | n/a | yes |
 | <a name="input_green_lanes_update_email"></a> [green\_lanes\_update\_email](#input\_green\_lanes\_update\_email) | Email address for the green lanes policy team. | `string` | n/a | yes |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -84,6 +84,7 @@ Terraform to deploy the service into AWS.
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |
+| <a name="input_execute_clean_up_changes_table"></a> [execute\_clean\_up\_changes\_table](#input\_execute\_clean\_up\_changes\_table) | Defaults to true except in STAGING only to stop daily cleanup of the Changes table for TGP testing (HMRC-434). | `bool` | `true` | no |
 | <a name="input_frontend_base_domain"></a> [frontend\_base\_domain](#input\_frontend\_base\_domain) | Host address of the frontend service. | `string` | n/a | yes |
 | <a name="input_green_lanes_notify_measure_updates"></a> [green\_lanes\_notify\_measure\_updates](#input\_green\_lanes\_notify\_measure\_updates) | Flag to indicate if updated or expired measure records should be included in green lanes update email. | `bool` | n/a | yes |
 | <a name="input_green_lanes_update_email"></a> [green\_lanes\_update\_email](#input\_green\_lanes\_update\_email) | Email address for the green lanes policy team. | `string` | n/a | yes |
@@ -92,7 +93,6 @@ Terraform to deploy the service into AWS.
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Largest number of tasks the service can scale-out to. | `number` | `5` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory to allocate in MB. Powers of 2 only. | `number` | n/a | yes |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | Smallest number of tasks the service can scale-in to. | `number` | `1` | no |
-| <a name="input_process_extra_changes_for_tgp"></a> [process\_extra\_changes\_for\_tgp](#input\_process\_extra\_changes\_for\_tgp) | Defaults to false except in STAGING only for TGP testing (HMRC-434). | `bool` | `false` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region to use. | `string` | n/a | yes |
 | <a name="input_service_count"></a> [service\_count](#input\_service\_count) | Number of services to use. | `number` | `2` | no |
 | <a name="input_stemming_exclusion_reference_analyzer"></a> [stemming\_exclusion\_reference\_analyzer](#input\_stemming\_exclusion\_reference\_analyzer) | Stemmer package file path in opensearch | `string` | n/a | yes |

--- a/terraform/config_staging.tfvars
+++ b/terraform/config_staging.tfvars
@@ -14,4 +14,3 @@ management_email                      = "hmrc-trade-tariff-support-g@digital.hmr
 green_lanes_update_email              = ""
 green_lanes_notify_measure_updates    = false
 legacy_search_enhancements_enabled    = true
-execute_clean_up_changes_table        = false

--- a/terraform/config_staging.tfvars
+++ b/terraform/config_staging.tfvars
@@ -14,4 +14,4 @@ management_email                      = "hmrc-trade-tariff-support-g@digital.hmr
 green_lanes_update_email              = ""
 green_lanes_notify_measure_updates    = false
 legacy_search_enhancements_enabled    = true
-process_extra_changes_for_tgp         = true
+execute_clean_up_changes_table        = false

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -115,8 +115,8 @@ locals {
       value = var.green_lanes_notify_measure_updates
     },
     {
-      name  = "PROCESS_EXTRA_CHANGES_FOR_TGP"
-      value = var.process_extra_changes_for_tgp
+      name  = "EXECUTE_CLEAN_UP_CHANGES_TABLE"
+      value = var.execute_clean_up_changes_table
     }
   ]
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -113,10 +113,6 @@ locals {
     {
       name  = "GREEN_LANES_NOTIFY_MEASURE_UPDATES"
       value = var.green_lanes_notify_measure_updates
-    },
-    {
-      name  = "EXECUTE_CLEAN_UP_CHANGES_TABLE"
-      value = var.execute_clean_up_changes_table
     }
   ]
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -86,9 +86,3 @@ variable "green_lanes_notify_measure_updates" {
   description = "Flag to indicate if updated or expired measure records should be included in green lanes update email."
   type        = bool
 }
-
-variable "execute_clean_up_changes_table" {
-  description = "Defaults to true except in STAGING only to stop daily cleanup of the Changes table for TGP testing (HMRC-434)."
-  type        = bool
-  default     = true
-}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -87,8 +87,8 @@ variable "green_lanes_notify_measure_updates" {
   type        = bool
 }
 
-variable "process_extra_changes_for_tgp" {
-  description = "Defaults to false except in STAGING only for TGP testing (HMRC-434)."
+variable "execute_clean_up_changes_table" {
+  description = "Defaults to true except in STAGING only to stop daily cleanup of the Changes table for TGP testing (HMRC-434)."
   type        = bool
-  default     = false
+  default     = true
 }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HMRC-511

### What?

I have reverted commits 
[658f19329f582839c9c6ce241ff06fe3ab0551fc](https://github.com/trade-tariff/trade-tariff-backend/commit/658f19329f582839c9c6ce241ff06fe3ab0551fc) 

And

 [65b718728165aa613f405925d55910d31414a470](https://github.com/trade-tariff/trade-tariff-backend/commit/65b718728165aa613f405925d55910d31414a470)

### Why?

I am doing this because:

- Jira [HMRC-434](https://transformuk.atlassian.net/browse/HMRC-434) must be completely backed out. 

- These were both merge commits for PRs: 

  - https://github.com/trade-tariff/trade-tariff-backend/pull/2030 (Didn't work in staging)
  - https://github.com/trade-tariff/trade-tariff-backend/pull/2033 (Did work in staging)


- The reason there were two merges to be backed out is that the code in the first PR didn't work in staging and the second merged PR did.