### PR TITLE
Fix: convert chapters to array

### DIFF
--- a/app/workers/stop_press_subscription_worker.rb
+++ b/app/workers/stop_press_subscription_worker.rb
@@ -17,9 +17,11 @@ class StopPressSubscriptionWorker
 private
 
   def users
+    chapters = @stop_press.chapters.split(',').map(&:strip)
+
     PublicUsers::User
       .active
       .with_active_stop_press_subscription
-      .matching_chapters(@stop_press.chapters)
+      .matching_chapters(chapters)
   end
 end

--- a/spec/models/public_users/user_spec.rb
+++ b/spec/models/public_users/user_spec.rb
@@ -200,6 +200,22 @@ RSpec.describe PublicUsers::User do
       end
 
       context 'when no chapters are specified' do
+        let(:chapters) { '' }
+
+        it 'returns all users' do
+          expect(dataset).to contain_exactly(
+            user_with_chapter_1,
+            user_with_chapter_2_3,
+            user_with_chapter_3_4,
+            user_with_chapter_4,
+            user_with_chapter_1_2_3_4,
+            user_with_nil_preference,
+            user_with_empty_preference,
+          )
+        end
+      end
+
+      context 'when no chapters are specified with nil' do
         let(:chapters) { nil }
 
         it 'returns all users' do
@@ -215,8 +231,16 @@ RSpec.describe PublicUsers::User do
         end
       end
 
-      context 'when 1 chapter is specified' do
+      context 'when 1 chapter is specified as array' do
         let(:chapters) { %w[01] }
+
+        it 'returns expected users' do
+          expect(dataset).to contain_exactly(user_with_chapter_1, user_with_chapter_1_2_3_4, user_with_nil_preference, user_with_empty_preference)
+        end
+      end
+
+      context 'when 1 chapter is specified as string' do
+        let(:chapters) { '01' }
 
         it 'returns expected users' do
           expect(dataset).to contain_exactly(user_with_chapter_1, user_with_chapter_1_2_3_4, user_with_nil_preference, user_with_empty_preference)

--- a/spec/workers/stop_press_subscription_worker_spec.rb
+++ b/spec/workers/stop_press_subscription_worker_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe StopPressSubscriptionWorker, type: :worker do
 
     context 'when news item is emailable' do
       it 'returns users with active stop press subscriptions matching chapters', :aggregate_failures do
-        allow(stop_press).to receive_messages(emailable?: true, chapters: %w[01 02])
+        allow(stop_press).to receive_messages(emailable?: true, chapters: '01, 02')
         allow(PublicUsers::User).to receive_messages(active: PublicUsers::User, with_active_stop_press_subscription: PublicUsers::User)
         allow(PublicUsers::User).to receive(:matching_chapters).with(%w[01 02]).and_return(PublicUsers::User)
         allow(News::Item).to receive(:find).and_return(stop_press)
@@ -30,9 +30,9 @@ RSpec.describe StopPressSubscriptionWorker, type: :worker do
       end
 
       it 'queues emails' do
-        allow(stop_press).to receive_messages(emailable?: true, chapters: %w[01 02])
+        allow(stop_press).to receive_messages(emailable?: true, chapters: '01')
         allow(PublicUsers::User).to receive(:with_active_stop_press_subscription).and_return(PublicUsers::User)
-        allow(PublicUsers::User).to receive(:matching_chapters).with(%w[01 02]).and_return([user])
+        allow(PublicUsers::User).to receive(:matching_chapters).with(%w[01]).and_return([user])
         allow(News::Item).to receive(:find).and_return(stop_press)
         allow(StopPressEmailWorker).to receive(:perform_async)
 


### PR DESCRIPTION
### What?

`matching_chapters` method expects chapters to be an array or single string value


