### PR TITLE
MyOTT-128 User Commodities Summary

### DIFF
--- a/app/serializers/api/user/public_user_serializer.rb
+++ b/app/serializers/api/user/public_user_serializer.rb
@@ -7,7 +7,7 @@ module Api
 
       set_id :external_id
 
-      attributes :email, :chapter_ids, :commodity_codes, :stop_press_subscription
+      attributes :email, :chapter_ids, :active_commodity_codes, :expired_commodity_codes, :erroneous_commodity_codes, :stop_press_subscription
     end
   end
 end

--- a/spec/serializers/api/user/public_user_serializer_spec.rb
+++ b/spec/serializers/api/user/public_user_serializer_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe Api::User::PublicUserSerializer do
           chapter_ids: '01,99',
           email: 'oliver@email.com',
           stop_press_subscription: false,
-          commodity_codes: %w[1234567890 1234567891],
+          erroneous_commodity_codes: %w[1234567890 1234567891],
+          active_commodity_codes: %w[1111111111 2222222222],
+          expired_commodity_codes: %w[3333333333 4444444444],
         },
       },
     }
@@ -23,6 +25,14 @@ RSpec.describe Api::User::PublicUserSerializer do
       serializable.preferences.update(chapter_ids: '01,99')
       serializable.add_delta_preference(PublicUsers::DeltaPreferences.new(commodity_code: '1234567890'))
       serializable.add_delta_preference(PublicUsers::DeltaPreferences.new(commodity_code: '1234567891'))
+      serializable.add_delta_preference(PublicUsers::DeltaPreferences.new(commodity_code: '1111111111'))
+      serializable.add_delta_preference(PublicUsers::DeltaPreferences.new(commodity_code: '2222222222'))
+      serializable.add_delta_preference(PublicUsers::DeltaPreferences.new(commodity_code: '3333333333'))
+      serializable.add_delta_preference(PublicUsers::DeltaPreferences.new(commodity_code: '4444444444'))
+      create(:goods_nomenclature, goods_nomenclature_item_id: '1111111111', validity_start_date: Time.zone.now)
+      create(:goods_nomenclature, goods_nomenclature_item_id: '2222222222', validity_start_date: Time.zone.now)
+      create(:goods_nomenclature, goods_nomenclature_item_id: '3333333333', validity_start_date: Time.zone.now - 1.week, validity_end_date: Time.zone.now - 1.day)
+      create(:goods_nomenclature, goods_nomenclature_item_id: '4444444444', validity_start_date: Time.zone.now - 1.week, validity_end_date: Time.zone.now - 1.day)
     end
 
     it { expect(serialized).to eq(expected) }


### PR DESCRIPTION
Extended public user model and API to split commodities into three status categories for front end presentation

### Jira link

[MYOTT-128](https://transformuk.atlassian.net/browse/MYOTT-128)

### What?

I have altered:

- [x] Public user model and API to split commodities into three status categories for front end presentation (Active, Expired, Erroneous)

### Why?

I am doing this because:

- It is required for front end presentation
- Users will eventually be able to drill down into each category to see details.  For drilling down the commodity detail should be in a different API.  If a user has 1000s of commodities it will be expensive and suboptimal to carry the relevant commodity data in this API and would also move away from the context of what user api is actually for.

### Deployment risks (optional)

- Changes an api that is used in production

```curl -X PUT "http://localhost:3000/uk/user/users" \ 
  -H "Content-Type: application/json" \
  -d '{  
    "data": {
      "attributes": {
        "commodity_codes": [
          "0702009907",
          "0406902190",
          "1905903000",
          "0702009000",
          "1234567890",
          "1234567891",
          "9999999999"
        ]
      }
    }
  }'
```

<img width="594" height="856" alt="image" src="https://github.com/user-attachments/assets/2a90acf4-8f1e-41b5-96e3-8f1e477cfcf1" />
