### PR TITLE
HMRC-1365: Rationalise routing

### DIFF
--- a/app/controllers/api/admin/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/api/admin/green_lanes/category_assessments_controller.rb
@@ -32,7 +32,6 @@ module Api
 
           if ca.valid? && ca.save
             render json: serialize(ca),
-                   location: api_admin_green_lanes_category_assessment_url(ca.id),
                    status: :created
           else
             render json: serialize_errors(ca),
@@ -46,7 +45,6 @@ module Api
 
           if ca.valid? && ca.save
             render json: serialize(ca),
-                   location: api_admin_green_lanes_category_assessment_url(ca.id),
                    status: :ok
           else
             render json: serialize_errors(ca),
@@ -67,7 +65,6 @@ module Api
 
           if ca.add_exemption(exemption)
             render json: serialize(ca),
-                   location: api_admin_green_lanes_category_assessment_url(ca.id),
                    status: :ok
           else
             render json: serialize_errors(ca),
@@ -81,7 +78,6 @@ module Api
 
           if ca.remove_exemption(exemption)
             render json: serialize(ca),
-                   location: api_admin_green_lanes_category_assessment_url(ca.id),
                    status: :ok
           else
             render json: serialize_errors(ca),

--- a/app/controllers/api/admin/green_lanes/exempting_additional_code_overrides_controller.rb
+++ b/app/controllers/api/admin/green_lanes/exempting_additional_code_overrides_controller.rb
@@ -21,7 +21,6 @@ module Api
 
           if eco.valid? && eco.save
             render json: serialize(eco),
-                   location: api_admin_green_lanes_exempting_additional_code_override_url(eco.id),
                    status: :created
           else
             render json: serialize_errors(eco),

--- a/app/controllers/api/admin/green_lanes/exempting_certificate_overrides_controller.rb
+++ b/app/controllers/api/admin/green_lanes/exempting_certificate_overrides_controller.rb
@@ -21,7 +21,6 @@ module Api
 
           if eco.valid? && eco.save
             render json: serialize(eco),
-                   location: api_admin_green_lanes_exempting_certificate_override_url(eco.id),
                    status: :created
           else
             render json: serialize_errors(eco),

--- a/app/controllers/api/admin/green_lanes/exemptions_controller.rb
+++ b/app/controllers/api/admin/green_lanes/exemptions_controller.rb
@@ -21,7 +21,6 @@ module Api
 
           if ex.valid? && ex.save
             render json: serialize(ex),
-                   location: api_admin_green_lanes_exemption_url(ex.id),
                    status: :created
           else
             render json: serialize_errors(ex),
@@ -35,7 +34,6 @@ module Api
 
           if ex.valid? && ex.save
             render json: serialize(ex),
-                   location: api_admin_green_lanes_exemption_url(ex.id),
                    status: :ok
           else
             render json: serialize_errors(ex),

--- a/app/controllers/api/admin/green_lanes/measure_type_mappings_controller.rb
+++ b/app/controllers/api/admin/green_lanes/measure_type_mappings_controller.rb
@@ -24,7 +24,6 @@ module Api
 
           if ex.valid? && ex.save
             render json: serialize(ex),
-                   location: api_admin_green_lanes_measure_type_mapping_url(ex.id),
                    status: :created
           else
             render json: serialize_errors(ex),

--- a/app/controllers/api/admin/green_lanes/measures_controller.rb
+++ b/app/controllers/api/admin/green_lanes/measures_controller.rb
@@ -35,7 +35,6 @@ module Api
 
             if gn.present? && measure.valid? && measure.save
               render json: serialize(measure),
-                     location: api_admin_green_lanes_measure_url(measure.id),
                      status: :created
             else
               render json: serialize_errors(measure),
@@ -52,7 +51,6 @@ module Api
 
           if measure.valid? && measure.save
             render json: serialize(measure),
-                   location: api_admin_green_lanes_measure_url(measure.id),
                    status: :ok
           else
             render json: serialize_errors(measure),

--- a/app/controllers/api/admin/green_lanes/update_notifications_controller.rb
+++ b/app/controllers/api/admin/green_lanes/update_notifications_controller.rb
@@ -22,7 +22,6 @@ module Api
 
           if update.save
             render json: serialize(update),
-                   location: api_admin_green_lanes_update_notification_url(update.id),
                    status: :ok
           else
             render json: serialize_errors(update),

--- a/app/controllers/api/admin/news/collections_controller.rb
+++ b/app/controllers/api/admin/news/collections_controller.rb
@@ -22,7 +22,6 @@ module Api
 
           if news_collection.valid? && news_collection.save
             render json: serialize(news_collection),
-                   location: api_admin_news_collection_url(news_collection.id),
                    status: :created
           else
             render json: serialize_errors(news_collection),
@@ -36,7 +35,6 @@ module Api
 
           if news_collection.valid? && news_collection.save
             render json: serialize(news_collection),
-                   location: api_admin_news_collection_url(news_collection.id),
                    status: :ok
           else
             render json: serialize_errors(news_collection),

--- a/app/controllers/api/admin/news/items_controller.rb
+++ b/app/controllers/api/admin/news/items_controller.rb
@@ -19,7 +19,6 @@ module Api
 
           if news_item.valid? && news_item.save
             render json: serialize(news_item),
-                   location: api_admin_news_item_url(news_item.id),
                    status: :created
           else
             render json: serialize_errors(news_item),
@@ -33,7 +32,6 @@ module Api
 
           if news_item.valid? && news_item.save
             render json: serialize(news_item),
-                   location: api_admin_news_item_url(news_item.id),
                    status: :ok
           else
             render json: serialize_errors(news_item),

--- a/app/controllers/api/v2/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/goods_nomenclatures_controller.rb
@@ -80,16 +80,16 @@ module Api
 
         case object
         when Chapter
-          "/#{service}/api/v2/chapters/#{gnid.first(2)}"
+          "/#{service}/api/chapters/#{gnid.first(2)}"
         when Heading
-          "/#{service}/api/v2/headings/#{gnid.first(4)}"
+          "/#{service}/api/headings/#{gnid.first(4)}"
         when Subheading
-          "/#{service}/api/v2/subheadings/#{object.to_param}"
+          "/#{service}/api/subheadings/#{object.to_param}"
         else
           if check_for_subheadings && !object.declarable?
-            "/#{service}/api/v2/subheadings/#{gnid.first(10)}-#{object.producline_suffix}"
+            "/#{service}/api/subheadings/#{gnid.first(10)}-#{object.producline_suffix}"
           else
-            "/#{service}/api/v2/commodities/#{gnid.first(10)}"
+            "/#{service}/api/commodities/#{gnid.first(10)}"
           end
         end
       end

--- a/app/controllers/api/v2/green_lanes/faq_feedback_controller.rb
+++ b/app/controllers/api/v2/green_lanes/faq_feedback_controller.rb
@@ -8,12 +8,9 @@ module Api
           faq_feedback = ::GreenLanes::FaqFeedback.new(faq_feedback_params)
 
           if faq_feedback.valid? && faq_feedback.save
-            render json: serialize(faq_feedback),
-                   location: api_green_lanes_faq_feedback_url(faq_feedback.id),
-                   status: :created
+            render json: serialize(faq_feedback), status: :created
           else
-            render json: serialize_errors(faq_feedback),
-                   status: :unprocessable_entity
+            render json: serialize_errors(faq_feedback), status: :unprocessable_entity
           end
         end
 

--- a/app/controllers/api/v2/preference_codes_controller.rb
+++ b/app/controllers/api/v2/preference_codes_controller.rb
@@ -2,23 +2,21 @@ module Api
   module V2
     class PreferenceCodesController < ApiController
       def index
-        respond_to do |format|
-          format.json do
-            render json: PreferenceCodeSerializer.new(
-              PreferenceCode.all,
-            ).serializable_hash
-          end
-        end
+        render json: preference_codes
       end
 
       def show
-        preference_code = PreferenceCode[params[:id]]
+        render json: preference_code
+      end
 
-        raise Sequel::RecordNotFound unless preference_code
+      private
 
-        serializer = Api::V2::PreferenceCodeSerializer.new(preference_code)
+      def preference_codes
+        PreferenceCodeSerializer.new(PreferenceCode.all).serializable_hash
+      end
 
-        render json: serializer.serializable_hash
+      def preference_code
+        Api::V2::PreferenceCodeSerializer.new(PreferenceCode.take(params[:id])).serializable_hash
       end
     end
   end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -56,14 +56,18 @@ private
   end
 
   def serialize_errors(errors)
-    # TODO: Remove custom Accept header management
-    if request.headers['Accept'] == 'application/vnd.uktt.v2'
-      Api::V2::ErrorSerializationService.new.serialized_errors(errors)
-    elsif request.url.include?('v2')
-      Api::V2::ErrorSerializationService.new.serialized_errors(errors)
-    else
+    if version == '1.0'
       Api::V1::ErrorSerializationService.new.serialized_errors(errors)
+    else
+      Api::V2::ErrorSerializationService.new.serialized_errors(errors)
     end
+  end
+
+  def version
+    accept = request.headers['Accept'].to_s
+    match = accept.match(VersionedAcceptHeader::VERSION_REGEX)
+
+    match&.[](:version) || VersionedAcceptHeader::DEFAULT_VERSION
   end
 end
 # rubocop:enable Rails/ApplicationController

--- a/app/engines/admin_api.rb
+++ b/app/engines/admin_api.rb
@@ -2,7 +2,7 @@ class AdminApi < ::Rails::Engine
 end
 
 AdminApi.routes.draw do
-  namespace :api, defaults: { format: 'json' }, path: '/admin' do
+  namespace :api, defaults: { format: 'json' }, path: '' do
     scope module: :admin do
       resources :sections, only: %i[index show] do
         scope module: 'sections', constraints: { id: /\d+/ } do

--- a/app/lib/versioned_accept_header.rb
+++ b/app/lib/versioned_accept_header.rb
@@ -1,9 +1,18 @@
 class VersionedAcceptHeader
+  DEFAULT_VERSION = '2.0'.freeze
+  VERSION_REGEX = /\Aapplication\/vnd\.hmrc\.(?<version>\d+\.\d+)\+(?<format>.*)\z/
+
   def initialize(version:)
     @version = version.to_s
   end
 
-  def matches?(req)
-    req.headers['ACCEPT'].to_s.include?("application/vnd.hmrc.#{@version}+json")
+  def matches?(request)
+    accept = request.headers['ACCEPT'].to_s[0, 255]
+
+    return @version == DEFAULT_VERSION if accept.blank?
+
+    match = accept.match(VERSION_REGEX)
+
+    match&.[](:version) == @version
   end
 end

--- a/app/lib/versioned_forwarder.rb
+++ b/app/lib/versioned_forwarder.rb
@@ -1,0 +1,21 @@
+class VersionedForwarder
+  def call(env)
+    path_params = env['action_dispatch.request.path_parameters'] || {}
+    service = path_params[:service]
+    version = path_params[:version]
+    path = path_params[:path]
+
+    # Reapply the router (and full middleware stack) with modified env
+    Rails.application.call(transform_env(env, service, version, path))
+  end
+
+  private
+
+  def transform_env(env, service, version, path)
+    env['action_dispatch.old-path'] = env['PATH_INFO'].dup
+    env['PATH_INFO'] = "/#{service}/api/#{path}"
+    env['HTTP_ACCEPT'] = "application/vnd.hmrc.#{version}.0+json"
+    env['action_dispatch.path-transformed'] = true
+    env
+  end
+end

--- a/app/models/exchange_rate_file.rb
+++ b/app/models/exchange_rate_file.rb
@@ -13,7 +13,7 @@ class ExchangeRateFile < Sequel::Model
   content_addressable_fields :format, :type, :publication_date, :period_year, :period_month
 
   def file_path
-    "/api/v2/exchange_rates/files/#{filename}"
+    "/uk/api/exchange_rates/files/#{filename}"
   end
 
   def object_key

--- a/app/models/preference_code.rb
+++ b/app/models/preference_code.rb
@@ -91,6 +91,14 @@ class PreferenceCode
       preference_codes.values
     end
 
+    def take(code)
+      preference_code = self[code]
+
+      return preference_code if preference_code
+
+      raise Sequel::RecordNotFound
+    end
+
     def preference_codes
       @preference_codes ||= codes_from_file.each_with_object({}) do |preference_code, acc|
         code = preference_code['id']

--- a/app/workers/invalidate_cache_worker.rb
+++ b/app/workers/invalidate_cache_worker.rb
@@ -2,7 +2,7 @@ class InvalidateCacheWorker
   include Sidekiq::Worker
 
   SERVICES = ['/uk', '/xi', ''].freeze
-  PATHS = %w[/api/v1/* /api/v2/*].freeze
+  PATHS = %w[/api/*].freeze
 
   def perform(client = self.class.client)
     cdn = client.list_distributions.distribution_list.items.find do |d|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,23 +11,25 @@ Rails.application.routes.draw do
   draw(:sidekiq)
 
   # Admin routes
-  mount AdminApi => '/xi', as: 'xi_admin_api' if TradeTariffBackend.xi?
-  mount AdminApi => '/uk', as: 'uk_admin_api' if TradeTariffBackend.uk?
-  mount AdminApi => '/', as: 'admin' # TODO: Remove me once admin is migrated off
+  mount AdminApi => '/uk/admin', as: 'uk_admin_api' if TradeTariffBackend.uk?
+  mount AdminApi => '/xi/admin', as: 'xi_admin_api' if TradeTariffBackend.xi?
+
+  # User routes
+  mount UserApi => '/uk/user', as: 'uk_user_api' if TradeTariffBackend.uk?
 
   # V1 routes
-  mount V1Api => '/api/v1', as: 'v1_api' # TODO: Redirect these to the UK routes below in the ALB and remove
-  mount V1Api => '/xi/api/v1', as: 'xi_v1_api' if TradeTariffBackend.xi?
-  mount V1Api => '/uk/api/v1', as: 'uk_v1_api' if TradeTariffBackend.uk?
+  mount V1Api => '/uk/api', as: 'uk_v1_versioned_api', constraints: VersionedAcceptHeader.new(version: 1.0) if TradeTariffBackend.uk?
+  mount V1Api => '/xi/api', as: 'xi_v1_versioned_api', constraints: VersionedAcceptHeader.new(version: 1.0) if TradeTariffBackend.xi?
 
   # V2 routes
-  mount V2Api => '/api/xi', as: 'xi_v2_versioned_api', constraints: VersionedAcceptHeader.new(version: 2.0) if TradeTariffBackend.xi?
-  mount V2Api => '/api/uk', as: 'uk_v2_versioned_api', constraints: VersionedAcceptHeader.new(version: 2.0) if TradeTariffBackend.uk?
+  mount V2Api => '/uk/api', as: 'uk_v2_versioned_api', constraints: VersionedAcceptHeader.new(version: 2.0) if TradeTariffBackend.uk?
+  mount V2Api => '/xi/api', as: 'xi_v2_versioned_api', constraints: VersionedAcceptHeader.new(version: 2.0) if TradeTariffBackend.xi?
 
-  # TODO: Redirect these to the V2 routes above in the ALB and remove
-  mount V2Api => '/api/v2', as: 'v2_api'
-  mount V2Api => '/xi/api/v2', as: 'xi_v2_api' if TradeTariffBackend.xi?
-  mount V2Api => '/uk/api/v2', as: 'uk_v2_api' if TradeTariffBackend.uk?
+  match '/:service/api/v:version/*path',
+        via: :all,
+        to: VersionedForwarder.new,
+        constraints: { service: /uk|xi/, version: /\d+/ }
 
-  mount UserApi => '/api/uk/user', as: 'uk_user_api' if TradeTariffBackend.uk?
+  match '/api/*path', via: :all, to: redirect('/uk/api/%{path}') if TradeTariffBackend.uk?
+  match '/api/*path', via: :all, to: redirect('/xi/api/%{path}') if TradeTariffBackend.xi?
 end

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -19,7 +19,7 @@ Working from 'inside' out, we cache at multiple levels
   * by default this is set to cache for 2 minutes then revalidate for anything older.
   * A response is valid unless a backend Deployment or a Sync has happened
 * Frontend uses these cache headers to control how it caches responses in it API client
-* CDN ignores the cache headers and caches anything under `/api`, eg `/api/sections.json` for 30 minutes
+* CDN ignores the cache headers and caches anything under `/uk/api`, eg `/uk/api/sections.json` for 30 minutes
 * CDN does not cache HTML pages from the frontend
 
 ## Rails.cache

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -19,7 +19,7 @@ Working from 'inside' out, we cache at multiple levels
   * by default this is set to cache for 2 minutes then revalidate for anything older.
   * A response is valid unless a backend Deployment or a Sync has happened
 * Frontend uses these cache headers to control how it caches responses in it API client
-* CDN ignores the cache headers and caches anything under `/api`, eg `/api/v2/sections.json` for 30 minutes
+* CDN ignores the cache headers and caches anything under `/api`, eg `/api/sections.json` for 30 minutes
 * CDN does not cache HTML pages from the frontend
 
 ## Rails.cache

--- a/docs/rules_of_origin.md
+++ b/docs/rules_of_origin.md
@@ -5,7 +5,7 @@
 The primary API endpoint for rules of origin is
 
 ```
-/api/rules_of_origin_schemes/<commodity_code>/<country_code>
+/uk/api/rules_of_origin_schemes/<commodity_code>/<country_code>
 ```
 
 This will return a JSON-API response containing a list of all applicable schemes and their rules which are relevant to the `commodity_code`
@@ -13,13 +13,13 @@ This will return a JSON-API response containing a list of all applicable schemes
 There are also;
 
 ```
-/api/rules_of_origin_schemes/<commodity_code>
+/uk/api/rules_of_origin_schemes/<commodity_code>
 ```
 
 Returning the rules across all schemes for a commodity code, the json format for the schemes themselves is reduced to exclude heavier elements like articles markdown
 
 ```
-/api/rules_of_origin_schemes
+/uk/api/rules_of_origin_schemes
 ```
 
 This returns a listing of all schemes, again with reduced information. This api supports filtering, - at present the only filter is `?filter[has_article]=<article_name>` which will filter the schemes for only those which have the required article.

--- a/docs/rules_of_origin.md
+++ b/docs/rules_of_origin.md
@@ -5,7 +5,7 @@
 The primary API endpoint for rules of origin is
 
 ```
-/api/v2/rules_of_origin_schemes/<commodity_code>/<country_code>
+/api/rules_of_origin_schemes/<commodity_code>/<country_code>
 ```
 
 This will return a JSON-API response containing a list of all applicable schemes and their rules which are relevant to the `commodity_code`
@@ -13,13 +13,13 @@ This will return a JSON-API response containing a list of all applicable schemes
 There are also;
 
 ```
-/api/v2/rules_of_origin_schemes/<commodity_code>
+/api/rules_of_origin_schemes/<commodity_code>
 ```
 
 Returning the rules across all schemes for a commodity code, the json format for the schemes themselves is reduced to exclude heavier elements like articles markdown
 
 ```
-/api/v2/rules_of_origin_schemes
+/api/rules_of_origin_schemes
 ```
 
 This returns a listing of all schemes, again with reduced information. This api supports filtering, - at present the only filter is `?filter[has_article]=<article_name>` which will filter the schemes for only those which have the required article.

--- a/spec/controllers/api/admin/updates_controller_spec.rb
+++ b/spec/controllers/api/admin/updates_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Api::Admin::UpdatesController do
       let(:pattern) do
         {
           error: 'not found',
-          url: 'http://test.host/admin/updates/foo',
+          url: 'http://test.host/uk/admin/updates/foo',
         }
       end
 

--- a/spec/controllers/api/v2/measure_types_controller_spec.rb
+++ b/spec/controllers/api/v2/measure_types_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Api::V2::MeasureTypesController, type: :controller do
       let(:pattern) do
         {
           error: 'not found',
-          url: 'http://test.host/uk/api/v2/measure_types/foo',
+          url: 'http://test.host/uk/api/measure_types/foo',
         }
       end
 

--- a/spec/controllers/api/v2/sections_controller_spec.rb
+++ b/spec/controllers/api/v2/sections_controller_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Api::V2::SectionsController do
   routes { V2Api.routes }
-  # GET /api/v2/sections/:id
+  # GET /api/sections/:id
 
   describe '#show' do
     let(:heading) { create :heading, :with_chapter }
@@ -89,7 +89,7 @@ RSpec.describe Api::V2::SectionsController do
     end
   end
 
-  # GET /api/v2/sections
+  # GET /api/sections
   describe '#index' do
     before { create :section_note, section_id: section1.id }
 

--- a/spec/controllers/api/v2/sections_controller_spec.rb
+++ b/spec/controllers/api/v2/sections_controller_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe Api::V2::SectionsController do
   routes { V2Api.routes }
-  # GET /api/sections/:id
 
   describe '#show' do
     let(:heading) { create :heading, :with_chapter }
@@ -89,7 +88,6 @@ RSpec.describe Api::V2::SectionsController do
     end
   end
 
-  # GET /api/sections
   describe '#index' do
     before { create :section_note, section_id: section1.id }
 

--- a/spec/lib/versioned_accept_header_spec.rb
+++ b/spec/lib/versioned_accept_header_spec.rb
@@ -1,22 +1,44 @@
 RSpec.describe VersionedAcceptHeader do
   describe '#matches?' do
-    subject(:matches?) { described_class.new(version: '1.0').matches?(request) }
+    subject(:matches?) { described_class.new(version: '2.0').matches?(request) }
 
     let(:request) { ActionDispatch::Request.new(Rack::MockRequest.env_for('/', headers)) }
 
     context 'when the Accept header is present' do
-      let(:headers) { { 'HTTP_ACCEPT' => 'application/vnd.hmrc.1.0+json' } }
+      let(:headers) { { 'HTTP_ACCEPT' => 'application/vnd.hmrc.2.0+json' } }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the Accept header specifies a different format' do
+      let(:headers) { { 'HTTP_ACCEPT' => 'application/vnd.hmrc.2.0+csv' } }
 
       it { is_expected.to be true }
     end
 
     context 'when the Accept header does not match the versioned format' do
-      let(:headers) { { 'HTTP_ACCEPT' => 'application/vnd.hmrc.2.0+json' } }
+      let(:headers) { { 'HTTP_ACCEPT' => 'application/vnd.hmrc.1.0+json' } }
 
       it { is_expected.to be false }
     end
 
-    context 'when the Accept header is missing' do
+    context 'when the Accept header is longer than 255 characters' do
+      let(:headers) { { 'HTTP_ACCEPT' => "#{'a' * 256}application/vnd.hmrc.2.0+json" } }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when the Accept header is missing and the configured constraint version is the default' do
+      subject(:matches?) { described_class.new(version: '2.0').matches?(request) }
+
+      let(:headers) { {} }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the Accept header is missing and the configured constraint version is not the default' do
+      subject(:matches?) { described_class.new(version: '1.0').matches?(request) }
+
       let(:headers) { {} }
 
       it { is_expected.to be false }

--- a/spec/lib/versioned_forwarder_spec.rb
+++ b/spec/lib/versioned_forwarder_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe VersionedForwarder do
+  describe '#call' do
+    subject(:call) { described_class.new.call(env) }
+
+    before do
+      allow(Rails.application).to receive(:call).and_return([200, {}, %w[OK]])
+    end
+
+    let(:env) do
+      {
+        'PATH_INFO' => '/uk/api/v2/sections',
+        'action_dispatch.request.path_parameters' => {
+          service: 'uk',
+          version: '2',
+          path: 'sections',
+        },
+      }
+    end
+
+    it 'transforms the environment correctly' do
+      call
+      expect(env).to include(
+        'action_dispatch.old-path' => '/uk/api/v2/sections',
+        'PATH_INFO' => '/uk/api/sections',
+        'HTTP_ACCEPT' => 'application/vnd.hmrc.2.0+json',
+        'action_dispatch.path-transformed' => true,
+      )
+    end
+
+    it 'calls Rails application with transformed env' do
+      call
+      expect(Rails.application).to have_received(:call).with(env)
+    end
+  end
+end

--- a/spec/middleware/handle_goods_nomenclature_spec.rb
+++ b/spec/middleware/handle_goods_nomenclature_spec.rb
@@ -5,15 +5,15 @@ RSpec.describe HandleGoodsNomenclature do
 
   describe '#call' do
     context 'when the request path matches a chapter commodity' do
-      let(:original_path) { '/xi/api/v2/commodities/0100000000' }
+      let(:original_path) { '/xi/api/commodities/0100000000' }
       let(:env) { Rack::MockRequest.env_for(original_path) }
 
       it 'transforms the path to chapters with the short code', :aggregate_failures do
         _, updated_env, _response = middleware.call(env)
 
         expect(updated_env['action_dispatch.old-path']).to eq(original_path)
-        expect(updated_env['action_dispatch.path-transformed']).to eq('/xi/api/v2/chapters/01')
-        expect(updated_env['PATH_INFO']).to eq('/xi/api/v2/chapters/01')
+        expect(updated_env['action_dispatch.path-transformed']).to eq('/xi/api/chapters/01')
+        expect(updated_env['PATH_INFO']).to eq('/xi/api/chapters/01')
       end
     end
 

--- a/spec/models/exchange_rate_file_spec.rb
+++ b/spec/models/exchange_rate_file_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe ExchangeRateFile, type: :model do
   describe '#file_path' do
     let(:exchange_rate_file) { build(:exchange_rate_file) }
 
-    it { expect(exchange_rate_file.file_path).to eq('/api/v2/exchange_rates/files/monthly_csv_2023-6.csv') }
+    it { expect(exchange_rate_file.file_path).to eq('/uk/api/exchange_rates/files/monthly_csv_2023-6.csv') }
   end
 
   describe '#id' do

--- a/spec/requests/api/admin/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/category_assessments_controller_spec.rb
@@ -178,7 +178,6 @@ RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentsController, :admin do
       let(:ca_attrs) { build(:category_assessment).to_hash }
 
       it { is_expected.to have_http_status :created }
-      it { is_expected.to have_attributes location: api_admin_green_lanes_category_assessment_url(GreenLanes::CategoryAssessment.last.id) }
       it { expect { page_response }.to change(GreenLanes::CategoryAssessment, :count).by(1) }
     end
 
@@ -210,7 +209,6 @@ RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentsController, :admin do
 
     context 'with valid params' do
       it { is_expected.to have_http_status :success }
-      it { is_expected.to have_attributes location: api_admin_green_lanes_category_assessment_url(category.id) }
       it { expect { page_response }.not_to change(category.reload, :regulation_role) }
     end
 
@@ -249,7 +247,6 @@ RSpec.describe Api::Admin::GreenLanes::CategoryAssessmentsController, :admin do
 
     context 'with valid params' do
       it { is_expected.to have_http_status :success }
-      it { is_expected.to have_attributes location: api_admin_green_lanes_category_assessment_url(category.id) }
       it { expect { page_response }.not_to change(category.reload, :regulation_role) }
     end
 

--- a/spec/requests/api/admin/green_lanes/exempting_additional_code_overrides_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/exempting_additional_code_overrides_controller_spec.rb
@@ -66,7 +66,6 @@ RSpec.describe Api::Admin::GreenLanes::ExemptingAdditionalCodeOverridesControlle
       let(:eaco_attrs) { build(:exempting_additional_code_override).to_hash }
 
       it { is_expected.to have_http_status :created }
-      it { is_expected.to have_attributes location: api_admin_green_lanes_exempting_additional_code_override_url(GreenLanes::ExemptingAdditionalCodeOverride.last.id) }
       it { expect { page_response }.to change(GreenLanes::ExemptingAdditionalCodeOverride, :count).by(1) }
     end
 

--- a/spec/requests/api/admin/green_lanes/exempting_certificate_overrides_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/exempting_certificate_overrides_controller_spec.rb
@@ -66,7 +66,6 @@ RSpec.describe Api::Admin::GreenLanes::ExemptingCertificateOverridesController, 
       let(:eco_attrs) { build(:exempting_certificate_override).to_hash }
 
       it { is_expected.to have_http_status :created }
-      it { is_expected.to have_attributes location: api_admin_green_lanes_exempting_certificate_override_url(GreenLanes::ExemptingCertificateOverride.last.id) }
       it { expect { page_response }.to change(GreenLanes::ExemptingCertificateOverride, :count).by(1) }
     end
 

--- a/spec/requests/api/admin/green_lanes/exemptions_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/exemptions_controller_spec.rb
@@ -64,7 +64,6 @@ RSpec.describe Api::Admin::GreenLanes::ExemptionsController, :admin do
       let(:ex_attrs) { build(:green_lanes_exemption).to_hash }
 
       it { is_expected.to have_http_status :created }
-      it { is_expected.to have_attributes location: api_admin_green_lanes_exemption_url(GreenLanes::Exemption.last.id) }
       it { expect { page_response }.to change(GreenLanes::Exemption, :count).by(1) }
     end
 
@@ -96,7 +95,6 @@ RSpec.describe Api::Admin::GreenLanes::ExemptionsController, :admin do
 
     context 'with valid params' do
       it { is_expected.to have_http_status :success }
-      it { is_expected.to have_attributes location: api_admin_green_lanes_exemption_url(exemption.id) }
       it { expect { page_response }.not_to change(exemption.reload, :description) }
     end
 

--- a/spec/requests/api/admin/green_lanes/measure_type_mappings_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/measure_type_mappings_controller_spec.rb
@@ -64,7 +64,6 @@ RSpec.describe Api::Admin::GreenLanes::MeasureTypeMappingsController, :admin do
       let(:ex_attrs) { build(:identified_measure_type_category_assessment).to_hash }
 
       it { is_expected.to have_http_status :created }
-      it { is_expected.to have_attributes location: api_admin_green_lanes_measure_type_mapping_url(GreenLanes::IdentifiedMeasureTypeCategoryAssessment.last.id) }
       it { expect { page_response }.to change(GreenLanes::IdentifiedMeasureTypeCategoryAssessment, :count).by(1) }
     end
 

--- a/spec/requests/api/admin/green_lanes/measures_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/measures_controller_spec.rb
@@ -64,7 +64,6 @@ RSpec.describe Api::Admin::GreenLanes::MeasuresController, :admin do
       let(:measure_attrs) { build(:green_lanes_measure).to_hash }
 
       it { is_expected.to have_http_status :created }
-      it { is_expected.to have_attributes location: api_admin_green_lanes_measure_url(GreenLanes::Measure.last.id) }
       it { expect { page_response }.to change(GreenLanes::Measure, :count).by(1) }
     end
 
@@ -98,7 +97,6 @@ RSpec.describe Api::Admin::GreenLanes::MeasuresController, :admin do
       let(:new_category_assessment_id) { new_category_assessment.id }
 
       it { is_expected.to have_http_status :success }
-      it { is_expected.to have_attributes location: api_admin_green_lanes_measure_url(measure.id) }
       it { expect { page_response }.not_to change(measure.reload, :productline_suffix) }
     end
 

--- a/spec/requests/api/admin/green_lanes/update_notifications_controller_spec.rb
+++ b/spec/requests/api/admin/green_lanes/update_notifications_controller_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe Api::Admin::GreenLanes::UpdateNotificationsController, :admin do
 
     context 'with valid params' do
       it { is_expected.to have_http_status :success }
-      it { is_expected.to have_attributes location: api_admin_green_lanes_update_notification_url(update.id) }
       it { expect { page_response }.not_to change(update.reload, :status) }
     end
 

--- a/spec/requests/api/admin/news/collections_controller_spec.rb
+++ b/spec/requests/api/admin/news/collections_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Api::Admin::News::CollectionsController, :admin do
       let(:news_collection_attrs) { attributes_for :news_collection }
 
       it { is_expected.to have_http_status :created }
-      it { is_expected.to have_attributes location: api_admin_news_collection_url(News::Collection.last.id) }
+
       it { expect { page_response }.to change(News::Collection, :count).by(1) }
     end
 
@@ -90,7 +90,6 @@ RSpec.describe Api::Admin::News::CollectionsController, :admin do
 
     context 'with valid params' do
       it { is_expected.to have_http_status :success }
-      it { is_expected.to have_attributes location: api_admin_news_collection_url(news_collection.id) }
       it { expect { page_response }.not_to change(news_collection.reload, :name) }
     end
 

--- a/spec/requests/api/admin/news/items_controller_spec.rb
+++ b/spec/requests/api/admin/news/items_controller_spec.rb
@@ -58,7 +58,6 @@ RSpec.describe Api::Admin::News::ItemsController, :admin do
       let(:news_item_attrs) { attributes_for :news_item }
 
       it { is_expected.to have_http_status :created }
-      it { is_expected.to have_attributes location: api_admin_news_item_url(News::Item.last.id) }
       it { expect { page_response }.to change(News::Item, :count).by(1) }
     end
 
@@ -90,7 +89,6 @@ RSpec.describe Api::Admin::News::ItemsController, :admin do
 
     context 'with valid params' do
       it { is_expected.to have_http_status :success }
-      it { is_expected.to have_attributes location: api_admin_news_item_url(news_item.id) }
       it { expect { page_response }.not_to change(news_item.reload, :title) }
     end
 

--- a/spec/requests/api/api_controller_spec.rb
+++ b/spec/requests/api/api_controller_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe Api::ApiController, type: :request do
-  subject(:page_response) { get(testpath, headers:) && response }
+  subject(:page_response) { api_get(testpath, headers:) && response }
 
   let(:chapter) { create :chapter, :with_section }
 
   let(:headers) { { 'HTTP_USER_AGENT' => 'TradeTariffFrontend/2ebf4292' } }
 
   describe 'GET to #show' do
-    let(:testpath) { "/api/v2/chapters/#{chapter.short_code}" }
+    let(:testpath) { "/uk/api/chapters/#{chapter.short_code}" }
 
     it { is_expected.to have_http_status :success }
 
@@ -18,7 +18,7 @@ RSpec.describe Api::ApiController, type: :request do
           receive(:perform_caching).and_return(true)
       end
 
-      let(:earlier_request) { get(testpath, headers:) && response }
+      let(:earlier_request) { api_get(testpath, headers:) && response }
 
       it { is_expected.to include 'etag' }
       it { is_expected.to include 'cache-control' => /public/i }
@@ -58,7 +58,7 @@ RSpec.describe Api::ApiController, type: :request do
         end
 
         let :testpath do
-          "/api/v2/chapters/#{chapter.short_code}?as_of=#{Time.zone.today.to_fs :db}"
+          "/uk/api/chapters/#{chapter.short_code}?as_of=#{Time.zone.today.to_fs :db}"
         end
 
         it { is_expected.to include 'etag' => earlier_request.headers['ETag'] }
@@ -67,9 +67,9 @@ RSpec.describe Api::ApiController, type: :request do
       context 'when request originates not from the frontend' do
         subject { response.headers.to_h }
 
-        before { get testpath, headers: }
+        before { api_get testpath, headers: }
 
-        let(:testpath) { "/api/v2/chapters/#{chapter.short_code}" }
+        let(:testpath) { "/uk/api/chapters/#{chapter.short_code}" }
         let(:headers) { { 'HTTP_USER_AGENT' => 'curl/7.64.1' } }
 
         it { is_expected.to have_key('etag') }

--- a/spec/requests/api/v2/chapters_controller_spec.rb
+++ b/spec/requests/api/v2/chapters_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Api::V2::ChaptersController, :v2 do
 
   describe 'GET #index' do
     it 'caches the serialized chapters' do
-      get '/api/v2/chapters'
+      api_get '/uk/api/chapters'
 
       expect(Rails.cache)
         .to have_received(:fetch)
@@ -19,7 +19,7 @@ RSpec.describe Api::V2::ChaptersController, :v2 do
     end
 
     it_behaves_like 'a successful csv response' do
-      let(:path) { '/api/v2/chapters' }
+      let(:path) { '/uk/api/chapters' }
       let(:expected_filename) { "uk-chapters-#{Time.zone.today.iso8601}.csv" }
 
       before do
@@ -32,7 +32,7 @@ RSpec.describe Api::V2::ChaptersController, :v2 do
     let(:chapter) { create :chapter, :with_section }
 
     it 'caches the serialized chapters' do
-      get "/api/v2/chapters/#{chapter.short_code}"
+      api_get "/uk/api/chapters/#{chapter.short_code}"
 
       expect(Rails.cache)
         .to have_received(:fetch)
@@ -47,7 +47,7 @@ RSpec.describe Api::V2::ChaptersController, :v2 do
     let(:chapter) { create :chapter, :with_section }
 
     it 'caches the serialized chapter changes' do
-      get changes_api_chapter_path(chapter)
+      api_get changes_api_chapter_path(chapter)
 
       expect(Rails.cache)
         .to have_received(:fetch)
@@ -65,7 +65,7 @@ RSpec.describe Api::V2::ChaptersController, :v2 do
     let(:expected_filename) { "uk-chapter-#{chapter.short_code}-headings-#{Time.zone.today.iso8601}.csv" }
 
     it_behaves_like 'a successful csv response' do
-      let(:path) { "/api/v2/chapters/#{chapter.short_code}/headings" }
+      let(:path) { "/uk/api/chapters/#{chapter.short_code}/headings" }
     end
   end
 end

--- a/spec/requests/api/v2/chemical_substances_controller_spec.rb
+++ b/spec/requests/api/v2/chemical_substances_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Api::V2::ChemicalSubstancesController, :v2 do
     let(:make_request) do
       create(:full_chemical, cus: '1234567890')
 
-      get api_chemical_substances_path(params:, format: :json)
+      api_get api_chemical_substances_path(params:, format: :json)
     end
 
     context 'when no filter is provided' do

--- a/spec/requests/api/v2/exchange_rates/files_controller_spec.rb
+++ b/spec/requests/api/v2/exchange_rates/files_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Api::V2::ExchangeRates::FilesController, :v2 do
       let(:type) { 'monthly_csv' }
       let(:format) { 'csv' }
 
-      before { get api_exchange_rates_file_path("#{type}_#{year}-#{month}", format: :csv) }
+      before { api_get api_exchange_rates_file_path("#{type}_#{year}-#{month}", format: :csv) }
 
       it 'returns HTTP status :ok' do
         expect(response).to have_http_status(:ok)
@@ -37,7 +37,7 @@ RSpec.describe Api::V2::ExchangeRates::FilesController, :v2 do
       let(:type) { 'monthly_xml' }
       let(:format) { 'xml' }
 
-      before { get api_exchange_rates_file_path("#{type}_#{year}-#{month}", format: :xml) }
+      before { api_get api_exchange_rates_file_path("#{type}_#{year}-#{month}", format: :xml) }
 
       it 'returns HTTP status :ok' do
         expect(response).to have_http_status(:ok)
@@ -60,7 +60,7 @@ RSpec.describe Api::V2::ExchangeRates::FilesController, :v2 do
       let(:type) { 'monthly_csv_hmrc' }
       let(:format) { 'csv' }
 
-      before { get api_exchange_rates_file_path("#{type}_#{year}-#{month}", format: :csv) }
+      before { api_get api_exchange_rates_file_path("#{type}_#{year}-#{month}", format: :csv) }
 
       it 'returns HTTP status :ok' do
         expect(response).to have_http_status(:ok)
@@ -83,7 +83,7 @@ RSpec.describe Api::V2::ExchangeRates::FilesController, :v2 do
       let(:type) { 'non_existing_type' }
       let(:format) { 'csv' }
 
-      before { get api_exchange_rates_file_path("#{type}_#{year}-#{month}", format: :csv) }
+      before { api_get api_exchange_rates_file_path("#{type}_#{year}-#{month}", format: :csv) }
 
       it 'returns HTTP status :not_found' do
         expect(response).to have_http_status(:not_found)

--- a/spec/requests/api/v2/exchange_rates/period_lists_controller_spec.rb
+++ b/spec/requests/api/v2/exchange_rates/period_lists_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Api::V2::ExchangeRates::PeriodListsController, :v2 do
       let(:year) { 2023 }
 
       let(:make_request) do
-        get api_exchange_rates_period_list_path(
+        api_get api_exchange_rates_period_list_path(
           year: '2023',
           filter: { type: 'monthly' },
           format: :json,
@@ -51,7 +51,7 @@ RSpec.describe Api::V2::ExchangeRates::PeriodListsController, :v2 do
       let(:year) { nil }
 
       let(:make_request) do
-        get api_exchange_rates_period_list_path(
+        api_get api_exchange_rates_period_list_path(
           filter: { type: 'monthly' },
           format: :json,
         )
@@ -83,7 +83,7 @@ RSpec.describe Api::V2::ExchangeRates::PeriodListsController, :v2 do
       let(:period_list) { build(:period_list, exchange_rate_periods: [], year: 1970) }
 
       let(:make_request) do
-        get api_exchange_rates_period_list_path(
+        api_get api_exchange_rates_period_list_path(
           year: '1970',
           filter: { type: 'monthly' },
           format: :json,
@@ -115,7 +115,7 @@ RSpec.describe Api::V2::ExchangeRates::PeriodListsController, :v2 do
       let(:year) { '2023idadas' }
 
       let(:make_request) do
-        get api_exchange_rates_period_list_path(
+        api_get api_exchange_rates_period_list_path(
           year: '2023idadas',
           filter: { type: 'monthly' },
           format: :json,
@@ -125,7 +125,7 @@ RSpec.describe Api::V2::ExchangeRates::PeriodListsController, :v2 do
       let(:pattern) do
         {
           error: 'not found',
-          url: 'http://www.example.com/uk/api/v2/exchange_rates/period_lists/2023idadas?filter%5Btype%5D=monthly',
+          url: 'http://www.example.com/uk/api/exchange_rates/period_lists/2023idadas?filter%5Btype%5D=monthly',
         }
       end
 
@@ -137,7 +137,7 @@ RSpec.describe Api::V2::ExchangeRates::PeriodListsController, :v2 do
       let(:year) { 2023 }
 
       let(:make_request) do
-        get api_exchange_rates_period_list_path(
+        api_get api_exchange_rates_period_list_path(
           year: '2023',
           filter: { type: 'invalid' },
           format: :json,
@@ -147,7 +147,7 @@ RSpec.describe Api::V2::ExchangeRates::PeriodListsController, :v2 do
       let(:pattern) do
         {
           error: 'invalid',
-          url: 'http://www.example.com/uk/api/v2/exchange_rates/period_lists/2023?filter%5Btype%5D=invalid',
+          url: 'http://www.example.com/uk/api/exchange_rates/period_lists/2023?filter%5Btype%5D=invalid',
         }
       end
 

--- a/spec/requests/api/v2/exchange_rates_controller_spec.rb
+++ b/spec/requests/api/v2/exchange_rates_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Api::V2::ExchangeRatesController, :v2 do
 
     context 'when the year and month parameters are valid' do
       let(:make_request) do
-        get api_exchange_rate_path(
+        api_get api_exchange_rate_path(
           '2023-6',
           filter: { type: 'monthly' },
           format: :json,
@@ -49,7 +49,7 @@ RSpec.describe Api::V2::ExchangeRatesController, :v2 do
 
     context 'when the year and month parameters are invalid' do
       let(:make_request) do
-        get api_exchange_rate_path(
+        api_get api_exchange_rate_path(
           '2023idadas-6',
           filter: { type: 'monthly' },
           format: :json,
@@ -59,7 +59,7 @@ RSpec.describe Api::V2::ExchangeRatesController, :v2 do
       let(:pattern) do
         {
           error: 'not found',
-          url: 'http://www.example.com/uk/api/v2/exchange_rates/2023idadas-6?filter%5Btype%5D=monthly',
+          url: 'http://www.example.com/uk/api/exchange_rates/2023idadas-6?filter%5Btype%5D=monthly',
         }
       end
 
@@ -72,7 +72,7 @@ RSpec.describe Api::V2::ExchangeRatesController, :v2 do
 
     context 'when the type parameter is invalid' do
       let(:make_request) do
-        get api_exchange_rate_path(
+        api_get api_exchange_rate_path(
           '2023-6',
           filter: { type: 'invalid' },
           format: :json,
@@ -82,7 +82,7 @@ RSpec.describe Api::V2::ExchangeRatesController, :v2 do
       let(:pattern) do
         {
           'error' => 'invalid',
-          'url' => 'http://www.example.com/uk/api/v2/exchange_rates/2023-6?filter%5Btype%5D=invalid',
+          'url' => 'http://www.example.com/uk/api/exchange_rates/2023-6?filter%5Btype%5D=invalid',
         }
       end
 

--- a/spec/requests/api/v2/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/api/v2/green_lanes/category_assessments_controller_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentsController, :v2 do
     subject(:rendered) { make_request && response }
 
     let :make_request do
-      get api_green_lanes_category_assessments_path(format: :json),
-          headers: { 'HTTP_AUTHORIZATION' => authorization }
+      api_get api_green_lanes_category_assessments_path(format: :json),
+              headers: { 'HTTP_AUTHORIZATION' => authorization }
     end
 
     let :authorization do
@@ -56,8 +56,8 @@ RSpec.describe Api::V2::GreenLanes::CategoryAssessmentsController, :v2 do
     subject(:rendered) { make_request && response }
 
     let :make_request do
-      get api_green_lanes_category_assessments_path(format: :json),
-          headers: { 'HTTP_AUTHORIZATION' => authorization }
+      api_get api_green_lanes_category_assessments_path(format: :json),
+              headers: { 'HTTP_AUTHORIZATION' => authorization }
     end
 
     context 'when presence of incorrect bearer token' do

--- a/spec/requests/api/v2/green_lanes/faq_feedback_controller_spec.rb
+++ b/spec/requests/api/v2/green_lanes/faq_feedback_controller_spec.rb
@@ -16,24 +16,34 @@ RSpec.describe Api::V2::GreenLanes::FaqFeedbackController, :v2 do
 
   describe 'POST to #create' do
     let(:make_request) do
-      post api_green_lanes_faq_feedback_index_path(format: :json), params: faq_feedback_data, headers: {
-        'HTTP_AUTHORIZATION' => authorization,
+      post api_green_lanes_faq_feedback_index_path, params: params, headers: headers, as: :json
+    end
+
+    let(:params) do
+      {
+        data: {
+          type: :green_lanes_faq_feedback,
+          attributes: attributes,
+        },
       }
     end
 
-    let :faq_feedback_data do
-      { data: { type: :green_lanes_faq_feedback, attributes: ex_attrs } }
+    let(:headers) do
+      {
+        'HTTP_AUTHORIZATION' => authorization,
+        'Accept' => 'application/vnd.hmrc.2.0+json',
+        'Content-Type' => 'application/json',
+      }
     end
 
     context 'with valid params' do
-      let(:ex_attrs) { build(:green_lanes_faq_feedback).to_hash }
+      let(:attributes) { attributes_for(:green_lanes_faq_feedback) }
 
       it { is_expected.to have_http_status :created }
-      it { is_expected.to have_attributes location: api_green_lanes_faq_feedback_url(GreenLanes::FaqFeedback.last.id) }
     end
 
     context 'with invalid params' do
-      let(:ex_attrs) { build(:green_lanes_faq_feedback, session_id: nil).to_hash }
+      let(:attributes) { attributes_for(:green_lanes_faq_feedback, session_id: nil) }
 
       it { is_expected.to have_http_status :unprocessable_entity }
 

--- a/spec/requests/api/v2/green_lanes/goods_nomenclatures_controller_spec.rb
+++ b/spec/requests/api/v2/green_lanes/goods_nomenclatures_controller_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclaturesController, :v2 do
   end
 
   let :make_request do
-    get api_green_lanes_goods_nomenclature_path(request_item_id, format: :json),
-        headers: { 'HTTP_AUTHORIZATION' => authorization },
-        params:
+    api_get api_green_lanes_goods_nomenclature_path(request_item_id, format: :json),
+            headers: { 'HTTP_AUTHORIZATION' => authorization },
+            params:
   end
 
   let(:params) { {} }

--- a/spec/requests/api/v2/green_lanes/themes_controller_spec.rb
+++ b/spec/requests/api/v2/green_lanes/themes_controller_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Api::V2::GreenLanes::ThemesController, :v2 do
 
   describe 'GET to #index' do
     let(:make_request) do
-      get api_green_lanes_themes_path(format: :json),
-          headers: { 'HTTP_AUTHORIZATION' => authorization }
+      api_get api_green_lanes_themes_path(format: :json),
+              headers: { 'HTTP_AUTHORIZATION' => authorization }
     end
 
     let :authorization do

--- a/spec/requests/api/v2/headings_controller_spec.rb
+++ b/spec/requests/api/v2/headings_controller_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Api::V2::HeadingsController, :v2 do
   describe 'GET #headings' do
     it_behaves_like 'a successful csv response' do
-      let(:path) { "/api/v2/headings/#{heading.short_code}/commodities" }
+      let(:path) { "/uk/api/headings/#{heading.short_code}/commodities" }
       let(:expected_filename) { "uk-headings-#{heading.short_code}-commodities-#{Time.zone.today.iso8601}.csv" }
       let(:heading) { create(:heading, :non_declarable) }
     end

--- a/spec/requests/api/v2/live_issues_controller_spec.rb
+++ b/spec/requests/api/v2/live_issues_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Api::V2::LiveIssuesController, :v2 do
         active_live_issue
         resolved_live_issue
 
-        get api_live_issues_path(format: :json), params: {}
+        api_get api_live_issues_path, params: {}
 
         expect(response).to have_http_status(:success)
         expect(json_response).to include('data')
@@ -22,7 +22,7 @@ RSpec.describe Api::V2::LiveIssuesController, :v2 do
         active_live_issue
         resolved_live_issue
 
-        get api_live_issues_path(format: :json), params: { filter: { status: 'Active' } }
+        api_get api_live_issues_path(format: :json), params: { filter: { status: 'Active' } }
 
         expect(response).to have_http_status(:success)
         expect(json_response).to include('data')
@@ -34,7 +34,7 @@ RSpec.describe Api::V2::LiveIssuesController, :v2 do
         active_live_issue
         resolved_live_issue
 
-        get api_live_issues_path(format: :json), params: { filter: { status: 'Resolved' } }
+        api_get api_live_issues_path, params: { filter: { status: 'Resolved' } }
 
         expect(response).to have_http_status(:success)
         expect(json_response).to include('data')
@@ -49,7 +49,7 @@ RSpec.describe Api::V2::LiveIssuesController, :v2 do
       end
 
       it 'returns 400 if serialization fails' do
-        get api_live_issues_path(format: :json)
+        api_get api_live_issues_path
         expect(response).to have_http_status(:bad_request)
         expect(json_response['errors'].first['detail']).to include('Bad request')
       end

--- a/spec/requests/api/v2/measures_controller_spec.rb
+++ b/spec/requests/api/v2/measures_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Api::V2::MeasuresController, :v2 do
     let(:measure) { create(:measure) }
 
     let :make_request do
-      get api_measure_path(id: measure.measure_sid, format: :json)
+      api_get api_measure_path(id: measure.measure_sid)
     end
 
     it_behaves_like 'a successful jsonapi response'

--- a/spec/requests/api/v2/news/collections_controller_spec.rb
+++ b/spec/requests/api/v2/news/collections_controller_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Api::V2::News::CollectionsController, :v2 do
     subject(:rendered) { make_request && response }
 
     let :make_request do
-      get api_news_collections_path(format: :json)
+      api_get api_news_collections_path(format: :json)
     end
 
     it_behaves_like 'a successful jsonapi response'

--- a/spec/requests/api/v2/news/items_controller_spec.rb
+++ b/spec/requests/api/v2/news/items_controller_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Api::V2::News::ItemsController, :v2 do
     subject(:rendered) { make_request && response }
 
     let :make_request do
-      get api_news_items_path(request_params.merge(format: :json))
+      api_get api_news_items_path(request_params.merge(format: :json))
     end
 
     let(:request_params) { {} }
@@ -34,7 +34,7 @@ RSpec.describe Api::V2::News::ItemsController, :v2 do
       let(:collection) { item.collections.first }
 
       let :make_request do
-        get api_news_collection_items_path(collection_id:, format: :json)
+        api_get api_news_collection_items_path(collection_id:, format: :json)
       end
 
       context 'with known collection' do
@@ -93,14 +93,14 @@ RSpec.describe Api::V2::News::ItemsController, :v2 do
     let(:news_item) { create :news_item }
 
     let :make_request do
-      get api_news_item_path(news_item.id, format: :json)
+      api_get api_news_item_path(news_item.id, format: :json)
     end
 
     it_behaves_like 'a successful jsonapi response'
 
     context 'with unknown news item' do
       let :make_request do
-        get api_news_item_path(9999, format: :json)
+        api_get api_news_item_path(9999, format: :json)
       end
 
       it { is_expected.to have_http_status :not_found }
@@ -108,7 +108,7 @@ RSpec.describe Api::V2::News::ItemsController, :v2 do
 
     context 'with slug' do
       let :make_request do
-        get api_news_item_path(news_item.slug, format: :json)
+        api_get api_news_item_path(news_item.slug, format: :json)
       end
 
       it_behaves_like 'a successful jsonapi response'
@@ -116,7 +116,7 @@ RSpec.describe Api::V2::News::ItemsController, :v2 do
 
     context 'with an unknown slug' do
       let :make_request do
-        get api_news_item_path('something-unknown', format: :json)
+        api_get api_news_item_path('something-unknown', format: :json)
       end
 
       it { is_expected.to have_http_status :not_found }

--- a/spec/requests/api/v2/news/years_controller_spec.rb
+++ b/spec/requests/api/v2/news/years_controller_spec.rb
@@ -3,14 +3,14 @@ RSpec.describe Api::V2::News::YearsController, :v2 do
     subject(:rendered) { make_request && response }
 
     let :make_request do
-      get api_news_years_path(format: :json)
+      api_get api_news_years_path
     end
 
     it_behaves_like 'a successful jsonapi response'
 
     context 'with specific service' do
       let :make_request do
-        get api_news_years_path(service: 'uk', format: :json)
+        api_get api_news_years_path(service: 'uk')
       end
 
       it_behaves_like 'a successful jsonapi response'

--- a/spec/requests/api/v2/preference_codes_controller_spec.rb
+++ b/spec/requests/api/v2/preference_codes_controller_spec.rb
@@ -2,9 +2,7 @@ RSpec.describe Api::V2::PreferenceCodesController, :v2 do
   describe 'GET #index' do
     subject(:rendered) { make_request && response }
 
-    let :make_request do
-      get api_preference_codes_path(format: :json)
-    end
+    let(:make_request) { api_get api_preference_codes_path }
 
     it_behaves_like 'a successful jsonapi response'
   end
@@ -13,13 +11,9 @@ RSpec.describe Api::V2::PreferenceCodesController, :v2 do
     context 'when it finds a preference_code' do
       subject(:rendered) { make_request && response }
 
-      let(:preference_code) { PreferenceCode[code] }
+      let(:preference_code) { PreferenceCode['100'] }
 
-      let(:code) { '100' }
-
-      let :make_request do
-        get api_preference_code_path(preference_code.code, format: :json)
-      end
+      let(:make_request) { api_get api_preference_code_path(preference_code.code) }
 
       it_behaves_like 'a successful jsonapi response'
 
@@ -30,7 +24,7 @@ RSpec.describe Api::V2::PreferenceCodesController, :v2 do
       subject(:rendered) { make_request && response }
 
       let :make_request do
-        get api_preference_code_path('foo', format: :json)
+        get api_preference_code_path('foo')
       end
 
       it { is_expected.to have_http_status :not_found }

--- a/spec/requests/api/v2/rules_of_origin/product_specific_rules_controller_spec.rb
+++ b/spec/requests/api/v2/rules_of_origin/product_specific_rules_controller_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Api::V2::RulesOfOrigin::ProductSpecificRulesController, :v2 do
     subject(:rendered) { make_request && response }
 
     let :make_request do
-      get api_product_specific_rules_path(commodity, format: :json)
+      api_get api_product_specific_rules_path(commodity, format: :json)
     end
     let(:commodity) { build :commodity }
 

--- a/spec/requests/api/v2/rules_of_origin/schemes_controller_spec.rb
+++ b/spec/requests/api/v2/rules_of_origin/schemes_controller_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemesController, :v2 do
     let(:first_scheme) { JSON.parse(rendered.body)['data'].first['attributes'] }
 
     let :make_request do
-      get api_rules_of_origin_schemes_path(format: :json),
-          params: { heading_code:, country_code: }
+      api_get api_rules_of_origin_schemes_path(format: :json),
+              params: { heading_code:, country_code: }
     end
 
     it_behaves_like 'a successful jsonapi response'
@@ -29,7 +29,7 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemesController, :v2 do
 
     context 'with path params' do
       let :make_request do
-        get api_rules_of_origin_path(heading_code:, country_code:, format: :json)
+        api_get api_rules_of_origin_path(heading_code:, country_code:, format: :json)
       end
 
       it_behaves_like 'a successful jsonapi response'
@@ -37,7 +37,7 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemesController, :v2 do
 
     context 'when listing all schemes' do
       let :make_request do
-        get api_rules_of_origin_schemes_path(format: :json)
+        api_get api_rules_of_origin_schemes_path(format: :json)
       end
 
       it_behaves_like 'a successful jsonapi response'
@@ -48,7 +48,7 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemesController, :v2 do
         subject { JSON.parse(rendered.body)['included'] }
 
         let :make_request do
-          get api_rules_of_origin_schemes_path(include: 'proofs', format: :json)
+          api_get api_rules_of_origin_schemes_path(include: 'proofs', format: :json)
         end
 
         it { is_expected.to include include 'type' => 'rules_of_origin_proof' }
@@ -57,7 +57,7 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemesController, :v2 do
 
     context 'with filtered list of schemes' do
       let :make_request do
-        get api_rules_of_origin_schemes_path(filter: { has_article: 'duty-drawback' }, format: :json)
+        api_get api_rules_of_origin_schemes_path(filter: { has_article: 'duty-drawback' }, format: :json)
       end
 
       it_behaves_like 'a successful jsonapi response'

--- a/spec/requests/api/v2/sections_controller_chapters_spec.rb
+++ b/spec/requests/api/v2/sections_controller_chapters_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Api::V2::Sections, :v2 do
     let(:section) { create(:section, :with_chapter) }
 
     it_behaves_like 'a successful csv response' do
-      let(:path) { "/api/v2/sections/#{section.position}/chapters" }
+      let(:path) { "/uk/api/sections/#{section.position}/chapters" }
       let(:expected_filename) { "uk-sections-#{section.position}-chapters-#{Time.zone.today.iso8601}.csv" }
     end
   end

--- a/spec/requests/api/v2/sections_controller_spec.rb
+++ b/spec/requests/api/v2/sections_controller_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Api::V2::SectionsController, :v2 do
   describe 'GET #index' do
     it_behaves_like 'a successful csv response' do
-      let(:path) { '/api/v2/sections' }
+      let(:path) { '/uk/api/sections' }
       let(:expected_filename) { "uk-sections-#{Time.zone.today.iso8601}.csv" }
 
       before do

--- a/spec/requests/api/v2/subheadings_controller_spec.rb
+++ b/spec/requests/api/v2/subheadings_controller_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Api::V2::SubheadingsController, :v2 do
   describe 'GET #show' do
     subject(:rendered) { make_request && response } # Subheading api requires the producline suffix to identify the subheading
 
-    let(:make_request) { get api_subheading_path('0101210000-10') }
+    let(:make_request) { api_get api_subheading_path('0101210000-10') }
 
     context 'when the subheading has at least one child, a heading, a chapter and a section' do
       before do

--- a/spec/requests/api/v2/validity_periods_controller_spec.rb
+++ b/spec/requests/api/v2/validity_periods_controller_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Api::V2::ValidityPeriodsController, :v2 do
   shared_examples 'a correctly routing validity periods api request' do
     subject(:do_response) do
-      get validity_period_path
+      api_get validity_period_path
 
       response
     end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe ApplicationController, type: :request do
   describe 'GET #index' do
-    subject(:do_response) { get('/api/v2/healthcheck') && response }
+    subject(:do_response) { api_get('/uk/api/healthcheck') && response }
 
     context 'when the request propagates a handled error' do
       before do

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -10,21 +10,15 @@ RSpec.describe ErrorsController do
   end
 
   shared_examples 'a csv or json error response' do |status_code, message|
-    context 'with html request' do
-      let(:make_request) { get "/api/v1/#{status_code}" }
-
-      it_behaves_like 'a json error response', status_code, message
-    end
-
     context 'with json request' do
-      let(:make_request) { get "/api/v1/#{status_code}.json" }
+      let(:make_request) { get "/uk/api/#{status_code}.json", headers: { 'HTTP_ACCEPT' => 'application/vnd.hmrc.1.0+json' } }
 
       it_behaves_like 'a json error response', status_code, message
     end
 
     context 'with jsonapi request' do
       let :make_request do
-        get "/api/v2/#{status_code}.json"
+        get "/uk/api/#{status_code}.json", headers: { 'HTTP_ACCEPT' => 'application/vnd.hmrc.2.0+json' }
       end
 
       it { is_expected.to have_http_status status_code }
@@ -33,7 +27,7 @@ RSpec.describe ErrorsController do
     end
 
     context 'with csv request' do
-      let(:make_request) { get "/api/v1/#{status_code}.csv" }
+      let(:make_request) { get "/uk/api/#{status_code}.csv", headers: { 'HTTP_ACCEPT' => 'application/vnd.hmrc.2.0+csv' } }
 
       it { is_expected.to have_http_status status_code }
       it { is_expected.to have_attributes media_type: 'text/csv' }
@@ -41,7 +35,7 @@ RSpec.describe ErrorsController do
     end
 
     context 'with other request' do
-      let(:make_request) { get "/api/v1/#{status_code}.pdf" }
+      let(:make_request) { get "/uk/api/#{status_code}.pdf", headers: { 'HTTP_ACCEPT' => 'application/vnd.hmrc.1.0+pdf' } }
 
       it_behaves_like 'a json error response', status_code, message
     end
@@ -74,7 +68,7 @@ RSpec.describe ErrorsController do
   end
 
   describe 'GET #maintenance' do
-    let(:make_request) { get '/api/v2/maintenance' }
+    let(:make_request) { get '/api/maintenance' }
 
     it_behaves_like 'a csv or json error response', 503, 'Service is unavailable'
   end

--- a/spec/requests/excess_query_spec.rb
+++ b/spec/requests/excess_query_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'excess query counts', :v2 do
   before { allow(NewRelic::Agent).to receive(:notice_error).and_return true }
 
-  let(:get_page) { get api_heading_path(heading, format: :json) }
+  let(:get_page) { api_get api_heading_path(heading, format: :json) }
 
   let :heading do
     create(:commodity,

--- a/spec/requests/healthcheck_controller_spec.rb
+++ b/spec/requests/healthcheck_controller_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe HealthcheckController, type: :request do
   describe 'GET #index' do
     subject(:rendered) { make_request && response }
 
-    let(:make_request) { get '/api/v2/healthcheck' }
+    let(:make_request) { api_get '/uk/api/healthcheck' }
     let(:healthcheck) { Healthcheck.instance }
 
     before do

--- a/spec/requests/maintenance_mode_spec.rb
+++ b/spec/requests/maintenance_mode_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Maintenance mode' do
     end
 
     context 'without bypass enabled' do
-      before { get '/api/v2/sections.json' }
+      before { api_get '/uk/api/sections.json' }
 
       it { is_expected.to have_http_status :service_unavailable }
     end
@@ -19,20 +19,20 @@ RSpec.describe 'Maintenance mode' do
       end
 
       context 'without bypass param' do
-        before { get '/api/v2/sections.json' }
+        before { api_get '/uk/api/sections.json' }
 
         it { is_expected.to have_http_status :service_unavailable }
       end
 
       context 'with wrong bypass param' do
-        before { get '/api/v2/sections.json?maintenance_bypass=something' }
+        before { api_get '/uk/api/sections.json?maintenance_bypass=something' }
 
         it { is_expected.to have_http_status :service_unavailable }
       end
 
       context 'with correct bypass param' do
         before do
-          get '/api/v2/sections.json?maintenance_bypass=bypass'
+          api_get '/uk/api/sections.json?maintenance_bypass=bypass'
         end
 
         it { is_expected.to have_http_status :success }

--- a/spec/serializers/api/v2/csv/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/api/v2/csv/goods_nomenclature_serializer_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Api::V2::Csv::GoodsNomenclatureSerializer do
           '0',
           goods_nomenclature.description,
           '80',
-          "/uk/api/v2/headings/#{goods_nomenclature.short_code}",
+          "/uk/api/headings/#{goods_nomenclature.short_code}",
           goods_nomenclature.formatted_description,
           "#{goods_nomenclature.validity_start_date.to_date} 00:00:00 UTC",
           '',
@@ -47,7 +47,7 @@ RSpec.describe Api::V2::Csv::GoodsNomenclatureSerializer do
     context 'with subheading' do
       let(:goods_nomenclature) { create :commodity, :with_children }
 
-      it { expect(rows[1]).to match "/uk/api/v2/subheadings/#{goods_nomenclature.to_param}" }
+      it { expect(rows[1]).to match "/uk/api/subheadings/#{goods_nomenclature.to_param}" }
     end
 
     context 'with parent' do

--- a/spec/serializers/api/v2/goods_nomenclatures/goods_nomenclature_extended_serializer_spec.rb
+++ b/spec/serializers/api/v2/goods_nomenclatures/goods_nomenclature_extended_serializer_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Api::V2::GoodsNomenclatures::GoodsNomenclatureExtendedSerializer 
       it { is_expected.to include producline_suffix: gn.producline_suffix }
       it { is_expected.to include description: gn.description }
       it { is_expected.to include number_indents: gn.number_indents }
-      it { is_expected.to include href: "/uk/api/v2/commodities/#{gn.goods_nomenclature_item_id}" }
+      it { is_expected.to include href: "/uk/api/commodities/#{gn.goods_nomenclature_item_id}" }
       it { is_expected.to include formatted_description: gn.formatted_description }
       it { is_expected.to include validity_start_date: gn.validity_start_date }
       it { is_expected.to include validity_end_date: gn.validity_end_date }
@@ -45,21 +45,21 @@ RSpec.describe Api::V2::GoodsNomenclatures::GoodsNomenclatureExtendedSerializer 
       context 'with heading' do
         let(:gn) { create :heading, :with_children }
 
-        it { is_expected.to include href: "/uk/api/v2/headings/#{gn.short_code}" }
+        it { is_expected.to include href: "/uk/api/headings/#{gn.short_code}" }
         it { is_expected.to include declarable: false }
       end
 
       context 'with declarable heading' do
         let(:gn) { create :heading }
 
-        it { is_expected.to include href: "/uk/api/v2/headings/#{gn.short_code}" }
+        it { is_expected.to include href: "/uk/api/headings/#{gn.short_code}" }
         it { is_expected.to include declarable: true }
       end
 
       context 'with subheading' do
         let(:gn) { create :subheading, :with_children }
 
-        it { is_expected.to include href: "/uk/api/v2/subheadings/#{gn.to_param}" }
+        it { is_expected.to include href: "/uk/api/subheadings/#{gn.to_param}" }
         it { is_expected.to include declarable: false }
       end
     end

--- a/spec/serializers/api/v2/goods_nomenclatures/goods_nomenclature_list_serializer_spec.rb
+++ b/spec/serializers/api/v2/goods_nomenclatures/goods_nomenclature_list_serializer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Api::V2::GoodsNomenclatures::GoodsNomenclatureListSerializer do
       it { is_expected.to include producline_suffix: gn.producline_suffix }
       it { is_expected.to include description: gn.description }
       it { is_expected.to include number_indents: gn.number_indents }
-      it { is_expected.to include href: "/uk/api/v2/commodities/#{gn.goods_nomenclature_item_id}" }
+      it { is_expected.to include href: "/uk/api/commodities/#{gn.goods_nomenclature_item_id}" }
     end
   end
 end

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -1,28 +1,36 @@
 module RequestSpecHelper
-  def authenticated_head(path, **kwargs)
-    head path, **add_authentication_header(**kwargs)
-  end
+  %i[head get post patch delete].each do |method|
+    define_method "api_#{method}" do |path, **kwargs|
+      public_send(method, path, **add_default_headers(**kwargs))
+    end
 
-  def authenticated_get(path, **kwargs)
-    get path, **add_authentication_header(**kwargs)
-  end
-
-  def authenticated_post(path, **kwargs)
-    post path, **add_authentication_header(**kwargs)
-  end
-
-  def authenticated_patch(path, **kwargs)
-    patch path, **add_authentication_header(**kwargs)
-  end
-
-  def authenticated_delete(path, **kwargs)
-    delete path, **add_authentication_header(**kwargs)
+    define_method "authenticated_#{method}" do |path, **kwargs|
+      public_send(method, path, **add_authentication_header(**kwargs))
+    end
   end
 
 private
 
+  def add_green_lanes_authentication_header(headers: {}, **kwargs)
+    allow(TradeTariffBackend).to receive_messages(
+      green_lanes_api_tokens: 'Trade-Tariff-Test',
+      uk?: false,
+    )
+
+    headers['HTTP_AUTHORIZATION'] ||= ActionController::HttpAuthentication::Token.encode_credentials('Trade-Tariff-Test')
+
+    kwargs.merge(headers:)
+  end
+
   def add_authentication_header(headers: {}, **kwargs)
     headers['HTTP_AUTHORIZATION'] ||= 'Bearer tariff-api-test-token'
+
+    kwargs.merge(headers:)
+  end
+
+  def add_default_headers(headers: {}, **kwargs)
+    headers['Accept'] ||= 'application/vnd.hmrc.2.0+json'
+    headers['Content-Type'] ||= 'application/json'
 
     kwargs.merge(headers:)
   end

--- a/spec/support/shared_examples/api_request_examples.rb
+++ b/spec/support/shared_examples/api_request_examples.rb
@@ -11,7 +11,7 @@ end
 RSpec.shared_examples 'a successful csv response' do
   subject(:do_request) { make_request && response }
 
-  let(:make_request) { get "#{path}.csv" }
+  let(:make_request) { api_get "#{path}.csv" }
 
   it { expect(do_request.headers['Content-Disposition']).to eq("attachment; filename=#{expected_filename}") }
   it { is_expected.to have_http_status :success }


### PR DESCRIPTION
### Jira link

[HMRC-1365](https://transformuk.atlassian.net/browse/HMRC-1365)

### What?

Move to:

- Supporting transparent forwarding for versioned paths
- Redirects for paths that aren't explicit about the service prefix
- Specifying a default version when none is specified
- Remove redundant location headers in various admin controllers (these are unused in the admin app)
- Fixes a bunch of references to versioned paths
- Fixes a bunch of references to unprefixed paths

### Why?

I am doing this because:

- This is part of a wider move to be explicit about services in paths and to make sure we're following HMRC standards when specifying versions
- The default version support just makes us more compatible in cases such as exchange rate file links (which needs a refactor - I propose Active Storage)
