### PR TITLE
HMRC-971: Clear Cache-Control header on non-frontend requests

### DIFF
--- a/app/middleware/clear_cache_control.rb
+++ b/app/middleware/clear_cache_control.rb
@@ -1,0 +1,22 @@
+class ClearCacheControl
+  FRONTEND_USER_AGENT = 'TradeTariffFrontend'.freeze
+  HTTP_USER_AGENT = 'HTTP_USER_AGENT'.freeze
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, body = @app.call(env)
+
+    headers.delete(Rack::CACHE_CONTROL) unless frontend_request?(env)
+
+    [status, headers, body]
+  end
+
+  private
+
+  def frontend_request?(env)
+    env[HTTP_USER_AGENT].to_s.start_with?(FRONTEND_USER_AGENT)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require_relative 'boot'
 require_relative '../lib/core_ext/object'
 require_relative '../app/middleware/handle_goods_nomenclature'
+require_relative '../app/middleware/clear_cache_control'
 
 require 'action_controller/railtie'
 require 'action_mailer/railtie'
@@ -64,6 +65,7 @@ module TradeTariffBackend
     config.sequel.allow_missing_migration_files = ENV['ALLOW_MISSING_MIGRATION_FILES'].to_s == 'true'
 
     config.middleware.use ::HandleGoodsNomenclature
+    config.middleware.insert_before Rack::ETag, ::ClearCacheControl
   end
 
   Rails.autoloaders.main.ignore(Rails.root.join('lib/core_ext'))


### PR DESCRIPTION
### Jira link

[HMRC-971](https://transformuk.atlassian.net/browse/HMRC-971)

### What?

I have added/removed/altered:

- [x] Added middleware to conditionally clear out [Cache-Control][cache-control] headers

### Why?

I am doing this because:

- This is required to prevent instructions to cache responses in the CDN for a very short lifetime.
- Without this the API requests have the same duration as the etagged requests from the frontend which are purposely short lived because verifying etags is a lightweight request

[cache-control]: https://datatracker.ietf.org/doc/html/rfc5861#:~:text=RFC%205861%20%2D%20HTTP%20Cache%2DControl%20Extensions%20for%20Stale%20Content
