### PR TITLE
HMRC-657: Register backend_uk and backend_xi

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -45,6 +45,8 @@ Terraform to deploy the service into AWS.
 | [aws_kms_key.opensearch_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_kms_key.s3_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_kms_key.secretsmanager_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
+| [aws_lb_target_group.backend_uk](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
+| [aws_lb_target_group.backend_xi](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
 | [aws_s3_bucket.persistence](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 | [aws_s3_bucket.reporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 | [aws_secretsmanager_secret.aurora_ro_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |

--- a/terraform/backend_uk.tf
+++ b/terraform/backend_uk.tf
@@ -1,13 +1,15 @@
 module "backend_uk" {
   source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.12.0"
 
+  region = var.region
+
   service_name  = "backend-uk"
   service_count = var.service_count
-  region        = var.region
 
   cluster_name              = "trade-tariff-cluster-${var.environment}"
   subnet_ids                = data.aws_subnets.private.ids
   security_groups           = [data.aws_security_group.this.id]
+  target_group_arn          = data.aws_lb_target_group.backend_uk.arn
   cloudwatch_log_group_name = "platform-logs-${var.environment}"
 
   min_capacity = var.min_capacity

--- a/terraform/backend_xi.tf
+++ b/terraform/backend_xi.tf
@@ -1,13 +1,15 @@
 module "backend_xi" {
   source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.12.0"
 
+  region = var.region
+
   service_name  = "backend-xi"
   service_count = var.service_count
-  region        = var.region
 
   cluster_name              = "trade-tariff-cluster-${var.environment}"
   subnet_ids                = data.aws_subnets.private.ids
   security_groups           = [data.aws_security_group.this.id]
+  target_group_arn          = data.aws_lb_target_group.backend_xi.arn
   cloudwatch_log_group_name = "platform-logs-${var.environment}"
 
   min_capacity = var.min_capacity

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -146,3 +146,11 @@ data "aws_s3_bucket" "persistence" {
 data "aws_s3_bucket" "reporting" {
   bucket = "trade-tariff-reporting-${local.account_id}"
 }
+
+data "aws_lb_target_group" "backend_uk" {
+  name = "backend-uk"
+}
+
+data "aws_lb_target_group" "backend_xi" {
+  name = "backend-xi"
+}


### PR DESCRIPTION
### Jira link

HMRC-657

### What?

I have added/removed/altered:

- [x] Added target group for backend_uk apps
- [x] Added target group for backend_xi apps

### Why?

I am doing this because:

- These need to be deployed behind an ALB target group to route traffic
properly
