### PR TITLE
Refactor QuotaEvent

### DIFF
--- a/app/models/quota_event.rb
+++ b/app/models/quota_event.rb
@@ -1,10 +1,12 @@
 class QuotaEvent
   EVENTS = %w[exhaustion balance critical reopening unblocking unsuspension].freeze
 
-  # Generate SELECT .. UNION from all event types
+  # Generate a UNION query of all quota event types for a specific quota definition
   def self.for_quota_definition(quota_sid, point_in_time)
-    EVENTS.from(1).inject(for_event(EVENTS.first, quota_sid, point_in_time)) { |memo, event_type|
-      memo.union(for_event(event_type, quota_sid, point_in_time), from_self: true)
+    event_queries = EVENTS.map { |event_type| for_event(event_type, quota_sid, point_in_time) }
+
+    event_queries.inject { |combined_query, event_query|
+      combined_query.union(event_query, from_self: true)
     }.order(Sequel.desc(:occurrence_timestamp), Sequel.desc(:event_type))
   end
 
@@ -12,17 +14,23 @@ class QuotaEvent
     event = for_quota_definition(quota_sid, point_in_time).first
 
     if event.present?
-      Object.const_get("Quota#{event[:event_type].capitalize}Event")
+      event_class_for(event[:event_type])
     else
       NullObject.new
     end
   end
 
   def self.for_event(event_type, quota_sid, point_in_time)
-    Object.const_get("Quota#{event_type.capitalize}Event").select(:quota_definition_sid,
-                                                                  :occurrence_timestamp,
-                                                                  Sequel.as(event_type, 'event_type'))
-                                                          .where(quota_definition_sid: quota_sid)
-                                                          .where('occurrence_timestamp <= ?', point_in_time)
+    event_class_for(event_type).select(:quota_definition_sid,
+                                       :occurrence_timestamp,
+                                       Sequel.as(event_type, 'event_type'))
+                               .where(quota_definition_sid: quota_sid)
+                               .where('occurrence_timestamp <= ?', point_in_time)
+  end
+
+  def self.event_class_for(event_type)
+    Object.const_get("Quota#{event_type.capitalize}Event")
+  rescue NameError => e
+    raise ArgumentError, "Unknown event type: #{event_type}. #{e.message}"
   end
 end

--- a/spec/models/quota_event_spec.rb
+++ b/spec/models/quota_event_spec.rb
@@ -33,5 +33,50 @@ RSpec.describe QuotaEvent do
         described_class.last_for(quota_definition.quota_definition_sid, Time.zone.today),
       ).to eq QuotaExhaustionEvent
     end
+
+    context 'when no events exist' do
+      it 'returns NullObject' do
+        expect(
+          described_class.last_for(99_999, Time.zone.today),
+        ).to be_a(NullObject)
+      end
+    end
+  end
+
+  describe '.for_event' do
+    it 'returns a dataset for the specified event type' do
+      dataset = described_class.for_event('balance', quota_definition.quota_definition_sid, Time.zone.today)
+      expect(dataset).to be_a(Sequel::Dataset)
+      expect(dataset.sql).to include('quota_balance_events')
+      expect(dataset.sql).to include("'balance' AS")
+    end
+
+    it 'filters by quota_definition_sid' do
+      dataset = described_class.for_event('balance', quota_definition.quota_definition_sid, Time.zone.today)
+      expect(dataset.sql).to include("quota_definition_sid\" = #{quota_definition.quota_definition_sid}")
+    end
+
+    it 'filters by occurrence_timestamp' do
+      point_in_time = Time.zone.today
+      dataset = described_class.for_event('balance', quota_definition.quota_definition_sid, point_in_time)
+      expect(dataset.sql).to include('occurrence_timestamp <= ')
+    end
+  end
+
+  describe '.event_class_for' do
+    it 'returns the correct event class for valid event types' do
+      expect(described_class.event_class_for('balance')).to eq QuotaBalanceEvent
+      expect(described_class.event_class_for('exhaustion')).to eq QuotaExhaustionEvent
+      expect(described_class.event_class_for('critical')).to eq QuotaCriticalEvent
+      expect(described_class.event_class_for('reopening')).to eq QuotaReopeningEvent
+      expect(described_class.event_class_for('unblocking')).to eq QuotaUnblockingEvent
+      expect(described_class.event_class_for('unsuspension')).to eq QuotaUnsuspensionEvent
+    end
+
+    it 'raises ArgumentError for invalid event types' do
+      expect {
+        described_class.event_class_for('invalid_event')
+      }.to raise_error(ArgumentError, /Unknown event type: invalid_event/)
+    end
   end
 end


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Refactored `for_quota_definition`
- Added `event_class_for` method
- Added some tests

### Why?

I am doing this because:

Existing `for_quota_definition` method was a bit confusing with its use of inject with `EVENTS.from(1)`
