### PR TITLE
Fix use of footnote code

### DIFF
--- a/app/services/delta_report_service/footnote_association_goods_nomenclature_changes.rb
+++ b/app/services/delta_report_service/footnote_association_goods_nomenclature_changes.rb
@@ -11,7 +11,7 @@ class DeltaReportService
     end
 
     def object_name
-      "Footnote #{record.footnote.code}"
+      'Footnote'
     end
 
     def analyze
@@ -24,7 +24,7 @@ class DeltaReportService
         goods_nomenclature_item_id: record.goods_nomenclature.goods_nomenclature_item_id,
         description:,
         date_of_effect:,
-        change: change,
+        change: change.present? ? "#{record.footnote.code}: #{change}" : record.footnote.code,
       }
     end
 

--- a/app/services/delta_report_service/footnote_association_measure_changes.rb
+++ b/app/services/delta_report_service/footnote_association_measure_changes.rb
@@ -11,7 +11,7 @@ class DeltaReportService
     end
 
     def object_name
-      "Footnote #{record.footnote.code}"
+      'Footnote'
     end
 
     def analyze
@@ -29,7 +29,7 @@ class DeltaReportService
         duty_expression: duty_expression(record.measure),
         description:,
         date_of_effect:,
-        change: change,
+        change: change.present? ? "#{record.footnote.code}: #{change}" : record.footnote.code,
       }
     end
 

--- a/app/services/delta_report_service/footnote_changes.rb
+++ b/app/services/delta_report_service/footnote_changes.rb
@@ -9,7 +9,11 @@ class DeltaReportService
     end
 
     def object_name
-      "Footnote #{record.code}"
+      'Footnote'
+    end
+
+    def excluded_columns
+      super + %i[national]
     end
 
     def analyze
@@ -20,7 +24,7 @@ class DeltaReportService
         footnote_oid: record.oid,
         description:,
         date_of_effect:,
-        change: change || "#{record.code}: #{record.footnote_description.description}",
+        change: change.present? ? "#{record.code}: #{change}" : record.code,
       }
     end
 

--- a/app/services/delta_report_service/measure_changes.rb
+++ b/app/services/delta_report_service/measure_changes.rb
@@ -15,7 +15,7 @@ class DeltaReportService
     end
 
     def excluded_columns
-      super + %i[measure_generating_regulation_id justification_regulation_role justification_regulation_id]
+      super + %i[measure_generating_regulation_id justification_regulation_role justification_regulation_id national]
     end
 
     def analyze

--- a/app/services/delta_report_service/measure_presenter.rb
+++ b/app/services/delta_report_service/measure_presenter.rb
@@ -26,7 +26,7 @@ class DeltaReportService
     end
 
     def additional_code(additional_code)
-      return nil if additional_code.blank?
+      return nil if additional_code.blank? || additional_code.additional_code_description.blank?
 
       "#{additional_code.code}: #{additional_code.description}"
     end

--- a/spec/services/delta_report_service/footnote_association_goods_nomenclature_changes_spec.rb
+++ b/spec/services/delta_report_service/footnote_association_goods_nomenclature_changes_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe DeltaReportService::FootnoteAssociationGoodsNomenclatureChanges d
 
   describe '#object_name' do
     it 'returns the correct object name with footnote code' do
-      expect(instance.object_name).to eq("Footnote #{footnote.code}")
+      expect(instance.object_name).to eq('Footnote')
     end
   end
 
@@ -123,7 +123,7 @@ RSpec.describe DeltaReportService::FootnoteAssociationGoodsNomenclatureChanges d
           goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
           description: 'Footnote TN001 updated',
           date_of_effect: date,
-          change: nil,
+          change: footnote.code,
         })
       end
     end
@@ -138,7 +138,7 @@ RSpec.describe DeltaReportService::FootnoteAssociationGoodsNomenclatureChanges d
 
       it 'includes the change value in the result' do
         result = instance.analyze
-        expect(result[:change]).to eq('validity_start_date updated')
+        expect(result[:change]).to eq("#{footnote.code}: validity_start_date updated")
       end
     end
 
@@ -157,7 +157,7 @@ RSpec.describe DeltaReportService::FootnoteAssociationGoodsNomenclatureChanges d
           goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
           description: 'Footnote TN001 updated',
           date_of_effect: date,
-          change: nil,
+          change: footnote.code,
         })
       end
     end

--- a/spec/services/delta_report_service/footnote_association_measure_changes_spec.rb
+++ b/spec/services/delta_report_service/footnote_association_measure_changes_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe DeltaReportService::FootnoteAssociationMeasureChanges do
     let(:instance) { described_class.new(footnote_association, date) }
 
     it 'returns the correct object name with footnote code' do
-      expect(instance.object_name).to eq("Footnote #{footnote.code}")
+      expect(instance.object_name).to eq('Footnote')
     end
   end
 
@@ -144,7 +144,7 @@ RSpec.describe DeltaReportService::FootnoteAssociationMeasureChanges do
           duty_expression: '10%',
           description: 'Footnote TN001 updated',
           date_of_effect: date,
-          change: nil,
+          change: footnote.code,
         })
       end
     end
@@ -159,7 +159,7 @@ RSpec.describe DeltaReportService::FootnoteAssociationMeasureChanges do
 
       it 'includes the change value in the result' do
         result = instance.analyze
-        expect(result[:change]).to eq('national updated')
+        expect(result[:change]).to eq("#{footnote.code}: national updated")
       end
     end
 
@@ -183,7 +183,7 @@ RSpec.describe DeltaReportService::FootnoteAssociationMeasureChanges do
           duty_expression: '10%',
           description: 'Footnote TN001 updated',
           date_of_effect: date,
-          change: nil,
+          change: footnote.code,
         })
       end
     end

--- a/spec/services/delta_report_service/footnote_changes_spec.rb
+++ b/spec/services/delta_report_service/footnote_changes_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe DeltaReportService::FootnoteChanges do
 
   describe '#object_name' do
     it 'returns the correct object name' do
-      expect(instance.object_name).to eq("Footnote #{footnote.code}")
+      expect(instance.object_name).to eq('Footnote')
     end
   end
 
@@ -67,7 +67,7 @@ RSpec.describe DeltaReportService::FootnoteChanges do
           footnote_oid: 999,
           date_of_effect: date,
           description: 'Footnote updated',
-          change: "#{footnote.code}: Footnote description",
+          change: footnote.code,
         })
       end
     end
@@ -75,9 +75,9 @@ RSpec.describe DeltaReportService::FootnoteChanges do
     context 'when change is not nil' do
       before { allow(instance).to receive(:change).and_return('description updated') }
 
-      it 'uses the change value instead of footnote id' do
+      it 'uses the change value with the footnote code' do
         result = instance.analyze
-        expect(result[:change]).to eq('description updated')
+        expect(result[:change]).to eq("#{footnote.code}: description updated")
       end
     end
   end

--- a/spec/services/delta_report_service/measure_presenter_spec.rb
+++ b/spec/services/delta_report_service/measure_presenter_spec.rb
@@ -97,11 +97,11 @@ RSpec.describe DeltaReportService::MeasurePresenter do
 
   describe '#additional_code' do
     context 'when additional_code is present' do
-      let(:additional_code) { instance_double(AdditionalCode, code: 'A123', description: 'Special additional code') }
+      let(:additional_code) { build(:additional_code, :with_description, additional_code: '123') }
 
       it 'returns formatted additional code with code and description' do
         result = instance.additional_code(additional_code)
-        expect(result).to eq('A123: Special additional code')
+        expect(result).to eq("1123: #{additional_code.additional_code_description.description}")
       end
     end
 


### PR DESCRIPTION
### What?

- Remove Footnote code from "type of change" field
- Ignore changes to "national" value for Footnotes and Measures
- Check Additional Code has a description before trying to use it
