### PR TITLE
HMRC-668: Fixes broken data migration

### DIFF
--- a/db/data_migrations/20230522102427_kill_broken_balance_events.rb
+++ b/db/data_migrations/20230522102427_kill_broken_balance_events.rb
@@ -6,16 +6,16 @@ Sequel.migration do
       quota_definition = QuotaDefinition.where(
         quota_definition_sid: 22_046,
         filename: 'tariff_dailyExtract_v1_20230109T235959.gzip',
-      ).take
+      ).first
 
-      quota_definition.update(initial_volume: 1_471_000.0)
+      quota_definition.update(initial_volume: 1_471_000.0) if quota_definition
 
       quota_definition = QuotaDefinition.where(
         quota_definition_sid: 22_052,
         filename: 'tariff_dailyExtract_v1_20230109T235959.gzip',
-      ).take
+      ).first
 
-      quota_definition.update(initial_volume: 1_471_000.0)
+      quota_definition.update(initial_volume: 1_471_000.0) if quota_definition
     end
   end
 


### PR DESCRIPTION
### Jira link

HMRC-668

### What?

I have added/removed/altered:

- [x] Fixed an issue with running one of our data migrations after a large rollback of data to the tail end of 2022

### Why?

I am doing this because:

- Data migrations should run cleanly
