### PR TITLE
HMRC-544 Added emailer service for FAQ Feedback statistics

### DIFF
--- a/app/mailers/faq_feedback_mailer.rb
+++ b/app/mailers/faq_feedback_mailer.rb
@@ -1,0 +1,48 @@
+class FaqFeedbackMailer < ApplicationMailer
+  default to: TradeTariffBackend.support_email
+
+  def faq_feedback_message
+    mail subject: "[HMRC Online Trade Tariff Support] UK tariff - Green Lanes FAQ Feedback Report - #{TradeTariffBackend.service == 'uk' ? 'UK' : 'Northern Ireland'}",
+         content_type: 'text/html',
+         body: faq_feedback_statistics_body(GreenLanes::FaqFeedback.statistics)
+  end
+
+  def faq_feedback_statistics_body(results)
+    report_html = <<~HTML
+      <html>
+      <body>
+        <h2>Green Lanes FAQ Feedback Report for #{TradeTariffBackend.service == 'uk' ? 'UK' : 'Northern Ireland'}</h2>
+        <p>A summary of FAQ Feedback Categories and Questions and their usefulness:</p>
+        <table border="1" cellspacing="0" cellpadding="5">
+          <thead>
+            <tr>
+              <th>Category ID</th>
+              <th>Question ID</th>
+              <th>Useful Count</th>
+              <th>Not Useful Count</th>
+            </tr>
+          </thead>
+          <tbody>
+    HTML
+
+    results.each do |row|
+      report_html += <<~HTML
+        <tr>
+          <td>#{row[:category_id]}</td>
+          <td>#{row[:question_id]}</td>
+          <td>#{row[:useful_count]}</td>
+          <td>#{row[:not_useful_count]}</td>
+        </tr>
+      HTML
+    end
+
+    report_html += <<~HTML
+          </tbody>
+        </table>
+      </body>
+      </html>
+    HTML
+
+    report_html
+  end
+end

--- a/app/models/green_lanes/faq_feedback.rb
+++ b/app/models/green_lanes/faq_feedback.rb
@@ -8,5 +8,14 @@ module GreenLanes
       super
       validates_unique(%i[session_id category_id question_id])
     end
+
+    def self.statistics
+      GreenLanes::FaqFeedback
+               .select(:category_id, :question_id,
+                       Sequel.as(Sequel.lit('SUM(CASE WHEN useful THEN 1 ELSE 0 END)'), :useful_count),
+                       Sequel.as(Sequel.lit('SUM(CASE WHEN useful THEN 0 ELSE 1 END)'), :not_useful_count))
+               .group(:category_id, :question_id)
+               .order(:category_id, :question_id)
+    end
   end
 end

--- a/app/workers/faq_feedback_report_worker.rb
+++ b/app/workers/faq_feedback_report_worker.rb
@@ -1,0 +1,17 @@
+class FaqFeedbackReportWorker
+  include Sidekiq::Worker
+
+  sidekiq_options retry: 1, retry_in: 1.hour
+
+  def perform(deliver_email = true)
+    if deliver_email
+      send_faq_feedback_report_email
+    end
+  end
+
+  private
+
+  def send_faq_feedback_report_email
+    FaqFeedbackMailer.faq_feedback_message.deliver_now
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -74,3 +74,7 @@
       cron: "0 1 * * 2"  # 1am every Tuesday
       description: "Checks if the differences report has run"
       class: DifferencesReportCheckWorker
+    FAQFeedbackReportWorker:
+      cron: "0 9 * * 2"  # 9am every Tuesday
+      description: "Sends FAQ Feedback Report"
+      class: FaqFeedbackReportWorker

--- a/lib/tasks/reporting.rake
+++ b/lib/tasks/reporting.rake
@@ -8,4 +8,9 @@ namespace :reporting do
   task generate_differences_report: :environment do
     DifferencesReportWorker.perform_async(ENV['NOEMAIL'] != 'true')
   end
+
+  desc 'Generate FAQ Feedback report , add NOEMAIL=true to not send email'
+  task generate_faq_feedback_report: :environment do
+    FaqFeedbackReportWorker.perform_async(ENV['NOEMAIL'] != 'true')
+  end
 end

--- a/spec/models/green_lanes/faq_feedback_spec.rb
+++ b/spec/models/green_lanes/faq_feedback_spec.rb
@@ -31,4 +31,23 @@ RSpec.describe GreenLanes::FaqFeedback do
       end
     end
   end
+
+  describe '.statistics' do
+    subject(:statistics) { described_class.statistics }
+
+    before do
+      create(:green_lanes_faq_feedback, category_id: 1, question_id: 1, useful: true)
+      create(:green_lanes_faq_feedback, category_id: 1, question_id: 1, useful: false)
+      create(:green_lanes_faq_feedback, category_id: 1, question_id: 2, useful: true)
+      create(:green_lanes_faq_feedback, category_id: 2, question_id: 1, useful: false)
+    end
+
+    it 'returns the correct statistics grouped by category and question' do
+      expect(statistics).to contain_exactly(
+        include(category_id: 1, question_id: 1, useful_count: 1, not_useful_count: 1),
+        include(category_id: 1, question_id: 2, useful_count: 1, not_useful_count: 0),
+        include(category_id: 2, question_id: 1, useful_count: 0, not_useful_count: 1),
+      )
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HMRC-544
https://transformuk.atlassian.net/browse/HMRC-442 (Epic)

### What?

I have added emailer service for FAQ Feedback statistics to email every Tuesday at 9am to the support inbox

### Why?

I am doing this because:

- We need some way of reporting the statistics for Green Lanes FAQ Feedback