### PR TITLE
Fix commodity description on delta report

### DIFF
--- a/app/services/delta_report_service/delta_presenter.rb
+++ b/app/services/delta_report_service/delta_presenter.rb
@@ -1,7 +1,9 @@
 class DeltaReportService
   module DeltaPresenter
     def commodity_description(commodity)
-      commodity.goods_nomenclature_description.csv_formatted_description
+      TimeMachine.at(commodity.validity_start_date) do
+        commodity.goods_nomenclature_description.csv_formatted_description
+      end
     end
 
     def footnote_description(footnote)

--- a/spec/services/delta_report_service/delta_presenter_spec.rb
+++ b/spec/services/delta_report_service/delta_presenter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DeltaReportService::DeltaPresenter do
 
   describe '#commodity_description' do
     let(:goods_nomenclature_description) { instance_double(GoodsNomenclatureDescription, csv_formatted_description: 'Formatted commodity description') }
-    let(:commodity) { instance_double(Commodity, goods_nomenclature_description: goods_nomenclature_description) }
+    let(:commodity) { instance_double(Commodity, goods_nomenclature_description: goods_nomenclature_description, validity_start_date: Time.zone.today) }
 
     it 'returns the csv formatted description from the commodity' do
       result = instance.commodity_description(commodity)
@@ -17,7 +17,7 @@ RSpec.describe DeltaReportService::DeltaPresenter do
     end
 
     context 'when goods_nomenclature_description is nil' do
-      let(:commodity) { instance_double(Commodity, goods_nomenclature_description: nil) }
+      let(:commodity) { instance_double(Commodity, goods_nomenclature_description: nil, validity_start_date: Time.zone.today) }
 
       it 'raises an error' do
         expect { instance.commodity_description(commodity) }.to raise_error(NoMethodError)

--- a/spec/services/delta_report_service_spec.rb
+++ b/spec/services/delta_report_service_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe DeltaReportService do
                                 goods_nomenclature_item_id: item_id,
                                 goods_nomenclature_sid: sid,
                                 declarable?: declarable,
+                                validity_start_date: Time.zone.today,
                                 chapter_short_code: item_id[0..1])
     # rubocop:disable RSpec/VerifiedDoubles
     description_double = double('GoodsNomenclatureDescription',


### PR DESCRIPTION
### What?

Use TimeMachine to get the description

### Why?

Where the commodity starts in the future, the description was not showing.
