### PR TITLE
Fix Geographical Area matching

### DIFF
--- a/app/services/delta_report_service.rb
+++ b/app/services/delta_report_service.rb
@@ -126,7 +126,7 @@ class DeltaReportService
 
   def find_declarable_goods_for_geographical_area(change)
     measures = Sequel::Model.db[:measures]
-      .where(geographical_area_id: change[:geographical_area_id])
+      .where(geographical_area_sid: change[:geographical_area_sid])
       .where(operation_date: date)
       .distinct(:goods_nomenclature_item_id)
 

--- a/app/services/delta_report_service/geographical_area_changes.rb
+++ b/app/services/delta_report_service/geographical_area_changes.rb
@@ -17,13 +17,15 @@ class DeltaReportService
     def analyze
       return if no_changes?
 
-      {
-        type: 'GeographicalArea',
-        geographical_area_id: geo_area(record),
-        date_of_effect: date_of_effect,
-        description: description,
-        change: change || geo_area(record),
-      }
+      TimeMachine.at(record.validity_start_date) do
+        {
+          type: 'GeographicalArea',
+          geographical_area_sid: record.geographical_area_sid,
+          date_of_effect: date_of_effect,
+          description: description,
+          change: change || geo_area(record),
+        }
+      end
     rescue StandardError => e
       Rails.logger.error "Error with #{object_name} OID #{record.oid}"
       raise e

--- a/spec/services/delta_report_service/geographical_area_changes_spec.rb
+++ b/spec/services/delta_report_service/geographical_area_changes_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe DeltaReportService::GeographicalAreaChanges do
 
         expect(result).to eq({
           type: 'GeographicalArea',
-          geographical_area_id: 'GB: United Kingdom',
+          geographical_area_sid: geographical_area.geographical_area_sid,
           date_of_effect: date,
           description: 'Geo Area updated',
           change: 'GB: United Kingdom',

--- a/spec/services/delta_report_service_spec.rb
+++ b/spec/services/delta_report_service_spec.rb
@@ -508,7 +508,7 @@ RSpec.describe DeltaReportService do
     end
 
     context 'when change type is GeographicalArea' do
-      let(:change) { { type: 'GeographicalArea', geographical_area_id: 'GB' } }
+      let(:change) { { type: 'GeographicalArea', geographical_area_sid: 123 } }
       let(:measure_records) { [{ goods_nomenclature_item_id: '0101000000' }] }
       let(:declarable_commodity) { instance_double(Commodity, goods_nomenclature_item_id: '0101000000', declarable?: true) }
 
@@ -516,7 +516,7 @@ RSpec.describe DeltaReportService do
         service.instance_variable_set(:@date, date)
         measures_dataset = mock_database_query(:measures)
         filtered_dataset = mock_filtered_dataset(measures_dataset, [
-          [:where, { geographical_area_id: 'GB' }],
+          [:where, { geographical_area_sid: 123 }],
           [:where, { operation_date: date }],
           %i[distinct goods_nomenclature_item_id],
         ])


### PR DESCRIPTION
### What?

Use the geographical_area_sid value when matching GeographicalArea changes to Measures. Also uses TimeMachine so we get the correct value when the change was made.
