### PR TITLE
HMRC-1404: Basic auth to admin backends when auth disabled

### DIFF
--- a/app/controllers/api/admin/admin_controller.rb
+++ b/app/controllers/api/admin/admin_controller.rb
@@ -4,10 +4,6 @@ module Api
       include GDS::SSO::ControllerMethods
       include AdminApi.routes.url_helpers
 
-      def authenticate_user!
-        TradeTariffBackend.disable_admin_api_authentication? || super
-      end
-
       no_caching
     end
   end

--- a/app/controllers/api/admin/admin_controller.rb
+++ b/app/controllers/api/admin/admin_controller.rb
@@ -3,6 +3,27 @@ module Api
     class AdminController < ApiController
       include GDS::SSO::ControllerMethods
       include AdminApi.routes.url_helpers
+      include ActionController::HttpAuthentication::Token::ControllerMethods
+
+      def authenticate_user!
+        if TradeTariffBackend.disable_admin_api_authentication?
+          if TradeTariffBackend.admin_api_bearer_token.blank?
+            render json: { error: 'Admin API Key is not valid' }, status: :internal_server_error
+            return
+          end
+          authenticate_with_bearer_token
+        else
+          super
+        end
+      end
+
+      def authenticate_with_bearer_token
+        authenticate_or_request_with_http_token do |provided_token, _options|
+          ActiveSupport::SecurityUtils.secure_compare(provided_token, TradeTariffBackend.admin_api_bearer_token)
+        end
+
+        true
+      end
 
       no_caching
     end

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -250,10 +250,6 @@ module TradeTariffBackend
       ENV['OPTIMISED_SEARCH_ENABLED'].to_s == 'true'
     end
 
-    def disable_admin_api_authentication?
-      ENV.fetch('DISABLE_ADMIN_API_AUTHENTICATION', 'false').to_s == 'true'
-    end
-
     def implicit_deletion_cutoff
       Date.parse(ENV.fetch('IMPLICIT_DELETION_CUTOFF', '2024-03-25'))
     end

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -250,6 +250,14 @@ module TradeTariffBackend
       ENV['OPTIMISED_SEARCH_ENABLED'].to_s == 'true'
     end
 
+    def disable_admin_api_authentication?
+      ENV.fetch('DISABLE_ADMIN_API_AUTHENTICATION', 'false').to_s == 'true'
+    end
+
+    def admin_api_bearer_token
+      ENV['ADMIN_API_BEARER_TOKEN']
+    end
+
     def implicit_deletion_cutoff
       Date.parse(ENV.fetch('IMPLICIT_DELETION_CUTOFF', '2024-03-25'))
     end


### PR DESCRIPTION
### Jira link

[HMRC-1404](https://transformuk.atlassian.net/browse/HMRC-1404)

### What?

I have added/removed/altered:

- [ ] Removed disable_admin_api_authentication flag from admin api request authentication for basic user

### Why?

I am doing this because:

- Admin use long living auth token for request auth in backend, it is not related to the logged in user in admin api. So the token can be used regardless of GDS SSO or Basic user auth use in prod and lower env. Token is set up in admin secrets of BEARER_TOKEN


### Have you? (optional)

- [ ] Added documentation for new apis
- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical data
- Changes an api that is used in production
