### PR TITLE
HMRC-1479: Adds handling for non-existing measure types in updates

### DIFF
--- a/app/controllers/api/admin/green_lanes/update_notifications_controller.rb
+++ b/app/controllers/api/admin/green_lanes/update_notifications_controller.rb
@@ -8,7 +8,7 @@ module Api
         before_action :check_service, :authenticate_user!
 
         def index
-          render json: serialize(update_notifications.to_a, pagination_meta)
+          render json: serialize(update_notifications, pagination_meta)
         end
 
         def show
@@ -32,13 +32,14 @@ module Api
         private
 
         def record_count
-          @update_notifications.pagination_record_count
+          update_notifications.pagination_record_count
         end
 
         def update_notifications
           @update_notifications ||= ::GreenLanes::UpdateNotification
-                                      .where(Sequel.lit('status != ?', ::GreenLanes::UpdateNotification::NotificationStatus::INACTIVE))
-                                      .order(Sequel.asc(:id)).paginate(current_page, per_page)
+            .exclude(status: ::GreenLanes::UpdateNotification::NotificationStatus::INACTIVE)
+            .order(Sequel.asc(:id))
+            .paginate(current_page, per_page)
         end
 
         def serialize(*args)

--- a/app/models/green_lanes/update_notification.rb
+++ b/app/models/green_lanes/update_notification.rb
@@ -13,10 +13,10 @@ module GreenLanes
     plugin :association_pks
     plugin :association_dependencies
 
-    many_to_one :measure_type, class: :MeasureType
-    many_to_one :base_regulation, class: :BaseRegulation,
+    many_to_one :measure_type, class: MeasureType
+    many_to_one :base_regulation, class: BaseRegulation,
                                   key: %i[regulation_id regulation_role]
-    many_to_one :modification_regulation, class: :ModificationRegulation,
+    many_to_one :modification_regulation, class: ModificationRegulation,
                                           key: %i[regulation_id regulation_role]
 
     many_to_one :theme

--- a/app/serializers/api/admin/green_lanes/update_notification_serializer.rb
+++ b/app/serializers/api/admin/green_lanes/update_notification_serializer.rb
@@ -14,7 +14,7 @@ module Api
                    :status
 
         attribute :measure_type_description do |update|
-          update.measure_type.description
+          update.measure_type&.description
         end
 
         attribute :regulation_description do |update|


### PR DESCRIPTION
### Jira link

[HMRC-1479](https://transformuk.atlassian.net/browse/HMRC-1479)

### What?

I have added/removed/altered:

- [x] Added handling for non-existant measure types on update notification

### Why?

I am doing this because:

- This triggers a 5xx on some pages in the admin UI
