### PR TITLE
HMRC-841: Fuzzy search test extension: remove non-active CCs from results

### DIFF
--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -22,7 +22,7 @@ class SearchService
   class EmptyQuery < StandardError
   end
 
-  attr_reader :q, :result, :as_of, :data_serializer
+  attr_reader :q, :result, :data_serializer
   attr_accessor :resource_id
 
   delegate :serializable_hash, to: :result
@@ -36,6 +36,10 @@ class SearchService
       end
     end
     @data_serializer = data_serializer
+  end
+
+  def as_of
+    @as_of || Time.zone.today
   end
 
   def as_of=(date)


### PR DESCRIPTION
### Jira link

[HMRC-<TODO>](https://transformuk.atlassian.net/browse/HMRC-841)

### What?

I have added/removed/altered:

- [ ] Added cuurent date as the default date to as_of date in search api

### Why?

I am doing this because:

- When as_of parameter is not present, search api doesn't set a as_of date and then consider all the expired data to generate the response