### PR TITLE
HMRC-1067 Add Notify Subscribers To News Item API 

### DIFF
--- a/app/controllers/api/admin/news/items_controller.rb
+++ b/app/controllers/api/admin/news/items_controller.rb
@@ -65,6 +65,7 @@ module Api
             :show_on_banner,
             :display_style,
             :chapters,
+            :notify_subscribers,
             collection_ids: [],
           )
         end

--- a/app/serializers/api/admin/news/item_serializer.rb
+++ b/app/serializers/api/admin/news/item_serializer.rb
@@ -21,6 +21,7 @@ module Api
                    :start_date,
                    :end_date,
                    :chapters,
+                   :notify_subscribers,
                    :collection_ids,
                    :created_at,
                    :updated_at

--- a/app/serializers/api/v2/news/item_serializer.rb
+++ b/app/serializers/api/v2/news/item_serializer.rb
@@ -20,6 +20,7 @@ module Api
                    :start_date,
                    :end_date,
                    :chapters,
+                   :email_subscribers,
                    :created_at,
                    :updated_at
 

--- a/spec/serializers/api/admin/news/item_serializer_spec.rb
+++ b/spec/serializers/api/admin/news/item_serializer_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Api::Admin::News::ItemSerializer do
           start_date: news_item.start_date,
           end_date: news_item.end_date,
           chapters: news_item.chapters,
+          notify_subscribers: news_item.notify_subscribers,
           collection_ids: news_item.collections.map(&:id),
           created_at: news_item.created_at,
           updated_at: news_item.updated_at,

--- a/spec/serializers/api/v2/news/item_serializer_spec.rb
+++ b/spec/serializers/api/v2/news/item_serializer_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Api::V2::News::ItemSerializer do
           start_date: news_item.start_date,
           end_date: news_item.end_date,
           chapters: news_item.chapters,
+          notify_subscribers: news_item.notify_subscribers,
           created_at: news_item.created_at,
           updated_at: news_item.updated_at,
         },


### PR DESCRIPTION
### Jira link

[HMRC-1067](https://transformuk.atlassian.net/browse/HMRC-1067)

### What?

I have added notify subscribers to news item api

### Why?

I am doing this because:

- Admin news items can be checked or unchecked to notify subscribers of stop press updates
- 
### Deployment risks

- Changes an api that is used in production
