### PR TITLE
BAU: Adds ecs exec capability to admin API boxes

### DIFF
--- a/terraform/admin_uk.tf
+++ b/terraform/admin_uk.tf
@@ -17,6 +17,8 @@ module "backend_admin_uk" {
   docker_tag   = var.docker_tag
   skip_destroy = true
 
+  enable_ecs_exec = true
+
   container_port        = 8080
   private_dns_namespace = "tariff.internal"
 
@@ -24,10 +26,10 @@ module "backend_admin_uk" {
   memory = var.memory
 
   task_role_policy_arns = [
+    aws_iam_policy.exec.arn,
     aws_iam_policy.s3.arn,
     aws_iam_policy.task_role_kms_keys.arn
   ]
-
   execution_role_policy_arns = [
     aws_iam_policy.secrets.arn
   ]

--- a/terraform/admin_xi.tf
+++ b/terraform/admin_xi.tf
@@ -17,6 +17,8 @@ module "backend_admin_xi" {
   docker_tag   = var.docker_tag
   skip_destroy = true
 
+  enable_ecs_exec = true
+
   container_port        = 8080
   private_dns_namespace = "tariff.internal"
 
@@ -24,6 +26,7 @@ module "backend_admin_xi" {
   memory = var.memory
 
   task_role_policy_arns = [
+    aws_iam_policy.exec.arn,
     aws_iam_policy.s3.arn,
     aws_iam_policy.task_role_kms_keys.arn
   ]


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added ECS permission and option to admin uk and admin xi machines

### Why?

I am doing this because:

- This is required to debug a live issue with these services
