### PR TITLE
Fix xi Basic Report

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -514,7 +514,9 @@ class Measure < Sequel::Model
   end
 
   def supplementary_unit_duty_expression
-    measurement_unit = measure_components.first.measurement_unit
+    measurement_unit = measure_components.first&.measurement_unit
+    return nil unless measurement_unit
+
     "#{measurement_unit.description} (#{measurement_unit.abbreviation})"
   end
 

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -1194,9 +1194,19 @@ RSpec.describe Measure do
   end
 
   describe '#supplementary_unit_duty_expression' do
-    subject(:supplementary_unit_duty_expression) { create(:measure, :supplementary, :with_measure_components).supplementary_unit_duty_expression }
+    subject(:supplementary_unit_duty_expression) { measure.supplementary_unit_duty_expression }
+
+    let(:measure) { create(:measure, :supplementary, :with_measure_components) }
 
     it { is_expected.to match(/\.* \(.*\)/) }
+
+    context 'when there are no measure components' do
+      before do
+        allow(measure).to receive(:measure_components).and_return([])
+      end
+
+      it { is_expected.to be_nil }
+    end
   end
 
   describe '.with_additional_code_sid' do


### PR DESCRIPTION
### Jira link

[HMRC-<TODO>](https://transformuk.atlassian.net/browse/HMRC-<TODO>)

### What?

Basic report is failing due to the `Measure.supplementary_unit_duty_expression` method
Commodity "8708405025" has a supplementary measure without a measure component which causes an exception.
