### PR TITLE
 HMRC-683 Scale down backend-admin-uk & backend-admin-xi

### DIFF
--- a/terraform/admin_uk.tf
+++ b/terraform/admin_uk.tf
@@ -2,7 +2,7 @@ module "backend_admin_uk" {
   source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.12.0"
 
   service_name  = "backend-admin-uk"
-  service_count = var.service_count
+  service_count = 0
   region        = var.region
 
   cluster_name              = "trade-tariff-cluster-${var.environment}"
@@ -10,7 +10,7 @@ module "backend_admin_uk" {
   security_groups           = [data.aws_security_group.this.id]
   cloudwatch_log_group_name = "platform-logs-${var.environment}"
 
-  min_capacity = var.min_capacity
+  min_capacity = 0
   max_capacity = var.max_capacity
 
   docker_image = data.aws_ssm_parameter.ecr_url.value

--- a/terraform/admin_xi.tf
+++ b/terraform/admin_xi.tf
@@ -2,7 +2,7 @@ module "backend_admin_xi" {
   source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.12.0"
 
   service_name  = "backend-admin-xi"
-  service_count = var.service_count
+  service_count = 0
   region        = var.region
 
   cluster_name              = "trade-tariff-cluster-${var.environment}"
@@ -10,7 +10,7 @@ module "backend_admin_xi" {
   security_groups           = [data.aws_security_group.this.id]
   cloudwatch_log_group_name = "platform-logs-${var.environment}"
 
-  min_capacity = var.min_capacity
+  min_capacity = 0
   max_capacity = var.max_capacity
 
   docker_image = data.aws_ssm_parameter.ecr_url.value


### PR DESCRIPTION
### Jira link

HMRC-683

### What?

Scaled down the `backend-admin-*` services to zero as they should no longer be required.  Should we require them we can manually scale up and revert this PR.

Should we prove they are not required after a few days we will decommission the services.