### PR TITLE
HMRC-1192 Add reply email ID and change template ID

### DIFF
--- a/app/services/govuk_notifier.rb
+++ b/app/services/govuk_notifier.rb
@@ -7,12 +7,13 @@ class GovukNotifier
     @client = client || Notifications::Client.new(api_key)
   end
 
-  def send_email(email, template_id, personalisation = {})
+  def send_email(email, template_id, personalisation = {}, email_reply_to_id = nil)
     # TODO: one_click_unsubscribe_url https://docs.notifications.service.gov.uk/ruby.html#one-click-unsubscribe-url-recommended
     email_response = @client.send_email(
       email_address: use_email(email),
-      template_id: template_id,
-      personalisation: personalisation,
+      template_id:,
+      personalisation:,
+      email_reply_to_id:,
     )
     audit(email_response)
   rescue Notifications::Client::RequestError => e

--- a/app/workers/stop_press_email_worker.rb
+++ b/app/workers/stop_press_email_worker.rb
@@ -1,7 +1,8 @@
 class StopPressEmailWorker
   include Sidekiq::Worker
 
-  TEMPLATE_ID = 'a3b813e7-77ce-47c6-bdac-69ea24d7cdcd'.freeze
+  TEMPLATE_ID = '3295f0bf-c75f-4202-8dcf-703e4564b932'.freeze
+  REPLY_TO_ID = '61e19d5e-4fae-4b7e-aa2e-cd05a87f4cf8'.freeze
 
   def perform(stop_press_id, user_id)
     stop_press = News::Item.find(id: stop_press_id)
@@ -18,7 +19,7 @@ class StopPressEmailWorker
       site_url: URI.join(TradeTariffBackend.frontend_host, 'subscriptions/').to_s,
       unsubscribe_url: URI.join(TradeTariffBackend.frontend_host, 'subscriptions/unsubscribe/', user.stop_press_subscription).to_s,
     }
-    client.send_email(user.email, TEMPLATE_ID, personalisation)
+    client.send_email(user.email, TEMPLATE_ID, personalisation, REPLY_TO_ID)
   end
 
   def client

--- a/spec/services/govuk_notifier_spec.rb
+++ b/spec/services/govuk_notifier_spec.rb
@@ -11,9 +11,10 @@ RSpec.describe GovukNotifier do
 
     it 'sends an email' do
       allow(notifier).to receive(:audit).and_return(nil)
-      notifier.send_email('test@example.com', 'b0f0c2b2-c5f5-4f3a-8d9c-f4c8e8ea1a7c', { foo: 'bar' })
+      notifier.send_email('test@example.com', 'b0f0c2b2-c5f5-4f3a-8d9c-f4c8e8ea1a7c', { foo: 'bar' }, 'f47ac10b-58cc-4372-a567-0e02b2c3d479')
       expect(client).to have_received(:send_email).with(
         email_address: 'test@example.com',
+        email_reply_to_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
         template_id: 'b0f0c2b2-c5f5-4f3a-8d9c-f4c8e8ea1a7c',
         personalisation: {
           foo: 'bar',
@@ -27,6 +28,7 @@ RSpec.describe GovukNotifier do
       notifier.send_email('test@example.com', 'b0f0c2b2-c5f5-4f3a-8d9c-f4c8e8ea1a7c', { foo: 'bar' })
       expect(client).to have_received(:send_email).with(
         email_address: 'foo@example.com',
+        email_reply_to_id: nil,
         template_id: 'b0f0c2b2-c5f5-4f3a-8d9c-f4c8e8ea1a7c',
         personalisation: {
           foo: 'bar',

--- a/spec/workers/stop_press_email_worker_spec.rb
+++ b/spec/workers/stop_press_email_worker_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe StopPressEmailWorker, type: :worker do
     it 'sends request to client' do
       instance.perform(stop_press.id, user.id)
 
-      expect(client).to have_received(:send_email).with(email_address, StopPressEmailWorker::TEMPLATE_ID, expected_personalisation)
+      expect(client).to have_received(:send_email).with(email_address, StopPressEmailWorker::TEMPLATE_ID, expected_personalisation, StopPressEmailWorker::REPLY_TO_ID)
     end
 
     it 'returns if stop press is nil' do


### PR DESCRIPTION
### Jira link

[HMRC-1192](https://transformuk.atlassian.net/browse/HMRC-1192)

### What?

I have added/removed/altered:

- Updated Notify template ID to use live account
- Added email reply ID

### Why?

I am doing this because:

- Getting ready for production
