### PR TITLE
HMRC-997 Set result count for exact searches and refactor SearchInstrumentationService

### DIFF
--- a/app/controllers/api/v2/search_controller.rb
+++ b/app/controllers/api/v2/search_controller.rb
@@ -5,7 +5,7 @@ module Api
 
       def search
         results = SearchService.new(Api::V2::SearchSerializationService.new, params).to_json
-        SearchInstrumentationService.log_search_results(params[:q], results)
+        instrumentation_service.log_search_results(results)
         render json: results
       end
 
@@ -15,11 +15,15 @@ module Api
                   else
                     Api::V2::SearchSuggestionSerializer.new(matching_suggestions).serializable_hash
                   end
-        SearchInstrumentationService.log_search_suggestions_results(params[:q], results)
+        instrumentation_service.log_search_suggestions_results(results)
         render json: results
       end
 
       private
+
+      def instrumentation_service
+        @instrumentation_service ||= SearchInstrumentationService.new(params[:q])
+      end
 
       def matching_suggestions
         if params[:q].present? && !SearchService::RogueSearchService.call(params[:q])

--- a/app/services/search_instrumentation_service.rb
+++ b/app/services/search_instrumentation_service.rb
@@ -2,54 +2,68 @@ class SearchInstrumentationService
   MATCH_TYPES = %i[goods_nomenclature_match reference_match].freeze
   LEVELS = %w[sections chapters headings commodities].freeze
 
-  def self.log_search_suggestions_results(query, results)
-    results_count = results[:data].size
-    results_zero = results_count.nil? || results_count.zero?
-    query_length = query.present? ? query.length : 0
+  attr_reader :search_query
+
+  def initialize(search_query)
+    @search_query = search_query
+  end
+
+  def log_search_suggestions_results(results)
+    result_count = results[:data].size
+    result_zero = result_count.nil? || result_count.zero?
 
     log_entry = {
       timestamp: Time.zone.now.utc.iso8601,
       level: 'INFO',
       service: 'api/v2/search_suggestions',
       message: 'Search Suggestion Request',
-      search_query: query,
-      query_length: query_length,
-      result_count: results_count,
-      result_zero: results_zero,
+      search_query:,
+      query_length:,
+      result_count:,
+      result_zero:,
     }
 
     Rails.logger.info(log_entry.to_json)
   end
 
-  def self.log_search_results(query, results)
+  def log_search_results(results)
     results_type = results[:data][:type]
     attributes = results[:data][:attributes]
-
-    max_score = MATCH_TYPES.product(LEVELS).map { |group|
-      match, level = group
-      attributes&.dig(match)&.dig(level)&.first&.dig('_score') || 0
-    }.max
-
-    results_count = MATCH_TYPES.product(LEVELS).map { |group|
-      match, level = group
-      attributes&.dig(match)&.dig(level)&.size || 0
-    }.sum
-
-    query_length = query.present? ? query.length : 0
+    result_count = count_results(attributes, results_type)
 
     log_entry = {
       timestamp: Time.zone.now.utc.iso8601,
       level: 'INFO',
       service: 'api/v2/search',
       message: 'Search Request',
-      search_query: query,
-      query_length: query_length,
-      results_type: results_type,
-      max_score: max_score,
-      result_count: results_count,
-      result_zero: results_count.zero?,
+      search_query:,
+      query_length:,
+      results_type:,
+      max_score: max_score(attributes),
+      result_count:,
+      result_zero: result_count.zero?,
     }
 
     Rails.logger.info(log_entry.to_json)
+  end
+
+  private
+
+  def max_score(attributes)
+    MATCH_TYPES.product(LEVELS).map { |group|
+      match, level = group
+      attributes&.dig(match)&.dig(level)&.first&.dig('_score') || 0
+    }.max
+  end
+
+  def count_results(attributes, results_type)
+    MATCH_TYPES.product(LEVELS).map { |group|
+      match, level = group
+      attributes&.dig(match)&.dig(level)&.size || 0
+    }.sum
+  end
+
+  def query_length
+    search_query.present? ? search_query.length : 0
   end
 end

--- a/app/services/search_instrumentation_service.rb
+++ b/app/services/search_instrumentation_service.rb
@@ -57,6 +57,9 @@ class SearchInstrumentationService
   end
 
   def count_results(attributes, results_type)
+    # override results_count if exact search
+    return 1 if results_type == :exact_search
+
     MATCH_TYPES.product(LEVELS).map { |group|
       match, level = group
       attributes&.dig(match)&.dig(level)&.size || 0

--- a/spec/services/search_instrumentation_service_spec.rb
+++ b/spec/services/search_instrumentation_service_spec.rb
@@ -1,4 +1,34 @@
 RSpec.describe SearchInstrumentationService do
+  describe '.log_search_suggestions_results' do
+    let(:query) { 'test query' }
+    let(:results) do
+      {
+        data: [
+          { type: :search_suggestion },
+          { type: :search_suggestion },
+          { type: :search_suggestion },
+        ],
+      }
+    end
+
+    before do
+      allow(Rails.logger).to receive(:info)
+      described_class.new(query).log_search_suggestions_results(results)
+    end
+
+    it 'logs the expected result count' do
+      expect(Rails.logger).to have_received(:info).with(
+        satisfy { |msg|
+          begin
+            JSON.parse(msg)['result_count'] == 3
+          rescue StandardError
+            false
+          end
+        },
+      )
+    end
+  end
+
   describe '.log_search_results' do
     let(:test_data) do
       {

--- a/spec/services/search_instrumentation_service_spec.rb
+++ b/spec/services/search_instrumentation_service_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe SearchInstrumentationService do
     let(:results) do
       {
         data: {
-          type: 'fuzzy_search',
+          type: :fuzzy_search,
           attributes: test_data,
         },
       }
@@ -59,7 +59,7 @@ RSpec.describe SearchInstrumentationService do
 
     before do
       allow(Rails.logger).to receive(:info)
-      described_class.log_search_results(query, results)
+      described_class.new(query).log_search_results(results)
     end
 
     it 'logs the max score correctly' do
@@ -84,6 +84,41 @@ RSpec.describe SearchInstrumentationService do
           end
         },
       )
+    end
+
+    context 'when the results type is exact_search' do
+      let(:results) do
+        {
+          data: {
+            type: :exact_search,
+            attributes: test_data,
+          },
+        }
+      end
+
+      it 'overrides the result count to 1' do
+        expect(Rails.logger).to have_received(:info).with(
+          satisfy { |msg|
+            begin
+              JSON.parse(msg)['result_count'] == 1
+            rescue StandardError
+              false
+            end
+          },
+        )
+      end
+
+      it 'logs the result zero correctly' do
+        expect(Rails.logger).to have_received(:info).with(
+          satisfy { |msg|
+            begin
+              JSON.parse(msg)['result_zero'] == false
+            rescue StandardError
+              false
+            end
+          },
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
### Jira link

[HMRC-997](https://transformuk.atlassian.net/browse/HMRC-997)

### What?

I have added/removed/altered:

- Refactored the service
- When logging details of an exact search, an override has been added to set the result count to be 1

### Why?

I am doing this because:

- Exact search results currently log as having no results

