### PR TITLE
Fix effect date in delta report

### DIFF
--- a/app/services/delta_report_service.rb
+++ b/app/services/delta_report_service.rb
@@ -135,13 +135,15 @@ class DeltaReportService
   end
 
   def find_declarable_goods_for_certificate(change)
-    conditions = Sequel::Model.db[:measure_conditions]
+    conditions = Sequel::Model.db[:measure_conditions_oplog]
       .where(certificate_type_code: change[:certificate_type_code])
       .where(certificate_code: change[:certificate_code])
       .distinct(:measure_sid)
 
     affected_goods = []
     conditions.each do |condition|
+      next if condition[:operation_date] == date
+
       measure = Sequel::Model.db[:measures]
         .where(measure_sid: condition[:measure_sid])
         .first

--- a/app/services/delta_report_service/base_changes.rb
+++ b/app/services/delta_report_service/base_changes.rb
@@ -41,14 +41,14 @@ class DeltaReportService
     end
 
     def date_of_effect
-      if changes.include?('validity_start_date')
+      if changes.include?('validity start date') && record.validity_start_date.present?
         record.validity_start_date
-      elsif changes.include?('validity_end_date')
-        record.validity_end_date
-      elsif record.validity_start_date > record.operation_date
-        record.validity_start_date
+      elsif changes.include?('validity end date') && record.validity_end_date.present?
+        record.validity_end_date + 1.day
+      elsif record.operation == :create && record.respond_to?(:validity_start_date)
+        record.validity_start_date + 1.day
       else
-        date
+        date + 1.day
       end
     end
 

--- a/app/services/delta_report_service/measure_condition_changes.rb
+++ b/app/services/delta_report_service/measure_condition_changes.rb
@@ -11,12 +11,14 @@ class DeltaReportService
     end
 
     def object_name
-      'Measure Condition'
+      (record.requirement_type || 'Measure Condition').to_s.humanize&.capitalize
     end
 
     def analyze
       return if no_changes?
       return if record.operation == :create && record.measure.operation_date == record.operation_date
+
+      @changes = []
 
       {
         type: 'MeasureCondition',
@@ -28,8 +30,18 @@ class DeltaReportService
         duty_expression: duty_expression(record.measure),
         description:,
         date_of_effect:,
-        change: change || '',
+        change:,
       }
+    end
+
+    def change
+      if record.requirement_type == :document
+        "#{record.document_code}: #{record.certificate_description}: #{record.action}"
+      elsif record.requirement_type == :duty_expression
+        "#{record.last.requirement_duty_expression} : #{record.action}"
+      else
+        record.action
+      end
     end
 
     def date_of_effect

--- a/spec/services/delta_report_service/base_changes_spec.rb
+++ b/spec/services/delta_report_service/base_changes_spec.rb
@@ -157,10 +157,10 @@ RSpec.describe DeltaReportService::BaseChanges do
     end
 
     context 'when validity_end_date is in changes' do
-      before { date_instance.changes = %w[validity_end_date] }
+      before { date_instance.changes = ['validity end date'] }
 
       it 'returns validity_end_date' do
-        expect(date_instance.date_of_effect).to eq(validity_end_date)
+        expect(date_instance.date_of_effect).to eq(validity_end_date + 1.day)
       end
     end
 
@@ -168,17 +168,7 @@ RSpec.describe DeltaReportService::BaseChanges do
       before { date_instance.changes = [] }
 
       it 'returns validity_start_date' do
-        expect(date_instance.date_of_effect).to eq(validity_start_date)
-      end
-    end
-
-    context 'when validity_start_date is not after operation_date and no validity changes' do
-      let(:validity_start_date) { Date.parse('2024-08-05') }
-
-      before { date_instance.changes = [] }
-
-      it 'returns the date parameter' do
-        expect(date_instance.date_of_effect).to eq(date)
+        expect(date_instance.date_of_effect).to eq(validity_start_date + 1.day)
       end
     end
   end

--- a/spec/services/delta_report_service/certificate_changes_spec.rb
+++ b/spec/services/delta_report_service/certificate_changes_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe DeltaReportService::CertificateChanges do
   let(:date) { Date.parse('2024-08-11') }
 
   let(:certificate) do
-    build(:certificate, certificate_type_code: 'Y', certificate_code: '999')
+    create(:certificate, :with_description, certificate_type_code: 'Y', certificate_code: '999')
   end
   let(:instance) { described_class.new(certificate, date) }
 

--- a/spec/services/delta_report_service/measure_condition_changes_spec.rb
+++ b/spec/services/delta_report_service/measure_condition_changes_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe DeltaReportService::MeasureConditionChanges do
 
   describe '#object_name' do
     it 'returns the correct object name' do
-      expect(instance.object_name).to eq('Measure Condition')
+      expect(instance.object_name).to eq('Document')
     end
   end
 
@@ -111,7 +111,7 @@ RSpec.describe DeltaReportService::MeasureConditionChanges do
 
       it 'sets change to empty string' do
         result = instance.analyze
-        expect(result[:change]).to eq('')
+        expect(result[:change]).to be_nil
       end
     end
   end

--- a/spec/services/delta_report_service_spec.rb
+++ b/spec/services/delta_report_service_spec.rb
@@ -538,7 +538,7 @@ RSpec.describe DeltaReportService do
 
     context 'when change type is Certificate' do
       let(:change) { { type: 'Certificate', certificate_type_code: 'Y', certificate_code: '999' } }
-      let(:condition_records) { [{ measure_sid: 123 }] }
+      let(:condition_records) { [{ measure_sid: 123, operation_date: Date.parse('2024-08-10') }] }
       let(:measure_record) { { goods_nomenclature_item_id: '0101000000' } }
       let(:declarable_commodity) { instance_double(Commodity, goods_nomenclature_item_id: '0101000000', declarable?: true) }
 
@@ -548,7 +548,7 @@ RSpec.describe DeltaReportService do
         measures_dataset = instance_double(Sequel::Dataset)
 
         allow(Sequel::Model).to receive(:db).and_return(db_double)
-        allow(db_double).to receive(:[]).with(:measure_conditions).and_return(conditions_dataset)
+        allow(db_double).to receive(:[]).with(:measure_conditions_oplog).and_return(conditions_dataset)
         allow(db_double).to receive(:[]).with(:measures).and_return(measures_dataset)
 
         filtered_conditions = mock_filtered_dataset(conditions_dataset, [


### PR DESCRIPTION
### What?

Effect date is now based on the validity start date + 1 day, the validity end date, or the change date + 1 day.
This better reflects when the listed change actually comes into effect.

More details have been added for changes to Certificates and MeasureConditions to give more context to users.

Changes to certificates that happen on the same day as a related MeasureCondition change are now ignored to prevent duplication.
