### PR TITLE
HMRC-869: Sets the path to nullable on goods_nomenclatures_oplog

### DIFF
--- a/db/migrate/20250324091812_alter_column_nullable_path_in_goods_nomenclatures_oplog.rb
+++ b/db/migrate/20250324091812_alter_column_nullable_path_in_goods_nomenclatures_oplog.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table :goods_nomenclatures_oplog do
+      set_column_allow_null :path
+      set_column_default :path, []
+    end
+  end
+
+  down do
+    alter_table :goods_nomenclatures_oplog do
+      set_column_not_null :path
+      set_column_default :path, []
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 13.14 (Debian 13.14-1.pgdg120+2)
--- Dumped by pg_dump version 16.2
+-- Dumped from database version 16.8
+-- Dumped by pg_dump version 16.8
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -197,20 +197,20 @@ CREATE TABLE uk.additional_code_description_periods_oplog (
 --
 
 CREATE VIEW uk.additional_code_description_periods AS
- SELECT additional_code_description_periods1.additional_code_description_period_sid,
-    additional_code_description_periods1.additional_code_sid,
-    additional_code_description_periods1.additional_code_type_id,
-    additional_code_description_periods1.additional_code,
-    additional_code_description_periods1.validity_start_date,
-    additional_code_description_periods1.validity_end_date,
-    additional_code_description_periods1.oid,
-    additional_code_description_periods1.operation,
-    additional_code_description_periods1.operation_date,
-    additional_code_description_periods1.filename
+ SELECT additional_code_description_period_sid,
+    additional_code_sid,
+    additional_code_type_id,
+    additional_code,
+    validity_start_date,
+    validity_end_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.additional_code_description_periods_oplog additional_code_description_periods1
-  WHERE ((additional_code_description_periods1.oid IN ( SELECT max(additional_code_description_periods2.oid) AS max
+  WHERE ((oid IN ( SELECT max(additional_code_description_periods2.oid) AS max
            FROM uk.additional_code_description_periods_oplog additional_code_description_periods2
-          WHERE ((additional_code_description_periods1.additional_code_description_period_sid = additional_code_description_periods2.additional_code_description_period_sid) AND (additional_code_description_periods1.additional_code_sid = additional_code_description_periods2.additional_code_sid) AND ((additional_code_description_periods1.additional_code_type_id)::text = (additional_code_description_periods2.additional_code_type_id)::text)))) AND ((additional_code_description_periods1.operation)::text <> 'D'::text));
+          WHERE ((additional_code_description_periods1.additional_code_description_period_sid = additional_code_description_periods2.additional_code_description_period_sid) AND (additional_code_description_periods1.additional_code_sid = additional_code_description_periods2.additional_code_sid) AND ((additional_code_description_periods1.additional_code_type_id)::text = (additional_code_description_periods2.additional_code_type_id)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -257,21 +257,21 @@ CREATE TABLE uk.additional_code_descriptions_oplog (
 --
 
 CREATE VIEW uk.additional_code_descriptions AS
- SELECT additional_code_descriptions1.additional_code_description_period_sid,
-    additional_code_descriptions1.language_id,
-    additional_code_descriptions1.additional_code_sid,
-    additional_code_descriptions1.additional_code_type_id,
-    additional_code_descriptions1.additional_code,
-    additional_code_descriptions1.description,
-    additional_code_descriptions1."national",
-    additional_code_descriptions1.oid,
-    additional_code_descriptions1.operation,
-    additional_code_descriptions1.operation_date,
-    additional_code_descriptions1.filename
+ SELECT additional_code_description_period_sid,
+    language_id,
+    additional_code_sid,
+    additional_code_type_id,
+    additional_code,
+    description,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.additional_code_descriptions_oplog additional_code_descriptions1
-  WHERE ((additional_code_descriptions1.oid IN ( SELECT max(additional_code_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(additional_code_descriptions2.oid) AS max
            FROM uk.additional_code_descriptions_oplog additional_code_descriptions2
-          WHERE ((additional_code_descriptions1.additional_code_description_period_sid = additional_code_descriptions2.additional_code_description_period_sid) AND (additional_code_descriptions1.additional_code_sid = additional_code_descriptions2.additional_code_sid)))) AND ((additional_code_descriptions1.operation)::text <> 'D'::text));
+          WHERE ((additional_code_descriptions1.additional_code_description_period_sid = additional_code_descriptions2.additional_code_description_period_sid) AND (additional_code_descriptions1.additional_code_sid = additional_code_descriptions2.additional_code_sid)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -315,18 +315,18 @@ CREATE TABLE uk.additional_code_type_descriptions_oplog (
 --
 
 CREATE VIEW uk.additional_code_type_descriptions AS
- SELECT additional_code_type_descriptions1.additional_code_type_id,
-    additional_code_type_descriptions1.language_id,
-    additional_code_type_descriptions1.description,
-    additional_code_type_descriptions1."national",
-    additional_code_type_descriptions1.oid,
-    additional_code_type_descriptions1.operation,
-    additional_code_type_descriptions1.operation_date,
-    additional_code_type_descriptions1.filename
+ SELECT additional_code_type_id,
+    language_id,
+    description,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.additional_code_type_descriptions_oplog additional_code_type_descriptions1
-  WHERE ((additional_code_type_descriptions1.oid IN ( SELECT max(additional_code_type_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(additional_code_type_descriptions2.oid) AS max
            FROM uk.additional_code_type_descriptions_oplog additional_code_type_descriptions2
-          WHERE (((additional_code_type_descriptions1.additional_code_type_id)::text = (additional_code_type_descriptions2.additional_code_type_id)::text) AND ((additional_code_type_descriptions1.language_id)::text = (additional_code_type_descriptions2.language_id)::text)))) AND ((additional_code_type_descriptions1.operation)::text <> 'D'::text));
+          WHERE (((additional_code_type_descriptions1.additional_code_type_id)::text = (additional_code_type_descriptions2.additional_code_type_id)::text) AND ((additional_code_type_descriptions1.language_id)::text = (additional_code_type_descriptions2.language_id)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -371,19 +371,19 @@ CREATE TABLE uk.additional_code_type_measure_types_oplog (
 --
 
 CREATE VIEW uk.additional_code_type_measure_types AS
- SELECT additional_code_type_measure_types1.measure_type_id,
-    additional_code_type_measure_types1.additional_code_type_id,
-    additional_code_type_measure_types1.validity_start_date,
-    additional_code_type_measure_types1.validity_end_date,
-    additional_code_type_measure_types1."national",
-    additional_code_type_measure_types1.oid,
-    additional_code_type_measure_types1.operation,
-    additional_code_type_measure_types1.operation_date,
-    additional_code_type_measure_types1.filename
+ SELECT measure_type_id,
+    additional_code_type_id,
+    validity_start_date,
+    validity_end_date,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.additional_code_type_measure_types_oplog additional_code_type_measure_types1
-  WHERE ((additional_code_type_measure_types1.oid IN ( SELECT max(additional_code_type_measure_types2.oid) AS max
+  WHERE ((oid IN ( SELECT max(additional_code_type_measure_types2.oid) AS max
            FROM uk.additional_code_type_measure_types_oplog additional_code_type_measure_types2
-          WHERE (((additional_code_type_measure_types1.measure_type_id)::text = (additional_code_type_measure_types2.measure_type_id)::text) AND ((additional_code_type_measure_types1.additional_code_type_id)::text = (additional_code_type_measure_types2.additional_code_type_id)::text)))) AND ((additional_code_type_measure_types1.operation)::text <> 'D'::text));
+          WHERE (((additional_code_type_measure_types1.measure_type_id)::text = (additional_code_type_measure_types2.measure_type_id)::text) AND ((additional_code_type_measure_types1.additional_code_type_id)::text = (additional_code_type_measure_types2.additional_code_type_id)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -429,20 +429,20 @@ CREATE TABLE uk.additional_code_types_oplog (
 --
 
 CREATE VIEW uk.additional_code_types AS
- SELECT additional_code_types1.additional_code_type_id,
-    additional_code_types1.validity_start_date,
-    additional_code_types1.validity_end_date,
-    additional_code_types1.application_code,
-    additional_code_types1.meursing_table_plan_id,
-    additional_code_types1."national",
-    additional_code_types1.oid,
-    additional_code_types1.operation,
-    additional_code_types1.operation_date,
-    additional_code_types1.filename
+ SELECT additional_code_type_id,
+    validity_start_date,
+    validity_end_date,
+    application_code,
+    meursing_table_plan_id,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.additional_code_types_oplog additional_code_types1
-  WHERE ((additional_code_types1.oid IN ( SELECT max(additional_code_types2.oid) AS max
+  WHERE ((oid IN ( SELECT max(additional_code_types2.oid) AS max
            FROM uk.additional_code_types_oplog additional_code_types2
-          WHERE ((additional_code_types1.additional_code_type_id)::text = (additional_code_types2.additional_code_type_id)::text))) AND ((additional_code_types1.operation)::text <> 'D'::text));
+          WHERE ((additional_code_types1.additional_code_type_id)::text = (additional_code_types2.additional_code_type_id)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -488,20 +488,20 @@ CREATE TABLE uk.additional_codes_oplog (
 --
 
 CREATE VIEW uk.additional_codes AS
- SELECT additional_codes1.additional_code_sid,
-    additional_codes1.additional_code_type_id,
-    additional_codes1.additional_code,
-    additional_codes1.validity_start_date,
-    additional_codes1.validity_end_date,
-    additional_codes1."national",
-    additional_codes1.oid,
-    additional_codes1.operation,
-    additional_codes1.operation_date,
-    additional_codes1.filename
+ SELECT additional_code_sid,
+    additional_code_type_id,
+    additional_code,
+    validity_start_date,
+    validity_end_date,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.additional_codes_oplog additional_codes1
-  WHERE ((additional_codes1.oid IN ( SELECT max(additional_codes2.oid) AS max
+  WHERE ((oid IN ( SELECT max(additional_codes2.oid) AS max
            FROM uk.additional_codes_oplog additional_codes2
-          WHERE (additional_codes1.additional_code_sid = additional_codes2.additional_code_sid))) AND ((additional_codes1.operation)::text <> 'D'::text));
+          WHERE (additional_codes1.additional_code_sid = additional_codes2.additional_code_sid))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -617,18 +617,18 @@ CREATE TABLE uk.quota_associations_oplog (
 --
 
 CREATE VIEW uk.quota_associations AS
- SELECT quota_associations1.main_quota_definition_sid,
-    quota_associations1.sub_quota_definition_sid,
-    quota_associations1.relation_type,
-    quota_associations1.coefficient,
-    quota_associations1.oid,
-    quota_associations1.operation,
-    quota_associations1.operation_date,
-    quota_associations1.filename
+ SELECT main_quota_definition_sid,
+    sub_quota_definition_sid,
+    relation_type,
+    coefficient,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.quota_associations_oplog quota_associations1
-  WHERE ((quota_associations1.oid IN ( SELECT max(quota_associations2.oid) AS max
+  WHERE ((oid IN ( SELECT max(quota_associations2.oid) AS max
            FROM uk.quota_associations_oplog quota_associations2
-          WHERE ((quota_associations1.main_quota_definition_sid = quota_associations2.main_quota_definition_sid) AND (quota_associations1.sub_quota_definition_sid = quota_associations2.sub_quota_definition_sid)))) AND ((quota_associations1.operation)::text <> 'D'::text));
+          WHERE ((quota_associations1.main_quota_definition_sid = quota_associations2.main_quota_definition_sid) AND (quota_associations1.sub_quota_definition_sid = quota_associations2.sub_quota_definition_sid)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -663,28 +663,28 @@ CREATE TABLE uk.quota_definitions_oplog (
 --
 
 CREATE VIEW uk.quota_definitions AS
- SELECT quota_definitions1.quota_definition_sid,
-    quota_definitions1.quota_order_number_id,
-    quota_definitions1.validity_start_date,
-    quota_definitions1.validity_end_date,
-    quota_definitions1.quota_order_number_sid,
-    quota_definitions1.volume,
-    quota_definitions1.initial_volume,
-    quota_definitions1.measurement_unit_code,
-    quota_definitions1.maximum_precision,
-    quota_definitions1.critical_state,
-    quota_definitions1.critical_threshold,
-    quota_definitions1.monetary_unit_code,
-    quota_definitions1.measurement_unit_qualifier_code,
-    quota_definitions1.description,
-    quota_definitions1.oid,
-    quota_definitions1.operation,
-    quota_definitions1.operation_date,
-    quota_definitions1.filename
+ SELECT quota_definition_sid,
+    quota_order_number_id,
+    validity_start_date,
+    validity_end_date,
+    quota_order_number_sid,
+    volume,
+    initial_volume,
+    measurement_unit_code,
+    maximum_precision,
+    critical_state,
+    critical_threshold,
+    monetary_unit_code,
+    measurement_unit_qualifier_code,
+    description,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.quota_definitions_oplog quota_definitions1
-  WHERE ((quota_definitions1.oid IN ( SELECT max(quota_definitions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(quota_definitions2.oid) AS max
            FROM uk.quota_definitions_oplog quota_definitions2
-          WHERE (quota_definitions1.quota_definition_sid = quota_definitions2.quota_definition_sid))) AND ((quota_definitions1.operation)::text <> 'D'::text));
+          WHERE (quota_definitions1.quota_definition_sid = quota_definitions2.quota_definition_sid))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -711,20 +711,20 @@ CREATE TABLE uk.quota_order_number_origins_oplog (
 --
 
 CREATE VIEW uk.quota_order_number_origins AS
- SELECT quota_order_number_origins1.quota_order_number_origin_sid,
-    quota_order_number_origins1.quota_order_number_sid,
-    quota_order_number_origins1.geographical_area_id,
-    quota_order_number_origins1.validity_start_date,
-    quota_order_number_origins1.validity_end_date,
-    quota_order_number_origins1.geographical_area_sid,
-    quota_order_number_origins1.oid,
-    quota_order_number_origins1.operation,
-    quota_order_number_origins1.operation_date,
-    quota_order_number_origins1.filename
+ SELECT quota_order_number_origin_sid,
+    quota_order_number_sid,
+    geographical_area_id,
+    validity_start_date,
+    validity_end_date,
+    geographical_area_sid,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.quota_order_number_origins_oplog quota_order_number_origins1
-  WHERE ((quota_order_number_origins1.oid IN ( SELECT max(quota_order_number_origins2.oid) AS max
+  WHERE ((oid IN ( SELECT max(quota_order_number_origins2.oid) AS max
            FROM uk.quota_order_number_origins_oplog quota_order_number_origins2
-          WHERE (quota_order_number_origins1.quota_order_number_origin_sid = quota_order_number_origins2.quota_order_number_origin_sid))) AND ((quota_order_number_origins1.operation)::text <> 'D'::text));
+          WHERE (quota_order_number_origins1.quota_order_number_origin_sid = quota_order_number_origins2.quota_order_number_origin_sid))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -749,18 +749,18 @@ CREATE TABLE uk.quota_order_numbers_oplog (
 --
 
 CREATE VIEW uk.quota_order_numbers AS
- SELECT quota_order_numbers1.quota_order_number_sid,
-    quota_order_numbers1.quota_order_number_id,
-    quota_order_numbers1.validity_start_date,
-    quota_order_numbers1.validity_end_date,
-    quota_order_numbers1.oid,
-    quota_order_numbers1.operation,
-    quota_order_numbers1.operation_date,
-    quota_order_numbers1.filename
+ SELECT quota_order_number_sid,
+    quota_order_number_id,
+    validity_start_date,
+    validity_end_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.quota_order_numbers_oplog quota_order_numbers1
-  WHERE ((quota_order_numbers1.oid IN ( SELECT max(quota_order_numbers2.oid) AS max
+  WHERE ((oid IN ( SELECT max(quota_order_numbers2.oid) AS max
            FROM uk.quota_order_numbers_oplog quota_order_numbers2
-          WHERE (quota_order_numbers1.quota_order_number_sid = quota_order_numbers2.quota_order_number_sid))) AND ((quota_order_numbers1.operation)::text <> 'D'::text));
+          WHERE (quota_order_numbers1.quota_order_number_sid = quota_order_numbers2.quota_order_number_sid))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -830,35 +830,35 @@ CREATE TABLE uk.base_regulations_oplog (
 --
 
 CREATE VIEW uk.base_regulations AS
- SELECT base_regulations1.base_regulation_role,
-    base_regulations1.base_regulation_id,
-    base_regulations1.validity_start_date,
-    base_regulations1.validity_end_date,
-    base_regulations1.community_code,
-    base_regulations1.regulation_group_id,
-    base_regulations1.replacement_indicator,
-    base_regulations1.stopped_flag,
-    base_regulations1.information_text,
-    base_regulations1.approved_flag,
-    base_regulations1.published_date,
-    base_regulations1.officialjournal_number,
-    base_regulations1.officialjournal_page,
-    base_regulations1.effective_end_date,
-    base_regulations1.antidumping_regulation_role,
-    base_regulations1.related_antidumping_regulation_id,
-    base_regulations1.complete_abrogation_regulation_role,
-    base_regulations1.complete_abrogation_regulation_id,
-    base_regulations1.explicit_abrogation_regulation_role,
-    base_regulations1.explicit_abrogation_regulation_id,
-    base_regulations1."national",
-    base_regulations1.oid,
-    base_regulations1.operation,
-    base_regulations1.operation_date,
-    base_regulations1.filename
+ SELECT base_regulation_role,
+    base_regulation_id,
+    validity_start_date,
+    validity_end_date,
+    community_code,
+    regulation_group_id,
+    replacement_indicator,
+    stopped_flag,
+    information_text,
+    approved_flag,
+    published_date,
+    officialjournal_number,
+    officialjournal_page,
+    effective_end_date,
+    antidumping_regulation_role,
+    related_antidumping_regulation_id,
+    complete_abrogation_regulation_role,
+    complete_abrogation_regulation_id,
+    explicit_abrogation_regulation_role,
+    explicit_abrogation_regulation_id,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.base_regulations_oplog base_regulations1
-  WHERE ((base_regulations1.oid IN ( SELECT max(base_regulations2.oid) AS max
+  WHERE ((oid IN ( SELECT max(base_regulations2.oid) AS max
            FROM uk.base_regulations_oplog base_regulations2
-          WHERE (((base_regulations1.base_regulation_id)::text = (base_regulations2.base_regulation_id)::text) AND (base_regulations1.base_regulation_role = base_regulations2.base_regulation_role)))) AND ((base_regulations1.operation)::text <> 'D'::text));
+          WHERE (((base_regulations1.base_regulation_id)::text = (base_regulations2.base_regulation_id)::text) AND (base_regulations1.base_regulation_role = base_regulations2.base_regulation_role)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -904,20 +904,20 @@ CREATE TABLE uk.certificate_description_periods_oplog (
 --
 
 CREATE VIEW uk.certificate_description_periods AS
- SELECT certificate_description_periods1.certificate_description_period_sid,
-    certificate_description_periods1.certificate_type_code,
-    certificate_description_periods1.certificate_code,
-    certificate_description_periods1.validity_start_date,
-    certificate_description_periods1.validity_end_date,
-    certificate_description_periods1."national",
-    certificate_description_periods1.oid,
-    certificate_description_periods1.operation,
-    certificate_description_periods1.operation_date,
-    certificate_description_periods1.filename
+ SELECT certificate_description_period_sid,
+    certificate_type_code,
+    certificate_code,
+    validity_start_date,
+    validity_end_date,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.certificate_description_periods_oplog certificate_description_periods1
-  WHERE ((certificate_description_periods1.oid IN ( SELECT max(certificate_description_periods2.oid) AS max
+  WHERE ((oid IN ( SELECT max(certificate_description_periods2.oid) AS max
            FROM uk.certificate_description_periods_oplog certificate_description_periods2
-          WHERE (certificate_description_periods1.certificate_description_period_sid = certificate_description_periods2.certificate_description_period_sid))) AND ((certificate_description_periods1.operation)::text <> 'D'::text));
+          WHERE (certificate_description_periods1.certificate_description_period_sid = certificate_description_periods2.certificate_description_period_sid))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -963,20 +963,20 @@ CREATE TABLE uk.certificate_descriptions_oplog (
 --
 
 CREATE VIEW uk.certificate_descriptions AS
- SELECT certificate_descriptions1.certificate_description_period_sid,
-    certificate_descriptions1.language_id,
-    certificate_descriptions1.certificate_type_code,
-    certificate_descriptions1.certificate_code,
-    certificate_descriptions1.description,
-    certificate_descriptions1."national",
-    certificate_descriptions1.oid,
-    certificate_descriptions1.operation,
-    certificate_descriptions1.operation_date,
-    certificate_descriptions1.filename
+ SELECT certificate_description_period_sid,
+    language_id,
+    certificate_type_code,
+    certificate_code,
+    description,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.certificate_descriptions_oplog certificate_descriptions1
-  WHERE ((certificate_descriptions1.oid IN ( SELECT max(certificate_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(certificate_descriptions2.oid) AS max
            FROM uk.certificate_descriptions_oplog certificate_descriptions2
-          WHERE (certificate_descriptions1.certificate_description_period_sid = certificate_descriptions2.certificate_description_period_sid))) AND ((certificate_descriptions1.operation)::text <> 'D'::text));
+          WHERE (certificate_descriptions1.certificate_description_period_sid = certificate_descriptions2.certificate_description_period_sid))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -1020,18 +1020,18 @@ CREATE TABLE uk.certificate_type_descriptions_oplog (
 --
 
 CREATE VIEW uk.certificate_type_descriptions AS
- SELECT certificate_type_descriptions1.certificate_type_code,
-    certificate_type_descriptions1.language_id,
-    certificate_type_descriptions1.description,
-    certificate_type_descriptions1."national",
-    certificate_type_descriptions1.oid,
-    certificate_type_descriptions1.operation,
-    certificate_type_descriptions1.operation_date,
-    certificate_type_descriptions1.filename
+ SELECT certificate_type_code,
+    language_id,
+    description,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.certificate_type_descriptions_oplog certificate_type_descriptions1
-  WHERE ((certificate_type_descriptions1.oid IN ( SELECT max(certificate_type_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(certificate_type_descriptions2.oid) AS max
            FROM uk.certificate_type_descriptions_oplog certificate_type_descriptions2
-          WHERE ((certificate_type_descriptions1.certificate_type_code)::text = (certificate_type_descriptions2.certificate_type_code)::text))) AND ((certificate_type_descriptions1.operation)::text <> 'D'::text));
+          WHERE ((certificate_type_descriptions1.certificate_type_code)::text = (certificate_type_descriptions2.certificate_type_code)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -1075,18 +1075,18 @@ CREATE TABLE uk.certificate_types_oplog (
 --
 
 CREATE VIEW uk.certificate_types AS
- SELECT certificate_types1.certificate_type_code,
-    certificate_types1.validity_start_date,
-    certificate_types1.validity_end_date,
-    certificate_types1."national",
-    certificate_types1.oid,
-    certificate_types1.operation,
-    certificate_types1.operation_date,
-    certificate_types1.filename
+ SELECT certificate_type_code,
+    validity_start_date,
+    validity_end_date,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.certificate_types_oplog certificate_types1
-  WHERE ((certificate_types1.oid IN ( SELECT max(certificate_types2.oid) AS max
+  WHERE ((oid IN ( SELECT max(certificate_types2.oid) AS max
            FROM uk.certificate_types_oplog certificate_types2
-          WHERE ((certificate_types1.certificate_type_code)::text = (certificate_types2.certificate_type_code)::text))) AND ((certificate_types1.operation)::text <> 'D'::text));
+          WHERE ((certificate_types1.certificate_type_code)::text = (certificate_types2.certificate_type_code)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -1132,20 +1132,20 @@ CREATE TABLE uk.certificates_oplog (
 --
 
 CREATE VIEW uk.certificates AS
- SELECT certificates1.certificate_type_code,
-    certificates1.certificate_code,
-    certificates1.validity_start_date,
-    certificates1.validity_end_date,
-    certificates1."national",
-    certificates1.national_abbrev,
-    certificates1.oid,
-    certificates1.operation,
-    certificates1.operation_date,
-    certificates1.filename
+ SELECT certificate_type_code,
+    certificate_code,
+    validity_start_date,
+    validity_end_date,
+    "national",
+    national_abbrev,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.certificates_oplog certificates1
-  WHERE ((certificates1.oid IN ( SELECT max(certificates2.oid) AS max
+  WHERE ((oid IN ( SELECT max(certificates2.oid) AS max
            FROM uk.certificates_oplog certificates2
-          WHERE (((certificates1.certificate_code)::text = (certificates2.certificate_code)::text) AND ((certificates1.certificate_type_code)::text = (certificates2.certificate_type_code)::text)))) AND ((certificates1.operation)::text <> 'D'::text));
+          WHERE (((certificates1.certificate_code)::text = (certificates2.certificate_code)::text) AND ((certificates1.certificate_type_code)::text = (certificates2.certificate_type_code)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -1699,22 +1699,22 @@ CREATE TABLE uk.complete_abrogation_regulations_oplog (
 --
 
 CREATE VIEW uk.complete_abrogation_regulations AS
- SELECT complete_abrogation_regulations1.complete_abrogation_regulation_role,
-    complete_abrogation_regulations1.complete_abrogation_regulation_id,
-    complete_abrogation_regulations1.published_date,
-    complete_abrogation_regulations1.officialjournal_number,
-    complete_abrogation_regulations1.officialjournal_page,
-    complete_abrogation_regulations1.replacement_indicator,
-    complete_abrogation_regulations1.information_text,
-    complete_abrogation_regulations1.approved_flag,
-    complete_abrogation_regulations1.oid,
-    complete_abrogation_regulations1.operation,
-    complete_abrogation_regulations1.operation_date,
-    complete_abrogation_regulations1.filename
+ SELECT complete_abrogation_regulation_role,
+    complete_abrogation_regulation_id,
+    published_date,
+    officialjournal_number,
+    officialjournal_page,
+    replacement_indicator,
+    information_text,
+    approved_flag,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.complete_abrogation_regulations_oplog complete_abrogation_regulations1
-  WHERE ((complete_abrogation_regulations1.oid IN ( SELECT max(complete_abrogation_regulations2.oid) AS max
+  WHERE ((oid IN ( SELECT max(complete_abrogation_regulations2.oid) AS max
            FROM uk.complete_abrogation_regulations_oplog complete_abrogation_regulations2
-          WHERE (((complete_abrogation_regulations1.complete_abrogation_regulation_id)::text = (complete_abrogation_regulations2.complete_abrogation_regulation_id)::text) AND (complete_abrogation_regulations1.complete_abrogation_regulation_role = complete_abrogation_regulations2.complete_abrogation_regulation_role)))) AND ((complete_abrogation_regulations1.operation)::text <> 'D'::text));
+          WHERE (((complete_abrogation_regulations1.complete_abrogation_regulation_id)::text = (complete_abrogation_regulations2.complete_abrogation_regulation_id)::text) AND (complete_abrogation_regulations1.complete_abrogation_regulation_role = complete_abrogation_regulations2.complete_abrogation_regulation_role)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -1817,17 +1817,17 @@ CREATE TABLE uk.duty_expression_descriptions_oplog (
 --
 
 CREATE VIEW uk.duty_expression_descriptions AS
- SELECT duty_expression_descriptions1.duty_expression_id,
-    duty_expression_descriptions1.language_id,
-    duty_expression_descriptions1.description,
-    duty_expression_descriptions1.oid,
-    duty_expression_descriptions1.operation,
-    duty_expression_descriptions1.operation_date,
-    duty_expression_descriptions1.filename
+ SELECT duty_expression_id,
+    language_id,
+    description,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.duty_expression_descriptions_oplog duty_expression_descriptions1
-  WHERE ((duty_expression_descriptions1.oid IN ( SELECT max(duty_expression_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(duty_expression_descriptions2.oid) AS max
            FROM uk.duty_expression_descriptions_oplog duty_expression_descriptions2
-          WHERE ((duty_expression_descriptions1.duty_expression_id)::text = (duty_expression_descriptions2.duty_expression_id)::text))) AND ((duty_expression_descriptions1.operation)::text <> 'D'::text));
+          WHERE ((duty_expression_descriptions1.duty_expression_id)::text = (duty_expression_descriptions2.duty_expression_id)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -1873,20 +1873,20 @@ CREATE TABLE uk.duty_expressions_oplog (
 --
 
 CREATE VIEW uk.duty_expressions AS
- SELECT duty_expressions1.duty_expression_id,
-    duty_expressions1.validity_start_date,
-    duty_expressions1.validity_end_date,
-    duty_expressions1.duty_amount_applicability_code,
-    duty_expressions1.measurement_unit_applicability_code,
-    duty_expressions1.monetary_unit_applicability_code,
-    duty_expressions1.oid,
-    duty_expressions1.operation,
-    duty_expressions1.operation_date,
-    duty_expressions1.filename
+ SELECT duty_expression_id,
+    validity_start_date,
+    validity_end_date,
+    duty_amount_applicability_code,
+    measurement_unit_applicability_code,
+    monetary_unit_applicability_code,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.duty_expressions_oplog duty_expressions1
-  WHERE ((duty_expressions1.oid IN ( SELECT max(duty_expressions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(duty_expressions2.oid) AS max
            FROM uk.duty_expressions_oplog duty_expressions2
-          WHERE ((duty_expressions1.duty_expression_id)::text = (duty_expressions2.duty_expression_id)::text))) AND ((duty_expressions1.operation)::text <> 'D'::text));
+          WHERE ((duty_expressions1.duty_expression_id)::text = (duty_expressions2.duty_expression_id)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -2046,23 +2046,23 @@ CREATE TABLE uk.explicit_abrogation_regulations_oplog (
 --
 
 CREATE VIEW uk.explicit_abrogation_regulations AS
- SELECT explicit_abrogation_regulations1.explicit_abrogation_regulation_role,
-    explicit_abrogation_regulations1.explicit_abrogation_regulation_id,
-    explicit_abrogation_regulations1.published_date,
-    explicit_abrogation_regulations1.officialjournal_number,
-    explicit_abrogation_regulations1.officialjournal_page,
-    explicit_abrogation_regulations1.replacement_indicator,
-    explicit_abrogation_regulations1.abrogation_date,
-    explicit_abrogation_regulations1.information_text,
-    explicit_abrogation_regulations1.approved_flag,
-    explicit_abrogation_regulations1.oid,
-    explicit_abrogation_regulations1.operation,
-    explicit_abrogation_regulations1.operation_date,
-    explicit_abrogation_regulations1.filename
+ SELECT explicit_abrogation_regulation_role,
+    explicit_abrogation_regulation_id,
+    published_date,
+    officialjournal_number,
+    officialjournal_page,
+    replacement_indicator,
+    abrogation_date,
+    information_text,
+    approved_flag,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.explicit_abrogation_regulations_oplog explicit_abrogation_regulations1
-  WHERE ((explicit_abrogation_regulations1.oid IN ( SELECT max(explicit_abrogation_regulations2.oid) AS max
+  WHERE ((oid IN ( SELECT max(explicit_abrogation_regulations2.oid) AS max
            FROM uk.explicit_abrogation_regulations_oplog explicit_abrogation_regulations2
-          WHERE (((explicit_abrogation_regulations1.explicit_abrogation_regulation_id)::text = (explicit_abrogation_regulations2.explicit_abrogation_regulation_id)::text) AND (explicit_abrogation_regulations1.explicit_abrogation_regulation_role = explicit_abrogation_regulations2.explicit_abrogation_regulation_role)))) AND ((explicit_abrogation_regulations1.operation)::text <> 'D'::text));
+          WHERE (((explicit_abrogation_regulations1.explicit_abrogation_regulation_id)::text = (explicit_abrogation_regulations2.explicit_abrogation_regulation_id)::text) AND (explicit_abrogation_regulations1.explicit_abrogation_regulation_role = explicit_abrogation_regulations2.explicit_abrogation_regulation_role)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -2110,22 +2110,22 @@ CREATE TABLE uk.export_refund_nomenclature_description_periods_oplog (
 --
 
 CREATE VIEW uk.export_refund_nomenclature_description_periods AS
- SELECT export_refund_nomenclature_description_periods1.export_refund_nomenclature_description_period_sid,
-    export_refund_nomenclature_description_periods1.export_refund_nomenclature_sid,
-    export_refund_nomenclature_description_periods1.validity_start_date,
-    export_refund_nomenclature_description_periods1.goods_nomenclature_item_id,
-    export_refund_nomenclature_description_periods1.additional_code_type,
-    export_refund_nomenclature_description_periods1.export_refund_code,
-    export_refund_nomenclature_description_periods1.productline_suffix,
-    export_refund_nomenclature_description_periods1.validity_end_date,
-    export_refund_nomenclature_description_periods1.oid,
-    export_refund_nomenclature_description_periods1.operation,
-    export_refund_nomenclature_description_periods1.operation_date,
-    export_refund_nomenclature_description_periods1.filename
+ SELECT export_refund_nomenclature_description_period_sid,
+    export_refund_nomenclature_sid,
+    validity_start_date,
+    goods_nomenclature_item_id,
+    additional_code_type,
+    export_refund_code,
+    productline_suffix,
+    validity_end_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.export_refund_nomenclature_description_periods_oplog export_refund_nomenclature_description_periods1
-  WHERE ((export_refund_nomenclature_description_periods1.oid IN ( SELECT max(export_refund_nomenclature_description_periods2.oid) AS max
+  WHERE ((oid IN ( SELECT max(export_refund_nomenclature_description_periods2.oid) AS max
            FROM uk.export_refund_nomenclature_description_periods_oplog export_refund_nomenclature_description_periods2
-          WHERE ((export_refund_nomenclature_description_periods1.export_refund_nomenclature_sid = export_refund_nomenclature_description_periods2.export_refund_nomenclature_sid) AND (export_refund_nomenclature_description_periods1.export_refund_nomenclature_description_period_sid = export_refund_nomenclature_description_periods2.export_refund_nomenclature_description_period_sid)))) AND ((export_refund_nomenclature_description_periods1.operation)::text <> 'D'::text));
+          WHERE ((export_refund_nomenclature_description_periods1.export_refund_nomenclature_sid = export_refund_nomenclature_description_periods2.export_refund_nomenclature_sid) AND (export_refund_nomenclature_description_periods1.export_refund_nomenclature_description_period_sid = export_refund_nomenclature_description_periods2.export_refund_nomenclature_description_period_sid)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -2173,22 +2173,22 @@ CREATE TABLE uk.export_refund_nomenclature_descriptions_oplog (
 --
 
 CREATE VIEW uk.export_refund_nomenclature_descriptions AS
- SELECT export_refund_nomenclature_descriptions1.export_refund_nomenclature_description_period_sid,
-    export_refund_nomenclature_descriptions1.language_id,
-    export_refund_nomenclature_descriptions1.export_refund_nomenclature_sid,
-    export_refund_nomenclature_descriptions1.goods_nomenclature_item_id,
-    export_refund_nomenclature_descriptions1.additional_code_type,
-    export_refund_nomenclature_descriptions1.export_refund_code,
-    export_refund_nomenclature_descriptions1.productline_suffix,
-    export_refund_nomenclature_descriptions1.description,
-    export_refund_nomenclature_descriptions1.oid,
-    export_refund_nomenclature_descriptions1.operation,
-    export_refund_nomenclature_descriptions1.operation_date,
-    export_refund_nomenclature_descriptions1.filename
+ SELECT export_refund_nomenclature_description_period_sid,
+    language_id,
+    export_refund_nomenclature_sid,
+    goods_nomenclature_item_id,
+    additional_code_type,
+    export_refund_code,
+    productline_suffix,
+    description,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.export_refund_nomenclature_descriptions_oplog export_refund_nomenclature_descriptions1
-  WHERE ((export_refund_nomenclature_descriptions1.oid IN ( SELECT max(export_refund_nomenclature_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(export_refund_nomenclature_descriptions2.oid) AS max
            FROM uk.export_refund_nomenclature_descriptions_oplog export_refund_nomenclature_descriptions2
-          WHERE (export_refund_nomenclature_descriptions1.export_refund_nomenclature_description_period_sid = export_refund_nomenclature_descriptions2.export_refund_nomenclature_description_period_sid))) AND ((export_refund_nomenclature_descriptions1.operation)::text <> 'D'::text));
+          WHERE (export_refund_nomenclature_descriptions1.export_refund_nomenclature_description_period_sid = export_refund_nomenclature_descriptions2.export_refund_nomenclature_description_period_sid))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -2237,23 +2237,23 @@ CREATE TABLE uk.export_refund_nomenclature_indents_oplog (
 --
 
 CREATE VIEW uk.export_refund_nomenclature_indents AS
- SELECT export_refund_nomenclature_indents1.export_refund_nomenclature_indents_sid,
-    export_refund_nomenclature_indents1.export_refund_nomenclature_sid,
-    export_refund_nomenclature_indents1.validity_start_date,
-    export_refund_nomenclature_indents1.number_export_refund_nomenclature_indents,
-    export_refund_nomenclature_indents1.goods_nomenclature_item_id,
-    export_refund_nomenclature_indents1.additional_code_type,
-    export_refund_nomenclature_indents1.export_refund_code,
-    export_refund_nomenclature_indents1.productline_suffix,
-    export_refund_nomenclature_indents1.validity_end_date,
-    export_refund_nomenclature_indents1.oid,
-    export_refund_nomenclature_indents1.operation,
-    export_refund_nomenclature_indents1.operation_date,
-    export_refund_nomenclature_indents1.filename
+ SELECT export_refund_nomenclature_indents_sid,
+    export_refund_nomenclature_sid,
+    validity_start_date,
+    number_export_refund_nomenclature_indents,
+    goods_nomenclature_item_id,
+    additional_code_type,
+    export_refund_code,
+    productline_suffix,
+    validity_end_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.export_refund_nomenclature_indents_oplog export_refund_nomenclature_indents1
-  WHERE ((export_refund_nomenclature_indents1.oid IN ( SELECT max(export_refund_nomenclature_indents2.oid) AS max
+  WHERE ((oid IN ( SELECT max(export_refund_nomenclature_indents2.oid) AS max
            FROM uk.export_refund_nomenclature_indents_oplog export_refund_nomenclature_indents2
-          WHERE (export_refund_nomenclature_indents1.export_refund_nomenclature_indents_sid = export_refund_nomenclature_indents2.export_refund_nomenclature_indents_sid))) AND ((export_refund_nomenclature_indents1.operation)::text <> 'D'::text));
+          WHERE (export_refund_nomenclature_indents1.export_refund_nomenclature_indents_sid = export_refund_nomenclature_indents2.export_refund_nomenclature_indents_sid))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -2301,22 +2301,22 @@ CREATE TABLE uk.export_refund_nomenclatures_oplog (
 --
 
 CREATE VIEW uk.export_refund_nomenclatures AS
- SELECT export_refund_nomenclatures1.export_refund_nomenclature_sid,
-    export_refund_nomenclatures1.goods_nomenclature_item_id,
-    export_refund_nomenclatures1.additional_code_type,
-    export_refund_nomenclatures1.export_refund_code,
-    export_refund_nomenclatures1.productline_suffix,
-    export_refund_nomenclatures1.validity_start_date,
-    export_refund_nomenclatures1.validity_end_date,
-    export_refund_nomenclatures1.goods_nomenclature_sid,
-    export_refund_nomenclatures1.oid,
-    export_refund_nomenclatures1.operation,
-    export_refund_nomenclatures1.operation_date,
-    export_refund_nomenclatures1.filename
+ SELECT export_refund_nomenclature_sid,
+    goods_nomenclature_item_id,
+    additional_code_type,
+    export_refund_code,
+    productline_suffix,
+    validity_start_date,
+    validity_end_date,
+    goods_nomenclature_sid,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.export_refund_nomenclatures_oplog export_refund_nomenclatures1
-  WHERE ((export_refund_nomenclatures1.oid IN ( SELECT max(export_refund_nomenclatures2.oid) AS max
+  WHERE ((oid IN ( SELECT max(export_refund_nomenclatures2.oid) AS max
            FROM uk.export_refund_nomenclatures_oplog export_refund_nomenclatures2
-          WHERE (export_refund_nomenclatures1.export_refund_nomenclature_sid = export_refund_nomenclatures2.export_refund_nomenclature_sid))) AND ((export_refund_nomenclatures1.operation)::text <> 'D'::text));
+          WHERE (export_refund_nomenclatures1.export_refund_nomenclature_sid = export_refund_nomenclatures2.export_refund_nomenclature_sid))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -2363,21 +2363,21 @@ CREATE TABLE uk.footnote_association_additional_codes_oplog (
 --
 
 CREATE VIEW uk.footnote_association_additional_codes AS
- SELECT footnote_association_additional_codes1.additional_code_sid,
-    footnote_association_additional_codes1.footnote_type_id,
-    footnote_association_additional_codes1.footnote_id,
-    footnote_association_additional_codes1.validity_start_date,
-    footnote_association_additional_codes1.validity_end_date,
-    footnote_association_additional_codes1.additional_code_type_id,
-    footnote_association_additional_codes1.additional_code,
-    footnote_association_additional_codes1.oid,
-    footnote_association_additional_codes1.operation,
-    footnote_association_additional_codes1.operation_date,
-    footnote_association_additional_codes1.filename
+ SELECT additional_code_sid,
+    footnote_type_id,
+    footnote_id,
+    validity_start_date,
+    validity_end_date,
+    additional_code_type_id,
+    additional_code,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.footnote_association_additional_codes_oplog footnote_association_additional_codes1
-  WHERE ((footnote_association_additional_codes1.oid IN ( SELECT max(footnote_association_additional_codes2.oid) AS max
+  WHERE ((oid IN ( SELECT max(footnote_association_additional_codes2.oid) AS max
            FROM uk.footnote_association_additional_codes_oplog footnote_association_additional_codes2
-          WHERE (((footnote_association_additional_codes1.footnote_id)::text = (footnote_association_additional_codes2.footnote_id)::text) AND ((footnote_association_additional_codes1.footnote_type_id)::text = (footnote_association_additional_codes2.footnote_type_id)::text) AND (footnote_association_additional_codes1.additional_code_sid = footnote_association_additional_codes2.additional_code_sid)))) AND ((footnote_association_additional_codes1.operation)::text <> 'D'::text));
+          WHERE (((footnote_association_additional_codes1.footnote_id)::text = (footnote_association_additional_codes2.footnote_id)::text) AND ((footnote_association_additional_codes1.footnote_type_id)::text = (footnote_association_additional_codes2.footnote_type_id)::text) AND (footnote_association_additional_codes1.additional_code_sid = footnote_association_additional_codes2.additional_code_sid)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -2426,23 +2426,23 @@ CREATE TABLE uk.footnote_association_erns_oplog (
 --
 
 CREATE VIEW uk.footnote_association_erns AS
- SELECT footnote_association_erns1.export_refund_nomenclature_sid,
-    footnote_association_erns1.footnote_type,
-    footnote_association_erns1.footnote_id,
-    footnote_association_erns1.validity_start_date,
-    footnote_association_erns1.validity_end_date,
-    footnote_association_erns1.goods_nomenclature_item_id,
-    footnote_association_erns1.additional_code_type,
-    footnote_association_erns1.export_refund_code,
-    footnote_association_erns1.productline_suffix,
-    footnote_association_erns1.oid,
-    footnote_association_erns1.operation,
-    footnote_association_erns1.operation_date,
-    footnote_association_erns1.filename
+ SELECT export_refund_nomenclature_sid,
+    footnote_type,
+    footnote_id,
+    validity_start_date,
+    validity_end_date,
+    goods_nomenclature_item_id,
+    additional_code_type,
+    export_refund_code,
+    productline_suffix,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.footnote_association_erns_oplog footnote_association_erns1
-  WHERE ((footnote_association_erns1.oid IN ( SELECT max(footnote_association_erns2.oid) AS max
+  WHERE ((oid IN ( SELECT max(footnote_association_erns2.oid) AS max
            FROM uk.footnote_association_erns_oplog footnote_association_erns2
-          WHERE ((footnote_association_erns1.export_refund_nomenclature_sid = footnote_association_erns2.export_refund_nomenclature_sid) AND ((footnote_association_erns1.footnote_id)::text = (footnote_association_erns2.footnote_id)::text) AND ((footnote_association_erns1.footnote_type)::text = (footnote_association_erns2.footnote_type)::text) AND (footnote_association_erns1.validity_start_date = footnote_association_erns2.validity_start_date)))) AND ((footnote_association_erns1.operation)::text <> 'D'::text));
+          WHERE ((footnote_association_erns1.export_refund_nomenclature_sid = footnote_association_erns2.export_refund_nomenclature_sid) AND ((footnote_association_erns1.footnote_id)::text = (footnote_association_erns2.footnote_id)::text) AND ((footnote_association_erns1.footnote_type)::text = (footnote_association_erns2.footnote_type)::text) AND (footnote_association_erns1.validity_start_date = footnote_association_erns2.validity_start_date)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -2490,22 +2490,22 @@ CREATE TABLE uk.footnote_association_goods_nomenclatures_oplog (
 --
 
 CREATE VIEW uk.footnote_association_goods_nomenclatures AS
- SELECT footnote_association_goods_nomenclatures1.goods_nomenclature_sid,
-    footnote_association_goods_nomenclatures1.footnote_type,
-    footnote_association_goods_nomenclatures1.footnote_id,
-    footnote_association_goods_nomenclatures1.validity_start_date,
-    footnote_association_goods_nomenclatures1.validity_end_date,
-    footnote_association_goods_nomenclatures1.goods_nomenclature_item_id,
-    footnote_association_goods_nomenclatures1.productline_suffix,
-    footnote_association_goods_nomenclatures1."national",
-    footnote_association_goods_nomenclatures1.oid,
-    footnote_association_goods_nomenclatures1.operation,
-    footnote_association_goods_nomenclatures1.operation_date,
-    footnote_association_goods_nomenclatures1.filename
+ SELECT goods_nomenclature_sid,
+    footnote_type,
+    footnote_id,
+    validity_start_date,
+    validity_end_date,
+    goods_nomenclature_item_id,
+    productline_suffix,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.footnote_association_goods_nomenclatures_oplog footnote_association_goods_nomenclatures1
-  WHERE ((footnote_association_goods_nomenclatures1.oid IN ( SELECT max(footnote_association_goods_nomenclatures2.oid) AS max
+  WHERE ((oid IN ( SELECT max(footnote_association_goods_nomenclatures2.oid) AS max
            FROM uk.footnote_association_goods_nomenclatures_oplog footnote_association_goods_nomenclatures2
-          WHERE (((footnote_association_goods_nomenclatures1.footnote_id)::text = (footnote_association_goods_nomenclatures2.footnote_id)::text) AND ((footnote_association_goods_nomenclatures1.footnote_type)::text = (footnote_association_goods_nomenclatures2.footnote_type)::text) AND (footnote_association_goods_nomenclatures1.goods_nomenclature_sid = footnote_association_goods_nomenclatures2.goods_nomenclature_sid)))) AND ((footnote_association_goods_nomenclatures1.operation)::text <> 'D'::text));
+          WHERE (((footnote_association_goods_nomenclatures1.footnote_id)::text = (footnote_association_goods_nomenclatures2.footnote_id)::text) AND ((footnote_association_goods_nomenclatures1.footnote_type)::text = (footnote_association_goods_nomenclatures2.footnote_type)::text) AND (footnote_association_goods_nomenclatures1.goods_nomenclature_sid = footnote_association_goods_nomenclatures2.goods_nomenclature_sid)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -2549,18 +2549,18 @@ CREATE TABLE uk.footnote_association_measures_oplog (
 --
 
 CREATE VIEW uk.footnote_association_measures AS
- SELECT footnote_association_measures1.measure_sid,
-    footnote_association_measures1.footnote_type_id,
-    footnote_association_measures1.footnote_id,
-    footnote_association_measures1."national",
-    footnote_association_measures1.oid,
-    footnote_association_measures1.operation,
-    footnote_association_measures1.operation_date,
-    footnote_association_measures1.filename
+ SELECT measure_sid,
+    footnote_type_id,
+    footnote_id,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.footnote_association_measures_oplog footnote_association_measures1
-  WHERE ((footnote_association_measures1.oid IN ( SELECT max(footnote_association_measures2.oid) AS max
+  WHERE ((oid IN ( SELECT max(footnote_association_measures2.oid) AS max
            FROM uk.footnote_association_measures_oplog footnote_association_measures2
-          WHERE ((footnote_association_measures1.measure_sid = footnote_association_measures2.measure_sid) AND ((footnote_association_measures1.footnote_id)::text = (footnote_association_measures2.footnote_id)::text) AND ((footnote_association_measures1.footnote_type_id)::text = (footnote_association_measures2.footnote_type_id)::text)))) AND ((footnote_association_measures1.operation)::text <> 'D'::text));
+          WHERE ((footnote_association_measures1.measure_sid = footnote_association_measures2.measure_sid) AND ((footnote_association_measures1.footnote_id)::text = (footnote_association_measures2.footnote_id)::text) AND ((footnote_association_measures1.footnote_type_id)::text = (footnote_association_measures2.footnote_type_id)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -2607,21 +2607,21 @@ CREATE TABLE uk.footnote_association_meursing_headings_oplog (
 --
 
 CREATE VIEW uk.footnote_association_meursing_headings AS
- SELECT footnote_association_meursing_headings1.meursing_table_plan_id,
-    footnote_association_meursing_headings1.meursing_heading_number,
-    footnote_association_meursing_headings1.row_column_code,
-    footnote_association_meursing_headings1.footnote_type,
-    footnote_association_meursing_headings1.footnote_id,
-    footnote_association_meursing_headings1.validity_start_date,
-    footnote_association_meursing_headings1.validity_end_date,
-    footnote_association_meursing_headings1.oid,
-    footnote_association_meursing_headings1.operation,
-    footnote_association_meursing_headings1.operation_date,
-    footnote_association_meursing_headings1.filename
+ SELECT meursing_table_plan_id,
+    meursing_heading_number,
+    row_column_code,
+    footnote_type,
+    footnote_id,
+    validity_start_date,
+    validity_end_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.footnote_association_meursing_headings_oplog footnote_association_meursing_headings1
-  WHERE ((footnote_association_meursing_headings1.oid IN ( SELECT max(footnote_association_meursing_headings2.oid) AS max
+  WHERE ((oid IN ( SELECT max(footnote_association_meursing_headings2.oid) AS max
            FROM uk.footnote_association_meursing_headings_oplog footnote_association_meursing_headings2
-          WHERE (((footnote_association_meursing_headings1.footnote_id)::text = (footnote_association_meursing_headings2.footnote_id)::text) AND ((footnote_association_meursing_headings1.meursing_table_plan_id)::text = (footnote_association_meursing_headings2.meursing_table_plan_id)::text)))) AND ((footnote_association_meursing_headings1.operation)::text <> 'D'::text));
+          WHERE (((footnote_association_meursing_headings1.footnote_id)::text = (footnote_association_meursing_headings2.footnote_id)::text) AND ((footnote_association_meursing_headings1.meursing_table_plan_id)::text = (footnote_association_meursing_headings2.meursing_table_plan_id)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -2667,20 +2667,20 @@ CREATE TABLE uk.footnote_description_periods_oplog (
 --
 
 CREATE VIEW uk.footnote_description_periods AS
- SELECT footnote_description_periods1.footnote_description_period_sid,
-    footnote_description_periods1.footnote_type_id,
-    footnote_description_periods1.footnote_id,
-    footnote_description_periods1.validity_start_date,
-    footnote_description_periods1.validity_end_date,
-    footnote_description_periods1."national",
-    footnote_description_periods1.oid,
-    footnote_description_periods1.operation,
-    footnote_description_periods1.operation_date,
-    footnote_description_periods1.filename
+ SELECT footnote_description_period_sid,
+    footnote_type_id,
+    footnote_id,
+    validity_start_date,
+    validity_end_date,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.footnote_description_periods_oplog footnote_description_periods1
-  WHERE ((footnote_description_periods1.oid IN ( SELECT max(footnote_description_periods2.oid) AS max
+  WHERE ((oid IN ( SELECT max(footnote_description_periods2.oid) AS max
            FROM uk.footnote_description_periods_oplog footnote_description_periods2
-          WHERE (((footnote_description_periods1.footnote_id)::text = (footnote_description_periods2.footnote_id)::text) AND ((footnote_description_periods1.footnote_type_id)::text = (footnote_description_periods2.footnote_type_id)::text) AND (footnote_description_periods1.footnote_description_period_sid = footnote_description_periods2.footnote_description_period_sid)))) AND ((footnote_description_periods1.operation)::text <> 'D'::text));
+          WHERE (((footnote_description_periods1.footnote_id)::text = (footnote_description_periods2.footnote_id)::text) AND ((footnote_description_periods1.footnote_type_id)::text = (footnote_description_periods2.footnote_type_id)::text) AND (footnote_description_periods1.footnote_description_period_sid = footnote_description_periods2.footnote_description_period_sid)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -2726,20 +2726,20 @@ CREATE TABLE uk.footnote_descriptions_oplog (
 --
 
 CREATE VIEW uk.footnote_descriptions AS
- SELECT footnote_descriptions1.footnote_description_period_sid,
-    footnote_descriptions1.footnote_type_id,
-    footnote_descriptions1.footnote_id,
-    footnote_descriptions1.language_id,
-    footnote_descriptions1.description,
-    footnote_descriptions1."national",
-    footnote_descriptions1.oid,
-    footnote_descriptions1.operation,
-    footnote_descriptions1.operation_date,
-    footnote_descriptions1.filename
+ SELECT footnote_description_period_sid,
+    footnote_type_id,
+    footnote_id,
+    language_id,
+    description,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.footnote_descriptions_oplog footnote_descriptions1
-  WHERE ((footnote_descriptions1.oid IN ( SELECT max(footnote_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(footnote_descriptions2.oid) AS max
            FROM uk.footnote_descriptions_oplog footnote_descriptions2
-          WHERE ((footnote_descriptions1.footnote_description_period_sid = footnote_descriptions2.footnote_description_period_sid) AND ((footnote_descriptions1.footnote_id)::text = (footnote_descriptions2.footnote_id)::text) AND ((footnote_descriptions1.footnote_type_id)::text = (footnote_descriptions2.footnote_type_id)::text)))) AND ((footnote_descriptions1.operation)::text <> 'D'::text));
+          WHERE ((footnote_descriptions1.footnote_description_period_sid = footnote_descriptions2.footnote_description_period_sid) AND ((footnote_descriptions1.footnote_id)::text = (footnote_descriptions2.footnote_id)::text) AND ((footnote_descriptions1.footnote_type_id)::text = (footnote_descriptions2.footnote_type_id)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -2783,18 +2783,18 @@ CREATE TABLE uk.footnote_type_descriptions_oplog (
 --
 
 CREATE VIEW uk.footnote_type_descriptions AS
- SELECT footnote_type_descriptions1.footnote_type_id,
-    footnote_type_descriptions1.language_id,
-    footnote_type_descriptions1.description,
-    footnote_type_descriptions1."national",
-    footnote_type_descriptions1.oid,
-    footnote_type_descriptions1.operation,
-    footnote_type_descriptions1.operation_date,
-    footnote_type_descriptions1.filename
+ SELECT footnote_type_id,
+    language_id,
+    description,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.footnote_type_descriptions_oplog footnote_type_descriptions1
-  WHERE ((footnote_type_descriptions1.oid IN ( SELECT max(footnote_type_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(footnote_type_descriptions2.oid) AS max
            FROM uk.footnote_type_descriptions_oplog footnote_type_descriptions2
-          WHERE ((footnote_type_descriptions1.footnote_type_id)::text = (footnote_type_descriptions2.footnote_type_id)::text))) AND ((footnote_type_descriptions1.operation)::text <> 'D'::text));
+          WHERE ((footnote_type_descriptions1.footnote_type_id)::text = (footnote_type_descriptions2.footnote_type_id)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -2839,19 +2839,19 @@ CREATE TABLE uk.footnote_types_oplog (
 --
 
 CREATE VIEW uk.footnote_types AS
- SELECT footnote_types1.footnote_type_id,
-    footnote_types1.application_code,
-    footnote_types1.validity_start_date,
-    footnote_types1.validity_end_date,
-    footnote_types1."national",
-    footnote_types1.oid,
-    footnote_types1.operation,
-    footnote_types1.operation_date,
-    footnote_types1.filename
+ SELECT footnote_type_id,
+    application_code,
+    validity_start_date,
+    validity_end_date,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.footnote_types_oplog footnote_types1
-  WHERE ((footnote_types1.oid IN ( SELECT max(footnote_types2.oid) AS max
+  WHERE ((oid IN ( SELECT max(footnote_types2.oid) AS max
            FROM uk.footnote_types_oplog footnote_types2
-          WHERE ((footnote_types1.footnote_type_id)::text = (footnote_types2.footnote_type_id)::text))) AND ((footnote_types1.operation)::text <> 'D'::text));
+          WHERE ((footnote_types1.footnote_type_id)::text = (footnote_types2.footnote_type_id)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -2896,19 +2896,19 @@ CREATE TABLE uk.footnotes_oplog (
 --
 
 CREATE VIEW uk.footnotes AS
- SELECT footnotes1.footnote_id,
-    footnotes1.footnote_type_id,
-    footnotes1.validity_start_date,
-    footnotes1.validity_end_date,
-    footnotes1."national",
-    footnotes1.oid,
-    footnotes1.operation,
-    footnotes1.operation_date,
-    footnotes1.filename
+ SELECT footnote_id,
+    footnote_type_id,
+    validity_start_date,
+    validity_end_date,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.footnotes_oplog footnotes1
-  WHERE ((footnotes1.oid IN ( SELECT max(footnotes2.oid) AS max
+  WHERE ((oid IN ( SELECT max(footnotes2.oid) AS max
            FROM uk.footnotes_oplog footnotes2
-          WHERE (((footnotes1.footnote_type_id)::text = (footnotes2.footnote_type_id)::text) AND ((footnotes1.footnote_id)::text = (footnotes2.footnote_id)::text)))) AND ((footnotes1.operation)::text <> 'D'::text));
+          WHERE (((footnotes1.footnote_type_id)::text = (footnotes2.footnote_type_id)::text) AND ((footnotes1.footnote_id)::text = (footnotes2.footnote_id)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -2978,18 +2978,18 @@ CREATE TABLE uk.fts_regulation_actions_oplog (
 --
 
 CREATE VIEW uk.fts_regulation_actions AS
- SELECT fts_regulation_actions1.fts_regulation_role,
-    fts_regulation_actions1.fts_regulation_id,
-    fts_regulation_actions1.stopped_regulation_role,
-    fts_regulation_actions1.stopped_regulation_id,
-    fts_regulation_actions1.oid,
-    fts_regulation_actions1.operation,
-    fts_regulation_actions1.operation_date,
-    fts_regulation_actions1.filename
+ SELECT fts_regulation_role,
+    fts_regulation_id,
+    stopped_regulation_role,
+    stopped_regulation_id,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.fts_regulation_actions_oplog fts_regulation_actions1
-  WHERE ((fts_regulation_actions1.oid IN ( SELECT max(fts_regulation_actions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(fts_regulation_actions2.oid) AS max
            FROM uk.fts_regulation_actions_oplog fts_regulation_actions2
-          WHERE (((fts_regulation_actions1.fts_regulation_id)::text = (fts_regulation_actions2.fts_regulation_id)::text) AND (fts_regulation_actions1.fts_regulation_role = fts_regulation_actions2.fts_regulation_role) AND ((fts_regulation_actions1.stopped_regulation_id)::text = (fts_regulation_actions2.stopped_regulation_id)::text) AND (fts_regulation_actions1.stopped_regulation_role = fts_regulation_actions2.stopped_regulation_role)))) AND ((fts_regulation_actions1.operation)::text <> 'D'::text));
+          WHERE (((fts_regulation_actions1.fts_regulation_id)::text = (fts_regulation_actions2.fts_regulation_id)::text) AND (fts_regulation_actions1.fts_regulation_role = fts_regulation_actions2.fts_regulation_role) AND ((fts_regulation_actions1.stopped_regulation_id)::text = (fts_regulation_actions2.stopped_regulation_id)::text) AND (fts_regulation_actions1.stopped_regulation_role = fts_regulation_actions2.stopped_regulation_role)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -3064,29 +3064,29 @@ CREATE TABLE uk.full_temporary_stop_regulations_oplog (
 --
 
 CREATE VIEW uk.full_temporary_stop_regulations AS
- SELECT full_temporary_stop_regulations1.full_temporary_stop_regulation_role,
-    full_temporary_stop_regulations1.full_temporary_stop_regulation_id,
-    full_temporary_stop_regulations1.published_date,
-    full_temporary_stop_regulations1.officialjournal_number,
-    full_temporary_stop_regulations1.officialjournal_page,
-    full_temporary_stop_regulations1.validity_start_date,
-    full_temporary_stop_regulations1.validity_end_date,
-    full_temporary_stop_regulations1.effective_enddate,
-    full_temporary_stop_regulations1.explicit_abrogation_regulation_role,
-    full_temporary_stop_regulations1.explicit_abrogation_regulation_id,
-    full_temporary_stop_regulations1.replacement_indicator,
-    full_temporary_stop_regulations1.information_text,
-    full_temporary_stop_regulations1.approved_flag,
-    full_temporary_stop_regulations1.oid,
-    full_temporary_stop_regulations1.operation,
-    full_temporary_stop_regulations1.operation_date,
-    full_temporary_stop_regulations1.complete_abrogation_regulation_role,
-    full_temporary_stop_regulations1.complete_abrogation_regulation_id,
-    full_temporary_stop_regulations1.filename
+ SELECT full_temporary_stop_regulation_role,
+    full_temporary_stop_regulation_id,
+    published_date,
+    officialjournal_number,
+    officialjournal_page,
+    validity_start_date,
+    validity_end_date,
+    effective_enddate,
+    explicit_abrogation_regulation_role,
+    explicit_abrogation_regulation_id,
+    replacement_indicator,
+    information_text,
+    approved_flag,
+    oid,
+    operation,
+    operation_date,
+    complete_abrogation_regulation_role,
+    complete_abrogation_regulation_id,
+    filename
    FROM uk.full_temporary_stop_regulations_oplog full_temporary_stop_regulations1
-  WHERE ((full_temporary_stop_regulations1.oid IN ( SELECT max(full_temporary_stop_regulations2.oid) AS max
+  WHERE ((oid IN ( SELECT max(full_temporary_stop_regulations2.oid) AS max
            FROM uk.full_temporary_stop_regulations_oplog full_temporary_stop_regulations2
-          WHERE (((full_temporary_stop_regulations1.full_temporary_stop_regulation_id)::text = (full_temporary_stop_regulations2.full_temporary_stop_regulation_id)::text) AND (full_temporary_stop_regulations1.full_temporary_stop_regulation_role = full_temporary_stop_regulations2.full_temporary_stop_regulation_role)))) AND ((full_temporary_stop_regulations1.operation)::text <> 'D'::text));
+          WHERE (((full_temporary_stop_regulations1.full_temporary_stop_regulation_id)::text = (full_temporary_stop_regulations2.full_temporary_stop_regulation_id)::text) AND (full_temporary_stop_regulations1.full_temporary_stop_regulation_role = full_temporary_stop_regulations2.full_temporary_stop_regulation_role)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -3132,20 +3132,20 @@ CREATE TABLE uk.geographical_area_description_periods_oplog (
 --
 
 CREATE VIEW uk.geographical_area_description_periods AS
- SELECT geographical_area_description_periods1.geographical_area_description_period_sid,
-    geographical_area_description_periods1.geographical_area_sid,
-    geographical_area_description_periods1.validity_start_date,
-    geographical_area_description_periods1.geographical_area_id,
-    geographical_area_description_periods1.validity_end_date,
-    geographical_area_description_periods1."national",
-    geographical_area_description_periods1.oid,
-    geographical_area_description_periods1.operation,
-    geographical_area_description_periods1.operation_date,
-    geographical_area_description_periods1.filename
+ SELECT geographical_area_description_period_sid,
+    geographical_area_sid,
+    validity_start_date,
+    geographical_area_id,
+    validity_end_date,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.geographical_area_description_periods_oplog geographical_area_description_periods1
-  WHERE ((geographical_area_description_periods1.oid IN ( SELECT max(geographical_area_description_periods2.oid) AS max
+  WHERE ((oid IN ( SELECT max(geographical_area_description_periods2.oid) AS max
            FROM uk.geographical_area_description_periods_oplog geographical_area_description_periods2
-          WHERE ((geographical_area_description_periods1.geographical_area_description_period_sid = geographical_area_description_periods2.geographical_area_description_period_sid) AND (geographical_area_description_periods1.geographical_area_sid = geographical_area_description_periods2.geographical_area_sid)))) AND ((geographical_area_description_periods1.operation)::text <> 'D'::text));
+          WHERE ((geographical_area_description_periods1.geographical_area_description_period_sid = geographical_area_description_periods2.geographical_area_description_period_sid) AND (geographical_area_description_periods1.geographical_area_sid = geographical_area_description_periods2.geographical_area_sid)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -3191,20 +3191,20 @@ CREATE TABLE uk.geographical_area_descriptions_oplog (
 --
 
 CREATE VIEW uk.geographical_area_descriptions AS
- SELECT geographical_area_descriptions1.geographical_area_description_period_sid,
-    geographical_area_descriptions1.language_id,
-    geographical_area_descriptions1.geographical_area_sid,
-    geographical_area_descriptions1.geographical_area_id,
-    geographical_area_descriptions1.description,
-    geographical_area_descriptions1."national",
-    geographical_area_descriptions1.oid,
-    geographical_area_descriptions1.operation,
-    geographical_area_descriptions1.operation_date,
-    geographical_area_descriptions1.filename
+ SELECT geographical_area_description_period_sid,
+    language_id,
+    geographical_area_sid,
+    geographical_area_id,
+    description,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.geographical_area_descriptions_oplog geographical_area_descriptions1
-  WHERE ((geographical_area_descriptions1.oid IN ( SELECT max(geographical_area_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(geographical_area_descriptions2.oid) AS max
            FROM uk.geographical_area_descriptions_oplog geographical_area_descriptions2
-          WHERE ((geographical_area_descriptions1.geographical_area_description_period_sid = geographical_area_descriptions2.geographical_area_description_period_sid) AND (geographical_area_descriptions1.geographical_area_sid = geographical_area_descriptions2.geographical_area_sid)))) AND ((geographical_area_descriptions1.operation)::text <> 'D'::text));
+          WHERE ((geographical_area_descriptions1.geographical_area_description_period_sid = geographical_area_descriptions2.geographical_area_description_period_sid) AND (geographical_area_descriptions1.geographical_area_sid = geographical_area_descriptions2.geographical_area_sid)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -3252,22 +3252,22 @@ CREATE TABLE uk.geographical_area_memberships_oplog (
 --
 
 CREATE VIEW uk.geographical_area_memberships AS
- SELECT geographical_area_memberships1.geographical_area_sid,
-    geographical_area_memberships1.geographical_area_group_sid,
-    geographical_area_memberships1.validity_start_date,
-    geographical_area_memberships1.validity_end_date,
-    geographical_area_memberships1."national",
-    geographical_area_memberships1.oid,
-    geographical_area_memberships1.operation,
-    geographical_area_memberships1.operation_date,
-    geographical_area_memberships1.filename,
-    geographical_area_memberships1.hjid,
-    geographical_area_memberships1.geographical_area_hjid,
-    geographical_area_memberships1.geographical_area_group_hjid
+ SELECT geographical_area_sid,
+    geographical_area_group_sid,
+    validity_start_date,
+    validity_end_date,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename,
+    hjid,
+    geographical_area_hjid,
+    geographical_area_group_hjid
    FROM uk.geographical_area_memberships_oplog geographical_area_memberships1
-  WHERE ((geographical_area_memberships1.oid IN ( SELECT max(geographical_area_memberships2.oid) AS max
+  WHERE ((oid IN ( SELECT max(geographical_area_memberships2.oid) AS max
            FROM uk.geographical_area_memberships_oplog geographical_area_memberships2
-          WHERE ((geographical_area_memberships1.geographical_area_sid = geographical_area_memberships2.geographical_area_sid) AND (geographical_area_memberships1.geographical_area_group_sid = geographical_area_memberships2.geographical_area_group_sid) AND (geographical_area_memberships1.validity_start_date = geographical_area_memberships2.validity_start_date)))) AND ((geographical_area_memberships1.operation)::text <> 'D'::text));
+          WHERE ((geographical_area_memberships1.geographical_area_sid = geographical_area_memberships2.geographical_area_sid) AND (geographical_area_memberships1.geographical_area_group_sid = geographical_area_memberships2.geographical_area_group_sid) AND (geographical_area_memberships1.validity_start_date = geographical_area_memberships2.validity_start_date)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -3315,22 +3315,22 @@ CREATE TABLE uk.geographical_areas_oplog (
 --
 
 CREATE VIEW uk.geographical_areas AS
- SELECT geographical_areas1.geographical_area_sid,
-    geographical_areas1.parent_geographical_area_group_sid,
-    geographical_areas1.validity_start_date,
-    geographical_areas1.validity_end_date,
-    geographical_areas1.geographical_code,
-    geographical_areas1.geographical_area_id,
-    geographical_areas1."national",
-    geographical_areas1.oid,
-    geographical_areas1.operation,
-    geographical_areas1.operation_date,
-    geographical_areas1.filename,
-    geographical_areas1.hjid
+ SELECT geographical_area_sid,
+    parent_geographical_area_group_sid,
+    validity_start_date,
+    validity_end_date,
+    geographical_code,
+    geographical_area_id,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename,
+    hjid
    FROM uk.geographical_areas_oplog geographical_areas1
-  WHERE ((geographical_areas1.oid IN ( SELECT max(geographical_areas2.oid) AS max
+  WHERE ((oid IN ( SELECT max(geographical_areas2.oid) AS max
            FROM uk.geographical_areas_oplog geographical_areas2
-          WHERE (geographical_areas1.geographical_area_sid = geographical_areas2.geographical_area_sid))) AND ((geographical_areas1.operation)::text <> 'D'::text));
+          WHERE (geographical_areas1.geographical_area_sid = geographical_areas2.geographical_area_sid))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -3376,20 +3376,20 @@ CREATE TABLE uk.goods_nomenclature_description_periods_oplog (
 --
 
 CREATE VIEW uk.goods_nomenclature_description_periods AS
- SELECT goods_nomenclature_description_periods1.goods_nomenclature_description_period_sid,
-    goods_nomenclature_description_periods1.goods_nomenclature_sid,
-    goods_nomenclature_description_periods1.validity_start_date,
-    goods_nomenclature_description_periods1.goods_nomenclature_item_id,
-    goods_nomenclature_description_periods1.productline_suffix,
-    goods_nomenclature_description_periods1.validity_end_date,
-    goods_nomenclature_description_periods1.oid,
-    goods_nomenclature_description_periods1.operation,
-    goods_nomenclature_description_periods1.operation_date,
-    goods_nomenclature_description_periods1.filename
+ SELECT goods_nomenclature_description_period_sid,
+    goods_nomenclature_sid,
+    validity_start_date,
+    goods_nomenclature_item_id,
+    productline_suffix,
+    validity_end_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.goods_nomenclature_description_periods_oplog goods_nomenclature_description_periods1
-  WHERE ((goods_nomenclature_description_periods1.oid IN ( SELECT max(goods_nomenclature_description_periods2.oid) AS max
+  WHERE ((oid IN ( SELECT max(goods_nomenclature_description_periods2.oid) AS max
            FROM uk.goods_nomenclature_description_periods_oplog goods_nomenclature_description_periods2
-          WHERE (goods_nomenclature_description_periods1.goods_nomenclature_description_period_sid = goods_nomenclature_description_periods2.goods_nomenclature_description_period_sid))) AND ((goods_nomenclature_description_periods1.operation)::text <> 'D'::text));
+          WHERE (goods_nomenclature_description_periods1.goods_nomenclature_description_period_sid = goods_nomenclature_description_periods2.goods_nomenclature_description_period_sid))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -3435,20 +3435,20 @@ CREATE TABLE uk.goods_nomenclature_descriptions_oplog (
 --
 
 CREATE VIEW uk.goods_nomenclature_descriptions AS
- SELECT goods_nomenclature_descriptions1.goods_nomenclature_description_period_sid,
-    goods_nomenclature_descriptions1.language_id,
-    goods_nomenclature_descriptions1.goods_nomenclature_sid,
-    goods_nomenclature_descriptions1.goods_nomenclature_item_id,
-    goods_nomenclature_descriptions1.productline_suffix,
-    goods_nomenclature_descriptions1.description,
-    goods_nomenclature_descriptions1.oid,
-    goods_nomenclature_descriptions1.operation,
-    goods_nomenclature_descriptions1.operation_date,
-    goods_nomenclature_descriptions1.filename
+ SELECT goods_nomenclature_description_period_sid,
+    language_id,
+    goods_nomenclature_sid,
+    goods_nomenclature_item_id,
+    productline_suffix,
+    description,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.goods_nomenclature_descriptions_oplog goods_nomenclature_descriptions1
-  WHERE ((goods_nomenclature_descriptions1.oid IN ( SELECT max(goods_nomenclature_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(goods_nomenclature_descriptions2.oid) AS max
            FROM uk.goods_nomenclature_descriptions_oplog goods_nomenclature_descriptions2
-          WHERE ((goods_nomenclature_descriptions1.goods_nomenclature_sid = goods_nomenclature_descriptions2.goods_nomenclature_sid) AND (goods_nomenclature_descriptions1.goods_nomenclature_description_period_sid = goods_nomenclature_descriptions2.goods_nomenclature_description_period_sid)))) AND ((goods_nomenclature_descriptions1.operation)::text <> 'D'::text));
+          WHERE ((goods_nomenclature_descriptions1.goods_nomenclature_sid = goods_nomenclature_descriptions2.goods_nomenclature_sid) AND (goods_nomenclature_descriptions1.goods_nomenclature_description_period_sid = goods_nomenclature_descriptions2.goods_nomenclature_description_period_sid)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -3492,18 +3492,18 @@ CREATE TABLE uk.goods_nomenclature_group_descriptions_oplog (
 --
 
 CREATE VIEW uk.goods_nomenclature_group_descriptions AS
- SELECT goods_nomenclature_group_descriptions1.goods_nomenclature_group_type,
-    goods_nomenclature_group_descriptions1.goods_nomenclature_group_id,
-    goods_nomenclature_group_descriptions1.language_id,
-    goods_nomenclature_group_descriptions1.description,
-    goods_nomenclature_group_descriptions1.oid,
-    goods_nomenclature_group_descriptions1.operation,
-    goods_nomenclature_group_descriptions1.operation_date,
-    goods_nomenclature_group_descriptions1.filename
+ SELECT goods_nomenclature_group_type,
+    goods_nomenclature_group_id,
+    language_id,
+    description,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.goods_nomenclature_group_descriptions_oplog goods_nomenclature_group_descriptions1
-  WHERE ((goods_nomenclature_group_descriptions1.oid IN ( SELECT max(goods_nomenclature_group_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(goods_nomenclature_group_descriptions2.oid) AS max
            FROM uk.goods_nomenclature_group_descriptions_oplog goods_nomenclature_group_descriptions2
-          WHERE (((goods_nomenclature_group_descriptions1.goods_nomenclature_group_id)::text = (goods_nomenclature_group_descriptions2.goods_nomenclature_group_id)::text) AND ((goods_nomenclature_group_descriptions1.goods_nomenclature_group_type)::text = (goods_nomenclature_group_descriptions2.goods_nomenclature_group_type)::text)))) AND ((goods_nomenclature_group_descriptions1.operation)::text <> 'D'::text));
+          WHERE (((goods_nomenclature_group_descriptions1.goods_nomenclature_group_id)::text = (goods_nomenclature_group_descriptions2.goods_nomenclature_group_id)::text) AND ((goods_nomenclature_group_descriptions1.goods_nomenclature_group_type)::text = (goods_nomenclature_group_descriptions2.goods_nomenclature_group_type)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -3548,19 +3548,19 @@ CREATE TABLE uk.goods_nomenclature_groups_oplog (
 --
 
 CREATE VIEW uk.goods_nomenclature_groups AS
- SELECT goods_nomenclature_groups1.goods_nomenclature_group_type,
-    goods_nomenclature_groups1.goods_nomenclature_group_id,
-    goods_nomenclature_groups1.validity_start_date,
-    goods_nomenclature_groups1.validity_end_date,
-    goods_nomenclature_groups1.nomenclature_group_facility_code,
-    goods_nomenclature_groups1.oid,
-    goods_nomenclature_groups1.operation,
-    goods_nomenclature_groups1.operation_date,
-    goods_nomenclature_groups1.filename
+ SELECT goods_nomenclature_group_type,
+    goods_nomenclature_group_id,
+    validity_start_date,
+    validity_end_date,
+    nomenclature_group_facility_code,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.goods_nomenclature_groups_oplog goods_nomenclature_groups1
-  WHERE ((goods_nomenclature_groups1.oid IN ( SELECT max(goods_nomenclature_groups2.oid) AS max
+  WHERE ((oid IN ( SELECT max(goods_nomenclature_groups2.oid) AS max
            FROM uk.goods_nomenclature_groups_oplog goods_nomenclature_groups2
-          WHERE (((goods_nomenclature_groups1.goods_nomenclature_group_id)::text = (goods_nomenclature_groups2.goods_nomenclature_group_id)::text) AND ((goods_nomenclature_groups1.goods_nomenclature_group_type)::text = (goods_nomenclature_groups2.goods_nomenclature_group_type)::text)))) AND ((goods_nomenclature_groups1.operation)::text <> 'D'::text));
+          WHERE (((goods_nomenclature_groups1.goods_nomenclature_group_id)::text = (goods_nomenclature_groups2.goods_nomenclature_group_id)::text) AND ((goods_nomenclature_groups1.goods_nomenclature_group_type)::text = (goods_nomenclature_groups2.goods_nomenclature_group_type)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -3607,21 +3607,21 @@ CREATE TABLE uk.goods_nomenclature_indents_oplog (
 --
 
 CREATE VIEW uk.goods_nomenclature_indents AS
- SELECT goods_nomenclature_indents1.goods_nomenclature_indent_sid,
-    goods_nomenclature_indents1.goods_nomenclature_sid,
-    goods_nomenclature_indents1.validity_start_date,
-    goods_nomenclature_indents1.number_indents,
-    goods_nomenclature_indents1.goods_nomenclature_item_id,
-    goods_nomenclature_indents1.productline_suffix,
-    goods_nomenclature_indents1.validity_end_date,
-    goods_nomenclature_indents1.oid,
-    goods_nomenclature_indents1.operation,
-    goods_nomenclature_indents1.operation_date,
-    goods_nomenclature_indents1.filename
+ SELECT goods_nomenclature_indent_sid,
+    goods_nomenclature_sid,
+    validity_start_date,
+    number_indents,
+    goods_nomenclature_item_id,
+    productline_suffix,
+    validity_end_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.goods_nomenclature_indents_oplog goods_nomenclature_indents1
-  WHERE ((goods_nomenclature_indents1.oid IN ( SELECT max(goods_nomenclature_indents2.oid) AS max
+  WHERE ((oid IN ( SELECT max(goods_nomenclature_indents2.oid) AS max
            FROM uk.goods_nomenclature_indents_oplog goods_nomenclature_indents2
-          WHERE (goods_nomenclature_indents1.goods_nomenclature_indent_sid = goods_nomenclature_indents2.goods_nomenclature_indent_sid))) AND ((goods_nomenclature_indents1.operation)::text <> 'D'::text));
+          WHERE (goods_nomenclature_indents1.goods_nomenclature_indent_sid = goods_nomenclature_indents2.goods_nomenclature_indent_sid))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -3666,19 +3666,19 @@ CREATE TABLE uk.goods_nomenclature_origins_oplog (
 --
 
 CREATE VIEW uk.goods_nomenclature_origins AS
- SELECT goods_nomenclature_origins1.goods_nomenclature_sid,
-    goods_nomenclature_origins1.derived_goods_nomenclature_item_id,
-    goods_nomenclature_origins1.derived_productline_suffix,
-    goods_nomenclature_origins1.goods_nomenclature_item_id,
-    goods_nomenclature_origins1.productline_suffix,
-    goods_nomenclature_origins1.oid,
-    goods_nomenclature_origins1.operation,
-    goods_nomenclature_origins1.operation_date,
-    goods_nomenclature_origins1.filename
+ SELECT goods_nomenclature_sid,
+    derived_goods_nomenclature_item_id,
+    derived_productline_suffix,
+    goods_nomenclature_item_id,
+    productline_suffix,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.goods_nomenclature_origins_oplog goods_nomenclature_origins1
-  WHERE ((goods_nomenclature_origins1.oid IN ( SELECT max(goods_nomenclature_origins2.oid) AS max
+  WHERE ((oid IN ( SELECT max(goods_nomenclature_origins2.oid) AS max
            FROM uk.goods_nomenclature_origins_oplog goods_nomenclature_origins2
-          WHERE ((goods_nomenclature_origins1.goods_nomenclature_sid = goods_nomenclature_origins2.goods_nomenclature_sid) AND ((goods_nomenclature_origins1.derived_goods_nomenclature_item_id)::text = (goods_nomenclature_origins2.derived_goods_nomenclature_item_id)::text) AND ((goods_nomenclature_origins1.derived_productline_suffix)::text = (goods_nomenclature_origins2.derived_productline_suffix)::text) AND ((goods_nomenclature_origins1.goods_nomenclature_item_id)::text = (goods_nomenclature_origins2.goods_nomenclature_item_id)::text) AND ((goods_nomenclature_origins1.productline_suffix)::text = (goods_nomenclature_origins2.productline_suffix)::text)))) AND ((goods_nomenclature_origins1.operation)::text <> 'D'::text));
+          WHERE ((goods_nomenclature_origins1.goods_nomenclature_sid = goods_nomenclature_origins2.goods_nomenclature_sid) AND ((goods_nomenclature_origins1.derived_goods_nomenclature_item_id)::text = (goods_nomenclature_origins2.derived_goods_nomenclature_item_id)::text) AND ((goods_nomenclature_origins1.derived_productline_suffix)::text = (goods_nomenclature_origins2.derived_productline_suffix)::text) AND ((goods_nomenclature_origins1.goods_nomenclature_item_id)::text = (goods_nomenclature_origins2.goods_nomenclature_item_id)::text) AND ((goods_nomenclature_origins1.productline_suffix)::text = (goods_nomenclature_origins2.productline_suffix)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -3723,19 +3723,19 @@ CREATE TABLE uk.goods_nomenclature_successors_oplog (
 --
 
 CREATE VIEW uk.goods_nomenclature_successors AS
- SELECT goods_nomenclature_successors1.goods_nomenclature_sid,
-    goods_nomenclature_successors1.absorbed_goods_nomenclature_item_id,
-    goods_nomenclature_successors1.absorbed_productline_suffix,
-    goods_nomenclature_successors1.goods_nomenclature_item_id,
-    goods_nomenclature_successors1.productline_suffix,
-    goods_nomenclature_successors1.oid,
-    goods_nomenclature_successors1.operation,
-    goods_nomenclature_successors1.operation_date,
-    goods_nomenclature_successors1.filename
+ SELECT goods_nomenclature_sid,
+    absorbed_goods_nomenclature_item_id,
+    absorbed_productline_suffix,
+    goods_nomenclature_item_id,
+    productline_suffix,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.goods_nomenclature_successors_oplog goods_nomenclature_successors1
-  WHERE ((goods_nomenclature_successors1.oid IN ( SELECT max(goods_nomenclature_successors2.oid) AS max
+  WHERE ((oid IN ( SELECT max(goods_nomenclature_successors2.oid) AS max
            FROM uk.goods_nomenclature_successors_oplog goods_nomenclature_successors2
-          WHERE ((goods_nomenclature_successors1.goods_nomenclature_sid = goods_nomenclature_successors2.goods_nomenclature_sid) AND ((goods_nomenclature_successors1.absorbed_goods_nomenclature_item_id)::text = (goods_nomenclature_successors2.absorbed_goods_nomenclature_item_id)::text) AND ((goods_nomenclature_successors1.absorbed_productline_suffix)::text = (goods_nomenclature_successors2.absorbed_productline_suffix)::text) AND ((goods_nomenclature_successors1.goods_nomenclature_item_id)::text = (goods_nomenclature_successors2.goods_nomenclature_item_id)::text) AND ((goods_nomenclature_successors1.productline_suffix)::text = (goods_nomenclature_successors2.productline_suffix)::text)))) AND ((goods_nomenclature_successors1.operation)::text <> 'D'::text));
+          WHERE ((goods_nomenclature_successors1.goods_nomenclature_sid = goods_nomenclature_successors2.goods_nomenclature_sid) AND ((goods_nomenclature_successors1.absorbed_goods_nomenclature_item_id)::text = (goods_nomenclature_successors2.absorbed_goods_nomenclature_item_id)::text) AND ((goods_nomenclature_successors1.absorbed_productline_suffix)::text = (goods_nomenclature_successors2.absorbed_productline_suffix)::text) AND ((goods_nomenclature_successors1.goods_nomenclature_item_id)::text = (goods_nomenclature_successors2.goods_nomenclature_item_id)::text) AND ((goods_nomenclature_successors1.productline_suffix)::text = (goods_nomenclature_successors2.productline_suffix)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -3800,7 +3800,7 @@ CREATE TABLE uk.goods_nomenclatures_oplog (
     operation character varying(1) DEFAULT 'C'::character varying,
     operation_date date,
     filename text,
-    path integer[] DEFAULT ARRAY[]::integer[] NOT NULL
+    path integer[]
 );
 
 
@@ -3809,26 +3809,26 @@ CREATE TABLE uk.goods_nomenclatures_oplog (
 --
 
 CREATE VIEW uk.goods_nomenclatures AS
- SELECT goods_nomenclatures1.goods_nomenclature_sid,
-    goods_nomenclatures1.goods_nomenclature_item_id,
-    goods_nomenclatures1.producline_suffix,
-    goods_nomenclatures1.validity_start_date,
-    goods_nomenclatures1.validity_end_date,
-    goods_nomenclatures1.statistical_indicator,
-    goods_nomenclatures1.oid,
-    goods_nomenclatures1.operation,
-    goods_nomenclatures1.operation_date,
-    goods_nomenclatures1.filename,
-    goods_nomenclatures1.path,
+ SELECT goods_nomenclature_sid,
+    goods_nomenclature_item_id,
+    producline_suffix,
+    validity_start_date,
+    validity_end_date,
+    statistical_indicator,
+    oid,
+    operation,
+    operation_date,
+    filename,
+    path,
         CASE
-            WHEN ((goods_nomenclatures1.goods_nomenclature_item_id)::text ~~ '__00000000'::text) THEN NULL::text
-            ELSE "left"((goods_nomenclatures1.goods_nomenclature_item_id)::text, 4)
+            WHEN ((goods_nomenclature_item_id)::text ~~ '__00000000'::text) THEN NULL::text
+            ELSE "left"((goods_nomenclature_item_id)::text, 4)
         END AS heading_short_code,
-    "left"((goods_nomenclatures1.goods_nomenclature_item_id)::text, 2) AS chapter_short_code
+    "left"((goods_nomenclature_item_id)::text, 2) AS chapter_short_code
    FROM uk.goods_nomenclatures_oplog goods_nomenclatures1
-  WHERE ((goods_nomenclatures1.oid IN ( SELECT max(goods_nomenclatures2.oid) AS max
+  WHERE ((oid IN ( SELECT max(goods_nomenclatures2.oid) AS max
            FROM uk.goods_nomenclatures_oplog goods_nomenclatures2
-          WHERE (goods_nomenclatures1.goods_nomenclature_sid = goods_nomenclatures2.goods_nomenclature_sid))) AND ((goods_nomenclatures1.operation)::text <> 'D'::text));
+          WHERE (goods_nomenclatures1.goods_nomenclature_sid = goods_nomenclatures2.goods_nomenclature_sid))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -4198,17 +4198,17 @@ CREATE TABLE uk.language_descriptions_oplog (
 --
 
 CREATE VIEW uk.language_descriptions AS
- SELECT language_descriptions1.language_code_id,
-    language_descriptions1.language_id,
-    language_descriptions1.description,
-    language_descriptions1.oid,
-    language_descriptions1.operation,
-    language_descriptions1.operation_date,
-    language_descriptions1.filename
+ SELECT language_code_id,
+    language_id,
+    description,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.language_descriptions_oplog language_descriptions1
-  WHERE ((language_descriptions1.oid IN ( SELECT max(language_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(language_descriptions2.oid) AS max
            FROM uk.language_descriptions_oplog language_descriptions2
-          WHERE (((language_descriptions1.language_id)::text = (language_descriptions2.language_id)::text) AND ((language_descriptions1.language_code_id)::text = (language_descriptions2.language_code_id)::text)))) AND ((language_descriptions1.operation)::text <> 'D'::text));
+          WHERE (((language_descriptions1.language_id)::text = (language_descriptions2.language_id)::text) AND ((language_descriptions1.language_code_id)::text = (language_descriptions2.language_code_id)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -4251,17 +4251,17 @@ CREATE TABLE uk.languages_oplog (
 --
 
 CREATE VIEW uk.languages AS
- SELECT languages1.language_id,
-    languages1.validity_start_date,
-    languages1.validity_end_date,
-    languages1.oid,
-    languages1.operation,
-    languages1.operation_date,
-    languages1.filename
+ SELECT language_id,
+    validity_start_date,
+    validity_end_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.languages_oplog languages1
-  WHERE ((languages1.oid IN ( SELECT max(languages2.oid) AS max
+  WHERE ((oid IN ( SELECT max(languages2.oid) AS max
            FROM uk.languages_oplog languages2
-          WHERE ((languages1.language_id)::text = (languages2.language_id)::text))) AND ((languages1.operation)::text <> 'D'::text));
+          WHERE ((languages1.language_id)::text = (languages2.language_id)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -4304,17 +4304,17 @@ CREATE TABLE uk.measure_action_descriptions_oplog (
 --
 
 CREATE VIEW uk.measure_action_descriptions AS
- SELECT measure_action_descriptions1.action_code,
-    measure_action_descriptions1.language_id,
-    measure_action_descriptions1.description,
-    measure_action_descriptions1.oid,
-    measure_action_descriptions1.operation,
-    measure_action_descriptions1.operation_date,
-    measure_action_descriptions1.filename
+ SELECT action_code,
+    language_id,
+    description,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.measure_action_descriptions_oplog measure_action_descriptions1
-  WHERE ((measure_action_descriptions1.oid IN ( SELECT max(measure_action_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(measure_action_descriptions2.oid) AS max
            FROM uk.measure_action_descriptions_oplog measure_action_descriptions2
-          WHERE ((measure_action_descriptions1.action_code)::text = (measure_action_descriptions2.action_code)::text))) AND ((measure_action_descriptions1.operation)::text <> 'D'::text));
+          WHERE ((measure_action_descriptions1.action_code)::text = (measure_action_descriptions2.action_code)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -4357,17 +4357,17 @@ CREATE TABLE uk.measure_actions_oplog (
 --
 
 CREATE VIEW uk.measure_actions AS
- SELECT measure_actions1.action_code,
-    measure_actions1.validity_start_date,
-    measure_actions1.validity_end_date,
-    measure_actions1.oid,
-    measure_actions1.operation,
-    measure_actions1.operation_date,
-    measure_actions1.filename
+ SELECT action_code,
+    validity_start_date,
+    validity_end_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.measure_actions_oplog measure_actions1
-  WHERE ((measure_actions1.oid IN ( SELECT max(measure_actions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(measure_actions2.oid) AS max
            FROM uk.measure_actions_oplog measure_actions2
-          WHERE ((measure_actions1.action_code)::text = (measure_actions2.action_code)::text))) AND ((measure_actions1.operation)::text <> 'D'::text));
+          WHERE ((measure_actions1.action_code)::text = (measure_actions2.action_code)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -4413,20 +4413,20 @@ CREATE TABLE uk.measure_components_oplog (
 --
 
 CREATE VIEW uk.measure_components AS
- SELECT measure_components1.measure_sid,
-    measure_components1.duty_expression_id,
-    measure_components1.duty_amount,
-    measure_components1.monetary_unit_code,
-    measure_components1.measurement_unit_code,
-    measure_components1.measurement_unit_qualifier_code,
-    measure_components1.oid,
-    measure_components1.operation,
-    measure_components1.operation_date,
-    measure_components1.filename
+ SELECT measure_sid,
+    duty_expression_id,
+    duty_amount,
+    monetary_unit_code,
+    measurement_unit_code,
+    measurement_unit_qualifier_code,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.measure_components_oplog measure_components1
-  WHERE ((measure_components1.oid IN ( SELECT max(measure_components2.oid) AS max
+  WHERE ((oid IN ( SELECT max(measure_components2.oid) AS max
            FROM uk.measure_components_oplog measure_components2
-          WHERE ((measure_components1.measure_sid = measure_components2.measure_sid) AND ((measure_components1.duty_expression_id)::text = (measure_components2.duty_expression_id)::text)))) AND ((measure_components1.operation)::text <> 'D'::text));
+          WHERE ((measure_components1.measure_sid = measure_components2.measure_sid) AND ((measure_components1.duty_expression_id)::text = (measure_components2.duty_expression_id)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -4469,17 +4469,17 @@ CREATE TABLE uk.measure_condition_code_descriptions_oplog (
 --
 
 CREATE VIEW uk.measure_condition_code_descriptions AS
- SELECT measure_condition_code_descriptions1.condition_code,
-    measure_condition_code_descriptions1.language_id,
-    measure_condition_code_descriptions1.description,
-    measure_condition_code_descriptions1.oid,
-    measure_condition_code_descriptions1.operation,
-    measure_condition_code_descriptions1.operation_date,
-    measure_condition_code_descriptions1.filename
+ SELECT condition_code,
+    language_id,
+    description,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.measure_condition_code_descriptions_oplog measure_condition_code_descriptions1
-  WHERE ((measure_condition_code_descriptions1.oid IN ( SELECT max(measure_condition_code_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(measure_condition_code_descriptions2.oid) AS max
            FROM uk.measure_condition_code_descriptions_oplog measure_condition_code_descriptions2
-          WHERE ((measure_condition_code_descriptions1.condition_code)::text = (measure_condition_code_descriptions2.condition_code)::text))) AND ((measure_condition_code_descriptions1.operation)::text <> 'D'::text));
+          WHERE ((measure_condition_code_descriptions1.condition_code)::text = (measure_condition_code_descriptions2.condition_code)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -4522,17 +4522,17 @@ CREATE TABLE uk.measure_condition_codes_oplog (
 --
 
 CREATE VIEW uk.measure_condition_codes AS
- SELECT measure_condition_codes1.condition_code,
-    measure_condition_codes1.validity_start_date,
-    measure_condition_codes1.validity_end_date,
-    measure_condition_codes1.oid,
-    measure_condition_codes1.operation,
-    measure_condition_codes1.operation_date,
-    measure_condition_codes1.filename
+ SELECT condition_code,
+    validity_start_date,
+    validity_end_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.measure_condition_codes_oplog measure_condition_codes1
-  WHERE ((measure_condition_codes1.oid IN ( SELECT max(measure_condition_codes2.oid) AS max
+  WHERE ((oid IN ( SELECT max(measure_condition_codes2.oid) AS max
            FROM uk.measure_condition_codes_oplog measure_condition_codes2
-          WHERE ((measure_condition_codes1.condition_code)::text = (measure_condition_codes2.condition_code)::text))) AND ((measure_condition_codes1.operation)::text <> 'D'::text));
+          WHERE ((measure_condition_codes1.condition_code)::text = (measure_condition_codes2.condition_code)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -4578,20 +4578,20 @@ CREATE TABLE uk.measure_condition_components_oplog (
 --
 
 CREATE VIEW uk.measure_condition_components AS
- SELECT measure_condition_components1.measure_condition_sid,
-    measure_condition_components1.duty_expression_id,
-    measure_condition_components1.duty_amount,
-    measure_condition_components1.monetary_unit_code,
-    measure_condition_components1.measurement_unit_code,
-    measure_condition_components1.measurement_unit_qualifier_code,
-    measure_condition_components1.oid,
-    measure_condition_components1.operation,
-    measure_condition_components1.operation_date,
-    measure_condition_components1.filename
+ SELECT measure_condition_sid,
+    duty_expression_id,
+    duty_amount,
+    monetary_unit_code,
+    measurement_unit_code,
+    measurement_unit_qualifier_code,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.measure_condition_components_oplog measure_condition_components1
-  WHERE ((measure_condition_components1.oid IN ( SELECT max(measure_condition_components2.oid) AS max
+  WHERE ((oid IN ( SELECT max(measure_condition_components2.oid) AS max
            FROM uk.measure_condition_components_oplog measure_condition_components2
-          WHERE ((measure_condition_components1.measure_condition_sid = measure_condition_components2.measure_condition_sid) AND ((measure_condition_components1.duty_expression_id)::text = (measure_condition_components2.duty_expression_id)::text)))) AND ((measure_condition_components1.operation)::text <> 'D'::text));
+          WHERE ((measure_condition_components1.measure_condition_sid = measure_condition_components2.measure_condition_sid) AND ((measure_condition_components1.duty_expression_id)::text = (measure_condition_components2.duty_expression_id)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -4642,25 +4642,25 @@ CREATE TABLE uk.measure_conditions_oplog (
 --
 
 CREATE VIEW uk.measure_conditions AS
- SELECT measure_conditions1.measure_condition_sid,
-    measure_conditions1.measure_sid,
-    measure_conditions1.condition_code,
-    measure_conditions1.component_sequence_number,
-    measure_conditions1.condition_duty_amount,
-    measure_conditions1.condition_monetary_unit_code,
-    measure_conditions1.condition_measurement_unit_code,
-    measure_conditions1.condition_measurement_unit_qualifier_code,
-    measure_conditions1.action_code,
-    measure_conditions1.certificate_type_code,
-    measure_conditions1.certificate_code,
-    measure_conditions1.oid,
-    measure_conditions1.operation,
-    measure_conditions1.operation_date,
-    measure_conditions1.filename
+ SELECT measure_condition_sid,
+    measure_sid,
+    condition_code,
+    component_sequence_number,
+    condition_duty_amount,
+    condition_monetary_unit_code,
+    condition_measurement_unit_code,
+    condition_measurement_unit_qualifier_code,
+    action_code,
+    certificate_type_code,
+    certificate_code,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.measure_conditions_oplog measure_conditions1
-  WHERE ((measure_conditions1.oid IN ( SELECT max(measure_conditions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(measure_conditions2.oid) AS max
            FROM uk.measure_conditions_oplog measure_conditions2
-          WHERE (measure_conditions1.measure_condition_sid = measure_conditions2.measure_condition_sid))) AND ((measure_conditions1.operation)::text <> 'D'::text));
+          WHERE (measure_conditions1.measure_condition_sid = measure_conditions2.measure_condition_sid))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -4703,17 +4703,17 @@ CREATE TABLE uk.measure_excluded_geographical_areas_oplog (
 --
 
 CREATE VIEW uk.measure_excluded_geographical_areas AS
- SELECT measure_excluded_geographical_areas1.measure_sid,
-    measure_excluded_geographical_areas1.excluded_geographical_area,
-    measure_excluded_geographical_areas1.geographical_area_sid,
-    measure_excluded_geographical_areas1.oid,
-    measure_excluded_geographical_areas1.operation,
-    measure_excluded_geographical_areas1.operation_date,
-    measure_excluded_geographical_areas1.filename
+ SELECT measure_sid,
+    excluded_geographical_area,
+    geographical_area_sid,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.measure_excluded_geographical_areas_oplog measure_excluded_geographical_areas1
-  WHERE ((measure_excluded_geographical_areas1.oid IN ( SELECT max(measure_excluded_geographical_areas2.oid) AS max
+  WHERE ((oid IN ( SELECT max(measure_excluded_geographical_areas2.oid) AS max
            FROM uk.measure_excluded_geographical_areas_oplog measure_excluded_geographical_areas2
-          WHERE ((measure_excluded_geographical_areas1.measure_sid = measure_excluded_geographical_areas2.measure_sid) AND (measure_excluded_geographical_areas1.geographical_area_sid = measure_excluded_geographical_areas2.geographical_area_sid)))) AND ((measure_excluded_geographical_areas1.operation)::text <> 'D'::text));
+          WHERE ((measure_excluded_geographical_areas1.measure_sid = measure_excluded_geographical_areas2.measure_sid) AND (measure_excluded_geographical_areas1.geographical_area_sid = measure_excluded_geographical_areas2.geographical_area_sid)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -4762,23 +4762,23 @@ CREATE TABLE uk.measure_partial_temporary_stops_oplog (
 --
 
 CREATE VIEW uk.measure_partial_temporary_stops AS
- SELECT measure_partial_temporary_stops1.measure_sid,
-    measure_partial_temporary_stops1.validity_start_date,
-    measure_partial_temporary_stops1.validity_end_date,
-    measure_partial_temporary_stops1.partial_temporary_stop_regulation_id,
-    measure_partial_temporary_stops1.partial_temporary_stop_regulation_officialjournal_number,
-    measure_partial_temporary_stops1.partial_temporary_stop_regulation_officialjournal_page,
-    measure_partial_temporary_stops1.abrogation_regulation_id,
-    measure_partial_temporary_stops1.abrogation_regulation_officialjournal_number,
-    measure_partial_temporary_stops1.abrogation_regulation_officialjournal_page,
-    measure_partial_temporary_stops1.oid,
-    measure_partial_temporary_stops1.operation,
-    measure_partial_temporary_stops1.operation_date,
-    measure_partial_temporary_stops1.filename
+ SELECT measure_sid,
+    validity_start_date,
+    validity_end_date,
+    partial_temporary_stop_regulation_id,
+    partial_temporary_stop_regulation_officialjournal_number,
+    partial_temporary_stop_regulation_officialjournal_page,
+    abrogation_regulation_id,
+    abrogation_regulation_officialjournal_number,
+    abrogation_regulation_officialjournal_page,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.measure_partial_temporary_stops_oplog measure_partial_temporary_stops1
-  WHERE ((measure_partial_temporary_stops1.oid IN ( SELECT max(measure_partial_temporary_stops2.oid) AS max
+  WHERE ((oid IN ( SELECT max(measure_partial_temporary_stops2.oid) AS max
            FROM uk.measure_partial_temporary_stops_oplog measure_partial_temporary_stops2
-          WHERE ((measure_partial_temporary_stops1.measure_sid = measure_partial_temporary_stops2.measure_sid) AND ((measure_partial_temporary_stops1.partial_temporary_stop_regulation_id)::text = (measure_partial_temporary_stops2.partial_temporary_stop_regulation_id)::text)))) AND ((measure_partial_temporary_stops1.operation)::text <> 'D'::text));
+          WHERE ((measure_partial_temporary_stops1.measure_sid = measure_partial_temporary_stops2.measure_sid) AND ((measure_partial_temporary_stops1.partial_temporary_stop_regulation_id)::text = (measure_partial_temporary_stops2.partial_temporary_stop_regulation_id)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -4822,18 +4822,18 @@ CREATE TABLE uk.measure_type_descriptions_oplog (
 --
 
 CREATE VIEW uk.measure_type_descriptions AS
- SELECT measure_type_descriptions1.measure_type_id,
-    measure_type_descriptions1.language_id,
-    measure_type_descriptions1.description,
-    measure_type_descriptions1."national",
-    measure_type_descriptions1.oid,
-    measure_type_descriptions1.operation,
-    measure_type_descriptions1.operation_date,
-    measure_type_descriptions1.filename
+ SELECT measure_type_id,
+    language_id,
+    description,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.measure_type_descriptions_oplog measure_type_descriptions1
-  WHERE ((measure_type_descriptions1.oid IN ( SELECT max(measure_type_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(measure_type_descriptions2.oid) AS max
            FROM uk.measure_type_descriptions_oplog measure_type_descriptions2
-          WHERE ((measure_type_descriptions1.measure_type_id)::text = (measure_type_descriptions2.measure_type_id)::text))) AND ((measure_type_descriptions1.operation)::text <> 'D'::text));
+          WHERE ((measure_type_descriptions1.measure_type_id)::text = (measure_type_descriptions2.measure_type_id)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -4877,18 +4877,18 @@ CREATE TABLE uk.measure_type_series_oplog (
 --
 
 CREATE VIEW uk.measure_type_series AS
- SELECT measure_type_series1.measure_type_series_id,
-    measure_type_series1.validity_start_date,
-    measure_type_series1.validity_end_date,
-    measure_type_series1.measure_type_combination,
-    measure_type_series1.oid,
-    measure_type_series1.operation,
-    measure_type_series1.operation_date,
-    measure_type_series1.filename
+ SELECT measure_type_series_id,
+    validity_start_date,
+    validity_end_date,
+    measure_type_combination,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.measure_type_series_oplog measure_type_series1
-  WHERE ((measure_type_series1.oid IN ( SELECT max(measure_type_series2.oid) AS max
+  WHERE ((oid IN ( SELECT max(measure_type_series2.oid) AS max
            FROM uk.measure_type_series_oplog measure_type_series2
-          WHERE ((measure_type_series1.measure_type_series_id)::text = (measure_type_series2.measure_type_series_id)::text))) AND ((measure_type_series1.operation)::text <> 'D'::text));
+          WHERE ((measure_type_series1.measure_type_series_id)::text = (measure_type_series2.measure_type_series_id)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -4912,17 +4912,17 @@ CREATE TABLE uk.measure_type_series_descriptions_oplog (
 --
 
 CREATE VIEW uk.measure_type_series_descriptions AS
- SELECT measure_type_series_descriptions1.measure_type_series_id,
-    measure_type_series_descriptions1.language_id,
-    measure_type_series_descriptions1.description,
-    measure_type_series_descriptions1.oid,
-    measure_type_series_descriptions1.operation,
-    measure_type_series_descriptions1.operation_date,
-    measure_type_series_descriptions1.filename
+ SELECT measure_type_series_id,
+    language_id,
+    description,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.measure_type_series_descriptions_oplog measure_type_series_descriptions1
-  WHERE ((measure_type_series_descriptions1.oid IN ( SELECT max(measure_type_series_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(measure_type_series_descriptions2.oid) AS max
            FROM uk.measure_type_series_descriptions_oplog measure_type_series_descriptions2
-          WHERE ((measure_type_series_descriptions1.measure_type_series_id)::text = (measure_type_series_descriptions2.measure_type_series_id)::text))) AND ((measure_type_series_descriptions1.operation)::text <> 'D'::text));
+          WHERE ((measure_type_series_descriptions1.measure_type_series_id)::text = (measure_type_series_descriptions2.measure_type_series_id)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -4993,26 +4993,26 @@ CREATE TABLE uk.measure_types_oplog (
 --
 
 CREATE VIEW uk.measure_types AS
- SELECT measure_types1.measure_type_id,
-    measure_types1.validity_start_date,
-    measure_types1.validity_end_date,
-    measure_types1.trade_movement_code,
-    measure_types1.priority_code,
-    measure_types1.measure_component_applicable_code,
-    measure_types1.origin_dest_code,
-    measure_types1.order_number_capture_code,
-    measure_types1.measure_explosion_level,
-    measure_types1.measure_type_series_id,
-    measure_types1."national",
-    measure_types1.measure_type_acronym,
-    measure_types1.oid,
-    measure_types1.operation,
-    measure_types1.operation_date,
-    measure_types1.filename
+ SELECT measure_type_id,
+    validity_start_date,
+    validity_end_date,
+    trade_movement_code,
+    priority_code,
+    measure_component_applicable_code,
+    origin_dest_code,
+    order_number_capture_code,
+    measure_explosion_level,
+    measure_type_series_id,
+    "national",
+    measure_type_acronym,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.measure_types_oplog measure_types1
-  WHERE ((measure_types1.oid IN ( SELECT max(measure_types2.oid) AS max
+  WHERE ((oid IN ( SELECT max(measure_types2.oid) AS max
            FROM uk.measure_types_oplog measure_types2
-          WHERE ((measure_types1.measure_type_id)::text = (measure_types2.measure_type_id)::text))) AND ((measure_types1.operation)::text <> 'D'::text));
+          WHERE ((measure_types1.measure_type_id)::text = (measure_types2.measure_type_id)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -5086,17 +5086,17 @@ CREATE TABLE uk.measurement_unit_descriptions_oplog (
 --
 
 CREATE VIEW uk.measurement_unit_descriptions AS
- SELECT measurement_unit_descriptions1.measurement_unit_code,
-    measurement_unit_descriptions1.language_id,
-    measurement_unit_descriptions1.description,
-    measurement_unit_descriptions1.oid,
-    measurement_unit_descriptions1.operation,
-    measurement_unit_descriptions1.operation_date,
-    measurement_unit_descriptions1.filename
+ SELECT measurement_unit_code,
+    language_id,
+    description,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.measurement_unit_descriptions_oplog measurement_unit_descriptions1
-  WHERE ((measurement_unit_descriptions1.oid IN ( SELECT max(measurement_unit_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(measurement_unit_descriptions2.oid) AS max
            FROM uk.measurement_unit_descriptions_oplog measurement_unit_descriptions2
-          WHERE ((measurement_unit_descriptions1.measurement_unit_code)::text = (measurement_unit_descriptions2.measurement_unit_code)::text))) AND ((measurement_unit_descriptions1.operation)::text <> 'D'::text));
+          WHERE ((measurement_unit_descriptions1.measurement_unit_code)::text = (measurement_unit_descriptions2.measurement_unit_code)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -5139,17 +5139,17 @@ CREATE TABLE uk.measurement_unit_qualifier_descriptions_oplog (
 --
 
 CREATE VIEW uk.measurement_unit_qualifier_descriptions AS
- SELECT measurement_unit_qualifier_descriptions1.measurement_unit_qualifier_code,
-    measurement_unit_qualifier_descriptions1.language_id,
-    measurement_unit_qualifier_descriptions1.description,
-    measurement_unit_qualifier_descriptions1.oid,
-    measurement_unit_qualifier_descriptions1.operation,
-    measurement_unit_qualifier_descriptions1.operation_date,
-    measurement_unit_qualifier_descriptions1.filename
+ SELECT measurement_unit_qualifier_code,
+    language_id,
+    description,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.measurement_unit_qualifier_descriptions_oplog measurement_unit_qualifier_descriptions1
-  WHERE ((measurement_unit_qualifier_descriptions1.oid IN ( SELECT max(measurement_unit_qualifier_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(measurement_unit_qualifier_descriptions2.oid) AS max
            FROM uk.measurement_unit_qualifier_descriptions_oplog measurement_unit_qualifier_descriptions2
-          WHERE ((measurement_unit_qualifier_descriptions1.measurement_unit_qualifier_code)::text = (measurement_unit_qualifier_descriptions2.measurement_unit_qualifier_code)::text))) AND ((measurement_unit_qualifier_descriptions1.operation)::text <> 'D'::text));
+          WHERE ((measurement_unit_qualifier_descriptions1.measurement_unit_qualifier_code)::text = (measurement_unit_qualifier_descriptions2.measurement_unit_qualifier_code)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -5192,17 +5192,17 @@ CREATE TABLE uk.measurement_unit_qualifiers_oplog (
 --
 
 CREATE VIEW uk.measurement_unit_qualifiers AS
- SELECT measurement_unit_qualifiers1.measurement_unit_qualifier_code,
-    measurement_unit_qualifiers1.validity_start_date,
-    measurement_unit_qualifiers1.validity_end_date,
-    measurement_unit_qualifiers1.oid,
-    measurement_unit_qualifiers1.operation,
-    measurement_unit_qualifiers1.operation_date,
-    measurement_unit_qualifiers1.filename
+ SELECT measurement_unit_qualifier_code,
+    validity_start_date,
+    validity_end_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.measurement_unit_qualifiers_oplog measurement_unit_qualifiers1
-  WHERE ((measurement_unit_qualifiers1.oid IN ( SELECT max(measurement_unit_qualifiers2.oid) AS max
+  WHERE ((oid IN ( SELECT max(measurement_unit_qualifiers2.oid) AS max
            FROM uk.measurement_unit_qualifiers_oplog measurement_unit_qualifiers2
-          WHERE ((measurement_unit_qualifiers1.measurement_unit_qualifier_code)::text = (measurement_unit_qualifiers2.measurement_unit_qualifier_code)::text))) AND ((measurement_unit_qualifiers1.operation)::text <> 'D'::text));
+          WHERE ((measurement_unit_qualifiers1.measurement_unit_qualifier_code)::text = (measurement_unit_qualifiers2.measurement_unit_qualifier_code)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -5245,17 +5245,17 @@ CREATE TABLE uk.measurement_units_oplog (
 --
 
 CREATE VIEW uk.measurement_units AS
- SELECT measurement_units1.measurement_unit_code,
-    measurement_units1.validity_start_date,
-    measurement_units1.validity_end_date,
-    measurement_units1.oid,
-    measurement_units1.operation,
-    measurement_units1.operation_date,
-    measurement_units1.filename
+ SELECT measurement_unit_code,
+    validity_start_date,
+    validity_end_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.measurement_units_oplog measurement_units1
-  WHERE ((measurement_units1.oid IN ( SELECT max(measurement_units2.oid) AS max
+  WHERE ((oid IN ( SELECT max(measurement_units2.oid) AS max
            FROM uk.measurement_units_oplog measurement_units2
-          WHERE ((measurement_units1.measurement_unit_code)::text = (measurement_units2.measurement_unit_code)::text))) AND ((measurement_units1.operation)::text <> 'D'::text));
+          WHERE ((measurement_units1.measurement_unit_code)::text = (measurement_units2.measurement_unit_code)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -5299,18 +5299,18 @@ CREATE TABLE uk.measurements_oplog (
 --
 
 CREATE VIEW uk.measurements AS
- SELECT measurements1.measurement_unit_code,
-    measurements1.measurement_unit_qualifier_code,
-    measurements1.validity_start_date,
-    measurements1.validity_end_date,
-    measurements1.oid,
-    measurements1.operation,
-    measurements1.operation_date,
-    measurements1.filename
+ SELECT measurement_unit_code,
+    measurement_unit_qualifier_code,
+    validity_start_date,
+    validity_end_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.measurements_oplog measurements1
-  WHERE ((measurements1.oid IN ( SELECT max(measurements2.oid) AS max
+  WHERE ((oid IN ( SELECT max(measurements2.oid) AS max
            FROM uk.measurements_oplog measurements2
-          WHERE (((measurements1.measurement_unit_code)::text = (measurements2.measurement_unit_code)::text) AND ((measurements1.measurement_unit_qualifier_code)::text = (measurements2.measurement_unit_qualifier_code)::text)))) AND ((measurements1.operation)::text <> 'D'::text));
+          WHERE (((measurements1.measurement_unit_code)::text = (measurements2.measurement_unit_code)::text) AND ((measurements1.measurement_unit_qualifier_code)::text = (measurements2.measurement_unit_qualifier_code)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -5373,37 +5373,37 @@ CREATE TABLE uk.measures_oplog (
 --
 
 CREATE VIEW uk.measures AS
- SELECT measures1.measure_sid,
-    measures1.measure_type_id,
-    measures1.geographical_area_id,
-    measures1.goods_nomenclature_item_id,
-    measures1.validity_start_date,
-    measures1.validity_end_date,
-    measures1.measure_generating_regulation_role,
-    measures1.measure_generating_regulation_id,
-    measures1.justification_regulation_role,
-    measures1.justification_regulation_id,
-    measures1.stopped_flag,
-    measures1.geographical_area_sid,
-    measures1.goods_nomenclature_sid,
-    measures1.ordernumber,
-    measures1.additional_code_type_id,
-    measures1.additional_code_id,
-    measures1.additional_code_sid,
-    measures1.reduction_indicator,
-    measures1.export_refund_nomenclature_sid,
-    measures1."national",
-    measures1.tariff_measure_number,
-    measures1.invalidated_by,
-    measures1.invalidated_at,
-    measures1.oid,
-    measures1.operation,
-    measures1.operation_date,
-    measures1.filename
+ SELECT measure_sid,
+    measure_type_id,
+    geographical_area_id,
+    goods_nomenclature_item_id,
+    validity_start_date,
+    validity_end_date,
+    measure_generating_regulation_role,
+    measure_generating_regulation_id,
+    justification_regulation_role,
+    justification_regulation_id,
+    stopped_flag,
+    geographical_area_sid,
+    goods_nomenclature_sid,
+    ordernumber,
+    additional_code_type_id,
+    additional_code_id,
+    additional_code_sid,
+    reduction_indicator,
+    export_refund_nomenclature_sid,
+    "national",
+    tariff_measure_number,
+    invalidated_by,
+    invalidated_at,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.measures_oplog measures1
-  WHERE ((measures1.oid IN ( SELECT max(measures2.oid) AS max
+  WHERE ((oid IN ( SELECT max(measures2.oid) AS max
            FROM uk.measures_oplog measures2
-          WHERE (measures1.measure_sid = measures2.measure_sid))) AND ((measures1.operation)::text <> 'D'::text));
+          WHERE (measures1.measure_sid = measures2.measure_sid))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -5447,18 +5447,18 @@ CREATE TABLE uk.meursing_additional_codes_oplog (
 --
 
 CREATE VIEW uk.meursing_additional_codes AS
- SELECT meursing_additional_codes1.meursing_additional_code_sid,
-    meursing_additional_codes1.additional_code,
-    meursing_additional_codes1.validity_start_date,
-    meursing_additional_codes1.validity_end_date,
-    meursing_additional_codes1.oid,
-    meursing_additional_codes1.operation,
-    meursing_additional_codes1.operation_date,
-    meursing_additional_codes1.filename
+ SELECT meursing_additional_code_sid,
+    additional_code,
+    validity_start_date,
+    validity_end_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.meursing_additional_codes_oplog meursing_additional_codes1
-  WHERE ((meursing_additional_codes1.oid IN ( SELECT max(meursing_additional_codes2.oid) AS max
+  WHERE ((oid IN ( SELECT max(meursing_additional_codes2.oid) AS max
            FROM uk.meursing_additional_codes_oplog meursing_additional_codes2
-          WHERE (meursing_additional_codes1.meursing_additional_code_sid = meursing_additional_codes2.meursing_additional_code_sid))) AND ((meursing_additional_codes1.operation)::text <> 'D'::text));
+          WHERE (meursing_additional_codes1.meursing_additional_code_sid = meursing_additional_codes2.meursing_additional_code_sid))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -5503,19 +5503,19 @@ CREATE TABLE uk.meursing_heading_texts_oplog (
 --
 
 CREATE VIEW uk.meursing_heading_texts AS
- SELECT meursing_heading_texts1.meursing_table_plan_id,
-    meursing_heading_texts1.meursing_heading_number,
-    meursing_heading_texts1.row_column_code,
-    meursing_heading_texts1.language_id,
-    meursing_heading_texts1.description,
-    meursing_heading_texts1.oid,
-    meursing_heading_texts1.operation,
-    meursing_heading_texts1.operation_date,
-    meursing_heading_texts1.filename
+ SELECT meursing_table_plan_id,
+    meursing_heading_number,
+    row_column_code,
+    language_id,
+    description,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.meursing_heading_texts_oplog meursing_heading_texts1
-  WHERE ((meursing_heading_texts1.oid IN ( SELECT max(meursing_heading_texts2.oid) AS max
+  WHERE ((oid IN ( SELECT max(meursing_heading_texts2.oid) AS max
            FROM uk.meursing_heading_texts_oplog meursing_heading_texts2
-          WHERE (((meursing_heading_texts1.meursing_table_plan_id)::text = (meursing_heading_texts2.meursing_table_plan_id)::text) AND (meursing_heading_texts1.meursing_heading_number = meursing_heading_texts2.meursing_heading_number) AND (meursing_heading_texts1.row_column_code = meursing_heading_texts2.row_column_code)))) AND ((meursing_heading_texts1.operation)::text <> 'D'::text));
+          WHERE (((meursing_heading_texts1.meursing_table_plan_id)::text = (meursing_heading_texts2.meursing_table_plan_id)::text) AND (meursing_heading_texts1.meursing_heading_number = meursing_heading_texts2.meursing_heading_number) AND (meursing_heading_texts1.row_column_code = meursing_heading_texts2.row_column_code)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -5560,19 +5560,19 @@ CREATE TABLE uk.meursing_headings_oplog (
 --
 
 CREATE VIEW uk.meursing_headings AS
- SELECT meursing_headings1.meursing_table_plan_id,
-    meursing_headings1.meursing_heading_number,
-    meursing_headings1.row_column_code,
-    meursing_headings1.validity_start_date,
-    meursing_headings1.validity_end_date,
-    meursing_headings1.oid,
-    meursing_headings1.operation,
-    meursing_headings1.operation_date,
-    meursing_headings1.filename
+ SELECT meursing_table_plan_id,
+    meursing_heading_number,
+    row_column_code,
+    validity_start_date,
+    validity_end_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.meursing_headings_oplog meursing_headings1
-  WHERE ((meursing_headings1.oid IN ( SELECT max(meursing_headings2.oid) AS max
+  WHERE ((oid IN ( SELECT max(meursing_headings2.oid) AS max
            FROM uk.meursing_headings_oplog meursing_headings2
-          WHERE (((meursing_headings1.meursing_table_plan_id)::text = (meursing_headings2.meursing_table_plan_id)::text) AND (meursing_headings1.meursing_heading_number = meursing_headings2.meursing_heading_number) AND (meursing_headings1.row_column_code = meursing_headings2.row_column_code)))) AND ((meursing_headings1.operation)::text <> 'D'::text));
+          WHERE (((meursing_headings1.meursing_table_plan_id)::text = (meursing_headings2.meursing_table_plan_id)::text) AND (meursing_headings1.meursing_heading_number = meursing_headings2.meursing_heading_number) AND (meursing_headings1.row_column_code = meursing_headings2.row_column_code)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -5619,21 +5619,21 @@ CREATE TABLE uk.meursing_subheadings_oplog (
 --
 
 CREATE VIEW uk.meursing_subheadings AS
- SELECT meursing_subheadings1.meursing_table_plan_id,
-    meursing_subheadings1.meursing_heading_number,
-    meursing_subheadings1.row_column_code,
-    meursing_subheadings1.subheading_sequence_number,
-    meursing_subheadings1.validity_start_date,
-    meursing_subheadings1.validity_end_date,
-    meursing_subheadings1.description,
-    meursing_subheadings1.oid,
-    meursing_subheadings1.operation,
-    meursing_subheadings1.operation_date,
-    meursing_subheadings1.filename
+ SELECT meursing_table_plan_id,
+    meursing_heading_number,
+    row_column_code,
+    subheading_sequence_number,
+    validity_start_date,
+    validity_end_date,
+    description,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.meursing_subheadings_oplog meursing_subheadings1
-  WHERE ((meursing_subheadings1.oid IN ( SELECT max(meursing_subheadings2.oid) AS max
+  WHERE ((oid IN ( SELECT max(meursing_subheadings2.oid) AS max
            FROM uk.meursing_subheadings_oplog meursing_subheadings2
-          WHERE (((meursing_subheadings1.meursing_table_plan_id)::text = (meursing_subheadings2.meursing_table_plan_id)::text) AND (meursing_subheadings1.meursing_heading_number = meursing_subheadings2.meursing_heading_number) AND (meursing_subheadings1.row_column_code = meursing_subheadings2.row_column_code) AND (meursing_subheadings1.subheading_sequence_number = meursing_subheadings2.subheading_sequence_number)))) AND ((meursing_subheadings1.operation)::text <> 'D'::text));
+          WHERE (((meursing_subheadings1.meursing_table_plan_id)::text = (meursing_subheadings2.meursing_table_plan_id)::text) AND (meursing_subheadings1.meursing_heading_number = meursing_subheadings2.meursing_heading_number) AND (meursing_subheadings1.row_column_code = meursing_subheadings2.row_column_code) AND (meursing_subheadings1.subheading_sequence_number = meursing_subheadings2.subheading_sequence_number)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -5681,22 +5681,22 @@ CREATE TABLE uk.meursing_table_cell_components_oplog (
 --
 
 CREATE VIEW uk.meursing_table_cell_components AS
- SELECT meursing_table_cell_components1.meursing_additional_code_sid,
-    meursing_table_cell_components1.meursing_table_plan_id,
-    meursing_table_cell_components1.heading_number,
-    meursing_table_cell_components1.row_column_code,
-    meursing_table_cell_components1.subheading_sequence_number,
-    meursing_table_cell_components1.validity_start_date,
-    meursing_table_cell_components1.validity_end_date,
-    meursing_table_cell_components1.additional_code,
-    meursing_table_cell_components1.oid,
-    meursing_table_cell_components1.operation,
-    meursing_table_cell_components1.operation_date,
-    meursing_table_cell_components1.filename
+ SELECT meursing_additional_code_sid,
+    meursing_table_plan_id,
+    heading_number,
+    row_column_code,
+    subheading_sequence_number,
+    validity_start_date,
+    validity_end_date,
+    additional_code,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.meursing_table_cell_components_oplog meursing_table_cell_components1
-  WHERE ((meursing_table_cell_components1.oid IN ( SELECT max(meursing_table_cell_components2.oid) AS max
+  WHERE ((oid IN ( SELECT max(meursing_table_cell_components2.oid) AS max
            FROM uk.meursing_table_cell_components_oplog meursing_table_cell_components2
-          WHERE (((meursing_table_cell_components1.meursing_table_plan_id)::text = (meursing_table_cell_components2.meursing_table_plan_id)::text) AND (meursing_table_cell_components1.heading_number = meursing_table_cell_components2.heading_number) AND (meursing_table_cell_components1.row_column_code = meursing_table_cell_components2.row_column_code) AND (meursing_table_cell_components1.meursing_additional_code_sid = meursing_table_cell_components2.meursing_additional_code_sid)))) AND ((meursing_table_cell_components1.operation)::text <> 'D'::text));
+          WHERE (((meursing_table_cell_components1.meursing_table_plan_id)::text = (meursing_table_cell_components2.meursing_table_plan_id)::text) AND (meursing_table_cell_components1.heading_number = meursing_table_cell_components2.heading_number) AND (meursing_table_cell_components1.row_column_code = meursing_table_cell_components2.row_column_code) AND (meursing_table_cell_components1.meursing_additional_code_sid = meursing_table_cell_components2.meursing_additional_code_sid)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -5739,17 +5739,17 @@ CREATE TABLE uk.meursing_table_plans_oplog (
 --
 
 CREATE VIEW uk.meursing_table_plans AS
- SELECT meursing_table_plans1.meursing_table_plan_id,
-    meursing_table_plans1.validity_start_date,
-    meursing_table_plans1.validity_end_date,
-    meursing_table_plans1.oid,
-    meursing_table_plans1.operation,
-    meursing_table_plans1.operation_date,
-    meursing_table_plans1.filename
+ SELECT meursing_table_plan_id,
+    validity_start_date,
+    validity_end_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.meursing_table_plans_oplog meursing_table_plans1
-  WHERE ((meursing_table_plans1.oid IN ( SELECT max(meursing_table_plans2.oid) AS max
+  WHERE ((oid IN ( SELECT max(meursing_table_plans2.oid) AS max
            FROM uk.meursing_table_plans_oplog meursing_table_plans2
-          WHERE ((meursing_table_plans1.meursing_table_plan_id)::text = (meursing_table_plans2.meursing_table_plan_id)::text))) AND ((meursing_table_plans1.operation)::text <> 'D'::text));
+          WHERE ((meursing_table_plans1.meursing_table_plan_id)::text = (meursing_table_plans2.meursing_table_plan_id)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -5807,32 +5807,32 @@ CREATE TABLE uk.modification_regulations_oplog (
 --
 
 CREATE VIEW uk.modification_regulations AS
- SELECT modification_regulations1.modification_regulation_role,
-    modification_regulations1.modification_regulation_id,
-    modification_regulations1.validity_start_date,
-    modification_regulations1.validity_end_date,
-    modification_regulations1.published_date,
-    modification_regulations1.officialjournal_number,
-    modification_regulations1.officialjournal_page,
-    modification_regulations1.base_regulation_role,
-    modification_regulations1.base_regulation_id,
-    modification_regulations1.replacement_indicator,
-    modification_regulations1.stopped_flag,
-    modification_regulations1.information_text,
-    modification_regulations1.approved_flag,
-    modification_regulations1.explicit_abrogation_regulation_role,
-    modification_regulations1.explicit_abrogation_regulation_id,
-    modification_regulations1.effective_end_date,
-    modification_regulations1.complete_abrogation_regulation_role,
-    modification_regulations1.complete_abrogation_regulation_id,
-    modification_regulations1.oid,
-    modification_regulations1.operation,
-    modification_regulations1.operation_date,
-    modification_regulations1.filename
+ SELECT modification_regulation_role,
+    modification_regulation_id,
+    validity_start_date,
+    validity_end_date,
+    published_date,
+    officialjournal_number,
+    officialjournal_page,
+    base_regulation_role,
+    base_regulation_id,
+    replacement_indicator,
+    stopped_flag,
+    information_text,
+    approved_flag,
+    explicit_abrogation_regulation_role,
+    explicit_abrogation_regulation_id,
+    effective_end_date,
+    complete_abrogation_regulation_role,
+    complete_abrogation_regulation_id,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.modification_regulations_oplog modification_regulations1
-  WHERE ((modification_regulations1.oid IN ( SELECT max(modification_regulations2.oid) AS max
+  WHERE ((oid IN ( SELECT max(modification_regulations2.oid) AS max
            FROM uk.modification_regulations_oplog modification_regulations2
-          WHERE (((modification_regulations1.modification_regulation_id)::text = (modification_regulations2.modification_regulation_id)::text) AND (modification_regulations1.modification_regulation_role = modification_regulations2.modification_regulation_role)))) AND ((modification_regulations1.operation)::text <> 'D'::text));
+          WHERE (((modification_regulations1.modification_regulation_id)::text = (modification_regulations2.modification_regulation_id)::text) AND (modification_regulations1.modification_regulation_role = modification_regulations2.modification_regulation_role)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -5876,18 +5876,18 @@ CREATE TABLE uk.monetary_exchange_periods_oplog (
 --
 
 CREATE VIEW uk.monetary_exchange_periods AS
- SELECT monetary_exchange_periods1.monetary_exchange_period_sid,
-    monetary_exchange_periods1.parent_monetary_unit_code,
-    monetary_exchange_periods1.validity_start_date,
-    monetary_exchange_periods1.validity_end_date,
-    monetary_exchange_periods1.oid,
-    monetary_exchange_periods1.operation,
-    monetary_exchange_periods1.operation_date,
-    monetary_exchange_periods1.filename
+ SELECT monetary_exchange_period_sid,
+    parent_monetary_unit_code,
+    validity_start_date,
+    validity_end_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.monetary_exchange_periods_oplog monetary_exchange_periods1
-  WHERE ((monetary_exchange_periods1.oid IN ( SELECT max(monetary_exchange_periods2.oid) AS max
+  WHERE ((oid IN ( SELECT max(monetary_exchange_periods2.oid) AS max
            FROM uk.monetary_exchange_periods_oplog monetary_exchange_periods2
-          WHERE ((monetary_exchange_periods1.monetary_exchange_period_sid = monetary_exchange_periods2.monetary_exchange_period_sid) AND ((monetary_exchange_periods1.parent_monetary_unit_code)::text = (monetary_exchange_periods2.parent_monetary_unit_code)::text)))) AND ((monetary_exchange_periods1.operation)::text <> 'D'::text));
+          WHERE ((monetary_exchange_periods1.monetary_exchange_period_sid = monetary_exchange_periods2.monetary_exchange_period_sid) AND ((monetary_exchange_periods1.parent_monetary_unit_code)::text = (monetary_exchange_periods2.parent_monetary_unit_code)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -5930,17 +5930,17 @@ CREATE TABLE uk.monetary_exchange_rates_oplog (
 --
 
 CREATE VIEW uk.monetary_exchange_rates AS
- SELECT monetary_exchange_rates1.monetary_exchange_period_sid,
-    monetary_exchange_rates1.child_monetary_unit_code,
-    monetary_exchange_rates1.exchange_rate,
-    monetary_exchange_rates1.oid,
-    monetary_exchange_rates1.operation,
-    monetary_exchange_rates1.operation_date,
-    monetary_exchange_rates1.filename
+ SELECT monetary_exchange_period_sid,
+    child_monetary_unit_code,
+    exchange_rate,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.monetary_exchange_rates_oplog monetary_exchange_rates1
-  WHERE ((monetary_exchange_rates1.oid IN ( SELECT max(monetary_exchange_rates2.oid) AS max
+  WHERE ((oid IN ( SELECT max(monetary_exchange_rates2.oid) AS max
            FROM uk.monetary_exchange_rates_oplog monetary_exchange_rates2
-          WHERE ((monetary_exchange_rates1.monetary_exchange_period_sid = monetary_exchange_rates2.monetary_exchange_period_sid) AND ((monetary_exchange_rates1.child_monetary_unit_code)::text = (monetary_exchange_rates2.child_monetary_unit_code)::text)))) AND ((monetary_exchange_rates1.operation)::text <> 'D'::text));
+          WHERE ((monetary_exchange_rates1.monetary_exchange_period_sid = monetary_exchange_rates2.monetary_exchange_period_sid) AND ((monetary_exchange_rates1.child_monetary_unit_code)::text = (monetary_exchange_rates2.child_monetary_unit_code)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -5983,17 +5983,17 @@ CREATE TABLE uk.monetary_unit_descriptions_oplog (
 --
 
 CREATE VIEW uk.monetary_unit_descriptions AS
- SELECT monetary_unit_descriptions1.monetary_unit_code,
-    monetary_unit_descriptions1.language_id,
-    monetary_unit_descriptions1.description,
-    monetary_unit_descriptions1.oid,
-    monetary_unit_descriptions1.operation,
-    monetary_unit_descriptions1.operation_date,
-    monetary_unit_descriptions1.filename
+ SELECT monetary_unit_code,
+    language_id,
+    description,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.monetary_unit_descriptions_oplog monetary_unit_descriptions1
-  WHERE ((monetary_unit_descriptions1.oid IN ( SELECT max(monetary_unit_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(monetary_unit_descriptions2.oid) AS max
            FROM uk.monetary_unit_descriptions_oplog monetary_unit_descriptions2
-          WHERE ((monetary_unit_descriptions1.monetary_unit_code)::text = (monetary_unit_descriptions2.monetary_unit_code)::text))) AND ((monetary_unit_descriptions1.operation)::text <> 'D'::text));
+          WHERE ((monetary_unit_descriptions1.monetary_unit_code)::text = (monetary_unit_descriptions2.monetary_unit_code)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -6036,17 +6036,17 @@ CREATE TABLE uk.monetary_units_oplog (
 --
 
 CREATE VIEW uk.monetary_units AS
- SELECT monetary_units1.monetary_unit_code,
-    monetary_units1.validity_start_date,
-    monetary_units1.validity_end_date,
-    monetary_units1.oid,
-    monetary_units1.operation,
-    monetary_units1.operation_date,
-    monetary_units1.filename
+ SELECT monetary_unit_code,
+    validity_start_date,
+    validity_end_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.monetary_units_oplog monetary_units1
-  WHERE ((monetary_units1.oid IN ( SELECT max(monetary_units2.oid) AS max
+  WHERE ((oid IN ( SELECT max(monetary_units2.oid) AS max
            FROM uk.monetary_units_oplog monetary_units2
-          WHERE ((monetary_units1.monetary_unit_code)::text = (monetary_units2.monetary_unit_code)::text))) AND ((monetary_units1.operation)::text <> 'D'::text));
+          WHERE ((monetary_units1.monetary_unit_code)::text = (monetary_units2.monetary_unit_code)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -6171,21 +6171,21 @@ CREATE TABLE uk.nomenclature_group_memberships_oplog (
 --
 
 CREATE VIEW uk.nomenclature_group_memberships AS
- SELECT nomenclature_group_memberships1.goods_nomenclature_sid,
-    nomenclature_group_memberships1.goods_nomenclature_group_type,
-    nomenclature_group_memberships1.goods_nomenclature_group_id,
-    nomenclature_group_memberships1.validity_start_date,
-    nomenclature_group_memberships1.validity_end_date,
-    nomenclature_group_memberships1.goods_nomenclature_item_id,
-    nomenclature_group_memberships1.productline_suffix,
-    nomenclature_group_memberships1.oid,
-    nomenclature_group_memberships1.operation,
-    nomenclature_group_memberships1.operation_date,
-    nomenclature_group_memberships1.filename
+ SELECT goods_nomenclature_sid,
+    goods_nomenclature_group_type,
+    goods_nomenclature_group_id,
+    validity_start_date,
+    validity_end_date,
+    goods_nomenclature_item_id,
+    productline_suffix,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.nomenclature_group_memberships_oplog nomenclature_group_memberships1
-  WHERE ((nomenclature_group_memberships1.oid IN ( SELECT max(nomenclature_group_memberships2.oid) AS max
+  WHERE ((oid IN ( SELECT max(nomenclature_group_memberships2.oid) AS max
            FROM uk.nomenclature_group_memberships_oplog nomenclature_group_memberships2
-          WHERE ((nomenclature_group_memberships1.goods_nomenclature_sid = nomenclature_group_memberships2.goods_nomenclature_sid) AND ((nomenclature_group_memberships1.goods_nomenclature_group_id)::text = (nomenclature_group_memberships2.goods_nomenclature_group_id)::text) AND ((nomenclature_group_memberships1.goods_nomenclature_group_type)::text = (nomenclature_group_memberships2.goods_nomenclature_group_type)::text) AND ((nomenclature_group_memberships1.goods_nomenclature_item_id)::text = (nomenclature_group_memberships2.goods_nomenclature_item_id)::text) AND (nomenclature_group_memberships1.validity_start_date = nomenclature_group_memberships2.validity_start_date)))) AND ((nomenclature_group_memberships1.operation)::text <> 'D'::text));
+          WHERE ((nomenclature_group_memberships1.goods_nomenclature_sid = nomenclature_group_memberships2.goods_nomenclature_sid) AND ((nomenclature_group_memberships1.goods_nomenclature_group_id)::text = (nomenclature_group_memberships2.goods_nomenclature_group_id)::text) AND ((nomenclature_group_memberships1.goods_nomenclature_group_type)::text = (nomenclature_group_memberships2.goods_nomenclature_group_type)::text) AND ((nomenclature_group_memberships1.goods_nomenclature_item_id)::text = (nomenclature_group_memberships2.goods_nomenclature_item_id)::text) AND (nomenclature_group_memberships1.validity_start_date = nomenclature_group_memberships2.validity_start_date)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -6230,19 +6230,19 @@ CREATE TABLE uk.prorogation_regulation_actions_oplog (
 --
 
 CREATE VIEW uk.prorogation_regulation_actions AS
- SELECT prorogation_regulation_actions1.prorogation_regulation_role,
-    prorogation_regulation_actions1.prorogation_regulation_id,
-    prorogation_regulation_actions1.prorogated_regulation_role,
-    prorogation_regulation_actions1.prorogated_regulation_id,
-    prorogation_regulation_actions1.prorogated_date,
-    prorogation_regulation_actions1.oid,
-    prorogation_regulation_actions1.operation,
-    prorogation_regulation_actions1.operation_date,
-    prorogation_regulation_actions1.filename
+ SELECT prorogation_regulation_role,
+    prorogation_regulation_id,
+    prorogated_regulation_role,
+    prorogated_regulation_id,
+    prorogated_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.prorogation_regulation_actions_oplog prorogation_regulation_actions1
-  WHERE ((prorogation_regulation_actions1.oid IN ( SELECT max(prorogation_regulation_actions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(prorogation_regulation_actions2.oid) AS max
            FROM uk.prorogation_regulation_actions_oplog prorogation_regulation_actions2
-          WHERE (((prorogation_regulation_actions1.prorogation_regulation_id)::text = (prorogation_regulation_actions2.prorogation_regulation_id)::text) AND (prorogation_regulation_actions1.prorogation_regulation_role = prorogation_regulation_actions2.prorogation_regulation_role) AND ((prorogation_regulation_actions1.prorogated_regulation_id)::text = (prorogation_regulation_actions2.prorogated_regulation_id)::text) AND (prorogation_regulation_actions1.prorogated_regulation_role = prorogation_regulation_actions2.prorogated_regulation_role)))) AND ((prorogation_regulation_actions1.operation)::text <> 'D'::text));
+          WHERE (((prorogation_regulation_actions1.prorogation_regulation_id)::text = (prorogation_regulation_actions2.prorogation_regulation_id)::text) AND (prorogation_regulation_actions1.prorogation_regulation_role = prorogation_regulation_actions2.prorogation_regulation_role) AND ((prorogation_regulation_actions1.prorogated_regulation_id)::text = (prorogation_regulation_actions2.prorogated_regulation_id)::text) AND (prorogation_regulation_actions1.prorogated_regulation_role = prorogation_regulation_actions2.prorogated_regulation_role)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -6290,22 +6290,22 @@ CREATE TABLE uk.prorogation_regulations_oplog (
 --
 
 CREATE VIEW uk.prorogation_regulations AS
- SELECT prorogation_regulations1.prorogation_regulation_role,
-    prorogation_regulations1.prorogation_regulation_id,
-    prorogation_regulations1.published_date,
-    prorogation_regulations1.officialjournal_number,
-    prorogation_regulations1.officialjournal_page,
-    prorogation_regulations1.replacement_indicator,
-    prorogation_regulations1.information_text,
-    prorogation_regulations1.approved_flag,
-    prorogation_regulations1.oid,
-    prorogation_regulations1.operation,
-    prorogation_regulations1.operation_date,
-    prorogation_regulations1.filename
+ SELECT prorogation_regulation_role,
+    prorogation_regulation_id,
+    published_date,
+    officialjournal_number,
+    officialjournal_page,
+    replacement_indicator,
+    information_text,
+    approved_flag,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.prorogation_regulations_oplog prorogation_regulations1
-  WHERE ((prorogation_regulations1.oid IN ( SELECT max(prorogation_regulations2.oid) AS max
+  WHERE ((oid IN ( SELECT max(prorogation_regulations2.oid) AS max
            FROM uk.prorogation_regulations_oplog prorogation_regulations2
-          WHERE (((prorogation_regulations1.prorogation_regulation_id)::text = (prorogation_regulations2.prorogation_regulation_id)::text) AND (prorogation_regulations1.prorogation_regulation_role = prorogation_regulations2.prorogation_regulation_role)))) AND ((prorogation_regulations1.operation)::text <> 'D'::text));
+          WHERE (((prorogation_regulations1.prorogation_regulation_id)::text = (prorogation_regulations2.prorogation_regulation_id)::text) AND (prorogation_regulations1.prorogation_regulation_role = prorogation_regulations2.prorogation_regulation_role)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -6351,20 +6351,20 @@ CREATE TABLE uk.publication_sigles_oplog (
 --
 
 CREATE VIEW uk.publication_sigles AS
- SELECT publication_sigles1.oid,
-    publication_sigles1.code_type_id,
-    publication_sigles1.code,
-    publication_sigles1.publication_code,
-    publication_sigles1.publication_sigle,
-    publication_sigles1.validity_end_date,
-    publication_sigles1.validity_start_date,
-    publication_sigles1.operation,
-    publication_sigles1.operation_date,
-    publication_sigles1.filename
+ SELECT oid,
+    code_type_id,
+    code,
+    publication_code,
+    publication_sigle,
+    validity_end_date,
+    validity_start_date,
+    operation,
+    operation_date,
+    filename
    FROM uk.publication_sigles_oplog publication_sigles1
-  WHERE ((publication_sigles1.oid IN ( SELECT max(publication_sigles2.oid) AS max
+  WHERE ((oid IN ( SELECT max(publication_sigles2.oid) AS max
            FROM uk.publication_sigles_oplog publication_sigles2
-          WHERE (((publication_sigles1.code)::text = (publication_sigles2.code)::text) AND ((publication_sigles1.code_type_id)::text = (publication_sigles2.code_type_id)::text)))) AND ((publication_sigles1.operation)::text <> 'D'::text));
+          WHERE (((publication_sigles1.code)::text = (publication_sigles2.code)::text) AND ((publication_sigles1.code_type_id)::text = (publication_sigles2.code_type_id)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -6429,20 +6429,20 @@ CREATE TABLE uk.quota_balance_events_oplog (
 --
 
 CREATE VIEW uk.quota_balance_events AS
- SELECT quota_balance_events1.quota_definition_sid,
-    quota_balance_events1.occurrence_timestamp,
-    quota_balance_events1.last_import_date_in_allocation,
-    quota_balance_events1.old_balance,
-    quota_balance_events1.new_balance,
-    quota_balance_events1.imported_amount,
-    quota_balance_events1.oid,
-    quota_balance_events1.operation,
-    quota_balance_events1.operation_date,
-    quota_balance_events1.filename
+ SELECT quota_definition_sid,
+    occurrence_timestamp,
+    last_import_date_in_allocation,
+    old_balance,
+    new_balance,
+    imported_amount,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.quota_balance_events_oplog quota_balance_events1
-  WHERE ((quota_balance_events1.oid IN ( SELECT max(quota_balance_events2.oid) AS max
+  WHERE ((oid IN ( SELECT max(quota_balance_events2.oid) AS max
            FROM uk.quota_balance_events_oplog quota_balance_events2
-          WHERE ((quota_balance_events1.quota_definition_sid = quota_balance_events2.quota_definition_sid) AND (quota_balance_events1.occurrence_timestamp = quota_balance_events2.occurrence_timestamp)))) AND ((quota_balance_events1.operation)::text <> 'D'::text));
+          WHERE ((quota_balance_events1.quota_definition_sid = quota_balance_events2.quota_definition_sid) AND (quota_balance_events1.occurrence_timestamp = quota_balance_events2.occurrence_timestamp)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -6488,20 +6488,20 @@ CREATE TABLE uk.quota_blocking_periods_oplog (
 --
 
 CREATE VIEW uk.quota_blocking_periods AS
- SELECT quota_blocking_periods1.quota_blocking_period_sid,
-    quota_blocking_periods1.quota_definition_sid,
-    quota_blocking_periods1.blocking_start_date,
-    quota_blocking_periods1.blocking_end_date,
-    quota_blocking_periods1.blocking_period_type,
-    quota_blocking_periods1.description,
-    quota_blocking_periods1.oid,
-    quota_blocking_periods1.operation,
-    quota_blocking_periods1.operation_date,
-    quota_blocking_periods1.filename
+ SELECT quota_blocking_period_sid,
+    quota_definition_sid,
+    blocking_start_date,
+    blocking_end_date,
+    blocking_period_type,
+    description,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.quota_blocking_periods_oplog quota_blocking_periods1
-  WHERE ((quota_blocking_periods1.oid IN ( SELECT max(quota_blocking_periods2.oid) AS max
+  WHERE ((oid IN ( SELECT max(quota_blocking_periods2.oid) AS max
            FROM uk.quota_blocking_periods_oplog quota_blocking_periods2
-          WHERE (quota_blocking_periods1.quota_blocking_period_sid = quota_blocking_periods2.quota_blocking_period_sid))) AND ((quota_blocking_periods1.operation)::text <> 'D'::text));
+          WHERE (quota_blocking_periods1.quota_blocking_period_sid = quota_blocking_periods2.quota_blocking_period_sid))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -6547,19 +6547,19 @@ CREATE TABLE uk.quota_closed_and_transferred_events_oplog (
 --
 
 CREATE VIEW uk.quota_closed_and_transferred_events AS
- SELECT quota_closed_and_transferred_events1.oid,
-    quota_closed_and_transferred_events1.quota_definition_sid,
-    quota_closed_and_transferred_events1.target_quota_definition_sid,
-    quota_closed_and_transferred_events1.occurrence_timestamp,
-    quota_closed_and_transferred_events1.operation,
-    quota_closed_and_transferred_events1.operation_date,
-    quota_closed_and_transferred_events1.transferred_amount,
-    quota_closed_and_transferred_events1.closing_date,
-    quota_closed_and_transferred_events1.filename
+ SELECT oid,
+    quota_definition_sid,
+    target_quota_definition_sid,
+    occurrence_timestamp,
+    operation,
+    operation_date,
+    transferred_amount,
+    closing_date,
+    filename
    FROM uk.quota_closed_and_transferred_events_oplog quota_closed_and_transferred_events1
-  WHERE ((quota_closed_and_transferred_events1.oid IN ( SELECT max(quota_closed_and_transferred_events2.oid) AS max
+  WHERE ((oid IN ( SELECT max(quota_closed_and_transferred_events2.oid) AS max
            FROM uk.quota_closed_and_transferred_events_oplog quota_closed_and_transferred_events2
-          WHERE ((quota_closed_and_transferred_events1.quota_definition_sid = quota_closed_and_transferred_events2.quota_definition_sid) AND (quota_closed_and_transferred_events1.occurrence_timestamp = quota_closed_and_transferred_events2.occurrence_timestamp)))) AND ((quota_closed_and_transferred_events1.operation)::text <> 'D'::text));
+          WHERE ((quota_closed_and_transferred_events1.quota_definition_sid = quota_closed_and_transferred_events2.quota_definition_sid) AND (quota_closed_and_transferred_events1.occurrence_timestamp = quota_closed_and_transferred_events2.occurrence_timestamp)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -6598,18 +6598,18 @@ CREATE TABLE uk.quota_critical_events_oplog (
 --
 
 CREATE VIEW uk.quota_critical_events AS
- SELECT quota_critical_events1.quota_definition_sid,
-    quota_critical_events1.occurrence_timestamp,
-    quota_critical_events1.critical_state,
-    quota_critical_events1.critical_state_change_date,
-    quota_critical_events1.oid,
-    quota_critical_events1.operation,
-    quota_critical_events1.operation_date,
-    quota_critical_events1.filename
+ SELECT quota_definition_sid,
+    occurrence_timestamp,
+    critical_state,
+    critical_state_change_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.quota_critical_events_oplog quota_critical_events1
-  WHERE ((quota_critical_events1.oid IN ( SELECT max(quota_critical_events2.oid) AS max
+  WHERE ((oid IN ( SELECT max(quota_critical_events2.oid) AS max
            FROM uk.quota_critical_events_oplog quota_critical_events2
-          WHERE ((quota_critical_events1.quota_definition_sid = quota_critical_events2.quota_definition_sid) AND (quota_critical_events1.occurrence_timestamp = quota_critical_events2.occurrence_timestamp)))) AND ((quota_critical_events1.operation)::text <> 'D'::text));
+          WHERE ((quota_critical_events1.quota_definition_sid = quota_critical_events2.quota_definition_sid) AND (quota_critical_events1.occurrence_timestamp = quota_critical_events2.occurrence_timestamp)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -6671,17 +6671,17 @@ CREATE TABLE uk.quota_exhaustion_events_oplog (
 --
 
 CREATE VIEW uk.quota_exhaustion_events AS
- SELECT quota_exhaustion_events1.quota_definition_sid,
-    quota_exhaustion_events1.occurrence_timestamp,
-    quota_exhaustion_events1.exhaustion_date,
-    quota_exhaustion_events1.oid,
-    quota_exhaustion_events1.operation,
-    quota_exhaustion_events1.operation_date,
-    quota_exhaustion_events1.filename
+ SELECT quota_definition_sid,
+    occurrence_timestamp,
+    exhaustion_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.quota_exhaustion_events_oplog quota_exhaustion_events1
-  WHERE ((quota_exhaustion_events1.oid IN ( SELECT max(quota_exhaustion_events2.oid) AS max
+  WHERE ((oid IN ( SELECT max(quota_exhaustion_events2.oid) AS max
            FROM uk.quota_exhaustion_events_oplog quota_exhaustion_events2
-          WHERE ((quota_exhaustion_events1.quota_definition_sid = quota_exhaustion_events2.quota_definition_sid) AND (quota_exhaustion_events1.occurrence_timestamp = quota_exhaustion_events2.occurrence_timestamp)))) AND ((quota_exhaustion_events1.operation)::text <> 'D'::text));
+          WHERE ((quota_exhaustion_events1.quota_definition_sid = quota_exhaustion_events2.quota_definition_sid) AND (quota_exhaustion_events1.occurrence_timestamp = quota_exhaustion_events2.occurrence_timestamp)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -6723,16 +6723,16 @@ CREATE TABLE uk.quota_order_number_origin_exclusions_oplog (
 --
 
 CREATE VIEW uk.quota_order_number_origin_exclusions AS
- SELECT quota_order_number_origin_exclusions1.quota_order_number_origin_sid,
-    quota_order_number_origin_exclusions1.excluded_geographical_area_sid,
-    quota_order_number_origin_exclusions1.oid,
-    quota_order_number_origin_exclusions1.operation,
-    quota_order_number_origin_exclusions1.operation_date,
-    quota_order_number_origin_exclusions1.filename
+ SELECT quota_order_number_origin_sid,
+    excluded_geographical_area_sid,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.quota_order_number_origin_exclusions_oplog quota_order_number_origin_exclusions1
-  WHERE ((quota_order_number_origin_exclusions1.oid IN ( SELECT max(quota_order_number_origin_exclusions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(quota_order_number_origin_exclusions2.oid) AS max
            FROM uk.quota_order_number_origin_exclusions_oplog quota_order_number_origin_exclusions2
-          WHERE ((quota_order_number_origin_exclusions1.quota_order_number_origin_sid = quota_order_number_origin_exclusions2.quota_order_number_origin_sid) AND (quota_order_number_origin_exclusions1.excluded_geographical_area_sid = quota_order_number_origin_exclusions2.excluded_geographical_area_sid)))) AND ((quota_order_number_origin_exclusions1.operation)::text <> 'D'::text));
+          WHERE ((quota_order_number_origin_exclusions1.quota_order_number_origin_sid = quota_order_number_origin_exclusions2.quota_order_number_origin_sid) AND (quota_order_number_origin_exclusions1.excluded_geographical_area_sid = quota_order_number_origin_exclusions2.excluded_geographical_area_sid)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -6813,17 +6813,17 @@ CREATE TABLE uk.quota_reopening_events_oplog (
 --
 
 CREATE VIEW uk.quota_reopening_events AS
- SELECT quota_reopening_events1.quota_definition_sid,
-    quota_reopening_events1.occurrence_timestamp,
-    quota_reopening_events1.reopening_date,
-    quota_reopening_events1.oid,
-    quota_reopening_events1.operation,
-    quota_reopening_events1.operation_date,
-    quota_reopening_events1.filename
+ SELECT quota_definition_sid,
+    occurrence_timestamp,
+    reopening_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.quota_reopening_events_oplog quota_reopening_events1
-  WHERE ((quota_reopening_events1.oid IN ( SELECT max(quota_reopening_events2.oid) AS max
+  WHERE ((oid IN ( SELECT max(quota_reopening_events2.oid) AS max
            FROM uk.quota_reopening_events_oplog quota_reopening_events2
-          WHERE ((quota_reopening_events1.quota_definition_sid = quota_reopening_events2.quota_definition_sid) AND (quota_reopening_events1.occurrence_timestamp = quota_reopening_events2.occurrence_timestamp)))) AND ((quota_reopening_events1.operation)::text <> 'D'::text));
+          WHERE ((quota_reopening_events1.quota_definition_sid = quota_reopening_events2.quota_definition_sid) AND (quota_reopening_events1.occurrence_timestamp = quota_reopening_events2.occurrence_timestamp)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -6868,19 +6868,19 @@ CREATE TABLE uk.quota_suspension_periods_oplog (
 --
 
 CREATE VIEW uk.quota_suspension_periods AS
- SELECT quota_suspension_periods1.quota_suspension_period_sid,
-    quota_suspension_periods1.quota_definition_sid,
-    quota_suspension_periods1.suspension_start_date,
-    quota_suspension_periods1.suspension_end_date,
-    quota_suspension_periods1.description,
-    quota_suspension_periods1.oid,
-    quota_suspension_periods1.operation,
-    quota_suspension_periods1.operation_date,
-    quota_suspension_periods1.filename
+ SELECT quota_suspension_period_sid,
+    quota_definition_sid,
+    suspension_start_date,
+    suspension_end_date,
+    description,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.quota_suspension_periods_oplog quota_suspension_periods1
-  WHERE ((quota_suspension_periods1.oid IN ( SELECT max(quota_suspension_periods2.oid) AS max
+  WHERE ((oid IN ( SELECT max(quota_suspension_periods2.oid) AS max
            FROM uk.quota_suspension_periods_oplog quota_suspension_periods2
-          WHERE (quota_suspension_periods1.quota_suspension_period_sid = quota_suspension_periods2.quota_suspension_period_sid))) AND ((quota_suspension_periods1.operation)::text <> 'D'::text));
+          WHERE (quota_suspension_periods1.quota_suspension_period_sid = quota_suspension_periods2.quota_suspension_period_sid))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -6923,17 +6923,17 @@ CREATE TABLE uk.quota_unblocking_events_oplog (
 --
 
 CREATE VIEW uk.quota_unblocking_events AS
- SELECT quota_unblocking_events1.quota_definition_sid,
-    quota_unblocking_events1.occurrence_timestamp,
-    quota_unblocking_events1.unblocking_date,
-    quota_unblocking_events1.oid,
-    quota_unblocking_events1.operation,
-    quota_unblocking_events1.operation_date,
-    quota_unblocking_events1.filename
+ SELECT quota_definition_sid,
+    occurrence_timestamp,
+    unblocking_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.quota_unblocking_events_oplog quota_unblocking_events1
-  WHERE ((quota_unblocking_events1.oid IN ( SELECT max(quota_unblocking_events2.oid) AS max
+  WHERE ((oid IN ( SELECT max(quota_unblocking_events2.oid) AS max
            FROM uk.quota_unblocking_events_oplog quota_unblocking_events2
-          WHERE (quota_unblocking_events1.quota_definition_sid = quota_unblocking_events2.quota_definition_sid))) AND ((quota_unblocking_events1.operation)::text <> 'D'::text));
+          WHERE (quota_unblocking_events1.quota_definition_sid = quota_unblocking_events2.quota_definition_sid))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -6976,17 +6976,17 @@ CREATE TABLE uk.quota_unsuspension_events_oplog (
 --
 
 CREATE VIEW uk.quota_unsuspension_events AS
- SELECT quota_unsuspension_events1.quota_definition_sid,
-    quota_unsuspension_events1.occurrence_timestamp,
-    quota_unsuspension_events1.unsuspension_date,
-    quota_unsuspension_events1.oid,
-    quota_unsuspension_events1.operation,
-    quota_unsuspension_events1.operation_date,
-    quota_unsuspension_events1.filename
+ SELECT quota_definition_sid,
+    occurrence_timestamp,
+    unsuspension_date,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.quota_unsuspension_events_oplog quota_unsuspension_events1
-  WHERE ((quota_unsuspension_events1.oid IN ( SELECT max(quota_unsuspension_events2.oid) AS max
+  WHERE ((oid IN ( SELECT max(quota_unsuspension_events2.oid) AS max
            FROM uk.quota_unsuspension_events_oplog quota_unsuspension_events2
-          WHERE ((quota_unsuspension_events1.quota_definition_sid = quota_unsuspension_events2.quota_definition_sid) AND (quota_unsuspension_events1.occurrence_timestamp = quota_unsuspension_events2.occurrence_timestamp)))) AND ((quota_unsuspension_events1.operation)::text <> 'D'::text));
+          WHERE ((quota_unsuspension_events1.quota_definition_sid = quota_unsuspension_events2.quota_definition_sid) AND (quota_unsuspension_events1.occurrence_timestamp = quota_unsuspension_events2.occurrence_timestamp)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -7030,18 +7030,18 @@ CREATE TABLE uk.regulation_group_descriptions_oplog (
 --
 
 CREATE VIEW uk.regulation_group_descriptions AS
- SELECT regulation_group_descriptions1.regulation_group_id,
-    regulation_group_descriptions1.language_id,
-    regulation_group_descriptions1.description,
-    regulation_group_descriptions1."national",
-    regulation_group_descriptions1.oid,
-    regulation_group_descriptions1.operation,
-    regulation_group_descriptions1.operation_date,
-    regulation_group_descriptions1.filename
+ SELECT regulation_group_id,
+    language_id,
+    description,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.regulation_group_descriptions_oplog regulation_group_descriptions1
-  WHERE ((regulation_group_descriptions1.oid IN ( SELECT max(regulation_group_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(regulation_group_descriptions2.oid) AS max
            FROM uk.regulation_group_descriptions_oplog regulation_group_descriptions2
-          WHERE ((regulation_group_descriptions1.regulation_group_id)::text = (regulation_group_descriptions2.regulation_group_id)::text))) AND ((regulation_group_descriptions1.operation)::text <> 'D'::text));
+          WHERE ((regulation_group_descriptions1.regulation_group_id)::text = (regulation_group_descriptions2.regulation_group_id)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -7085,18 +7085,18 @@ CREATE TABLE uk.regulation_groups_oplog (
 --
 
 CREATE VIEW uk.regulation_groups AS
- SELECT regulation_groups1.regulation_group_id,
-    regulation_groups1.validity_start_date,
-    regulation_groups1.validity_end_date,
-    regulation_groups1."national",
-    regulation_groups1.oid,
-    regulation_groups1.operation,
-    regulation_groups1.operation_date,
-    regulation_groups1.filename
+ SELECT regulation_group_id,
+    validity_start_date,
+    validity_end_date,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.regulation_groups_oplog regulation_groups1
-  WHERE ((regulation_groups1.oid IN ( SELECT max(regulation_groups2.oid) AS max
+  WHERE ((oid IN ( SELECT max(regulation_groups2.oid) AS max
            FROM uk.regulation_groups_oplog regulation_groups2
-          WHERE ((regulation_groups1.regulation_group_id)::text = (regulation_groups2.regulation_group_id)::text))) AND ((regulation_groups1.operation)::text <> 'D'::text));
+          WHERE ((regulation_groups1.regulation_group_id)::text = (regulation_groups2.regulation_group_id)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -7143,21 +7143,21 @@ CREATE TABLE uk.regulation_replacements_oplog (
 --
 
 CREATE VIEW uk.regulation_replacements AS
- SELECT regulation_replacements1.geographical_area_id,
-    regulation_replacements1.chapter_heading,
-    regulation_replacements1.replacing_regulation_role,
-    regulation_replacements1.replacing_regulation_id,
-    regulation_replacements1.replaced_regulation_role,
-    regulation_replacements1.replaced_regulation_id,
-    regulation_replacements1.measure_type_id,
-    regulation_replacements1.oid,
-    regulation_replacements1.operation,
-    regulation_replacements1.operation_date,
-    regulation_replacements1.filename
+ SELECT geographical_area_id,
+    chapter_heading,
+    replacing_regulation_role,
+    replacing_regulation_id,
+    replaced_regulation_role,
+    replaced_regulation_id,
+    measure_type_id,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.regulation_replacements_oplog regulation_replacements1
-  WHERE ((regulation_replacements1.oid IN ( SELECT max(regulation_replacements2.oid) AS max
+  WHERE ((oid IN ( SELECT max(regulation_replacements2.oid) AS max
            FROM uk.regulation_replacements_oplog regulation_replacements2
-          WHERE (((regulation_replacements1.replacing_regulation_id)::text = (regulation_replacements2.replacing_regulation_id)::text) AND (regulation_replacements1.replacing_regulation_role = regulation_replacements2.replacing_regulation_role) AND ((regulation_replacements1.replaced_regulation_id)::text = (regulation_replacements2.replaced_regulation_id)::text) AND (regulation_replacements1.replaced_regulation_role = regulation_replacements2.replaced_regulation_role)))) AND ((regulation_replacements1.operation)::text <> 'D'::text));
+          WHERE (((regulation_replacements1.replacing_regulation_id)::text = (regulation_replacements2.replacing_regulation_id)::text) AND (regulation_replacements1.replacing_regulation_role = regulation_replacements2.replacing_regulation_role) AND ((regulation_replacements1.replaced_regulation_id)::text = (regulation_replacements2.replaced_regulation_id)::text) AND (regulation_replacements1.replaced_regulation_role = regulation_replacements2.replaced_regulation_role)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -7201,18 +7201,18 @@ CREATE TABLE uk.regulation_role_type_descriptions_oplog (
 --
 
 CREATE VIEW uk.regulation_role_type_descriptions AS
- SELECT regulation_role_type_descriptions1.regulation_role_type_id,
-    regulation_role_type_descriptions1.language_id,
-    regulation_role_type_descriptions1.description,
-    regulation_role_type_descriptions1."national",
-    regulation_role_type_descriptions1.oid,
-    regulation_role_type_descriptions1.operation,
-    regulation_role_type_descriptions1.operation_date,
-    regulation_role_type_descriptions1.filename
+ SELECT regulation_role_type_id,
+    language_id,
+    description,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.regulation_role_type_descriptions_oplog regulation_role_type_descriptions1
-  WHERE ((regulation_role_type_descriptions1.oid IN ( SELECT max(regulation_role_type_descriptions2.oid) AS max
+  WHERE ((oid IN ( SELECT max(regulation_role_type_descriptions2.oid) AS max
            FROM uk.regulation_role_type_descriptions_oplog regulation_role_type_descriptions2
-          WHERE ((regulation_role_type_descriptions1.regulation_role_type_id)::text = (regulation_role_type_descriptions2.regulation_role_type_id)::text))) AND ((regulation_role_type_descriptions1.operation)::text <> 'D'::text));
+          WHERE ((regulation_role_type_descriptions1.regulation_role_type_id)::text = (regulation_role_type_descriptions2.regulation_role_type_id)::text))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -7256,18 +7256,18 @@ CREATE TABLE uk.regulation_role_types_oplog (
 --
 
 CREATE VIEW uk.regulation_role_types AS
- SELECT regulation_role_types1.regulation_role_type_id,
-    regulation_role_types1.validity_start_date,
-    regulation_role_types1.validity_end_date,
-    regulation_role_types1."national",
-    regulation_role_types1.oid,
-    regulation_role_types1.operation,
-    regulation_role_types1.operation_date,
-    regulation_role_types1.filename
+ SELECT regulation_role_type_id,
+    validity_start_date,
+    validity_end_date,
+    "national",
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.regulation_role_types_oplog regulation_role_types1
-  WHERE ((regulation_role_types1.oid IN ( SELECT max(regulation_role_types2.oid) AS max
+  WHERE ((oid IN ( SELECT max(regulation_role_types2.oid) AS max
            FROM uk.regulation_role_types_oplog regulation_role_types2
-          WHERE (regulation_role_types1.regulation_role_type_id = regulation_role_types2.regulation_role_type_id))) AND ((regulation_role_types1.operation)::text <> 'D'::text));
+          WHERE (regulation_role_types1.regulation_role_type_id = regulation_role_types2.regulation_role_type_id))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -7625,17 +7625,17 @@ CREATE TABLE uk.transmission_comments_oplog (
 --
 
 CREATE VIEW uk.transmission_comments AS
- SELECT transmission_comments1.comment_sid,
-    transmission_comments1.language_id,
-    transmission_comments1.comment_text,
-    transmission_comments1.oid,
-    transmission_comments1.operation,
-    transmission_comments1.operation_date,
-    transmission_comments1.filename
+ SELECT comment_sid,
+    language_id,
+    comment_text,
+    oid,
+    operation,
+    operation_date,
+    filename
    FROM uk.transmission_comments_oplog transmission_comments1
-  WHERE ((transmission_comments1.oid IN ( SELECT max(transmission_comments2.oid) AS max
+  WHERE ((oid IN ( SELECT max(transmission_comments2.oid) AS max
            FROM uk.transmission_comments_oplog transmission_comments2
-          WHERE ((transmission_comments1.comment_sid = transmission_comments2.comment_sid) AND ((transmission_comments1.language_id)::text = (transmission_comments2.language_id)::text)))) AND ((transmission_comments1.operation)::text <> 'D'::text));
+          WHERE ((transmission_comments1.comment_sid = transmission_comments2.comment_sid) AND ((transmission_comments1.language_id)::text = (transmission_comments2.language_id)::text)))) AND ((operation)::text <> 'D'::text));
 
 
 --
@@ -12578,4 +12578,8 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20240808113431_update_gree
 INSERT INTO "schema_migrations" ("filename") VALUES ('20240830142019_add_differences_log.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20241210100900_add_green_lanes_faq_feedback_table.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20250108092900_elevate_privileges_green_lanes_faq_feedback_table.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20250120112727_update_currency_vef_to_ved.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20250128110215_update_diacritics_in_currencies.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20250207141527_update_currency_vef_end_date.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20250219092427_delete_chief_guidance_column_from_appendix5a.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20250324091812_alter_column_nullable_path_in_goods_nomenclatures_oplog.rb');


### PR DESCRIPTION
### Jira link

[HMRC-869](https://transformuk.atlassian.net/browse/HMRC-869)

### What?

I have added/removed/altered:

- [x] Changes the unused path column to be nullable

### Why?

I am doing this because:


- Fixes updates to goods nomenclatures oplog in the xi service
- This path got removed from updates in the code in a proxy object since its not used. It was missed that this path value was not nullable at the database level so updates to these rows was broken in a daily file (see https://github.com/trade-tariff/trade-tariff-backend/pull/2144)
