### PR TITLE
HMRC-1402: Make sure we're invalidating CDN caches where relevant

### DIFF
--- a/app/workers/cds_updates_synchronizer_worker.rb
+++ b/app/workers/cds_updates_synchronizer_worker.rb
@@ -31,7 +31,6 @@ class CdsUpdatesSynchronizerWorker
     Sidekiq::Client.enqueue(ClearInvalidSearchReferences)
     Sidekiq::Client.enqueue(TreeIntegrityCheckWorker)
     Sidekiq::Client.enqueue(ClearCacheWorker)
-    Sidekiq::Client.enqueue(InvalidateCacheWorker)
   rescue TariffSynchronizer::CdsUpdateDownloader::ListDownloadFailedError
     attempt_reschedule!
   end

--- a/app/workers/clear_cache_worker.rb
+++ b/app/workers/clear_cache_worker.rb
@@ -11,5 +11,6 @@ class ClearCacheWorker
     Sidekiq::Client.enqueue(PrecacheHeadingsWorker, Time.zone.today.to_formatted_s(:db))
     Sidekiq::Client.enqueue(PrewarmQuotaOrderNumbersWorker)
     Sidekiq::Client.enqueue(ReindexModelsWorker)
+    Sidekiq::Client.enqueue(InvalidateCacheWorker)
   end
 end

--- a/app/workers/taric_updates_synchronizer_worker.rb
+++ b/app/workers/taric_updates_synchronizer_worker.rb
@@ -24,7 +24,6 @@ class TaricUpdatesSynchronizerWorker
     Sidekiq::Client.enqueue(ClearInvalidSearchReferences)
     Sidekiq::Client.enqueue(TreeIntegrityCheckWorker)
     Sidekiq::Client.enqueue(ClearCacheWorker)
-    Sidekiq::Client.enqueue(InvalidateCacheWorker)
   end
 
 private

--- a/spec/workers/clear_cache_worker_spec.rb
+++ b/spec/workers/clear_cache_worker_spec.rb
@@ -14,4 +14,5 @@ RSpec.describe ClearCacheWorker, type: :worker do
   it { expect(Sidekiq::Client).to have_received(:enqueue).with(PrecacheHeadingsWorker, Time.zone.today.to_s) }
   it { expect(Sidekiq::Client).to have_received(:enqueue).with(PrewarmQuotaOrderNumbersWorker) }
   it { expect(Sidekiq::Client).to have_received(:enqueue).with(ReindexModelsWorker) }
+  it { expect(Sidekiq::Client).to have_received(:enqueue).with(InvalidateCacheWorker) }
 end


### PR DESCRIPTION
### Jira link

[HMRC-1402](https://transformuk.atlassian.net/browse/HMRC-1402)

### What?

I have added/removed/altered:

- [x] Consolidate invalidation of CDN

### Why?

I am doing this because:

- This makes sure we're doing this everywhere where cache invalidation makes sense
