### PR TITLE
HMRC-725 Update CircleCI config for Postgres version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ jobs:
           DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/tariff_test"
           PGHOST: localhost
           RAILS_ENV: test
-      - image: cimg/postgres:13.6
+      - image: cimg/postgres:16.8
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: tariff_test
@@ -228,7 +228,7 @@ jobs:
           PGHOST: localhost
           RAILS_ENV: test
           REDIS_URL: "redis://localhost:6379/"
-      - image: cimg/postgres:13.6
+      - image: cimg/postgres:16.8
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: tariff_test


### PR DESCRIPTION
### Jira link

[HMRC-725](https://transformuk.atlassian.net/browse/HMRC-725)

### What?

I have updated the circleCI config to use Postgres 16 for testing
