### PR TITLE
Add footnote association changes to report

### DIFF
--- a/app/models/footnote_association_goods_nomenclature.rb
+++ b/app/models/footnote_association_goods_nomenclature.rb
@@ -5,4 +5,9 @@ class FootnoteAssociationGoodsNomenclature < Sequel::Model
                                  goods_nomenclature_sid]
 
   set_primary_key %i[footnote_id footnote_type goods_nomenclature_sid]
+
+  one_to_one :footnote, key: %i[footnote_id footnote_type_id],
+                        primary_key: %i[footnote_id footnote_type]
+  one_to_one :goods_nomenclature, key: :goods_nomenclature_sid,
+                                  primary_key: :goods_nomenclature_sid
 end

--- a/app/models/footnote_association_measure.rb
+++ b/app/models/footnote_association_measure.rb
@@ -4,8 +4,8 @@ class FootnoteAssociationMeasure < Sequel::Model
                                  footnote_id
                                  footnote_type_id]
 
-  one_to_one :footnote, key: :footnote_id,
-                        primary_key: :footnote_id
+  one_to_one :footnote, key: %i[footnote_id footnote_type_id],
+                        primary_key: %i[footnote_id footnote_type_id]
   one_to_one :measure, key: :measure_sid,
                        primary_key: :measure_sid
 end

--- a/app/services/delta_report_service.rb
+++ b/app/services/delta_report_service.rb
@@ -11,7 +11,7 @@ class DeltaReportService
   end
 
   def generate_report
-    TimeMachine.now do
+    TimeMachine.at(date) do
       collect_all_changes
       generate_commodity_change_records
     end
@@ -39,6 +39,8 @@ class DeltaReportService
     @changes[:additional_codes] = AdditionalCodeChanges.collect(date)
     @changes[:excluded_geographical_areas] = ExcludedGeographicalAreaChanges.collect(date)
     @changes[:footnotes] = FootnoteChanges.collect(date)
+    @changes[:footnote_association_measures] = FootnoteAssociationMeasureChanges.collect(date)
+    @changes[:footnote_association_goods_nomenclature] = FootnoteAssociationGoodsNomenclatureChanges.collect(date)
   end
 
   def generate_commodity_change_records
@@ -72,9 +74,9 @@ class DeltaReportService
 
   def find_affected_declarable_goods(change)
     case change[:type]
-    when 'Measure', 'GoodsNomenclature'
+    when 'Measure', 'GoodsNomenclature', 'FootnoteAssociationGoodsNomenclature'
       find_declarable_goods_for(change)
-    when 'MeasureComponent', 'MeasureCondition', 'ExcludedGeographicalArea'
+    when 'MeasureComponent', 'MeasureCondition', 'ExcludedGeographicalArea', 'FootnoteAssociationMeasure'
       find_declarable_goods_for_measure_association(change)
     when 'GeographicalArea'
       find_declarable_goods_for_geographical_area(change)
@@ -169,9 +171,7 @@ class DeltaReportService
   def find_declarable_goods_under_code(goods_nomenclature_item_id)
     return [] unless goods_nomenclature_item_id
 
-    gn = GoodsNomenclature.actual
-      .where(goods_nomenclature_item_id: goods_nomenclature_item_id)
-      .first
+    gn = GoodsNomenclature.where(goods_nomenclature_item_id: goods_nomenclature_item_id).first
 
     return [] unless gn
 
@@ -186,4 +186,4 @@ end
 # Example usage:
 #
 # Generate report for specific date
-# report = DeltaReportService.generate(date: Date.new(2024, 8, 11))
+# report = DeltaReportService.generate(date: Date.new(2025, 7, 24))

--- a/app/services/delta_report_service/footnote_association_goods_nomenclature_changes.rb
+++ b/app/services/delta_report_service/footnote_association_goods_nomenclature_changes.rb
@@ -1,0 +1,39 @@
+class DeltaReportService
+  class FootnoteAssociationGoodsNomenclatureChanges < BaseChanges
+    include MeasurePresenter
+
+    def self.collect(date)
+      FootnoteAssociationGoodsNomenclature
+        .where(operation_date: date)
+        .order(:oid)
+        .map { |record| new(record, date).analyze }
+        .compact
+    end
+
+    def object_name
+      "Footnote #{record.footnote.code}"
+    end
+
+    def analyze
+      return if no_changes?
+      return if record.operation == :create && record.goods_nomenclature.operation_date == record.operation_date
+      return if record.operation == :create && record.footnote.operation_date == record.operation_date
+
+      {
+        type: 'FootnoteAssociationGoodsNomenclature',
+        goods_nomenclature_item_id: record.goods_nomenclature.goods_nomenclature_item_id,
+        description:,
+        date_of_effect:,
+        change: change,
+      }
+    end
+
+    def previous_record
+      @previous_record ||= FootnoteAssociationGoodsNomenclature.operation_klass
+                             .where(goods_nomenclature_sid: record.goods_nomenclature_sid, footnote_id: record.footnote_id, footnote_type: record.footnote_type)
+                             .where(Sequel.lit('oid < ?', record.oid))
+                             .order(Sequel.desc(:oid))
+                             .first
+    end
+  end
+end

--- a/app/services/delta_report_service/footnote_association_measure_changes.rb
+++ b/app/services/delta_report_service/footnote_association_measure_changes.rb
@@ -1,0 +1,48 @@
+class DeltaReportService
+  class FootnoteAssociationMeasureChanges < BaseChanges
+    include MeasurePresenter
+
+    def self.collect(date)
+      FootnoteAssociationMeasure
+        .where(operation_date: date)
+        .order(:oid)
+        .map { |record| new(record, date).analyze }
+        .compact
+    end
+
+    def object_name
+      "Footnote #{record.footnote.code}"
+    end
+
+    def analyze
+      return if no_changes?
+      return if record.operation == :create && record.measure.operation_date == record.operation_date
+      return if record.operation == :create && record.footnote.operation_date == record.operation_date
+
+      {
+        type: 'FootnoteAssociationMeasure',
+        measure_sid: record.measure_sid,
+        measure_type: measure_type(record.measure),
+        import_export: import_export(record.measure),
+        geo_area: geo_area(record.measure.geographical_area),
+        additional_code: additional_code(record.measure.additional_code),
+        duty_expression: duty_expression(record.measure),
+        description:,
+        date_of_effect:,
+        change: change,
+      }
+    end
+
+    def date_of_effect
+      date
+    end
+
+    def previous_record
+      @previous_record ||= FootnoteAssociationMeasure.operation_klass
+                             .where(measure_sid: record.measure_sid, footnote_id: record.footnote_id, footnote_type_id: record.footnote_type_id)
+                             .where(Sequel.lit('oid < ?', record.oid))
+                             .order(Sequel.desc(:oid))
+                             .first
+    end
+  end
+end

--- a/spec/services/delta_report_service/footnote_association_goods_nomenclature_changes_spec.rb
+++ b/spec/services/delta_report_service/footnote_association_goods_nomenclature_changes_spec.rb
@@ -1,0 +1,189 @@
+RSpec.describe DeltaReportService::FootnoteAssociationGoodsNomenclatureChanges do
+  let(:date) { Date.parse('2024-08-11') }
+
+  let(:goods_nomenclature) { build(:goods_nomenclature, goods_nomenclature_item_id: '0101000000') }
+  let(:footnote) { build(:footnote, footnote_id: '001', footnote_type_id: 'TN', oid: '999') }
+  let(:footnote_association) do
+    build(
+      :footnote_association_goods_nomenclature,
+      oid: '123',
+      footnote_id: footnote.footnote_id,
+      footnote_type: footnote.footnote_type_id,
+      goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
+      operation_date: date,
+    )
+  end
+  let(:instance) { described_class.new(footnote_association, date) }
+
+  before do
+    allow(instance).to receive(:get_changes)
+    allow(footnote_association).to receive_messages(
+      footnote: footnote,
+      goods_nomenclature: goods_nomenclature,
+    )
+    allow(footnote).to receive(:code).and_return("#{footnote.footnote_type_id}#{footnote.footnote_id}")
+  end
+
+  describe '.collect' do
+    let(:association1) { build(:footnote_association_goods_nomenclature, oid: 1, operation_date: date) }
+    let(:association2) { build(:footnote_association_goods_nomenclature, oid: 2, operation_date: date) }
+    let(:associations) { [association1, association2] }
+
+    before do
+      allow(FootnoteAssociationGoodsNomenclature).to receive_message_chain(:where, :order).and_return(associations)
+    end
+
+    it 'finds footnote association goods nomenclatures for the given date and returns analyzed changes' do
+      instance1 = described_class.new(association1, date)
+      instance2 = described_class.new(association2, date)
+
+      allow(described_class).to receive(:new).and_return(instance1, instance2)
+      allow(instance1).to receive(:analyze).and_return({ type: 'FootnoteAssociationGoodsNomenclature' })
+      allow(instance2).to receive(:analyze).and_return({ type: 'FootnoteAssociationGoodsNomenclature' })
+
+      result = described_class.collect(date)
+
+      expect(FootnoteAssociationGoodsNomenclature).to have_received(:where).with(operation_date: date)
+      expect(result).to eq([{ type: 'FootnoteAssociationGoodsNomenclature' }, { type: 'FootnoteAssociationGoodsNomenclature' }])
+    end
+
+    it 'filters out nil results from analyze' do
+      instance1 = described_class.new(association1, date)
+      instance2 = described_class.new(association2, date)
+
+      allow(described_class).to receive(:new).and_return(instance1, instance2)
+      allow(instance1).to receive(:analyze).and_return({ type: 'FootnoteAssociationGoodsNomenclature' })
+      allow(instance2).to receive(:analyze).and_return(nil)
+
+      result = described_class.collect(date)
+
+      expect(result).to eq([{ type: 'FootnoteAssociationGoodsNomenclature' }])
+    end
+  end
+
+  describe '#object_name' do
+    it 'returns the correct object name with footnote code' do
+      expect(instance.object_name).to eq("Footnote #{footnote.code}")
+    end
+  end
+
+  describe '#analyze' do
+    before do
+      allow(instance).to receive_messages(
+        no_changes?: false,
+        date_of_effect: date,
+        description: 'Footnote TN001 updated',
+        change: nil,
+      )
+    end
+
+    context 'when there are no changes' do
+      before { allow(instance).to receive(:no_changes?).and_return(true) }
+
+      it 'returns nil' do
+        expect(instance.analyze).to be_nil
+      end
+    end
+
+    context 'when record is a create operation and goods nomenclature was created on the same date' do
+      before do
+        allow(footnote_association).to receive(:operation).and_return(:create)
+        allow(goods_nomenclature).to receive(:operation_date).and_return(date)
+      end
+
+      it 'returns nil' do
+        expect(instance.analyze).to be_nil
+      end
+    end
+
+    context 'when record is a create operation and footnote was created on the same date' do
+      before do
+        allow(footnote_association).to receive(:operation).and_return(:create)
+        allow(goods_nomenclature).to receive(:operation_date).and_return(date - 1)
+        allow(footnote).to receive(:operation_date).and_return(date)
+      end
+
+      it 'returns nil' do
+        expect(instance.analyze).to be_nil
+      end
+    end
+
+    context 'when changes should be included' do
+      before do
+        allow(footnote_association).to receive(:operation).and_return(:update)
+        allow(goods_nomenclature).to receive(:operation_date).and_return(date - 1)
+        allow(footnote).to receive(:operation_date).and_return(date - 1)
+      end
+
+      it 'returns the correct analysis hash' do
+        result = instance.analyze
+
+        expect(result).to eq({
+          type: 'FootnoteAssociationGoodsNomenclature',
+          goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
+          description: 'Footnote TN001 updated',
+          date_of_effect: date,
+          change: nil,
+        })
+      end
+    end
+
+    context 'when change value is present' do
+      before do
+        allow(footnote_association).to receive(:operation).and_return(:update)
+        allow(goods_nomenclature).to receive(:operation_date).and_return(date - 1)
+        allow(footnote).to receive(:operation_date).and_return(date - 1)
+        allow(instance).to receive(:change).and_return('validity_start_date updated')
+      end
+
+      it 'includes the change value in the result' do
+        result = instance.analyze
+        expect(result[:change]).to eq('validity_start_date updated')
+      end
+    end
+
+    context 'when record is a create operation but entities were created on different dates' do
+      before do
+        allow(footnote_association).to receive(:operation).and_return(:create)
+        allow(goods_nomenclature).to receive(:operation_date).and_return(date - 1)
+        allow(footnote).to receive(:operation_date).and_return(date - 2)
+      end
+
+      it 'returns the analysis hash' do
+        result = instance.analyze
+
+        expect(result).to eq({
+          type: 'FootnoteAssociationGoodsNomenclature',
+          goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
+          description: 'Footnote TN001 updated',
+          date_of_effect: date,
+          change: nil,
+        })
+      end
+    end
+  end
+
+  describe '#previous_record' do
+    let(:instance) { described_class.new(footnote_association, date) }
+    let(:previous_footnote_association) { build(:footnote_association_goods_nomenclature) }
+
+    before do
+      allow(FootnoteAssociationGoodsNomenclature).to receive(:operation_klass).and_return(FootnoteAssociationGoodsNomenclature)
+      allow(FootnoteAssociationGoodsNomenclature).to receive_message_chain(:where, :where, :order, :first)
+                         .and_return(previous_footnote_association)
+    end
+
+    it 'queries for the previous record by goods_nomenclature_sid, footnote_id, footnote_type and oid' do
+      result = instance.previous_record
+
+      expect(result).to eq(previous_footnote_association)
+    end
+
+    it 'memoizes the result' do
+      instance.previous_record
+      instance.previous_record
+
+      expect(FootnoteAssociationGoodsNomenclature).to have_received(:operation_klass).once
+    end
+  end
+end

--- a/spec/services/delta_report_service/footnote_association_measure_changes_spec.rb
+++ b/spec/services/delta_report_service/footnote_association_measure_changes_spec.rb
@@ -1,0 +1,223 @@
+RSpec.describe DeltaReportService::FootnoteAssociationMeasureChanges do
+  let(:date) { Date.parse('2024-08-11') }
+  let(:measure) { build(:measure, measure_sid: '12345') }
+  let(:footnote) { build(:footnote, footnote_id: '001', footnote_type_id: 'TN', oid: '999') }
+  let(:footnote_association) do
+    build(
+      :footnote_association_measure,
+      oid: '123',
+      measure_sid: measure.measure_sid,
+      footnote_id: footnote.footnote_id,
+      footnote_type_id: footnote.footnote_type_id,
+      operation_date: date,
+    )
+  end
+
+  before do
+    allow(footnote_association).to receive_messages(
+      footnote: footnote,
+      measure: measure,
+    )
+    allow(footnote).to receive(:code).and_return("#{footnote.footnote_type_id}#{footnote.footnote_id}")
+  end
+
+  describe '.collect' do
+    let(:association1) { build(:footnote_association_measure, oid: 1, operation_date: date) }
+    let(:association2) { build(:footnote_association_measure, oid: 2, operation_date: date) }
+    let(:associations) { [association1, association2] }
+
+    before do
+      allow(FootnoteAssociationMeasure).to receive_message_chain(:where, :order).and_return(associations)
+    end
+
+    it 'finds footnote association measures for the given date and returns analyzed changes' do
+      instance1 = described_class.new(association1, date)
+      instance2 = described_class.new(association2, date)
+
+      allow(described_class).to receive(:new).and_return(instance1, instance2)
+      allow(instance1).to receive(:analyze).and_return({ type: 'FootnoteAssociationMeasure' })
+      allow(instance2).to receive(:analyze).and_return({ type: 'FootnoteAssociationMeasure' })
+
+      result = described_class.collect(date)
+
+      expect(FootnoteAssociationMeasure).to have_received(:where).with(operation_date: date)
+      expect(result).to eq([{ type: 'FootnoteAssociationMeasure' }, { type: 'FootnoteAssociationMeasure' }])
+    end
+
+    it 'filters out nil results from analyze' do
+      instance1 = described_class.new(association1, date)
+      instance2 = described_class.new(association2, date)
+
+      allow(described_class).to receive(:new).and_return(instance1, instance2)
+      allow(instance1).to receive(:analyze).and_return({ type: 'FootnoteAssociationMeasure' })
+      allow(instance2).to receive(:analyze).and_return(nil)
+
+      result = described_class.collect(date)
+
+      expect(result).to eq([{ type: 'FootnoteAssociationMeasure' }])
+    end
+  end
+
+  describe '#object_name' do
+    let(:instance) { described_class.new(footnote_association, date) }
+
+    it 'returns the correct object name with footnote code' do
+      expect(instance.object_name).to eq("Footnote #{footnote.code}")
+    end
+  end
+
+  describe '#analyze' do
+    let(:instance) { described_class.new(footnote_association, date) }
+    let(:geographical_area) { build(:geographical_area, geographical_area_id: 'GB') }
+    let(:additional_code) { build(:additional_code, additional_code: '1234') }
+
+    before do
+      allow(instance).to receive_messages(
+        no_changes?: false,
+        description: 'Footnote TN001 updated',
+        change: nil,
+      )
+      allow(measure).to receive_messages(
+        geographical_area: geographical_area,
+        additional_code: additional_code,
+        measure_type: instance_double(MeasureType, id: '103', description: 'Import duty', trade_movement_code: 0),
+        duty_expression: '10%',
+      )
+      allow(additional_code).to receive_messages(
+        additional_code_description: instance_double(AdditionalCodeDescription, description: '1234'),
+        code: '1234',
+      )
+      allow(geographical_area).to receive_messages(
+        geographical_area_description: instance_double(GeographicalAreaDescription, description: 'United Kingdom'),
+        id: 'GB',
+      )
+    end
+
+    context 'when there are no changes' do
+      before { allow(instance).to receive(:no_changes?).and_return(true) }
+
+      it 'returns nil' do
+        expect(instance.analyze).to be_nil
+      end
+    end
+
+    context 'when record is a create operation and measure was created on the same date' do
+      before do
+        allow(footnote_association).to receive(:operation).and_return(:create)
+        allow(measure).to receive(:operation_date).and_return(date)
+      end
+
+      it 'returns nil' do
+        expect(instance.analyze).to be_nil
+      end
+    end
+
+    context 'when record is a create operation and footnote was created on the same date' do
+      before do
+        allow(footnote_association).to receive(:operation).and_return(:create)
+        allow(measure).to receive(:operation_date).and_return(date - 1)
+        allow(footnote).to receive(:operation_date).and_return(date)
+      end
+
+      it 'returns nil' do
+        expect(instance.analyze).to be_nil
+      end
+    end
+
+    context 'when changes should be included' do
+      before do
+        allow(footnote_association).to receive(:operation).and_return(:update)
+        allow(measure).to receive(:operation_date).and_return(date - 1)
+        allow(footnote).to receive(:operation_date).and_return(date - 1)
+      end
+
+      it 'returns the correct analysis hash' do
+        result = instance.analyze
+
+        expect(result).to eq({
+          type: 'FootnoteAssociationMeasure',
+          measure_sid: measure.measure_sid,
+          measure_type: '103: Import duty',
+          import_export: 'Import',
+          geo_area: 'GB: United Kingdom',
+          additional_code: '1234: 1234',
+          duty_expression: '10%',
+          description: 'Footnote TN001 updated',
+          date_of_effect: date,
+          change: nil,
+        })
+      end
+    end
+
+    context 'when change value is present' do
+      before do
+        allow(footnote_association).to receive(:operation).and_return(:update)
+        allow(measure).to receive(:operation_date).and_return(date - 1)
+        allow(footnote).to receive(:operation_date).and_return(date - 1)
+        allow(instance).to receive(:change).and_return('national updated')
+      end
+
+      it 'includes the change value in the result' do
+        result = instance.analyze
+        expect(result[:change]).to eq('national updated')
+      end
+    end
+
+    context 'when record is a create operation but entities were created on different dates' do
+      before do
+        allow(footnote_association).to receive(:operation).and_return(:create)
+        allow(measure).to receive(:operation_date).and_return(date - 1)
+        allow(footnote).to receive(:operation_date).and_return(date - 2)
+      end
+
+      it 'returns the analysis hash' do
+        result = instance.analyze
+
+        expect(result).to eq({
+          type: 'FootnoteAssociationMeasure',
+          measure_sid: measure.measure_sid,
+          measure_type: '103: Import duty',
+          import_export: 'Import',
+          geo_area: 'GB: United Kingdom',
+          additional_code: '1234: 1234',
+          duty_expression: '10%',
+          description: 'Footnote TN001 updated',
+          date_of_effect: date,
+          change: nil,
+        })
+      end
+    end
+  end
+
+  describe '#date_of_effect' do
+    let(:instance) { described_class.new(footnote_association, date) }
+
+    it 'returns the date passed to the instance' do
+      expect(instance.date_of_effect).to eq(date)
+    end
+  end
+
+  describe '#previous_record' do
+    let(:instance) { described_class.new(footnote_association, date) }
+    let(:previous_footnote_association) { build(:footnote_association_measure) }
+
+    before do
+      allow(FootnoteAssociationMeasure).to receive(:operation_klass).and_return(FootnoteAssociationMeasure)
+      allow(FootnoteAssociationMeasure).to receive_message_chain(:where, :where, :order, :first)
+                         .and_return(previous_footnote_association)
+    end
+
+    it 'queries for the previous record by measure_sid, footnote_id, footnote_type_id and oid' do
+      result = instance.previous_record
+
+      expect(result).to eq(previous_footnote_association)
+    end
+
+    it 'memoizes the result' do
+      instance.previous_record
+      instance.previous_record
+
+      expect(FootnoteAssociationMeasure).to have_received(:operation_klass).once
+    end
+  end
+end


### PR DESCRIPTION
### What?

Adds oplog changes for FootnoteAssociationGoodsNomenclature and FootnoteAssociationMeasure to myott changes report. These models show when a footnote is added or removed from a Measure of GoodsNomenclature.
FootnoteAssociationGoodsNomenclature items can also have their validity date changed.

Also:
- Adds one_to_one associations for FootnoteAssociationGoodsNomenclature to Footnote and GoodsNomenclature
- Fixes FootnoteAssociationMeasure association to Footnote by adding missing primary key
