### PR TITLE
HMRC-1115: Adds handling for expired search reference search suggestions

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -1,9 +1,6 @@
 name: Deploy to development
 
 on:
-  push:
-    branches-ignore:
-      - main
   workflow_dispatch:
 
 permissions:

--- a/app/models/search_suggestion.rb
+++ b/app/models/search_suggestion.rb
@@ -85,6 +85,10 @@ class SearchSuggestion < Sequel::Model
       )
     end
 
+    def search_reference_type
+      where(type: [TYPE_SEARCH_REFERENCE])
+    end
+
     def numeric_type
       where(
         type: [

--- a/app/services/search_suggestion_populator_service.rb
+++ b/app/services/search_suggestion_populator_service.rb
@@ -26,13 +26,18 @@ class SearchSuggestionPopulatorService
 
   private
 
+  def clear_old_suggestions
+    handle_expired_goods_nomenclature
+    handle_expired_search_references
+  end
+
   # A search suggestion always points to an associated goods nomenclature
   #
   # This goods nomenclature may expire or be replaced by a new goods nomenclature
   # and the suggestions point to now-expired goods nomenclatures
   #
   # This method clears out these expired suggestions
-  def clear_old_suggestions
+  def handle_expired_goods_nomenclature
     candidate_goods_nomenclature_sids = SearchSuggestion.goods_nomenclature_type.select_map(:id)
 
     all_goods_nomenclature_sids = GoodsNomenclature
@@ -51,6 +56,22 @@ class SearchSuggestionPopulatorService
     SearchSuggestion
       .where(id: expired_goods_nomenclature_sids.map(&:to_s))
       .goods_nomenclature_type
+      .delete
+  end
+
+  # NOTE: Search references get deleted when the classification team decides to move
+  # them to a different goods nomenclature. They also get deleted when goods_nomenclature that are associated with them are expired by the ClearInvalidSearchReferences job
+  #
+  # This method clears out search suggestions that are no longer valid
+  def handle_expired_search_references
+    current_suggestions = SearchSuggestion.search_reference_type.pluck(:id)
+    current_search_references = SearchReference.pluck(:id).map(&:to_s)
+    expired_search_references = current_suggestions - current_search_references
+
+    Rails.logger.info "Deleting #{expired_search_references.count} expired search references"
+
+    SearchSuggestion
+      .where(id: expired_search_references.map(&:to_s))
       .delete
   end
 end

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -1413,7 +1413,7 @@ RSpec.describe Measure do
       end
 
       it 'applies the filter' do
-        expect(dataset.pluck(:certificate_code)).to eq %w[123 456]
+        expect(dataset.pluck(:certificate_code)).to match_array %w[123 456]
       end
     end
   end

--- a/spec/services/search_suggestion_populator_service_spec.rb
+++ b/spec/services/search_suggestion_populator_service_spec.rb
@@ -81,4 +81,18 @@ RSpec.describe SearchSuggestionPopulatorService do
       expect { call }.to change_expired.to(nil)
     end
   end
+
+  context 'when some search suggestions belong to removed search references' do
+    let!(:search_suggestion) do
+      create(
+        :search_suggestion,
+        :search_reference,
+        value: 'something else',
+      )
+    end
+
+    it 'removes the no longer existing search reference search suggestion' do
+      expect { call }.to change { SearchSuggestion.where(id: search_suggestion.id).first }.to(nil)
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

[HMRC-1115](https://transformuk.atlassian.net/browse/HMRC-1115)

### What?

I have added/removed/altered:

- [x] Added handling for deleted search references in search suggestions table
- [x] Added test coverage for the new handling

### Why?

I am doing this because:

- This adds handling for search references that were deleted from the search references table and were causing issues recently
