### PR TITLE
Reduce dev service scale

### DIFF
--- a/terraform/config_development.tfvars
+++ b/terraform/config_development.tfvars
@@ -1,4 +1,6 @@
-region      = "eu-west-2"
-environment = "development"
-cpu         = 1024
-memory      = 2048
+region       = "eu-west-2"
+environment  = "development"
+cpu          = 1024
+memory       = 2048
+min_capacity = 1
+max_capacity = 1


### PR DESCRIPTION
BAU: Dev is running 5x instances for backend, so 10x total across uk/xi. 

We don't need this.