### PR TITLE
HMRC-657: Match the semantics of the frontend api requests

### DIFF
--- a/app/controllers/api/admin/commodities/search_references_controller.rb
+++ b/app/controllers/api/admin/commodities/search_references_controller.rb
@@ -46,12 +46,16 @@ module Api
           end
         end
 
+        def admin_commodity_id
+          params[:admin_commodity_id].presence || params[:commodity_id]
+        end
+
         def commodity_id
-          params[:commodity_id].split('-', 2).first
+          admin_commodity_id.split('-', 2).first
         end
 
         def productline_suffix
-          params[:commodity_id].split('-', 2)[1] || '80'
+          admin_commodity_id.split('-', 2)[1] || '80'
         end
       end
     end

--- a/app/controllers/api/admin/green_lanes/faq_feedback_controller.rb
+++ b/app/controllers/api/admin/green_lanes/faq_feedback_controller.rb
@@ -2,7 +2,7 @@ module Api
   module Admin
     module GreenLanes
       class FaqFeedbackController < AdminController
-        # before_action :authenticate_user!
+        before_action :authenticate_user!
 
         def create
           faq_feedback = ::GreenLanes::FaqFeedback.new(faq_feedback_params)
@@ -10,7 +10,7 @@ module Api
           if faq_feedback.valid? && faq_feedback.save
             Rails.logger.info("FAQ feedback created: #{faq_feedback.id}")
             render json: serialize(faq_feedback),
-                   location: api_green_lanes_faq_feedback_url(faq_feedback.id),
+                   location: api_admin_green_lanes_faq_feedback_url(faq_feedback.id),
                    status: :created
           else
             render json: serialize_errors(faq_feedback),

--- a/app/engines/v1_api.rb
+++ b/app/engines/v1_api.rb
@@ -1,0 +1,41 @@
+class V1Api < ::Rails::Engine
+end
+
+V1Api.routes.draw do
+  namespace :api, defaults: { format: 'json' }, path: '/' do
+    scope module: :v1 do
+      resources :sections, only: %i[index show] do
+        collection do
+          get :tree
+        end
+        scope module: 'sections', constraints: { id: /\d+/ } do
+          resource :section_note, only: %i[show]
+        end
+      end
+
+      resources :chapters, only: %i[index show], constraints: { id: /\d{2}/ } do
+        member do
+          get :changes
+        end
+
+        scope module: 'chapters', constraints: { chapter_id: /\d{2}/, id: /\d+/ } do
+          resource :chapter_note, only: %i[show]
+        end
+      end
+
+      resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
+        member do
+          get :changes
+        end
+      end
+
+      resources :commodities, only: [:show], constraints: { id: /\d{10}/, as_of: /.*/ } do
+        member do
+          get :changes
+        end
+      end
+
+      get '/headings/:id/tree' => 'headings#tree'
+    end
+  end
+end

--- a/app/engines/v2_api.rb
+++ b/app/engines/v2_api.rb
@@ -1,0 +1,148 @@
+class V2Api < ::Rails::Engine
+end
+
+V2Api.routes.draw do
+  namespace :api, defaults: { format: 'json' }, path: '/' do
+    scope module: :v2 do
+      resources :sections, only: %i[index show] do
+        collection do
+          get :tree
+        end
+
+        member do
+          get :chapters
+        end
+      end
+
+      namespace :exchange_rates do
+        get 'period_lists(/:year)', to: 'period_lists#show', as: :period_list
+        resources :files, only: [:show]
+      end
+
+      resources :exchange_rates, only: [:show]
+
+      resources :chapters, only: %i[index show], constraints: { id: /\d{1,2}/ } do
+        member do
+          get :changes
+          get :headings
+        end
+      end
+
+      resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
+        member do
+          get :changes
+          get :commodities
+        end
+
+        resources :validity_periods, only: [:index]
+      end
+
+      resources :subheadings, only: [:show] do
+        resources :validity_periods, only: [:index]
+      end
+
+      resources :commodities, only: [:show], constraints: { id: /\d{10}/ } do
+        member do
+          get :changes
+        end
+
+        resources :validity_periods, only: [:index]
+      end
+
+      resources :geographical_areas, only: %i[index show] do
+        collection { get :countries }
+      end
+
+      resources :chemical_substances, only: %i[index]
+      resources :simplified_procedural_code_measures, only: %i[index]
+
+      resources :preference_codes, only: %i[index show]
+
+      resources :monetary_exchange_rates, only: [:index]
+
+      resources :updates, only: [] do
+        collection { get :latest }
+      end
+
+      resources :search_references, only: [:index]
+
+      resources :quotas, only: [] do
+        collection { get :search }
+      end
+
+      resources :certificates, only: [:index] do
+        collection { get :search }
+      end
+
+      resources :certificate_types, only: [:index]
+
+      resources :measure_actions, only: %i[index]
+      resources :measure_condition_codes, only: %i[index]
+      resources :quota_order_numbers, only: %i[index]
+      resources :measure_types, only: %i[index show]
+      resources :measures, only: %i[show], constraints: { id: /-?\d+/ }
+
+      resources :additional_codes, only: [] do
+        collection { get :search }
+      end
+
+      resources :additional_code_types, only: [:index]
+
+      resources :footnotes, only: [] do
+        collection { get :search }
+      end
+
+      resources :footnote_types, only: [:index]
+
+      resources :chemicals, only: %i[index show] do
+        collection { get :search }
+      end
+
+      scope module: :rules_of_origin do
+        resources :rules_of_origin_schemes,
+                  controller: 'schemes',
+                  only: %i[index]
+        get '/rules_of_origin_schemes/:heading_code/:country_code',
+            to: 'schemes#index',
+            as: :rules_of_origin
+        get '/rules_of_origin_schemes/:commodity_code',
+            to: 'product_specific_rules#index',
+            as: :product_specific_rules
+      end
+
+      if Rails.env.development? || TradeTariffBackend.uk?
+        namespace :news do
+          resources :items, only: %i[index show]
+          resources :years, only: %i[index]
+          resources :collections, only: %i[index] do
+            resources :items, only: %i[index], shallow: true
+          end
+        end
+
+        get '/news_items/:id', to: 'news/items#show', as: nil
+        get '/news_items', to: 'news/items#index', as: nil
+      end
+
+      get '/changes(/:as_of)', to: 'changes#index', as: :changes, constraints: { as_of: /\d{4}-\d{1,2}-\d{1,2}/ }
+
+      post 'search' => 'search#search'
+      get 'search' => 'search#search'
+      get 'search_suggestions' => 'search#suggestions'
+
+      get '/headings/:id/tree' => 'headings#tree'
+
+      get 'goods_nomenclatures/section/:position', to: 'goods_nomenclatures#show_by_section', constraints: { position: /\d+/ }
+      get 'goods_nomenclatures/chapter/:chapter_id', to: 'goods_nomenclatures#show_by_chapter', constraints: { chapter_id: /\d{2}/ }
+      get 'goods_nomenclatures/heading/:heading_id', to: 'goods_nomenclatures#show_by_heading', constraints: { heading_id: /\d{4}/ }
+      get 'goods_nomenclatures/:id', to: 'goods_nomenclatures#show', constraints: { id: /\d{4,10}/ }
+
+      namespace :green_lanes do
+        resources :goods_nomenclatures, only: %i[show], constraints: { id: /\d{4,10}/ }
+
+        resources :category_assessments, only: %i[index]
+
+        resources :themes, only: %i[index]
+      end
+    end
+  end
+end

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -183,10 +183,6 @@ module TradeTariffBackend
       }
     end
 
-    def bulk_search_api_enabled?
-      ENV.fetch('BULK_SEARCH_API_ENABLED', 'false') == 'true'
-    end
-
     def opensearch_host
       ENV.fetch('ELASTICSEARCH_URL', 'http://host.docker.internal:9200')
     end

--- a/config/initializers/rabl_config.rb
+++ b/config/initializers/rabl_config.rb
@@ -1,4 +1,9 @@
 require 'rabl'
+require 'v1_api'
+
+Rabl::Engine.class_eval do
+  include V1Api.routes.url_helpers
+end
 
 Rabl.configure do |config|
   config.include_json_root = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,194 +1,3 @@
-class V1Api < ::Rails::Engine
-end
-
-class V2Api < ::Rails::Engine
-end
-
-V1Api.routes.draw do
-  namespace :api, defaults: { format: 'json' }, path: '/' do
-    scope module: :v1 do
-      resources :sections, only: %i[index show] do
-        collection do
-          get :tree
-        end
-        scope module: 'sections', constraints: { id: /\d+/ } do
-          resource :section_note, only: %i[show]
-        end
-      end
-
-      resources :chapters, only: %i[index show], constraints: { id: /\d{2}/ } do
-        member do
-          get :changes
-        end
-
-        scope module: 'chapters', constraints: { chapter_id: /\d{2}/, id: /\d+/ } do
-          resource :chapter_note, only: %i[show]
-        end
-      end
-
-      resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
-        member do
-          get :changes
-        end
-      end
-
-      resources :commodities, only: [:show], constraints: { id: /\d{10}/, as_of: /.*/ } do
-        member do
-          get :changes
-        end
-      end
-
-      get '/headings/:id/tree' => 'headings#tree'
-    end
-  end
-end
-
-V2Api.routes.draw do
-  namespace :api, defaults: { format: 'json' }, path: '/' do
-    scope module: :v2 do
-      resources :sections, only: %i[index show] do
-        collection do
-          get :tree
-        end
-
-        member do
-          get :chapters
-        end
-      end
-
-      namespace :exchange_rates do
-        get 'period_lists(/:year)', to: 'period_lists#show', as: :period_list
-        resources :files, only: [:show]
-      end
-
-      resources :exchange_rates, only: [:show]
-
-      resources :chapters, only: %i[index show], constraints: { id: /\d{1,2}/ } do
-        member do
-          get :changes
-          get :headings
-        end
-      end
-
-      resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
-        member do
-          get :changes
-          get :commodities
-        end
-
-        resources :validity_periods, only: [:index]
-      end
-
-      resources :subheadings, only: [:show] do
-        resources :validity_periods, only: [:index]
-      end
-
-      resources :commodities, only: [:show], constraints: { id: /\d{10}/ } do
-        member do
-          get :changes
-        end
-
-        resources :validity_periods, only: [:index]
-      end
-
-      resources :geographical_areas, only: %i[index show] do
-        collection { get :countries }
-      end
-
-      resources :chemical_substances, only: %i[index]
-      resources :simplified_procedural_code_measures, only: %i[index]
-
-      resources :preference_codes, only: %i[index show]
-
-      resources :monetary_exchange_rates, only: [:index]
-
-      resources :updates, only: [] do
-        collection { get :latest }
-      end
-
-      resources :search_references, only: [:index]
-
-      resources :quotas, only: [] do
-        collection { get :search }
-      end
-
-      resources :certificates, only: [:index] do
-        collection { get :search }
-      end
-
-      resources :certificate_types, only: [:index]
-
-      resources :measure_actions, only: %i[index]
-      resources :measure_condition_codes, only: %i[index]
-      resources :quota_order_numbers, only: %i[index]
-      resources :measure_types, only: %i[index show]
-      resources :measures, only: %i[show], constraints: { id: /-?\d+/ }
-
-      resources :additional_codes, only: [] do
-        collection { get :search }
-      end
-
-      resources :additional_code_types, only: [:index]
-
-      resources :footnotes, only: [] do
-        collection { get :search }
-      end
-
-      resources :footnote_types, only: [:index]
-
-      resources :chemicals, only: %i[index show] do
-        collection { get :search }
-      end
-
-      scope module: :rules_of_origin do
-        resources :rules_of_origin_schemes,
-                  controller: 'schemes',
-                  only: %i[index]
-        get '/rules_of_origin_schemes/:heading_code/:country_code',
-            to: 'schemes#index',
-            as: :rules_of_origin
-        get '/rules_of_origin_schemes/:commodity_code',
-            to: 'product_specific_rules#index',
-            as: :product_specific_rules
-      end
-
-      if Rails.env.development? || TradeTariffBackend.uk?
-        namespace :news do
-          resources :items, only: %i[index show]
-          resources :years, only: %i[index]
-          resources :collections, only: %i[index] do
-            resources :items, only: %i[index], shallow: true
-          end
-        end
-
-        get '/news_items/:id', to: 'news/items#show', as: nil
-        get '/news_items', to: 'news/items#index', as: nil
-      end
-
-      get '/changes(/:as_of)', to: 'changes#index', as: :changes, constraints: { as_of: /\d{4}-\d{1,2}-\d{1,2}/ }
-
-      post 'search' => 'search#search'
-      get 'search' => 'search#search'
-      get 'search_suggestions' => 'search#suggestions'
-
-      get '/headings/:id/tree' => 'headings#tree'
-
-      get 'goods_nomenclatures/section/:position', to: 'goods_nomenclatures#show_by_section', constraints: { position: /\d+/ }
-      get 'goods_nomenclatures/chapter/:chapter_id', to: 'goods_nomenclatures#show_by_chapter', constraints: { chapter_id: /\d{2}/ }
-      get 'goods_nomenclatures/heading/:heading_id', to: 'goods_nomenclatures#show_by_heading', constraints: { heading_id: /\d{4}/ }
-      get 'goods_nomenclatures/:id', to: 'goods_nomenclatures#show', constraints: { id: /\d{4,10}/ }
-
-      namespace :green_lanes do
-        resources :goods_nomenclatures, only: %i[show], constraints: { id: /\d{4,10}/ }
-
-        resources :category_assessments, only: %i[index]
-
-        resources :themes, only: %i[index]
-      end
-    end
-  end
-end
-
 Rails.application.routes.draw do
   root to: 'application#nothing'
 
@@ -197,18 +6,18 @@ Rails.application.routes.draw do
   get 'healthcheckz' => 'healthcheck#checkz'
 
   # Legacy routes
-  mount V1Api => '/', as: 'v1', constraints: ApiConstraints.new(version: 1), module: ''
-  mount V2Api => '/', as: 'v2', constraints: ApiConstraints.new(version: 2), module: ''
+  mount V2Api => '/', as: 'v2', constraints: ApiConstraints.new(version: 2)
+  mount V1Api => '/', as: 'v1', constraints: ApiConstraints.new(version: 1)
 
   # V1 routes
-  mount V1Api => '/api/v1', as: 'v1_api', module: ''
-  mount V1Api => '/xi/api/v1', as: 'xi_v1_api', module: '' if TradeTariffBackend.xi?
-  mount V1Api => '/uk/api/v1', as: 'uk_v1_api', module: '' if TradeTariffBackend.uk?
+  mount V1Api => '/api/v1', as: 'v1_api'
+  mount V1Api => '/xi/api/v1', as: 'xi_v1_api' if TradeTariffBackend.xi?
+  mount V1Api => '/uk/api/v1', as: 'uk_v1_api' if TradeTariffBackend.uk?
 
   # V2 routes
-  mount V2Api => '/api/v2', as: 'v2_api', module: ''
-  mount V2Api => '/xi/api/v2', as: 'xi_v2_api', module: '' if TradeTariffBackend.xi?
-  mount V2Api => '/uk/api/v2', as: 'uk_v2_api', module: '' if TradeTariffBackend.uk?
+  mount V2Api => '/api/v2', as: 'v2_api'
+  mount V2Api => '/xi/api/v2', as: 'xi_v2_api' if TradeTariffBackend.xi?
+  mount V2Api => '/uk/api/v2', as: 'uk_v2_api' if TradeTariffBackend.uk?
 
   # Admin routes
   if TradeTariffBackend.enable_admin?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,94 +1,51 @@
-Rails.application.routes.draw do
-  get 'healthcheck' => 'healthcheck#index'
-  get 'healthcheckz' => 'healthcheck#checkz'
+class V1Api < ::Rails::Engine
+end
 
-  if TradeTariffBackend.enable_admin?
-    namespace :api, defaults: { format: 'json' }, path: '/admin' do
-      scope module: :admin do
-        resources :sections, only: %i[index show] do
-          scope module: 'sections', constraints: { id: /\d+/ } do
-            resource :section_note, only: %i[show create update destroy]
-          end
+class V2Api < ::Rails::Engine
+end
+
+V1Api.routes.draw do
+  namespace :api, defaults: { format: 'json' }, path: '/' do
+    scope module: :v1 do
+      resources :sections, only: %i[index show] do
+        collection do
+          get :tree
         end
-
-        resources :updates, only: %i[index show]
-        resources :rollbacks, only: %i[create index]
-        resources :clear_caches, only: %i[create]
-        resources :downloads, only: %i[create]
-        resources :applies, only: %i[create]
-        resources :footnotes, only: %i[index show update]
-        resources :search_references, only: [:index]
-
-        resources :chapters, only: %i[index show], constraints: { id: /\d{2}/ } do
-          scope module: 'chapters', constraints: { chapter_id: /\d{2}/, id: /\d+/ } do
-            resource :chapter_note, only: %i[show create update destroy]
-            resources :search_references, only: %i[show index destroy create update]
-          end
-        end
-
-        resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
-          scope module: 'headings', constraints: { heading_id: /\d{4}/, id: /\d+/ } do
-            resources :search_references, only: %i[show index destroy create update]
-          end
-        end
-
-        resources :commodities, only: %i[show] do
-          scope module: 'commodities' do
-            resources :search_references, only: %i[show index destroy create update]
-          end
-        end
-
-        resources :quota_order_numbers, module: 'quota_order_numbers', only: %i[] do
-          resources :quota_definitions, only: %i[index show]
+        scope module: 'sections', constraints: { id: /\d+/ } do
+          resource :section_note, only: %i[show]
         end
       end
 
-      # avoid admin named routes clashing with public api named routes
-      namespace :admin, path: '' do
-        if Rails.env.development? || TradeTariffBackend.uk?
-          namespace :news do
-            resources :items, only: %i[index show create update destroy]
-            resources :collections, only: %i[index show create update]
-          end
-
-          resources :news_items, only: %i[index show create update destroy],
-                                 controller: 'news/items'
+      resources :chapters, only: %i[index show], constraints: { id: /\d{2}/ } do
+        member do
+          get :changes
         end
 
-        namespace :green_lanes do
-          resources :category_assessments, only: %i[index show create update destroy] do
-            member do
-              post 'exemptions', to: 'category_assessments#add_exemption'
-              delete 'exemptions', to: 'category_assessments#remove_exemption'
-            end
-          end
-          resources :themes, only: %i[index]
-          resources :exempting_certificate_overrides, only: %i[index show create destroy]
-          resources :exempting_additional_code_overrides, only: %i[index show create destroy]
-          resources :exemptions, only: %i[index show create update destroy]
-          resources :measures, only: %i[index show create update destroy]
-          resources :update_notifications, only: %i[index show update]
+        scope module: 'chapters', constraints: { chapter_id: /\d{2}/, id: /\d+/ } do
+          resource :chapter_note, only: %i[show]
         end
       end
+
+      resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
+        member do
+          get :changes
+        end
+      end
+
+      resources :commodities, only: [:show], constraints: { id: /\d{10}/, as_of: /.*/ } do
+        member do
+          get :changes
+        end
+      end
+
+      get '/headings/:id/tree' => 'headings#tree'
     end
   end
+end
 
+V2Api.routes.draw do
   namespace :api, defaults: { format: 'json' }, path: '/' do
-    # TODO: The api versioning is hierarchical as far as the defined order of the routes below.
-    #
-    # If your default api scope (as defined in env['DEFAULT_API_VERSION']) comes before the scopes that are defined below it, then the default scope will always match.
-    #
-    # For example (broken/incorrect scoping arrangement):
-    #   v2 scope (default)
-    #   v1 scope (unreachable)
-    #
-    # For example (correct scoping arrangement): (correct)
-    #   v1 scope (reachable)
-    #   v2 scope (default)
-    #
-    # We should adjust this carefully since it's old behaviour
-
-    scope module: :v2, constraints: ApiConstraints.new(version: 2) do
+    scope module: :v2 do
       resources :sections, only: %i[index show] do
         collection do
           get :tree
@@ -214,10 +171,6 @@ Rails.application.routes.draw do
       get 'search' => 'search#search'
       get 'search_suggestions' => 'search#suggestions'
 
-      if TradeTariffBackend.bulk_search_api_enabled?
-        resources :bulk_searches, only: %i[create show]
-      end
-
       get '/headings/:id/tree' => 'headings#tree'
 
       get 'goods_nomenclatures/section/:position', to: 'goods_nomenclatures#show_by_section', constraints: { position: /\d+/ }
@@ -231,48 +184,105 @@ Rails.application.routes.draw do
         resources :category_assessments, only: %i[index]
 
         resources :themes, only: %i[index]
-
-        resources :faq_feedback, only: %i[create index show], controller: '/api/admin/green_lanes/faq_feedback'
       end
-    end
-
-    scope module: :v1, constraints: ApiConstraints.new(version: 1) do
-      resources :sections, only: %i[index show] do
-        collection do
-          get :tree
-        end
-        scope module: 'sections', constraints: { id: /\d+/ } do
-          resource :section_note, only: %i[show]
-        end
-      end
-
-      resources :chapters, only: %i[index show], constraints: { id: /\d{2}/ } do
-        member do
-          get :changes
-        end
-
-        scope module: 'chapters', constraints: { chapter_id: /\d{2}/, id: /\d+/ } do
-          resource :chapter_note, only: %i[show]
-        end
-      end
-
-      resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
-        member do
-          get :changes
-        end
-      end
-
-      resources :commodities, only: [:show], constraints: { id: /\d{10}/, as_of: /.*/ } do
-        member do
-          get :changes
-        end
-      end
-
-      get '/headings/:id/tree' => 'headings#tree'
     end
   end
+end
 
+Rails.application.routes.draw do
   root to: 'application#nothing'
+
+  # Application liveness
+  get 'healthcheck' => 'healthcheck#index'
+  get 'healthcheckz' => 'healthcheck#checkz'
+
+  # Legacy routes
+  mount V1Api => '/', as: 'v1', constraints: ApiConstraints.new(version: 1), module: ''
+  mount V2Api => '/', as: 'v2', constraints: ApiConstraints.new(version: 2), module: ''
+
+  # V1 routes
+  mount V1Api => '/api/v1', as: 'v1_api', module: ''
+  mount V1Api => '/xi/api/v1', as: 'xi_v1_api', module: '' if TradeTariffBackend.xi?
+  mount V1Api => '/uk/api/v1', as: 'uk_v1_api', module: '' if TradeTariffBackend.uk?
+
+  # V2 routes
+  mount V2Api => '/api/v2', as: 'v2_api', module: ''
+  mount V2Api => '/xi/api/v2', as: 'xi_v2_api', module: '' if TradeTariffBackend.xi?
+  mount V2Api => '/uk/api/v2', as: 'uk_v2_api', module: '' if TradeTariffBackend.uk?
+
+  # Admin routes
+  if TradeTariffBackend.enable_admin?
+    namespace :api, defaults: { format: 'json' }, path: '/admin' do
+      scope module: :admin do
+        resources :sections, only: %i[index show] do
+          scope module: 'sections', constraints: { id: /\d+/ } do
+            resource :section_note, only: %i[show create update destroy]
+          end
+        end
+
+        resources :updates, only: %i[index show]
+        resources :rollbacks, only: %i[create index]
+        resources :clear_caches, only: %i[create]
+        resources :downloads, only: %i[create]
+        resources :applies, only: %i[create]
+        resources :footnotes, only: %i[index show update]
+        resources :search_references, only: [:index]
+
+        resources :chapters, only: %i[index show], constraints: { id: /\d{2}/ } do
+          scope module: 'chapters', constraints: { chapter_id: /\d{2}/, id: /\d+/ } do
+            resource :chapter_note, only: %i[show create update destroy]
+            resources :search_references, only: %i[show index destroy create update]
+          end
+        end
+
+        resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
+          scope module: 'headings', constraints: { heading_id: /\d{4}/, id: /\d+/ } do
+            resources :search_references, only: %i[show index destroy create update]
+          end
+        end
+
+        resources :commodities, as: :admin_commodity, only: %i[show] do
+          scope module: 'commodities' do
+            resources :search_references, only: %i[show index destroy create update]
+          end
+        end
+
+        resources :quota_order_numbers, module: 'quota_order_numbers', only: %i[] do
+          resources :quota_definitions, only: %i[index show]
+        end
+      end
+
+      # avoid admin named routes clashing with public api named routes
+      namespace :admin, path: '' do
+        if Rails.env.development? || TradeTariffBackend.uk?
+          namespace :news do
+            resources :items, only: %i[index show create update destroy]
+            resources :collections, only: %i[index show create update]
+          end
+
+          resources :news_items, only: %i[index show create update destroy],
+                                 controller: 'news/items'
+        end
+
+        namespace :green_lanes do
+          resources :category_assessments, only: %i[index show create update destroy] do
+            member do
+              post 'exemptions', to: 'category_assessments#add_exemption'
+              delete 'exemptions', to: 'category_assessments#remove_exemption'
+            end
+          end
+
+          resources :themes, only: %i[index]
+          resources :exempting_certificate_overrides, only: %i[index show create destroy]
+          resources :exempting_additional_code_overrides, only: %i[index show create destroy]
+          resources :exemptions, only: %i[index show create update destroy]
+          resources :measures, only: %i[index show create update destroy]
+          resources :update_notifications, only: %i[index show update]
+          resources :faq_feedback, only: %i[create index show]
+        end
+      end
+    end
+  end
 
   match '/400', to: 'errors#bad_request', via: :all
   match '/404', to: 'errors#not_found', via: :all

--- a/spec/controllers/api/admin/commodities/search_references_controller_spec.rb
+++ b/spec/controllers/api/admin/commodities/search_references_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::Admin::Commodities::SearchReferencesController do
     let(:search_reference_parent)  { create :commodity, :declarable, :with_heading }
     let(:search_reference)         { create :search_reference, referenced: search_reference_parent }
     let(:collection_query)         do
-      { commodity_id: search_reference_parent.goods_nomenclature_item_id }
+      { admin_commodity_id: search_reference_parent.goods_nomenclature_item_id }
     end
     let(:resource_query) do
       collection_query.merge(id: search_reference.id)
@@ -28,7 +28,7 @@ RSpec.describe Api::Admin::Commodities::SearchReferencesController do
       let(:params) do
         {
           data: { type: :search_reference, attributes: { title: 'foo' } },
-          commodity_id: "#{referenced.goods_nomenclature_item_id}-#{referenced.producline_suffix}",
+          admin_commodity_id: "#{referenced.goods_nomenclature_item_id}-#{referenced.producline_suffix}",
         }
       end
 
@@ -51,7 +51,7 @@ RSpec.describe Api::Admin::Commodities::SearchReferencesController do
       let(:params) do
         {
           data: { type: :search_reference, attributes: { title: 'foo' } },
-          commodity_id: "#{referenced.goods_nomenclature_item_id}-75",
+          admin_commodity_id: "#{referenced.goods_nomenclature_item_id}-75",
         }
       end
 
@@ -63,7 +63,7 @@ RSpec.describe Api::Admin::Commodities::SearchReferencesController do
       let(:params) do
         {
           data: { type: :search_reference, attributes: { title: 'foo' } },
-          commodity_id: referenced.goods_nomenclature_item_id, # This is missing the productline suffix
+          admin_commodity_id: referenced.goods_nomenclature_item_id, # This is missing the productline suffix
         }
       end
 
@@ -88,7 +88,7 @@ RSpec.describe Api::Admin::Commodities::SearchReferencesController do
       let(:params) do
         {
           data: { type: :search_reference, attributes: { title: 'foo' } },
-          commodity_id: "#{referenced.goods_nomenclature_item_id}-#{referenced.producline_suffix}",
+          admin_commodity_id: "#{referenced.goods_nomenclature_item_id}-#{referenced.producline_suffix}",
         }
       end
 

--- a/spec/controllers/api/v1/chapters/chapter_notes_controller_spec.rb
+++ b/spec/controllers/api/v1/chapters/chapter_notes_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V1::Chapters::ChapterNotesController do
+  routes { V1Api.routes }
+
   let(:pattern) do
     {
       id: Integer,

--- a/spec/controllers/api/v1/chapters_controller_spec.rb
+++ b/spec/controllers/api/v1/chapters_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V1::ChaptersController do
+  routes { V1Api.routes }
+
   let(:now) { Time.zone.today }
   let(:expires_at) { now.end_of_day }
 

--- a/spec/controllers/api/v1/commodities_controller_spec.rb
+++ b/spec/controllers/api/v1/commodities_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V1::CommoditiesController do
+  routes { V1Api.routes }
+
   describe 'GET #show' do
     render_views
 

--- a/spec/controllers/api/v1/headings_controller_spec.rb
+++ b/spec/controllers/api/v1/headings_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V1::HeadingsController, :flaky do
+  routes { V1Api.routes }
+
   render_views
 
   describe 'GET #show' do

--- a/spec/controllers/api/v1/sections/section_notes_controller_spec.rb
+++ b/spec/controllers/api/v1/sections/section_notes_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V1::Sections::SectionNotesController do
+  routes { V1Api.routes }
+
   let(:pattern) do
     {
       id: Integer,

--- a/spec/controllers/api/v1/sections_controller_spec.rb
+++ b/spec/controllers/api/v1/sections_controller_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe Api::V1::SectionsController do
+  routes { V1Api.routes }
   render_views
 
   describe 'GET #show' do

--- a/spec/controllers/api/v2/additional_code_types_controller_spec.rb
+++ b/spec/controllers/api/v2/additional_code_types_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::AdditionalCodeTypesController, type: :controller do
+  routes { V2Api.routes }
+
   describe '#index' do
     let(:pattern) do
       {

--- a/spec/controllers/api/v2/additional_codes_controller_spec.rb
+++ b/spec/controllers/api/v2/additional_codes_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::AdditionalCodesController, type: :controller do
+  routes { V2Api.routes }
+
   describe 'GET #search' do
     subject(:response) { get :search, params:, format: :json }
 

--- a/spec/controllers/api/v2/certificate_types_controller_spec.rb
+++ b/spec/controllers/api/v2/certificate_types_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::CertificateTypesController, type: :controller do
+  routes { V2Api.routes }
+
   describe 'GET #index' do
     subject(:do_response) do
       get :index, format: :json

--- a/spec/controllers/api/v2/certificates_controller_index_spec.rb
+++ b/spec/controllers/api/v2/certificates_controller_index_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::CertificatesController, type: :controller do
+  routes { V2Api.routes }
+
   describe 'GET #index' do
     subject(:do_response) do
       get :index, format: :json

--- a/spec/controllers/api/v2/certificates_controller_search_spec.rb
+++ b/spec/controllers/api/v2/certificates_controller_search_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::CertificatesController, type: :controller do
+  routes { V2Api.routes }
+
   describe 'GET #search' do
     subject(:do_response) { get :search, params:, format: :json && response }
 

--- a/spec/controllers/api/v2/changes_controller_spec.rb
+++ b/spec/controllers/api/v2/changes_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::ChangesController do
+  routes { V2Api.routes }
+
   let(:no_changes_response) { { 'data' => [] } }
   let(:goods_nomenclature_item_id) { nil }
   let(:goods_nomenclature_sid) { nil }

--- a/spec/controllers/api/v2/chapters_controller_spec.rb
+++ b/spec/controllers/api/v2/chapters_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::ChaptersController do
+  routes { V2Api.routes }
+
   describe 'GET #show' do
     let(:heading) { create :heading, :with_chapter }
     let(:chapter) { heading.reload.chapter }

--- a/spec/controllers/api/v2/chemicals_controller_spec.rb
+++ b/spec/controllers/api/v2/chemicals_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::ChemicalsController, type: :controller do
+  routes { V2Api.routes }
+
   let(:chemical1) { create :chemical, :with_name }
   let(:goods_nomenclature) { create :goods_nomenclature }
   let(:chemical_gn_association) { create :chemicals_goods_nomenclatures, chemical_id: chemical1.id, goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid }

--- a/spec/controllers/api/v2/commodities_controller_spec.rb
+++ b/spec/controllers/api/v2/commodities_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::CommoditiesController do
+  routes { V2Api.routes }
+
   let(:commodity) do
     create(
       :commodity,

--- a/spec/controllers/api/v2/footnote_types_controller_spec.rb
+++ b/spec/controllers/api/v2/footnote_types_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::FootnoteTypesController, type: :controller do
+  routes { V2Api.routes }
+
   describe '#index' do
     let(:footnote_type_1) { create :footnote_type }
     let(:pattern) do

--- a/spec/controllers/api/v2/footnotes_controller_spec.rb
+++ b/spec/controllers/api/v2/footnotes_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::FootnotesController, type: :controller do
+  routes { V2Api.routes }
+
   subject(:do_response) { get :search, params:, format: :json && response }
 
   let(:footnote) { create(:footnote, :with_description) }

--- a/spec/controllers/api/v2/geographical_areas_controller_spec.rb
+++ b/spec/controllers/api/v2/geographical_areas_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::GeographicalAreasController do
+  routes { V2Api.routes }
+
   before do
     Rails.cache.clear
     allow(Rails.cache).to receive(:fetch).and_call_original

--- a/spec/controllers/api/v2/goods_nomenclatures_controller_spec.rb
+++ b/spec/controllers/api/v2/goods_nomenclatures_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::GoodsNomenclaturesController do
+  routes { V2Api.routes }
+
   subject { response }
 
   before { commodity }

--- a/spec/controllers/api/v2/headings_controller_spec.rb
+++ b/spec/controllers/api/v2/headings_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::HeadingsController, type: :controller do
+  routes { V2Api.routes }
+
   describe '#show' do
     subject(:do_response) { get :show, params: { id:, filter: } }
 

--- a/spec/controllers/api/v2/measure_actions_controller_spec.rb
+++ b/spec/controllers/api/v2/measure_actions_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::MeasureActionsController, type: :controller do
+  routes { V2Api.routes }
+
   describe '#index' do
     subject(:do_request) { get :index }
 

--- a/spec/controllers/api/v2/measure_condition_codes_controller_spec.rb
+++ b/spec/controllers/api/v2/measure_condition_codes_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::MeasureConditionCodesController, type: :controller do
+  routes { V2Api.routes }
+
   describe '#index' do
     subject(:do_request) { get :index }
 

--- a/spec/controllers/api/v2/measure_types_controller_spec.rb
+++ b/spec/controllers/api/v2/measure_types_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::MeasureTypesController, type: :controller do
+  routes { V2Api.routes }
+
   describe '#index' do
     subject(:do_request) { get :index }
 
@@ -56,7 +58,7 @@ RSpec.describe Api::V2::MeasureTypesController, type: :controller do
       let(:pattern) do
         {
           error: 'not found',
-          url: 'http://test.host/measure_types/foo',
+          url: 'http://test.host/uk/api/v2/measure_types/foo',
         }
       end
 

--- a/spec/controllers/api/v2/monetary_exchange_rates_controller_spec.rb
+++ b/spec/controllers/api/v2/monetary_exchange_rates_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::MonetaryExchangeRatesController do
+  routes { V2Api.routes }
+
   describe 'GET #index' do
     before do
       create(:monetary_unit, monetary_unit_code: 'GBP', validity_start_date: 10.years.ago.beginning_of_day)

--- a/spec/controllers/api/v2/quota_order_numbers_controller_spec.rb
+++ b/spec/controllers/api/v2/quota_order_numbers_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::QuotaOrderNumbersController, type: :controller do
+  routes { V2Api.routes }
+
   describe '#index' do
     subject(:do_request) { get :index }
 

--- a/spec/controllers/api/v2/quotas_controller_spec.rb
+++ b/spec/controllers/api/v2/quotas_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::QuotasController, type: :controller do
+  routes { V2Api.routes }
+
   describe 'GET /quotas/search.json' do
     let(:validity_start_date) { Date.new(Time.zone.today.year, 1, 1) }
     let(:quota_order_number) { create :quota_order_number }

--- a/spec/controllers/api/v2/search_controller_search_spec.rb
+++ b/spec/controllers/api/v2/search_controller_search_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::SearchController do
+  routes { V2Api.routes }
+
   describe 'GET /search' do
     subject(:response) { get :search, params: { q: chapter.to_param, as_of: chapter.validity_start_date } }
 

--- a/spec/controllers/api/v2/search_references_controller_spec.rb
+++ b/spec/controllers/api/v2/search_references_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::SearchReferencesController do
+  routes { V2Api.routes }
+
   before do
     TradeTariffRequest.time_machine_now = Time.current
 

--- a/spec/controllers/api/v2/sections_controller_spec.rb
+++ b/spec/controllers/api/v2/sections_controller_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe Api::V2::SectionsController do
+  routes { V2Api.routes }
   # GET /api/v2/sections/:id
 
   describe '#show' do

--- a/spec/controllers/api/v2/updates_controller_spec.rb
+++ b/spec/controllers/api/v2/updates_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V2::UpdatesController do
+  routes { V2Api.routes }
+
   describe 'GET #latest' do
     let(:pattern) do
       {

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -78,6 +78,8 @@ RSpec.configure do |config|
   end
 
   config.after { travel_back }
+
+  config.include V2Api.routes.url_helpers, type: :request
 end
 
 def silence

--- a/spec/requests/api/admin/commodities_controller_spec.rb
+++ b/spec/requests/api/admin/commodities_controller_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Api::Admin::CommoditiesController, type: :request do
   describe 'GET #show' do
     subject(:do_request) do
-      authenticated_get api_commodity_path(id: goods_nomenclature.to_admin_param)
+      authenticated_get api_admin_commodity_path(id: goods_nomenclature.to_admin_param)
       response
     end
 

--- a/spec/requests/api/admin/green_lanes/faq_feedback_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/faq_feedback_controller_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Api::Admin::GreenLanes::FaqFeedbackController do
 
   describe 'POST to #create' do
     let(:make_request) do
-      authenticated_post api_green_lanes_faq_feedback_index_path(format: :json), params: faq_feedback_data
+      path = api_admin_green_lanes_faq_feedback_index_path(format: :json)
+      authenticated_post path, params: faq_feedback_data
     end
     let :faq_feedback_data do
       {
@@ -21,7 +22,7 @@ RSpec.describe Api::Admin::GreenLanes::FaqFeedbackController do
       let(:ex_attrs) { build(:green_lanes_faq_feedback).to_hash }
 
       it { is_expected.to have_http_status :created }
-      it { is_expected.to have_attributes location: api_green_lanes_faq_feedback_url(GreenLanes::FaqFeedback.last.id) }
+      it { is_expected.to have_attributes location: api_admin_green_lanes_faq_feedback_url(GreenLanes::FaqFeedback.last.id) }
     end
 
     context 'with invalid params' do

--- a/spec/requests/api/v2/exchange_rates/period_lists_controller_spec.rb
+++ b/spec/requests/api/v2/exchange_rates/period_lists_controller_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Api::V2::ExchangeRates::PeriodListsController, type: :request do
       let(:pattern) do
         {
           error: 'not found',
-          url: 'http://www.example.com/exchange_rates/period_lists/2023idadas?filter%5Btype%5D=monthly',
+          url: 'http://www.example.com/uk/api/v2/exchange_rates/period_lists/2023idadas?filter%5Btype%5D=monthly',
         }
       end
 
@@ -149,7 +149,7 @@ RSpec.describe Api::V2::ExchangeRates::PeriodListsController, type: :request do
       let(:pattern) do
         {
           error: 'invalid',
-          url: 'http://www.example.com/exchange_rates/period_lists/2023?filter%5Btype%5D=invalid',
+          url: 'http://www.example.com/uk/api/v2/exchange_rates/period_lists/2023?filter%5Btype%5D=invalid',
         }
       end
 

--- a/spec/requests/api/v2/exchange_rates_controller_spec.rb
+++ b/spec/requests/api/v2/exchange_rates_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Api::V2::ExchangeRatesController, type: :request do
       let(:pattern) do
         {
           error: 'not found',
-          url: 'http://www.example.com/exchange_rates/2023idadas-6?filter%5Btype%5D=monthly',
+          url: 'http://www.example.com/uk/api/v2/exchange_rates/2023idadas-6?filter%5Btype%5D=monthly',
         }
       end
 
@@ -84,7 +84,7 @@ RSpec.describe Api::V2::ExchangeRatesController, type: :request do
       let(:pattern) do
         {
           'error' => 'invalid',
-          'url' => 'http://www.example.com/exchange_rates/2023-6?filter%5Btype%5D=invalid',
+          'url' => 'http://www.example.com/uk/api/v2/exchange_rates/2023-6?filter%5Btype%5D=invalid',
         }
       end
 


### PR DESCRIPTION
### Jira link

HMRC-657


```mermaid
 flowchart TD
  style AFTER fill:#9f9,stroke:#333,stroke-width:2px

  %% After Flow
  subgraph AFTER [After]
    E[User Request] --> F[CDN/WAF]
    F --> G[Application Load Balancer]
    G --> H[Target Group XI]
    G --> I[Target Group UK]
  end

  %% Spacer between flows
  style BEFORE fill:#f9f,stroke:#333,stroke-width:2px
  %% Before Flow
  subgraph BEFORE [Before]
    A[User Request] --> B[CDN/WAF]
    B --> C[Application Load Balancer]
    C --> D[Frontend Request Forwarder]
    D --> X[Backend XI]
    D --> Y[Backend UK]
  end
```

### What?

I have added/removed/altered:

- [x] Added v1/v2 engines
- [x] Include v1/v2 engines under different paths to match frontend api request semantics
- [x] Consume engines as routes value in controller tests
- [x] Consume engine in rabl template rendered for v1
- [x] Fixes an issue with a misplaced faq controller route
- [x] Fixes an issue with some namespacing around admin commodities which were colliding with v2 commodity endpoints

### Why?

I am doing this because:

- This enables direct routing through the load balancer
- I picked engines since concerns wouldn't work for me and engines give us clear lines to load each of our main scopes (v1/v2) multiple times
