### PR TITLE
HMRC-635 Fix Rack Timeout timeouts to protect app

### DIFF
--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -2,7 +2,7 @@ if Rails.env.production?
   Rails.application.config.middleware.insert_before(
     Rack::Runtime,
     Rack::Timeout,
-    service_timeout: Integer(ENV.fetch('RACK_TIMEOUT_SERVICE', 6)),
+    service_timeout: Integer(ENV.fetch('RACK_TIMEOUT_SERVICE', 5)),
   )
 
   Rack::Timeout::Logger.level = ::Logger::WARN

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -52,15 +52,15 @@ locals {
     },
     {
       name  = "RACK_TIMEOUT_SERVICE"
-      value = "50"
+      value = "5"
     },
     {
       name  = "RACK_TIMEOUT_SERVICE_TIMEOUT"
-      value = "50"
+      value = "5"
     },
     {
       name  = "RACK_TIMEOUT_WAIT_TIMEOUT"
-      value = "100"
+      value = "5"
     },
     {
       name  = "RUBYOPT",


### PR DESCRIPTION
### Jira link

HMRC-635

### What?

Rack timeout is set way too high to be useful.  This PR sets this to a more realistic level to provide the protection it's intended to