### PR TITLE
HMRC-1290 Schedule email of myott action log report

### DIFF
--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -281,5 +281,9 @@ module TradeTariffBackend
     def myott?
       ENV['MYOTT_ENABLED'].to_s == 'true'
     end
+
+    def myott_report_email
+      ENV['MYOTT_REPORT_EMAIL']
+    end
   end
 end

--- a/app/mailers/action_log_mailer.rb
+++ b/app/mailers/action_log_mailer.rb
@@ -1,0 +1,19 @@
+class ActionLogMailer < ApplicationMailer
+  default from: TradeTariffBackend.from_email
+
+  def daily_report(csv_data, date)
+    return if TradeTariffBackend.myott_report_email.blank?
+
+    @date = date
+
+    attachments["action_logs_#{date}.csv"] = {
+      mime_type: 'text/csv',
+      content: csv_data,
+    }
+
+    mail(
+      to: TradeTariffBackend.myott_report_email,
+      subject: "[HMRC Online Trade Tariff] User Action Logs Report #{@date}",
+    )
+  end
+end

--- a/app/views/action_log_mailer/daily_report.text.erb
+++ b/app/views/action_log_mailer/daily_report.text.erb
@@ -1,0 +1,3 @@
+User Event Logs Report
+
+Please find attached the report of all user event logs created on <%= @date %>.

--- a/app/workers/action_log_report_worker.rb
+++ b/app/workers/action_log_report_worker.rb
@@ -1,0 +1,36 @@
+require 'csv'
+
+class ActionLogReportWorker
+  include Sidekiq::Worker
+
+  def perform
+    yesterday = Time.zone.yesterday
+    start_date = yesterday.beginning_of_day
+    end_date = yesterday.end_of_day
+
+    action_logs = PublicUsers::ActionLog
+                    .where(Sequel.lit('created_at >= ? AND created_at <= ?', start_date, end_date))
+                    .all
+
+    return if action_logs.empty?
+
+    csv_data = generate_csv(action_logs)
+    ActionLogMailer.daily_report(csv_data, yesterday.strftime('%Y-%m-%d')).deliver_now
+  end
+
+  private
+
+  def generate_csv(action_logs)
+    CSV.generate do |csv|
+      csv << ['ID', 'User ID', 'Action', 'Created At']
+      action_logs.each do |log|
+        csv << [
+          log.id,
+          log.user_id,
+          log.action,
+          log.created_at,
+        ]
+      end
+    end
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -84,3 +84,8 @@
       description: "Removes failed myott subscribers"
       class: RemoveFailedSubscribersWorker
       status: <%= ENV.fetch('SERVICE', 'uk') == 'uk' ? 'enabled' : 'disabled' %>
+    ActionLogReportWorker:
+      cron: "0 6 * * *" # 6am every day
+      description: Generates and emails a CSV report of the previous day's user action logs
+      class: ActionLogReportWorker
+      status: <%= ENV.fetch('SERVICE', 'uk') == 'uk' ? 'enabled' : 'disabled' %>

--- a/spec/factories/public_users/action_logs.rb
+++ b/spec/factories/public_users/action_logs.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :action_log, class: 'PublicUsers::ActionLog' do
+    user { create(:public_user) }
+    action { PublicUsers::ActionLog::REGISTERED }
+  end
+end

--- a/spec/mailers/action_log_mailer_spec.rb
+++ b/spec/mailers/action_log_mailer_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe ActionLogMailer do
+  describe '#daily_report' do
+    subject(:mail) { described_class.daily_report(csv_data, yesterday) }
+
+    let(:yesterday) { Date.yesterday }
+    let(:csv_data) { "ID,Action,Created At\r\n1,registered,2025-06-17" }
+
+    before do
+      allow(TradeTariffBackend).to receive(:myott_report_email).and_return('myottreport@example.com')
+    end
+
+    it 'sets the correct subject' do
+      expect(mail.subject).to eq("[HMRC Online Trade Tariff] User Action Logs Report #{yesterday.strftime('%Y-%m-%d')}")
+    end
+
+    it 'sets the recipient from TradeTariffBackend.myott_report_email' do
+      expect(mail.to).to eq(['myottreport@example.com'])
+    end
+
+    it 'includes one attachment' do
+      expect(mail.attachments.count).to eq(1)
+    end
+
+    it 'sets the correct attachment filename' do
+      attachment = mail.attachments.first
+      expect(attachment.filename).to eq("action_logs_#{yesterday.strftime('%Y-%m-%d')}.csv")
+    end
+
+    it 'sets the correct attachment content type' do
+      attachment = mail.attachments.first
+      expect(attachment.content_type).to eq('text/csv')
+    end
+
+    it 'sets the correct attachment content' do
+      attachment = mail.attachments.first
+      expect(attachment.body.raw_source).to eq(csv_data)
+    end
+
+    it 'renders the email body with the correct date' do
+      expect(mail.body.encoded).to include(yesterday.strftime('%Y-%m-%d'))
+    end
+  end
+end

--- a/spec/workers/action_log_report_worker_spec.rb
+++ b/spec/workers/action_log_report_worker_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe ActionLogReportWorker do
+  describe '#perform' do
+    subject(:worker) { described_class.new }
+
+    let(:yesterday) { Time.zone.yesterday }
+    let(:start_date) { yesterday.beginning_of_day }
+    let(:end_date) { yesterday.end_of_day }
+
+    context 'when there are action logs from yesterday' do
+      let(:user) { create(:public_user) }
+      let(:mailer) { instance_double(ActionMailer::MessageDelivery, deliver_now: true) }
+
+      before do
+        # Create action logs within the time range
+        create(:action_log, user: user, action: PublicUsers::ActionLog::REGISTERED, created_at: start_date + 2.hours)
+        create(:action_log, user: user, action: PublicUsers::ActionLog::SUBSCRIBED, created_at: start_date + 4.hours)
+
+        # Create an action log outside of the time range
+        create(:action_log, user: user, action: PublicUsers::ActionLog::DELETED, created_at: start_date - 1.day)
+
+        allow(ActionLogMailer).to receive(:daily_report).and_return(mailer)
+      end
+
+      it 'generates CSV and sends an email with the correct data', :aggregate_failures do
+        worker.perform
+
+        expect(ActionLogMailer).to have_received(:daily_report) do |csv_data, date|
+          expect(date).to eq(yesterday.strftime('%Y-%m-%d'))
+          expect(csv_data).to include('ID,User ID,Action,Created At')
+          expect(csv_data).to include(PublicUsers::ActionLog::REGISTERED)
+          expect(csv_data).to include(PublicUsers::ActionLog::SUBSCRIBED)
+          expect(csv_data).not_to include(PublicUsers::ActionLog::DELETED)
+        end
+
+        expect(mailer).to have_received(:deliver_now)
+      end
+    end
+
+    context 'when there are no action logs from yesterday' do
+      before do
+        # Create an action log outside of the time range
+        create(:action_log, action: PublicUsers::ActionLog::REGISTERED, created_at: start_date - 1.day)
+
+        allow(ActionLogMailer).to receive(:daily_report)
+      end
+
+      it 'does not send an email' do
+        worker.perform
+
+        expect(ActionLogMailer).not_to have_received(:daily_report)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[HMRC-1290](https://transformuk.atlassian.net/browse/HMRC-1290)

### What?

I have added/removed/altered:

- Added a task that emails CSV of myott action logs records for the previous day

### Why?

I am doing this because:

- So we can keep track of actions during private beta
