### PR TITLE
MyOTT-117 Replace irrelevant spec

### DIFF
--- a/spec/controllers/api/user/public_users_controller_spec.rb
+++ b/spec/controllers/api/user/public_users_controller_spec.rb
@@ -162,11 +162,11 @@ RSpec.describe Api::User::PublicUsersController do
         end
       end
 
-      context 'when invalid commodity codes are updated' do
+      context 'when there aren\'t any commodity codes updated' do
         let!(:user) { create(:public_user) }
 
         let(:make_request) do
-          patch :update, params: { data: { attributes: { commodity_codes: %(foo bar) } } }
+          patch :update, params: { data: { attributes: { commodity_codes: nil } } }
         end
 
         let(:token) do


### PR DESCRIPTION
### Jira link

[MyOTT-117](https://transformuk.atlassian.net/browse/MyOTT-117)

### What?

I have :

- [x] Replaced CC validation spec with nil CC spec 

### Why?

I am doing this because:

- There is currently no requirement for CC validation