### PR TITLE
BAU: Fixes redirects with a query

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,6 @@ Rails.application.routes.draw do
         to: VersionedForwarder.new,
         constraints: { service: /uk|xi/, version: /\d+/ }
 
-  match '/api/*path', via: :all, to: redirect('/uk/api/%{path}') if TradeTariffBackend.uk?
-  match '/api/*path', via: :all, to: redirect('/xi/api/%{path}') if TradeTariffBackend.xi?
+  match '/api/*path', via: :all, to: redirect { |params, request| "/uk/api/#{params[:path]}?#{request.query_string}" } if TradeTariffBackend.uk?
+  match '/api/*path', via: :all, to: redirect { |params, request| "/xi/api/#{params[:path]}?#{request.query_string}" } if TradeTariffBackend.xi?
 end


### PR DESCRIPTION
### Jira link

BAU

```
I, [2025-07-24T10:31:01.910358 #1232636]  INFO -- : Started GET "/api/v2/commodities/0101210000?filter[geographical_area_id]=KP" for ::1 at 2025-07-24 10:31:01 +0100
I, [2025-07-24T10:31:01.960376 #1232636]  INFO -- : Redirected to http://localhost:3000/uk/api/v2/commodities/0101210000?filter[geographical_area_id]=KP
I, [2025-07-24T10:31:01.960722 #1232636]  INFO -- : Completed 301 Moved Permanently in 2ms


I, [2025-07-24T10:31:01.966138 #1232636]  INFO -- : Started GET "/uk/api/v2/commodities/0101210000?filter[geographical_area_id]=KP" for ::1 at 2025-07-24 10:31:01 +0100
I, [2025-07-24T10:31:01.995094 #1232636]  INFO -- : Started GET "/uk/api/commodities/0101210000?filter[geographical_area_id]=KP" for ::1 at 2025-07-24 10:31:01 +0100
I, [2025-07-24T10:31:02.047649 #1232636]  INFO -- : Processing by Api::V2::CommoditiesController#show as JSON
I, [2025-07-24T10:31:02.047787 #1232636]  INFO -- :   Parameters: {"filter" => {"geographical_area_id" => "KP"}, "service" => "uk", "version" => "2", "path" => "commodities/0101210000", "id" => "0101210000"}
```

### What?

I have added/removed/altered:

- [x] Added handling for queries when redirecting from the legacy non-service-prefixed /api paths

### Why?

I am doing this because:

- The redirect behaviour that effectively forces the /uk prefix on all
paths was missing the inclusion of the query part
