### PR TITLE
HMRC-573: Adds environment configuration to disable admin api auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,22 +355,16 @@ workflows:
           ssm_parameter: "/development/BACKEND_ECR_URL"
           <<: *filter-not-main
 
-      - confirm-deploy-for-qa?:
-          type: approval
+      - apply-terraform:
+          name: apply-terraform-dev
+          context: trade-tariff-terraform-aws-development
+          environment: development
           requires:
             - test
             - ruby-checks
             - pre-commit
             - plan-terraform-dev
             - build-and-push-dev
-          <<: *filter-not-main
-
-      - apply-terraform:
-          name: apply-terraform-dev
-          context: trade-tariff-terraform-aws-development
-          environment: development
-          requires:
-            - confirm-deploy-for-qa?
           <<: *filter-not-main
 
       - sync-opensearch-packages:

--- a/app/controllers/api/admin/admin_controller.rb
+++ b/app/controllers/api/admin/admin_controller.rb
@@ -1,6 +1,16 @@
 module Api
   module Admin
     class AdminController < ApiController
+      include GDS::SSO::ControllerMethods
+
+      def authenticate_user!
+        if TradeTariffBackend.disable_admin_api_authentication?
+          true
+        else
+          super
+        end
+      end
+
       no_caching
     end
   end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,6 +1,5 @@
 module Api
   class ApiController < ApplicationController
-    include GDS::SSO::ControllerMethods
     include EtagCaching
 
     respond_to :json

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -268,5 +268,9 @@ module TradeTariffBackend
     def green_lanes_notify_measure_updates
       ENV['GREEN_LANES_NOTIFY_MEASURE_UPDATES'].to_s == 'true'
     end
+
+    def disable_admin_api_authentication?
+      ENV.fetch('DISABLE_ADMIN_API_AUTHENTICATION', 'false').to_s == 'true'
+    end
   end
 end

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -82,6 +82,7 @@ Terraform to deploy the service into AWS.
 | <a name="input_alcohol_coercian_starts_from"></a> [alcohol\_coercian\_starts\_from](#input\_alcohol\_coercian\_starts\_from) | When alcohol measurement unit coercian starts from for excise measurement units | `string` | `"2023-01-01"` | no |
 | <a name="input_base_domain"></a> [base\_domain](#input\_base\_domain) | Host address of the service. | `string` | n/a | yes |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
+| <a name="input_disable_admin_api_authentication"></a> [disable\_admin\_api\_authentication](#input\_disable\_admin\_api\_authentication) | Flag to indicate if admin API authentication should be disabled. | `bool` | `false` | no |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |
 | <a name="input_frontend_base_domain"></a> [frontend\_base\_domain](#input\_frontend\_base\_domain) | Host address of the frontend service. | `string` | n/a | yes |

--- a/terraform/config_development.tfvars
+++ b/terraform/config_development.tfvars
@@ -11,3 +11,4 @@ management_email                      = "hmrc-trade-tariff-support-g@digital.hmr
 green_lanes_update_email              = ""
 green_lanes_notify_measure_updates    = false
 legacy_search_enhancements_enabled    = true
+disable_admin_api_authentication      = true

--- a/terraform/config_production.tfvars
+++ b/terraform/config_production.tfvars
@@ -14,3 +14,4 @@ management_email                      = "tariffmanagement@hmrc.gov.uk"
 green_lanes_update_email              = "hmrc-trade-tariff-support-g@digital.hmrc.gov.uk"
 green_lanes_notify_measure_updates    = false
 legacy_search_enhancements_enabled    = true
+disable_admin_api_authentication      = false

--- a/terraform/config_staging.tfvars
+++ b/terraform/config_staging.tfvars
@@ -14,3 +14,4 @@ management_email                      = "hmrc-trade-tariff-support-g@digital.hmr
 green_lanes_update_email              = ""
 green_lanes_notify_measure_updates    = false
 legacy_search_enhancements_enabled    = true
+disable_admin_api_authentication      = true

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -31,6 +31,10 @@ locals {
       value = "1"
     },
     {
+      name  = "DISABLE_ADMIN_API_AUTHENTICATION"
+      value = var.disable_admin_api_authentication
+    },
+    {
       name  = "FRONTEND_HOST"
       value = "https://${var.frontend_base_domain}/"
     },

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -86,3 +86,9 @@ variable "green_lanes_notify_measure_updates" {
   description = "Flag to indicate if updated or expired measure records should be included in green lanes update email."
   type        = bool
 }
+
+variable "disable_admin_api_authentication" {
+  description = "Flag to indicate if admin API authentication should be disabled."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
### Jira link

[HMRC-573](https://transformuk.atlassian.net/browse/HMRC-573)

### What?

I have added/removed/altered:

- [x] Added terraform configuration to set environment variable in dev/staging
- [x] Added backend wrapping method to default to enabled
- [x] Move GDS::SSO configuration into the admin controller
- [x] Removed Deploy Dev for QA  

### Why?

I am doing this because:

- This only affects authentication between the admin frontend app and the
backend apis and does not impact the need to authenticate users with
signon currently.
- We're doing this to reflect that development/staging hosted signon applications are currently in a broken state and need fixing separately
- Moved the GDS::SSO configuration because it is specific to admin
- Removed deploy for QA as the team is smaller now and not required
