### PR TITLE
Add footnote changes to delta report

### DIFF
--- a/app/services/delta_report_service/footnote_changes.rb
+++ b/app/services/delta_report_service/footnote_changes.rb
@@ -1,0 +1,35 @@
+class DeltaReportService
+  class FootnoteChanges < BaseChanges
+    def self.collect(date)
+      Footnote
+        .where(operation_date: date)
+        .order(:oid)
+        .map { |record| new(record, date).analyze }
+        .compact
+    end
+
+    def object_name
+      "Footnote #{record.code}"
+    end
+
+    def analyze
+      return if no_changes?
+
+      {
+        type: 'Footnote',
+        footnote_oid: record.oid,
+        description:,
+        date_of_effect:,
+        change: change || "#{record.code}: #{record.footnote_description.description}",
+      }
+    end
+
+    def previous_record
+      @previous_record ||= Footnote.operation_klass
+                             .where(footnote_id: record.footnote_id, footnote_type_id: record.footnote_type_id)
+                             .where(Sequel.lit('oid < ?', record.oid))
+                             .order(Sequel.desc(:oid))
+                             .first
+    end
+  end
+end

--- a/spec/services/delta_report_service/footnote_changes_spec.rb
+++ b/spec/services/delta_report_service/footnote_changes_spec.rb
@@ -1,0 +1,107 @@
+RSpec.describe DeltaReportService::FootnoteChanges do
+  let(:date) { Date.parse('2024-08-11') }
+
+  let(:footnote) { build(:footnote, oid: '999') }
+  let(:footnote_desc) { build(:footnote_description, description: 'Footnote description') }
+  let(:instance) { described_class.new(footnote, date) }
+
+  before do
+    allow(instance).to receive(:get_changes)
+    allow(footnote).to receive(:footnote_description).and_return(footnote_desc)
+  end
+
+  describe '.collect' do
+    let(:footnote1) { build(:footnote, oid: 1, operation_date: date) }
+    let(:footnote2) { build(:footnote, oid: 2, operation_date: date) }
+    let(:footnotes) { [footnote1, footnote2] }
+
+    before do
+      allow(Footnote).to receive_message_chain(:where, :order).and_return(footnotes)
+    end
+
+    it 'finds footnotes for the given date and returns analyzed changes' do
+      instance1 = described_class.new(footnote1, date)
+      instance2 = described_class.new(footnote2, date)
+
+      allow(described_class).to receive(:new).and_return(instance1, instance2)
+      allow(instance1).to receive(:analyze).and_return({ type: 'Footnote' })
+      allow(instance2).to receive(:analyze).and_return({ type: 'Footnote' })
+
+      result = described_class.collect(date)
+
+      expect(Footnote).to have_received(:where).with(operation_date: date)
+      expect(result).to eq([{ type: 'Footnote' }, { type: 'Footnote' }])
+    end
+  end
+
+  describe '#object_name' do
+    it 'returns the correct object name' do
+      expect(instance.object_name).to eq("Footnote #{footnote.code}")
+    end
+  end
+
+  describe '#analyze' do
+    before do
+      allow(instance).to receive_messages(
+        no_changes?: false,
+        date_of_effect: date,
+        description: 'Footnote updated',
+        change: nil,
+      )
+    end
+
+    context 'when there are no changes' do
+      before { allow(instance).to receive(:no_changes?).and_return(true) }
+
+      it 'returns nil' do
+        expect(instance.analyze).to be_nil
+      end
+    end
+
+    context 'when changes should be included' do
+      it 'returns the correct analysis hash' do
+        result = instance.analyze
+
+        expect(result).to eq({
+          type: 'Footnote',
+          footnote_oid: 999,
+          date_of_effect: date,
+          description: 'Footnote updated',
+          change: "#{footnote.code}: Footnote description",
+        })
+      end
+    end
+
+    context 'when change is not nil' do
+      before { allow(instance).to receive(:change).and_return('description updated') }
+
+      it 'uses the change value instead of footnote id' do
+        result = instance.analyze
+        expect(result[:change]).to eq('description updated')
+      end
+    end
+  end
+
+  describe '#previous_record' do
+    let(:previous_footnote) { build(:footnote) }
+
+    before do
+      allow(Footnote).to receive(:operation_klass).and_return(Footnote)
+      allow(Footnote).to receive_message_chain(:where, :where, :order, :first)
+                         .and_return(previous_footnote)
+    end
+
+    it 'queries for the previous record by footnote_code, footnote_type_code and oid' do
+      result = instance.previous_record
+
+      expect(result).to eq(previous_footnote)
+    end
+
+    it 'memoizes the result' do
+      instance.previous_record
+      instance.previous_record
+
+      expect(Footnote).to have_received(:operation_klass).once
+    end
+  end
+end


### PR DESCRIPTION
Added Footnote oplog changes to the delta report.

Footnote changes are linked directly to Goods Nomenclatures or via Measures.
