### PR TITLE
HMRC-1074 Add subscribable attribute to News Collections

### DIFF
--- a/app/controllers/api/admin/news/collections_controller.rb
+++ b/app/controllers/api/admin/news/collections_controller.rb
@@ -52,6 +52,7 @@ module Api
             :priority,
             :description,
             :name,
+            :subscribable,
             :slug,
           )
         end

--- a/app/serializers/api/admin/news/collection_serializer.rb
+++ b/app/serializers/api/admin/news/collection_serializer.rb
@@ -8,7 +8,7 @@ module Api
 
         set_id :id
 
-        attributes :name, :slug, :created_at, :updated_at, :description, :priority, :published
+        attributes :name, :slug, :created_at, :updated_at, :description, :priority, :published, :subscribable
       end
     end
   end

--- a/db/migrate/20250522141643_add_subscribable_to_news_collection.rb
+++ b/db/migrate/20250522141643_add_subscribable_to_news_collection.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table :news_collections do
+      add_column :subscribable, TrueClass, default: false
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6221,7 +6221,8 @@ CREATE TABLE uk.news_collections (
     priority integer DEFAULT 0 NOT NULL,
     description text,
     slug character varying(255),
-    published boolean DEFAULT true
+    published boolean DEFAULT true,
+    subscribable boolean DEFAULT false
 );
 
 
@@ -12804,3 +12805,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20250417142520_create_subs
 INSERT INTO "schema_migrations" ("filename") VALUES ('20250425145123_add_chapters_to_news_item.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20250514093320_create_user_preferences.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20250516154516_add_notify_subscribers_to_news_item.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20250522141643_add_subscribable_to_news_collection.rb');

--- a/spec/factories/news_factory.rb
+++ b/spec/factories/news_factory.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     sequence(:name) { |n| "News Collection #{n}" }
     sequence(:slug) { |n| "news_collection_#{n}" }
     published { true }
+    subscribable { false }
 
     trait :with_description do
       sequence(:description) { |n| "Description of News collection #{n}" }

--- a/spec/serializers/api/admin/news/collection_serializer_spec.rb
+++ b/spec/serializers/api/admin/news/collection_serializer_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Api::Admin::News::CollectionSerializer do
             description: collection.description,
             priority: collection.priority,
             published: collection.published,
+            subscribable: collection.subscribable,
           },
         },
       }


### PR DESCRIPTION
### Jira link

[HMRC-1074](https://transformuk.atlassian.net/browse/HMRC-1074)

### What?

I have added/removed/altered:

- Added a new field to news collections called `subscribable`
- Added to the serializer and made updateable

### Why?

I am doing this because:

- Only subscribable news items should be sent to subscribers
