### PR TITLE
HMRC-1093 Remove tariff_stop_press description

### DIFF
--- a/db/data_migrations/20250603103404_remove_tariff_stop_press_description.rb
+++ b/db/data_migrations/20250603103404_remove_tariff_stop_press_description.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    
+    tariff_stop_press_collection = News::Collection.where(id: 3)
+    tariff_stop_press_collection.update(description: '')
+    
+  end
+
+  down do
+    original_description = <<~DESC
+      ## More information
+
+      To stop getting the Tariff stop press notices, or to add recipients to
+      the distribution list, email: [tariff.management@hmrc.gov.uk](mailto:tariff.management@hmrc.gov.uk).
+    DESC
+
+    tariff_stop_press_collection = News::Collection.where(id: 3)
+    tariff_stop_press_collection.update(description: original_description)
+  end
+end


### PR DESCRIPTION
### Jira link

[HMRC-1093](https://transformuk.atlassian.net/browse/HMRC-1093)

### What?

I have removed description of tariff_stop_press

### Why?

I am doing this because:

- The description is in the front end with a CTA button (see PR https://github.com/trade-tariff/trade-tariff-frontend/pull/2347)

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical data
