### PR TITLE
Fix scheduled jobs syntax

### DIFF
--- a/app/workers/action_log_report_worker.rb
+++ b/app/workers/action_log_report_worker.rb
@@ -6,6 +6,8 @@ class ActionLogReportWorker
   START_DATE = Date.new(2025, 6, 19).freeze
 
   def perform
+    return unless TradeTariffBackend.uk?
+
     yesterday = Time.zone.yesterday
     start_date = START_DATE.beginning_of_day
     end_date = yesterday.end_of_day

--- a/app/workers/remove_failed_subscribers_worker.rb
+++ b/app/workers/remove_failed_subscribers_worker.rb
@@ -2,6 +2,8 @@ class RemoveFailedSubscribersWorker
   include Sidekiq::Worker
 
   def perform
+    return unless TradeTariffBackend.uk?
+
     PublicUsers::User.failed_subscribers.each do |user|
       user.soft_delete!
       PublicUsers::ActionLog.create(user_id: user.id, action: PublicUsers::ActionLog::FAILED_SUBSCRIBER)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -38,12 +38,12 @@
       cron: "0 5 * * *"
       description: "Runs ETL of CDS files and populates indexes"
       class: CdsUpdatesSynchronizerWorker
-      status: <%= ENV.fetch('SERVICE', 'uk') == 'uk' ? 'enabled' : 'disabled' %>
+      enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' %>
     XIUpdatesSynchronizerWorker:
       cron: "0 0 * * *"
       description: "Runs ETL of Taric files and populates indexes"
       class: TaricUpdatesSynchronizerWorker
-      status: <%= ENV.fetch('SERVICE', 'uk') == 'xi' ? 'enabled' : 'disabled' %>
+      enabled: <%= ENV.fetch('SERVICE', 'uk') == 'xi' %>
     HealthcheckWorker:
       every: 30.minutes
       description: Trigger the health check
@@ -69,8 +69,7 @@
     GreenLanesUpdatesWorker:
       cron: "0 4 * * *"
       description: "Runs green lanes related data updates worker that will create new category assessments and send notifications"
-      class: GreenLanesUpdatesWorker
-      status: <%= ENV.fetch('SERVICE', 'uk') == 'xi' ? 'enabled' : 'disabled' %>
+      enabled: <%= ENV.fetch('SERVICE', 'uk') == 'xi' %>
     CheckDifferencesReportHasRun:
       cron: "0 1 * * 2"  # 1am every Tuesday
       description: "Checks if the differences report has run"
@@ -82,10 +81,8 @@
     RemoveFailedSubscribersWorker:
       cron: "0 3 * * 0"  # 3am every Sunday
       description: "Removes failed myott subscribers"
-      class: RemoveFailedSubscribersWorker
-      status: <%= ENV.fetch('SERVICE', 'uk') == 'uk' ? 'enabled' : 'disabled' %>
+      enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' %>
     ActionLogReportWorker:
       cron: "0 6 * * *" # 6am every day
       description: Generates and emails a CSV report of the previous day's user action logs
-      class: ActionLogReportWorker
-      status: <%= ENV.fetch('SERVICE', 'uk') == 'uk' ? 'enabled' : 'disabled' %>
+      enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' %>


### PR DESCRIPTION
### What?

The syntax being used to disable a cron job was incorrect. Existing jobs were not affected because the job also checked it was being run on the correct service. A couple of new myott jobs have been running twice.

The enabled syntax has been updated, and all the relevant jobs also do a check when the job is run.

### Why?

I am doing this because:

- To ensure jobs run on the expected service / are not repeated

