### PR TITLE
HMRC-670 Remove 'appendix 5a' jobs and infrastructure for CHIEF guidance

### DIFF
--- a/app/models/appendix_5a.rb
+++ b/app/models/appendix_5a.rb
@@ -1,5 +1,5 @@
 class Appendix5a < Sequel::Model(:appendix_5as)
-  CDS_GUIDANCE_OBJECT_KEY = 'config/chief_cds_guidance.json'.freeze
+  CDS_GUIDANCE_OBJECT_KEY = 'config/cds_guidance.json'.freeze
 
   set_primary_key %i[certificate_type_code certificate_code]
 
@@ -20,7 +20,7 @@ class Appendix5a < Sequel::Model(:appendix_5as)
   end
 
   def guidance_chief
-    chief_guidance
+    ''
   end
 
   def guidance_cds

--- a/app/services/appendix_5a_populator_service.rb
+++ b/app/services/appendix_5a_populator_service.rb
@@ -37,13 +37,11 @@ class Appendix5aPopulatorService
         certificate_type_code = document_code[0]
         certificate_code = document_code[1..]
         cds_guidance = guidance['guidance_cds']
-        chief_guidance = guidance['guidance_chief']
 
         Appendix5a.new(
           certificate_type_code:,
           certificate_code:,
           cds_guidance:,
-          chief_guidance:,
         )
       end
     end
@@ -58,7 +56,6 @@ class Appendix5aPopulatorService
           next unless guidance.document_code == document_code
 
           guidance.cds_guidance = new_guidance[document_code]['guidance_cds']
-          guidance.chief_guidance = new_guidance[document_code]['guidance_chief']
 
           if guidance.column_changes.any?
             acc << guidance

--- a/spec/factories/appendix_5a_factory.rb
+++ b/spec/factories/appendix_5a_factory.rb
@@ -3,6 +3,5 @@ FactoryBot.define do
     certificate_type_code { '1' }
     certificate_code { '123' }
     cds_guidance { 'foo' }
-    chief_guidance { 'bar' }
   end
 end

--- a/spec/services/appendix5a_populator_service_spec.rb
+++ b/spec/services/appendix5a_populator_service_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Appendix5aPopulatorService do
       create(
         :appendix_5a,
         cds_guidance: 'foo',
-        chief_guidance: 'bar',
       )
     end
 
@@ -21,8 +20,7 @@ RSpec.describe Appendix5aPopulatorService do
       let(:new_guidance) do
         {
           '1123' => {
-            'guidance_cds' => 'foo',
-            'guidance_chief' => 'baz',
+            'guidance_cds' => 'bar',
           },
         }
       end
@@ -45,7 +43,6 @@ RSpec.describe Appendix5aPopulatorService do
         {
           '1123' => {
             'guidance_cds' => 'foo',
-            'guidance_chief' => 'bar',
           },
         }
       end
@@ -82,11 +79,9 @@ RSpec.describe Appendix5aPopulatorService do
         {
           '1123' => {
             'guidance_cds' => 'foo',
-            'guidance_chief' => 'bar',
           },
           '2123' => {
             'guidance_cds' => 'foo',
-            'guidance_chief' => 'bar',
           },
         }
       end

--- a/spec/support/shared_contexts/with_a_stubbed_appendix_5a_guidance_s3_bucket.rb
+++ b/spec/support/shared_contexts/with_a_stubbed_appendix_5a_guidance_s3_bucket.rb
@@ -6,7 +6,7 @@ RSpec.shared_context 'with a stubbed appendix 5a guidance s3 bucket' do
   let(:get_object_handler) do
     lambda do |context|
       case context.params[:key]
-      when 'config/chief_cds_guidance.json'
+      when 'config/cds_guidance.json'
         { body: StringIO.new(file_fixture('appendix_5a_guidance.json').read) }
       end
     end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HMRC-670

### What?

I have removed CHIEF Guidance from Appendix5a Populator Service

### Why?

I am doing this because:

- HMRC do not need CHIEF Guidance anymore and has been deprecated from the front end and in this [PR](https://github.com/trade-tariff/process-appendix-5a/pull/79) for the process-appendix-5a python script
- NOTE following successfuly merge to main, AWS `ci-appendix5a-persistence-readwrite-policy`  must be updated to allow `appendix-5a` user to `PUT` into S3 `config/cds_guidance.json` in Staging and Prod.

