### PR TITLE
HMRC-693 Invalidate CF cache on import

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'sequel-rails'
 
 # File uploads and AWS
 gem 'aws-actionmailer-ses'
+gem 'aws-sdk-cloudfront', '~> 1.111'
 gem 'aws-sdk-rails'
 gem 'aws-sdk-s3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,9 @@ GEM
       aws-sdk-sesv2 (~> 1, >= 1.34.0)
     aws-eventstream (1.3.1)
     aws-partitions (1.1056.0)
+    aws-sdk-cloudfront (1.114.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sigv4 (~> 1.5)
     aws-sdk-core (3.219.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
@@ -472,6 +475,7 @@ PLATFORMS
 DEPENDENCIES
   awesome_print
   aws-actionmailer-ses
+  aws-sdk-cloudfront (~> 1.111)
   aws-sdk-rails
   aws-sdk-s3
   bootsnap

--- a/app/workers/cds_updates_synchronizer_worker.rb
+++ b/app/workers/cds_updates_synchronizer_worker.rb
@@ -29,6 +29,7 @@ class CdsUpdatesSynchronizerWorker
     Sidekiq::Client.enqueue(ClearInvalidSearchReferences)
     Sidekiq::Client.enqueue(TreeIntegrityCheckWorker)
     Sidekiq::Client.enqueue(ClearCacheWorker)
+    Sidekiq::Client.enqueue(InvalidateCacheWorker)
   rescue TariffSynchronizer::CdsUpdateDownloader::ListDownloadFailedError
     attempt_reschedule!
   end

--- a/app/workers/invalidate_cache_worker.rb
+++ b/app/workers/invalidate_cache_worker.rb
@@ -2,7 +2,8 @@ class InvalidateCacheWorker
   include Sidekiq::Worker
 
   def perform
-    client = Aws::CloudFront::Client.new
+    creds = Aws::ECSCredentials.new(retries: 3)
+    client = Aws::CloudFront::Client.new(credentials: creds)
 
     production_cdn = client.list_distributions.distribution_list.items.select { |d| d.comment = 'Production CDN' }
     if production_cdn.count.positive?

--- a/app/workers/invalidate_cache_worker.rb
+++ b/app/workers/invalidate_cache_worker.rb
@@ -5,7 +5,7 @@ class InvalidateCacheWorker
     creds = Aws::ECSCredentials.new(retries: 3)
     client = Aws::CloudFront::Client.new(credentials: creds)
 
-    production_cdn = client.list_distributions.distribution_list.items.select { |d| d.comment = 'Production CDN' }
+    production_cdn = client.list_distributions.distribution_list.items.find { |d| d.comment = 'Production CDN' }
     if production_cdn.count.positive?
       distribution_id = production_cdn.first.id
     end

--- a/app/workers/invalidate_cache_worker.rb
+++ b/app/workers/invalidate_cache_worker.rb
@@ -7,7 +7,7 @@ class InvalidateCacheWorker
 
     production_cdn = client.list_distributions.distribution_list.items.find { |d| d.comment = 'Production CDN' }
     if production_cdn
-      distribution_id = production_cdn.first.id
+      distribution_id = production_cdn.id
     end
 
     if distro

--- a/app/workers/invalidate_cache_worker.rb
+++ b/app/workers/invalidate_cache_worker.rb
@@ -6,7 +6,7 @@ class InvalidateCacheWorker
     client = Aws::CloudFront::Client.new(credentials: creds)
 
     production_cdn = client.list_distributions.distribution_list.items.find { |d| d.comment = 'Production CDN' }
-    if production_cdn.count.positive?
+    if production_cdn
       distribution_id = production_cdn.first.id
     end
 

--- a/app/workers/invalidate_cache_worker.rb
+++ b/app/workers/invalidate_cache_worker.rb
@@ -12,7 +12,7 @@ class InvalidateCacheWorker
         invalidation_batch: {
           paths: {
             quantity: 1,
-            items: ['*'],
+            items: ['/*'],
           },
           caller_reference: 'InvalidateCacheWorker',
         },

--- a/app/workers/invalidate_cache_worker.rb
+++ b/app/workers/invalidate_cache_worker.rb
@@ -1,0 +1,25 @@
+class InvalidateCacheWorker
+  include Sidekiq::Worker
+
+  def perform
+    client = Aws::CloudFront::Client.new
+
+    production_cdn = client.list_distributions.distribution_list.items.select { |d| d.comment = 'Production CDN' }
+    if production_cdn.count.positive?
+      distribution_id = production_cdn.first.id
+    end
+
+    if distro
+      client.create_invalidation({
+        distribution_id: distribution_id,
+        invalidation_batch: {
+          paths: {
+            quantity: 1,
+            items: ['*'],
+          },
+          caller_reference: 'InvalidateCacheWorker',
+        },
+      })
+    end
+  end
+end

--- a/app/workers/invalidate_cache_worker.rb
+++ b/app/workers/invalidate_cache_worker.rb
@@ -5,14 +5,11 @@ class InvalidateCacheWorker
     creds = Aws::ECSCredentials.new(retries: 3)
     client = Aws::CloudFront::Client.new(credentials: creds)
 
-    production_cdn = client.list_distributions.distribution_list.items.find { |d| d.comment = 'Production CDN' }
-    if production_cdn
-      distribution_id = production_cdn.id
-    end
+    production_cdn = client.list_distributions.distribution_list.items.find { |d| d.comment = ENV.fetch('CDN_DISTRIBUTION_NAME', 'Production CDN') }
 
-    if distro
+    if production_cdn
       client.create_invalidation({
-        distribution_id: distribution_id,
+        distribution_id: production_cdn.id,
         invalidation_batch: {
           paths: {
             quantity: 1,

--- a/app/workers/invalidate_cache_worker.rb
+++ b/app/workers/invalidate_cache_worker.rb
@@ -5,7 +5,7 @@ class InvalidateCacheWorker
     creds = Aws::ECSCredentials.new(retries: 3)
     client = Aws::CloudFront::Client.new(credentials: creds)
 
-    production_cdn = client.list_distributions.distribution_list.items.find { |d| d.comment = ENV.fetch('CDN_DISTRIBUTION_NAME', 'Production CDN') }
+    production_cdn = client.list_distributions.distribution_list.items.find { |d| d.comment = "#{ENV['ENVIRONMENT'].capitalize} CDN" }
 
     if production_cdn
       client.create_invalidation({

--- a/app/workers/taric_updates_synchronizer_worker.rb
+++ b/app/workers/taric_updates_synchronizer_worker.rb
@@ -22,6 +22,7 @@ class TaricUpdatesSynchronizerWorker
     Sidekiq::Client.enqueue(ClearInvalidSearchReferences)
     Sidekiq::Client.enqueue(TreeIntegrityCheckWorker)
     Sidekiq::Client.enqueue(ClearCacheWorker)
+    Sidekiq::Client.enqueue(InvalidateCacheWorker)
   end
 
 private

--- a/spec/workers/invalidate_cache_worker_spec.rb
+++ b/spec/workers/invalidate_cache_worker_spec.rb
@@ -1,0 +1,100 @@
+RSpec.describe InvalidateCacheWorker, type: :worker do
+  subject(:worker) { described_class.new }
+
+  let(:client) { Aws::CloudFront::Client.new(stub_responses: true) }
+
+  let(:base_distribution) do
+    {
+      id: 'DEFAULT123',
+      comment: 'Default CDN',
+      arn: 'arn:aws:cloudfront::123456789012:distribution/bar',
+      status: 'Deployed',
+      last_modified_time: Time.zone.now,
+      domain_name: 'foo.cloudfront.net',
+      aliases: { quantity: 0, items: [] },
+      origins: { quantity: 1, items: [{ id: 'origin1', domain_name: 'example.com' }] },
+      default_cache_behavior: { target_origin_id: 'origin1', viewer_protocol_policy: 'allow-all' },
+      cache_behaviors: { quantity: 0, items: [] },
+      custom_error_responses: { quantity: 0, items: [] },
+      price_class: 'PriceClass_All',
+      enabled: true,
+      viewer_certificate: {},
+      restrictions: { geo_restriction: { restriction_type: 'none', quantity: 0 } },
+      web_acl_id: '',
+      http_version: 'http2',
+      is_ipv6_enabled: true,
+      staging: false,
+    }
+  end
+
+  describe '#perform' do
+    context 'when the targeted CDN exists' do
+      let(:test_distribution) { base_distribution.merge(id: 'TEST123', comment: 'Test CDN') }
+      let(:prod_distribution) { base_distribution.merge(id: 'PROD123', comment: 'Production CDN') }
+
+      before do
+        client.stub_responses(:list_distributions, {
+          distribution_list: {
+            marker: '',
+            max_items: 100,
+            is_truncated: false,
+            quantity: 2,
+            items: [
+              test_distribution,
+              prod_distribution,
+            ],
+          },
+        })
+        client.stub_responses(:create_invalidation)
+      end
+
+      it 'creates an invalidation' do
+        worker.perform(client)
+        expect(client.api_requests.pluck(:operation_name)).to include(:list_distributions, :create_invalidation)
+      end
+    end
+
+    context 'when the targeted CDN does not exist' do
+      let(:distribution) { base_distribution.merge(id: 'PROD123', comment: 'Production CDN') }
+
+      before do
+        client.stub_responses(
+          :list_distributions,
+          distribution_list: {
+            marker: '',
+            max_items: 100,
+            is_truncated: false,
+            quantity: 1,
+            items: [distribution],
+          },
+        )
+      end
+
+      it 'does not create an invalidation' do
+        worker.perform(client)
+
+        expect(client.api_requests.pluck(:operation_name)).to eq([:list_distributions])
+      end
+    end
+
+    context 'when distribution list is empty' do
+      before do
+        client.stub_responses(
+          :list_distributions,
+          distribution_list: {
+            marker: '',
+            max_items: 100,
+            is_truncated: false,
+            quantity: 1,
+            items: [],
+          },
+        )
+      end
+
+      it 'does not create an invalidation' do
+        worker.perform(client)
+        expect(client.api_requests.pluck(:operation_name)).to eq([:list_distributions])
+      end
+    end
+  end
+end

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -5,7 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.67.0"
   constraints = "~> 4.0"
   hashes = [
-    "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
+    "h1:P43vwcDPG99x5WBbmqwUPgfJrfXf6/ucAIbGlRb7k1w=",
     "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
     "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
     "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
@@ -28,7 +28,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.7.1"
   constraints = ">= 3.4.3"
   hashes = [
-    "h1:t152MY0tQH4a8fLzTtEWx70ITd3azVOrFDn/pQblbto=",
+    "h1:ji/JgTChmJj8a9PaXja2PiYJhR4iZBX34FDfxnqeZIA=",
     "zh:3193b89b43bf5805493e290374cdda5132578de6535f8009547c8b5d7a351585",
     "zh:3218320de4be943e5812ed3de995946056db86eb8d03aa3f074e0c7316599bef",
     "zh:419861805a37fa443e7d63b69fb3279926ccf98a79d256c422d5d82f0f387d1d",

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -29,12 +29,14 @@ Terraform to deploy the service into AWS.
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.cloudfront](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.emails](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.task_role_kms_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.cloudfront](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.emails](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/terraform/backend_uk.tf
+++ b/terraform/backend_uk.tf
@@ -29,7 +29,8 @@ module "backend_uk" {
     aws_iam_policy.exec.arn,
     aws_iam_policy.s3.arn,
     aws_iam_policy.task_role_kms_keys.arn,
-    aws_iam_policy.emails.arn
+    aws_iam_policy.emails.arn,
+    aws_iam_policy.cloudfront.arn,
   ]
 
   execution_role_policy_arns = [

--- a/terraform/backend_xi.tf
+++ b/terraform/backend_xi.tf
@@ -28,7 +28,9 @@ module "backend_xi" {
   task_role_policy_arns = [
     aws_iam_policy.exec.arn,
     aws_iam_policy.s3.arn,
-    aws_iam_policy.task_role_kms_keys.arn
+    aws_iam_policy.task_role_kms_keys.arn,
+    aws_iam_policy.emails.arn,
+    aws_iam_policy.cloudfront.arn,
   ]
 
   execution_role_policy_arns = [

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -187,6 +187,11 @@ data "aws_iam_policy_document" "cloudfront" {
     actions   = ["cloudfront:CreateInvalidation"]
     resources = ["arn:aws:cloudfront::${local.account_id}:distribution/*"]
   }
+  statement {
+    effect    = "Allow"
+    actions   = ["cloudfront:ListDistributions"]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "cloudfront" {

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -180,3 +180,16 @@ resource "aws_iam_policy" "emails" {
   name   = "frontend-execution-role-emails-policy"
   policy = data.aws_iam_policy_document.emails.json
 }
+
+data "aws_iam_policy_document" "cloudfront" {
+  statement {
+    effect    = "Allow"
+    actions   = ["cloudfront:CreateInvalidation"]
+    resources = ["arn:aws:cloudfront::${local.account_id}:distribution/*"]
+  }
+}
+
+resource "aws_iam_policy" "cloudfront" {
+  name   = "backend-task-role-cloudfront-policy"
+  policy = data.aws_iam_policy_document.cloudfront.json
+}

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -27,7 +27,8 @@ module "worker_uk" {
     aws_iam_policy.exec.arn,
     aws_iam_policy.s3.arn,
     aws_iam_policy.task_role_kms_keys.arn,
-    aws_iam_policy.emails.arn
+    aws_iam_policy.emails.arn,
+    aws_iam_policy.cloudfront.arn,
   ]
 
   execution_role_policy_arns = [

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -27,7 +27,8 @@ module "worker_xi" {
     aws_iam_policy.exec.arn,
     aws_iam_policy.s3.arn,
     aws_iam_policy.task_role_kms_keys.arn,
-    aws_iam_policy.emails.arn
+    aws_iam_policy.emails.arn,
+    aws_iam_policy.cloudfront.arn,
   ]
 
   execution_role_policy_arns = [


### PR DESCRIPTION
### Jira link

HMRC-693

### What?

I have added a job that will invalidate the entire CloudFront cache each time we do a file import.  We can probably refine this further.  

Before this can ship though we need some extra configuration setup for AWS Authentication:

```
ENV['AWS_REGION']
ENV['AWS_ACCESS_KEY_ID']
ENV['AWS_SECRET_ACCESS_KEY']
ENV['AWS_SESSION_TOKEN']
```