### PR TITLE
HMRC-1317: Move views to materialized views - refresh task

### DIFF
--- a/app/helpers/materialize_view_helper.rb
+++ b/app/helpers/materialize_view_helper.rb
@@ -8,4 +8,6 @@ module MaterializeViewHelper
 
     GoodsNomenclatures::TreeNode.refresh!(concurrently:)
   end
+
+  module_function :refresh_materialized_view
 end

--- a/app/workers/apply_worker.rb
+++ b/app/workers/apply_worker.rb
@@ -3,7 +3,7 @@ class ApplyWorker
   include Sidekiq::Worker
   include MaterializeViewHelper
 
-  sidekiq_options queue: :rollbacks, retry: false
+  sidekiq_options queue: :sync, retry: false
 
   def perform
     if TradeTariffBackend.uk?

--- a/app/workers/clear_invalid_search_references.rb
+++ b/app/workers/clear_invalid_search_references.rb
@@ -1,7 +1,7 @@
 class ClearInvalidSearchReferences
   include Sidekiq::Worker
 
-  sidekiq_options retry: false
+  sidekiq_options queue: :sync, retry: false
 
   def perform
     cleared = SearchReference.each_with_object({}) do |search_reference, acc|

--- a/app/workers/download_worker.rb
+++ b/app/workers/download_worker.rb
@@ -1,7 +1,7 @@
 class DownloadWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :rollbacks, retry: false
+  sidekiq_options queue: :sync, retry: false
 
   def perform
     if TradeTariffBackend.uk?

--- a/app/workers/healthcheck_worker.rb
+++ b/app/workers/healthcheck_worker.rb
@@ -1,5 +1,6 @@
 class HealthcheckWorker
   include Sidekiq::Worker
+
   sidekiq_options queue: :healthcheck, retry: 1
 
   def perform

--- a/app/workers/precache_headings_worker.rb
+++ b/app/workers/precache_headings_worker.rb
@@ -1,6 +1,8 @@
 class PrecacheHeadingsWorker
   include Sidekiq::Worker
 
+  sidekiq_options queue: :sync
+
   def perform(date = nil)
     date = date ? Time.zone.parse(date).to_date : Time.zone.tomorrow
 

--- a/app/workers/prewarm_quota_order_numbers_worker.rb
+++ b/app/workers/prewarm_quota_order_numbers_worker.rb
@@ -1,7 +1,7 @@
 class PrewarmQuotaOrderNumbersWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :default, retry: true
+  sidekiq_options queue: :sync, retry: true
 
   def perform
     TimeMachine.now do

--- a/app/workers/reindex_models_worker.rb
+++ b/app/workers/reindex_models_worker.rb
@@ -1,7 +1,7 @@
 class ReindexModelsWorker
   include Sidekiq::Worker
 
-  sidekiq_options retry: false
+  sidekiq_options queue: :sync, retry: false
 
   def perform
     logger.info 'Reindexing models in Elastic Search...'

--- a/app/workers/rollback_worker.rb
+++ b/app/workers/rollback_worker.rb
@@ -3,7 +3,7 @@ class RollbackWorker
   include Sidekiq::Worker
   include MaterializeViewHelper
 
-  sidekiq_options queue: :rollbacks, retry: false
+  sidekiq_options queue: :sync, retry: false
 
   def perform(date, redownload = false)
     if TradeTariffBackend.uk?

--- a/app/workers/tree_integrity_check_worker.rb
+++ b/app/workers/tree_integrity_check_worker.rb
@@ -1,6 +1,8 @@
 class TreeIntegrityCheckWorker
   include Sidekiq::Worker
 
+  sidekiq_options queue: :sync
+
   def perform
     check(7)
     check(14)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,11 +1,9 @@
 :verbose: false
 :concurrency: 10
 :queues:
-  - healthcheck
-  - rollbacks
   - sync
   - default
-  - bulk_search
+  - healthcheck
 :scheduler:
   :schedule:
     #
@@ -35,7 +33,7 @@
       cron: "30 10 * * *" # Needs to run even if the UpdatesSynchronizerWorker failed
       description: "Generates reports and persists them to S3"
     UKUpdatesSynchronizerWorker:
-      cron: "0 5 * * *"
+      cron: "30 0 * * *"
       description: "Runs ETL of CDS files and populates indexes"
       class: CdsUpdatesSynchronizerWorker
       enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' %>
@@ -47,9 +45,6 @@
     HealthcheckWorker:
       every: 30.minutes
       description: Trigger the health check
-    PrecacheHeadingsWorker:
-      cron: "00 22 * * *"
-      description: Precaches all headings and subheadings ready for tomorrow
     OneWeekTreeIntegrityCheck:
       cron: '05 8 * * 1'
       class: TreeIntegrityCheckWorker

--- a/lib/tasks/tariff.rake
+++ b/lib/tasks/tariff.rake
@@ -113,7 +113,7 @@ namespace :tariff do
     end
   end
 
-  desc "Refresh materialized views"
+  desc 'Refresh materialized views'
   task refresh: :environment do
     require_relative '../../app/helpers/materialize_view_helper'
 

--- a/lib/tasks/tariff.rake
+++ b/lib/tasks/tariff.rake
@@ -112,4 +112,17 @@ namespace :tariff do
       ChangesTablePopulator.populate_backlog
     end
   end
+
+  desc "Refresh materialized views"
+  task refresh: :environment do
+    require_relative '../../app/helpers/materialize_view_helper'
+
+    helper = Object.new
+    helper.extend(MaterializeViewHelper)
+
+    concurrently = ENV['CONCURRENTLY'] == 'true'
+
+    puts "Refreshing materialized views#{' concurrently' if concurrently}..."
+    helper.refresh_materialized_view(concurrently: concurrently)
+  end
 end

--- a/lib/tasks/tariff.rake
+++ b/lib/tasks/tariff.rake
@@ -117,12 +117,9 @@ namespace :tariff do
   task refresh: :environment do
     require_relative '../../app/helpers/materialize_view_helper'
 
-    helper = Object.new
-    helper.extend(MaterializeViewHelper)
-
     concurrently = ENV['CONCURRENTLY'] == 'true'
 
     puts "Refreshing materialized views#{' concurrently' if concurrently}..."
-    helper.refresh_materialized_view(concurrently: concurrently)
+    MaterializeViewHelper.refresh_materialized_view(concurrently: concurrently)
   end
 end

--- a/spec/workers/clear_cache_worker_spec.rb
+++ b/spec/workers/clear_cache_worker_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ClearCacheWorker, type: :worker do
   before do
     allow(Rails.cache).to receive(:clear)
     allow(Sidekiq::Client).to receive(:enqueue)
+    allow(Sidekiq::Client).to receive(:enqueue_in)
 
     silence do
       worker.perform
@@ -14,5 +15,5 @@ RSpec.describe ClearCacheWorker, type: :worker do
   it { expect(Sidekiq::Client).to have_received(:enqueue).with(PrecacheHeadingsWorker, Time.zone.today.to_s) }
   it { expect(Sidekiq::Client).to have_received(:enqueue).with(PrewarmQuotaOrderNumbersWorker) }
   it { expect(Sidekiq::Client).to have_received(:enqueue).with(ReindexModelsWorker) }
-  it { expect(Sidekiq::Client).to have_received(:enqueue).with(InvalidateCacheWorker) }
+  it { expect(Sidekiq::Client).to have_received(:enqueue_in).with(1.minute, InvalidateCacheWorker) }
 end


### PR DESCRIPTION
### Jira link

[HMRC-1317](https://transformuk.atlassian.net/browse/HMRC-1317)

### What?

I have added/removed/altered:

- [ ] Added rake task to refresh materialized views
- [ ] Join ClearInvalidSearchReferences and ReindexModelsWorker with tarrif sync job to distribute the load on DB

### Why?

I am doing this because:

- There is a performace drawback in running all those job asynchronously
