### PR TITLE
Add indexes to speed up views

### DIFF
--- a/db/migrate/20250331102817_update_view_indexes.rb
+++ b/db/migrate/20250331102817_update_view_indexes.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    run <<-SQL
+      DROP INDEX IF EXISTS quota_def_pk;
+      CREATE INDEX quota_def_pk ON quota_definitions_oplog (quota_definition_sid, oid DESC);
+
+      DROP INDEX IF EXISTS quota_balance_evt_pk;
+      CREATE INDEX quota_balance_evt_pk ON quota_balance_events_oplog (quota_definition_sid, occurrence_timestamp, oid DESC)
+    SQL
+  end
+
+  down do
+    run <<-SQL
+      DROP INDEX IF EXISTS quota_def_pk;
+      CREATE INDEX quota_def_pk ON quota_definitions_oplog (quota_definition_sid);
+
+      DROP INDEX IF EXISTS quota_balance_evt_pk;
+      CREATE INDEX quota_balance_evt_pk ON quota_balance_events_oplog (quota_definition_sid, occurrence_timestamp)
+    SQL
+  end
+
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -12025,7 +12025,7 @@ CREATE INDEX quota_assoc_pk ON uk.quota_associations_oplog USING btree (main_quo
 -- Name: quota_balance_evt_pk; Type: INDEX; Schema: uk; Owner: -
 --
 
-CREATE INDEX quota_balance_evt_pk ON uk.quota_balance_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
+CREATE INDEX quota_balance_evt_pk ON uk.quota_balance_events_oplog USING btree (quota_definition_sid, occurrence_timestamp, oid DESC);
 
 
 --
@@ -12053,7 +12053,7 @@ CREATE INDEX quota_crit_evt_pk ON uk.quota_critical_events_oplog USING btree (qu
 -- Name: quota_def_pk; Type: INDEX; Schema: uk; Owner: -
 --
 
-CREATE INDEX quota_def_pk ON uk.quota_definitions_oplog USING btree (quota_definition_sid);
+CREATE INDEX quota_def_pk ON uk.quota_definitions_oplog USING btree (quota_definition_sid, oid DESC);
 
 
 --
@@ -12583,3 +12583,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20250128110215_update_diac
 INSERT INTO "schema_migrations" ("filename") VALUES ('20250207141527_update_currency_vef_end_date.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20250219092427_delete_chief_guidance_column_from_appendix5a.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20250324091812_alter_column_nullable_path_in_goods_nomenclatures_oplog.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20250331102817_update_view_indexes.rb');


### PR DESCRIPTION
### Jira link

[HMRC-811](https://transformuk.atlassian.net/browse/HMRC-811)

### What?

I have updated:

- Index on quota_definitions_oplog
- Index on quota_balance_events_oplog

In both cases an oid in descending order has been to an existing index which is mainly used to create the related view.

### Why?

I am doing this because:

Speeds up queries on 3 views (old and new time to count all rows):
- quota_definitions (9 seconds -> 0.35 seconds)
- bad_quota_associations (10 seconds -> 1.5 seconds)
- quota_balance_events (300 seconds -> 12 seconds)

In particular this should help to speed up quota search

### Have you? (optional)

- [ ] Added documentation for new apis
- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical data
- Changes an api that is used in production
