### PR TITLE
HMRC-1360: More rollback fixes

### DIFF
--- a/app/lib/sequel/plugins/oplog.rb
+++ b/app/lib/sequel/plugins/oplog.rb
@@ -37,6 +37,15 @@ module Sequel
           materialized
         end
 
+        model.define_singleton_method(:actually_materialized?) do
+          result = db.fetch(<<~SQL, table_name.to_s).first
+            SELECT relkind = 'm' as is_materialized
+            FROM pg_class
+            WHERE relname = ?
+          SQL
+          result && result[:is_materialized]
+        end
+
         # Associations
         model.one_to_one :source, key: :oid,
                                   primary_key: :oid,

--- a/db/migrate/20250619131935_add_base_geographical_area_materialized_views.rb
+++ b/db/migrate/20250619131935_add_base_geographical_area_materialized_views.rb
@@ -135,4 +135,69 @@ Sequel.migration do
               AND geographical_area_description_periods1.operation::text <> 'D'::text
     EOVIEW
   end
+
+  down do
+    # NOTE: Subsequent migrations duplicate this migration
+    drop_view(:geographical_areas, materialized: true) if GeographicalArea.actually_materialized?
+    drop_view(:geographical_area_descriptions, materialized: true) if GeographicalAreaDescription.actually_materialized?
+    drop_view(:geographical_area_description_periods, materialized: true) if GeographicalAreaDescriptionPeriod.actually_materialized?
+
+    create_or_replace_view :geographical_areas, <<~EOVIEW
+      SELECT geographical_areas1.geographical_area_sid,
+        geographical_areas1.parent_geographical_area_group_sid,
+        geographical_areas1.validity_start_date,
+        geographical_areas1.validity_end_date,
+        geographical_areas1.geographical_code,
+        geographical_areas1.geographical_area_id,
+        geographical_areas1."national",
+        geographical_areas1.oid,
+        geographical_areas1.operation,
+        geographical_areas1.operation_date,
+        geographical_areas1.filename,
+        geographical_areas1.hjid
+      FROM uk.geographical_areas_oplog geographical_areas1
+      WHERE (geographical_areas1.oid IN ( SELECT max(geographical_areas2.oid) AS max
+              FROM uk.geographical_areas_oplog geographical_areas2
+              WHERE geographical_areas1.geographical_area_sid = geographical_areas2.geographical_area_sid))
+                AND geographical_areas1.operation::text <> 'D'::text
+    EOVIEW
+
+    create_or_replace_view :geographical_area_descriptions, <<~EOVIEW
+      SELECT geographical_area_descriptions1.geographical_area_description_period_sid,
+        geographical_area_descriptions1.language_id,
+        geographical_area_descriptions1.geographical_area_sid,
+        geographical_area_descriptions1.geographical_area_id,
+        geographical_area_descriptions1.description,
+        geographical_area_descriptions1."national",
+        geographical_area_descriptions1.oid,
+        geographical_area_descriptions1.operation,
+        geographical_area_descriptions1.operation_date,
+        geographical_area_descriptions1.filename
+      FROM uk.geographical_area_descriptions_oplog geographical_area_descriptions1
+      WHERE (geographical_area_descriptions1.oid IN ( SELECT max(geographical_area_descriptions2.oid) AS max
+              FROM uk.geographical_area_descriptions_oplog geographical_area_descriptions2
+              WHERE geographical_area_descriptions1.geographical_area_description_period_sid = geographical_area_descriptions2.geographical_area_description_period_sid
+                AND geographical_area_descriptions1.geographical_area_sid = geographical_area_descriptions2.geographical_area_sid))
+                AND geographical_area_descriptions1.operation::text <> 'D'::text
+    EOVIEW
+
+    create_or_replace_view :geographical_area_description_periods, <<~EOVIEW
+      SELECT geographical_area_description_periods1.geographical_area_description_period_sid,
+        geographical_area_description_periods1.geographical_area_sid,
+        geographical_area_description_periods1.validity_start_date,
+        geographical_area_description_periods1.geographical_area_id,
+        geographical_area_description_periods1.validity_end_date,
+        geographical_area_description_periods1."national",
+        geographical_area_description_periods1.oid,
+        geographical_area_description_periods1.operation,
+        geographical_area_description_periods1.operation_date,
+        geographical_area_description_periods1.filename
+      FROM uk.geographical_area_description_periods_oplog geographical_area_description_periods1
+      WHERE (geographical_area_description_periods1.oid IN ( SELECT max(geographical_area_description_periods2.oid) AS max
+              FROM uk.geographical_area_description_periods_oplog geographical_area_description_periods2
+              WHERE geographical_area_description_periods1.geographical_area_description_period_sid = geographical_area_description_periods2.geographical_area_description_period_sid
+              AND geographical_area_description_periods1.geographical_area_sid = geographical_area_description_periods2.geographical_area_sid))
+              AND geographical_area_description_periods1.operation::text <> 'D'::text
+    EOVIEW
+  end
 end

--- a/db/migrate/20250620150030_add_geographical_area_materialized_views_fix.rb
+++ b/db/migrate/20250620150030_add_geographical_area_materialized_views_fix.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 Sequel.migration do
-  change do
-    drop_view :geographical_areas, materialized: true
-    drop_view :geographical_area_descriptions, materialized: true
-    drop_view :geographical_area_description_periods, materialized: true
-    drop_view :measure_excluded_geographical_areas, materialized: true
-    drop_view :geographical_area_memberships, materialized: true
+  up do
+    drop_view :geographical_areas, materialized: true if GeographicalArea.actually_materialized?
+    drop_view :geographical_area_descriptions, materialized: true if GeographicalAreaDescription.actually_materialized?
+    drop_view :geographical_area_description_periods, materialized: true if GeographicalAreaDescriptionPeriod.actually_materialized?
+    drop_view :measure_excluded_geographical_areas, materialized: true if MeasureExcludedGeographicalArea.actually_materialized?
+    drop_view :geographical_area_memberships, materialized: true if GeographicalAreaMembership.actually_materialized?
 
     create_view :geographical_areas, <<~EOVIEW, materialized: true
       SELECT geographical_areas1.geographical_area_sid,
@@ -26,7 +26,6 @@ Sequel.migration do
               FROM geographical_areas_oplog geographical_areas2
               WHERE geographical_areas1.geographical_area_sid = geographical_areas2.geographical_area_sid))
                 AND geographical_areas1.operation::text <> 'D'::text
-      WITH DATA
     EOVIEW
 
     create_view :geographical_area_descriptions, <<~EOVIEW, materialized: true
@@ -46,7 +45,6 @@ Sequel.migration do
               WHERE geographical_area_descriptions1.geographical_area_description_period_sid = geographical_area_descriptions2.geographical_area_description_period_sid
                 AND geographical_area_descriptions1.geographical_area_sid = geographical_area_descriptions2.geographical_area_sid))
                 AND geographical_area_descriptions1.operation::text <> 'D'::text
-      WITH DATA
     EOVIEW
 
     create_view :geographical_area_description_periods, <<~EOVIEW, materialized: true
@@ -66,7 +64,6 @@ Sequel.migration do
               WHERE geographical_area_description_periods1.geographical_area_description_period_sid = geographical_area_description_periods2.geographical_area_description_period_sid
               AND geographical_area_description_periods1.geographical_area_sid = geographical_area_description_periods2.geographical_area_sid))
               AND geographical_area_description_periods1.operation::text <> 'D'::text
-      WITH DATA
     EOVIEW
 
     create_view :measure_excluded_geographical_areas, <<~EOVIEW, materialized: true
@@ -83,7 +80,6 @@ Sequel.migration do
       WHERE geographical_areas.measure_sid = geographical_areas2.measure_sid
             AND geographical_areas.geographical_area_sid = geographical_areas2.geographical_area_sid))
             AND geographical_areas.operation::text <> 'D'::text
-      WITH DATA
     EOVIEW
 
     create_view :geographical_area_memberships, <<~EOVIEW, materialized: true
@@ -106,7 +102,6 @@ Sequel.migration do
               AND memberships.geographical_area_group_sid = memberships2.geographical_area_group_sid
               AND memberships.validity_start_date = memberships2.validity_start_date))
               AND memberships.operation::text <> 'D'::text
-      WITH DATA
     EOVIEW
 
     add_index :geographical_areas, :oid, unique: true
@@ -114,5 +109,115 @@ Sequel.migration do
     add_index :geographical_area_description_periods, :oid, unique: true
     add_index :measure_excluded_geographical_areas, :oid, unique: true
     add_index :geographical_area_memberships, :oid, unique: true
+  end
+
+  down do
+    remove_index :geographical_areas, :oid, unique: true
+    remove_index :geographical_area_descriptions, :oid, unique: true
+    remove_index :geographical_area_description_periods, :oid, unique: true
+    remove_index :measure_excluded_geographical_areas, :oid, unique: true
+    remove_index :geographical_area_memberships, :oid, unique: true
+
+    drop_view :geographical_areas, materialized: true
+    drop_view :geographical_area_descriptions, materialized: true
+    drop_view :geographical_area_description_periods, materialized: true
+    drop_view :measure_excluded_geographical_areas, materialized: true
+    drop_view :geographical_area_memberships, materialized: true
+
+    create_view :geographical_areas, <<~EOVIEW
+      SELECT geographical_areas1.geographical_area_sid,
+        geographical_areas1.parent_geographical_area_group_sid,
+        geographical_areas1.validity_start_date,
+        geographical_areas1.validity_end_date,
+        geographical_areas1.geographical_code,
+        geographical_areas1.geographical_area_id,
+        geographical_areas1."national",
+        geographical_areas1.oid,
+        geographical_areas1.operation,
+        geographical_areas1.operation_date,
+        geographical_areas1.filename,
+        geographical_areas1.hjid
+      FROM geographical_areas_oplog geographical_areas1
+      WHERE (geographical_areas1.oid IN ( SELECT max(geographical_areas2.oid) AS max
+              FROM geographical_areas_oplog geographical_areas2
+              WHERE geographical_areas1.geographical_area_sid = geographical_areas2.geographical_area_sid))
+                AND geographical_areas1.operation::text <> 'D'::text
+    EOVIEW
+
+    create_view :geographical_area_descriptions, <<~EOVIEW
+      SELECT geographical_area_descriptions1.geographical_area_description_period_sid,
+        geographical_area_descriptions1.language_id,
+        geographical_area_descriptions1.geographical_area_sid,
+        geographical_area_descriptions1.geographical_area_id,
+        geographical_area_descriptions1.description,
+        geographical_area_descriptions1."national",
+        geographical_area_descriptions1.oid,
+        geographical_area_descriptions1.operation,
+        geographical_area_descriptions1.operation_date,
+        geographical_area_descriptions1.filename
+      FROM geographical_area_descriptions_oplog geographical_area_descriptions1
+      WHERE (geographical_area_descriptions1.oid IN ( SELECT max(geographical_area_descriptions2.oid) AS max
+              FROM geographical_area_descriptions_oplog geographical_area_descriptions2
+              WHERE geographical_area_descriptions1.geographical_area_description_period_sid = geographical_area_descriptions2.geographical_area_description_period_sid
+                AND geographical_area_descriptions1.geographical_area_sid = geographical_area_descriptions2.geographical_area_sid))
+                AND geographical_area_descriptions1.operation::text <> 'D'::text
+    EOVIEW
+
+    create_view :geographical_area_description_periods, <<~EOVIEW
+      SELECT geographical_area_description_periods1.geographical_area_description_period_sid,
+        geographical_area_description_periods1.geographical_area_sid,
+        geographical_area_description_periods1.validity_start_date,
+        geographical_area_description_periods1.geographical_area_id,
+        geographical_area_description_periods1.validity_end_date,
+        geographical_area_description_periods1."national",
+        geographical_area_description_periods1.oid,
+        geographical_area_description_periods1.operation,
+        geographical_area_description_periods1.operation_date,
+        geographical_area_description_periods1.filename
+      FROM geographical_area_description_periods_oplog geographical_area_description_periods1
+      WHERE (geographical_area_description_periods1.oid IN ( SELECT max(geographical_area_description_periods2.oid) AS max
+              FROM geographical_area_description_periods_oplog geographical_area_description_periods2
+              WHERE geographical_area_description_periods1.geographical_area_description_period_sid = geographical_area_description_periods2.geographical_area_description_period_sid
+              AND geographical_area_description_periods1.geographical_area_sid = geographical_area_description_periods2.geographical_area_sid))
+              AND geographical_area_description_periods1.operation::text <> 'D'::text
+    EOVIEW
+
+    create_view :measure_excluded_geographical_areas, <<~EOVIEW
+      SELECT geographical_areas.measure_sid,
+             geographical_areas.excluded_geographical_area,
+             geographical_areas.geographical_area_sid,
+             geographical_areas.oid,
+             geographical_areas.operation,
+             geographical_areas.operation_date,
+             geographical_areas.filename
+      FROM measure_excluded_geographical_areas_oplog geographical_areas
+      WHERE (geographical_areas.oid IN ( SELECT max(geographical_areas2.oid) AS max
+      FROM measure_excluded_geographical_areas_oplog geographical_areas2
+      WHERE geographical_areas.measure_sid = geographical_areas2.measure_sid
+            AND geographical_areas.geographical_area_sid = geographical_areas2.geographical_area_sid))
+            AND geographical_areas.operation::text <> 'D'::text
+    EOVIEW
+
+    create_view :geographical_area_memberships, <<~EOVIEW
+      SELECT memberships.geographical_area_sid,
+        memberships.geographical_area_group_sid,
+        memberships.validity_start_date,
+        memberships.validity_end_date,
+        memberships."national",
+        memberships.oid,
+        memberships.operation,
+        memberships.operation_date,
+        memberships.filename,
+        memberships.hjid,
+        memberships.geographical_area_hjid,
+        memberships.geographical_area_group_hjid
+      FROM geographical_area_memberships_oplog memberships
+      WHERE (memberships.oid IN ( SELECT max(memberships2.oid) AS max
+              FROM geographical_area_memberships_oplog memberships2
+              WHERE memberships.geographical_area_sid = memberships2.geographical_area_sid
+              AND memberships.geographical_area_group_sid = memberships2.geographical_area_group_sid
+              AND memberships.validity_start_date = memberships2.validity_start_date))
+              AND memberships.operation::text <> 'D'::text
+    EOVIEW
   end
 end


### PR DESCRIPTION
### Jira link

HMRC-1360

![image](https://github.com/user-attachments/assets/0df58199-b573-4e6d-a71a-e5b60bf1f7ce)

### What?

I have added/removed/altered:

- Enables dynamically rolling forward and backwards after creating duplicate indexes

### Why?

I am doing this because:

- The duplicate indexes were misapplied in some production environments but worked in others and rather than manually rolling back and forward to fix these we created additional migrations.
- This gets us into a steady state
