### PR TITLE
HMRC-635 Add throttle on worst abusers

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -12,6 +12,8 @@ if Rails.env.production?
       end
     end
   end
+
+  Rack::Attack.throttle('requests by ip', limit: 10_000, period: 600, &:ip)
 else
   logger.info 'Rack::Attack is disabled in Dev env.'
 end


### PR DESCRIPTION
### Jira link

HMRC-635

### What?

This PR adds a rule to Rack::Attack to throttle users to 10k requests every 10 mins on a leaky bucket system.  

There are only a couple of users way above this amount which we are looking to cut.  Whilst this is a limit, it's still way about what should be considered reasonable.
[logs-insights-results.csv](https://github.com/user-attachments/files/18655891/logs-insights-results.csv)
