### PR TITLE
MYOTT-71 Don't log unsubscribe if already unsubscribed

### DIFF
--- a/app/models/public_users/subscription.rb
+++ b/app/models/public_users/subscription.rb
@@ -7,8 +7,10 @@ module PublicUsers
     many_to_one :subscription_type, class: 'Subscriptions::Type'
 
     def unsubscribe
-      update(active: false)
-      PublicUsers::ActionLog.create(user_id: user.id, action: PublicUsers::ActionLog::UNSUBSCRIBED)
+      if active
+        update(active: false)
+        PublicUsers::ActionLog.create(user_id: user.id, action: PublicUsers::ActionLog::UNSUBSCRIBED)
+      end
       user.soft_delete!
     end
   end

--- a/spec/models/public_users/subscription_spec.rb
+++ b/spec/models/public_users/subscription_spec.rb
@@ -31,5 +31,14 @@ RSpec.describe PublicUsers::Subscription do
       subscription.unsubscribe
       expect(user).to have_received(:soft_delete!)
     end
+
+    context 'when the subscription is already inactive' do
+      before { subscription.update(active: false) }
+
+      it 'does not log an unsubscribe action' do
+        subscription.unsubscribe
+        expect(PublicUsers::ActionLog).not_to have_received(:create).with(user_id: user.id, action: PublicUsers::ActionLog::UNSUBSCRIBED)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Jira link

[MYOTT-71](https://transformuk.atlassian.net/browse/MYOTT-71)

### What?

Checks if subscription has already been disabled. Only logs an unsubscribe if still active

### Why?

This action should be idempotent in case of multiple submissions by a user.
