### PR TITLE
Allow override of default mailer url in dev

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # Mailcatcher configuration.
-  config.action_mailer.default_url_options = { host: 'host.docker.internal', port: 3000 }
+  config.action_mailer.default_url_options = { host: ENV.fetch('DEFAULT_MAIL_HOST', 'host.docker.internal'), port: 3000 }
   config.action_mailer.delivery_method = :letter_opener
 
   # Print deprecation notices to the Rails logger.


### PR DESCRIPTION
### Jira link

BAU

### What?

Noticed that the default mailer options were hardcoded to `host.docker.internal`.  This allows you to override that in .env