### PR TITLE
HMRC-1651 Delay follow-up jobs on data syncs

### DIFF
--- a/app/workers/cds_updates_synchronizer_worker.rb
+++ b/app/workers/cds_updates_synchronizer_worker.rb
@@ -31,6 +31,7 @@ class CdsUpdatesSynchronizerWorker
     Sidekiq::Client.enqueue_in(5.minutes, ClearInvalidSearchReferences)
     Sidekiq::Client.enqueue_in(10.minutes, TreeIntegrityCheckWorker)
     Sidekiq::Client.enqueue_in(11.minutes, PopulateChangesTableWorker)
+    Sidekiq::Client.enqueue_in(15.minutes, ClearCacheWorker)
   rescue TariffSynchronizer::CdsUpdateDownloader::ListDownloadFailedError
     attempt_reschedule!
   end

--- a/app/workers/cds_updates_synchronizer_worker.rb
+++ b/app/workers/cds_updates_synchronizer_worker.rb
@@ -27,10 +27,10 @@ class CdsUpdatesSynchronizerWorker
     migrate_data if reapply_data_migrations
     refresh_materialized_view
 
-    Sidekiq::Client.enqueue(ClearInvalidSearchReferences)
-    Sidekiq::Client.enqueue(TreeIntegrityCheckWorker)
-    Sidekiq::Client.enqueue(PopulateChangesTableWorker)
-    Sidekiq::Client.enqueue_in(1.minute, ClearCacheWorker)
+    Sidekiq::Client.enqueue_in(5.minutes, ClearCacheWorker)
+    Sidekiq::Client.enqueue_in(5.minutes, ClearInvalidSearchReferences)
+    Sidekiq::Client.enqueue_in(10.minutes, TreeIntegrityCheckWorker)
+    Sidekiq::Client.enqueue_in(11.minutes, PopulateChangesTableWorker)
   rescue TariffSynchronizer::CdsUpdateDownloader::ListDownloadFailedError
     attempt_reschedule!
   end

--- a/app/workers/taric_updates_synchronizer_worker.rb
+++ b/app/workers/taric_updates_synchronizer_worker.rb
@@ -30,7 +30,7 @@ class TaricUpdatesSynchronizerWorker
     Sidekiq::Client.enqueue_in(11.minutes, PopulateChangesTableWorker)
 
     # NOTE: This will create some category assessments.
-    #       - Delay for 5 minutes as some of the category assessment queries rely on materialized views
+    #       - Delay for 15 minutes as some of the category assessment queries rely on materialized views
     #       - Pass the oldest pending date to process all changes inclusive of the oldest pending update
     Sidekiq::Client.enqueue_in(15.minutes, GreenLanesUpdatesWorker, oldest_pending_date.iso8601)
   end

--- a/app/workers/taric_updates_synchronizer_worker.rb
+++ b/app/workers/taric_updates_synchronizer_worker.rb
@@ -33,6 +33,8 @@ class TaricUpdatesSynchronizerWorker
     #       - Delay for 15 minutes as some of the category assessment queries rely on materialized views
     #       - Pass the oldest pending date to process all changes inclusive of the oldest pending update
     Sidekiq::Client.enqueue_in(15.minutes, GreenLanesUpdatesWorker, oldest_pending_date.iso8601)
+
+    Sidekiq::Client.enqueue_in(20.minutes, ClearCacheWorker)
   end
 
 private

--- a/app/workers/taric_updates_synchronizer_worker.rb
+++ b/app/workers/taric_updates_synchronizer_worker.rb
@@ -19,20 +19,20 @@ class TaricUpdatesSynchronizerWorker
     migrate_data if reapply_data_migrations
     refresh_materialized_view
 
-    Sidekiq::Client.enqueue(ClearInvalidSearchReferences)
-    Sidekiq::Client.enqueue(TreeIntegrityCheckWorker)
-    Sidekiq::Client.enqueue(PopulateChangesTableWorker)
-
-    # NOTE: This will create some category assessments.
-    #       - Delay for 5 minutes as some of the category assessment queries rely on materialized views
-    #       - Pass the oldest pending date to process all changes inclusive of the oldest pending update
-    Sidekiq::Client.enqueue_in(5.minutes, GreenLanesUpdatesWorker, oldest_pending_date.iso8601)
-
     # NOTE: Make sure caches have been refreshed including the CDN
     #       otherwise we serve up stale responses.
     #
     #       We let all of the other work complete off of the same queue first and whilst all items are dequeued in the correct order they have different runtimes so we add a further delay to be sure.
-    Sidekiq::Client.enqueue_in(10.minutes, ClearCacheWorker)
+    Sidekiq::Client.enqueue_in(5.minutes, ClearCacheWorker)
+
+    Sidekiq::Client.enqueue_in(5.minutes, ClearInvalidSearchReferences)
+    Sidekiq::Client.enqueue_in(10.minutes, TreeIntegrityCheckWorker)
+    Sidekiq::Client.enqueue_in(11.minutes, PopulateChangesTableWorker)
+
+    # NOTE: This will create some category assessments.
+    #       - Delay for 5 minutes as some of the category assessment queries rely on materialized views
+    #       - Pass the oldest pending date to process all changes inclusive of the oldest pending update
+    Sidekiq::Client.enqueue_in(15.minutes, GreenLanesUpdatesWorker, oldest_pending_date.iso8601)
   end
 
 private

--- a/spec/workers/cds_updates_synchronizer_worker_spec.rb
+++ b/spec/workers/cds_updates_synchronizer_worker_spec.rb
@@ -2,9 +2,9 @@ require 'data_migrator'
 
 RSpec.describe CdsUpdatesSynchronizerWorker, type: :worker do
   shared_examples_for 'a synchronizer worker that queues other workers' do
-    it { expect(Sidekiq::Client).to have_received(:enqueue).with(ClearInvalidSearchReferences) }
-    it { expect(Sidekiq::Client).to have_received(:enqueue).with(PopulateChangesTableWorker) }
-    it { expect(Sidekiq::Client).to have_received(:enqueue_in).with(1.minute, ClearCacheWorker) }
+    it { expect(Sidekiq::Client).to have_received(:enqueue_in).with(5.minutes, ClearInvalidSearchReferences) }
+    it { expect(Sidekiq::Client).to have_received(:enqueue_in).with(11.minutes, PopulateChangesTableWorker) }
+    it { expect(Sidekiq::Client).to have_received(:enqueue_in).with(5.minutes, ClearCacheWorker) }
   end
 
   describe '#perform' do

--- a/spec/workers/taric_updates_synchronizer_worker_spec.rb
+++ b/spec/workers/taric_updates_synchronizer_worker_spec.rb
@@ -2,10 +2,10 @@ require 'data_migrator'
 
 RSpec.describe TaricUpdatesSynchronizerWorker, type: :worker do
   shared_examples_for 'a synchronizer worker that queues other workers' do
-    it { expect(Sidekiq::Client).to have_received(:enqueue).with(ClearInvalidSearchReferences) }
-    it { expect(Sidekiq::Client).to have_received(:enqueue).with(TreeIntegrityCheckWorker) }
-    it { expect(Sidekiq::Client).to have_received(:enqueue_in).with(5.minutes, GreenLanesUpdatesWorker, Time.zone.today.iso8601) }
-    it { expect(Sidekiq::Client).to have_received(:enqueue_in).with(10.minutes, ClearCacheWorker) }
+    it { expect(Sidekiq::Client).to have_received(:enqueue_in).with(5.minutes, ClearInvalidSearchReferences) }
+    it { expect(Sidekiq::Client).to have_received(:enqueue_in).with(10.minutes, TreeIntegrityCheckWorker) }
+    it { expect(Sidekiq::Client).to have_received(:enqueue_in).with(15.minutes, GreenLanesUpdatesWorker, Time.zone.today.iso8601) }
+    it { expect(Sidekiq::Client).to have_received(:enqueue_in).with(5.minutes, ClearCacheWorker) }
   end
 
   describe '#perform' do


### PR DESCRIPTION
### Jira link

[HMRC-1651](https://transformuk.atlassian.net/browse/HMRC-1651)

### What?

I have added a bit of delay to various sync follow on jobs.  This is intended to alleviate some of the alerting we get overnight.  There's no guarantees this will work so can be reverted if no improvement is made.
