### PR TITLE
PEX-18 & PEX-130 Enquiry From API

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,6 +2,7 @@ AWS_BUCKET_NAME=trade-tariff-persistence-development
 AWS_DEFAULT_REGION=eu-west-2
 AWS_REPORTING_BUCKET_NAME=trade-tariff-reporting
 DIFFERENCES_TO_EMAILS=Online Trade Tariff Support <hmrc-trade-tariff-support-g@digital.hmrc.gov.uk>
+ENQUIRY_FORM_EMAIL=support@example.com
 ENVIRONMENT=development
 EXCESS_QUERY_THRESHOLD=1000
 FRONTEND_HOST=http://host.docker.internal:3001

--- a/.env.test
+++ b/.env.test
@@ -5,6 +5,7 @@ COGNITO_USER_POOL_ID=123abc
 DB_USER=postgres
 DIFFERENCES_TO_EMAILS=differences@example.com
 ELASTICSEARCH_URL=http://host.docker.internal:9200
+ENQUIRY_FORM_EMAIL=support@example.com
 ENVIRONMENT=test
 EXCESS_QUERY_THRESHOLD=200 # so high because commodities_controller_spec with --seed=4780
 FRONTEND_HOST=http://host.docker.internal:3001

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,7 @@ RSpec/SpecFilePathFormat:
   Exclude:
     - spec/presenters/**/*
     - spec/serializers/**/*
+    - spec/requests/**/*
 
 RSpec/ContextWording:
   Prefixes:

--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ end
 group :development, :test do
   gem 'awesome_print'
   gem 'dotenv-rails'
+  gem 'factory_bot_rails', require: false
   gem 'pry-rails'
   gem 'ruby-lsp-rails'
   gem 'ruby-lsp-rspec'
@@ -72,7 +73,6 @@ end
 group :test do
   gem 'brakeman'
   gem 'database_cleaner-sequel'
-  gem 'factory_bot_rails', require: false
   gem 'forgery'
   gem 'json_expressions'
   gem 'rspec-ctrf'

--- a/app/controllers/api/v2/enquiry_form/submissions_controller.rb
+++ b/app/controllers/api/v2/enquiry_form/submissions_controller.rb
@@ -1,0 +1,47 @@
+module Api
+  module V2
+    class EnquiryForm::SubmissionsController < ApiController
+      include ::EnquiryForm::SubmissionHelper
+      before_action :set_reference_number, only: [:create]
+
+      def create
+        @csv_data = ::EnquiryForm::CsvGeneratorService.new(enquiry_form_data).generate
+        ::EnquiryForm::SendSubmissionEmailWorker.perform_async(enquiry_form_data.to_json, @csv_data)
+
+        begin
+          render json: serialize(OpenStruct.new(reference_number: @set_reference_number)), status: :created
+        rescue ActionController::ParameterMissing => e
+          render json: { errors: [e.message] }, status: :unprocessable_content
+        end
+      end
+
+      private
+
+      def enquiry_form_params
+        params.require(:data).require(:attributes).permit(
+          :name,
+          :company_name,
+          :job_title,
+          :email,
+          :enquiry_category,
+          :enquiry_description,
+        )
+      end
+
+      def enquiry_form_data
+        enquiry_form_params.merge(
+          reference_number: @set_reference_number,
+          created_at: Time.zone.now.strftime('%Y-%m-%d %H:%M'),
+        )
+      end
+
+      def serialize(*args)
+        Api::V2::EnquiryForm::SubmissionSerializer.new(*args).serializable_hash
+      end
+
+      def serialize_errors(*args)
+        Api::V2::ErrorSerializationService.new(*args).call
+      end
+    end
+  end
+end

--- a/app/engines/v2_api.rb
+++ b/app/engines/v2_api.rb
@@ -127,6 +127,10 @@ V2Api.routes.draw do
 
       get 'live_issues', to: 'live_issues#index'
 
+      namespace :enquiry_form do
+        resources :submissions, only: %i[create]
+      end
+
       get '/changes(/:as_of)', to: 'changes#index', as: :changes, constraints: { as_of: /\d{4}-\d{1,2}-\d{1,2}/ }
 
       post 'search' => 'search#search'

--- a/app/helpers/enquiry_form/submission_helper.rb
+++ b/app/helpers/enquiry_form/submission_helper.rb
@@ -1,0 +1,12 @@
+module EnquiryForm::SubmissionHelper
+  # Exlude O and I as they're usually avoided in GOV.UK reference numbers
+  CHARSET = ('A'..'Z').to_a + (0..9).to_a.map(&:to_s) - %w[O I]
+
+  def create_reference_number(length = 8)
+    CHARSET.sample(length).join
+  end
+
+  def set_reference_number
+    @set_reference_number ||= create_reference_number
+  end
+end

--- a/app/serializers/api/v2/enquiry_form/submission_serializer.rb
+++ b/app/serializers/api/v2/enquiry_form/submission_serializer.rb
@@ -1,0 +1,11 @@
+module Api
+  module V2
+    class EnquiryForm::SubmissionSerializer
+      include JSONAPI::Serializer
+
+      set_type 'enquiry_form/submission'
+
+      set_id :reference_number
+    end
+  end
+end

--- a/app/services/enquiry_form/csv_generator_service.rb
+++ b/app/services/enquiry_form/csv_generator_service.rb
@@ -1,0 +1,34 @@
+class EnquiryForm::CsvGeneratorService
+  def initialize(enquiry_form_data)
+    @enquiry_form_data = enquiry_form_data.to_h.symbolize_keys
+  end
+
+  def generate
+    headers = [
+      'Reference',
+      'Submission date',
+      'Full name',
+      'Company name',
+      'Job title',
+      'Email address',
+      'What do you need help with?',
+      'How can we help?',
+    ]
+
+    keys = %i[
+      reference_number
+      created_at
+      name
+      company_name
+      job_title
+      email
+      enquiry_category
+      enquiry_description
+    ]
+
+    CSV.generate do |csv|
+      csv << headers
+      csv << keys.map { |key| @enquiry_form_data[key] }
+    end
+  end
+end

--- a/app/services/govuk_notifier.rb
+++ b/app/services/govuk_notifier.rb
@@ -7,14 +7,19 @@ class GovukNotifier
     @client = client || Notifications::Client.new(api_key)
   end
 
-  def send_email(email, template_id, personalisation = {}, email_reply_to_id = nil)
-    # TODO: one_click_unsubscribe_url https://docs.notifications.service.gov.uk/ruby.html#one-click-unsubscribe-url-recommended
-    email_response = @client.send_email(
+  def send_email(email, template_id, personalisation = {}, email_reply_to_id = nil, reference = nil)
+    params = {
+      # TODO: one_click_unsubscribe_url https://docs.notifications.service.gov.uk/ruby.html#one-click-unsubscribe-url-recommended
       email_address: use_email(email),
       template_id:,
       personalisation:,
-      email_reply_to_id:,
-    )
+    }
+
+    params[:email_reply_to_id] = email_reply_to_id if email_reply_to_id
+    params[:reference] = reference if reference
+
+    email_response = @client.send_email(params)
+
     audit(email_response)
   rescue Notifications::Client::RequestError => e
     raise e

--- a/app/workers/enquiry_form/send_submission_email_worker.rb
+++ b/app/workers/enquiry_form/send_submission_email_worker.rb
@@ -1,0 +1,35 @@
+require 'notifications/client'
+
+class EnquiryForm::SendSubmissionEmailWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :mailers, retry: 5
+
+  TEMPLATE_ID = '104e74e3-8f43-4642-a594-4d4ef931b121'.freeze
+
+  def perform(enquiry_form_data, csv_data)
+    parsed_data = JSON.parse(enquiry_form_data).symbolize_keys
+
+    personalisation = {
+      name: parsed_data[:name],
+      company_name: parsed_data[:company_name],
+      job_title: parsed_data[:job_title],
+      email: parsed_data[:email],
+      enquiry_category: parsed_data[:enquiry_category],
+      enquiry_description: parsed_data[:enquiry_description],
+      reference_number: parsed_data[:reference_number],
+      created_at: parsed_data[:created_at],
+      csv_file: Notifications.prepare_upload(StringIO.new(csv_data), filename: "enquiry_form_#{parsed_data[:reference_number]}.csv"),
+    }
+
+    reference = parsed_data[:reference_number]
+
+    client.send_email(ENV['ENQUIRY_FORM_EMAIL'], TEMPLATE_ID, personalisation, nil, reference)
+  end
+
+  private
+
+  def client
+    @client ||= GovukNotifier.new
+  end
+end

--- a/app/workers/enquiry_form/send_submission_email_worker.rb
+++ b/app/workers/enquiry_form/send_submission_email_worker.rb
@@ -3,8 +3,6 @@ require 'notifications/client'
 class EnquiryForm::SendSubmissionEmailWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :mailers, retry: 5
-
   TEMPLATE_ID = '104e74e3-8f43-4642-a594-4d4ef931b121'.freeze
 
   def perform(enquiry_form_data, csv_data)

--- a/app/workers/stop_press_email_worker.rb
+++ b/app/workers/stop_press_email_worker.rb
@@ -20,7 +20,7 @@ class StopPressEmailWorker
       unsubscribe_url: URI.join(TradeTariffBackend.frontend_host, 'subscriptions/unsubscribe/', user.stop_press_subscription).to_s,
     }
 
-    client.send_email(user.email, TEMPLATE_ID, personalisation, REPLY_TO_ID)
+    client.send_email(user.email, TEMPLATE_ID, personalisation, REPLY_TO_ID, nil)
   end
 
   def client

--- a/spec/helpers/enquiry_form/submission_helper_spec.rb
+++ b/spec/helpers/enquiry_form/submission_helper_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe EnquiryForm::SubmissionHelper, type: :helper do
+  describe '#create_reference_number' do
+    let(:charset) { described_class::CHARSET }
+
+    it 'returns a string of default length 8' do
+      ref = helper.create_reference_number
+      expect(ref.length).to eq(8)
+    end
+
+    it 'only contains characters from CHARSET' do
+      ref = helper.create_reference_number(8)
+      expect(ref.chars).to all(be_in(charset))
+    end
+
+    it 'does not contain O or I' do
+      ref = helper.create_reference_number(50)
+      expect(ref).not_to match(/[OI]/)
+    end
+
+    it 'produces different values on subsequent calls' do
+      ref1 = helper.create_reference_number
+      ref2 = helper.create_reference_number
+      expect(ref1).not_to eq(ref2)
+    end
+  end
+end

--- a/spec/requests/api/v2/enquiry_form/submissions_controller_spec.rb
+++ b/spec/requests/api/v2/enquiry_form/submissions_controller_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe Api::V2::EnquiryForm::SubmissionsController, :v2 do
+  describe 'POST #create' do
+    let(:params) do
+      {
+        name: 'John Doe',
+        company_name: 'Doe & Co Inc.',
+        job_title: 'CEO',
+        email: 'john@example.com',
+        enquiry_category: 'Quotas',
+        enquiry_description: 'I have a question.',
+      }
+    end
+
+    let(:headers) { { 'Content-Type' => 'application/json' } }
+
+    let(:csv_data) { 'csv,data' }
+    let(:reference_number) { 'ABC12345' }
+
+    before do
+      allow(controller).to receive(:set_reference_number) do
+        controller.instance_variable_set(:@set_reference_number, reference_number)
+      end
+
+      csv_service = instance_double(EnquiryForm::CsvGeneratorService, generate: csv_data)
+      allow(EnquiryForm::CsvGeneratorService).to receive(:new).and_return(csv_service)
+
+      allow(EnquiryForm::SendSubmissionEmailWorker).to receive(:perform_async)
+
+      serializer_double = instance_double(
+        Api::V2::EnquiryForm::SubmissionSerializer,
+        serializable_hash: { data: { id: reference_number, type: :"enquiry_form/submission" } },
+      )
+      allow(Api::V2::EnquiryForm::SubmissionSerializer).to receive(:new).and_return(serializer_double)
+    end
+
+    it 'returns 201 created with reference number' do
+      post api_enquiry_form_submissions_path,
+           params: { data: { attributes: params } },
+           headers: headers,
+           as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(JSON.parse(response.body)['data']['id']).to eq(reference_number)
+    end
+
+    it 'generates CSV and enqueues email worker' do
+      expect(::EnquiryForm::CsvGeneratorService).to receive(:new).and_call_original # rubocop:disable RSpec/MessageSpies
+
+      expect(::EnquiryForm::SendSubmissionEmailWorker).to receive(:perform_async) do |json_data, csv| # rubocop:disable RSpec/MessageSpies
+        parsed = JSON.parse(json_data)
+        expect(parsed['name']).to eq('John Doe')
+        expect(parsed['company_name']).to eq('Doe & Co Inc.')
+        expect(parsed['reference_number']).to eq(reference_number)
+        expect(parsed).to have_key('created_at')
+        expect(csv).to eq(csv_data)
+      end
+
+      post api_enquiry_form_submissions_path,
+           params: { data: { attributes: params } },
+           headers: headers,
+           as: :json
+    end
+
+    context 'when required params are missing' do
+      it 'returns a 422 Unporcessable Content with errors' do
+        post api_enquiry_form_submissions_path,
+             params: { data: nil },
+             headers: headers,
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+end

--- a/spec/services/enquiry_form/csv_generator_service_spec.rb
+++ b/spec/services/enquiry_form/csv_generator_service_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe EnquiryForm::CsvGeneratorService do
+  subject(:csv_content) { described_class.new(enquiry_data).generate }
+
+  let(:enquiry_data) do
+    {
+      reference_number: 'ABC123',
+      created_at: Time.zone.parse('2025-07-21 10:00'),
+      name: 'Jane Doe',
+      company_name: 'Jane Ltd.',
+      job_title: 'Product Manager',
+      email: 'jane@example.com',
+      enquiry_category: 'Quotas',
+      enquiry_description: 'Need help with quotas.',
+    }
+  end
+
+  it 'generates a CSV with correct headers and data' do
+    csv = CSV.parse(csv_content)
+
+    expect(csv.first).to eq([
+      'Reference',
+      'Submission date',
+      'Full name',
+      'Company name',
+      'Job title',
+      'Email address',
+      'What do you need help with?',
+      'How can we help?',
+    ])
+
+    expect(csv.second).to eq([
+      'ABC123',
+      '2025-07-21 10:00:00 UTC',
+      'Jane Doe',
+      'Jane Ltd.',
+      'Product Manager',
+      'jane@example.com',
+      'Quotas',
+      'Need help with quotas.',
+    ])
+  end
+end

--- a/spec/services/govuk_notifier_spec.rb
+++ b/spec/services/govuk_notifier_spec.rb
@@ -8,32 +8,34 @@ RSpec.describe GovukNotifier do
 
   describe '#send_email' do
     let(:mocked_response) { build(:notifications_client_post_email_response) }
-
-    it 'sends an email' do
-      allow(notifier).to receive(:audit).and_return(nil)
-      notifier.send_email('test@example.com', 'b0f0c2b2-c5f5-4f3a-8d9c-f4c8e8ea1a7c', { foo: 'bar' }, 'f47ac10b-58cc-4372-a567-0e02b2c3d479')
-      expect(client).to have_received(:send_email).with(
+    let(:params) do
+      {
         email_address: 'test@example.com',
         email_reply_to_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+
         template_id: 'b0f0c2b2-c5f5-4f3a-8d9c-f4c8e8ea1a7c',
         personalisation: {
           foo: 'bar',
         },
-      )
+        reference: 'ABC12345',
+      }
+    end
+
+    it 'sends an email' do
+      allow(notifier).to receive(:audit).and_return(nil)
+      notifier.send_email('test@example.com', 'b0f0c2b2-c5f5-4f3a-8d9c-f4c8e8ea1a7c', { foo: 'bar' }, 'f47ac10b-58cc-4372-a567-0e02b2c3d479', 'ABC12345')
+
+      expect(client).to have_received(:send_email).with(params)
     end
 
     it 'uses the override email if set' do
       stub_const('ENV', ENV.to_hash.merge('OVERRIDE_NOTIFY_EMAIL' => 'foo@example.com'))
       allow(notifier).to receive(:audit).and_return(nil)
-      notifier.send_email('test@example.com', 'b0f0c2b2-c5f5-4f3a-8d9c-f4c8e8ea1a7c', { foo: 'bar' })
-      expect(client).to have_received(:send_email).with(
-        email_address: 'foo@example.com',
-        email_reply_to_id: nil,
-        template_id: 'b0f0c2b2-c5f5-4f3a-8d9c-f4c8e8ea1a7c',
-        personalisation: {
-          foo: 'bar',
-        },
-      )
+      notifier.send_email('test@example.com', 'b0f0c2b2-c5f5-4f3a-8d9c-f4c8e8ea1a7c', { foo: 'bar' }, 'f47ac10b-58cc-4372-a567-0e02b2c3d479', 'ABC12345')
+
+      params[:email_address] = 'foo@example.com'
+
+      expect(client).to have_received(:send_email).with(params)
     end
 
     it 'audits the email' do

--- a/spec/workers/enquiry_form/send_submission_email_worker_spec.rb
+++ b/spec/workers/enquiry_form/send_submission_email_worker_spec.rb
@@ -1,0 +1,36 @@
+# spec/workers/enquiry_form/send_submission_email_worker_spec.rb
+require 'rails_helper'
+require 'sidekiq/testing'
+
+RSpec.describe EnquiryForm::SendSubmissionEmailWorker, type: :worker do
+  describe '.perform_async' do
+    let(:enquiry_form_data) do
+      {
+        name: 'John Doe',
+        company_name: 'Doe & Co Inc.',
+        job_title: 'CEO',
+        email: 'john@example.com',
+        enquiry_category: 'Quotas',
+        enquiry_description: 'I have a question about quotas',
+        reference_number: 'ABC123',
+        created_at: '2025-08-15 10:00',
+      }.to_json
+    end
+
+    let(:csv_data) { 'csv,data' }
+
+    before do
+      Sidekiq::Worker.clear_all
+    end
+
+    it 'enqueues the job on the mailers queue with the correct args' do
+      expect {
+        described_class.perform_async(enquiry_form_data, csv_data)
+      }.to change(described_class.jobs, :size).by(1)
+
+      job = described_class.jobs.last
+      expect(job['queue']).to eq('mailers')
+      expect(job['args']).to eq([enquiry_form_data, csv_data])
+    end
+  end
+end

--- a/spec/workers/enquiry_form/send_submission_email_worker_spec.rb
+++ b/spec/workers/enquiry_form/send_submission_email_worker_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe EnquiryForm::SendSubmissionEmailWorker, type: :worker do
       }.to change(described_class.jobs, :size).by(1)
 
       job = described_class.jobs.last
-      expect(job['queue']).to eq('mailers')
       expect(job['args']).to eq([enquiry_form_data, csv_data])
     end
   end

--- a/spec/workers/stop_press_email_worker_spec.rb
+++ b/spec/workers/stop_press_email_worker_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe StopPressEmailWorker, type: :worker do
     it 'sends request to client' do
       instance.perform(stop_press.id, user.id)
 
-      expect(client).to have_received(:send_email).with(email_address, StopPressEmailWorker::TEMPLATE_ID, expected_personalisation, StopPressEmailWorker::REPLY_TO_ID)
+      expect(client).to have_received(:send_email).with(email_address, StopPressEmailWorker::TEMPLATE_ID, expected_personalisation, StopPressEmailWorker::REPLY_TO_ID, nil)
     end
 
     it 'returns if stop press is nil' do


### PR DESCRIPTION
### Jira link

[PEX-18](https://transformuk.atlassian.net/browse/HMRC-18)
[PEX-130](https://transformuk.atlassian.net/browse/HMRC-130)

### What?

I have added/removed/altered:

- [x] Added Enquiry Form Submission API with functionality to generate a CSV of Enquiry Data 
- [x] Refactored new code to use gov.uk notify for emailing Enquiry Form with a CSV attachment. 

### Why?

I am doing this because:

- It's a requirement for the product experience workflow

Front End [PR](https://github.com/trade-tariff/trade-tariff-frontend/pull/2491) for this requirement