### PR TITLE
HMRC-649: Stop holding excessive objects in SAX parser stacks

### DIFF
--- a/app/lib/cds_importer.rb
+++ b/app/lib/cds_importer.rb
@@ -42,7 +42,7 @@ class CdsImporter
         # Read into memory
         xml_stream = entry.get_input_stream
         # do the xml parsing depending on records root depth
-        CdsImporter::XmlParser::Reader.new(xml_stream.read, handler).parse
+        CdsImporter::XmlParser::Reader.new(xml_stream, handler).parse
         Rails.logger.info "Successfully imported Cds file: #{@cds_update.filename}"
       end
     end

--- a/app/lib/cds_importer/xml_parser.rb
+++ b/app/lib/cds_importer/xml_parser.rb
@@ -43,7 +43,7 @@ class CdsImporter
       def end_element(key)
         @depth -= 1
         if @depth == @target_depth && @targets.include?(key)
-          @target_handler.process_xml_node(key, @stack[-1])
+          @target_handler.process_xml_node(key, @stack.pop)
           @in_target = false
         end
         return unless @in_target

--- a/app/lib/taric_importer/xml_parser.rb
+++ b/app/lib/taric_importer/xml_parser.rb
@@ -43,7 +43,7 @@ class TaricImporter
         key = strip_namespace(key)
 
         if key == @target
-          @target_handler.process_xml_node @stack[-1]
+          @target_handler.process_xml_node @stack.pop
           @in_target = false
         end
 


### PR DESCRIPTION
### Jira link

HMRC-649

### What?

I have added/removed/altered:

- [x] Altered pulling the target node off of the stack with a pop over a peak
- [x] Stop reading the whole buffer into a string and undermining the whole point of using a SAX parser

### Why?

I am doing this because:

- This should cap the memory overhead of using the SAX parsers
- This actually speeds up file loading for me (1.5 hours down to about 40 minutes for the annual file)
