### PR TITLE
BAU: Enable ECS-exec on backend-job

### DIFF
--- a/terraform/backend_job.tf
+++ b/terraform/backend_job.tf
@@ -20,5 +20,9 @@ module "backend-job" {
   cpu          = var.cpu
   memory       = var.memory
 
+  task_role_policy_arns = [aws_iam_policy.task.arn]
+
   service_environment_config = local.db_replicate_secret_env_vars
+
+  enable_ecs_exec = true
 }


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Enable ECS exec on backend-job tasks

### Why?

I am doing this because:

- I want arbitrary execution of scripts using ecs exec in the backend job task and I don't want to run in xi/uk since these have long-lived connections to the database
