### PR TITLE
Ignore new certificates for delta report

### DIFF
--- a/app/services/delta_report_service/base_changes.rb
+++ b/app/services/delta_report_service/base_changes.rb
@@ -51,7 +51,7 @@ class DeltaReportService
       elsif changes.include?('validity end date') && record.validity_end_date.present?
         record.validity_end_date + 1.day
       elsif record.operation == :create && record.respond_to?(:validity_start_date)
-        record.validity_start_date + 1.day
+        record.validity_start_date
       else
         date + 1.day
       end

--- a/app/services/delta_report_service/certificate_changes.rb
+++ b/app/services/delta_report_service/certificate_changes.rb
@@ -5,6 +5,7 @@ class DeltaReportService
     def self.collect(date)
       Certificate
         .where(operation_date: date)
+        .where(operation: 'U')
         .order(:oid)
         .map { |record| new(record, date).analyze }
         .compact
@@ -12,6 +13,10 @@ class DeltaReportService
 
     def object_name
       'Certificate'
+    end
+
+    def excluded_columns
+      super + %i[national]
     end
 
     def analyze

--- a/spec/services/delta_report_service/base_changes_spec.rb
+++ b/spec/services/delta_report_service/base_changes_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe DeltaReportService::BaseChanges do
       before { date_instance.changes = [] }
 
       it 'returns validity_start_date' do
-        expect(date_instance.date_of_effect).to eq(validity_start_date + 1.day)
+        expect(date_instance.date_of_effect).to eq(validity_start_date)
       end
     end
   end

--- a/spec/services/delta_report_service/certificate_changes_spec.rb
+++ b/spec/services/delta_report_service/certificate_changes_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe DeltaReportService::CertificateChanges do
     let(:certificates) { [certificate1, certificate2] }
 
     before do
-      allow(Certificate).to receive_message_chain(:where, :order).and_return(certificates)
+      allow(Certificate).to receive_message_chain(:where, :where, :order).and_return(certificates)
     end
 
     it 'finds certificates for the given date and returns analyzed changes' do
@@ -37,6 +37,22 @@ RSpec.describe DeltaReportService::CertificateChanges do
   describe '#object_name' do
     it 'returns the correct object name' do
       expect(instance.object_name).to eq('Certificate')
+    end
+  end
+
+  describe '#excluded_columns' do
+    it 'includes measure-specific excluded columns' do
+      expected = instance.send(:excluded_columns)
+      expect(expected).to include(:national)
+    end
+
+    it 'includes base excluded columns' do
+      base_excluded = %i[oid operation operation_date created_at updated_at filename]
+      expected = instance.send(:excluded_columns)
+
+      base_excluded.each do |column|
+        expect(expected).to include(column)
+      end
     end
   end
 


### PR DESCRIPTION
### What?

New certificates are linked to a commodity by Measure Condition. The change to a Measure Condition will be shown on the delta report.

Also fixes the use of the validity start date to be the actual date.
