### PR TITLE
HMRC-1284 Find matches between user prefs and stop press chapters

### DIFF
--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -66,14 +66,6 @@ module News
       URI.join(TradeTariffBackend.frontend_host, '/news/stories/', slug).to_s
     end
 
-    def subscription_reason
-      if chapters.present?
-        "You have previously subscribed to receive updates about this tariff chapter - #{chapters}"
-      else
-        'This is a non-chapter specific update from the UK Trade Tariff Service'
-      end
-    end
-
     dataset_module do
       def descending
         order(Sequel.desc(:start_date), Sequel.desc(:id))

--- a/app/workers/stop_press_email_worker.rb
+++ b/app/workers/stop_press_email_worker.rb
@@ -14,7 +14,7 @@ class StopPressEmailWorker
     personalisation = {
       stop_press_title: stop_press.title,
       stop_press_link: stop_press.public_url,
-      subscription_reason: stop_press.subscription_reason,
+      subscription_reason: subscription_reason(stop_press, user),
       site_url: URI.join(TradeTariffBackend.frontend_host, 'subscriptions/').to_s,
       unsubscribe_url: URI.join(TradeTariffBackend.frontend_host, 'subscriptions/unsubscribe/', user.stop_press_subscription).to_s,
     }
@@ -23,5 +23,19 @@ class StopPressEmailWorker
 
   def client
     @client ||= GovukNotifier.new
+  end
+
+  def subscription_reason(stop_press, user)
+    if stop_press.chapters.blank?
+      'This is a non-chapter specific update from the UK Trade Tariff Service'
+    else
+      chapters = if user.chapter_ids.empty?
+                   stop_press.chapters
+                 else
+                   # Find common chapters between stop press and user subscriptions
+                   (stop_press.chapters.split(',').map(&:strip) & user.chapter_ids.split(',').map(&:strip)).join(', ')
+                 end
+      "You have previously subscribed to receive updates about this tariff chapter - #{chapters}"
+    end
   end
 end

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -517,34 +517,6 @@ RSpec.describe News::Item do
     it { is_expected.to eq 'https://www.trade-tariff.service.gov.uk/news/stories/tariff-stop-press-notice---22-may-2025' }
   end
 
-  describe '#subscription_reason' do
-    subject(:reason) { news_item.subscription_reason }
-
-    context 'when chapters are present' do
-      let(:news_item) { build(:news_item, chapters: '12') }
-
-      it 'returns a chapter-specific subscription reason' do
-        expect(reason).to eq 'You have previously subscribed to receive updates about this tariff chapter - 12'
-      end
-    end
-
-    context 'when chapters are not present' do
-      let(:news_item) { build(:news_item, chapters: nil) }
-
-      it 'returns a non-chapter-specific subscription reason' do
-        expect(reason).to eq 'This is a non-chapter specific update from the UK Trade Tariff Service'
-      end
-    end
-
-    context 'when chapters are empty' do
-      let(:news_item) { build(:news_item, chapters: '') }
-
-      it 'returns a non-chapter-specific subscription reason' do
-        expect(reason).to eq 'This is a non-chapter specific update from the UK Trade Tariff Service'
-      end
-    end
-  end
-
   describe 'after_save callback' do
     let(:instance) { build(:news_item) }
 


### PR DESCRIPTION
### Jira link

[HMRC-1284](https://transformuk.atlassian.net/browse/HMRC-1284)

### What?

Finds union between users chapters preferences and chapters that the stop press relates to.
Adds a message to the stop press email detailing the matches

### Why?

I am doing this because:

- We want to inform the user why they are receiving the email
