### PR TITLE
HMRC-854 Fix Psych Gem in Backend DevContainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,4 +2,4 @@
 ARG RUBY_VERSION=3.4.2
 FROM ruby:$RUBY_VERSION-alpine3.21
 
-RUN apk add --update build-base docker gcompat git gpg postgresql-dev postgresql-client pre-commit python3 openssh shared-mime-info tzdata gnupg
+RUN apk add --update build-base docker gcompat git gpg postgresql-dev postgresql-client pre-commit python3 openssh shared-mime-info tzdata gnupg yaml-dev

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -532,4 +532,4 @@ RUBY VERSION
    ruby 3.4.2p28
 
 BUNDLED WITH
-   2.5.11
+   2.6.6


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HMRC-854

### What?

I have added yaml-dev to dockerfile so psych would bundle and updated bundler

### Why?

I am doing this because:

- App wasn't bundling in DevContainer due to psych missing yaml gem in container environment