### PR TITLE
HMRC-577 Update VEF Currency Exchange Rate Code End Date

### DIFF
--- a/db/migrate/20250120112727_update_currency_vef_to_ved.rb
+++ b/db/migrate/20250120112727_update_currency_vef_to_ved.rb
@@ -2,15 +2,21 @@
 
 Sequel.migration do
   change do
-    Sequel::Model.db.run "INSERT INTO exchange_rate_currencies (currency_code, currency_description, spot_rate_required) VALUES ('VED', 'Bolivar Fuerte', true)"
+    Sequel::Model.db.run "INSERT INTO exchange_rate_currencies (currency_code, currency_description, spot_rate_required) 
+                          SELECT 'VED', 'Bolivar Fuerte', true 
+                          WHERE NOT EXISTS (SELECT 1 FROM exchange_rate_currencies WHERE currency_code = 'VED')"
 
     ExchangeRateCountryCurrency.where(currency_code: 'VEF').update(validity_end_date: Date.new(2025, 1, 15))
-    ExchangeRateCountryCurrency.create(
-      currency_code: 'VED',
-      country_code: 'VE',
-      country_description: 'Venezuela',
-      currency_description: 'Venezuelan Bolívar',
-      validity_start_date: Date.new(2025, 1, 22),
-    )
+    
+    unless ExchangeRateCountryCurrency.where(currency_code: 'VED').first
+      ExchangeRateCountryCurrency.create(
+        currency_code: 'VED',
+        country_code: 'VE',
+        country_description: 'Venezuela',
+        currency_description: 'Venezuelan Bolívar',
+        validity_start_date: Date.new(2025, 1, 22),
+      )
+    end
   end
 end
+

--- a/db/migrate/20250207141527_update_currency_vef_end_date.rb
+++ b/db/migrate/20250207141527_update_currency_vef_end_date.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    ExchangeRateCountryCurrency.where(currency_code: 'VEF').update(validity_end_date: Date.new(2025, 1, 31))
+  end
+end
+


### PR DESCRIPTION


### Jira link

https://transformuk.atlassian.net/browse/HMRC-577

### What?

I have:

- [x] Added migration script to extend end date for VEF and mitigated table constraints of related script

### Why?

I am doing this because:

- The VEF end date must supersede the VED start date in January 2025 for the January 2025 rate for VEF to show
- The previous migration wouldn't run due to duplicate key table constraints
