### PR TITLE
Add commodity description changes

### DIFF
--- a/app/services/delta_report_service.rb
+++ b/app/services/delta_report_service.rb
@@ -34,8 +34,8 @@ class DeltaReportService
 
     {
       dates: dates,
-      total_records: @commodity_change_records.size,
-      commodity_changes: @commodity_change_records,
+      total_records: @commodity_change_records.flatten.size,
+      commodity_changes: @commodity_change_records.flatten,
     }
   end
 
@@ -45,6 +45,7 @@ class DeltaReportService
 
   def collect_all_changes
     @changes[:goods_nomenclatures] = CommodityChanges.collect(date)
+    @changes[:goods_nomenclature_descriptions] = CommodityDescriptionChanges.collect(date)
     @changes[:measures] = MeasureChanges.collect(date)
     @changes[:measure_components] = MeasureComponentChanges.collect(date)
     @changes[:measure_conditions] = MeasureConditionChanges.collect(date)
@@ -87,7 +88,9 @@ class DeltaReportService
 
   def find_affected_declarable_goods(change)
     case change[:type]
-    when 'Measure', 'GoodsNomenclature', 'FootnoteAssociationGoodsNomenclature'
+    when 'GoodsNomenclature', 'GoodsNomenclatureDescription', 'FootnoteAssociationGoodsNomenclature'
+      find_declarable_goods_for_sid(change[:goods_nomenclature_sid])
+    when 'Measure'
       find_declarable_goods_for(change)
     when 'MeasureComponent', 'MeasureCondition', 'ExcludedGeographicalArea', 'FootnoteAssociationMeasure'
       find_declarable_goods_for_measure_association(change)
@@ -191,6 +194,14 @@ class DeltaReportService
     return [] unless goods_nomenclature_item_id
 
     gn = GoodsNomenclature.where(goods_nomenclature_item_id: goods_nomenclature_item_id).first
+
+    find_declarable_goods_for_sid(gn&.goods_nomenclature_sid)
+  end
+
+  def find_declarable_goods_for_sid(sid)
+    return [] unless sid
+
+    gn = GoodsNomenclature.where(goods_nomenclature_sid: sid).first
 
     return [] unless gn
 

--- a/app/services/delta_report_service/commodity_changes.rb
+++ b/app/services/delta_report_service/commodity_changes.rb
@@ -21,7 +21,7 @@ class DeltaReportService
 
       {
         type: 'GoodsNomenclature',
-        goods_nomenclature_item_id: record.goods_nomenclature_item_id,
+        goods_nomenclature_sid: record.goods_nomenclature_sid,
         date_of_effect:,
         description:,
         change: change || record.code,

--- a/app/services/delta_report_service/commodity_description_changes.rb
+++ b/app/services/delta_report_service/commodity_description_changes.rb
@@ -1,0 +1,38 @@
+class DeltaReportService
+  class CommodityDescriptionChanges < BaseChanges
+    def self.collect(date)
+      GoodsNomenclatureDescription
+        .where(operation_date: date)
+        .order(:oid)
+        .map { |record| new(record, date).analyze }
+        .compact
+    end
+
+    def object_name
+      'Commodity'
+    end
+
+    def excluded_columns
+      super + %i[path heading_short_code chapter_short_code]
+    end
+
+    def analyze
+      return if no_changes?
+      return unless record.goods_nomenclature&.declarable?
+      return if record.operation == :create && GoodsNomenclature::Operation.where(goods_nomenclature_sid: record.goods_nomenclature_sid, operation_date: record.operation_date).any?
+
+      TimeMachine.at(record.validity_start_date) do
+        {
+          type: 'GoodsNomenclatureDescription',
+          goods_nomenclature_sid: record.goods_nomenclature_sid,
+          date_of_effect:,
+          description:,
+          change: change || record.description,
+        }
+      end
+    rescue StandardError => e
+      Rails.logger.error "Error with #{object_name} OID #{record.oid}"
+      raise e
+    end
+  end
+end

--- a/app/services/delta_report_service/footnote_association_goods_nomenclature_changes.rb
+++ b/app/services/delta_report_service/footnote_association_goods_nomenclature_changes.rb
@@ -21,7 +21,7 @@ class DeltaReportService
 
       {
         type: 'FootnoteAssociationGoodsNomenclature',
-        goods_nomenclature_item_id: record.goods_nomenclature.goods_nomenclature_item_id,
+        goods_nomenclature_sid: record.goods_nomenclature.goods_nomenclature_sid,
         description:,
         date_of_effect:,
         change: change.present? ? "#{record.footnote.code}: #{change}" : "#{record.footnote.code}: #{record.footnote.description}",

--- a/spec/services/delta_report_service/commodity_changes_spec.rb
+++ b/spec/services/delta_report_service/commodity_changes_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe DeltaReportService::CommodityChanges do
 
         expect(result).to eq({
           type: 'GoodsNomenclature',
-          goods_nomenclature_item_id: '0101000000',
+          goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
           date_of_effect: date,
           description: 'Commodity added',
           change: '0101000000',

--- a/spec/services/delta_report_service/commodity_description_changes_spec.rb
+++ b/spec/services/delta_report_service/commodity_description_changes_spec.rb
@@ -1,0 +1,227 @@
+RSpec.describe DeltaReportService::CommodityDescriptionChanges do
+  let(:date) { Date.parse('2024-08-11') }
+
+  let(:goods_nomenclature) { instance_double(GoodsNomenclature, goods_nomenclature_sid: '12345', declarable?: true) }
+  let(:goods_nomenclature_description) do
+    instance_double(
+      GoodsNomenclatureDescription,
+      goods_nomenclature: goods_nomenclature,
+      goods_nomenclature_sid: '12345',
+      description: 'Test description',
+      validity_start_date: date,
+      operation: :create,
+      operation_date: date,
+    )
+  end
+  let(:instance) { described_class.new(goods_nomenclature_description, date) }
+
+  before do
+    allow(instance).to receive(:get_changes)
+    allow(GoodsNomenclature::Operation).to receive_message_chain(:where, :any?).and_return(false)
+  end
+
+  describe '.collect' do
+    let(:goods_nomenclature1) { instance_double(GoodsNomenclature, goods_nomenclature_sid: '11111', declarable?: true) }
+    let(:goods_nomenclature2) { instance_double(GoodsNomenclature, goods_nomenclature_sid: '22222', declarable?: true) }
+    let(:goods_nomenclature_description1) do
+      instance_double(
+        GoodsNomenclatureDescription,
+        goods_nomenclature: goods_nomenclature1,
+        goods_nomenclature_sid: '11111',
+        operation: :create,
+        validity_start_date: date,
+      )
+    end
+    let(:goods_nomenclature_description2) do
+      instance_double(
+        GoodsNomenclatureDescription,
+        goods_nomenclature: goods_nomenclature2,
+        goods_nomenclature_sid: '22222',
+        operation: :create,
+        validity_start_date: date,
+      )
+    end
+    let(:goods_nomenclature_descriptions) { [goods_nomenclature_description1, goods_nomenclature_description2] }
+
+    before do
+      allow(GoodsNomenclatureDescription).to receive_message_chain(:where, :order).and_return(goods_nomenclature_descriptions)
+    end
+
+    it 'finds goods nomenclatures for the given date and returns analyzed changes' do
+      instance1 = described_class.new(goods_nomenclature_description1, date)
+      instance2 = described_class.new(goods_nomenclature_description2, date)
+
+      allow(described_class).to receive(:new).and_return(instance1, instance2)
+      allow(instance1).to receive(:analyze).and_return({ type: 'GoodsNomenclatureDescription' })
+      allow(instance2).to receive(:analyze).and_return({ type: 'GoodsNomenclatureDescription' })
+
+      result = described_class.collect(date)
+
+      expect(GoodsNomenclatureDescription).to have_received(:where).with(operation_date: date)
+      expect(result).to eq([{ type: 'GoodsNomenclatureDescription' }, { type: 'GoodsNomenclatureDescription' }])
+    end
+
+    context 'when some records return nil from analyze' do
+      it 'filters out nil results with compact' do
+        instance1 = described_class.new(goods_nomenclature_description1, date)
+        instance2 = described_class.new(goods_nomenclature_description2, date)
+
+        allow(described_class).to receive(:new).and_return(instance1, instance2)
+        allow(instance1).to receive(:analyze).and_return({ type: 'GoodsNomenclatureDescription' })
+        allow(instance2).to receive(:analyze).and_return(nil)
+
+        result = described_class.collect(date)
+
+        expect(result).to eq([{ type: 'GoodsNomenclatureDescription' }])
+      end
+    end
+
+    context 'when no goods nomenclature descriptions exist for the date' do
+      before do
+        allow(GoodsNomenclatureDescription).to receive_message_chain(:where, :order).and_return([])
+      end
+
+      it 'returns an empty array' do
+        result = described_class.collect(date)
+        expect(result).to eq([])
+      end
+    end
+  end
+
+  describe '#object_name' do
+    it 'returns the correct object name' do
+      expect(instance.object_name).to eq('Commodity')
+    end
+  end
+
+  describe '#excluded_columns' do
+    it 'returns the expected excluded columns including inherited ones' do
+      expected_columns = %i[oid operation operation_date created_at updated_at filename path heading_short_code chapter_short_code]
+      expect(instance.excluded_columns).to eq(expected_columns)
+    end
+  end
+
+  describe '#analyze' do
+    before do
+      allow(instance).to receive_messages(
+        no_changes?: false,
+        date_of_effect: date,
+        description: 'Commodity added',
+        change: nil,
+      )
+      allow(goods_nomenclature_description).to receive_messages(
+        validity_start_date: date,
+        goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
+        description: 'Test description',
+      )
+      allow(TimeMachine).to receive(:at).with(date).and_yield
+    end
+
+    context 'when there are no changes' do
+      before { allow(instance).to receive(:no_changes?).and_return(true) }
+
+      it 'returns nil' do
+        expect(instance.analyze).to be_nil
+      end
+    end
+
+    context 'when goods nomenclature is not declarable' do
+      before { allow(goods_nomenclature).to receive(:declarable?).and_return(false) }
+
+      it 'returns nil' do
+        expect(instance.analyze).to be_nil
+      end
+    end
+
+    context 'when goods nomenclature is nil' do
+      before { allow(goods_nomenclature_description).to receive(:goods_nomenclature).and_return(nil) }
+
+      it 'returns nil' do
+        expect(instance.analyze).to be_nil
+      end
+    end
+
+    context 'when operation is create and GoodsNomenclature::Operation exists for same date' do
+      before do
+        allow(GoodsNomenclature::Operation).to receive_message_chain(:where, :any?).and_return(true)
+      end
+
+      it 'returns nil' do
+        expect(instance.analyze).to be_nil
+      end
+    end
+
+    context 'when changes should be included' do
+      it 'returns the correct analysis hash' do
+        result = instance.analyze
+
+        expect(result).to eq({
+          type: 'GoodsNomenclatureDescription',
+          goods_nomenclature_sid: '12345',
+          date_of_effect: date,
+          description: 'Commodity added',
+          change: 'Test description',
+        })
+      end
+    end
+
+    context 'when change is not nil' do
+      before { allow(instance).to receive(:change).and_return('updated description') }
+
+      it 'uses the change value instead of record description' do
+        result = instance.analyze
+        expect(result[:change]).to eq('updated description')
+      end
+    end
+
+    context 'when an error occurs in TimeMachine block' do
+      before do
+        allow(TimeMachine).to receive(:at).and_raise(StandardError.new('Test error'))
+        allow(Rails.logger).to receive(:error)
+        allow(goods_nomenclature_description).to receive(:oid).and_return(123)
+      end
+
+      it 'logs the error with object name and OID' do
+        expect { instance.analyze }.to raise_error(StandardError, 'Test error')
+        expect(Rails.logger).to have_received(:error).with('Error with Commodity OID 123')
+      end
+    end
+
+    context 'with different operation types' do
+      let(:update_goods_nomenclature_description) do
+        instance_double(
+          GoodsNomenclatureDescription,
+          goods_nomenclature: goods_nomenclature,
+          goods_nomenclature_sid: '12345',
+          description: 'Updated description',
+          validity_start_date: date,
+          operation: :update,
+          operation_date: date,
+          previous_record: nil,
+        )
+      end
+
+      let(:update_instance) { described_class.new(update_goods_nomenclature_description, date) }
+
+      before do
+        allow(update_instance).to receive_messages(
+          no_changes?: false,
+          date_of_effect: date,
+          description: 'Commodity updated',
+          change: 'updated description',
+        )
+        allow(TimeMachine).to receive(:at).with(date).and_yield
+      end
+
+      it 'handles update operations correctly' do
+        result = update_instance.analyze
+
+        expect(result).to include(
+          type: 'GoodsNomenclatureDescription',
+          description: 'Commodity updated',
+          change: 'updated description',
+        )
+      end
+    end
+  end
+end

--- a/spec/services/delta_report_service/footnote_association_goods_nomenclature_changes_spec.rb
+++ b/spec/services/delta_report_service/footnote_association_goods_nomenclature_changes_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe DeltaReportService::FootnoteAssociationGoodsNomenclatureChanges do
   let(:date) { Date.parse('2024-08-11') }
 
-  let(:goods_nomenclature) { build(:goods_nomenclature, goods_nomenclature_item_id: '0101000000') }
+  let(:goods_nomenclature) { build(:goods_nomenclature) }
   let(:footnote) { create(:footnote, :with_description, footnote_id: '001', footnote_type_id: 'TN', oid: '999') }
   let(:footnote_association) do
     build(
@@ -127,7 +127,7 @@ RSpec.describe DeltaReportService::FootnoteAssociationGoodsNomenclatureChanges d
 
         expect(result).to eq({
           type: 'FootnoteAssociationGoodsNomenclature',
-          goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
+          goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
           description: 'Footnote TN001 updated',
           date_of_effect: date,
           change: "#{footnote.code}: #{footnote.description}",
@@ -161,7 +161,7 @@ RSpec.describe DeltaReportService::FootnoteAssociationGoodsNomenclatureChanges d
 
         expect(result).to eq({
           type: 'FootnoteAssociationGoodsNomenclature',
-          goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
+          goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
           description: 'Footnote TN001 updated',
           date_of_effect: date,
           change: "#{footnote.code}: #{footnote.description}",


### PR DESCRIPTION
### What?

- Adds changes to commodity descriptions to the delta report

Also:
- Identifies commodities by the sid, not the commodity code to ensure we match the right object
- Adds total changes to the object returned when the report is run

### Why?

I am doing this because:

- Users want to know when a commodity description changes
