### PR TITLE
HMRC-987: Migrate Download-CDS-Files to Ruby - Quota Definitions Sheet

### DIFF
--- a/app/lib/cds_importer/entity_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper.rb
@@ -36,7 +36,7 @@ class CdsImporter
           end
 
           if block_given?
-            yield CdsImporter::CdsEntity.new(@key, model_instance, mapper)
+            yield CdsImporter::CdsEntity.new(@xml_node['hjid'], @key, model_instance, mapper)
           end
         end
       end

--- a/app/lib/cds_importer/excel_writer.rb
+++ b/app/lib/cds_importer/excel_writer.rb
@@ -43,9 +43,9 @@ class CdsImporter
 
         if note.present?
           sheet.add_row(note, style: bold_style)
-          sheet.merge_cells(merge_cells_length(update,1))
+          sheet.merge_cells(merge_cells_length(update, 1))
           sheet.add_row
-          sheet.merge_cells(merge_cells_length(update,2))
+          sheet.merge_cells(merge_cells_length(update, 2))
         end
 
         sheet.add_row(update.heading, style: bold_style)
@@ -63,8 +63,8 @@ class CdsImporter
         b: true,
         font_name: 'Calibri',
         sz: 11,
-        bg_color: "e3e5e6",
-        )
+        bg_color: 'e3e5e6',
+      )
       @regular_style = workbook.styles.add_style(
         alignment: {
           wrap_text: true,
@@ -73,11 +73,11 @@ class CdsImporter
         },
         font_name: 'Calibri',
         sz: 11,
-        )
+      )
     end
 
     def excel_filename
-      "CDS updates " + xml_to_file_date + ".xlsx"
+      "CDS updates #{xml_to_file_date}.xlsx"
     end
 
     def xml_to_file_date

--- a/app/lib/cds_importer/excel_writer.rb
+++ b/app/lib/cds_importer/excel_writer.rb
@@ -1,0 +1,100 @@
+class CdsImporter
+  class ExcelWriter
+    SKIPPED_OPERATION = :skipped
+
+    delegate :instrument, to: ActiveSupport::Notifications
+
+    def initialize(filename)
+      @filename = filename
+      @xml_element_id = nil
+      @key = ''
+      @instances = []
+      create_excel_file
+    end
+
+    def write_record(cds_entity)
+      unless @xml_element_id.nil? || @xml_element_id == cds_entity.element_id
+        write(@key, @instances)
+        @instances = []
+      end
+
+      @key = cds_entity.key
+      @xml_element_id = cds_entity.element_id
+      @instances << cds_entity.instance
+    end
+
+    def save_file
+      FileUtils.mkdir_p(File.join(TariffSynchronizer.root_path, 'cds_updates'))
+      package.serialize(File.join(TariffSynchronizer.root_path, 'cds_updates', excel_filename))
+    end
+
+    private
+
+    attr_reader :workbook, :filename, :package, :bold_style, :regular_style
+
+    def write(key, instances)
+      update = Module.const_get("CdsImporter::ExcelWriter::#{key}").new(instances)
+      sheet_name = update.sheet_name
+      note = update.note
+
+      sheet = workbook.worksheets.find { |ws| ws.name == sheet_name }
+      unless sheet
+        sheet = workbook.add_worksheet(name: sheet_name)
+
+        if note.present?
+          sheet.add_row(note, style: bold_style)
+          sheet.merge_cells(merge_cells_length(update,1))
+          sheet.add_row
+          sheet.merge_cells(merge_cells_length(update,2))
+        end
+
+        sheet.add_row(update.heading, style: bold_style)
+        sheet.column_widths(*update.column_widths)
+      end
+
+      sheet.add_row(update.data_row, style: regular_style)
+      sheet.column_widths(*update.column_widths)
+    end
+
+    def create_excel_file
+      @package = Axlsx::Package.new
+      @workbook = package.workbook
+      @bold_style = workbook.styles.add_style(
+        b: true,
+        font_name: 'Calibri',
+        sz: 11,
+        bg_color: "e3e5e6",
+        )
+      @regular_style = workbook.styles.add_style(
+        alignment: {
+          wrap_text: true,
+          horizontal: :left,
+          vertical: :top,
+        },
+        font_name: 'Calibri',
+        sz: 11,
+        )
+    end
+
+    def excel_filename
+      "CDS updates " + xml_to_file_date + ".xlsx"
+    end
+
+    def xml_to_file_date
+      if filename =~ /(\d{8})T/
+        raw_date = Regexp.last_match(1)
+        year  = raw_date[0, 4]
+        month = raw_date[4, 2]
+        day   = raw_date[6, 2]
+
+        "#{year}-#{month}-#{day}"
+      else
+        ''
+      end
+    end
+
+    def merge_cells_length(update, row)
+      "#{update.table_span[0]}#{row}:#{update.table_span[1]}#{row}"
+    end
+  end
+end

--- a/app/lib/cds_importer/excel_writer/base_mapper.rb
+++ b/app/lib/cds_importer/excel_writer/base_mapper.rb
@@ -1,0 +1,41 @@
+class CdsImporter
+  class ExcelWriter
+    class BaseMapper
+
+      def initialize(models)
+        @models = models
+      end
+
+      attr_reader :models
+
+      def expand_operation(model)
+        text = ''
+        if model.operation.present?
+          case model.operation[0].upcase
+          when 'C'
+            text = 'Create a new'
+          when 'U'
+            text = 'Update an existing'
+          when 'D'
+            text = 'Delete a'
+          end
+        end
+        text
+      end
+
+      def format_date(d)
+        return "" if d.nil?
+        d.strftime("%d/%m/%Y")
+      end
+
+      def format_date_ymd(d)
+        return "" if d.nil?
+        d.strftime("%Y-%m-%d")
+      end
+
+      def note
+        nil
+      end
+    end
+  end
+end

--- a/app/lib/cds_importer/excel_writer/base_mapper.rb
+++ b/app/lib/cds_importer/excel_writer/base_mapper.rb
@@ -1,7 +1,6 @@
 class CdsImporter
   class ExcelWriter
     class BaseMapper
-
       def initialize(models)
         @models = models
       end
@@ -23,14 +22,16 @@ class CdsImporter
         text
       end
 
-      def format_date(d)
-        return "" if d.nil?
-        d.strftime("%d/%m/%Y")
+      def format_date(date)
+        return '' if date.nil?
+
+        date.strftime('%d/%m/%Y')
       end
 
-      def format_date_ymd(d)
-        return "" if d.nil?
-        d.strftime("%Y-%m-%d")
+      def format_date_ymd(date)
+        return '' if date.nil?
+
+        date.strftime('%Y-%m-%d')
       end
 
       def note

--- a/app/lib/cds_importer/excel_writer/quota_definition.rb
+++ b/app/lib/cds_importer/excel_writer/quota_definition.rb
@@ -2,11 +2,11 @@ class CdsImporter
   class ExcelWriter
     class QuotaDefinition < BaseMapper
       def sheet_name
-        "Quota definitions"
+        'Quota definitions'
       end
 
       def note
-        ["Please be careful when checking quota balances - each file may contains multiple updates on the same quota definition"]
+        ['Please be careful when checking quota balances - each file may contains multiple updates on the same quota definition']
       end
 
       def table_span
@@ -18,38 +18,37 @@ class CdsImporter
       end
 
       def heading
-        ["Action",
-         "Quota order number",
-         "Balance updates",
-         "Sample commodities",
-         "SID",
+        ['Action',
+         'Quota order number',
+         'Balance updates',
+         'Sample commodities',
+         'SID',
          'Critical state',
-         "Critical threshold",
-         "Initial volume",
-         "Volume",
-         "Maximum precision",
-         "Start date",
-         "End date"]
+         'Critical threshold',
+         'Initial volume',
+         'Volume',
+         'Maximum precision',
+         'Start date',
+         'End date']
       end
 
       def data_row
-        grouped = models.group_by { |model| model.class.name}
+        grouped = models.group_by { |model| model.class.name }
         quota_definition = grouped['QuotaDefinition'].first
         quota_balance_events = grouped['QuotaBalanceEvent']
 
-        [ expand_operation(quota_definition) + " definition",
-          quota_definition.quota_order_number_id,
-          quota_balance_event_string(quota_balance_events),
-          comm_code_string(quota_definition.quota_definition_sid),
-          quota_definition.quota_definition_sid,
-          quota_definition.critical_state,
-          quota_definition.critical_threshold,
-          quota_definition.initial_volume,
-          quota_definition.volume,
-          quota_definition.maximum_precision,
-          format_date(quota_definition.validity_start_date),
-          format_date(quota_definition.validity_end_date)
-        ]
+        ["#{expand_operation(quota_definition)} definition",
+         quota_definition.quota_order_number_id,
+         quota_balance_event_string(quota_balance_events),
+         comm_code_string(quota_definition.quota_definition_sid),
+         quota_definition.quota_definition_sid,
+         quota_definition.critical_state,
+         quota_definition.critical_threshold,
+         quota_definition.initial_volume,
+         quota_definition.volume,
+         quota_definition.maximum_precision,
+         format_date(quota_definition.validity_start_date),
+         format_date(quota_definition.validity_end_date)]
       end
 
       private
@@ -69,7 +68,7 @@ class CdsImporter
         definition = ::QuotaDefinition.where(quota_definition_sid: definition_id).eager(measures: []).first
         if definition.present?
           goods_nomenclature_item_ids = definition.measures.map(&:goods_nomenclature_item_id).uniq
-          goods_nomenclature_item_ids.join(",")
+          goods_nomenclature_item_ids.join(',')
         else
           ''
         end

--- a/app/lib/cds_importer/excel_writer/quota_definition.rb
+++ b/app/lib/cds_importer/excel_writer/quota_definition.rb
@@ -1,0 +1,79 @@
+class CdsImporter
+  class ExcelWriter
+    class QuotaDefinition < BaseMapper
+      def sheet_name
+        "Quota definitions"
+      end
+
+      def note
+        ["Please be careful when checking quota balances - each file may contains multiple updates on the same quota definition"]
+      end
+
+      def table_span
+        %w[A L]
+      end
+
+      def column_widths
+        [30, 20, 50, 70, 20, 20, 20, 20, 20, 20, 20, 20]
+      end
+
+      def heading
+        ["Action",
+         "Quota order number",
+         "Balance updates",
+         "Sample commodities",
+         "SID",
+         'Critical state',
+         "Critical threshold",
+         "Initial volume",
+         "Volume",
+         "Maximum precision",
+         "Start date",
+         "End date"]
+      end
+
+      def data_row
+        grouped = models.group_by { |model| model.class.name}
+        quota_definition = grouped['QuotaDefinition'].first
+        quota_balance_events = grouped['QuotaBalanceEvent']
+
+        [ expand_operation(quota_definition) + " definition",
+          quota_definition.quota_order_number_id,
+          quota_balance_event_string(quota_balance_events),
+          comm_code_string(quota_definition.quota_definition_sid),
+          quota_definition.quota_definition_sid,
+          quota_definition.critical_state,
+          quota_definition.critical_threshold,
+          quota_definition.initial_volume,
+          quota_definition.volume,
+          quota_definition.maximum_precision,
+          format_date(quota_definition.validity_start_date),
+          format_date(quota_definition.validity_end_date)
+        ]
+      end
+
+      private
+
+      def quota_balance_event_string(quota_balance_events)
+        if quota_balance_events.empty?
+          ''
+        else
+          quota_balance_events.sort_by!(&:occurrence_timestamp)
+          last_event = quota_balance_events.last
+
+          "#{format_date_ymd(last_event.occurrence_timestamp)} - New: #{last_event.new_balance} : Old: #{last_event.old_balance}"
+        end
+      end
+
+      def comm_code_string(definition_id)
+        definition = ::QuotaDefinition.where(quota_definition_sid: definition_id).eager(measures: []).first
+        if definition.present?
+          goods_nomenclature_item_ids = definition.measures.map(&:goods_nomenclature_item_id).uniq
+          goods_nomenclature_item_ids.join(",")
+        else
+          ''
+        end
+      end
+    end
+  end
+end

--- a/app/lib/cds_importer/record_inserter.rb
+++ b/app/lib/cds_importer/record_inserter.rb
@@ -4,9 +4,31 @@ class CdsImporter
 
     delegate :instrument, to: ActiveSupport::Notifications
 
-    def initialize(record_batch, filename)
-      @record_batch = record_batch
+    def initialize(filename)
+      @count = 0
+      @record_batch = []
       @filename = filename
+    end
+
+    def insert_record(cds_entity)
+      @record_batch << cds_entity
+      @count += 1
+
+      if @count >= batch_size
+        process_batch
+      end
+    end
+
+    def process_batch
+      save_batch
+      @record_batch.clear
+      @count = 0
+    end
+
+    private
+
+    def batch_size
+      TradeTariffBackend.cds_importer_batch_size
     end
 
     def save_batch
@@ -49,9 +71,7 @@ class CdsImporter
       instrument('cds_importer.import.operations', mapper:, operation: SKIPPED_OPERATION, count: 1, record:)
     end
 
-    private
-
-    attr_reader :record_batch, :mapper, :filename
+    attr_reader :record_batch, :filename
 
     def logger_enabled?
       CdsSynchronizer.cds_logger_enabled

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -266,6 +266,10 @@ module TradeTariffBackend
       ENV.fetch('CDS_IMPORT_BATCH_SIZE', '100').to_i
     end
 
+    def cds_importer_write_update_excel
+      ENV.fetch('CDS_IMPORT_WRITE_UPDATE_EXCEL', 'false').to_s == 'true'
+    end
+
     def cupid_team_to_emails
       ENV['CUPID_TEAM_TO_EMAILS']
     end

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   sequence(:measure_sid) { |n| n }
+  sequence(:quota_definition_sid) { |n| n }
   # offset sequence id to avoid conflicting with special casing of certain measure
   # types in the code base
   sequence(:measure_type_id, 10_000) { |n| n }
@@ -591,11 +592,13 @@ FactoryBot.define do
 
       transient do
         initial_volume { 1000 }
+        quota_definition_sid { generate(:quota_definition_sid) }
       end
 
       after(:build) do |measure, evaluator|
         create(
           :quota_definition,
+          quota_definition_sid: evaluator.quota_definition_sid,
           quota_order_number_id: measure.ordernumber,
           initial_volume: evaluator.initial_volume,
         )

--- a/spec/integration/cds_importer/cds_importer_spec.rb
+++ b/spec/integration/cds_importer/cds_importer_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe CdsImporter do
         end
 
         it 'invokes RecordInserter' do
-          allow(CdsImporter::RecordInserter).to receive(:new).with(kind_of(Array), cds_update.filename).and_call_original
+          allow(CdsImporter::RecordInserter).to receive(:new).with(cds_update.filename).and_call_original
 
           processor.process_xml_node('AdditionalCode', {})
 

--- a/spec/integration/cds_importer/record_inserter_spec.rb
+++ b/spec/integration/cds_importer/record_inserter_spec.rb
@@ -3,7 +3,13 @@ RSpec.describe CdsImporter::RecordInserter do
   let(:certificate_mapper) { CdsImporter::EntityMapper::CertificateMapper.new({}) }
 
   shared_examples_for 'a batch insert operation' do |measure, certificate|
-    subject(:do_insert) { described_class.new(batch, 'new_filename.gzip').save_batch }
+    subject(:inserter) { described_class.new('new_filename.gzip') }
+    let(:do_insert) {
+      batch.each do |record|
+        inserter.insert_record(record)
+      end
+      inserter.process_batch
+    }
 
     it 'persists a new record with the correct filename and operation' do
       expect {
@@ -53,9 +59,9 @@ RSpec.describe CdsImporter::RecordInserter do
     describe '#save_batch' do
       let(:measure2) { create(:measure, filename: 'initial_filename.gzip', operation: 'C') }
       let(:batch) do
-        [CdsImporter::CdsEntity.new('Measure', measure, measure_mapper),
-         CdsImporter::CdsEntity.new('Certificate', certificate, certificate_mapper),
-         CdsImporter::CdsEntity.new('Measure', measure2, measure_mapper)]
+        [CdsImporter::CdsEntity.new(1,'Measure', measure, measure_mapper),
+         CdsImporter::CdsEntity.new(2,'Certificate', certificate, certificate_mapper),
+         CdsImporter::CdsEntity.new(3,'Measure', measure2, measure_mapper)]
       end
 
       it_behaves_like 'a batch insert operation', 2, 1
@@ -64,24 +70,24 @@ RSpec.describe CdsImporter::RecordInserter do
     describe '#save_batch with skip record' do
       let(:measure2) { create(:measure, :with_skip_import, filename: 'initial_filename.gzip', operation: 'C') }
       let(:batch) do
-        [CdsImporter::CdsEntity.new('Measure', measure, measure_mapper),
-         CdsImporter::CdsEntity.new('Certificate', certificate, certificate_mapper),
-         CdsImporter::CdsEntity.new('Measure', measure2, measure_mapper)]
+        [CdsImporter::CdsEntity.new(1,'Measure', measure, measure_mapper),
+         CdsImporter::CdsEntity.new(2,'Certificate', certificate, certificate_mapper),
+         CdsImporter::CdsEntity.new(3,'Measure', measure2, measure_mapper)]
       end
 
       it_behaves_like 'a batch insert operation', 1, 1
     end
 
     describe '#save_batch error scenario' do
-      subject(:inserter) { described_class.new(batch, 'new_filename.gzip') }
+      subject(:inserter) { described_class.new('new_filename.gzip') }
 
       let(:measure2) { create(:measure, filename: 'initial_filename.gzip', operation: 'C') }
       let(:certificate2) { create(:certificate, filename: 'initial_filename.gzip', operation: 'C') }
       let(:batch) do
-        [CdsImporter::CdsEntity.new('Measure', measure, measure_mapper),
-         CdsImporter::CdsEntity.new('Certificate', certificate, certificate_mapper),
-         CdsImporter::CdsEntity.new('Certificate', certificate2, certificate_mapper),
-         CdsImporter::CdsEntity.new('Measure', measure2, measure_mapper)]
+        [CdsImporter::CdsEntity.new(1,'Measure', measure, measure_mapper),
+         CdsImporter::CdsEntity.new(2,'Certificate', certificate, certificate_mapper),
+         CdsImporter::CdsEntity.new(3,'Certificate', certificate2, certificate_mapper),
+         CdsImporter::CdsEntity.new(4,'Measure', measure2, measure_mapper)]
       end
 
       before do
@@ -89,7 +95,10 @@ RSpec.describe CdsImporter::RecordInserter do
       end
 
       it 'handles errors in save_group' do
-        inserter.save_batch
+        batch.each do |record|
+          inserter.insert_record(record)
+        end
+        inserter.process_batch
 
         expect(measure.class.operation_klass).to have_received(:multi_insert).at_least(:once)
       end

--- a/spec/integration/cds_importer/record_inserter_spec.rb
+++ b/spec/integration/cds_importer/record_inserter_spec.rb
@@ -4,12 +4,13 @@ RSpec.describe CdsImporter::RecordInserter do
 
   shared_examples_for 'a batch insert operation' do |measure, certificate|
     subject(:inserter) { described_class.new('new_filename.gzip') }
-    let(:do_insert) {
+
+    let(:do_insert) do
       batch.each do |record|
         inserter.insert_record(record)
       end
       inserter.process_batch
-    }
+    end
 
     it 'persists a new record with the correct filename and operation' do
       expect {
@@ -59,9 +60,9 @@ RSpec.describe CdsImporter::RecordInserter do
     describe '#save_batch' do
       let(:measure2) { create(:measure, filename: 'initial_filename.gzip', operation: 'C') }
       let(:batch) do
-        [CdsImporter::CdsEntity.new(1,'Measure', measure, measure_mapper),
-         CdsImporter::CdsEntity.new(2,'Certificate', certificate, certificate_mapper),
-         CdsImporter::CdsEntity.new(3,'Measure', measure2, measure_mapper)]
+        [CdsImporter::CdsEntity.new(1, 'Measure', measure, measure_mapper),
+         CdsImporter::CdsEntity.new(2, 'Certificate', certificate, certificate_mapper),
+         CdsImporter::CdsEntity.new(3, 'Measure', measure2, measure_mapper)]
       end
 
       it_behaves_like 'a batch insert operation', 2, 1
@@ -70,9 +71,9 @@ RSpec.describe CdsImporter::RecordInserter do
     describe '#save_batch with skip record' do
       let(:measure2) { create(:measure, :with_skip_import, filename: 'initial_filename.gzip', operation: 'C') }
       let(:batch) do
-        [CdsImporter::CdsEntity.new(1,'Measure', measure, measure_mapper),
-         CdsImporter::CdsEntity.new(2,'Certificate', certificate, certificate_mapper),
-         CdsImporter::CdsEntity.new(3,'Measure', measure2, measure_mapper)]
+        [CdsImporter::CdsEntity.new(1, 'Measure', measure, measure_mapper),
+         CdsImporter::CdsEntity.new(2, 'Certificate', certificate, certificate_mapper),
+         CdsImporter::CdsEntity.new(3, 'Measure', measure2, measure_mapper)]
       end
 
       it_behaves_like 'a batch insert operation', 1, 1
@@ -84,10 +85,10 @@ RSpec.describe CdsImporter::RecordInserter do
       let(:measure2) { create(:measure, filename: 'initial_filename.gzip', operation: 'C') }
       let(:certificate2) { create(:certificate, filename: 'initial_filename.gzip', operation: 'C') }
       let(:batch) do
-        [CdsImporter::CdsEntity.new(1,'Measure', measure, measure_mapper),
-         CdsImporter::CdsEntity.new(2,'Certificate', certificate, certificate_mapper),
-         CdsImporter::CdsEntity.new(3,'Certificate', certificate2, certificate_mapper),
-         CdsImporter::CdsEntity.new(4,'Measure', measure2, measure_mapper)]
+        [CdsImporter::CdsEntity.new(1, 'Measure', measure, measure_mapper),
+         CdsImporter::CdsEntity.new(2, 'Certificate', certificate, certificate_mapper),
+         CdsImporter::CdsEntity.new(3, 'Certificate', certificate2, certificate_mapper),
+         CdsImporter::CdsEntity.new(4, 'Measure', measure2, measure_mapper)]
       end
 
       before do

--- a/spec/lib/cds_importer/excel_writer/quota_definition_spec.rb
+++ b/spec/lib/cds_importer/excel_writer/quota_definition_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe CdsImporter::ExcelWriter::QuotaDefinition do
 
   let(:quota_definition) do
     instance_double(
-      :quota_definition,
-      class: instance_double(name: 'QuotaDefinition'),
+      QuotaDefinition,
+      class: instance_double(Class, name: 'QuotaDefinition'),
       quota_order_number_id: '123456',
       quota_definition_sid: 111,
       operation: 'C',
@@ -20,8 +20,8 @@ RSpec.describe CdsImporter::ExcelWriter::QuotaDefinition do
 
   let(:balance_event1) do
     instance_double(
-      :quota_balance_event,
-      class: instance_double(name: 'QuotaBalanceEvent'),
+      QuotaBalanceEvent,
+      class: instance_double(Class, name: 'QuotaBalanceEvent'),
       occurrence_timestamp: Time.utc(2025, 5, 27, 0, 0, 0),
       new_balance: 400,
       old_balance: 600,
@@ -30,8 +30,8 @@ RSpec.describe CdsImporter::ExcelWriter::QuotaDefinition do
 
   let(:balance_event2) do
     instance_double(
-      :quota_balance_event,
-      class: instance_double(name: 'QuotaBalanceEvent'),
+      QuotaBalanceEvent,
+      class: instance_double(Class, name: 'QuotaBalanceEvent'),
       occurrence_timestamp: Time.utc(2025, 5, 28, 0, 0, 0),
       new_balance: 300,
       old_balance: 400,

--- a/spec/lib/cds_importer/excel_writer/quota_definition_spec.rb
+++ b/spec/lib/cds_importer/excel_writer/quota_definition_spec.rb
@@ -2,74 +2,72 @@ RSpec.describe CdsImporter::ExcelWriter::QuotaDefinition do
   subject(:mapper) { described_class.new(models) }
 
   let(:quota_definition) do
-    double(
+    instance_double(
       :quota_definition,
-      class: double(name: "QuotaDefinition"),
-      quota_order_number_id: "123456",
+      class: instance_double(name: 'QuotaDefinition'),
+      quota_order_number_id: '123456',
       quota_definition_sid: 111,
       operation: 'C',
-      critical_state: "Y",
+      critical_state: 'Y',
       critical_threshold: 50,
       initial_volume: 1000,
       volume: 500,
       maximum_precision: 2,
       validity_start_date: Time.utc(2025, 1, 1, 0, 0, 0),
-      validity_end_date: Time.utc(2025, 12, 31, 23, 59, 59)
+      validity_end_date: Time.utc(2025, 12, 31, 23, 59, 59),
     )
   end
 
   let(:balance_event1) do
-    double(
+    instance_double(
       :quota_balance_event,
-      class: double(name: "QuotaBalanceEvent"),
+      class: instance_double(name: 'QuotaBalanceEvent'),
       occurrence_timestamp: Time.utc(2025, 5, 27, 0, 0, 0),
       new_balance: 400,
-      old_balance: 600
+      old_balance: 600,
     )
   end
 
   let(:balance_event2) do
-    double(
+    instance_double(
       :quota_balance_event,
-      class: double(name: "QuotaBalanceEvent"),
+      class: instance_double(name: 'QuotaBalanceEvent'),
       occurrence_timestamp: Time.utc(2025, 5, 28, 0, 0, 0),
       new_balance: 300,
-      old_balance: 400
+      old_balance: 400,
     )
   end
 
   let(:models) { [quota_definition, balance_event1, balance_event2] }
 
-
-  describe "#data_row" do
+  describe '#data_row' do
     let!(:measures) do
       create_list(:measure, 5, :with_quota_definition, quota_definition_sid: 111, ordernumber: '123456')
     end
 
-    it "returns a correctly formatted data row" do
+    it 'returns a correctly formatted data row' do
       row = mapper.data_row
 
-      expect(row[0]).to eq("Create a new definition")
-      expect(row[1]).to eq("123456")
+      expect(row[0]).to eq('Create a new definition')
+      expect(row[1]).to eq('123456')
       expect(row[4]).to eq(111)
-      expect(row[5]).to eq("Y")
+      expect(row[5]).to eq('Y')
       expect(row[6]).to eq(50)
       expect(row[7]).to eq(1000)
       expect(row[8]).to eq(500)
       expect(row[9]).to eq(2)
-      expect(row[10]).to eq("01/01/2025")
-      expect(row[11]).to eq("31/12/2025")
+      expect(row[10]).to eq('01/01/2025')
+      expect(row[11]).to eq('31/12/2025')
     end
 
-    it "uses the last balance event string" do
+    it 'uses the last balance event string' do
       row = mapper.data_row
       expect(row[2]).to match(/2025-05-28 - New: 300 : Old: 400/)
     end
 
-    it "joins comm codes into a comma-separated string" do
+    it 'joins comm codes into a comma-separated string' do
       row = mapper.data_row
-      expect(row[3]).to eq(measures.map(&:goods_nomenclature_item_id).join(","))
+      expect(row[3]).to eq(measures.map(&:goods_nomenclature_item_id).join(','))
     end
   end
 end
-

--- a/spec/lib/cds_importer/excel_writer/quota_definition_spec.rb
+++ b/spec/lib/cds_importer/excel_writer/quota_definition_spec.rb
@@ -1,0 +1,75 @@
+RSpec.describe CdsImporter::ExcelWriter::QuotaDefinition do
+  subject(:mapper) { described_class.new(models) }
+
+  let(:quota_definition) do
+    double(
+      :quota_definition,
+      class: double(name: "QuotaDefinition"),
+      quota_order_number_id: "123456",
+      quota_definition_sid: 111,
+      operation: 'C',
+      critical_state: "Y",
+      critical_threshold: 50,
+      initial_volume: 1000,
+      volume: 500,
+      maximum_precision: 2,
+      validity_start_date: Time.utc(2025, 1, 1, 0, 0, 0),
+      validity_end_date: Time.utc(2025, 12, 31, 23, 59, 59)
+    )
+  end
+
+  let(:balance_event1) do
+    double(
+      :quota_balance_event,
+      class: double(name: "QuotaBalanceEvent"),
+      occurrence_timestamp: Time.utc(2025, 5, 27, 0, 0, 0),
+      new_balance: 400,
+      old_balance: 600
+    )
+  end
+
+  let(:balance_event2) do
+    double(
+      :quota_balance_event,
+      class: double(name: "QuotaBalanceEvent"),
+      occurrence_timestamp: Time.utc(2025, 5, 28, 0, 0, 0),
+      new_balance: 300,
+      old_balance: 400
+    )
+  end
+
+  let(:models) { [quota_definition, balance_event1, balance_event2] }
+
+
+  describe "#data_row" do
+    let!(:measures) do
+      create_list(:measure, 5, :with_quota_definition, quota_definition_sid: 111, ordernumber: '123456')
+    end
+
+    it "returns a correctly formatted data row" do
+      row = mapper.data_row
+
+      expect(row[0]).to eq("Create a new definition")
+      expect(row[1]).to eq("123456")
+      expect(row[4]).to eq(111)
+      expect(row[5]).to eq("Y")
+      expect(row[6]).to eq(50)
+      expect(row[7]).to eq(1000)
+      expect(row[8]).to eq(500)
+      expect(row[9]).to eq(2)
+      expect(row[10]).to eq("01/01/2025")
+      expect(row[11]).to eq("31/12/2025")
+    end
+
+    it "uses the last balance event string" do
+      row = mapper.data_row
+      expect(row[2]).to match(/2025-05-28 - New: 300 : Old: 400/)
+    end
+
+    it "joins comm codes into a comma-separated string" do
+      row = mapper.data_row
+      expect(row[3]).to eq(measures.map(&:goods_nomenclature_item_id).join(","))
+    end
+  end
+end
+

--- a/spec/lib/cds_importer/excel_writer_spec.rb
+++ b/spec/lib/cds_importer/excel_writer_spec.rb
@@ -1,69 +1,70 @@
 RSpec.describe CdsImporter::ExcelWriter do
-  let(:filename) { "test.xlsx" }
   subject(:writer) { described_class.new(filename) }
 
+  let(:filename) { 'test.xlsx' }
+
   let(:entity1) do
-    double(
+    instance_double(
       :cds_entity,
-      key: "K1",
-      element_id: "E1",
-      instance: "I1"
+      key: 'K1',
+      element_id: 'E1',
+      instance: 'I1',
     )
   end
 
   let(:entity2) do
-    double(
+    instance_double(
       :cds_entity,
-      key: "K2",
-      element_id: "E2",
-      instance: "I2"
+      key: 'K2',
+      element_id: 'E2',
+      instance: 'I2',
     )
   end
 
-  describe "#initialize" do
-    it "sets defaults and creates an excel file" do
+  describe '#initialize' do
+    it 'sets defaults and creates an excel file' do
       expect(writer.instance_variable_get(:@filename)).to eq(filename)
       expect(writer.instance_variable_get(:@xml_element_id)).to be_nil
-      expect(writer.instance_variable_get(:@key)).to eq("")
+      expect(writer.instance_variable_get(:@key)).to eq('')
       expect(writer.instance_variable_get(:@instances)).to eq([])
       expect(writer.instance_variable_get(:@workbook)).not_to be_nil
     end
   end
 
-  describe "write_record" do
-    context "when xml_element_id is nil" do
-      it "sets key, xml_element_id, and adds the instance" do
+  describe 'write_record' do
+    context 'when xml_element_id is nil' do
+      it 'sets key, xml_element_id, and adds the instance' do
         writer.write_record(entity1)
 
-        expect(writer.instance_variable_get(:@key)).to eq("K1")
-        expect(writer.instance_variable_get(:@xml_element_id)).to eq("E1")
-        expect(writer.instance_variable_get(:@instances)).to eq(["I1"])
+        expect(writer.instance_variable_get(:@key)).to eq('K1')
+        expect(writer.instance_variable_get(:@xml_element_id)).to eq('E1')
+        expect(writer.instance_variable_get(:@instances)).to eq(%w[I1])
       end
     end
 
-    context "when xml_element_id changes" do
-      it "writes existing instances and resets before adding new one" do
+    context 'when xml_element_id changes' do
+      it 'writes existing instances and resets before adding new one' do
         allow(writer).to receive(:write)
 
         writer.write_record(entity1)
         writer.write_record(entity2)
 
-        expect(writer).to have_received(:write).with("K1", ["I1"])
-        expect(writer.instance_variable_get(:@key)).to eq("K2")
-        expect(writer.instance_variable_get(:@xml_element_id)).to eq("E2")
-        expect(writer.instance_variable_get(:@instances)).to eq(["I2"])
+        expect(writer).to have_received(:write).with('K1', %w[I1])
+        expect(writer.instance_variable_get(:@key)).to eq('K2')
+        expect(writer.instance_variable_get(:@xml_element_id)).to eq('E2')
+        expect(writer.instance_variable_get(:@instances)).to eq(%w[I2])
       end
     end
 
-    context "when xml_element_id stays the same" do
-      it "does not call write and accumulates instances" do
+    context 'when xml_element_id stays the same' do
+      it 'does not call write and accumulates instances' do
         allow(writer).to receive(:write)
 
         writer.write_record(entity1)
         writer.write_record(entity1)
 
         expect(writer).not_to have_received(:write)
-        expect(writer.instance_variable_get(:@instances)).to eq(["I1", "I1"])
+        expect(writer.instance_variable_get(:@instances)).to eq(%w[I1 I1])
       end
     end
   end

--- a/spec/lib/cds_importer/excel_writer_spec.rb
+++ b/spec/lib/cds_importer/excel_writer_spec.rb
@@ -1,0 +1,70 @@
+RSpec.describe CdsImporter::ExcelWriter do
+  let(:filename) { "test.xlsx" }
+  subject(:writer) { described_class.new(filename) }
+
+  let(:entity1) do
+    double(
+      :cds_entity,
+      key: "K1",
+      element_id: "E1",
+      instance: "I1"
+    )
+  end
+
+  let(:entity2) do
+    double(
+      :cds_entity,
+      key: "K2",
+      element_id: "E2",
+      instance: "I2"
+    )
+  end
+
+  describe "#initialize" do
+    it "sets defaults and creates an excel file" do
+      expect(writer.instance_variable_get(:@filename)).to eq(filename)
+      expect(writer.instance_variable_get(:@xml_element_id)).to be_nil
+      expect(writer.instance_variable_get(:@key)).to eq("")
+      expect(writer.instance_variable_get(:@instances)).to eq([])
+      expect(writer.instance_variable_get(:@workbook)).not_to be_nil
+    end
+  end
+
+  describe "write_record" do
+    context "when xml_element_id is nil" do
+      it "sets key, xml_element_id, and adds the instance" do
+        writer.write_record(entity1)
+
+        expect(writer.instance_variable_get(:@key)).to eq("K1")
+        expect(writer.instance_variable_get(:@xml_element_id)).to eq("E1")
+        expect(writer.instance_variable_get(:@instances)).to eq(["I1"])
+      end
+    end
+
+    context "when xml_element_id changes" do
+      it "writes existing instances and resets before adding new one" do
+        allow(writer).to receive(:write)
+
+        writer.write_record(entity1)
+        writer.write_record(entity2)
+
+        expect(writer).to have_received(:write).with("K1", ["I1"])
+        expect(writer.instance_variable_get(:@key)).to eq("K2")
+        expect(writer.instance_variable_get(:@xml_element_id)).to eq("E2")
+        expect(writer.instance_variable_get(:@instances)).to eq(["I2"])
+      end
+    end
+
+    context "when xml_element_id stays the same" do
+      it "does not call write and accumulates instances" do
+        allow(writer).to receive(:write)
+
+        writer.write_record(entity1)
+        writer.write_record(entity1)
+
+        expect(writer).not_to have_received(:write)
+        expect(writer.instance_variable_get(:@instances)).to eq(["I1", "I1"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[HMRC-987](https://transformuk.atlassian.net/browse/HMRC-987)

### What?

I have added/removed/altered:

- [ ] Added a handler to create a excel sheet of CDS updates into the CDS sync process
- [ ] Added CDS QuotaDefinition XML mapping to CDS updates sheet

### Why?

I am doing this because:

- We need to migrate CDS Updates report from python app to ruby
-
-

### Have you? (optional)

- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks (optional)

- We don't need to switch on this in any env until finalise the whole feature