### PR TITLE
HMRC-715: Migrate feedback to V2 Namespace

### DIFF
--- a/app/controllers/api/v2/green_lanes/faq_feedback_controller.rb
+++ b/app/controllers/api/v2/green_lanes/faq_feedback_controller.rb
@@ -1,16 +1,17 @@
 module Api
-  module Admin
+  module V2
     module GreenLanes
-      class FaqFeedbackController < AdminController
-        before_action :authenticate_user!
+      class FaqFeedbackController < BaseController
+        include V2Api.routes.url_helpers
+
+        skip_before_action :check_service
 
         def create
           faq_feedback = ::GreenLanes::FaqFeedback.new(faq_feedback_params)
-          Rails.logger.info("FAQ feedback valid?: #{faq_feedback.valid?}")
+
           if faq_feedback.valid? && faq_feedback.save
-            Rails.logger.info("FAQ feedback created: #{faq_feedback.id}")
             render json: serialize(faq_feedback),
-                   location: api_admin_green_lanes_faq_feedback_url(faq_feedback.id),
+                   location: api_green_lanes_faq_feedback_url(faq_feedback.id),
                    status: :created
           else
             render json: serialize_errors(faq_feedback),
@@ -35,11 +36,11 @@ module Api
         end
 
         def serialize(*args)
-          Api::Admin::GreenLanes::FaqFeedbackSerializer.new(*args).serializable_hash
+          Api::V2::GreenLanes::FaqFeedbackSerializer.new(*args).serializable_hash
         end
 
-        def serialize_errors(exemption)
-          Api::Admin::ErrorSerializationService.new(exemption).call
+        def serialize_errors(faq_feedback)
+          Api::V2::ErrorSerializationService.new.serialized_errors(faq_feedback.errors)
         end
       end
     end

--- a/app/engines/v2_api.rb
+++ b/app/engines/v2_api.rb
@@ -144,6 +144,8 @@ V2Api.routes.draw do
         resources :category_assessments, only: %i[index]
 
         resources :themes, only: %i[index]
+
+        resources :faq_feedback, only: %i[create index show]
       end
     end
   end

--- a/app/serializers/api/v2/green_lanes/faq_feedback_serializer.rb
+++ b/app/serializers/api/v2/green_lanes/faq_feedback_serializer.rb
@@ -1,5 +1,5 @@
 module Api
-  module Admin
+  module V2
     module GreenLanes
       class FaqFeedbackSerializer
         include JSONAPI::Serializer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,7 +86,6 @@ Rails.application.routes.draw do
           resources :exemptions, only: %i[index show create update destroy]
           resources :measures, only: %i[index show create update destroy]
           resources :update_notifications, only: %i[index show update]
-          resources :faq_feedback, only: %i[create index show]
         end
       end
     end

--- a/spec/requests/api/v2/green_lanes/faq_feedback_controller_spec.rb
+++ b/spec/requests/api/v2/green_lanes/faq_feedback_controller_spec.rb
@@ -1,28 +1,33 @@
-RSpec.describe Api::Admin::GreenLanes::FaqFeedbackController do
+RSpec.describe Api::V2::GreenLanes::FaqFeedbackController do
   subject(:page_response) { make_request && response }
 
   let(:json_response) { JSON.parse(page_response.body) }
   let(:faq_feedback) { create :green_lanes_faq_feedback }
+  let :authorization do
+    ActionController::HttpAuthentication::Token.encode_credentials('Trade-Tariff-Test')
+  end
+
+  before do
+    allow(TradeTariffBackend).to receive(:green_lanes_api_tokens).and_return 'Trade-Tariff-Test'
+  end
 
   describe 'POST to #create' do
     let(:make_request) do
-      path = api_admin_green_lanes_faq_feedback_index_path(format: :json)
-      authenticated_post path, params: faq_feedback_data
-    end
-    let :faq_feedback_data do
-      {
-        data: {
-          type: :green_lanes_faq_feedback,
-          attributes: ex_attrs,
-        },
+      post api_green_lanes_faq_feedback_index_path(format: :json), params: faq_feedback_data, headers: {
+        'Accept' => 'application/vnd.uktt.v2',
+        'HTTP_AUTHORIZATION' => authorization,
       }
+    end
+
+    let :faq_feedback_data do
+      { data: { type: :green_lanes_faq_feedback, attributes: ex_attrs } }
     end
 
     context 'with valid params' do
       let(:ex_attrs) { build(:green_lanes_faq_feedback).to_hash }
 
       it { is_expected.to have_http_status :created }
-      it { is_expected.to have_attributes location: api_admin_green_lanes_faq_feedback_url(GreenLanes::FaqFeedback.last.id) }
+      it { is_expected.to have_attributes location: api_green_lanes_faq_feedback_url(GreenLanes::FaqFeedback.last.id) }
     end
 
     context 'with invalid params' do

--- a/spec/serializers/api/v2/green_lanes/faq_feedback_serializer_spec.rb
+++ b/spec/serializers/api/v2/green_lanes/faq_feedback_serializer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Api::Admin::GreenLanes::FaqFeedbackSerializer do
+RSpec.describe Api::V2::GreenLanes::FaqFeedbackSerializer do
   subject(:serialized) do
     described_class.new(faq_feedback).serializable_hash
   end

--- a/terraform/backend_uk.tf
+++ b/terraform/backend_uk.tf
@@ -74,7 +74,7 @@ module "backend_uk" {
     [
       {
         name      = "DATABASE_URL"
-        valueFrom = local.read_only_db_arn
+        valueFrom = local.read_write_db_arn
       }
     ]
   ])

--- a/terraform/backend_xi.tf
+++ b/terraform/backend_xi.tf
@@ -72,7 +72,7 @@ module "backend_xi" {
     [
       {
         name      = "DATABASE_URL"
-        valueFrom = local.read_only_db_arn
+        valueFrom = local.read_write_db_arn
       }
     ]
   ])

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -6,7 +6,6 @@ locals {
   signon_url     = var.environment == "production" ? "https://signon.publishing.service.gov.uk" : "http://signon.tariff.internal:8080"
 
   read_write_db_arn = var.environment == "staging" ? try(data.aws_secretsmanager_secret.aurora_rw_connection_string[0].arn, "") : data.aws_secretsmanager_secret.database_connection_string.arn
-  read_only_db_arn  = var.environment == "staging" ? try(data.aws_secretsmanager_secret.aurora_ro_connection_string[0].arn, "") : data.aws_secretsmanager_secret.database_readonly_connection_string.arn
 
 
   backend_common_vars = [


### PR DESCRIPTION
### Jira link

HMRC-715

### What?

I have added/removed/altered:

- [x] Migrated faq feedback to v2 namespace

### Why?

I am doing this because:

- This is so that we can generate feedback in V2
