### PR TITLE
HMRC-962: Notify in production-alerts

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -88,3 +88,4 @@ jobs:
           with:
             result: ${{ needs.deploy.result }}
             slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+            slack_channel: production-alerts

--- a/.github/workflows/replicate-db-development.yml
+++ b/.github/workflows/replicate-db-development.yml
@@ -1,4 +1,4 @@
-name: Run DB Replicate Job
+name: Run Development DB Replicate Job
 
 on:
   schedule:

--- a/.github/workflows/replicate-db-staging.yml
+++ b/.github/workflows/replicate-db-staging.yml
@@ -1,4 +1,4 @@
-name: Run DB Replicate Job
+name: Run Staging DB Replicate Job
 
 on:
   schedule:


### PR DESCRIPTION
### Jira link

[HOTT-962](https://transformuk.atlassian.net/browse/HMRC-962)

### What?

I have added/removed/altered:

- [ ] Added production-alerts channel to notify prod deployment

### Why?

I am doing this because:

- When deploying to production, we’re notifying in production alerts 