### PR TITLE
PEX-57: Fixes etag caching for live issues

### DIFF
--- a/app/controllers/api/v2/live_issues_controller.rb
+++ b/app/controllers/api/v2/live_issues_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V2
     class LiveIssuesController < ApiController
+      no_caching
+
       def index
         render json: serialize(filtered_live_issues), status: :ok
       rescue StandardError => e


### PR DESCRIPTION
### Jira link

[PEX-57](https://transformuk.atlassian.net/browse/PEX-57)

### What?

I have added/removed/altered:

- [x] Added no_caching configuration to live issues

### Why?

I am doing this because:

- Live issues should always have fresh copies in the frontend
