### PR TITLE
MyOTT-390 handle non-declarable Chapters and declarable/non-declarable Headings and SubHeadings

### DIFF
--- a/spec/factories/goods_nomenclature_factory.rb
+++ b/spec/factories/goods_nomenclature_factory.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   sequence(:goods_nomenclature_sid, 100) # Some factories hard code SIDs, so avoid clashing
   sequence(:chapter_short_code, 10) { |n| sprintf '%02d', n }
   sequence(:heading_short_code, 10) { |n| sprintf '01%02d', n }
+  sequence(:subheading_short_code, 10) { |n| sprintf '%01%02%02d', n }
   sequence(:commodity_short_code) { |n| sprintf '%06d', n }
 
   factory :goods_nomenclature do
@@ -127,6 +128,11 @@ FactoryBot.define do
 
     trait :heading do
       goods_nomenclature_item_id { sprintf '%s000000', generate(:heading_short_code) }
+      indents { 0 }
+    end
+
+    trait :subheading do
+      goods_nomenclature_item_id { sprintf '%s0000', generate(:subheading_short_code) }
       indents { 0 }
     end
 


### PR DESCRIPTION
### Jira link

[MyOTT-390](https://transformuk.atlassian.net/browse/MyOTT-390)

### What?

I have altered:

- [x] `ActiveCommoditiesService>historically_declarable_commodity_codes` to reject a commodity code if any version of each commodity code was a Chapter class OR a non-declarable Heading or Subheading at some point in their history.

### Why?

I am doing this because:

- This ensures codes that may have changed classification over time are correctly identified as historically declarable.

Examples of Commodity Codes (CCs) to enforce change:

- A currently declarable `Heading`: 4705000000 (Should show as `Active`)
- A previously declarable `Subheading` (_ie. it's children were created at a later date_): 2912410000 (Should show as `Expired`)
- A never declarable `Chapter` & `Heading`: 0100000000 & 0101000000 (Should show as `Invalid`)

 
 
