### PR TITLE
HMRC-1023 Add chapters to news items

### DIFF
--- a/app/controllers/api/admin/news/items_controller.rb
+++ b/app/controllers/api/admin/news/items_controller.rb
@@ -64,6 +64,7 @@ module Api
             :show_on_home_page,
             :show_on_banner,
             :display_style,
+            :chapters,
             collection_ids: [],
           )
         end

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -49,6 +49,7 @@ module News
       validates_presence :slug
       validates_presence :precis if show_on_updates_page
       validates_presence :collection_ids, message: 'must include at least one collection'
+      errors.add(:chapters, 'have an invalid format') unless chapters.to_s.split.all? { |chapter| chapter.match?(/\A\d{2}\z/) }
     end
 
     def cache_key_with_version

--- a/app/serializers/api/admin/news/item_serializer.rb
+++ b/app/serializers/api/admin/news/item_serializer.rb
@@ -20,6 +20,7 @@ module Api
                    :show_on_banner,
                    :start_date,
                    :end_date,
+                   :chapters,
                    :collection_ids,
                    :created_at,
                    :updated_at

--- a/app/serializers/api/v2/news/item_serializer.rb
+++ b/app/serializers/api/v2/news/item_serializer.rb
@@ -19,6 +19,7 @@ module Api
                    :show_on_banner,
                    :start_date,
                    :end_date,
+                   :chapters,
                    :created_at,
                    :updated_at
 

--- a/db/migrate/20250425145123_add_chapters_to_news_item.rb
+++ b/db/migrate/20250425145123_add_chapters_to_news_item.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table :news_items do
+      add_column :chapters, String
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6161,7 +6161,8 @@ CREATE TABLE uk.news_items (
     show_on_banner boolean DEFAULT false NOT NULL,
     precis text,
     slug character varying(255),
-    imported_at timestamp without time zone
+    imported_at timestamp without time zone,
+    chapters text
 );
 
 
@@ -12634,3 +12635,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20250219092427_delete_chie
 INSERT INTO "schema_migrations" ("filename") VALUES ('20250324091812_alter_column_nullable_path_in_goods_nomenclatures_oplog.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20250331102817_update_view_indexes.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20250411114556_create_govuk_notifier_audit.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20250425145123_add_chapters_to_news_item.rb');

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -51,6 +51,24 @@ RSpec.describe News::Item do
 
       it { is_expected.to include(precis: ['is not present']) }
     end
+
+    context 'when chapters are invalid' do
+      let(:instance) { described_class.new(chapters: '1234') }
+
+      it { is_expected.to include(chapters: ['have an invalid format']) }
+    end
+
+    context 'when chapters are valid' do
+      let(:instance) { described_class.new(chapters: '12 34') }
+
+      it { is_expected.not_to include(chapters: ['have an invalid format']) }
+    end
+
+    context 'when chapters are empty' do
+      let(:instance) { described_class.new(chapters: '') }
+
+      it { is_expected.not_to include(chapters: ['have an invalid format']) }
+    end
   end
 
   describe 'associations' do

--- a/spec/serializers/api/admin/news/item_serializer_spec.rb
+++ b/spec/serializers/api/admin/news/item_serializer_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Api::Admin::News::ItemSerializer do
           show_on_banner: news_item.show_on_banner,
           start_date: news_item.start_date,
           end_date: news_item.end_date,
+          chapters: news_item.chapters,
           collection_ids: news_item.collections.map(&:id),
           created_at: news_item.created_at,
           updated_at: news_item.updated_at,

--- a/spec/serializers/api/v2/news/item_serializer_spec.rb
+++ b/spec/serializers/api/v2/news/item_serializer_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Api::V2::News::ItemSerializer do
           show_on_banner: news_item.show_on_banner,
           start_date: news_item.start_date,
           end_date: news_item.end_date,
+          chapters: news_item.chapters,
           created_at: news_item.created_at,
           updated_at: news_item.updated_at,
         },


### PR DESCRIPTION
### Jira link

[HMRC-1023](https://transformuk.atlassian.net/browse/HMRC-1023)

### What?

Adds chapters attribute for news items

### Why?

I am doing this because:

- This is required for stop press subscription feature

### Have you? (optional)

- [ ] Added documentation for new apis

### Deployment risks (optional)

- Changes an api that is used in production
