### PR TITLE
HMRC-633 Add VAT column to /headings and /subheadings pages on XI

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -421,12 +421,19 @@ class Measure < Sequel::Model
           },
         ]
 
-        if TradeTariffBackend.uk?
-          overview_types << {
-            measures__measure_type_id: MeasureType::VAT_TYPES,
-            measures__geographical_area_id: GeographicalArea::AREAS_SUBJECT_TO_VAT_OR_EXCISE_ID,
-          }
-        end
+        overview_types << if TradeTariffBackend.uk?
+                            {
+                              measures__measure_type_id: MeasureType::VAT_TYPES,
+                              measures__geographical_area_id: GeographicalArea::AREAS_SUBJECT_TO_VAT_OR_EXCISE_ID,
+                            }
+                          else
+
+                            {
+                              measures__measure_type_id: MeasureType::VAT_TYPES,
+                              measures__geographical_area_id: GeographicalArea::ERGA_OMNES_ID,
+                            }
+
+                          end
 
         Sequel.|(*overview_types)
       end

--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -6,7 +6,7 @@ class MeasureType < Sequel::Model
   IMPORT_MOVEMENT_CODES = [0, 2].freeze
   EXPORT_MOVEMENT_CODES = [1, 2].freeze
   THIRD_COUNTRY = %w[103 105].freeze # 105 measure types are for end use Third Country duties. 103 are for everything else
-  VAT_TYPES = %w[305].freeze
+  VAT_TYPES = %w[305 VTS].freeze
   SUPPLEMENTARY_TYPES = %w[109 110 111].freeze
   QUOTA_TYPES = %w[046 122 123 143 146 147 653 654].freeze
   NATIONAL_PR_TYPES = %w[AHC AIL ATT CEX CHM COE COI CVD DPO ECM EHC EQC EWP HOP HSE IWP PHC PRE PRT QRC SFS].freeze

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Measure do
       it_behaves_like 'excludes measure type', 'VAT_TYPES', 'FR'
     end
 
-    context 'for UK service with Geographical Area Subject to VAT or Excise' do
+    context 'for UK service with VAT Measure_Type and Geographical Area Subject to VAT or Excise' do
       let(:service) { 'uk' }
       let(:geographical_area_id) { GeographicalArea::AREAS_SUBJECT_TO_VAT_OR_EXCISE_ID }
 
@@ -126,13 +126,20 @@ RSpec.describe Measure do
 
     context 'for XI service' do
       let(:service) { 'xi' }
+      let(:geographical_area_id) { GeographicalArea::ERGA_OMNES_ID }
 
       it_behaves_like 'excludes measure type', 'TARIFF_PREFERENCE'
       it_behaves_like 'includes measure type', 'SUPPLEMENTARY_TYPES'
       it_behaves_like 'includes measure type', 'THIRD_COUNTRY'
       it_behaves_like 'excludes measure type', 'THIRD_COUNTRY', 'FR'
-      it_behaves_like 'excludes measure type', 'VAT_TYPES'
       it_behaves_like 'excludes measure type', 'VAT_TYPES', 'FR'
+    end
+
+    context 'for XI service with VAT Measure_Type and Geographical Area ERGA_OMNES' do
+      let(:service) { 'xi' }
+      let(:geographical_area_id) { GeographicalArea::ERGA_OMNES_ID }
+
+      it_behaves_like 'includes measure type', 'VAT_TYPES'
     end
   end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HMRC-633

### What?

I have added/removed/altered:

- [x] Added VTS as a VAT measure type to include XI VAT in Geographical Area 1011(Erga_Omnes) for Measure Overview

### Why?

I am doing this because:

- Client has asked for VAT in XI to be shown in commodity tree