### PR TITLE
HMRC-1068: Kill the totally non-json-api compliant x-meta in pagination

### DIFF
--- a/app/controllers/api/admin/search_references_base_controller.rb
+++ b/app/controllers/api/admin/search_references_base_controller.rb
@@ -10,11 +10,7 @@ module Api
     class SearchReferencesBaseController < AdminController
       before_action :authenticate_user!
 
-      after_action :set_pagination_headers, only: [:index]
-
       def index
-        search_references = search_reference_collection.by_title.paginate(page, per_page).all
-
         render json: Api::Admin::SearchReferences::SearchReferenceListSerializer.new(search_references).serializable_hash
       end
 
@@ -63,20 +59,8 @@ module Api
 
       private
 
-      def per_page
-        params.fetch(:per_page, default_limit).to_i
-      end
-
-      def page
-        params.fetch(:page, default_page).to_i
-      end
-
-      def default_page
-        1
-      end
-
-      def default_limit
-        25
+      def search_references
+        @search_references ||= search_reference_collection.by_title.all
       end
 
       def search_reference_params

--- a/spec/support/shared_examples/v2_search_reference_controller_examples.rb
+++ b/spec/support/shared_examples/v2_search_reference_controller_examples.rb
@@ -31,34 +31,6 @@ RSpec.shared_examples_for 'v2 search references controller' do
         expect(response.body).to match_json_expression pattern
       end
     end
-
-    context 'with pagination' do
-      context 'with odd pagination page/offset values' do
-        it 'does not raise exception with offset equal to zero' do
-          expect {
-            get(:index, params: { format: :json, offset: 0 }.merge(collection_query))
-          }.not_to raise_error
-        end
-
-        it 'does not raise exception with negative limit' do
-          expect {
-            get(:index, params: { format: :json, limit: -10 }.merge(collection_query))
-          }.not_to raise_error
-        end
-
-        it 'defaults to first page' do
-          get(:index, params: { format: :json }.merge(collection_query))
-
-          expect(response.body).to match_json_expression pattern
-        end
-      end
-    end
-
-    it 'includes pagination meta data in HTTP meta header' do
-      get(:index, params: { format: :json }.merge(collection_query))
-
-      expect(JSON.parse(response.headers['X-Meta'])).to have_key 'pagination'
-    end
   end
 
   describe 'GET to #show' do


### PR DESCRIPTION
### Jira link

[HMRC-1068](https://transformuk.atlassian.net/browse/HMRC-1068)

### What?

I have added/removed/altered:

- [ ] Removed pagination from admin search reference controller

### Why?

I am doing this because:

- It's not been used and built using non-json-api compliant x-meta header
