### PR TITLE
HMRC-986 Add CTA Link for SPIMM from OTT Homepage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,104 @@
+name: ci
+
+on:
+  push:
+    branches-ignore:
+      - main
+  pull_request:
+    branches-ignore:
+      - main
+  workflow_dispatch:
+
+env:
+  AWS_REGION: eu-west-2
+  BUNDLE_JOBS: "3"
+  BUNDLE_RETRY: "3"
+  DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/tariff_test"
+  ECR_URL: 382373577178.dkr.ecr.eu-west-2.amazonaws.com/tariff-backend-production
+  ENVIRONMENT: development
+  IAM_ROLE_ARN: arn:aws:iam::844815912454:role/GithubActions-ECS-Deployments-Role
+  RAILS_ENV: test
+  SKIP: terraform_docs,actionlint-docker
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3'
+      - id: ruby-version
+        run: echo "RUBY_VERSION=$(cat .ruby-version)" >> "$GITHUB_OUTPUT"
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ steps.ruby-version.outputs.RUBY_VERSION }}
+          bundler-cache: true
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.10.0
+      - uses: trade-tariff/trade-tariff-tools/.github/actions/setup-tflint@main
+      - uses: trade-tariff/trade-tariff-tools/.github/actions/setup-ssh@main
+        with:
+          ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
+      - run: cd terraform/ && terraform init -backend=false -reconfigure
+      - run: pip install pre-commit
+      - run: pre-commit run --all-files
+      - run: bundle exec brakeman
+
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: tariff_test
+        ports:
+          - 5432:5432
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ankane/setup-opensearch@v1
+        with:
+          opensearch-version: 2
+
+      - run: echo "127.0.0.1 host.docker.internal" | sudo tee -a /etc/hosts
+
+      - id: ruby-version
+        run: echo "RUBY_VERSION=$(cat .ruby-version)" >> "$GITHUB_OUTPUT"
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ steps.ruby-version.outputs.RUBY_VERSION }}
+          bundler-cache: true
+
+      - run: bundle exec rails db:structure:load --trace
+
+      - run: bundle exec rspec
+
+  notifications:
+      runs-on: ubuntu-latest
+      needs: test
+      if: always()
+      steps:
+        - uses: actions/checkout@v4
+        - uses: trade-tariff/trade-tariff-tools/.github/actions/slack-notify@main
+          with:
+            result: ${{ needs.test.result }}
+            slack_webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -24,73 +24,6 @@ env:
   SKIP: terraform_docs,actionlint-docker
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pre-commit-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3'
-      - id: ruby-version
-        run: echo "RUBY_VERSION=$(cat .ruby-version)" >> "$GITHUB_OUTPUT"
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ steps.ruby-version.outputs.RUBY_VERSION }}
-          bundler-cache: true
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.10.0
-      - uses: trade-tariff/trade-tariff-tools/.github/actions/setup-tflint@main
-      - uses: trade-tariff/trade-tariff-tools/.github/actions/setup-ssh@main
-        with:
-          ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
-      - run: cd terraform/ && terraform init -backend=false -reconfigure
-      - run: pip install pre-commit
-      - run: pre-commit run --all-files
-      - run: bundle exec brakeman
-
-  test:
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:17
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: tariff_test
-        ports:
-          - 5432:5432
-      redis:
-        image: redis:7
-        ports:
-          - 6379:6379
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: ankane/setup-opensearch@v1
-        with:
-          opensearch-version: 2
-
-      - run: echo "127.0.0.1 host.docker.internal" | sudo tee -a /etc/hosts
-
-      - id: ruby-version
-        run: echo "RUBY_VERSION=$(cat .ruby-version)" >> "$GITHUB_OUTPUT"
-
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ steps.ruby-version.outputs.RUBY_VERSION }}
-          bundler-cache: true
-
-      - run: bundle exec rails db:structure:load --trace
-
-      - run: bundle exec rspec
-
   build:
     runs-on: ubuntu-latest
     steps:
@@ -111,7 +44,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-      - test
     steps:
       - uses: actions/checkout@v4
       - id: docker-tag

--- a/app/models/public_users/user.rb
+++ b/app/models/public_users/user.rb
@@ -3,6 +3,6 @@ module PublicUsers
     plugin :auto_validations
     plugin :timestamps, update_on_create: true
 
-    one_to_many :subscriptions, class: 'PublicUsers::Subscriptions', key: :user_id
+    one_to_many :subscriptions, class: 'PublicUsers::Subscription', key: :user_id
   end
 end

--- a/db/data_migrations/20250429110718_set_news_item_1_show_on_home_page_false.rb
+++ b/db/data_migrations/20250429110718_set_news_item_1_show_on_home_page_false.rb
@@ -1,0 +1,11 @@
+Sequel.migration do
+  up do
+    if TradeTariffBackend.uk?
+      News::Item.where(title: 'Are you importing goods into Northern Ireland? ').update(show_on_home_page: false, end_date: Date.today)
+    end
+  end
+
+  down do
+    News::Item.where(title: 'Are you importing goods into Northern Ireland? ').update(show_on_home_page: true, end_date: nil)
+  end
+end

--- a/spec/factories/public_users/subscription.rb
+++ b/spec/factories/public_users/subscription.rb
@@ -1,10 +1,8 @@
 FactoryBot.define do
-  factory :user_subscription do
-    user
+  factory :user_subscription, class: 'PublicUsers::Subscription' do
+    user factory: :public_user
     subscription_type
     active { true }
     email { true }
-    created_at { Time.zone.now }
-    updated_at { Time.zone.now }
   end
 end

--- a/spec/factories/public_users/subscription.rb
+++ b/spec/factories/public_users/subscription.rb
@@ -1,8 +1,8 @@
-FactoryBot.define do
-  factory :user_subscription, class: 'PublicUsers::Subscription' do
-    user factory: :public_user
-    subscription_type
-    active { true }
-    email { true }
-  end
-end
+# FactoryBot.define do
+#   factory :user_subscription, class: 'PublicUsers::Subscription' do
+#     user factory: :public_user
+#     subscription_type
+#     active { true }
+#     email { true }
+#   end
+# end

--- a/spec/factories/public_users/user.rb
+++ b/spec/factories/public_users/user.rb
@@ -1,5 +1,5 @@
-FactoryBot.define do
-  factory :public_user, class: 'PublicUsers::User' do
-    external_id { SecureRandom.uuid }
-  end
-end
+# FactoryBot.define do
+#   factory :public_user, class: 'PublicUsers::User' do
+#     external_id { SecureRandom.uuid }
+#   end
+# end

--- a/spec/factories/public_users/user.rb
+++ b/spec/factories/public_users/user.rb
@@ -1,7 +1,5 @@
 FactoryBot.define do
-  factory :public_user do
+  factory :public_user, class: 'PublicUsers::User' do
     external_id { SecureRandom.uuid }
-    created_at { Time.zone.now }
-    updated_at { Time.zone.now }
   end
 end

--- a/spec/factories/subscriptions/type.rb
+++ b/spec/factories/subscriptions/type.rb
@@ -1,8 +1,6 @@
 FactoryBot.define do
-  factory :type do
+  factory :subscription_type, class: 'Subscriptions::Type' do
     name { 'test' }
     description { 'test' }
-    created_at { Time.zone.now }
-    updated_at { Time.zone.now }
   end
 end

--- a/spec/factories/subscriptions/type.rb
+++ b/spec/factories/subscriptions/type.rb
@@ -1,6 +1,6 @@
-FactoryBot.define do
-  factory :subscription_type, class: 'Subscriptions::Type' do
-    name { 'test' }
-    description { 'test' }
-  end
-end
+# FactoryBot.define do
+#   factory :subscription_type, class: 'Subscriptions::Type' do
+#     name { 'test' }
+#     description { 'test' }
+#   end
+# end

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -1400,7 +1400,7 @@ RSpec.describe Measure do
       let(:certificate_types_and_codes) { [] }
 
       it 'applies no filter' do
-        expect(dataset.pluck(:certificate_code)).to eq %w[123 456 789]
+        expect(dataset.order(:certificate_code).pluck(:certificate_code)).to eq %w[123 456 789]
       end
     end
 


### PR DESCRIPTION
### Jira link

[HMRC-986](https://transformuk.atlassian.net/browse/HMRC-986)

### What?

I have added migration script to hide GL news item from home page for UK 

### Why?

I am doing this because:

- A specifc banner with a CTA (call to action) button replaces it see front end PR https://github.com/trade-tariff/trade-tariff-frontend/pull/2276
- 
### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical data
