### PR TITLE
Disable caching on user API

### DIFF
--- a/app/controllers/api/user/public_users_controller.rb
+++ b/app/controllers/api/user/public_users_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module User
     class PublicUsersController < ApiController
+      no_caching
+
       before_action :authenticate_token!
 
       attr_reader :current_user

--- a/app/controllers/api/user/subscriptions_controller.rb
+++ b/app/controllers/api/user/subscriptions_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module User
     class SubscriptionsController < ApiController
+      no_caching
+
       before_action :authenticate_token!
 
       def show


### PR DESCRIPTION
### What?

- API has per user authentication so can't be cached


