### PR TITLE
HMRC-635 Reduce rack-attack bucket size

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -13,7 +13,7 @@ if Rails.env.production?
     end
   end
 
-  Rack::Attack.throttle('requests by ip', limit: 10_000, period: 600, &:ip)
+  Rack::Attack.throttle('requests by ip', limit: 1_000, period: 60, &:ip)
 else
   logger.info 'Rack::Attack is disabled in Dev env.'
 end


### PR DESCRIPTION

### Jira link

HMRC-635

### What?

Move from 10min bucket to 1min bucket (same limit, just a smaller sample)