### PR TITLE
HMRC-840: Add new Trade Defence CAs 'regulation role' types and Measure Types

### DIFF
--- a/lib/tasks/green_lanes.rake
+++ b/lib/tasks/green_lanes.rake
@@ -126,9 +126,8 @@ namespace :green_lanes do
     types = %w[551 552 553 554 555 561 562 564 565 566 570 690 695 696]
 
     GreenLanes::CategoryAssessment.db.transaction do
-      # select active measure_id, regulation_id and regulation_role of given measure type to create category_assessment
       Measure.where(measure_type_id: types)
-             .actual.with_regulation_dates_query
+             .with_generating_regulation
              .select_group(:measure_type_id, :measure_generating_regulation_id, :measure_generating_regulation_role)
              .all.each do |tr|
         key = [tr.measure_type_id, tr.measure_generating_regulation_id, tr.measure_generating_regulation_role]

--- a/lib/tasks/green_lanes.rake
+++ b/lib/tasks/green_lanes.rake
@@ -121,9 +121,9 @@ namespace :green_lanes do
     # load existing data
     theme = GreenLanes::Theme.where(section: '1', subsection: '3').first
     assessments = GreenLanes::CategoryAssessment.all.index_by do |assessment|
-      [assessment.measure_type_id, assessment.regulation_id]
+      [assessment.measure_type_id, assessment.regulation_id, assessment.regulation_role]
     end
-    types = %w[551 552 553 554 555 561 562 564 565 566 570 695]
+    types = %w[551 552 553 554 555 561 562 564 565 566 570 690 695 696]
 
     GreenLanes::CategoryAssessment.db.transaction do
       current_date = Time.zone.today
@@ -131,10 +131,16 @@ namespace :green_lanes do
                                       '(validity_end_date IS NULL OR validity_end_date > ?)')
 
       Measure.where(actual_condition, current_date, current_date)
-             .where(measure_type_id: types, measure_generating_regulation_role: 1)
+             .where(measure_type_id: types)
+             .where(
+                Sequel.|(
+                  { measure_generating_regulation_id: ModificationRegulation.where(actual_condition, current_date, current_date).select(:modification_regulation_id)},
+                  { measure_generating_regulation_id: BaseRegulation.where(actual_condition, current_date, current_date).select(:base_regulation_id)}
+                )
+             )
              .select_group(:measure_type_id, :measure_generating_regulation_id, :measure_generating_regulation_role)
              .all.each do |tr|
-        key = [tr.measure_type_id, tr.measure_generating_regulation_id]
+        key = [tr.measure_type_id, tr.measure_generating_regulation_id, tr.measure_generating_regulation_role]
         assessment = assessments[key]
 
         unless assessment

--- a/lib/tasks/green_lanes.rake
+++ b/lib/tasks/green_lanes.rake
@@ -133,10 +133,10 @@ namespace :green_lanes do
       Measure.where(actual_condition, current_date, current_date)
              .where(measure_type_id: types)
              .where(
-                Sequel.|(
-                  { measure_generating_regulation_id: ModificationRegulation.where(actual_condition, current_date, current_date).select(:modification_regulation_id)},
-                  { measure_generating_regulation_id: BaseRegulation.where(actual_condition, current_date, current_date).select(:base_regulation_id)}
-                )
+               Sequel.|(
+                 { measure_generating_regulation_id: ModificationRegulation.where(actual_condition, current_date, current_date).select(:modification_regulation_id) },
+                 { measure_generating_regulation_id: BaseRegulation.where(actual_condition, current_date, current_date).select(:base_regulation_id) },
+               ),
              )
              .select_group(:measure_type_id, :measure_generating_regulation_id, :measure_generating_regulation_role)
              .all.each do |tr|

--- a/lib/tasks/green_lanes.rake
+++ b/lib/tasks/green_lanes.rake
@@ -130,6 +130,7 @@ namespace :green_lanes do
       actual_condition = Sequel.lit('validity_start_date <= ? AND ' \
                                       '(validity_end_date IS NULL OR validity_end_date > ?)')
 
+      # select active measure_id, regulation_id and regulation_role of given measure type to create category_assessment
       Measure.where(actual_condition, current_date, current_date)
              .where(measure_type_id: types)
              .where(


### PR DESCRIPTION
### Jira link

[HMRC-840](https://transformuk.atlassian.net/browse/HMRC-840)

### What?

I have added/removed/altered:

- [ ] Added filter to Import Trade Remedies CategoryAssessments task to filter out inactive regulations
- [ ] Removed filter from Trade Remedies CategoryAssessments task that filter out regulation roles other than role 1

### Why?

I am doing this because:

- We should not control for the ‘regulation role’ at all, and any Measure of these given Measure Types should be a CA no matter what the ‘regulation role’ is

### Deployment risks (optional)

- Need to run this task in all the environemtns manually
