### PR TITLE
BAU: Fixes exchange rate links

### DIFF
--- a/app/lib/versioned_accept_header.rb
+++ b/app/lib/versioned_accept_header.rb
@@ -13,6 +13,13 @@ class VersionedAcceptHeader
 
     match = accept.match(VERSION_REGEX)
 
-    match&.[](:version) == @version
+    if match
+      match[:version] == @version
+    else
+      # NOTE: Use V2 when the accept header does not match the expected format (for example chrome-based
+      #       browsers send 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7'
+      #       when links are clicked in a UI
+      @version == DEFAULT_VERSION
+    end
   end
 end

--- a/spec/lib/versioned_accept_header_spec.rb
+++ b/spec/lib/versioned_accept_header_spec.rb
@@ -23,9 +23,17 @@ RSpec.describe VersionedAcceptHeader do
     end
 
     context 'when the Accept header is longer than 255 characters' do
+      let(:headers) do
+        { 'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7' }
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the Accept header is a browser default Accept header' do
       let(:headers) { { 'HTTP_ACCEPT' => "#{'a' * 256}application/vnd.hmrc.2.0+json" } }
 
-      it { is_expected.to be false }
+      it { is_expected.to be true }
     end
 
     context 'when the Accept header is missing and the configured constraint version is the default' do


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Adds handling for browser default accept headers

### Why?

I am doing this because:

- This is required to support exchange rate files which should really be using active storage/better encapsulation
- This makes the versioned routes hierarchical (v1 needs to be defined _before_ v2 in the routes.rb in order to make v1 routable)
