### PR TITLE
Extract previous_record method to oplog plugin

### DIFF
--- a/app/lib/sequel/plugins/oplog.rb
+++ b/app/lib/sequel/plugins/oplog.rb
@@ -97,6 +97,19 @@ module Sequel
           end
         end
 
+        def previous_record
+          primary_keys = operation_klass.primary_key - [:oid]
+          return nil if primary_keys.empty?
+
+          primary_key_conditions = primary_keys.index_with { |key| self[key] }
+
+          operation_klass
+            .where(primary_key_conditions)
+            .where(Sequel.lit('oid < ?', oid))
+            .order(Sequel.desc(:oid))
+            .first
+        end
+
         ##
         # Will be called by https://github.com/jeremyevans/sequel/blob/5afb0d0e28a89e68f1823d77d23cfa57d6b88dad/lib/sequel/model/base.rb#L1549
         # @note fixes `NotImplementedError: You should be inserting model instances`

--- a/app/services/delta_report_service/additional_code_changes.rb
+++ b/app/services/delta_report_service/additional_code_changes.rb
@@ -26,13 +26,5 @@ class DeltaReportService
         change: change || '',
       }
     end
-
-    def previous_record
-      @previous_record ||= AdditionalCode.operation_klass
-                             .where(additional_code_sid: record.additional_code_sid)
-                             .where(Sequel.lit('oid < ?', record.oid))
-                             .order(Sequel.desc(:oid))
-                             .first
-    end
   end
 end

--- a/app/services/delta_report_service/base_changes.rb
+++ b/app/services/delta_report_service/base_changes.rb
@@ -25,7 +25,7 @@ class DeltaReportService
 
       return unless record.operation == :update
 
-      if previous_record
+      if (previous_record = record.previous_record)
         comparable_columns = record.values.keys - excluded_columns
 
         comparable_columns.each do |column|

--- a/app/services/delta_report_service/certificate_changes.rb
+++ b/app/services/delta_report_service/certificate_changes.rb
@@ -26,13 +26,5 @@ class DeltaReportService
         change: change || record.id,
       }
     end
-
-    def previous_record
-      @previous_record ||= Certificate.operation_klass
-                             .where(certificate_code: record.certificate_code, certificate_type_code: record.certificate_type_code)
-                             .where(Sequel.lit('oid < ?', record.oid))
-                             .order(Sequel.desc(:oid))
-                             .first
-    end
   end
 end

--- a/app/services/delta_report_service/commodity_changes.rb
+++ b/app/services/delta_report_service/commodity_changes.rb
@@ -27,13 +27,5 @@ class DeltaReportService
         change: change || record.code,
       }
     end
-
-    def previous_record
-      @previous_record ||= GoodsNomenclature.operation_klass
-                             .where(goods_nomenclature_sid: record.goods_nomenclature_sid)
-                             .where(Sequel.lit('oid < ?', record.oid))
-                             .order(Sequel.desc(:oid))
-                             .first
-    end
   end
 end

--- a/app/services/delta_report_service/footnote_association_goods_nomenclature_changes.rb
+++ b/app/services/delta_report_service/footnote_association_goods_nomenclature_changes.rb
@@ -27,13 +27,5 @@ class DeltaReportService
         change: change.present? ? "#{record.footnote.code}: #{change}" : record.footnote.code,
       }
     end
-
-    def previous_record
-      @previous_record ||= FootnoteAssociationGoodsNomenclature.operation_klass
-                             .where(goods_nomenclature_sid: record.goods_nomenclature_sid, footnote_id: record.footnote_id, footnote_type: record.footnote_type)
-                             .where(Sequel.lit('oid < ?', record.oid))
-                             .order(Sequel.desc(:oid))
-                             .first
-    end
   end
 end

--- a/app/services/delta_report_service/footnote_association_measure_changes.rb
+++ b/app/services/delta_report_service/footnote_association_measure_changes.rb
@@ -36,13 +36,5 @@ class DeltaReportService
     def date_of_effect
       date
     end
-
-    def previous_record
-      @previous_record ||= FootnoteAssociationMeasure.operation_klass
-                             .where(measure_sid: record.measure_sid, footnote_id: record.footnote_id, footnote_type_id: record.footnote_type_id)
-                             .where(Sequel.lit('oid < ?', record.oid))
-                             .order(Sequel.desc(:oid))
-                             .first
-    end
   end
 end

--- a/app/services/delta_report_service/footnote_changes.rb
+++ b/app/services/delta_report_service/footnote_changes.rb
@@ -27,13 +27,5 @@ class DeltaReportService
         change: change.present? ? "#{record.code}: #{change}" : record.code,
       }
     end
-
-    def previous_record
-      @previous_record ||= Footnote.operation_klass
-                             .where(footnote_id: record.footnote_id, footnote_type_id: record.footnote_type_id)
-                             .where(Sequel.lit('oid < ?', record.oid))
-                             .order(Sequel.desc(:oid))
-                             .first
-    end
   end
 end

--- a/app/services/delta_report_service/geographical_area_changes.rb
+++ b/app/services/delta_report_service/geographical_area_changes.rb
@@ -25,13 +25,5 @@ class DeltaReportService
         change: change || geo_area(record),
       }
     end
-
-    def previous_record
-      @previous_record ||= GeographicalArea.operation_klass
-                             .where(geographical_area_id: record.geographical_area_id)
-                             .where(Sequel.lit('oid < ?', record.oid))
-                             .order(Sequel.desc(:oid))
-                             .first
-    end
   end
 end

--- a/app/services/delta_report_service/measure_changes.rb
+++ b/app/services/delta_report_service/measure_changes.rb
@@ -36,13 +36,5 @@ class DeltaReportService
         change: change || measure_type(record),
       }
     end
-
-    def previous_record
-      @previous_record ||= Measure.operation_klass
-                             .where(measure_sid: record.measure_sid)
-                             .where(Sequel.lit('oid < ?', record.oid))
-                             .order(Sequel.desc(:oid))
-                             .first
-    end
   end
 end

--- a/app/services/delta_report_service/measure_component_changes.rb
+++ b/app/services/delta_report_service/measure_component_changes.rb
@@ -35,14 +35,5 @@ class DeltaReportService
     def date_of_effect
       date
     end
-
-    def previous_record
-      @previous_record ||= MeasureComponent.operation_klass
-                             .where(measure_sid: record.measure_sid)
-                             .where(duty_expression_id: record.duty_expression_id)
-                             .where(Sequel.lit('oid < ?', record.oid))
-                             .order(Sequel.desc(:oid))
-                             .first
-    end
   end
 end

--- a/app/services/delta_report_service/measure_condition_changes.rb
+++ b/app/services/delta_report_service/measure_condition_changes.rb
@@ -39,13 +39,5 @@ class DeltaReportService
     def excluded_columns
       super + %i[component_sequence_number]
     end
-
-    def previous_record
-      @previous_record ||= MeasureCondition.operation_klass
-                             .where(measure_condition_sid: record.measure_condition_sid)
-                             .where(Sequel.lit('oid < ?', record.oid))
-                             .order(Sequel.desc(:oid))
-                             .first
-    end
   end
 end

--- a/spec/lib/sequel/plugins/oplog_spec.rb
+++ b/spec/lib/sequel/plugins/oplog_spec.rb
@@ -1,0 +1,217 @@
+# rubocop:disable Style/ConstantDefinitionInBlock
+# rubocop:disable Style/BeforeAfterAll
+# rubocop:disable Style/LeakyConstantDeclaration
+
+RSpec.describe Sequel::Plugins::Oplog do
+  before(:all) do
+    DB = Sequel::Model.db
+
+    DB.drop_table?(:test_records_oplog, cascade: true)
+    DB.drop_table?(:test_records, cascade: true)
+    DB.drop_table?(:composite_test_records_oplog, cascade: true)
+    DB.drop_table?(:composite_test_records, cascade: true)
+
+    DB.create_table!(:test_records) do
+      primary_key :id
+      String :name
+      String :description
+      DateTime :created_at
+      DateTime :updated_at
+      Integer :oid
+    end
+
+    DB.create_table!(:test_records_oplog) do
+      primary_key :oid
+      Integer :id
+      String :name
+      String :description
+      DateTime :created_at
+      DateTime :updated_at
+      String :operation
+      DateTime :operation_date
+    end
+
+    DB.create_table!(:composite_test_records) do
+      Integer :part_a
+      Integer :part_b
+      String :data
+      Integer :oid
+      primary_key %i[part_a part_b]
+    end
+
+    DB.create_table!(:composite_test_records_oplog) do
+      primary_key :oid
+      Integer :part_a
+      Integer :part_b
+      String :data
+      String :operation
+      DateTime :operation_date
+    end
+
+    class TestRecord < Sequel::Model(DB[:test_records])
+      plugin :oplog, primary_key: :id
+      unrestrict_primary_key
+    end
+
+    class CompositeTestRecord < Sequel::Model(DB[:composite_test_records])
+      plugin :oplog, primary_key: %i[part_a part_b]
+      unrestrict_primary_key
+    end
+  end
+
+  before do
+    DB[:test_records_oplog].truncate(restart: true, cascade: true)
+    DB[:test_records].truncate(restart: true, cascade: true)
+    DB[:composite_test_records_oplog].truncate(restart: true, cascade: true)
+    DB[:composite_test_records].truncate(restart: true, cascade: true)
+  end
+
+  describe '#previous_record' do
+    context 'when there are multiple operation records for the same entity' do
+      before do
+        # Create operation records directly for testing
+        TestRecord::Operation.insert(
+          id: 1,
+          name: 'First Record',
+          description: 'Initial version',
+          operation: 'C',
+          operation_date: Time.zone.now - 2.days,
+        )
+
+        TestRecord::Operation.insert(
+          id: 1,
+          name: 'First Record Updated',
+          description: 'Updated version',
+          operation: 'U',
+          operation_date: Time.zone.now - 1.day,
+        )
+
+        TestRecord::Operation.insert(
+          id: 1,
+          name: 'First Record Final',
+          description: 'Final version',
+          operation: 'U',
+          operation_date: Time.zone.now,
+        )
+
+        TestRecord::Operation.insert(
+          id: 2,
+          name: 'Second Record',
+          description: 'Different record',
+          operation: 'C',
+          operation_date: Time.zone.now,
+        )
+      end
+
+      it 'returns the previous operation record for the same entity' do
+        latest_operation = TestRecord::Operation.where(id: 1).order(Sequel.desc(:oid)).first
+        test_record = TestRecord.new(id: 1, oid: latest_operation.oid)
+
+        previous_record = test_record.previous_record
+
+        expect(previous_record).not_to be_nil
+        expect(previous_record.id).to eq(1)
+        expect(previous_record.name).to eq('First Record Updated')
+        expect(previous_record.oid).to be < latest_operation.oid
+      end
+
+      it 'returns records ordered by oid in descending order' do
+        latest_operation = TestRecord::Operation.where(id: 1).order(Sequel.desc(:oid)).first
+        test_record = TestRecord.new(id: 1, oid: latest_operation.oid)
+
+        previous_record = test_record.previous_record
+
+        expect(previous_record.oid).to be < latest_operation.oid
+
+        if previous_record
+          second_test_record = TestRecord.new(id: 1, oid: previous_record.oid)
+          second_previous = second_test_record.previous_record
+          if second_previous
+            expect(second_previous.oid).to be < previous_record.oid
+          end
+        end
+      end
+    end
+
+    context 'when there is only one operation record for an entity' do
+      before do
+        TestRecord::Operation.insert(
+          id: 1,
+          name: 'Single Record',
+          description: 'Only record',
+          operation: 'C',
+          operation_date: Time.zone.now,
+        )
+      end
+
+      it 'returns nil when there is no previous record' do
+        operation = TestRecord::Operation.where(id: 1).first
+        test_record = TestRecord.new(id: 1, oid: operation.oid)
+
+        previous_record = test_record.previous_record
+
+        expect(previous_record).to be_nil
+      end
+    end
+
+    context 'when filtering by primary keys other than oid' do
+      before do
+        3.times do |i|
+          TestRecord::Operation.insert(
+            id: 1,
+            name: "Version #{i + 1}",
+            description: "Description #{i + 1}",
+            operation: 'U',
+            operation_date: Time.zone.now - (i * 1.day),
+          )
+        end
+      end
+
+      it 'correctly filters by all primary keys except oid' do
+        latest_operation = TestRecord::Operation.where(id: 1).order(Sequel.desc(:oid)).first
+        test_record = TestRecord.new(id: 1, oid: latest_operation.oid)
+
+        previous_record = test_record.previous_record
+
+        expect(previous_record).not_to be_nil
+        expect(previous_record.id).to eq(1)
+        expect(previous_record.oid).to be < latest_operation.oid
+      end
+    end
+
+    context 'with composite primary keys' do
+      it 'handles composite primary keys correctly' do
+        CompositeTestRecord::Operation.insert(part_a: 1, part_b: 2, data: 'First', operation: 'C')
+        CompositeTestRecord::Operation.insert(part_a: 1, part_b: 2, data: 'Second', operation: 'U')
+        CompositeTestRecord::Operation.insert(part_a: 1, part_b: 3, data: 'Different', operation: 'C')
+
+        latest_operation = CompositeTestRecord::Operation.where(part_a: 1, part_b: 2).order(Sequel.desc(:oid)).first
+        test_record = CompositeTestRecord.new(part_a: 1, part_b: 2, oid: latest_operation.oid)
+
+        previous_record = test_record.previous_record
+
+        expect(previous_record).not_to be_nil
+        expect(previous_record.part_a).to eq(1)
+        expect(previous_record.part_b).to eq(2)
+        expect(previous_record.data).to eq('First')
+        expect(previous_record.oid).to be < latest_operation.oid
+      end
+
+      it 'does not return records with different composite key values' do
+        CompositeTestRecord::Operation.insert(part_a: 1, part_b: 2, data: 'Target', operation: 'C')
+        CompositeTestRecord::Operation.insert(part_a: 1, part_b: 3, data: 'Different', operation: 'C')
+
+        operation = CompositeTestRecord::Operation.where(part_a: 1, part_b: 2).first
+        test_record = CompositeTestRecord.new(part_a: 1, part_b: 2, oid: operation.oid)
+
+        previous_record = test_record.previous_record
+
+        expect(previous_record).to be_nil
+      end
+    end
+  end
+end
+
+# rubocop:enable Style/ConstantDefinitionInBlock
+# rubocop:enable Style/BeforeAfterAll
+# rubocop:enable Style/LeakyConstantDeclaration

--- a/spec/services/delta_report_service/additional_code_changes_spec.rb
+++ b/spec/services/delta_report_service/additional_code_changes_spec.rb
@@ -128,29 +128,6 @@ RSpec.describe DeltaReportService::AdditionalCodeChanges do
     end
   end
 
-  describe '#previous_record' do
-    let(:previous_additional_code) { build(:additional_code) }
-
-    before do
-      allow(AdditionalCode).to receive(:operation_klass).and_return(AdditionalCode)
-      allow(AdditionalCode).to receive_message_chain(:where, :where, :order, :first)
-                         .and_return(previous_additional_code)
-    end
-
-    it 'queries for the previous record by additional_code_sid and oid' do
-      result = instance.previous_record
-
-      expect(result).to eq(previous_additional_code)
-    end
-
-    it 'memoizes the result' do
-      instance.previous_record
-      instance.previous_record
-
-      expect(AdditionalCode).to have_received(:operation_klass).once
-    end
-  end
-
   describe 'integration with BaseChanges' do
     it 'inherits from BaseChanges' do
       expect(described_class.superclass).to eq(DeltaReportService::BaseChanges)

--- a/spec/services/delta_report_service/base_changes_spec.rb
+++ b/spec/services/delta_report_service/base_changes_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe DeltaReportService::BaseChanges do
     let(:get_changes_instance) { test_class.new(get_changes_record, date) }
 
     before do
-      get_changes_instance.previous_record = previous_record
+      allow(get_changes_record).to receive(:previous_record).and_return(previous_record)
     end
 
     context 'when operation is update' do
@@ -125,8 +125,7 @@ RSpec.describe DeltaReportService::BaseChanges do
 
     context 'when no previous record exists' do
       before do
-        allow(get_changes_record).to receive(:operation).and_return(:update)
-        get_changes_instance.previous_record = nil
+        allow(get_changes_record).to receive_messages(operation: :update, previous_record: nil)
       end
 
       it 'does not set changes' do

--- a/spec/services/delta_report_service/certificate_changes_spec.rb
+++ b/spec/services/delta_report_service/certificate_changes_spec.rb
@@ -82,27 +82,4 @@ RSpec.describe DeltaReportService::CertificateChanges do
       end
     end
   end
-
-  describe '#previous_record' do
-    let(:previous_certificate) { build(:certificate) }
-
-    before do
-      allow(Certificate).to receive(:operation_klass).and_return(Certificate)
-      allow(Certificate).to receive_message_chain(:where, :where, :order, :first)
-                         .and_return(previous_certificate)
-    end
-
-    it 'queries for the previous record by certificate_code, certificate_type_code and oid' do
-      result = instance.previous_record
-
-      expect(result).to eq(previous_certificate)
-    end
-
-    it 'memoizes the result' do
-      instance.previous_record
-      instance.previous_record
-
-      expect(Certificate).to have_received(:operation_klass).once
-    end
-  end
 end

--- a/spec/services/delta_report_service/commodity_changes_spec.rb
+++ b/spec/services/delta_report_service/commodity_changes_spec.rb
@@ -79,27 +79,4 @@ RSpec.describe DeltaReportService::CommodityChanges do
       end
     end
   end
-
-  describe '#previous_record' do
-    let(:previous_goods_nomenclature) { build(:goods_nomenclature) }
-
-    before do
-      allow(GoodsNomenclature).to receive(:operation_klass).and_return(GoodsNomenclature)
-      allow(GoodsNomenclature).to receive_message_chain(:where, :where, :order, :first)
-                               .and_return(previous_goods_nomenclature)
-    end
-
-    it 'queries for the previous record by goods_nomenclature_sid and oid' do
-      result = instance.previous_record
-
-      expect(result).to eq(previous_goods_nomenclature)
-    end
-
-    it 'memoizes the result' do
-      instance.previous_record
-      instance.previous_record
-
-      expect(GoodsNomenclature).to have_received(:operation_klass).once
-    end
-  end
 end

--- a/spec/services/delta_report_service/footnote_association_goods_nomenclature_changes_spec.rb
+++ b/spec/services/delta_report_service/footnote_association_goods_nomenclature_changes_spec.rb
@@ -162,28 +162,4 @@ RSpec.describe DeltaReportService::FootnoteAssociationGoodsNomenclatureChanges d
       end
     end
   end
-
-  describe '#previous_record' do
-    let(:instance) { described_class.new(footnote_association, date) }
-    let(:previous_footnote_association) { build(:footnote_association_goods_nomenclature) }
-
-    before do
-      allow(FootnoteAssociationGoodsNomenclature).to receive(:operation_klass).and_return(FootnoteAssociationGoodsNomenclature)
-      allow(FootnoteAssociationGoodsNomenclature).to receive_message_chain(:where, :where, :order, :first)
-                         .and_return(previous_footnote_association)
-    end
-
-    it 'queries for the previous record by goods_nomenclature_sid, footnote_id, footnote_type and oid' do
-      result = instance.previous_record
-
-      expect(result).to eq(previous_footnote_association)
-    end
-
-    it 'memoizes the result' do
-      instance.previous_record
-      instance.previous_record
-
-      expect(FootnoteAssociationGoodsNomenclature).to have_received(:operation_klass).once
-    end
-  end
 end

--- a/spec/services/delta_report_service/footnote_association_measure_changes_spec.rb
+++ b/spec/services/delta_report_service/footnote_association_measure_changes_spec.rb
@@ -196,28 +196,4 @@ RSpec.describe DeltaReportService::FootnoteAssociationMeasureChanges do
       expect(instance.date_of_effect).to eq(date)
     end
   end
-
-  describe '#previous_record' do
-    let(:instance) { described_class.new(footnote_association, date) }
-    let(:previous_footnote_association) { build(:footnote_association_measure) }
-
-    before do
-      allow(FootnoteAssociationMeasure).to receive(:operation_klass).and_return(FootnoteAssociationMeasure)
-      allow(FootnoteAssociationMeasure).to receive_message_chain(:where, :where, :order, :first)
-                         .and_return(previous_footnote_association)
-    end
-
-    it 'queries for the previous record by measure_sid, footnote_id, footnote_type_id and oid' do
-      result = instance.previous_record
-
-      expect(result).to eq(previous_footnote_association)
-    end
-
-    it 'memoizes the result' do
-      instance.previous_record
-      instance.previous_record
-
-      expect(FootnoteAssociationMeasure).to have_received(:operation_klass).once
-    end
-  end
 end

--- a/spec/services/delta_report_service/footnote_changes_spec.rb
+++ b/spec/services/delta_report_service/footnote_changes_spec.rb
@@ -81,27 +81,4 @@ RSpec.describe DeltaReportService::FootnoteChanges do
       end
     end
   end
-
-  describe '#previous_record' do
-    let(:previous_footnote) { build(:footnote) }
-
-    before do
-      allow(Footnote).to receive(:operation_klass).and_return(Footnote)
-      allow(Footnote).to receive_message_chain(:where, :where, :order, :first)
-                         .and_return(previous_footnote)
-    end
-
-    it 'queries for the previous record by footnote_code, footnote_type_code and oid' do
-      result = instance.previous_record
-
-      expect(result).to eq(previous_footnote)
-    end
-
-    it 'memoizes the result' do
-      instance.previous_record
-      instance.previous_record
-
-      expect(Footnote).to have_received(:operation_klass).once
-    end
-  end
 end

--- a/spec/services/delta_report_service/geographical_area_changes_spec.rb
+++ b/spec/services/delta_report_service/geographical_area_changes_spec.rb
@@ -80,27 +80,4 @@ RSpec.describe DeltaReportService::GeographicalAreaChanges do
       end
     end
   end
-
-  describe '#previous_record' do
-    let(:previous_geographical_area) { build(:geographical_area) }
-
-    before do
-      allow(GeographicalArea).to receive(:operation_klass).and_return(GeographicalArea)
-      allow(GeographicalArea).to receive_message_chain(:where, :where, :order, :first)
-                               .and_return(previous_geographical_area)
-    end
-
-    it 'queries for the previous record by geographical_area_id and oid' do
-      result = instance.previous_record
-
-      expect(result).to eq(previous_geographical_area)
-    end
-
-    it 'memoizes the result' do
-      instance.previous_record
-      instance.previous_record
-
-      expect(GeographicalArea).to have_received(:operation_klass).once
-    end
-  end
 end

--- a/spec/services/delta_report_service/measure_changes_spec.rb
+++ b/spec/services/delta_report_service/measure_changes_spec.rb
@@ -113,27 +113,4 @@ RSpec.describe DeltaReportService::MeasureChanges do
       end
     end
   end
-
-  describe '#previous_record' do
-    let(:previous_measure) { build(:measure) }
-
-    before do
-      allow(Measure).to receive(:operation_klass).and_return(Measure)
-      allow(Measure).to receive_message_chain(:where, :where, :order, :first)
-                     .and_return(previous_measure)
-    end
-
-    it 'queries for the previous record by measure_sid and oid' do
-      result = instance.previous_record
-
-      expect(result).to eq(previous_measure)
-    end
-
-    it 'memoizes the result' do
-      instance.previous_record
-      instance.previous_record
-
-      expect(Measure).to have_received(:operation_klass).once
-    end
-  end
 end

--- a/spec/services/delta_report_service/measure_component_changes_spec.rb
+++ b/spec/services/delta_report_service/measure_component_changes_spec.rb
@@ -119,27 +119,4 @@ RSpec.describe DeltaReportService::MeasureComponentChanges do
       expect(instance.date_of_effect).to eq(date)
     end
   end
-
-  describe '#previous_record' do
-    let(:previous_measure_component) { build(:measure_component) }
-
-    before do
-      allow(MeasureComponent).to receive(:operation_klass).and_return(MeasureComponent)
-      allow(MeasureComponent).to receive_message_chain(:where, :where, :where, :order, :first)
-                               .and_return(previous_measure_component)
-    end
-
-    it 'queries for the previous record by measure_sid, duty_expression_id and oid' do
-      result = instance.previous_record
-
-      expect(result).to eq(previous_measure_component)
-    end
-
-    it 'memoizes the result' do
-      instance.previous_record
-      instance.previous_record
-
-      expect(MeasureComponent).to have_received(:operation_klass).once
-    end
-  end
 end

--- a/spec/services/delta_report_service/measure_condition_changes_spec.rb
+++ b/spec/services/delta_report_service/measure_condition_changes_spec.rb
@@ -137,27 +137,4 @@ RSpec.describe DeltaReportService::MeasureConditionChanges do
       end
     end
   end
-
-  describe '#previous_record' do
-    let(:previous_measure_condition) { build(:measure_condition) }
-
-    before do
-      allow(MeasureCondition).to receive(:operation_klass).and_return(MeasureCondition)
-      allow(MeasureCondition).to receive_message_chain(:where, :where, :order, :first)
-                               .and_return(previous_measure_condition)
-    end
-
-    it 'queries for the previous record by measure_condition_sid and oid' do
-      result = instance.previous_record
-
-      expect(result).to eq(previous_measure_condition)
-    end
-
-    it 'memoizes the result' do
-      instance.previous_record
-      instance.previous_record
-
-      expect(MeasureCondition).to have_received(:operation_klass).once
-    end
-  end
 end


### PR DESCRIPTION
### What?

There were very similar 'previous_record' methods being used as part of the delta report. 
This method has been extracted and made available as part of the oplog plugin for all models.

The method retrieves the most recent previous record for the record according to the oplog. This is used by the delta report to see what attribute has changed.

