### PR TITLE
Various delta report changes

### DIFF
--- a/app/services/delta_report_service/additional_code_changes.rb
+++ b/app/services/delta_report_service/additional_code_changes.rb
@@ -25,6 +25,9 @@ class DeltaReportService
         date_of_effect:,
         change: change || '',
       }
+    rescue StandardError => e
+      Rails.logger.error "Error with #{object_name} OID #{record.oid}"
+      raise e
     end
   end
 end

--- a/app/services/delta_report_service/base_changes.rb
+++ b/app/services/delta_report_service/base_changes.rb
@@ -34,7 +34,12 @@ class DeltaReportService
 
           next if current_value == previous_value
 
-          @change = current_value if change.blank?
+          @change ||= if %i[validity_start_date validity_end_date].include?(column)
+                        current_value&.to_date&.iso8601 || 'Removed'
+                      else
+                        current_value
+                      end
+
           @changes << column.to_s.humanize.downcase
         end
       end

--- a/app/services/delta_report_service/certificate_changes.rb
+++ b/app/services/delta_report_service/certificate_changes.rb
@@ -17,14 +17,19 @@ class DeltaReportService
     def analyze
       return if no_changes?
 
-      {
-        type: 'Certificate',
-        certificate_type_code: record.certificate_type_code,
-        certificate_code: record.certificate_code,
-        date_of_effect:,
-        description:,
-        change: change || record.id,
-      }
+      TimeMachine.at(record.validity_start_date) do
+        {
+          type: 'Certificate',
+          certificate_type_code: record.certificate_type_code,
+          certificate_code: record.certificate_code,
+          date_of_effect:,
+          description:,
+          change: change || record.id,
+        }
+      end
+    rescue StandardError => e
+      Rails.logger.error "Error with #{object_name} OID #{record.oid}"
+      raise e
     end
   end
 end

--- a/app/services/delta_report_service/commodity_changes.rb
+++ b/app/services/delta_report_service/commodity_changes.rb
@@ -26,6 +26,9 @@ class DeltaReportService
         description:,
         change: change || record.code,
       }
+    rescue StandardError => e
+      Rails.logger.error "Error with #{object_name} OID #{record.oid}"
+      raise e
     end
   end
 end

--- a/app/services/delta_report_service/excel_generator.rb
+++ b/app/services/delta_report_service/excel_generator.rb
@@ -67,7 +67,6 @@ class DeltaReportService
         'Measure Type',
         'Measure Geo area',
         'Additional code',
-        'Duty Expression',
         'Type of change',
         'Updated code/data',
         'Date of effect',
@@ -88,7 +87,6 @@ class DeltaReportService
         30,  # Measure Type
         30,  # Geo Area
         30,  # Additional Code
-        30,  # Duty Expression
         30,  # Type of Change
         30,  # Updated code/data
         22,  # Date of effect
@@ -105,7 +103,6 @@ class DeltaReportService
         :string,  # Measure Type
         :string,  # Geo Area
         :string,  # Additional Code
-        :string,  # Duty Expression
         :string,  # Type of Change
         :string,  # Updated code/data
         :string,  # Date of effect
@@ -205,9 +202,8 @@ class DeltaReportService
         styles[:text],           # Measure Type
         styles[:text],           # Geo Area
         styles[:text],           # Additional Code
-        styles[:text],           # Duty Expression
-        change_style,            # Type of Change (conditional styling)
-        styles[:text],           # Updated code/data
+        styles[:text],           # Type of Change
+        change_style,            # Updated code/data (conditional styling)
         styles[:date],           # Date of effect
         styles[:date],           # Operation Date
       ]
@@ -222,7 +218,6 @@ class DeltaReportService
         record[:measure_type],
         record[:geo_area],
         record[:additional_code],
-        record[:duty_expression],
         record[:type_of_change],
         record[:change],
         record[:date_of_effect]&.strftime('%Y-%m-%d'),

--- a/app/services/delta_report_service/excluded_geographical_area_changes.rb
+++ b/app/services/delta_report_service/excluded_geographical_area_changes.rb
@@ -15,7 +15,7 @@ class DeltaReportService
     end
 
     def analyze
-      return if record.measure.operation_date == record.operation_date
+      return if Measure::Operation.where(measure_sid: record.measure_sid, operation_date: record.operation_date).any?
 
       {
         type: 'ExcludedGeographicalArea',
@@ -24,11 +24,13 @@ class DeltaReportService
         import_export: import_export(record.measure),
         geo_area: geo_area(record.geographical_area),
         additional_code: additional_code(record.measure.additional_code),
-        duty_expression: duty_expression(record.measure),
         date_of_effect: date,
-        description: 'Excluded geo area',
+        description:,
         change: "Excluded #{record.excluded_geographical_area}",
       }
+    rescue StandardError => e
+      Rails.logger.error "Error with #{object_name} OID #{record.oid}"
+      raise e
     end
   end
 end

--- a/app/services/delta_report_service/footnote_association_goods_nomenclature_changes.rb
+++ b/app/services/delta_report_service/footnote_association_goods_nomenclature_changes.rb
@@ -16,16 +16,19 @@ class DeltaReportService
 
     def analyze
       return if no_changes?
-      return if record.operation == :create && record.goods_nomenclature.operation_date == record.operation_date
-      return if record.operation == :create && record.footnote.operation_date == record.operation_date
+      return if record.operation == :create && GoodsNomenclature::Operation.where(goods_nomenclature_sid: record.goods_nomenclature_sid, operation_date: record.operation_date).any?
+      return if record.operation == :create && Footnote::Operation.where(footnote_type_id: record.footnote_type, footnote_id: record.footnote_id, operation_date: record.operation_date).any?
 
       {
         type: 'FootnoteAssociationGoodsNomenclature',
         goods_nomenclature_item_id: record.goods_nomenclature.goods_nomenclature_item_id,
         description:,
         date_of_effect:,
-        change: change.present? ? "#{record.footnote.code}: #{change}" : record.footnote.code,
+        change: change.present? ? "#{record.footnote.code}: #{change}" : "#{record.footnote.code}: #{record.footnote.description}",
       }
+    rescue StandardError => e
+      Rails.logger.error "Error with #{object_name} OID #{record.oid}"
+      raise e
     end
   end
 end

--- a/app/services/delta_report_service/footnote_association_measure_changes.rb
+++ b/app/services/delta_report_service/footnote_association_measure_changes.rb
@@ -16,8 +16,8 @@ class DeltaReportService
 
     def analyze
       return if no_changes?
-      return if record.operation == :create && record.measure.operation_date == record.operation_date
-      return if record.operation == :create && record.footnote.operation_date == record.operation_date
+      return if record.operation == :create && Measure::Operation.where(measure_sid: record.measure_sid, operation_date: record.operation_date).any?
+      return if record.operation == :create && Footnote::Operation.where(footnote_type_id: record.footnote_type_id, footnote_id: record.footnote_id, operation_date: record.operation_date).any?
 
       {
         type: 'FootnoteAssociationMeasure',
@@ -26,11 +26,13 @@ class DeltaReportService
         import_export: import_export(record.measure),
         geo_area: geo_area(record.measure.geographical_area),
         additional_code: additional_code(record.measure.additional_code),
-        duty_expression: duty_expression(record.measure),
         description:,
         date_of_effect:,
-        change: change.present? ? "#{record.footnote.code}: #{change}" : record.footnote.code,
+        change: change.present? ? "#{record.footnote.code}: #{change}" : "#{record.footnote.code}: #{record.footnote.description}",
       }
+    rescue StandardError => e
+      Rails.logger.error "Error with #{object_name} OID #{record.oid}"
+      raise e
     end
 
     def date_of_effect

--- a/app/services/delta_report_service/footnote_changes.rb
+++ b/app/services/delta_report_service/footnote_changes.rb
@@ -19,13 +19,18 @@ class DeltaReportService
     def analyze
       return if no_changes?
 
-      {
-        type: 'Footnote',
-        footnote_oid: record.oid,
-        description:,
-        date_of_effect:,
-        change: change.present? ? "#{record.code}: #{change}" : record.code,
-      }
+      TimeMachine.at(record.validity_start_date) do
+        {
+          type: 'Footnote',
+          footnote_oid: record.oid,
+          description:,
+          date_of_effect:,
+          change: change.present? ? "#{record.code}: #{change}" : "#{record.code}: #{record.description}",
+        }
+      end
+    rescue StandardError => e
+      Rails.logger.error "Error with #{object_name} OID #{record.oid}"
+      raise e
     end
   end
 end

--- a/app/services/delta_report_service/geographical_area_changes.rb
+++ b/app/services/delta_report_service/geographical_area_changes.rb
@@ -24,6 +24,9 @@ class DeltaReportService
         description: description,
         change: change || geo_area(record),
       }
+    rescue StandardError => e
+      Rails.logger.error "Error with #{object_name} OID #{record.oid}"
+      raise e
     end
   end
 end

--- a/app/services/delta_report_service/measure_changes.rb
+++ b/app/services/delta_report_service/measure_changes.rb
@@ -30,11 +30,13 @@ class DeltaReportService
         import_export: import_export(record),
         geo_area: geo_area(record.geographical_area),
         additional_code: additional_code(record.additional_code),
-        duty_expression: duty_expression(record),
         description:,
         date_of_effect:,
         change: change || measure_type(record),
       }
+    rescue StandardError => e
+      Rails.logger.error "Error with #{object_name} OID #{record.oid}"
+      raise e
     end
   end
 end

--- a/app/services/delta_report_service/measure_component_changes.rb
+++ b/app/services/delta_report_service/measure_component_changes.rb
@@ -11,7 +11,7 @@ class DeltaReportService
     end
 
     def object_name
-      'Measure Component'
+      record.measure.supplementary? ? 'Supplementary Unit' : 'Tariff Duty'
     end
 
     def analyze

--- a/app/services/delta_report_service/measure_component_changes.rb
+++ b/app/services/delta_report_service/measure_component_changes.rb
@@ -16,7 +16,7 @@ class DeltaReportService
 
     def analyze
       return if no_changes?
-      return if record.operation == :create && record.measure.operation_date == record.operation_date
+      return if record.operation == :create && Measure::Operation.where(measure_sid: record.measure_sid, operation_date: record.operation_date).any?
 
       {
         type: 'MeasureComponent',
@@ -25,11 +25,13 @@ class DeltaReportService
         import_export: import_export(record.measure),
         geo_area: geo_area(record.measure.geographical_area),
         additional_code: additional_code(record.measure.additional_code),
-        duty_expression: duty_expression(record.measure),
         description:,
         date_of_effect:,
         change: change || duty_expression(record.measure),
       }
+    rescue StandardError => e
+      Rails.logger.error "Error with #{object_name} OID #{record.oid}"
+      raise e
     end
 
     def date_of_effect

--- a/app/services/delta_report_service/measure_presenter.rb
+++ b/app/services/delta_report_service/measure_presenter.rb
@@ -32,7 +32,7 @@ class DeltaReportService
     end
 
     def duty_expression(measure)
-      measure.duty_expression
+      measure.supplementary_unit_duty_expression || measure.duty_expression
     end
   end
 end

--- a/spec/services/delta_report_service/excel_generator_spec.rb
+++ b/spec/services/delta_report_service/excel_generator_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe DeltaReportService::ExcelGenerator do
           measure_type: '103: Third country duty',
           geo_area: 'GB: United Kingdom',
           additional_code: 'A123: Special code',
-          duty_expression: '10%',
           type_of_change: 'Measure added',
           change: 'new measure',
           date_of_effect: date,
@@ -25,7 +24,6 @@ RSpec.describe DeltaReportService::ExcelGenerator do
           measure_type: '104: Export duty',
           geo_area: 'US: United States',
           additional_code: nil,
-          duty_expression: '5%',
           type_of_change: 'Measure updated',
           change: 'duty rate changed',
           date_of_effect: date + 1.day,
@@ -154,7 +152,6 @@ RSpec.describe DeltaReportService::ExcelGenerator do
         'Measure Type',
         'Measure Geo area',
         'Additional code',
-        'Duty Expression',
         'Type of change',
         'Updated code/data',
         'Date of effect',
@@ -169,7 +166,7 @@ RSpec.describe DeltaReportService::ExcelGenerator do
     let(:instance) { described_class.new(change_records, date) }
 
     it 'returns the correct autofilter range' do
-      expect(instance.excel_autofilter_range).to eq('A2:L2')
+      expect(instance.excel_autofilter_range).to eq('A2:K2')
     end
   end
 
@@ -180,7 +177,7 @@ RSpec.describe DeltaReportService::ExcelGenerator do
       widths = instance.excel_column_widths
 
       expect(widths).to be_an(Array)
-      expect(widths.size).to eq(12)
+      expect(widths.size).to eq(11)
       expect(widths[0]).to eq(15)  # Chapter
       expect(widths[1]).to eq(20)  # Commodity Code
       expect(widths[2]).to eq(50)  # Commodity Description
@@ -194,7 +191,7 @@ RSpec.describe DeltaReportService::ExcelGenerator do
       types = instance.excel_cell_types
 
       expect(types).to be_an(Array)
-      expect(types.size).to eq(12)
+      expect(types.size).to eq(11)
       expect(types).to all(eq(:string))
     end
   end
@@ -214,7 +211,6 @@ RSpec.describe DeltaReportService::ExcelGenerator do
         '103: Third country duty',
         'GB: United Kingdom',
         'A123: Special code',
-        '10%',
         'Measure added',
         'new measure',
         '2024-08-11',
@@ -227,7 +223,7 @@ RSpec.describe DeltaReportService::ExcelGenerator do
 
       it 'handles nil date_of_effect gracefully' do
         result = instance.build_excel_row(record)
-        expect(result[10]).to be_nil
+        expect(result[9]).to be_nil
       end
     end
   end
@@ -314,7 +310,7 @@ RSpec.describe DeltaReportService::ExcelGenerator do
     it 'returns the correct number of style elements' do
       record = { type_of_change: 'added' }
       result = instance.build_row_styles(styles, record)
-      expect(result.size).to eq(12)
+      expect(result.size).to eq(11)
     end
   end
 end

--- a/spec/services/delta_report_service/excluded_geographical_area_changes_spec.rb
+++ b/spec/services/delta_report_service/excluded_geographical_area_changes_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe DeltaReportService::ExcludedGeographicalAreaChanges do
       geographical_area: geographical_area,
     )
     allow(instance).to receive(:get_changes)
+    allow(Measure::Operation).to receive_message_chain(:where, :any?).and_return(false)
   end
 
   describe '.collect' do
@@ -64,7 +65,6 @@ RSpec.describe DeltaReportService::ExcludedGeographicalAreaChanges do
         import_export: 'Import',
         geo_area: 'GB: United Kingdom',
         additional_code: nil,
-        duty_expression: '10%',
       )
     end
 
@@ -72,6 +72,7 @@ RSpec.describe DeltaReportService::ExcludedGeographicalAreaChanges do
       before do
         allow(measure).to receive(:operation_date).and_return(date)
         allow(excluded_geo_area).to receive(:operation_date).and_return(date)
+        allow(Measure::Operation).to receive_message_chain(:where, :any?).and_return(true)
       end
 
       it 'returns nil (filters out matching dates)' do
@@ -99,9 +100,8 @@ RSpec.describe DeltaReportService::ExcludedGeographicalAreaChanges do
           import_export: 'Import',
           geo_area: 'GB: United Kingdom',
           additional_code: nil,
-          duty_expression: '10%',
           date_of_effect: date,
-          description: 'Excluded geo area',
+          description: 'Excluded Geo Area added',
           change: 'Excluded IE',
         })
       end
@@ -112,8 +112,8 @@ RSpec.describe DeltaReportService::ExcludedGeographicalAreaChanges do
         allow(excluded_geo_area).to receive(:measure).and_return(nil)
       end
 
-      it 'raises an error when trying to access operation_date' do
-        expect { instance.analyze }.to raise_error(NoMethodError, /undefined method.*operation_date.*for nil/)
+      it 'raises an error when trying to access additional_code' do
+        expect { instance.analyze }.to raise_error(NoMethodError, /undefined method.*additional_code.*for nil/)
       end
     end
 
@@ -251,7 +251,7 @@ RSpec.describe DeltaReportService::ExcludedGeographicalAreaChanges do
         expect(result[:measure_sid]).to eq('20260381')
         expect(result[:change]).to eq('Excluded RU')
         expect(result[:date_of_effect]).to eq(date)
-        expect(result[:description]).to eq('Excluded geo area')
+        expect(result[:description]).to eq('Excluded Geo Area added')
       end
     end
 
@@ -259,6 +259,7 @@ RSpec.describe DeltaReportService::ExcludedGeographicalAreaChanges do
       before do
         allow(measure).to receive(:operation_date).and_return(date)
         allow(excluded_geo_area).to receive(:operation_date).and_return(date)
+        allow(Measure::Operation).to receive_message_chain(:where, :any?).and_return(true)
       end
 
       it 'filters out records with matching operation dates' do

--- a/spec/services/delta_report_service/footnote_changes_spec.rb
+++ b/spec/services/delta_report_service/footnote_changes_spec.rb
@@ -1,13 +1,11 @@
 RSpec.describe DeltaReportService::FootnoteChanges do
   let(:date) { Date.parse('2024-08-11') }
 
-  let(:footnote) { build(:footnote, oid: '999') }
-  let(:footnote_desc) { build(:footnote_description, description: 'Footnote description') }
+  let(:footnote) { create(:footnote, :with_description, oid: '999') }
   let(:instance) { described_class.new(footnote, date) }
 
   before do
     allow(instance).to receive(:get_changes)
-    allow(footnote).to receive(:footnote_description).and_return(footnote_desc)
   end
 
   describe '.collect' do
@@ -64,10 +62,10 @@ RSpec.describe DeltaReportService::FootnoteChanges do
 
         expect(result).to eq({
           type: 'Footnote',
-          footnote_oid: 999,
+          footnote_oid: footnote.oid,
           date_of_effect: date,
           description: 'Footnote updated',
-          change: footnote.code,
+          change: "#{footnote.code}: #{footnote.description}",
         })
       end
     end

--- a/spec/services/delta_report_service/measure_changes_spec.rb
+++ b/spec/services/delta_report_service/measure_changes_spec.rb
@@ -96,7 +96,6 @@ RSpec.describe DeltaReportService::MeasureChanges do
           import_export: 'Import',
           geo_area: 'GB: United Kingdom',
           additional_code: 'A123: Special code',
-          duty_expression: '10%',
           description: 'Measure updated',
           date_of_effect: date,
           change: '103: Third country duty',

--- a/spec/services/delta_report_service/measure_component_changes_spec.rb
+++ b/spec/services/delta_report_service/measure_component_changes_spec.rb
@@ -68,6 +68,8 @@ RSpec.describe DeltaReportService::MeasureComponentChanges do
       allow(instance).to receive(:additional_code).with(nil).and_return(nil)
       allow(instance).to receive(:duty_expression).with(measure).and_return('5%')
       allow(measure).to receive(:additional_code).and_return(nil)
+      # By default, don't filter out records (no matching operations found)
+      allow(Measure::Operation).to receive_message_chain(:where, :any?).and_return(false)
     end
 
     context 'when there are no changes' do
@@ -87,6 +89,8 @@ RSpec.describe DeltaReportService::MeasureComponentChanges do
         allow(measure_component_create).to receive(:measure).and_return(measure_create)
         allow(instance_create).to receive(:get_changes)
         allow(instance_create).to receive(:no_changes?).and_return(false)
+        # Mock the Measure::Operation query to return true (measure found on same date)
+        allow(Measure::Operation).to receive_message_chain(:where, :any?).and_return(true)
       end
 
       it 'returns nil' do
@@ -105,7 +109,6 @@ RSpec.describe DeltaReportService::MeasureComponentChanges do
           import_export: 'Import',
           geo_area: 'GB: United Kingdom',
           additional_code: nil,
-          duty_expression: '5%',
           description: 'Measure Component updated',
           date_of_effect: date,
           change: '5%',

--- a/spec/services/delta_report_service/measure_component_changes_spec.rb
+++ b/spec/services/delta_report_service/measure_component_changes_spec.rb
@@ -40,8 +40,17 @@ RSpec.describe DeltaReportService::MeasureComponentChanges do
   end
 
   describe '#object_name' do
-    it 'returns the correct object name' do
-      expect(instance.object_name).to eq('Measure Component')
+    context 'when tariff duty' do
+      it 'returns the correct object name' do
+        expect(instance.object_name).to eq('Tariff Duty')
+      end
+    end
+
+    context 'when supplementary unit' do
+      it 'returns the correct object name' do
+        allow(measure).to receive(:supplementary?).and_return(true)
+        expect(instance.object_name).to eq('Supplementary Unit')
+      end
     end
   end
 

--- a/spec/services/delta_report_service/measure_condition_changes_spec.rb
+++ b/spec/services/delta_report_service/measure_condition_changes_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe DeltaReportService::MeasureConditionChanges do
       allow(instance).to receive(:geo_area).with(geographical_area).and_return('GB: United Kingdom')
       allow(instance).to receive(:additional_code).with(nil).and_return(additional_code)
       allow(instance).to receive(:duty_expression).with(measure).and_return('10%')
+      # By default, don't filter out records (no matching operations found)
+      allow(Measure::Operation).to receive_message_chain(:where, :any?).and_return(false)
     end
 
     context 'when there are no changes' do
@@ -80,6 +82,8 @@ RSpec.describe DeltaReportService::MeasureConditionChanges do
         allow(measure_condition_create).to receive(:measure).and_return(measure_create)
         allow(instance_create).to receive(:get_changes)
         allow(instance_create).to receive(:no_changes?).and_return(false)
+        # Mock the Measure::Operation query to return true (measure found on same date)
+        allow(Measure::Operation).to receive_message_chain(:where, :any?).and_return(true)
       end
 
       it 'returns nil' do
@@ -98,7 +102,6 @@ RSpec.describe DeltaReportService::MeasureConditionChanges do
           import_export: 'Import',
           geo_area: 'GB: United Kingdom',
           additional_code: additional_code,
-          duty_expression: '10%',
           description: 'Measure Condition updated',
           date_of_effect: date,
           change: 'new condition',

--- a/spec/services/delta_report_service/measure_presenter_spec.rb
+++ b/spec/services/delta_report_service/measure_presenter_spec.rb
@@ -114,11 +114,22 @@ RSpec.describe DeltaReportService::MeasurePresenter do
   end
 
   describe '#duty_expression' do
-    let(:measure) { instance_double(Measure, duty_expression: '10.5% + €15.25 / 100 kg') }
+    context 'when there is a supplementary duty expression' do
+      let(:measure) { instance_double(Measure, supplementary_unit_duty_expression: '10%', duty_expression: '10.5% + €15.25 / 100 kg') }
 
-    it 'returns the duty expression from the measure' do
-      result = instance.duty_expression(measure)
-      expect(result).to eq('10.5% + €15.25 / 100 kg')
+      it 'returns the supplementary duty expression from the measure' do
+        result = instance.duty_expression(measure)
+        expect(result).to eq('10%')
+      end
+    end
+
+    context 'when there is no supplementary duty expression' do
+      let(:measure) { instance_double(Measure, supplementary_unit_duty_expression: nil, duty_expression: '10.5% + €15.25 / 100 kg') }
+
+      it 'returns the duty expression from the measure' do
+        result = instance.duty_expression(measure)
+        expect(result).to eq('10.5% + €15.25 / 100 kg')
+      end
     end
   end
 end

--- a/spec/services/delta_report_service_spec.rb
+++ b/spec/services/delta_report_service_spec.rb
@@ -123,7 +123,6 @@ RSpec.describe DeltaReportService do
         import_export: nil,
         geo_area: nil,
         additional_code: nil,
-        duty_expression: nil,
         measure_type: nil,
         type_of_change: 'Commodity added',
         date_of_effect: date,
@@ -227,7 +226,6 @@ RSpec.describe DeltaReportService do
           import_export: nil,
           geo_area: nil,
           additional_code: nil,
-          duty_expression: nil,
           measure_type: nil,
           type_of_change: 'Footnote description',
           date_of_effect: date,
@@ -268,7 +266,6 @@ RSpec.describe DeltaReportService do
               import_export: 'Import',
               geo_area: 'GB: United Kingdom',
               additional_code: '1234: Additional code description',
-              duty_expression: '10%',
               description: 'Footnote TN001 updated',
               date_of_effect: date,
               change: nil,
@@ -299,7 +296,6 @@ RSpec.describe DeltaReportService do
           import_export: 'Import',
           geo_area: 'GB: United Kingdom',
           additional_code: '1234: Additional code description',
-          duty_expression: '10%',
           measure_type: '103: Import duty',
           type_of_change: 'Footnote TN001 updated',
           date_of_effect: date,
@@ -363,7 +359,6 @@ RSpec.describe DeltaReportService do
           import_export: nil,
           geo_area: nil,
           additional_code: nil,
-          duty_expression: nil,
           measure_type: nil,
           type_of_change: 'Footnote CD001 updated for goods nomenclature',
           date_of_effect: date,
@@ -546,6 +541,8 @@ RSpec.describe DeltaReportService do
         db_double = instance_double(Sequel::Database)
         conditions_dataset = instance_double(Sequel::Dataset)
         measures_dataset = instance_double(Sequel::Dataset)
+        measure_dataset = instance_double(Sequel::Dataset)
+        measure = build(:measure, goods_nomenclature_item_id: '0101000000')
 
         allow(Sequel::Model).to receive(:db).and_return(db_double)
         allow(db_double).to receive(:[]).with(:measure_conditions_oplog).and_return(conditions_dataset)
@@ -558,7 +555,8 @@ RSpec.describe DeltaReportService do
         ])
         allow(filtered_conditions).to receive(:each).and_yield(condition_records.first)
 
-        allow(measures_dataset).to receive(:where).with(measure_sid: 123).and_return(instance_double(Sequel::Dataset, first: measure_record))
+        allow(Measure).to receive(:where).with(measure_sid: 123).and_return(measure_dataset)
+        allow(measure_dataset).to receive(:first).and_return(measure)
 
         mock_goods_nomenclature_lookup(declarable_commodity)
       end


### PR DESCRIPTION
### What?

- Added error logging
- Formatted start and end dates with just the date
- If a end date is being removed, show as "Removed"
- Use TimeMachine to get details about Certificates and Footnotes at the time of the change
- Remove duty expression from the report
- On some records we make checks for changes to related models on the same day so we don't duplicate the changes in the report. This now uses the raw oplogs as this avoids an issue looking at old dates where subsequent changes mean the views have filtered out the original change so there was no match.
- Use better descriptions for MeasureComponent changes that will be recognisable to users ("Tariff Duty" or "Supplementary Unit")