### PR TITLE
HMRC-1067 Add Notify Subscribers Migration

### DIFF
--- a/db/migrate/20250516154516_add_notify_subscribers_to_news_item.rb
+++ b/db/migrate/20250516154516_add_notify_subscribers_to_news_item.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table :news_items do
+      add_column :notify_subscribers, TrueClass, default: false
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6272,7 +6272,8 @@ CREATE TABLE uk.news_items (
     precis text,
     slug character varying(255),
     imported_at timestamp without time zone,
-    chapters text
+    chapters text,
+    notify_subscribers boolean DEFAULT false
 );
 
 
@@ -12804,3 +12805,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20250411114556_create_govu
 INSERT INTO "schema_migrations" ("filename") VALUES ('20250417142520_create_subscription_models.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20250425145123_add_chapters_to_news_item.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20250514093320_create_user_preferences.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20250516154516_add_notify_subscribers_to_news_item.rb');


### PR DESCRIPTION
### Jira link

[HMRC-1067](https://transformuk.atlassian.net/browse/HMRC-1067)

### What?

I have Added migration to add email subscribers column to news item

### Why?

I am doing this because:

- Admin users can decide whether subscribers should be emailed with new/updated news items. 
