### PR TITLE
HMRC-1477: Refactor and fix automatic category assessments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.99.4
+    rev: v1.99.5
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -31,7 +31,7 @@ repos:
         args: ["--severity=warning"]
 
   - repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.89.2
+    rev: v3.90.2
     hooks:
       - id: trufflehog
 

--- a/app/lib/green_lanes_updates_publisher/data_updates_finder.rb
+++ b/app/lib/green_lanes_updates_publisher/data_updates_finder.rb
@@ -2,91 +2,131 @@ module GreenLanesUpdatesPublisher
   class DataUpdatesFinder
     DB = Sequel::Model.db
 
-    # Today date is passed in YYYY-MM-DD 00:00:00.000000+0000 format, which is the zeroth minute of the day.
-    # This will fetch all the recorded created by the data sync job which runs before this job as the created date
-    # added with exact time. Created data will always be greater than the zeroth minute timestamp of the same day
-    BASE_REGULATIONS =
-      "select br.base_regulation_id as regulation_id, br.base_regulation_role as regulation_role, mo.measure_type_id,
-      #{::GreenLanes::UpdateNotification::NotificationStatus::CREATED} as status
-      from base_regulations_oplog br
-      inner join measures_oplog mo
-      on br.base_regulation_id = mo.measure_generating_regulation_id and br.base_regulation_role = mo.measure_generating_regulation_role
-      inner join measure_types mt
-      on mo.measure_type_id = mt.measure_type_id and mt.trade_movement_code in (0,1)
-      where br.created_at > :today or mo.created_at > :today
-      group by(br.base_regulation_id, br.base_regulation_role, mo.measure_type_id)".freeze
+    attr_reader :start_date
 
-    MODIFICATION_REGULATIONS =
-      "select mr.modification_regulation_id as regulation_id, mr.modification_regulation_role as regulation_role, mo.measure_type_id,
-      #{::GreenLanes::UpdateNotification::NotificationStatus::CREATED} as status
-      from modification_regulations_oplog mr
-      inner join measures_oplog mo
-      on mr.modification_regulation_id  = mo.measure_generating_regulation_id and mr.modification_regulation_role = mo.measure_generating_regulation_role
-      inner join measure_types mt
-      on mo.measure_type_id = mt.measure_type_id and mt.trade_movement_code in (0,1)
-      where mr.created_at > :today or mo.created_at > :today
-      group by(mr.modification_regulation_id, mr.modification_regulation_role, mo.measure_type_id)".freeze
+    BASE_REGULATIONS = <<~SQL.squish.freeze
+      SELECT
+        br.base_regulation_id AS regulation_id,
+        br.base_regulation_role AS regulation_role,
+        mo.measure_type_id,
+        #{::GreenLanes::UpdateNotification::NotificationStatus::CREATED} AS status
+      FROM base_regulations_oplog br
+      INNER JOIN measures_oplog mo
+        ON br.base_regulation_id = mo.measure_generating_regulation_id
+        AND br.base_regulation_role = mo.measure_generating_regulation_role
+      INNER JOIN measure_types mt
+        ON mo.measure_type_id = mt.measure_type_id
+        AND mt.trade_movement_code IN (0, 1)
+      WHERE br.created_at > :today OR mo.created_at > :today
+      GROUP BY br.base_regulation_id, br.base_regulation_role, mo.measure_type_id
+    SQL
 
-    EXPIRED_BASE_REGULATIONS =
-      "select br.base_regulation_id as regulation_id, br.base_regulation_role as regulation_role, mo.measure_type_id,
-      #{::GreenLanes::UpdateNotification::NotificationStatus::EXPIRED} as status
-      from base_regulations_oplog br
-      inner join measures_oplog mo
-      on br.base_regulation_id = mo.measure_generating_regulation_id and br.base_regulation_role = mo.measure_generating_regulation_role
-      inner join measure_types mt
-      on mo.measure_type_id = mt.measure_type_id and mt.trade_movement_code in (0,1)
-      where least(br.validity_end_date, br.effective_end_date) between :yesterday and :today
-            or mo.validity_end_date between :yesterday and :today
-      group by(br.base_regulation_id, br.base_regulation_role, mo.measure_type_id)".freeze
+    MODIFICATION_REGULATIONS = <<~SQL.squish.freeze
+      SELECT
+        mr.modification_regulation_id AS regulation_id,
+        mr.modification_regulation_role AS regulation_role,
+        mo.measure_type_id,
+        #{::GreenLanes::UpdateNotification::NotificationStatus::CREATED} AS status
+      FROM modification_regulations_oplog mr
+      INNER JOIN measures_oplog mo
+        ON mr.modification_regulation_id = mo.measure_generating_regulation_id
+        AND mr.modification_regulation_role = mo.measure_generating_regulation_role
+      INNER JOIN measure_types mt
+        ON mo.measure_type_id = mt.measure_type_id
+        AND mt.trade_movement_code IN (0, 1)
+      WHERE mr.created_at > :today OR mo.created_at > :today
+      GROUP BY mr.modification_regulation_id, mr.modification_regulation_role, mo.measure_type_id
+    SQL
 
-    EXPIRED_MODIFICATION_REGULATIONS =
-      "select mr.modification_regulation_id as regulation_id, mr.modification_regulation_role as regulation_role, mo.measure_type_id,
-      #{::GreenLanes::UpdateNotification::NotificationStatus::EXPIRED} as status
-      from modification_regulations_oplog mr
-      inner join measures_oplog mo
-      on mr.modification_regulation_id  = mo.measure_generating_regulation_id and mr.modification_regulation_role = mo.measure_generating_regulation_role
-      inner join measure_types mt
-      on mo.measure_type_id = mt.measure_type_id and mt.trade_movement_code in (0,1)
-      where least(mr.validity_end_date, mr.effective_end_date) between :yesterday and :today
-            or mo.validity_end_date between :yesterday and :today
-      group by(mr.modification_regulation_id, mr.modification_regulation_role, mo.measure_type_id)".freeze
+    EXPIRED_BASE_REGULATIONS = <<~SQL.squish.freeze
+      SELECT
+        br.base_regulation_id AS regulation_id,
+        br.base_regulation_role AS regulation_role,
+        mo.measure_type_id,
+        #{::GreenLanes::UpdateNotification::NotificationStatus::EXPIRED} AS status
+      FROM base_regulations_oplog br
+      INNER JOIN measures_oplog mo
+        ON br.base_regulation_id = mo.measure_generating_regulation_id
+        AND br.base_regulation_role = mo.measure_generating_regulation_role
+      INNER JOIN measure_types mt
+        ON mo.measure_type_id = mt.measure_type_id
+        AND mt.trade_movement_code IN (0, 1)
+      WHERE LEAST(br.validity_end_date, br.effective_end_date) BETWEEN :yesterday AND :today
+        OR mo.validity_end_date BETWEEN :yesterday AND :today
+      GROUP BY br.base_regulation_id, br.base_regulation_role, mo.measure_type_id
+    SQL
 
-    UPDATED_MEASURES =
-      "select mo.measure_generating_regulation_id as regulation_id, mo.measure_generating_regulation_role as regulation_role, mo.measure_type_id,
-      #{::GreenLanes::UpdateNotification::NotificationStatus::UPDATED} as status
-      from measures_oplog mo
-      left join measure_conditions_oplog mc
-      on mo.measure_sid = mc.measure_sid
-      left join additional_codes_oplog ac
-      on mo.additional_code_sid = ac.additional_code_sid
-      left join measure_excluded_geographical_areas_oplog ga
-      on mo.measure_sid = ga.measure_sid
-      inner join measure_types mt
-      on mo.measure_type_id = mt.measure_type_id and mt.trade_movement_code in (0,1)
-      where mc.created_at > :today or ac.created_at > :today or ga.created_at > :today
-      group by(mo.measure_generating_regulation_id, mo.measure_generating_regulation_role, mo.measure_type_id)".freeze
+    EXPIRED_MODIFICATION_REGULATIONS = <<~SQL.squish.freeze
+      SELECT
+        mr.modification_regulation_id AS regulation_id,
+        mr.modification_regulation_role AS regulation_role,
+        mo.measure_type_id,
+        #{::GreenLanes::UpdateNotification::NotificationStatus::EXPIRED} AS status
+      FROM modification_regulations_oplog mr
+      INNER JOIN measures_oplog mo
+        ON mr.modification_regulation_id = mo.measure_generating_regulation_id
+        AND mr.modification_regulation_role = mo.measure_generating_regulation_role
+      INNER JOIN measure_types mt
+        ON mo.measure_type_id = mt.measure_type_id
+        AND mt.trade_movement_code IN (0, 1)
+      WHERE LEAST(mr.validity_end_date, mr.effective_end_date) BETWEEN :yesterday AND :today
+        OR mo.validity_end_date BETWEEN :yesterday AND :today
+      GROUP BY mr.modification_regulation_id, mr.modification_regulation_role, mo.measure_type_id
+    SQL
 
-    def initialize(date = Time.zone.today)
-      @start_date = date
+    UPDATED_MEASURES = <<~SQL.squish.freeze
+      SELECT
+        mo.measure_generating_regulation_id AS regulation_id,
+        mo.measure_generating_regulation_role AS regulation_role,
+        mo.measure_type_id,
+        #{::GreenLanes::UpdateNotification::NotificationStatus::UPDATED} AS status
+      FROM measures_oplog mo
+      LEFT JOIN measure_conditions_oplog mc
+        ON mo.measure_sid = mc.measure_sid
+      LEFT JOIN additional_codes_oplog ac
+        ON mo.additional_code_sid = ac.additional_code_sid
+      LEFT JOIN measure_excluded_geographical_areas_oplog ga
+        ON mo.measure_sid = ga.measure_sid
+      INNER JOIN measure_types mt
+        ON mo.measure_type_id = mt.measure_type_id
+        AND mt.trade_movement_code IN (0, 1)
+      WHERE mc.created_at > :today OR ac.created_at > :today OR ga.created_at > :today
+      GROUP BY mo.measure_generating_regulation_id, mo.measure_generating_regulation_role, mo.measure_type_id
+    SQL
+
+    def initialize(start_date = Time.zone.today)
+      @start_date = start_date
     end
 
     def call
-      all_updates = []
-      update_types = [BASE_REGULATIONS, MODIFICATION_REGULATIONS, EXPIRED_BASE_REGULATIONS, EXPIRED_MODIFICATION_REGULATIONS, UPDATED_MEASURES]
+      queries = [
+        BASE_REGULATIONS,
+        MODIFICATION_REGULATIONS,
+        EXPIRED_BASE_REGULATIONS,
+        EXPIRED_MODIFICATION_REGULATIONS,
+        UPDATED_MEASURES,
+      ]
 
-      update_types.each do |update_type|
-        updates = fetch_updates(update_type)
-        updates.each { |update| all_updates.push(update) }
-      end
-
-      all_updates
+      queries.flat_map { |query| fetch_updates(query) }
     end
 
     private
 
     def fetch_updates(query)
-      dataset = DB.fetch(query, today: @start_date, yesterday: @start_date - 1)
-      dataset.map { |row| GreenLanesUpdate.new(row[:regulation_id], row[:regulation_role], row[:measure_type_id], row[:status]) }
+      dataset = DB.fetch(
+        query,
+        today: start_date,
+        yesterday: start_date - 1.day,
+      )
+
+      dataset.map do |row|
+        GreenLanesUpdate.new(
+          row[:regulation_id],
+          row[:regulation_role],
+          row[:measure_type_id],
+          row[:status],
+        )
+      end
     end
   end
 end

--- a/app/workers/cds_updates_synchronizer_worker.rb
+++ b/app/workers/cds_updates_synchronizer_worker.rb
@@ -1,4 +1,3 @@
-require_relative '../helpers/materialize_view_helper'
 class CdsUpdatesSynchronizerWorker
   include Sidekiq::Worker
   include MaterializeViewHelper

--- a/app/workers/green_lanes_updates_worker.rb
+++ b/app/workers/green_lanes_updates_worker.rb
@@ -1,9 +1,6 @@
 class GreenLanesUpdatesWorker
   include Sidekiq::Worker
 
-  TRY_AGAIN_IN = 20.minutes
-  CUT_OFF_TIME = '10:00'.freeze
-
   sidekiq_options queue: :sync, retry: false
 
   def perform

--- a/app/workers/taric_updates_synchronizer_worker.rb
+++ b/app/workers/taric_updates_synchronizer_worker.rb
@@ -20,7 +20,9 @@ class TaricUpdatesSynchronizerWorker
     Sidekiq::Client.enqueue(ClearInvalidSearchReferences)
     Sidekiq::Client.enqueue(TreeIntegrityCheckWorker)
     Sidekiq::Client.enqueue(ClearCacheWorker)
-    Sidekiq::Client.enqueue(GreenLanesUpdatesWorker)
+
+    # NOTE: Delay for 5 minutes as some of the category assessment queries rely on materialized views that need to have refreshed before we try to enumerate new category assessments.
+    Sidekiq::Client.enqueue_in(5.minutes, GreenLanesUpdatesWorker)
   end
 
 private

--- a/app/workers/taric_updates_synchronizer_worker.rb
+++ b/app/workers/taric_updates_synchronizer_worker.rb
@@ -1,10 +1,6 @@
-require_relative '../helpers/materialize_view_helper'
 class TaricUpdatesSynchronizerWorker
   include Sidekiq::Worker
   include MaterializeViewHelper
-
-  TRY_AGAIN_IN = 20.minutes
-  CUT_OFF_TIME = '10:00'.freeze
 
   sidekiq_options queue: :sync, retry: false
 
@@ -24,6 +20,7 @@ class TaricUpdatesSynchronizerWorker
     Sidekiq::Client.enqueue(ClearInvalidSearchReferences)
     Sidekiq::Client.enqueue(TreeIntegrityCheckWorker)
     Sidekiq::Client.enqueue(ClearCacheWorker)
+    Sidekiq::Client.enqueue(GreenLanesUpdatesWorker)
   end
 
 private

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -32,15 +32,13 @@
     ReportWorker:
       cron: "30 10 * * *" # Needs to run even if the UpdatesSynchronizerWorker failed
       description: "Generates reports and persists them to S3"
-    UKUpdatesSynchronizerWorker:
+    CdsUpdatesSynchronizerWorker:
       cron: "30 0 * * *"
       description: "Runs ETL of CDS files and populates indexes"
-      class: CdsUpdatesSynchronizerWorker
       enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' %>
-    XIUpdatesSynchronizerWorker:
+    TaricUpdatesSynchronizerWorker:
       cron: "0 0 * * *"
       description: "Runs ETL of Taric files and populates indexes"
-      class: TaricUpdatesSynchronizerWorker
       enabled: <%= ENV.fetch('SERVICE', 'uk') == 'xi' %>
     HealthcheckWorker:
       every: 30.minutes
@@ -61,10 +59,6 @@
     SynchronizerCheckWorker:
       cron: "30 08 * * *"
       description: Checks we have recent Quota Balance Events - this is an early warning that our sync process has a potential issue
-    GreenLanesUpdatesWorker:
-      cron: "0 4 * * *"
-      description: "Runs green lanes related data updates worker that will create new category assessments and send notifications"
-      enabled: <%= ENV.fetch('SERVICE', 'uk') == 'xi' %>
     CheckDifferencesReportHasRun:
       cron: "0 1 * * 2"  # 1am every Tuesday
       description: "Checks if the differences report has run"

--- a/spec/workers/green_lanes_updates_worker_spec.rb
+++ b/spec/workers/green_lanes_updates_worker_spec.rb
@@ -1,19 +1,15 @@
 RSpec.describe GreenLanesUpdatesWorker, type: :worker do
   subject(:worker) { described_class.new }
 
-  let(:measure) { create :measure, trade_movement_code: '1', generating_regulation: create(:base_regulation) }
-  let(:ca) { create :identified_measure_type_category_assessment, measure: measure }
+  let!(:measure) { create :measure, trade_movement_code: '1', generating_regulation: create(:base_regulation) }
+  let!(:ca) { create :identified_measure_type_category_assessment, measure: measure }
 
   before do
     allow(TradeTariffBackend).to receive(:service).and_return 'xi'
-    ca.reload
+    worker.perform
   end
 
   describe 'run green lanes updates worker' do
-    before do
-      worker.perform
-    end
-
     it 'creates CA with identified measure type' do
       category_assessments = GreenLanes::CategoryAssessment.all.pluck(:measure_type_id, :regulation_id, :regulation_role)
 


### PR DESCRIPTION
### Jira link

[HMRC-1477](https://transformuk.atlassian.net/browse/HMRC-1477)

### What?

I have added/removed/altered:

- [x] Altered the updates to new category assessments to be behind the daily file
- [x] Refactored the data finder to be more readable

### Why?

I am doing this because:

When a new measure, regulation and measure type permutation comes in via
a daily file we update the category assessments that are interesting to
users of the Green Lanes SPIMM APIs.

If the daily file happens late then this process will miss these updates
and therefore the permutations for these new categories won't show up in
the API.