### PR TITLE
HMRC-1285 Move emailable check

### DIFF
--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -42,7 +42,7 @@ module News
       to_remove = collections.pluck(:id) - collection_ids
       to_remove.each(&method(:remove_collection))
 
-      StopPressSubscriptionWorker.perform_async(id) if TradeTariffBackend.myott?
+      StopPressSubscriptionWorker.perform_async(id) if TradeTariffBackend.myott? && emailable?
     end
 
     def validate

--- a/app/workers/stop_press_subscription_worker.rb
+++ b/app/workers/stop_press_subscription_worker.rb
@@ -3,8 +3,6 @@ class StopPressSubscriptionWorker
 
   def perform(stop_press_id)
     @stop_press = News::Item.find(id: stop_press_id)
-    return unless @stop_press.emailable?
-
     queue
   end
 

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -518,22 +518,31 @@ RSpec.describe News::Item do
   end
 
   describe 'after_save callback' do
-    let(:instance) { build(:news_item) }
+    let(:collection) { create :news_collection, subscribable: true }
+    let(:news_item) { create :news_item, notify_subscribers: true, collection_ids: collection.id }
 
     before do
       allow(StopPressSubscriptionWorker).to receive(:perform_async)
+      # disable calling worker initially
+      allow(TradeTariffBackend).to receive(:myott?).and_return(false)
+      news_item.save
     end
 
-    it 'calls worker on save' do
-      instance.save
-      expect(StopPressSubscriptionWorker).to have_received(:perform_async).with(instance.id)
+    it 'calls worker when saved' do
+      allow(TradeTariffBackend).to receive(:myott?).and_return(true)
+      news_item.update(precis: 'Updated precis')
+      expect(StopPressSubscriptionWorker).to have_received(:perform_async).with(news_item.id)
     end
 
     it 'does not call worker when feature flag is off' do
-      allow(TradeTariffBackend).to receive(:myott?).and_return(false)
+      news_item.update(precis: 'Updated precis')
+      expect(StopPressSubscriptionWorker).not_to have_received(:perform_async).with(news_item.id)
+    end
 
-      instance.save
-      expect(StopPressSubscriptionWorker).not_to have_received(:perform_async).with(instance.id)
+    it 'does not call worker when notify_subscribers is false' do
+      allow(TradeTariffBackend).to receive(:myott?).and_return(true)
+      news_item.update(notify_subscribers: false)
+      expect(StopPressSubscriptionWorker).not_to have_received(:perform_async).with(news_item.id)
     end
   end
 end

--- a/spec/workers/stop_press_subscription_worker_spec.rb
+++ b/spec/workers/stop_press_subscription_worker_spec.rb
@@ -5,41 +5,28 @@ RSpec.describe StopPressSubscriptionWorker, type: :worker do
   let(:user) { create(:public_user, :with_active_stop_press_subscription) }
 
   describe '#perform' do
-    context 'when news item is not emailable' do
-      it 'does nothing' do
-        allow(stop_press).to receive(:emailable?).and_return(false)
-        allow(PublicUsers::User).to receive(:with_active_stop_press_subscription).and_return(PublicUsers::User)
+    it 'returns users with active stop press subscriptions matching chapters', :aggregate_failures do
+      allow(stop_press).to receive_messages(emailable?: true, chapters: '01, 02')
+      allow(PublicUsers::User).to receive_messages(active: PublicUsers::User, with_active_stop_press_subscription: PublicUsers::User)
+      allow(PublicUsers::User).to receive(:matching_chapters).with(%w[01 02]).and_return(PublicUsers::User)
+      allow(News::Item).to receive(:find).and_return(stop_press)
 
-        instance.perform(stop_press.id)
+      instance.perform(stop_press.id)
 
-        expect(PublicUsers::User).not_to have_received(:with_active_stop_press_subscription)
-      end
+      expect(PublicUsers::User).to have_received(:with_active_stop_press_subscription)
+      expect(PublicUsers::User).to have_received(:matching_chapters).with(%w[01 02])
     end
 
-    context 'when news item is emailable' do
-      it 'returns users with active stop press subscriptions matching chapters', :aggregate_failures do
-        allow(stop_press).to receive_messages(emailable?: true, chapters: '01, 02')
-        allow(PublicUsers::User).to receive_messages(active: PublicUsers::User, with_active_stop_press_subscription: PublicUsers::User)
-        allow(PublicUsers::User).to receive(:matching_chapters).with(%w[01 02]).and_return(PublicUsers::User)
-        allow(News::Item).to receive(:find).and_return(stop_press)
+    it 'queues emails' do
+      allow(stop_press).to receive_messages(emailable?: true, chapters: '01')
+      allow(PublicUsers::User).to receive(:with_active_stop_press_subscription).and_return(PublicUsers::User)
+      allow(PublicUsers::User).to receive(:matching_chapters).with(%w[01]).and_return([user])
+      allow(News::Item).to receive(:find).and_return(stop_press)
+      allow(StopPressEmailWorker).to receive(:perform_async)
 
-        instance.perform(stop_press.id)
+      instance.perform(stop_press.id)
 
-        expect(PublicUsers::User).to have_received(:with_active_stop_press_subscription)
-        expect(PublicUsers::User).to have_received(:matching_chapters).with(%w[01 02])
-      end
-
-      it 'queues emails' do
-        allow(stop_press).to receive_messages(emailable?: true, chapters: '01')
-        allow(PublicUsers::User).to receive(:with_active_stop_press_subscription).and_return(PublicUsers::User)
-        allow(PublicUsers::User).to receive(:matching_chapters).with(%w[01]).and_return([user])
-        allow(News::Item).to receive(:find).and_return(stop_press)
-        allow(StopPressEmailWorker).to receive(:perform_async)
-
-        instance.perform(stop_press.id)
-
-        expect(StopPressEmailWorker).to have_received(:perform_async).with(stop_press.id, user.id)
-      end
+      expect(StopPressEmailWorker).to have_received(:perform_async).with(stop_press.id, user.id)
     end
   end
 end


### PR DESCRIPTION
### Jira link

[HMRC-1285](https://transformuk.atlassian.net/browse/HMRC-1285)

### What?

I have added/removed/altered:

- Moved check for whether a stop press object is emailable to the after_save

### Why?

I am doing this because:

- Ensure that we don't trigger the worker incorrectly
