### PR TITLE
HMRC-1457: Adds support for 0 prefixed months in filenames

### DIFF
--- a/app/controllers/api/v2/exchange_rates/files_controller.rb
+++ b/app/controllers/api/v2/exchange_rates/files_controller.rb
@@ -20,7 +20,7 @@ module Api
         end
 
         def month
-          @month ||= params[:id].split('-').last
+          @month ||= params[:id].split('-').last.sub('0', '')
         end
 
         def year

--- a/spec/requests/api/v2/exchange_rates/files_controller_spec.rb
+++ b/spec/requests/api/v2/exchange_rates/files_controller_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe Api::V2::ExchangeRates::FilesController, :v2 do
 
     before do
       create(:exchange_rate_file, type:, format:, period_year: year, period_month: month)
+
       allow(TariffSynchronizer::FileService).to receive(:get).and_call_original
-      allow(TariffSynchronizer::FileService).to receive(:get).with("data/exchange_rates/#{year}/#{month}/#{type}_#{year}-#{month}.#{format}").and_return(StringIO.new(data))
+      allow(TariffSynchronizer::FileService).to receive(:get).with("data/exchange_rates/#{year}/#{month.to_s.sub('0', '')}/#{type}_#{year}-#{month.to_s.sub('0', '')}.#{format}").and_return(StringIO.new(data))
     end
 
     context 'when requesting CSV format' do
@@ -30,6 +31,14 @@ RSpec.describe Api::V2::ExchangeRates::FilesController, :v2 do
 
       it 'returns the CSV data as the response body' do
         expect(response.body).to eq(data)
+      end
+
+      context 'when the month is prefixed with 0' do
+        let(:month) { '07' }
+
+        it 'returns HTTP status :ok' do
+          expect(response).to have_http_status(:ok)
+        end
       end
     end
 
@@ -54,6 +63,14 @@ RSpec.describe Api::V2::ExchangeRates::FilesController, :v2 do
       it 'returns the XML data as the response body' do
         expect(response.body).to eq(data)
       end
+
+      context 'when the month is prefixed with 0' do
+        let(:month) { '07' }
+
+        it 'returns HTTP status :ok' do
+          expect(response).to have_http_status(:ok)
+        end
+      end
     end
 
     context 'when requesting HMRC CSV format' do
@@ -76,6 +93,14 @@ RSpec.describe Api::V2::ExchangeRates::FilesController, :v2 do
 
       it 'returns the CSV data as the response body' do
         expect(response.body).to eq(data)
+      end
+
+      context 'when the month is prefixed with 0' do
+        let(:month) { '07' }
+
+        it 'returns HTTP status :ok' do
+          expect(response).to have_http_status(:ok)
+        end
       end
     end
 


### PR DESCRIPTION
### Jira link

[HMRC-1457](https://transformuk.atlassian.net/browse/HMRC-1457)

### What?

I have added/removed/altered:

- [x] Added support for `0`-prefixed months in the exchange rate files api

### Why?

I am doing this because:

- This makes sense as aligns with most iso standards and doesn't break the
existing implementation
