### PR TITLE
Delete external user worker

### DIFF
--- a/app/lib/identity_api_client.rb
+++ b/app/lib/identity_api_client.rb
@@ -2,14 +2,24 @@ module IdentityApiClient
   def self.get_email(username)
     return nil unless username
 
-    url = URI.join(TradeTariffBackend.identity_api_host, '/api/users/', username).to_s
-    response = Faraday.get(url) do |req|
-      req.headers['Authorization'] = "Token #{TradeTariffBackend.identity_api_key}"
-      req.headers['Content-Type'] = 'application/json'
-    end
-
+    response = user_request(:get, username)
     if response.success?
       JSON.parse(response.body)['user']['email']
+    end
+  end
+
+  def self.delete_user(username)
+    return nil unless username
+
+    response = user_request(:delete, username)
+    response.success?
+  end
+
+  def self.user_request(method, username)
+    url = URI.join(TradeTariffBackend.identity_api_host, '/api/users/', username).to_s
+    Faraday.public_send(method, url) do |req|
+      req.headers['Authorization'] = "Token #{TradeTariffBackend.identity_api_key}"
+      req.headers['Content-Type'] = 'application/json'
     end
   end
 end

--- a/app/models/public_users/user.rb
+++ b/app/models/public_users/user.rb
@@ -70,6 +70,8 @@ module PublicUsers
       update(deleted: true)
 
       PublicUsers::ActionLog.create(user_id: id, action: PublicUsers::ActionLog::DELETED)
+
+      ExternalUserDeletionWorker.perform_async(id)
     end
 
   private

--- a/app/workers/external_user_deletion_worker.rb
+++ b/app/workers/external_user_deletion_worker.rb
@@ -15,15 +15,9 @@ class ExternalUserDeletionWorker
         return
       end
 
-      if identity_api_delete(user.external_id)
+      if IdentityApiClient.delete_user(user.external_id)
         user.update(external_id: nil)
       end
     end
-  end
-
-  private
-
-  def identity_api_delete(external_id)
-    IdentityApiClient.delete_user(external_id)
   end
 end

--- a/app/workers/external_user_deletion_worker.rb
+++ b/app/workers/external_user_deletion_worker.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class ExternalUserDeletionWorker
+  include Sidekiq::Worker
+
+  def perform(user_id)
+    user = PublicUsers::User[user_id]
+    return unless user&.deleted
+
+    if user.external_id
+      # Check for another active user with the same external_id
+      active_user = PublicUsers::User.active.where(external_id: user.external_id).exclude(id: user.id).first
+      if active_user
+        user.update(external_id: nil)
+        return
+      end
+
+      if identity_api_delete(user.external_id)
+        user.update(external_id: nil)
+      end
+    end
+  end
+
+  private
+
+  def identity_api_delete(external_id)
+    IdentityApiClient.delete_user(external_id)
+  end
+end

--- a/db/migrate/20250612150328_allow_null_external_id_on_users.rb
+++ b/db/migrate/20250612150328_allow_null_external_id_on_users.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:public__users) do
+      set_column_allow_null :external_id
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -308,7 +308,7 @@ CREATE TABLE public.user_subscriptions (
 
 CREATE TABLE public.users (
     id integer NOT NULL,
-    external_id text NOT NULL,
+    external_id text,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     deleted boolean DEFAULT false
@@ -12910,3 +12910,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20250606144014_create_user
 INSERT INTO "schema_migrations" ("filename") VALUES ('20250609105128_add_deleted_attribute_to_public_users.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20250609121000_change_user_subscriptions_primary_key_to_uuid_sequel.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20250611135620_add_created_at_to_user_preferences.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20250612150328_allow_null_external_id_on_users.rb');

--- a/spec/lib/identity_api_client_spec.rb
+++ b/spec/lib/identity_api_client_spec.rb
@@ -37,4 +37,36 @@ RSpec.describe IdentityApiClient do
       end
     end
   end
+
+  describe '.delete_user' do
+    subject(:client) { described_class.delete_user(username) }
+
+    context 'when username is nil' do
+      let(:username) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with username' do
+      let(:username) { '123abc' }
+      let(:host) { 'https://identity.api' }
+
+      before do
+        allow(TradeTariffBackend).to receive(:identity_api_host).and_return(host)
+        stub_request(:delete, "#{host}/api/users/#{username}")
+          .to_return(status: 200)
+      end
+
+      it { is_expected.to be true }
+
+      context 'when api errors' do
+        before do
+          stub_request(:delete, "#{host}/api/users/#{username}")
+            .to_return(status: 500)
+        end
+
+        it { is_expected.to be false }
+      end
+    end
+  end
 end

--- a/spec/workers/external_user_deletion_worker_spec.rb
+++ b/spec/workers/external_user_deletion_worker_spec.rb
@@ -1,16 +1,18 @@
 RSpec.describe ExternalUserDeletionWorker, type: :worker do
-  let(:user) { instance_spy(PublicUsers::User, id: 1, deleted: true, external_id: 'abc123') }
+  let(:user) { create(:public_user, deleted: true, external_id: 'abc123') }
+  let(:worker) { described_class.new }
 
   before do
     allow(PublicUsers::User).to receive(:[]).with(user.id).and_return(user)
-    allow(user).to receive(:update)
   end
 
   context 'when user is not deleted' do
     it 'returns without doing anything' do
       allow(user).to receive(:deleted).and_return(false)
-      described_class.new.perform(user.id)
-      expect(user).not_to have_received(:update)
+
+      expect {
+        worker.perform(user.id)
+      }.not_to change(user, :external_id)
     end
   end
 
@@ -18,34 +20,35 @@ RSpec.describe ExternalUserDeletionWorker, type: :worker do
     let(:active_user) { instance_spy(PublicUsers::User) }
 
     before do
-      allow(user).to receive(:external_id).and_return('abc123')
       allow(PublicUsers::User).to receive_message_chain(:active, :where, :exclude, :first).and_return(active_user)
     end
 
     it 'removes external_id from deleted user and returns' do
-      described_class.new.perform(user.id)
-      expect(user).to have_received(:update).with(external_id: nil)
+      expect {
+        worker.perform(user.id)
+      }.to change(user, :external_id).from('abc123').to(nil)
     end
   end
 
   context 'when no other active user with same external_id' do
-    let(:worker) { described_class.new }
-
     before do
-      allow(user).to receive(:external_id).and_return('abc123')
       allow(PublicUsers::User).to receive_message_chain(:active, :where, :exclude, :first).and_return(nil)
     end
 
     it 'calls identity API and removes external_id if successful' do
-      allow(worker).to receive(:identity_api_delete).with('abc123').and_return(true)
-      worker.perform(user.id)
-      expect(user).to have_received(:update).with(external_id: nil)
+      allow(IdentityApiClient).to receive(:delete_user).and_return(true)
+
+      expect {
+        worker.perform(user.id)
+      }.to change(user, :external_id).from('abc123').to(nil)
     end
 
     it 'does not remove external_id if API call fails' do
-      allow(worker).to receive(:identity_api_delete).with('abc123').and_return(false)
-      worker.perform(user.id)
-      expect(user).not_to have_received(:update).with(external_id: nil)
+      allow(IdentityApiClient).to receive(:delete_user).and_return(false)
+
+      expect {
+        worker.perform(user.id)
+      }.not_to change(user, :external_id)
     end
   end
 end

--- a/spec/workers/external_user_deletion_worker_spec.rb
+++ b/spec/workers/external_user_deletion_worker_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe ExternalUserDeletionWorker, type: :worker do
+  let(:user) { instance_spy(PublicUsers::User, id: 1, deleted: true, external_id: 'abc123') }
+
+  before do
+    allow(PublicUsers::User).to receive(:[]).with(user.id).and_return(user)
+    allow(user).to receive(:update)
+  end
+
+  context 'when user is not deleted' do
+    it 'returns without doing anything' do
+      allow(user).to receive(:deleted).and_return(false)
+      described_class.new.perform(user.id)
+      expect(user).not_to have_received(:update)
+    end
+  end
+
+  context 'when another active user with same external_id exists' do
+    let(:active_user) { instance_spy(PublicUsers::User) }
+
+    before do
+      allow(user).to receive(:external_id).and_return('abc123')
+      allow(PublicUsers::User).to receive_message_chain(:active, :where, :exclude, :first).and_return(active_user)
+    end
+
+    it 'removes external_id from deleted user and returns' do
+      described_class.new.perform(user.id)
+      expect(user).to have_received(:update).with(external_id: nil)
+    end
+  end
+
+  context 'when no other active user with same external_id' do
+    let(:worker) { described_class.new }
+
+    before do
+      allow(user).to receive(:external_id).and_return('abc123')
+      allow(PublicUsers::User).to receive_message_chain(:active, :where, :exclude, :first).and_return(nil)
+    end
+
+    it 'calls identity API and removes external_id if successful' do
+      allow(worker).to receive(:identity_api_delete).with('abc123').and_return(true)
+      worker.perform(user.id)
+      expect(user).to have_received(:update).with(external_id: nil)
+    end
+
+    it 'does not remove external_id if API call fails' do
+      allow(worker).to receive(:identity_api_delete).with('abc123').and_return(false)
+      worker.perform(user.id)
+      expect(user).not_to have_received(:update).with(external_id: nil)
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[HMRC-1224](https://transformuk.atlassian.net/browse/HMRC-1224)

### What?

- Added worker to request users are deleted from Identity service

### Why?

I am doing this because:

- To remove users personal details when they are no longer required
