### PR TITLE
HMRC-1074 Subscription matcher worker

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_gem:
     - config/default.yml
     - config/rails.yml
 
-require:
+plugins:
   - rubocop-rspec
   - rubocop-performance
 

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -41,6 +41,8 @@ module News
 
       to_remove = collections.pluck(:id) - collection_ids
       to_remove.each(&method(:remove_collection))
+
+      StopPressSubscriptionWorker.perform_async(id)
     end
 
     def validate
@@ -54,6 +56,10 @@ module News
 
     def cache_key_with_version
       "News::Item/#{id}-#{updated_at}"
+    end
+
+    def emailable?
+      collections.any?(&:subscribable) && notify_subscribers
     end
 
     dataset_module do

--- a/app/workers/stop_press_subscription_worker.rb
+++ b/app/workers/stop_press_subscription_worker.rb
@@ -1,0 +1,24 @@
+class StopPressSubscriptionWorker
+  include Sidekiq::Worker
+
+  def perform(stop_press_id)
+    @stop_press = News::Item.find(id: stop_press_id)
+    return unless @stop_press.emailable?
+
+    queue
+  end
+
+  def queue
+    users.each do |user|
+      # TODO: StopPressEmailWorker.perform_async(@stop_press, user)
+    end
+  end
+
+private
+
+  def users
+    PublicUsers::User
+      .with_active_stop_press_subscription
+      .matching_chapters(@stop_press.chapters)
+  end
+end

--- a/spec/factories/public_users/user.rb
+++ b/spec/factories/public_users/user.rb
@@ -1,5 +1,27 @@
 FactoryBot.define do
   factory :public_user, class: 'PublicUsers::User' do
     external_id { SecureRandom.uuid }
+
+    transient do
+      chapters { nil }
+    end
+
+    trait :with_active_stop_press_subscription do
+      after(:create) do |user, _evaluator|
+        user.stop_press_subscription = true
+      end
+    end
+
+    trait :with_inactive_stop_press_subscription do
+      after(:create) do |user, _evaluator|
+        user.stop_press_subscription = false
+      end
+    end
+
+    trait :with_chapters_preference do
+      after(:create) do |user, evaluator|
+        user.preferences.update(chapter_ids: evaluator.chapters)
+      end
+    end
   end
 end

--- a/spec/models/public_users/user_spec.rb
+++ b/spec/models/public_users/user_spec.rb
@@ -79,4 +79,70 @@ RSpec.describe PublicUsers::User do
       end
     end
   end
+
+  describe 'scopes' do
+    describe '.with_active_stop_press_subscription' do
+      subject(:dataset) { described_class.with_active_stop_press_subscription }
+
+      let!(:user_with_active_subscription) { create(:public_user, :with_active_stop_press_subscription) }
+      let!(:another_user_with_active_subscription) { create(:public_user, :with_active_stop_press_subscription) }
+      let!(:user_with_inactive_subscription) { create(:public_user, :with_inactive_stop_press_subscription) }
+      let!(:user_without_subscription) { create(:public_user) }
+      let!(:user_with_different_active_subscription) { create(:public_user) }
+
+      before do
+        user_with_active_subscription
+        another_user_with_active_subscription
+        user_with_inactive_subscription
+        user_without_subscription
+        create(:user_subscription, user_id: user_with_different_active_subscription.id)
+      end
+
+      it 'returns expected users' do
+        expect(dataset).to contain_exactly(user_with_active_subscription, another_user_with_active_subscription)
+      end
+    end
+
+    describe '.matching_chapters' do
+      subject(:dataset) { described_class.matching_chapters(chapters) }
+
+      let(:user_with_chapter_1) { create(:public_user, :with_chapters_preference, chapters: '01') }
+      let(:user_with_chapter_2_3) { create(:public_user, :with_chapters_preference, chapters: '02,03') }
+      let(:user_with_chapter_3_4) { create(:public_user, :with_chapters_preference, chapters: '03,04') }
+      let(:user_with_chapter_4) { create(:public_user, :with_chapters_preference, chapters: '04') }
+      let(:user_with_chapter_1_2_3_4) { create(:public_user, :with_chapters_preference, chapters: '01,02,03,04') }
+
+      before do
+        user_with_chapter_1
+        user_with_chapter_2_3
+        user_with_chapter_3_4
+        user_with_chapter_4
+        user_with_chapter_1_2_3_4
+      end
+
+      context 'when no chapters are specified' do
+        let(:chapters) { nil }
+
+        it 'returns all users' do
+          expect(dataset).to contain_exactly(user_with_chapter_1, user_with_chapter_2_3, user_with_chapter_3_4, user_with_chapter_4, user_with_chapter_1_2_3_4)
+        end
+      end
+
+      context 'when 1 chapter is specified' do
+        let(:chapters) { %w[01] }
+
+        it 'returns expected users' do
+          expect(dataset).to contain_exactly(user_with_chapter_1, user_with_chapter_1_2_3_4)
+        end
+      end
+
+      context 'when multiple chapters are specified' do
+        let(:chapters) { %w[01 02] }
+
+        it 'returns expected users' do
+          expect(dataset).to contain_exactly(user_with_chapter_1, user_with_chapter_2_3, user_with_chapter_1_2_3_4)
+        end
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -78,7 +78,7 @@ RSpec.configure do |config|
 
   config.verbose_retry = true
   config.display_try_failure_messages = true
-  config.around { |ex| ex.run_with_retry retry: 3 }
+  config.around { |ex| ex.run_with_retry retry: ENV.fetch('TEST_RETRIES', 3) }
 end
 
 def silence

--- a/spec/workers/stop_press_subscription_worker_spec.rb
+++ b/spec/workers/stop_press_subscription_worker_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe StopPressSubscriptionWorker, type: :worker do
+  subject(:instance) { described_class.new }
+
+  let(:stop_press) { create(:news_item) }
+  let(:user) { create(:public_user, :with_active_stop_press_subscription) }
+
+  describe '#perform' do
+    context 'when news item is not emailable' do
+      it 'does nothing' do
+        allow(stop_press).to receive(:emailable?).and_return(false)
+        allow(PublicUsers::User).to receive(:with_active_stop_press_subscription).and_return(PublicUsers::User)
+
+        instance.perform(stop_press.id)
+
+        expect(PublicUsers::User).not_to have_received(:with_active_stop_press_subscription)
+      end
+    end
+
+    context 'when news item is emailable' do
+      it 'returns users with active stop press subscriptions matching chapters', :aggregate_failures do
+        allow(stop_press).to receive_messages(emailable?: true, chapters: %w[01 02])
+        allow(PublicUsers::User).to receive(:with_active_stop_press_subscription).and_return(PublicUsers::User)
+        allow(PublicUsers::User).to receive(:matching_chapters).with(%w[01 02]).and_return(PublicUsers::User)
+        allow(News::Item).to receive(:find).and_return(stop_press)
+
+        instance.perform(stop_press.id)
+
+        expect(PublicUsers::User).to have_received(:with_active_stop_press_subscription)
+        expect(PublicUsers::User).to have_received(:matching_chapters).with(%w[01 02])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[HMRC-1074](https://transformuk.atlassian.net/browse/HMRC-1074)

### What?

Triggers worker after news item is saved that identifies users whose subscription matches the news item.

Matching is based on:
- The user having an active subscription
- The news item being emailable
- The news item relating to chapters that the user set a preference for

### Why?

I am doing this because:

- Part of MyOTT subscriptions. 
