### PR TITLE
PRDEX-71 | Remove null validation for commodities

### DIFF
--- a/db/migrate/20250718101240_remove_null_validation_commodities_live_issues.rb
+++ b/db/migrate/20250718101240_remove_null_validation_commodities_live_issues.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:public__live_issues) do
+      set_column_allow_null :commodities
+    end
+  end
+
+  down do
+    alter_table(:public__live_issues) do
+      set_column_not_null :commodities
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -214,7 +214,7 @@ CREATE TABLE public.live_issues (
     id integer NOT NULL,
     title text NOT NULL,
     description text,
-    commodities text[] NOT NULL,
+    commodities text[],
     status text DEFAULT 'Active'::text NOT NULL,
     date_discovered date NOT NULL,
     date_resolved date,
@@ -13804,3 +13804,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20250701123907_add_materia
 INSERT INTO "schema_migrations" ("filename") VALUES ('20250702142253_add_goods_nomenclatures_materialized_views.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20250708114111_add_quota_materialized_views.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20250716082959_remove_char_limit_live_issues.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20250718101240_remove_null_validation_commodities_live_issues.rb');


### PR DESCRIPTION
### Jira link

[PRDEX-71](https://transformuk.atlassian.net/browse/PRDEX-71)

### What?

I have added/removed/altered:

- [x] Removed null validation from commodities in the live issues table

### Why?

I am doing this because:

- We want to be able to allow no commodities to be affected by a live issue
