### PR TITLE
HMRC-1141: Create Admin UI element to allow MTypes to be added for automation

### DIFF
--- a/app/controllers/api/admin/green_lanes/measure_type_mappings_controller.rb
+++ b/app/controllers/api/admin/green_lanes/measure_type_mappings_controller.rb
@@ -1,0 +1,66 @@
+module Api
+  module Admin
+    module GreenLanes
+      class MeasureTypeMappingsController < AdminController
+        include Pageable
+        include XiOnly
+
+        before_action :check_service, :authenticate_user!
+
+        def index
+          render json: serialize(measure_type_mappings.to_a, pagination_meta)
+        end
+
+        def show
+          ex = ::GreenLanes::IdentifiedMeasureTypeCategoryAssessment.with_pk!(params[:id])
+          render json: serialize(ex)
+        end
+
+        def create
+          ex = ::GreenLanes::IdentifiedMeasureTypeCategoryAssessment.new(measure_type_mapping_params)
+
+          if ex.valid? && ex.save
+            render json: serialize(ex),
+                   location: api_admin_green_lanes_measure_type_mapping_url(ex.id),
+                   status: :created
+          else
+            render json: serialize_errors(ex),
+                   status: :unprocessable_entity
+          end
+        end
+
+        def destroy
+          ex = ::GreenLanes::IdentifiedMeasureTypeCategoryAssessment.with_pk!(params[:id])
+          ex.destroy
+
+          head :no_content
+        end
+
+        private
+
+        def measure_type_mapping_params
+          params.require(:data).require(:attributes).permit(
+            :measure_type_id,
+            :theme_id,
+          )
+        end
+
+        def record_count
+          @measure_type_mappings.pagination_record_count
+        end
+
+        def measure_type_mappings
+          @measure_type_mappings ||= ::GreenLanes::IdentifiedMeasureTypeCategoryAssessment.order(Sequel.asc(:measure_type_id)).paginate(current_page, per_page)
+        end
+
+        def serialize(*args)
+          Api::Admin::GreenLanes::MeasureTypeMappingSerializer.new(*args).serializable_hash
+        end
+
+        def serialize_errors(measure_type_mapping)
+          Api::Admin::ErrorSerializationService.new(measure_type_mapping).call
+        end
+      end
+    end
+  end
+end

--- a/app/lib/green_lanes_updates_publisher/green_lanes_update.rb
+++ b/app/lib/green_lanes_updates_publisher/green_lanes_update.rb
@@ -1,24 +1,13 @@
 module GreenLanesUpdatesPublisher
   class GreenLanesUpdate
-    attr_reader :regulation_id, :regulation_role, :measure_type_id, :theme, :theme_id, :status
+    attr_accessor :theme, :theme_id, :status
+    attr_reader :regulation_id, :regulation_role, :measure_type_id
 
     def initialize(regulation_id, regulation_role, measure_type_id, status)
       @regulation_id = regulation_id
       @regulation_role = regulation_role
       @measure_type_id = measure_type_id
       @status = status
-    end
-
-    def status=(value)
-      @status = value
-    end
-
-    def theme=(value)
-      @theme = value
-    end
-
-    def theme_id=(value)
-      @theme_id = value
     end
   end
 end

--- a/app/serializers/api/admin/green_lanes/measure_type_mapping_serializer.rb
+++ b/app/serializers/api/admin/green_lanes/measure_type_mapping_serializer.rb
@@ -1,0 +1,15 @@
+module Api
+  module Admin
+    module GreenLanes
+      class MeasureTypeMappingSerializer
+        include JSONAPI::Serializer
+
+        set_type :green_lanes_measure_type_mapping
+
+        set_id :id
+
+        attributes :measure_type_id, :theme_id
+      end
+    end
+  end
+end

--- a/app/serializers/api/admin/green_lanes/update_notification_serializer.rb
+++ b/app/serializers/api/admin/green_lanes/update_notification_serializer.rb
@@ -24,6 +24,10 @@ module Api
         attribute :regulation_url do |update|
           ApplicationHelper.regulation_url(update.regulation)
         end
+
+        attribute :theme do  |update|
+          update.theme&.to_s
+        end
       end
     end
   end

--- a/app/workers/green_lanes_updates_worker.rb
+++ b/app/workers/green_lanes_updates_worker.rb
@@ -34,21 +34,20 @@ class GreenLanesUpdatesWorker
 
       next unless identified_ca
 
-      unless GreenLanes::CategoryAssessment[regulation_id: update.regulation_id,
-                                            regulation_role: update.regulation_role,
-                                            measure_type_id: update.measure_type_id]
+      next if GreenLanes::CategoryAssessment[regulation_id: update.regulation_id,
+                                             regulation_role: update.regulation_role,
+                                             measure_type_id: update.measure_type_id]
 
-        logger.info "Creating category assessment for #{update.measure_type_id}"
+      logger.info "Creating category assessment for #{update.measure_type_id}"
 
-        assessment = GreenLanes::CategoryAssessment.new(regulation_id: update.regulation_id,
-                                                        regulation_role: update.regulation_role,
-                                                        measure_type_id: update.measure_type_id,
-                                                        theme_id: identified_ca.theme_id)
-        assessment.save(validate: true)
-        update.status=::GreenLanes::UpdateNotification::NotificationStatus::CA_CREATED
-        update.theme_id=identified_ca.theme_id
-        update.theme=::GreenLanes::Theme.find(id: identified_ca.theme_id)&.to_s
-      end
+      assessment = GreenLanes::CategoryAssessment.new(regulation_id: update.regulation_id,
+                                                      regulation_role: update.regulation_role,
+                                                      measure_type_id: update.measure_type_id,
+                                                      theme_id: identified_ca.theme_id)
+      assessment.save(validate: true)
+      update.status = ::GreenLanes::UpdateNotification::NotificationStatus::CA_CREATED
+      update.theme_id = identified_ca.theme_id
+      update.theme = ::GreenLanes::Theme.find(id: identified_ca.theme_id)&.to_s
     end
   end
 

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -64,6 +64,7 @@ namespace :api, defaults: { format: 'json' }, path: '/admin' do
       resources :exemptions, only: %i[index show create update destroy]
       resources :measures, only: %i[index show create update destroy]
       resources :update_notifications, only: %i[index show update]
+      resources :measure_type_mappings, only: %i[index show create destroy]
     end
   end
 end

--- a/spec/models/green_lanes/update_notification_spec.rb
+++ b/spec/models/green_lanes/update_notification_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe GreenLanes::UpdateNotification do
 
       it 'is updates relationship attributes' do
         expect(notification).to have_attributes regulation_id: new_regulation.regulation_id,
-                                              regulation_role: new_regulation.role
+                                                regulation_role: new_regulation.role
       end
 
       it 'is is still updated after save and reload' do
@@ -151,7 +151,7 @@ RSpec.describe GreenLanes::UpdateNotification do
 
       it 'is updates relationship attributes' do
         expect(notification).to have_attributes regulation_id: new_regulation.regulation_id,
-                                              regulation_role: new_regulation.role
+                                                regulation_role: new_regulation.role
       end
 
       it 'is is still updated after save and reload' do

--- a/spec/requests/api/admin/green_lanes/measure_type_mappings_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/measure_type_mappings_controller_spec.rb
@@ -1,0 +1,104 @@
+RSpec.describe Api::Admin::GreenLanes::MeasureTypeMappingsController do
+  subject(:page_response) { make_request && response }
+
+  before do
+    allow(TradeTariffBackend).to receive(:service).and_return 'xi'
+  end
+
+  let(:json_response) { JSON.parse(page_response.body) }
+  let(:mapping) { create :identified_measure_type_category_assessment }
+
+
+  describe 'GET to #index' do
+    let(:make_request) do
+      authenticated_get api_admin_green_lanes_measure_type_mappings_path(format: :json)
+    end
+
+    context 'with some mappings' do
+      before { mapping }
+
+      it { is_expected.to have_http_status :success }
+      it { expect(json_response).to include('data') }
+      it { expect(json_response['data'].first['type']).to include('green_lanes_measure_type_mapping') }
+    end
+
+    context 'without any mappings' do
+      it { is_expected.to have_http_status :success }
+      it { expect(json_response).to include('data' => []) }
+    end
+  end
+
+  describe 'GET to #show' do
+    let(:make_request) do
+      authenticated_get api_admin_green_lanes_measure_type_mapping_path(id, format: :json)
+    end
+
+    context 'with existent mapping' do
+      let(:id) { mapping.id }
+
+      it { is_expected.to have_http_status :success }
+      it { expect(json_response).to include('data') }
+    end
+
+    context 'with non-existent mapping' do
+      let(:id) { 1001 }
+
+      it { is_expected.to have_http_status :not_found }
+    end
+  end
+
+  describe 'POST to #create' do
+    let(:make_request) do
+      authenticated_post api_admin_green_lanes_measure_type_mappings_path(format: :json), params: mapping_data
+    end
+
+    let :mapping_data do
+      {
+        data: {
+          type: :green_lanes_measure_type_mapping,
+          attributes: ex_attrs,
+        },
+      }
+    end
+
+    context 'with valid params' do
+      let(:ex_attrs) { build(:identified_measure_type_category_assessment).to_hash }
+
+      it { is_expected.to have_http_status :created }
+      it { is_expected.to have_attributes location: api_admin_green_lanes_measure_type_mapping_url(GreenLanes::IdentifiedMeasureTypeCategoryAssessment.last.id) }
+      it { expect { page_response }.to change(GreenLanes::IdentifiedMeasureTypeCategoryAssessment, :count).by(1) }
+    end
+
+    context 'with invalid params' do
+      let(:ex_attrs) { build(:identified_measure_type_category_assessment, theme_id: nil).to_hash }
+
+      it { is_expected.to have_http_status :unprocessable_entity }
+
+      it 'returns errors for mapping' do
+        expect(json_response).to include('errors')
+      end
+
+      it { expect { page_response }.not_to change(GreenLanes::IdentifiedMeasureTypeCategoryAssessment, :count) }
+    end
+  end
+
+  describe 'DELETE to #destroy' do
+    let :make_request do
+      authenticated_delete api_admin_green_lanes_measure_type_mapping_path(id, format: :json)
+    end
+
+    context 'with known mapping' do
+      let(:id) { mapping.id }
+
+      it { is_expected.to have_http_status :no_content }
+      it { expect { page_response }.to change(mapping, :exists?) }
+    end
+
+    context 'with unknown mapping' do
+      let(:id) { 9999 }
+
+      it { is_expected.to have_http_status :not_found }
+      it { expect { page_response }.not_to change(GreenLanes::IdentifiedMeasureTypeCategoryAssessment, :count) }
+    end
+  end
+end

--- a/spec/serializers/api/admin/green_lanes/measure_type_mapping_serializer_spec.rb
+++ b/spec/serializers/api/admin/green_lanes/measure_type_mapping_serializer_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe Api::Admin::GreenLanes::MeasureTypeMappingSerializer do
+  subject(:serialized) do
+    described_class.new(imtca).serializable_hash
+  end
+
+  let(:imtca) { create :identified_measure_type_category_assessment }
+
+  let :expected do
+    {
+      data: {
+        id: imtca.id.to_s,
+        type: :green_lanes_measure_type_mapping,
+        attributes: {
+          measure_type_id: imtca.measure_type_id,
+          theme_id: imtca.theme_id,
+        },
+      },
+    }
+  end
+
+  describe '#serializable_hash' do
+    it 'matches the expected hash' do
+      expect(serialized).to eq(expected)
+    end
+  end
+end

--- a/spec/workers/green_lanes_updates_worker_spec.rb
+++ b/spec/workers/green_lanes_updates_worker_spec.rb
@@ -12,15 +12,19 @@ RSpec.describe GreenLanesUpdatesWorker, type: :worker do
   end
 
   describe 'run green lanes updates worker' do
-    it 'creates CA with identified measure type' do
+    before do
       worker.perform
+    end
 
+    it 'creates CA with identified measure type' do
       category_assessments = GreenLanes::CategoryAssessment.all.pluck(:measure_type_id, :regulation_id, :regulation_role)
 
       expect(category_assessments).to include([measure.measure_type_id,
                                                measure.measure_generating_regulation_id,
                                                measure.measure_generating_regulation_role])
+    end
 
+    it 'update notification status and and theme id' do
       notification = GreenLanes::UpdateNotification.all.pluck(:measure_type_id, :regulation_id, :regulation_role,
                                                               :status, :theme_id)
 
@@ -28,8 +32,7 @@ RSpec.describe GreenLanesUpdatesWorker, type: :worker do
                                        measure.measure_generating_regulation_id,
                                        measure.measure_generating_regulation_role,
                                        ::GreenLanes::UpdateNotification::NotificationStatus::CA_CREATED,
-                                       ca.theme_id,
-                                      ])
+                                       ca.theme_id])
     end
   end
 
@@ -46,8 +49,7 @@ RSpec.describe GreenLanesUpdatesWorker, type: :worker do
                                        measure.measure_generating_regulation_id,
                                        measure.measure_generating_regulation_role,
                                        ::GreenLanes::UpdateNotification::NotificationStatus::CREATED,
-                                       nil,
-                                      ])
+                                       nil])
     end
   end
 end


### PR DESCRIPTION
### Jira link

[HMRC-1141](https://transformuk.atlassian.net/browse/HMRC-1141)

### What?

I have added/removed/altered:

- [ ] Added admin api to manage measure type category assessment mapping

### Why?

I am doing this because:

- Admin Ui should facilitate to manage measure type mapping

