### PR TITLE
HMRC-972 Fix flaky S3 tests

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -2,4 +2,3 @@
 --require rails_helper
 --tag ~roo_data
 --tag ~flaky
---format documentation

--- a/spec/lib/reporting/basic_spec.rb
+++ b/spec/lib/reporting/basic_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Reporting::Basic, skip: 'pending an investigation' do
+RSpec.describe Reporting::Basic do
   describe '.generate' do
     include_context 'with a stubbed reporting bucket'
 

--- a/spec/support/shared_contexts/with_a_stubbed_reporting_s3_bucket.rb
+++ b/spec/support/shared_contexts/with_a_stubbed_reporting_s3_bucket.rb
@@ -2,6 +2,7 @@ RSpec.shared_context 'with a stubbed reporting bucket' do
   before do
     s3_bucket.client.setup_stubbing
     s3_bucket.client.stub_responses(:put_object)
+    s3_bucket.client.api_requests.clear
   end
 
   let(:s3_bucket) do


### PR DESCRIPTION
### Jira link

[HMRC-972](https://transformuk.atlassian.net/browse/HMRC-972)

### What?

I have:

- Re-enabled tests
- Removed RSpec documentation formatting
- Clears api requests between tests

### Why?

Fixes tests and makes output less verbose
