### PR TITLE
Only match active users

### DIFF
--- a/app/controllers/api/user/public_users_controller.rb
+++ b/app/controllers/api/user/public_users_controller.rb
@@ -44,14 +44,14 @@ module Api
         if token.present?
           payload = CognitoTokenVerifier.verify_id_token(token)
           if payload
-            @current_user = PublicUsers::User.find(external_id: payload['sub'])
+            @current_user = PublicUsers::User.active[external_id: payload['sub']]
             @current_user ||= PublicUsers::User.create(external_id: payload['sub'])
             @current_user.email = payload['email']
           end
         end
 
         if Rails.env.development? && @current_user.nil?
-          @current_user = PublicUsers::User.find(external_id: 'dummy_user')
+          @current_user = PublicUsers::User.active[external_id: 'dummy_user']
           @current_user ||= PublicUsers::User.create(external_id: 'dummy_user')
           @current_user.email = 'dummy@user.com'
         end

--- a/spec/controllers/api/user/public_users_controller_spec.rb
+++ b/spec/controllers/api/user/public_users_controller_spec.rb
@@ -50,6 +50,24 @@ RSpec.describe Api::User::PublicUsersController do
 
       it { is_expected.to have_http_status :ok }
     end
+
+    describe 'when token is for deleted user' do
+      let!(:user) { create(:public_user, :has_been_soft_deleted) }
+      let(:token) do
+        {
+          'sub' => user.external_id,
+          'email' => 'alice@example.com',
+        }
+      end
+
+      it 'creates a user' do
+        expect {
+          get :show
+        }.to change(PublicUsers::User, :count).by 1
+      end
+
+      it { is_expected.to have_http_status :ok }
+    end
   end
 
   describe 'PATCH #update' do


### PR DESCRIPTION
### What?

When the myott user is loaded, first filter out deleted users. 
If there are no matches then create a new user

### Why?

I am doing this because:

- Deleted users can not be loaded

