### PR TITLE
BAU: Consolidate TimeMachine in search service

### DIFF
--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -22,7 +22,7 @@ class SearchService
   class EmptyQuery < StandardError
   end
 
-  attr_reader :q, :result, :as_of, :data_serializer
+  attr_reader :q, :result, :data_serializer
   attr_accessor :resource_id
 
   delegate :serializable_hash, to: :result
@@ -36,15 +36,6 @@ class SearchService
       end
     end
     @data_serializer = data_serializer
-  end
-
-  def as_of=(date)
-    date ||= Time.zone.today.to_s
-    @as_of = begin
-      Date.parse(date)
-    rescue StandardError
-      Time.zone.today
-    end
   end
 
   def q=(term)
@@ -83,21 +74,21 @@ class SearchService
 
   def perform
     @result = if SearchService::RogueSearchService.call(q)
-                NullSearch.new(q, as_of)
+                NullSearch.new(q)
               else
                 if q.present?
                   exact_search.presence || fuzzy_search.presence
-                end || NullSearch.new(q, as_of)
+                end || NullSearch.new(q)
               end
 
     @result
   end
 
   def exact_search
-    ExactSearch.new(q, as_of, resource_id).search!
+    ExactSearch.new(q, resource_id).search!
   end
 
   def fuzzy_search
-    FuzzySearch.new(q, as_of).search!
+    FuzzySearch.new(q).search!
   end
 end

--- a/app/services/search_service/base_search.rb
+++ b/app/services/search_service/base_search.rb
@@ -11,9 +11,9 @@ class SearchService
 
     attr_reader :query_string, :results, :date, :resource_id
 
-    def initialize(query_string, date, resource_id = nil)
+    def initialize(query_string, resource_id = nil)
       @query_string = query_string.to_s.squish.downcase
-      @date = date
+      @date = TradeTariffRequest.time_machine_now
       @resource_id = resource_id
     end
 

--- a/app/services/search_service/null_search.rb
+++ b/app/services/search_service/null_search.rb
@@ -1,6 +1,6 @@
 class SearchService
   class NullSearch < BaseSearch
-    def initialize(query_string, date)
+    def initialize(query_string)
       super
       @results = BLANK_RESULT
     end

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe SearchService do
   # Searching in search suggestions or find historic goods nomenclature
   describe 'exact search' do
     subject(:result) do
-      described_class.new(data_serializer, q: query, as_of: Time.zone.today).to_json[:data][:attributes]
+      described_class.new(data_serializer, q: query).to_json[:data][:attributes]
     end
 
     around do |example|
@@ -314,7 +314,7 @@ RSpec.describe SearchService do
   describe 'fuzzy search' do
     context 'when filtering by date' do
       context 'when with goods codes that have bounded validity period' do
-        subject { described_class.new(data_serializer, q: 'water', as_of: date).to_json[:data][:attributes] }
+        subject { described_class.new(data_serializer, q: 'water').to_json[:data][:attributes] }
 
         before do
           create :heading, :with_description,
@@ -339,16 +339,12 @@ RSpec.describe SearchService do
         end
 
         context 'with search date within goods code validity period' do
-          let(:date) { '2007-01-01' }
-
           around { |example| TimeMachine.at('2005-01-01') { example.run } }
 
-          it { is_expected.not_to match_json_expression heading_pattern }
+          it { is_expected.to match_json_expression heading_pattern }
         end
 
         context 'with search date outside goods code validity period' do
-          let(:date) { '2005-01-01' }
-
           around { |example| TimeMachine.at('2007-01-01') { example.run } }
 
           it { is_expected.not_to match_json_expression heading_pattern }
@@ -356,7 +352,9 @@ RSpec.describe SearchService do
       end
 
       context 'when with goods codes that have unbounded validity period' do
-        subject(:result) { described_class.new(data_serializer, q: 'Live bovine animals', as_of: date).to_json[:data][:attributes] }
+        subject(:result) { described_class.new(data_serializer, q: 'Live bovine animals').to_json[:data][:attributes] }
+
+        around { |example| TimeMachine.at(date) { example.run } }
 
         before do
           create :heading, :with_description,


### PR DESCRIPTION
### Jira link

BAU

<img width="813" height="523" alt="image" src="https://github.com/user-attachments/assets/52a95eb3-9159-4cef-a5cc-ade9eebed0a6" />


### What?

I have added/removed/altered:

- [x] Consolidate time machine usage under the search service

### Why?

I am doing this because:

- Previously we were using a custom implementation of the as_of handling that duplicates the existing implementation in the application controller
- This change also fixes a bug where the date is nil if the as_of isn't supplied as a query param since we were relying on the query parameter to be present in order to set even a default date.
