### PR TITLE
HMRC-1280 Email Subscription Confirmation

### DIFF
--- a/app/models/public_users/user.rb
+++ b/app/models/public_users/user.rb
@@ -64,6 +64,7 @@ module PublicUsers
       else
         add_subscription(subscription_type: Subscriptions::Type.stop_press, active:)
         if active
+          SubscriptionConfirmationEmailWorker.perform_async(id)
           PublicUsers::ActionLog.create(user_id: id, action: PublicUsers::ActionLog::SUBSCRIBED)
         end
       end

--- a/app/workers/subscription_confirmation_email_worker.rb
+++ b/app/workers/subscription_confirmation_email_worker.rb
@@ -1,0 +1,22 @@
+class SubscriptionConfirmationEmailWorker
+  include Sidekiq::Worker
+
+  TEMPLATE_ID = '1f2eeee9-a7f1-46d0-a9ad-aa5059aea8a6'.freeze
+
+  def perform(user_id)
+    user = PublicUsers::User.active[id: user_id]
+
+    return if user.nil?
+    return unless user.email
+
+    personalisation = {
+      site_url: URI.join(TradeTariffBackend.frontend_host, 'subscriptions/').to_s,
+      unsubscribe_url: URI.join(TradeTariffBackend.frontend_host, 'subscriptions/unsubscribe/', user.stop_press_subscription).to_s,
+    }
+    client.send_email(user.email, TEMPLATE_ID, personalisation)
+  end
+
+  def client
+    @client ||= GovukNotifier.new
+  end
+end

--- a/spec/workers/subscription_confirmation_email_worker_spec.rb
+++ b/spec/workers/subscription_confirmation_email_worker_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe SubscriptionConfirmationEmailWorker, type: :worker do
+  subject(:instance) { described_class.new }
+
+  let(:user) { create(:public_user, :with_active_stop_press_subscription) }
+  let(:client) { instance_double(GovukNotifier) }
+  let(:email_address) { 'test@example.com' }
+
+  before do
+    allow(instance).to receive(:client).and_return(client) # rubocop:disable RSpec/SubjectStub
+    allow(PublicUsers::User).to receive(:active).and_return(instance_double(Sequel::Dataset, :[] => user))
+    allow(user).to receive(:email).and_return(email_address)
+    allow(client).to receive(:send_email)
+  end
+
+  describe '#perform' do
+    let(:expected_personalisation) do
+      {
+        site_url: URI.join(TradeTariffBackend.frontend_host, 'subscriptions/').to_s,
+        unsubscribe_url: URI.join(TradeTariffBackend.frontend_host, 'subscriptions/unsubscribe/', user.stop_press_subscription).to_s,
+      }
+    end
+
+    it 'gets user email address' do
+      instance.perform(user.id)
+      expect(user).to have_received(:email).at_least(:once)
+    end
+
+    it 'sends request to client' do
+      instance.perform(user.id)
+
+      expect(client).to have_received(:send_email).with(email_address, SubscriptionConfirmationEmailWorker::TEMPLATE_ID, expected_personalisation)
+    end
+
+    context 'without valid user' do
+      let(:user) { nil }
+
+      it 'does not send email' do
+        instance.perform('invalid_user_id')
+        expect(client).not_to have_received(:send_email)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[HMRC-1280](https://transformuk.atlassian.net/browse/HMRC-1280)

### What?

I have added subscription confirmation email worker

### Why?

I am doing this because:

- To email users with confirmation when subscribed
