### PR TITLE
BAU: Put more specific routes first

### DIFF
--- a/app/controllers/api/v2/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/goods_nomenclatures_controller.rb
@@ -74,21 +74,22 @@ module Api
       end
 
       def self.api_path_builder(object, check_for_subheadings: false)
+        service = TradeTariffBackend.service
         gnid = object.goods_nomenclature_item_id
         return nil unless gnid
 
         case object
         when Chapter
-          "/api/v2/chapters/#{gnid.first(2)}"
+          "/#{service}/api/v2/chapters/#{gnid.first(2)}"
         when Heading
-          "/api/v2/headings/#{gnid.first(4)}"
+          "/#{service}/api/v2/headings/#{gnid.first(4)}"
         when Subheading
-          "/api/v2/subheadings/#{object.to_param}"
+          "/#{service}/api/v2/subheadings/#{object.to_param}"
         else
           if check_for_subheadings && !object.declarable?
-            "/api/v2/subheadings/#{gnid.first(10)}-#{object.producline_suffix}"
+            "/#{service}/api/v2/subheadings/#{gnid.first(10)}-#{object.producline_suffix}"
           else
-            "/api/v2/commodities/#{gnid.first(10)}"
+            "/#{service}/api/v2/commodities/#{gnid.first(10)}"
           end
         end
       end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,4 +17,12 @@ module ApplicationHelper
     regulation_id = regulation.regulation_id
     "#{regulation_id.first}#{regulation_id[3..6]}/#{regulation_id[1..2]}"
   end
+
+  # TODO: Remove this and use the original path helpers once we're removed legacy routes which clobber the correct helpers
+  def v1_api_path(resource, id = nil)
+    service = TradeTariffBackend.service
+    id = "/#{id}" if id
+
+    "/#{service}/api/v1/#{resource}#{id}"
+  end
 end

--- a/app/lib/api_constraints.rb
+++ b/app/lib/api_constraints.rb
@@ -4,7 +4,7 @@ class ApiConstraints
   end
 
   def matches?(req)
-    default? || req.headers['Accept'].include?("application/vnd.uktt.v#{@version}")
+    default? || req.headers['Accept'].to_s.include?("application/vnd.uktt.v#{@version}")
   end
 
   private

--- a/app/views/api/v1/chapters/show.json.rabl
+++ b/app/views/api/v1/chapters/show.json.rabl
@@ -31,7 +31,7 @@ node(:_response_info) do
   {
     links: [
       { rel: 'self', href: request.fullpath },
-      { rel: 'section', href: api_section_path(@chapter.section.position) },
+      { rel: 'section', href: v1_api_path('sections', @chapter.section.position) },
     ],
   }
 end

--- a/app/views/api/v1/commodities/show.json.rabl
+++ b/app/views/api/v1/commodities/show.json.rabl
@@ -47,9 +47,9 @@ node(:_response_info) do
   {
     links: [
       { rel: 'self', href: request.fullpath },
-      { rel: 'heading', href: api_heading_path(@commodity.heading) },
-      { rel: 'chapter', href: api_chapter_path(@commodity.chapter) },
-      { rel: 'section', href: api_section_path(@commodity.section.position) },
+      { rel: 'heading', href: v1_api_path('headings', @commodity.heading_short_code) },
+      { rel: 'chapter', href: v1_api_path('chapters', @commodity.chapter_short_code) },
+      { rel: 'section', href: v1_api_path('sections', @commodity.section.position) },
     ],
   }
 end

--- a/app/views/api/v1/headings/show.json.rabl
+++ b/app/views/api/v1/headings/show.json.rabl
@@ -53,8 +53,8 @@ node(:_response_info) do
   {
     links: [
       { rel: 'self', href: request.fullpath },
-      { rel: 'chapter', href: api_chapter_path(@heading.chapter) },
-      { rel: 'section', href: api_section_path(@heading.section.position) },
+      { rel: 'chapter', href: v1_api_path('chapters', @heading.chapter_short_code) },
+      { rel: 'section', href: v1_api_path('sections', @heading.section.position) },
     ],
   }
 end

--- a/app/views/api/v1/sections/show.json.rabl
+++ b/app/views/api/v1/sections/show.json.rabl
@@ -22,7 +22,7 @@ node(:_response_info) do
   {
     links: [
       { rel: 'self', href: request.fullpath },
-      { rel: 'sections', href: api_sections_path },
+      { rel: 'sections', href: v1_api_path('sections') },
     ],
   }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,9 +4,11 @@ Rails.application.routes.draw do
   # Application liveness
   get 'healthcheckz' => 'healthcheck#checkz'
 
-  # Legacy routes
-  mount V2Api => '/', as: 'v2', constraints: ApiConstraints.new(version: 2)
-  mount V1Api => '/', as: 'v1', constraints: ApiConstraints.new(version: 1)
+  # Admin routes
+  draw(:admin) if TradeTariffBackend.enable_admin?
+
+  # Error handling
+  draw(:errors)
 
   # V1 routes
   mount V1Api => '/api/v1', as: 'v1_api'
@@ -18,9 +20,7 @@ Rails.application.routes.draw do
   mount V2Api => '/xi/api/v2', as: 'xi_v2_api' if TradeTariffBackend.xi?
   mount V2Api => '/uk/api/v2', as: 'uk_v2_api' if TradeTariffBackend.uk?
 
-  # Admin routes
-  draw(:admin) if TradeTariffBackend.enable_admin?
-
-  # Error handling
-  draw(:errors)
+  # Legacy routes
+  mount V2Api => '/', as: 'v2', constraints: ApiConstraints.new(version: 2)
+  mount V1Api => '/', as: 'v1', constraints: ApiConstraints.new(version: 1)
 end

--- a/spec/controllers/api/v2/measure_types_controller_spec.rb
+++ b/spec/controllers/api/v2/measure_types_controller_spec.rb
@@ -58,7 +58,8 @@ RSpec.describe Api::V2::MeasureTypesController, type: :controller do
       let(:pattern) do
         {
           error: 'not found',
-          url: 'http://test.host/uk/api/v2/measure_types/foo',
+          # TODO: This will default to v2 pathed helper when legacy routes are removed
+          url: 'http://test.host/measure_types/foo',
         }
       end
 

--- a/spec/requests/api/v2/exchange_rates/period_lists_controller_spec.rb
+++ b/spec/requests/api/v2/exchange_rates/period_lists_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe Api::V2::ExchangeRates::PeriodListsController, type: :request do
   describe 'GET #show' do
     subject { make_request && response }
@@ -20,11 +18,7 @@ RSpec.describe Api::V2::ExchangeRates::PeriodListsController, type: :request do
       let(:year) { 2023 }
 
       let(:make_request) do
-        get api_exchange_rates_period_list_path(
-          year: '2023',
-          filter: { type: 'monthly' },
-          format: :json,
-        )
+        get "/uk/api/v2/exchange_rates/period_lists.json?year=#{year}&filter[type]=monthly"
       end
 
       let(:pattern) do
@@ -85,11 +79,7 @@ RSpec.describe Api::V2::ExchangeRates::PeriodListsController, type: :request do
       let(:period_list) { build(:period_list, exchange_rate_periods: [], year: 1970) }
 
       let(:make_request) do
-        get api_exchange_rates_period_list_path(
-          year: '1970',
-          filter: { type: 'monthly' },
-          format: :json,
-        )
+        get "/uk/api/v2/exchange_rates/period_lists.json?year=#{year}&filter[type]=monthly"
       end
 
       let(:pattern) do
@@ -117,17 +107,13 @@ RSpec.describe Api::V2::ExchangeRates::PeriodListsController, type: :request do
       let(:year) { '2023idadas' }
 
       let(:make_request) do
-        get api_exchange_rates_period_list_path(
-          year: '2023idadas',
-          filter: { type: 'monthly' },
-          format: :json,
-        )
+        get "/uk/api/v2/exchange_rates/period_lists/#{year}?filter[type]=monthly"
       end
 
       let(:pattern) do
         {
-          error: 'not found',
-          url: 'http://www.example.com/uk/api/v2/exchange_rates/period_lists/2023idadas?filter%5Btype%5D=monthly',
+          'error' => 'not found',
+          'url' => 'http://www.example.com/uk/api/v2/exchange_rates/period_lists/2023idadas?filter[type]=monthly',
         }
       end
 
@@ -139,17 +125,13 @@ RSpec.describe Api::V2::ExchangeRates::PeriodListsController, type: :request do
       let(:year) { 2023 }
 
       let(:make_request) do
-        get api_exchange_rates_period_list_path(
-          year: '2023',
-          filter: { type: 'invalid' },
-          format: :json,
-        )
+        get "/uk/api/v2/exchange_rates/period_lists/#{year}?filter[type]=invalid"
       end
 
       let(:pattern) do
         {
-          error: 'invalid',
-          url: 'http://www.example.com/uk/api/v2/exchange_rates/period_lists/2023?filter%5Btype%5D=invalid',
+          'error' => 'invalid',
+          'url' => 'http://www.example.com/uk/api/v2/exchange_rates/period_lists/2023?filter[type]=invalid',
         }
       end
 

--- a/spec/requests/api/v2/exchange_rates_controller_spec.rb
+++ b/spec/requests/api/v2/exchange_rates_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Api::V2::ExchangeRatesController, type: :request do
       let(:pattern) do
         {
           error: 'not found',
-          url: 'http://www.example.com/uk/api/v2/exchange_rates/2023idadas-6?filter%5Btype%5D=monthly',
+          url: 'http://www.example.com/exchange_rates/2023idadas-6?filter%5Btype%5D=monthly',
         }
       end
 
@@ -84,7 +84,7 @@ RSpec.describe Api::V2::ExchangeRatesController, type: :request do
       let(:pattern) do
         {
           'error' => 'invalid',
-          'url' => 'http://www.example.com/uk/api/v2/exchange_rates/2023-6?filter%5Btype%5D=invalid',
+          'url' => 'http://www.example.com/exchange_rates/2023-6?filter%5Btype%5D=invalid',
         }
       end
 

--- a/spec/serializers/api/v2/csv/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/api/v2/csv/goods_nomenclature_serializer_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Api::V2::Csv::GoodsNomenclatureSerializer do
           '0',
           goods_nomenclature.description,
           '80',
-          "/api/v2/headings/#{goods_nomenclature.short_code}",
+          "/uk/api/v2/headings/#{goods_nomenclature.short_code}",
           goods_nomenclature.formatted_description,
           "#{goods_nomenclature.validity_start_date.to_date} 00:00:00 UTC",
           '',
@@ -47,7 +47,7 @@ RSpec.describe Api::V2::Csv::GoodsNomenclatureSerializer do
     context 'with subheading' do
       let(:goods_nomenclature) { create :commodity, :with_children }
 
-      it { expect(rows[1]).to match "api/v2/subheadings/#{goods_nomenclature.to_param}" }
+      it { expect(rows[1]).to match "/uk/api/v2/subheadings/#{goods_nomenclature.to_param}" }
     end
 
     context 'with parent' do

--- a/spec/serializers/api/v2/goods_nomenclatures/goods_nomenclature_extended_serializer_spec.rb
+++ b/spec/serializers/api/v2/goods_nomenclatures/goods_nomenclature_extended_serializer_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Api::V2::GoodsNomenclatures::GoodsNomenclatureExtendedSerializer 
       it { is_expected.to include producline_suffix: gn.producline_suffix }
       it { is_expected.to include description: gn.description }
       it { is_expected.to include number_indents: gn.number_indents }
-      it { is_expected.to include href: "/api/v2/commodities/#{gn.goods_nomenclature_item_id}" }
+      it { is_expected.to include href: "/uk/api/v2/commodities/#{gn.goods_nomenclature_item_id}" }
       it { is_expected.to include formatted_description: gn.formatted_description }
       it { is_expected.to include validity_start_date: gn.validity_start_date }
       it { is_expected.to include validity_end_date: gn.validity_end_date }
@@ -45,21 +45,21 @@ RSpec.describe Api::V2::GoodsNomenclatures::GoodsNomenclatureExtendedSerializer 
       context 'with heading' do
         let(:gn) { create :heading, :with_children }
 
-        it { is_expected.to include href: "/api/v2/headings/#{gn.short_code}" }
+        it { is_expected.to include href: "/uk/api/v2/headings/#{gn.short_code}" }
         it { is_expected.to include declarable: false }
       end
 
       context 'with declarable heading' do
         let(:gn) { create :heading }
 
-        it { is_expected.to include href: "/api/v2/headings/#{gn.short_code}" }
+        it { is_expected.to include href: "/uk/api/v2/headings/#{gn.short_code}" }
         it { is_expected.to include declarable: true }
       end
 
       context 'with subheading' do
         let(:gn) { create :subheading, :with_children }
 
-        it { is_expected.to include href: "/api/v2/subheadings/#{gn.to_param}" }
+        it { is_expected.to include href: "/uk/api/v2/subheadings/#{gn.to_param}" }
         it { is_expected.to include declarable: false }
       end
     end

--- a/spec/serializers/api/v2/goods_nomenclatures/goods_nomenclature_list_serializer_spec.rb
+++ b/spec/serializers/api/v2/goods_nomenclatures/goods_nomenclature_list_serializer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Api::V2::GoodsNomenclatures::GoodsNomenclatureListSerializer do
       it { is_expected.to include producline_suffix: gn.producline_suffix }
       it { is_expected.to include description: gn.description }
       it { is_expected.to include number_indents: gn.number_indents }
-      it { is_expected.to include href: "/api/v2/commodities/#{gn.goods_nomenclature_item_id}" }
+      it { is_expected.to include href: "/uk/api/v2/commodities/#{gn.goods_nomenclature_item_id}" }
     end
   end
 end


### PR DESCRIPTION
### Jira link

BAU

### What?

Occasionally but not consistently the legacy routes are being hit and failing because the Accept header isn't being set. We only saw this in [production](https://engine-le.sentry.io/issues/6294252303/events/?end=2025-02-17T23%3A59%3A59&environment=production&project=5557005&referrer=issue-stream&start=2025-02-17T00%3A00%3A00&stream_index=0&utc=true)

This change moves us to match the more specific routes first (e.g. /api/v1 /api/v2) to avoid this problem. It also fixes the missing Accept header error by calling to_s on the result of fetching the header before we call `include?` against nil.

When you put the most specific mounts first there's an unwanted side effect of clobbering the previously defined helpers. This mostly affected the tests (controller specs use helpers implicitly and request specs were using helpers explicitly).

Essentially this means we're now guaranteeing correct matches for v1/v2 paths but rendered paths now need some adjustments

I have added/removed/altered:

- [x] Added more robust route ordering to force v1/v2 matches over legacy routes
- [x] Added handling of nil Accept headers in legacy ApiConstraints class
- [x] Adjusts helper rendered paths in the tests and under v1 rabl views

### Why?

I am doing this because:

- This forces more specific routes to be recognised first
- This reduces the flimsiness of the ApiConstraints implementation
- This guarantees that rendered paths follow the new convention (there's a bit of a TODO to revert back to helpers once the legacy paths have been dropped)
