### PR TITLE
HMRC-1306: Disable tests in development deployment

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -21,7 +21,7 @@ jobs:
     with:
       app-name: tariff-backend
       environment: development
+      test-flavour: none
     secrets:
-      basic-password: ${{ secrets.BASIC_PASSWORD }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
       ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}


### PR DESCRIPTION
### Jira link

[HMRC-1306](https://transformuk.atlassian.net/browse/HMRC-1306)

### What?

I have added/removed/altered:

- [x] Disabled the e2e tests after deploying to the development environment

### Why?

I am doing this because:

- This is needed as a simpler solution than making sure the backend and admin appsare also deployed via workflow calls (something to solve later)
