### PR TITLE
HMRC-1446: Migrate terraform backend to use_lockfile and update terraform version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           bundler-cache: true
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.11.0
+          terraform_version: 1.12.2
       - uses: trade-tariff/trade-tariff-tools/.github/actions/setup-tflint@main
       - uses: trade-tariff/trade-tariff-tools/.github/actions/setup-terraform-docs@main
       - uses: trade-tariff/trade-tariff-tools/.github/actions/setup-ssh@main

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-terraform 1.9.8
+terraform 1.12.2
 tfsec 1.28.1
 ruby 3.4.4

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"
   hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
     "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
     "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version = "3.7.2"
   hashes = [
     "h1:356j/3XnXEKr9nyicLUufzoF4Yr6hRy481KIxRVpK0c=",
+    "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
     "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
     "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
     "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -7,7 +7,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.10 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.12.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
 
 ## Providers

--- a/terraform/backends/production.tfbackend
+++ b/terraform/backends/production.tfbackend
@@ -2,4 +2,4 @@ bucket         = "terraform-state-production-382373577178"
 key            = "tariff-backend.tfstate"
 region         = "eu-west-2"
 encrypt        = true
-dynamodb_table = "backend-lock-382373577178"
+use_lockfile   = true

--- a/terraform/backends/staging.tfbackend
+++ b/terraform/backends/staging.tfbackend
@@ -2,4 +2,4 @@ bucket         = "terraform-state-staging-451934005581"
 key            = "tariff-backend.tfstate"
 region         = "eu-west-2"
 encrypt        = true
-dynamodb_table = "backend-lock-451934005581"
+use_lockfile   = true

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=1.10"
+  required_version = ">=1.12.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
### Jira link

[HMRC-1446](https://transformuk.atlassian.net/browse/HMRC-1446)

### What?

I have added/removed/altered:

- [x] Removed dynamodb_table from backend config in staging and prod
- [x]  Added use_lockfile = true to enable locking with native support in staging and prod
- [x] Upgraded terraform version

### Why?

I am doing this because:

- Terraform has deprecated dynamodb_table in favour of use_lockfile

#### References
[Terraform S3 backend documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3)
