### PR TITLE
BAU: Remove newrelic job

### DIFF
--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -20,18 +20,3 @@ jobs:
       basic-password: ${{ secrets.BASIC_PASSWORD }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
       ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
-
-  newrelic:
-    runs-on: ubuntu-latest
-    needs: deploy
-    steps:
-      - uses: actions/checkout@v5
-      - id: docker-tag
-        run: echo "DOCKER_TAG=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-      - uses: newrelic/deployment-marker-action@v2.5.1
-        with:
-          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
-          region: "EU"
-          guid: ${{ secrets.NEW_RELIC_APPLICATION_GUID }}
-          version: ${{ steps.docker-tag.outputs.DOCKER_TAG }}
-          user: "${{ github.actor }}"


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Removed `newrelic` job from `deploy-to-staging workflow`

### Why?

I am doing this because:

- No longer required in the current workflow

### Have you? (optional)

- [ ] Added documentation for new apis
- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical data
- Changes an api that is used in production
