### PR TITLE
Check user is active before emailing

### DIFF
--- a/app/workers/stop_press_email_worker.rb
+++ b/app/workers/stop_press_email_worker.rb
@@ -5,9 +5,10 @@ class StopPressEmailWorker
 
   def perform(stop_press_id, user_id)
     stop_press = News::Item.find(id: stop_press_id)
-    user = PublicUsers::User.find(id: user_id)
+    user = PublicUsers::User.active[id: user_id]
 
     return if stop_press.nil?
+    return if user.nil?
     return unless user.email
 
     personalisation = {


### PR DESCRIPTION
### What?

Verifies the user is still active before sending a subscriber email

### Why?

Handles edge case where sending email was delayed and in the meantime the user has unsubscribed.

