### PR TITLE
BAU: Switch to Aurora cluster

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -7,7 +7,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 1.9.8 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.9.8 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4 |
 
 ## Providers
@@ -47,10 +47,8 @@ Terraform to deploy the service into AWS.
 | [aws_lb_target_group.backend_xi](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
 | [aws_s3_bucket.persistence](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 | [aws_s3_bucket.reporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
-| [aws_secretsmanager_secret.aurora_ro_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.aurora_rw_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.database_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
-| [aws_secretsmanager_secret.database_readonly_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.differences_to_emails](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.green_lanes_api_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.green_lanes_api_tokens](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |

--- a/terraform/backend_uk.tf
+++ b/terraform/backend_uk.tf
@@ -74,7 +74,7 @@ module "backend_uk" {
     [
       {
         name      = "DATABASE_URL"
-        valueFrom = local.read_write_db_arn
+        valueFrom = local.database_url
       }
     ]
   ])

--- a/terraform/backend_xi.tf
+++ b/terraform/backend_xi.tf
@@ -72,7 +72,7 @@ module "backend_xi" {
     [
       {
         name      = "DATABASE_URL"
-        valueFrom = local.read_write_db_arn
+        valueFrom = local.database_url
       }
     ]
   ])

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -55,20 +55,9 @@ data "aws_secretsmanager_secret" "database_connection_string" {
   name = "tradetariffpostgres${var.environment}-connection-string"
 }
 
-data "aws_secretsmanager_secret" "database_readonly_connection_string" {
-  name = "postgres-read-only"
-}
-
-# HMRC-532: Aurora test
-
 data "aws_secretsmanager_secret" "aurora_rw_connection_string" {
-  count = var.environment == "staging" ? 1 : 0
+  count = var.environment == "development" ? 0 : 1
   name  = "aurora-postgres-rw-connection-string"
-}
-
-data "aws_secretsmanager_secret" "aurora_ro_connection_string" {
-  count = var.environment == "staging" ? 1 : 0
-  name  = "aurora-postgres-ro-connection-string"
 }
 
 data "aws_secretsmanager_secret" "secret_key_base" {

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -8,10 +8,8 @@ data "aws_iam_policy_document" "secrets" {
       "secretsmanager:ListSecretVersionIds"
     ]
     resources = compact([
-      try(data.aws_secretsmanager_secret.aurora_ro_connection_string[0].arn, null),
       try(data.aws_secretsmanager_secret.aurora_rw_connection_string[0].arn, null),
       data.aws_secretsmanager_secret.database_connection_string.arn,
-      data.aws_secretsmanager_secret.database_readonly_connection_string.arn,
       data.aws_secretsmanager_secret.differences_to_emails.arn,
       data.aws_secretsmanager_secret.green_lanes_api_keys.arn,
       data.aws_secretsmanager_secret.green_lanes_api_tokens.arn,

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -5,8 +5,9 @@ locals {
   init_command   = ["/bin/sh", "-c", "bundle exec rails db:migrate && bundle exec rails data:migrate"]
   signon_url     = var.environment == "production" ? "https://signon.publishing.service.gov.uk" : "http://signon.tariff.internal:8080"
 
-  read_write_db_arn = var.environment == "staging" ? try(data.aws_secretsmanager_secret.aurora_rw_connection_string[0].arn, "") : data.aws_secretsmanager_secret.database_connection_string.arn
-
+  database_url = (
+    var.environment == "development" ? data.aws_secretsmanager_secret.database_connection_string.arn : try(data.aws_secretsmanager_secret.aurora_rw_connection_string[0].arn, "")
+  )
 
   backend_common_vars = [
     {

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.9.8"
+  required_version = ">=1.9.8"
 
   required_providers {
     aws = {

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -77,7 +77,7 @@ module "worker_uk" {
     [
       {
         name      = "DATABASE_URL"
-        valueFrom = local.read_write_db_arn
+        valueFrom = local.database_url
       }
     ]
   ])

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -81,7 +81,7 @@ module "worker_xi" {
     [
       {
         name      = "DATABASE_URL"
-        valueFrom = local.read_write_db_arn
+        valueFrom = local.database_url
       }
     ]
   ])


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Switched over to RDS Aurora cluster in production.

### Why?

I am doing this because:

- We have proven this in staging, and now it's time to move this to production.

### Deployment risks (optional)

- Changes database to new RDS Aurora cluster. This will impact performance initially as the database reacts to usage.
