### PR TITLE
Update AdditionalCodeChanges

### DIFF
--- a/app/services/delta_report_service/additional_code_changes.rb
+++ b/app/services/delta_report_service/additional_code_changes.rb
@@ -16,6 +16,7 @@ class DeltaReportService
 
     def analyze
       return if no_changes?
+      return if record.operation == :create && Measure::Operation.where(additional_code_sid: record.additional_code_sid, operation_date: record.operation_date).any?
 
       {
         type: 'AdditionalCode',
@@ -23,7 +24,7 @@ class DeltaReportService
         additional_code: additional_code(record),
         description:,
         date_of_effect:,
-        change: change || '',
+        change: change || additional_code(record),
       }
     rescue StandardError => e
       Rails.logger.error "Error with #{object_name} OID #{record.oid}"


### PR DESCRIPTION
### What?

- Ignores change in AdditionalRecord if there is a change to the Measure
- Adds the additional code details to the change attribute when this is a new record