### PR TITLE
Exclude Commodity attributes

### DIFF
--- a/app/services/delta_report_service/commodity_changes.rb
+++ b/app/services/delta_report_service/commodity_changes.rb
@@ -12,6 +12,10 @@ class DeltaReportService
       'Commodity'
     end
 
+    def excluded_columns
+      super + %i[path heading_short_code chapter_short_code]
+    end
+
     def analyze
       return if no_changes?
 


### PR DESCRIPTION
### What?

Changes to these attributes do not reflect a meaningful change to the tariff.
- heading_short_code and chapter_short_code are generated fields so are not present in the oplog
- The path value can change without it changing the position of a commodity in the hierarchy.
