### PR TITLE
BAU: Move to populating changes after changes are available

### DIFF
--- a/app/workers/cds_updates_synchronizer_worker.rb
+++ b/app/workers/cds_updates_synchronizer_worker.rb
@@ -29,7 +29,8 @@ class CdsUpdatesSynchronizerWorker
 
     Sidekiq::Client.enqueue(ClearInvalidSearchReferences)
     Sidekiq::Client.enqueue(TreeIntegrityCheckWorker)
-    Sidekiq::Client.enqueue(ClearCacheWorker)
+    Sidekiq::Client.enqueue(PopulateChangesTableWorker)
+    Sidekiq::Client.enqueue_in(1.minute, ClearCacheWorker)
   rescue TariffSynchronizer::CdsUpdateDownloader::ListDownloadFailedError
     attempt_reschedule!
   end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -19,19 +19,6 @@
     #
     # Online converter: https://crontab.guru/#0_22_*_*_*
     #
-    RefreshAppendix5aGuidanceWorker:
-      # Runs workdays at 22:00
-      cron: "00 22 * * 1,2,3,4,5"
-      description: "Hot refreshes CDS Guidance"
-    PopulateChangesTableWorker:
-      cron: "30 4 * * *"
-      description: "Populates the changes table"
-    PopulateSearchSuggestionsWorker:
-      cron: "0 18 * * *"
-      description: "Populates search suggestions which are used in the frontend"
-    ReportWorker:
-      cron: "30 10 * * *" # Needs to run even if the UpdatesSynchronizerWorker failed
-      description: "Generates reports and persists them to S3"
     CdsUpdatesSynchronizerWorker:
       cron: "30 0 * * *"
       description: "Runs ETL of CDS files and populates indexes"
@@ -40,6 +27,16 @@
       cron: "0 0 * * *"
       description: "Runs ETL of Taric files and populates indexes"
       enabled: <%= ENV.fetch('SERVICE', 'uk') == 'xi' %>
+    RefreshAppendix5aGuidanceWorker:
+      # Runs workdays at 22:00
+      cron: "00 22 * * 1,2,3,4,5"
+      description: "Hot refreshes CDS Guidance"
+    PopulateSearchSuggestionsWorker:
+      cron: "0 18 * * *"
+      description: "Populates search suggestions which are used in the frontend"
+    ReportWorker:
+      cron: "30 10 * * *" # Needs to run even if the UpdatesSynchronizerWorker failed
+      description: "Generates reports and persists them to S3"
     HealthcheckWorker:
       every: 30.minutes
       description: Trigger the health check

--- a/spec/workers/cds_updates_synchronizer_worker_spec.rb
+++ b/spec/workers/cds_updates_synchronizer_worker_spec.rb
@@ -2,8 +2,9 @@ require 'data_migrator'
 
 RSpec.describe CdsUpdatesSynchronizerWorker, type: :worker do
   shared_examples_for 'a synchronizer worker that queues other workers' do
-    it { expect(Sidekiq::Client).to have_received(:enqueue).with(ClearCacheWorker) }
     it { expect(Sidekiq::Client).to have_received(:enqueue).with(ClearInvalidSearchReferences) }
+    it { expect(Sidekiq::Client).to have_received(:enqueue).with(PopulateChangesTableWorker) }
+    it { expect(Sidekiq::Client).to have_received(:enqueue_in).with(1.minute, ClearCacheWorker) }
   end
 
   describe '#perform' do
@@ -18,6 +19,7 @@ RSpec.describe CdsUpdatesSynchronizerWorker, type: :worker do
       allow(TradeTariffBackend).to receive(:service).and_return(service)
 
       allow(Sidekiq::Client).to receive(:enqueue)
+      allow(Sidekiq::Client).to receive(:enqueue_in)
 
       migrations_dir = Rails.root.join(file_fixture_path).join('data_migrations')
       allow(DataMigrator).to receive_messages(migrations_dir:, migrate_up!: true)

--- a/spec/workers/taric_updates_synchronizer_worker_spec.rb
+++ b/spec/workers/taric_updates_synchronizer_worker_spec.rb
@@ -2,8 +2,10 @@ require 'data_migrator'
 
 RSpec.describe TaricUpdatesSynchronizerWorker, type: :worker do
   shared_examples_for 'a synchronizer worker that queues other workers' do
-    it { expect(Sidekiq::Client).to have_received(:enqueue).with(ClearCacheWorker) }
     it { expect(Sidekiq::Client).to have_received(:enqueue).with(ClearInvalidSearchReferences) }
+    it { expect(Sidekiq::Client).to have_received(:enqueue).with(TreeIntegrityCheckWorker) }
+    it { expect(Sidekiq::Client).to have_received(:enqueue_in).with(5.minutes, GreenLanesUpdatesWorker, Time.zone.today.iso8601) }
+    it { expect(Sidekiq::Client).to have_received(:enqueue_in).with(10.minutes, ClearCacheWorker) }
   end
 
   describe '#perform' do
@@ -18,6 +20,7 @@ RSpec.describe TaricUpdatesSynchronizerWorker, type: :worker do
       allow(TradeTariffBackend).to receive(:service).and_return(service)
 
       allow(Sidekiq::Client).to receive(:enqueue)
+      allow(Sidekiq::Client).to receive(:enqueue_in)
 
       migrations_dir = Rails.root.join(file_fixture_path).join('data_migrations')
       allow(DataMigrator).to receive_messages(migrations_dir:, migrate_up!: true)


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Consolidate changes table population alongside file update
- [x] Increase cache clearing gap on XI to allow for other work

### Why?

I am doing this because:

- Using a schedule was brittle when we control the event that would drive the changes
