### PR TITLE
HMRC-1317: Do a materialized refresh only during testing

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -25,3 +25,11 @@ jobs:
     secrets:
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
       ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
+
+  start-services:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: trade-tariff/trade-tariff-tools/.github/actions/start-services@main
+        with:
+          service-names: backend-uk backend-xi worker-uk worker-xi backend-job
+          environment: development

--- a/app/lib/sequel/plugins/oplog.rb
+++ b/app/lib/sequel/plugins/oplog.rb
@@ -139,23 +139,18 @@ module Sequel
           operation_klass.insert(values)
         end
 
-        # NOTE: This method is called by Sequel::Model#refresh after we insert a new record
-        #       a materialized view is not refreshed in during TaricSynchronizer.apply work
-        #       to reduce the number of low value refreshes this would cause
+        # NOTE: This method is called by Sequel::Model#_refresh after we save a new record.
+        #       We skip refreshes of the full materialized view in production to avoid excessive work and
+        #       file apply slowness.
         #
         #       The original values are returned to avoid the default Sequel::Model#refresh handling of falsey values as an error
         #       but also preserve some of the instrumentation of oplog inserts we store for the admin UI.
         def _refresh_get(dataset)
-          if self.class.materialized?
-            if Rails.env.test?
-              db.refresh_view(self.class.table_name, concurrently: false)
-              super
-            else
-              values
-            end
-          else
-            super
-          end
+          return super unless self.class.materialized?
+          return values unless Rails.env.test?
+
+          self.class.refresh!(concurrently: false)
+          super
         end
       end
 


### PR DESCRIPTION
### Jira link

[HMRC-1317](https://transformuk.atlassian.net/browse/HMRC-1317)

### What?

I have added/removed/altered:

- [x] Added conditional materialized view refresh for test mode only

### Why?

I am doing this because:

- Refreshing during materialized oplog inserts is insanely wasteful and we actually just do these at the end of an apply anyway for all of the update files
