### PR TITLE
Fix Notify email audit

### DIFF
--- a/app/services/govuk_notifier.rb
+++ b/app/services/govuk_notifier.rb
@@ -31,14 +31,14 @@ class GovukNotifier
 
   def audit(email_response)
     GovukNotifierAudit.create(
-      notification_uuid: email_response['id'],
-      subject: email_response['content']['subject'],
-      body: email_response['content']['body'],
-      from_email: email_response['content']['from_email'],
-      template_id: email_response['template']['id'],
-      template_version: email_response['template']['version'],
-      template_uri: email_response['template']['uri'],
-      notification_uri: email_response['uri'],
+      notification_uuid: email_response.id,
+      subject: email_response.content['subject'],
+      body: email_response.content['body'],
+      from_email: email_response.content['from_email'],
+      template_id: email_response.template['id'],
+      template_version: email_response.template['version'],
+      template_uri: email_response.template['uri'],
+      notification_uri: email_response.uri,
       created_at: Time.zone.now,
     )
   end

--- a/spec/factories/notifications_client_post_email_response.rb
+++ b/spec/factories/notifications_client_post_email_response.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
     end
 
     initialize_with do
-      new(body)
+      Notifications::Client::ResponseNotification.new(body)
     end
   end
 end

--- a/spec/services/govuk_notifier_spec.rb
+++ b/spec/services/govuk_notifier_spec.rb
@@ -7,9 +7,7 @@ RSpec.describe GovukNotifier do
   let(:notifier) { described_class.new(client: client) }
 
   describe '#send_email' do
-    let(:mocked_response) do
-      attributes_for(:notifications_client_post_email_response)[:body]
-    end
+    let(:mocked_response) { build(:notifications_client_post_email_response) }
 
     it 'sends an email' do
       allow(notifier).to receive(:audit).and_return(nil)


### PR DESCRIPTION
### What?

An audit record is kept when an email is sent via Notify. The response object has a new format.
