### PR TITLE
HMRC-1472: Generate Changes API response for 1/1/2022 (XI and UK)

### DIFF
--- a/app/lib/changes_table_populator/descendant_populator.rb
+++ b/app/lib/changes_table_populator/descendant_populator.rb
@@ -2,6 +2,7 @@ module ChangesTablePopulator
   module DescendantPopulator
     def build_all_change_records(source_changes)
       source_changes
+        .reject { |element| element[:goods_nomenclature_sid].nil? }
         .uniq { |element| element[:goods_nomenclature_sid] }
         .collect_concat do |source_change|
           build_descendant_change_records(row: source_change, day:)


### PR DESCRIPTION
### Jira link

[HMRC-1472](https://transformuk.atlassian.net/browse/HMRC-1472)

### What?

I have added/removed/altered:

- [ ] Filter out measurs with null goods_nomenclature_sid from change report source set

### Why?

I am doing this because:

- Measures with goods_nomenclature_sid causing error in generating change report