### PR TITLE
MyOTT-117 Return Commodity Codes As Array

### DIFF
--- a/app/models/public_users/user.rb
+++ b/app/models/public_users/user.rb
@@ -11,7 +11,7 @@ module PublicUsers
     delegate :chapter_ids, to: :preferences
 
     def commodity_codes
-      delta_preferences.map(&:commodity_code).join(', ') if delta_preferences.any?
+      delta_preferences.map(&:commodity_code) if delta_preferences.any?
     end
 
     def commodity_codes=(codes)

--- a/spec/controllers/api/user/public_users_controller_spec.rb
+++ b/spec/controllers/api/user/public_users_controller_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Api::User::PublicUsersController do
 
         it 'updates the commodity_codes' do
           api_response
-          expect(user.commodity_codes).to eq '1234567890, 1234567891'
+          expect(user.commodity_codes).to eq %w[1234567890 1234567891]
         end
       end
 
@@ -158,7 +158,7 @@ RSpec.describe Api::User::PublicUsersController do
 
         it 'removes old codes and saves only the new ones' do
           api_response
-          expect(user.reload.commodity_codes).to eq '3333333333, 4444444444'
+          expect(user.reload.commodity_codes).to eq %w[3333333333 4444444444]
         end
       end
 
@@ -182,7 +182,7 @@ RSpec.describe Api::User::PublicUsersController do
 
         it 'keeps the original codes' do
           api_response
-          expect(user.reload.commodity_codes).to eq '1111111111, 2222222222'
+          expect(user.reload.commodity_codes).to eq %w[1111111111 2222222222]
         end
       end
 

--- a/spec/models/public_users/user_spec.rb
+++ b/spec/models/public_users/user_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe PublicUsers::User do
       end
 
       it 'returns a comma separated string of codes' do
-        expect(user.commodity_codes).to eq('1234567890, 1234567891')
+        expect(user.commodity_codes).to eq(%w[1234567890 1234567891])
       end
     end
   end
@@ -35,7 +35,7 @@ RSpec.describe PublicUsers::User do
     context 'when adding new codes' do
       it 'creates new delta preferences for each code' do
         user.commodity_codes = %w[1234567890 1234567891]
-        expect(user.commodity_codes).to eq('1234567890, 1234567891')
+        expect(user.commodity_codes).to eq(%w[1234567890 1234567891])
       end
     end
 
@@ -47,14 +47,14 @@ RSpec.describe PublicUsers::User do
 
       it 'removes codes not in the new list' do
         user.commodity_codes = %w[1234567891 1234567892]
-        expect(user.commodity_codes).to eq('1234567891, 1234567892')
+        expect(user.commodity_codes).to eq(%w[1234567891 1234567892])
       end
     end
 
     context 'when assigning a single string code' do
       it 'creates a single delta preference' do
         user.commodity_codes = '1234567890'
-        expect(user.commodity_codes).to eq('1234567890')
+        expect(user.commodity_codes).to eq(%w[1234567890])
       end
     end
   end

--- a/spec/serializers/api/user/public_user_serializer_spec.rb
+++ b/spec/serializers/api/user/public_user_serializer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::User::PublicUserSerializer do
           chapter_ids: '01,99',
           email: 'oliver@email.com',
           stop_press_subscription: false,
-          commodity_codes: '1234567890, 1234567891',
+          commodity_codes: %w[1234567890 1234567891],
         },
       },
     }


### PR DESCRIPTION
### Jira link

[MYOTT-117](https://transformuk.atlassian.net/browse/MYOTT-117)

### What?

I have altered:

- [x] Public_User API to ReturnUsers Commodity Codes as Array

### Why?

I am doing this because:

- It will facilitate expansion of returned object (for validation information purposes for example)
- It's a better structure for the front end to handle rather than relying on string manipulation
<img width="419" height="697" alt="image" src="https://github.com/user-attachments/assets/37ed0325-5e16-4c70-90e3-d55d4e070a15" />

