### PR TITLE
HMRC-439: Include CAS Codes in the Standard Search Index

### DIFF
--- a/app/elastic_search_indexes/search/goods_nomenclature_index.rb
+++ b/app/elastic_search_indexes/search/goods_nomenclature_index.rb
@@ -20,9 +20,16 @@ module Search
             producline_suffix: { type: 'keyword' },
             type: { type: 'keyword' },
             search_references: {
-              "properties": {
+              properties: {
                 title: { type: 'text', analyzer: 'ngram_analyzer', search_analyzer: 'lowercase_analyzer' },
                 reference_class: { type: 'keyword' },
+              },
+            },
+            chemicals: {
+              properties: {
+                cus: { type: 'text', analyzer: 'ngram_analyzer', search_analyzer: 'lowercase_analyzer' },
+                cas_rn: { type: 'text', analyzer: 'ngram_analyzer', search_analyzer: 'lowercase_analyzer' },
+                name: { type: 'text', analyzer: 'ngram_analyzer', search_analyzer: 'lowercase_analyzer' },
               },
             },
           },

--- a/app/lib/sequel/plugins/elasticsearch.rb
+++ b/app/lib/sequel/plugins/elasticsearch.rb
@@ -64,7 +64,7 @@ module Sequel
             TradeTariffBackend.search_client.index_by_name(index_name, id, Search::GoodsNomenclatureSerializer.new(self).as_json)
           elsif instance_of?(SearchReference)
             TradeTariffBackend.search_client.index_by_name(index_name, referenced.id, Search::GoodsNomenclatureSerializer.new(referenced.reload).as_json)
-          elsif instance_of?(FullChemical)
+          elsif instance_of?(FullChemical) && goods_nomenclature.present?
             TradeTariffBackend.search_client.index_by_name(index_name, goods_nomenclature.id, Search::GoodsNomenclatureSerializer.new(goods_nomenclature.reload).as_json)
           end
         end
@@ -76,7 +76,7 @@ module Sequel
             TradeTariffBackend.search_client.delete_by_name(index_name, id)
           elsif instance_of?(SearchReference)
             TradeTariffBackend.search_client.index_by_name(index_name, referenced.id, Search::GoodsNomenclatureSerializer.new(referenced.reload).as_json)
-          elsif instance_of?(FullChemical)
+          elsif instance_of?(FullChemical) && goods_nomenclature.present?
             TradeTariffBackend.search_client.index_by_name(index_name, goods_nomenclature.id, Search::GoodsNomenclatureSerializer.new(goods_nomenclature.reload).as_json)
           end
         end

--- a/app/models/full_chemical.rb
+++ b/app/models/full_chemical.rb
@@ -2,8 +2,9 @@ class FullChemical < Sequel::Model
   plugin :identification
   plugin :timestamps
   plugin :auto_validations, not_null: :presence
+  plugin :elasticsearch, index: ''
 
-  many_to_one :goods_nomenclature, key: :goods_nomenclature_sid,
+    many_to_one :goods_nomenclature, key: :goods_nomenclature_sid,
                                    foreign_key: :goods_nomenclature_sid do |ds|
                                      ds.with_actual(GoodsNomenclature)
                                    end

--- a/app/models/full_chemical.rb
+++ b/app/models/full_chemical.rb
@@ -4,10 +4,10 @@ class FullChemical < Sequel::Model
   plugin :auto_validations, not_null: :presence
   plugin :elasticsearch, index: ''
 
-    many_to_one :goods_nomenclature, key: :goods_nomenclature_sid,
+  many_to_one :goods_nomenclature, key: :goods_nomenclature_sid,
                                    foreign_key: :goods_nomenclature_sid do |ds|
-                                     ds.with_actual(GoodsNomenclature)
-                                   end
+    ds.with_actual(GoodsNomenclature)
+  end
 
   def validate
     super

--- a/app/serializers/search/goods_nomenclature_serializer.rb
+++ b/app/serializers/search/goods_nomenclature_serializer.rb
@@ -14,6 +14,7 @@ module Search
       }
 
       commodity_attributes[:search_references] = search_references_part if search_references.present?
+      commodity_attributes[:chemicals] = chemicals_part if full_chemicals.present?
       commodity_attributes
     end
 
@@ -34,6 +35,18 @@ module Search
         {
           title: search_reference.title,
           reference_class: search_reference.referenced_class,
+        }
+      end
+    end
+
+    def chemicals_part
+      return if full_chemicals.empty?
+
+      full_chemicals.map do |chemical|
+        {
+          cus: chemical.cus,
+          cas_rn: chemical.cas_rn,
+          name: chemical.name,
         }
       end
     end

--- a/app/services/elastic_search/query/search_suggestion_query.rb
+++ b/app/services/elastic_search/query/search_suggestion_query.rb
@@ -35,7 +35,7 @@ module ElasticSearch
                   {
                     multi_match: {
                       query: query_string,
-                      fields: %w[goods_nomenclature_item_id description search_references.title],
+                      fields: %w[goods_nomenclature_item_id description search_references.title chemicals.cus chemicals.cas_rn chemicals.name],
                       type: 'best_fields',
                       fuzziness: 'AUTO',
                       operator: 'and',

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 13.10 (Debian 13.10-1.pgdg110+1)
--- Dumped by pg_dump version 16.3
+-- Dumped from database version 13.14 (Debian 13.14-1.pgdg120+2)
+-- Dumped by pg_dump version 16.2
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/spec/services/elastic_search/elastic_search_service_spec.rb
+++ b/spec/services/elastic_search/elastic_search_service_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe ElasticSearch::ElasticSearchService do
             attributes: {
               value: 'Live bovine animals',
               goods_nomenclature_class: 'Heading',
-              suggestion_type: 'Goods Nomenclature Description',
+              suggestion_type: 'Description',
               query: 'bovine',
             }.ignore_extra_keys!,
           }.ignore_extra_keys!
@@ -143,7 +143,7 @@ RSpec.describe ElasticSearch::ElasticSearchService do
           attributes: {
             value: 'Live bovine animals',
             goods_nomenclature_class: 'Heading',
-            suggestion_type: 'Goods Nomenclature Description',
+            suggestion_type: 'Description',
             query: '! bovinn',
           }.ignore_extra_keys!,
         }.ignore_extra_keys!
@@ -172,7 +172,7 @@ RSpec.describe ElasticSearch::ElasticSearchService do
           attributes: {
             value: 'tea',
             goods_nomenclature_class: 'Commodity',
-            suggestion_type: 'Goods Nomenclature Search References',
+            suggestion_type: 'Search Reference',
             query: 'tea',
           }.ignore_extra_keys!,
         }.ignore_extra_keys!
@@ -180,6 +180,71 @@ RSpec.describe ElasticSearch::ElasticSearchService do
 
       context 'with search date falls within validity period' do
         let(:date) { '2005-01-01' }
+
+        it { is_expected.to match_json_expression heading_pattern }
+      end
+    end
+  end
+
+  context 'when chemical search' do
+    describe 'with search date falls within validity period' do
+      before do
+        chem = create :full_chemical
+        chem.save
+      end
+
+      let(:date) { '2005-01-01' }
+
+      context 'when search by chemical name' do
+        subject { described_class.new(q: 'powder', as_of: nil).to_suggestions[:data][0] }
+
+        let(:heading_pattern) do
+          {
+            type: :search_suggestion,
+            attributes: {
+              value: 'mel powder',
+              goods_nomenclature_class: 'Heading',
+              suggestion_type: 'Chemical Name',
+              query: 'powder',
+            }.ignore_extra_keys!,
+          }.ignore_extra_keys!
+        end
+
+        it { is_expected.to match_json_expression heading_pattern }
+      end
+
+      context 'when search by cus number' do
+        subject { described_class.new(q: '0154438', as_of: nil).to_suggestions[:data][0] }
+
+        let(:heading_pattern) do
+          {
+            type: :search_suggestion,
+            attributes: {
+              value: '0154438-3',
+              goods_nomenclature_class: 'Heading',
+              suggestion_type: 'CUS',
+              query: '0154438',
+            }.ignore_extra_keys!,
+          }.ignore_extra_keys!
+        end
+
+        it { is_expected.to match_json_expression heading_pattern }
+      end
+
+      context 'when search by cas_rn number' do
+        subject { described_class.new(q: '8028', as_of: nil).to_suggestions[:data][0] }
+
+        let(:heading_pattern) do
+          {
+            type: :search_suggestion,
+            attributes: {
+              value: '8028-66-8',
+              goods_nomenclature_class: 'Heading',
+              suggestion_type: 'CAS_RN',
+              query: '8028',
+            }.ignore_extra_keys!,
+          }.ignore_extra_keys!
+        end
 
         it { is_expected.to match_json_expression heading_pattern }
       end


### PR DESCRIPTION
### Jira link

[HMRC-439](https://transformuk.atlassian.net/browse/HMRC-439)

### What?

I have added/removed/altered:

- [ ] Added chemical info to goods_nomenclature index
