### PR TITLE
Ensure quota events cause a change in status in the delta report

### DIFF
--- a/app/services/delta_report_service.rb
+++ b/app/services/delta_report_service.rb
@@ -212,7 +212,6 @@ class DeltaReportService
       change[:measure_type] = measure_type(measure)
       change[:import_export] = import_export(measure)
       change[:geo_area] = geo_area(measure.geographical_area, measure.excluded_geographical_areas)
-      change[:change] = quota_definition.balance
       affected_goods += find_declarable_goods_under_code(measure.goods_nomenclature_item_id)
     end
 

--- a/app/services/delta_report_service/quota_event_changes.rb
+++ b/app/services/delta_report_service/quota_event_changes.rb
@@ -1,34 +1,52 @@
 class DeltaReportService
   class QuotaEventChanges < BaseChanges
     def self.collect(date)
-      events = {
-        'Exhausted' => QuotaExhaustionEvent,
-        'Critical' => QuotaCriticalEvent,
-      }
+      event_models = [QuotaExhaustionEvent, QuotaCriticalEvent]
 
-      events.each_with_object([]) do |(status, model), arr|
-        arr.concat(
-          model.where(operation_date: date)
-               .map { |record| new(record, date).analyze(status) }
-               .compact,
-        )
-      end
+      events = event_models.each_with_object([]) { |model, arr|
+        model.where(operation_date: date).each do |event|
+          arr << event.quota_definition_sid
+        end
+      }.uniq
+
+      events.map { |sid|
+        record = QuotaDefinition.first(quota_definition_sid: sid)
+        new(record, date).analyze
+      }.compact
     end
 
     def object_name
       'Quota Event'
     end
 
-    def analyze(status)
+    def analyze
+      status = record.status
+
+      return unless status.in?(%w[Exhausted Critical])
+
+      TimeMachine.at(date - 1.day) do
+        previous = QuotaDefinition.first(quota_definition_sid: record.quota_definition_sid)
+        return if status == previous.status
+      end
+
       {
         type: 'QuotaEvent',
         quota_definition_sid: record.quota_definition_sid,
         date_of_effect: date_of_effect,
         description: "Quota Status: #{status}",
+        change: change,
       }
     rescue StandardError => e
-      Rails.logger.error "Error with #{object_name} OID #{record.oid}"
+      Rails.logger.error "Error with #{object_name} SID #{record.quota_definition_sid}"
       raise e
+    end
+
+    def change
+      if record.status == 'Exhausted'
+        'Quota Exhausted'
+      else
+        "Balance: #{TradeTariffBackend.number_formatter.number_with_precision(record.balance, precision: 3, delimiter: ',')} #{record.measurement_unit}"
+      end
     end
 
     def date_of_effect

--- a/spec/services/delta_report_service_spec.rb
+++ b/spec/services/delta_report_service_spec.rb
@@ -412,6 +412,7 @@ RSpec.describe DeltaReportService do
               quota_definition_sid: 500,
               description: 'Quota Status: Exhausted',
               date_of_effect: date,
+              change: 'Quota Exhausted',
             },
           ],
         }
@@ -429,7 +430,7 @@ RSpec.describe DeltaReportService do
           measure_type: 'Third country duty',
           type_of_change: 'Quota Status: Exhausted',
           date_of_effect: date,
-          change: 100,
+          change: 'Quota Exhausted',
           ott_url: "https://www.trade-tariff.service.gov.uk/commodities/#{quota_definition.goods_nomenclature_item_id}?day=#{date.day}&month=#{date.month}&year=#{date.year}",
           api_url: "https://www.trade-tariff.service.gov.uk/uk/api/commodities/#{quota_definition.goods_nomenclature_item_id}",
         }
@@ -439,7 +440,8 @@ RSpec.describe DeltaReportService do
         quota_def_record = instance_double(QuotaDefinition,
                                            quota_definition_sid: 500,
                                            quota_order_number_id: '050001',
-                                           balance: 100)
+                                           balance: 100,
+                                           measurement_unit: 'kg')
         allow(QuotaDefinition).to receive(:first).with(quota_definition_sid: 500).and_return(quota_def_record)
 
         measure = instance_double(Measure, goods_nomenclature_item_id: '0505000000')
@@ -757,7 +759,7 @@ RSpec.describe DeltaReportService do
 
     context 'when change type is QuotaEvent' do
       let(:change) { { type: 'QuotaEvent', quota_definition_sid: 123 } }
-      let(:quota_definition) { instance_double(QuotaDefinition, quota_order_number_id: '050001', balance: 100) }
+      let(:quota_definition) { instance_double(QuotaDefinition, quota_order_number_id: '050001', balance: 100, measurement_unit: 'kg') }
       let(:measure) { instance_double(Measure, goods_nomenclature_item_id: '0505000000') }
       let(:measures) { [measure] }
       let(:geographical_area) { instance_double(GeographicalArea) }


### PR DESCRIPTION
### What?

Finds all `QuotaExhaustionEvent` and `QuotaExhaustionEvent` updates and then checks the status for related `QuotaDefinition` from the previous day. If the status has not changed then they are discarded.

Uses formatting to display quota balance to match frontend.


