### PR TITLE
Support UK and XI services running in a single instance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,92 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Trade Tariff Backend is a Rails API that serves commodity code data for UK and XI (Northern Ireland) trade tariffs. It provides search, duty calculations, and tariff data to the Frontend, Admin, and Duty Calculator applications.
+
+The app runs in one of two modes controlled by the `SERVICE` environment variable (`uk` or `xi`), which affects which routes, data, and logic are active.
+
+## Commands
+
+### Development
+
+```sh
+bin/setup           # Install dependencies and set up the database
+bin/dev             # Start Rails + Sidekiq together
+bin/rails s         # Start Rails server only
+```
+
+### Testing
+
+```sh
+bundle exec rspec                          # Run all tests
+bundle exec rspec spec/models/chapter_spec.rb   # Run a single spec file
+bundle exec rspec spec/models/chapter_spec.rb:42  # Run a specific line
+```
+
+### Linting
+
+```sh
+bin/rubocop                   # Run RuboCop
+bin/rubocop -a                # Auto-fix offences
+bin/brakeman                  # Security scan
+```
+
+### Database & Search
+
+```sh
+bin/rake db:migrate            # Run migrations
+bin/rake tariff:reindex        # Rebuild OpenSearch indexes
+bin/rake tariff:sync           # Trigger daily data sync via Sidekiq
+```
+
+## Architecture
+
+### Dual-service design
+
+The codebase serves both `uk` and `xi` services from a single Rails instance. All engines are mounted at both `/uk/...` and `/xi/...` URL prefixes simultaneously. The `SetRequestedService` middleware extracts the service from the request path and stores it in `TradeTariffRequest.service` (an `ActiveSupport::CurrentAttributes` attribute), making `TradeTariffBackend.service` / `.uk?` / `.xi?` return the correct value for the duration of each request. Background workers and non-HTTP contexts fall back to `ENV['SERVICE']` (default: `uk`).
+
+UK-only endpoints (exchange rates, news) include the `UkOnly` concern which raises a routing error for XI requests. XI-only endpoints (green lanes) use the `XiOnly` concern similarly.
+
+### API engines (`app/engines/`)
+
+Routes are split into Grape-like Rails engines mounted in `config/routes.rb`:
+- `V1Api` / `V2Api` — versioned public APIs, selected via `Accept` header (`application/vnd.uktt.v1` or `v2`)
+- `AdminApi` — admin interface
+- `InternalApi` — internal service-to-service routes
+- `UserApi` — user-facing routes (UK only)
+
+### Models use Sequel, not ActiveRecord
+
+All models inherit from `Sequel::Model`. ActiveRecord is not used. Key Sequel plugins are configured globally in `config/application.rb`: `:time_machine`, `:oplog`, `:pagination`, `:pg_array`, `:pg_json`.
+
+### TimeMachine
+
+The `TimeMachine` plugin/concern is central to the app — it gates all database queries to return records valid at a specific date. Tests wrap examples in `TimeMachine.now { ... }` automatically (see `spec/rails_helper.rb`). Worker specs use `TimeMachine.no_time_machine { ... }`.
+
+### GoodsNomenclature hierarchy (STI)
+
+`GoodsNomenclature` uses STI to distinguish `Chapter`, `Heading`, `Subheading`, and `Commodity` based on the `goods_nomenclature_item_id` format and `producline_suffix`.
+
+### Search
+
+OpenSearch (configured via `ELASTICSEARCH_URL`) powers commodity search. Indexes are defined in `app/elastic_search_indexes/`. The `TradeTariffBackend.search_client` wraps index management; `bin/rake tariff:reindex` rebuilds all indexes.
+
+### Background jobs
+
+Sidekiq workers in `app/workers/` handle data sync, cache warming, report generation, and search reindexing. Daily sync workers are `CdsUpdatesSynchronizerWorker` (UK/CDS) and `TaricUpdatesSynchronizerWorker` (XI/TARIC).
+
+### Services and serializers
+
+Business logic lives in `app/services/`. API responses use `jsonapi-serializer` (JSON:API format) in `app/serializers/`, with legacy RABL templates in `app/views/`.
+
+## Key conventions
+
+- **Single quotes** for strings (enforced by RuboCop)
+- **RuboCop govuk** preset (`rubocop-govuk`) — line length max 120
+- Sidekiq jobs must use **scalar arguments only** (Integer, String, Boolean) — enforced by a custom cop (`Custom/SidekiqComplexArguments`)
+- RSpec context blocks must be prefixed with `when`, `with`, `without`, or `for`
+- Database uses **PostgreSQL with pgvector** extension; migrations use Sequel migration DSL
+- Environment config is read via `TradeTariffBackend` module methods in `app/lib/trade_tariff_backend.rb`

--- a/app/controllers/api/admin/admin_configurations_controller.rb
+++ b/app/controllers/api/admin/admin_configurations_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module Admin
     class AdminConfigurationsController < AdminController
+      include UkOnly
+
       def index
         render json: serialize(configurations)
       end

--- a/app/controllers/api/admin/live_issues_controller.rb
+++ b/app/controllers/api/admin/live_issues_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module Admin
     class LiveIssuesController < AdminController
+      include UkOnly
+
       def index
         render json: serialize(live_issues)
       end

--- a/app/controllers/api/admin/news/collections_controller.rb
+++ b/app/controllers/api/admin/news/collections_controller.rb
@@ -2,6 +2,8 @@ module Api
   module Admin
     module News
       class CollectionsController < AdminController
+        include UkOnly
+
         def index
           collections = ::News::Collection.all
 

--- a/app/controllers/api/admin/news/items_controller.rb
+++ b/app/controllers/api/admin/news/items_controller.rb
@@ -2,6 +2,8 @@ module Api
   module Admin
     module News
       class ItemsController < AdminController
+        include UkOnly
+
         def index
           render json: serialize(news_items.to_a, pagination_meta)
         end

--- a/app/controllers/api/v2/exchange_rates/base_controller.rb
+++ b/app/controllers/api/v2/exchange_rates/base_controller.rb
@@ -2,6 +2,8 @@ module Api
   module V2
     module ExchangeRates
       class BaseController < ApiController
+        include UkOnly
+
         no_caching
 
         before_action :validate_exchange_rate_type

--- a/app/controllers/api/v2/news/collections_controller.rb
+++ b/app/controllers/api/v2/news/collections_controller.rb
@@ -2,6 +2,8 @@ module Api
   module V2
     module News
       class CollectionsController < ApiController
+        include UkOnly
+
         def index
           collections = ::News::Collection.published.all
           serializer = Api::V2::News::CollectionSerializer.new(collections)

--- a/app/controllers/api/v2/news/items_controller.rb
+++ b/app/controllers/api/v2/news/items_controller.rb
@@ -2,6 +2,8 @@ module Api
   module V2
     module News
       class ItemsController < ApiController
+        include UkOnly
+
         time_based_caching
 
         PAGE_SIZES = [1, 10, 20].freeze

--- a/app/controllers/api/v2/news/years_controller.rb
+++ b/app/controllers/api/v2/news/years_controller.rb
@@ -2,6 +2,8 @@ module Api
   module V2
     module News
       class YearsController < ApiController
+        include UkOnly
+
         def index
           years = ::News::Item.for_target('updates')
                               .for_service(params[:service])

--- a/app/controllers/concerns/uk_only.rb
+++ b/app/controllers/concerns/uk_only.rb
@@ -1,0 +1,13 @@
+module UkOnly
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :check_service
+
+    def check_service
+      if TradeTariffBackend.xi?
+        raise ActionController::RoutingError, 'Invalid service'
+      end
+    end
+  end
+end

--- a/app/engines/admin_api.rb
+++ b/app/engines/admin_api.rb
@@ -64,18 +64,16 @@ AdminApi.routes.draw do
 
     # avoid admin named routes clashing with public api named routes
     namespace :admin, path: '' do
-      if Rails.env.development? || TradeTariffBackend.uk?
-        namespace :news do
-          resources :items, only: %i[index show create update destroy]
-          resources :collections, only: %i[index show create update]
-        end
-
-        resources :news_items, only: %i[index show create update destroy],
-                               controller: 'news/items'
-
-        resources :live_issues, only: %i[index show create update destroy]
-        resources :admin_configurations, only: %i[index show update]
+      namespace :news do
+        resources :items, only: %i[index show create update destroy]
+        resources :collections, only: %i[index show create update]
       end
+
+      resources :news_items, only: %i[index show create update destroy],
+                             controller: 'news/items'
+
+      resources :live_issues, only: %i[index show create update destroy]
+      resources :admin_configurations, only: %i[index show update]
 
       namespace :green_lanes do
         resources :category_assessments, only: %i[index show create update destroy] do

--- a/app/engines/v2_api.rb
+++ b/app/engines/v2_api.rb
@@ -18,14 +18,12 @@ V2Api.routes.draw do
         end
       end
 
-      if TradeTariffBackend.uk?
-        namespace :exchange_rates do
-          get 'period_lists(/:year)', to: 'period_lists#show', as: :period_list
-          resources :files, only: [:show]
-        end
-
-        resources :exchange_rates, only: [:show]
+      namespace :exchange_rates do
+        get 'period_lists(/:year)', to: 'period_lists#show', as: :period_list
+        resources :files, only: [:show]
       end
+
+      resources :exchange_rates, only: [:show]
 
       resources :chapters, only: %i[index show], constraints: { id: /\d{1,2}/ } do
         member do
@@ -116,18 +114,16 @@ V2Api.routes.draw do
             as: :product_specific_rules
       end
 
-      if Rails.env.development? || TradeTariffBackend.uk?
-        namespace :news do
-          resources :items, only: %i[index show]
-          resources :years, only: %i[index]
-          resources :collections, only: %i[index] do
-            resources :items, only: %i[index], shallow: true
-          end
+      namespace :news do
+        resources :items, only: %i[index show]
+        resources :years, only: %i[index]
+        resources :collections, only: %i[index] do
+          resources :items, only: %i[index], shallow: true
         end
-
-        get '/news_items/:id', to: 'news/items#show', as: nil
-        get '/news_items', to: 'news/items#index', as: nil
       end
+
+      get '/news_items/:id', to: 'news/items#show', as: nil
+      get '/news_items', to: 'news/items#index', as: nil
 
       get 'live_issues', to: 'live_issues#index'
 

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -127,7 +127,7 @@ module TradeTariffBackend
     end
 
     def service
-      ENV.fetch('SERVICE', 'uk')
+      TradeTariffRequest.service.presence || ENV.fetch('SERVICE', 'uk')
     end
 
     def environment
@@ -219,7 +219,8 @@ module TradeTariffBackend
     end
 
     def rules_of_origin
-      @rules_of_origin ||= RulesOfOrigin::DataSet.load_default
+      @rules_of_origin ||= {}
+      @rules_of_origin[service] ||= RulesOfOrigin::DataSet.load_default
     end
 
     def stop_words

--- a/app/lib/trade_tariff_request.rb
+++ b/app/lib/trade_tariff_request.rb
@@ -10,5 +10,8 @@ class TradeTariffRequest < ActiveSupport::CurrentAttributes
             :meursing_additional_code_id,
             # Controls whether label fields (known_brands, colloquial_terms, synonyms)
             # are included in search suggestion queries
-            :search_labels_enabled
+            :search_labels_enabled,
+            # Holds the service ('uk' or 'xi') derived from the request URL prefix.
+            # When set, TradeTariffBackend.service reads this instead of ENV['SERVICE'].
+            :service
 end

--- a/app/middleware/set_requested_service.rb
+++ b/app/middleware/set_requested_service.rb
@@ -1,0 +1,18 @@
+# Extracts the trade tariff service ('uk' or 'xi') from the request URL prefix
+# and stores it in TradeTariffRequest.service so that TradeTariffBackend.service
+# returns the correct value for the duration of the request.
+class SetRequestedService
+  SERVICE_REGEX = %r{\A/(uk|xi)/}
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    path = env['PATH_INFO'].to_s
+    match = path.match(SERVICE_REGEX)
+    TradeTariffRequest.service = match ? match[1] : nil
+
+    @app.call(env)
+  end
+end

--- a/app/models/measure_type_exclusion.rb
+++ b/app/models/measure_type_exclusion.rb
@@ -1,36 +1,40 @@
 require 'csv'
 
 class MeasureTypeExclusion
-  DEFAULT_SOURCE = Rails.root.join(
-    "db/#{TradeTariffBackend.service}_measure_type_exclusions.csv",
-  ).freeze
-
-  class_attribute :exclusions
-  self.exclusions = nil
+  class_attribute :exclusions_by_service
+  self.exclusions_by_service = {}
 
   class << self
-    def load_from_file(file = DEFAULT_SOURCE)
-      init_data
+    def source_for(service)
+      Rails.root.join("db/#{service}_measure_type_exclusions.csv")
+    end
 
-      CSV.foreach(file, headers: true, &method(:load_row))
+    def exclusions
+      exclusions_by_service[TradeTariffBackend.service]
+    end
+
+    def load_from_file(file = source_for(TradeTariffBackend.service))
+      service = TradeTariffBackend.service
+      exclusions_by_service[service] = {}
+
+      CSV.foreach(file, headers: true) do |row|
+        load_row(row, service)
+      end
 
       self
     end
 
-    def init_data
-      self.exclusions ||= {}
-    end
-
     def reset_data
-      self.exclusions = nil
+      self.exclusions_by_service = {}
 
       self
     end
 
     def find(measure_type_id, geographical_area_id)
-      load_from_file if exclusions.nil?
+      service = TradeTariffBackend.service
+      load_from_file unless exclusions_by_service.key?(service)
 
-      exclusions[[measure_type_id.to_s, geographical_area_id.to_s]] || []
+      exclusions_by_service[service][[measure_type_id.to_s, geographical_area_id.to_s]] || []
     end
 
     def find_geographical_areas(measure_type_id, geographical_area_id)
@@ -42,11 +46,11 @@ class MeasureTypeExclusion
 
   private
 
-    def load_row(row)
+    def load_row(row, service)
       row_key = row.values_at('measure_type_id', 'geographical_area_id')
 
-      self.exclusions[row_key] ||= []
-      self.exclusions[row_key] << row['excluded_country']
+      exclusions_by_service[service][row_key] ||= []
+      exclusions_by_service[service][row_key] << row['excluded_country']
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,6 +3,7 @@ require_relative '../lib/core_ext/object'
 require_relative '../app/middleware/handle_goods_nomenclature'
 require_relative '../app/middleware/handle_api_gateway_params'
 require_relative '../app/middleware/clear_cache_control'
+require_relative '../app/middleware/set_requested_service'
 require_relative '../app/lib/trade_tariff_backend'
 
 require 'action_controller/railtie'
@@ -68,6 +69,7 @@ module TradeTariffBackend
 
     config.sequel.allow_missing_migration_files = TradeTariffBackend.allow_missing_migration_files
 
+    config.middleware.use ::SetRequestedService
     config.middleware.use ::HandleGoodsNomenclature
     config.middleware.use ::HandleApiGatewayParams
     config.middleware.insert_before Rack::ETag, ::ClearCacheControl

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,24 +10,24 @@ Rails.application.routes.draw do
   # Sidekiq web interface
   draw(:sidekiq)
 
-  # Admin routes
-  mount AdminApi => '/uk/admin', as: 'uk_admin_api' if TradeTariffBackend.uk?
-  mount AdminApi => '/xi/admin', as: 'xi_admin_api' if TradeTariffBackend.xi?
+  # Admin routes (xi first so uk is the preferred mount for route helpers)
+  mount AdminApi => '/xi/admin', as: 'xi_admin_api'
+  mount AdminApi => '/uk/admin', as: 'uk_admin_api'
 
   # Internal routes
-  mount InternalApi => '/uk/internal', as: 'uk_internal_api' if TradeTariffBackend.uk?
-  mount InternalApi => '/xi/internal', as: 'xi_internal_api' if TradeTariffBackend.xi?
+  mount InternalApi => '/xi/internal', as: 'xi_internal_api'
+  mount InternalApi => '/uk/internal', as: 'uk_internal_api'
 
   # User routes
-  mount UserApi => '/uk/user', as: 'uk_user_api' if TradeTariffBackend.uk?
+  mount UserApi => '/uk/user', as: 'uk_user_api'
 
-  # V1 routes
-  mount V1Api => '/uk/api', as: 'uk_v1_versioned_api', constraints: VersionedAcceptHeader.new(version: 1.0) if TradeTariffBackend.uk?
-  mount V1Api => '/xi/api', as: 'xi_v1_versioned_api', constraints: VersionedAcceptHeader.new(version: 1.0) if TradeTariffBackend.xi?
+  # V1 routes (xi first so uk is the preferred mount for route helpers)
+  mount V1Api => '/xi/api', as: 'xi_v1_versioned_api', constraints: VersionedAcceptHeader.new(version: 1.0)
+  mount V1Api => '/uk/api', as: 'uk_v1_versioned_api', constraints: VersionedAcceptHeader.new(version: 1.0)
 
-  # V2 routes
-  mount V2Api => '/uk/api', as: 'uk_v2_versioned_api', constraints: VersionedAcceptHeader.new(version: 2.0) if TradeTariffBackend.uk?
-  mount V2Api => '/xi/api', as: 'xi_v2_versioned_api', constraints: VersionedAcceptHeader.new(version: 2.0) if TradeTariffBackend.xi?
+  # V2 routes (xi first so uk is the preferred mount for route helpers)
+  mount V2Api => '/xi/api', as: 'xi_v2_versioned_api', constraints: VersionedAcceptHeader.new(version: 2.0)
+  mount V2Api => '/uk/api', as: 'uk_v2_versioned_api', constraints: VersionedAcceptHeader.new(version: 2.0)
 
   match '(/:service)/api/v:version(/*path)',
         via: :all,

--- a/config/routes/sidekiq.rb
+++ b/config/routes/sidekiq.rb
@@ -4,5 +4,5 @@ Sidekiq::Web.use ActionDispatch::Cookies
 Sidekiq::Web.use Rails.application.config.session_store, Rails.application.config.session_options
 
 mount Sidekiq::Web => '/sidekiq', as: 'sidekiq'
-mount Sidekiq::Web => '/uk/sidekiq', as: 'uk_sidekiq' if TradeTariffBackend.uk?
-mount Sidekiq::Web => '/xi/sidekiq', as: 'xi_sidekiq' if TradeTariffBackend.xi?
+mount Sidekiq::Web => '/uk/sidekiq', as: 'uk_sidekiq'
+mount Sidekiq::Web => '/xi/sidekiq', as: 'xi_sidekiq'

--- a/spec/middleware/set_requested_service_spec.rb
+++ b/spec/middleware/set_requested_service_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe SetRequestedService do
+  subject(:middleware) { described_class.new(app) }
+
+  let(:app) { ->(_env) { [200, {}, []] } }
+  let(:env) { Rack::MockRequest.env_for(path) }
+
+  after { TradeTariffRequest.reset }
+
+  describe '#call' do
+    context 'with a /uk/ prefixed path' do
+      let(:path) { '/uk/api/sections' }
+
+      it 'sets TradeTariffRequest.service to uk' do
+        middleware.call(env)
+
+        expect(TradeTariffRequest.service).to eq('uk')
+      end
+    end
+
+    context 'with a /xi/ prefixed path' do
+      let(:path) { '/xi/api/commodities/0101000000' }
+
+      it 'sets TradeTariffRequest.service to xi' do
+        middleware.call(env)
+
+        expect(TradeTariffRequest.service).to eq('xi')
+      end
+    end
+
+    context 'with a non-service path' do
+      let(:path) { '/healthcheckz' }
+
+      it 'sets TradeTariffRequest.service to nil' do
+        middleware.call(env)
+
+        expect(TradeTariffRequest.service).to be_nil
+      end
+    end
+
+    it 'passes the request to the next middleware' do
+      test_env = Rack::MockRequest.env_for('/uk/api/sections')
+
+      allow(app).to receive(:call).and_return([200, {}, []])
+      middleware.call(test_env)
+
+      expect(app).to have_received(:call).with(test_env)
+    end
+  end
+end

--- a/spec/models/measure_type_exclusion_spec.rb
+++ b/spec/models/measure_type_exclusion_spec.rb
@@ -1,10 +1,9 @@
 RSpec.describe MeasureTypeExclusion do
-  before do
-    allow(described_class).to receive(:exclusions).and_return(test_exclusions)
-  end
-
-  let(:test_exclusions) { {} }
   let(:test_csv_file) { file_fixture('measure_type_exclusions.csv') }
+
+  before { described_class.reset_data }
+
+  after { described_class.reset_data }
 
   describe '.load_from_file' do
     subject { described_class.load_from_file(test_csv_file).exclusions }

--- a/spec/requests/multi_service_spec.rb
+++ b/spec/requests/multi_service_spec.rb
@@ -1,0 +1,156 @@
+RSpec.describe 'Multi-service single instance', :v2 do
+  describe 'service detection from URL prefix' do
+    context 'when requesting a UK path' do
+      it 'sets TradeTariffBackend.service to uk during the request' do
+        observed_service = nil
+
+        allow(Api::V2::SectionsController).to receive(:new).and_wrap_original do |original, *args|
+          controller = original.call(*args)
+          observed_service = TradeTariffBackend.service
+          controller
+        end
+
+        api_get '/uk/api/sections'
+
+        expect(observed_service).to eq('uk')
+      end
+    end
+
+    context 'when requesting an XI path' do
+      it 'sets TradeTariffBackend.service to xi during the request' do
+        observed_service = nil
+
+        allow(Api::V2::SectionsController).to receive(:new).and_wrap_original do |original, *args|
+          controller = original.call(*args)
+          observed_service = TradeTariffBackend.service
+          controller
+        end
+
+        api_get '/xi/api/sections'
+
+        expect(observed_service).to eq('xi')
+      end
+    end
+
+    it 'resets the service to nil after the request ends' do
+      api_get '/uk/api/sections'
+
+      expect(TradeTariffRequest.service).to be_nil
+    end
+  end
+
+  describe 'UK routes are accessible' do
+    it 'responds to /uk/api/sections' do
+      api_get '/uk/api/sections'
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'responds to /uk/api/chapters' do
+      api_get '/uk/api/chapters'
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'XI routes are accessible' do
+    it 'responds to /xi/api/sections' do
+      api_get '/xi/api/sections'
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'responds to /xi/api/chapters' do
+      api_get '/xi/api/chapters'
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'UK-only endpoints' do
+    describe 'exchange rates' do
+      let(:exchange_rate_collection) { build(:exchange_rates_collection, month: 1, year: 2024) }
+
+      before do
+        allow(ExchangeRates::ExchangeRateCollection)
+          .to receive(:build)
+          .and_return(exchange_rate_collection)
+      end
+
+      it 'returns 200 on the UK service' do
+        api_get '/uk/api/exchange_rates/2024-1', params: { filter: { type: 'monthly' } }
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns 404 on the XI service' do
+        api_get '/xi/api/exchange_rates/2024-1', params: { filter: { type: 'monthly' } }
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    describe 'news items' do
+      it 'returns 200 on the UK service' do
+        api_get '/uk/api/news/items'
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns 404 on the XI service' do
+        api_get '/xi/api/news/items'
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe 'XI-only endpoints' do
+    describe 'green lanes goods nomenclatures' do
+      let(:authorization) do
+        ActionController::HttpAuthentication::Token.encode_credentials('Trade-Tariff-Test')
+      end
+
+      it 'returns 404 on the UK service' do
+        api_get '/uk/api/green_lanes/goods_nomenclatures/1234560000',
+                headers: { 'HTTP_AUTHORIZATION' => authorization }
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe 'service-dependent CSV filenames' do
+    before do
+      create(:section, id: 1, position: 1, numeral: 'I', title: 'Live animals')
+    end
+
+    it 'uses uk in the filename for UK requests' do
+      api_get '/uk/api/sections.csv'
+
+      expect(response.headers['Content-Disposition']).to include('uk-sections-')
+    end
+
+    it 'uses xi in the filename for XI requests' do
+      api_get '/xi/api/sections.csv'
+
+      expect(response.headers['Content-Disposition']).to include('xi-sections-')
+    end
+  end
+
+  describe 'SetRequestedService middleware' do
+    it 'sets service to uk for /uk/ paths' do
+      api_get '/uk/api/sections'
+
+      # TradeTariffRequest is reset after the request; the middleware worked
+      # correctly if the response was valid (service context drove routing)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'does not set a service for non-prefixed paths' do
+      get '/healthcheckz'
+
+      expect(TradeTariffRequest.service).to be_nil
+    end
+  end
+end

--- a/spec/unit/trade_tariff_backend_spec.rb
+++ b/spec/unit/trade_tariff_backend_spec.rb
@@ -1,4 +1,43 @@
 RSpec.describe TradeTariffBackend do
+  describe '.service' do
+    after { TradeTariffRequest.reset }
+
+    context 'when TradeTariffRequest.service is set' do
+      before { TradeTariffRequest.service = 'xi' }
+
+      it 'returns the request-scoped service' do
+        expect(described_class.service).to eq('xi')
+      end
+    end
+
+    context 'when TradeTariffRequest.service is nil' do
+      before { TradeTariffRequest.service = nil }
+
+      it 'falls back to ENV["SERVICE"]' do
+        stub_const('ENV', ENV.to_hash.merge('SERVICE' => 'uk'))
+        expect(described_class.service).to eq('uk')
+      end
+    end
+  end
+
+  describe '.uk?' do
+    after { TradeTariffRequest.reset }
+
+    context 'when service is uk' do
+      before { TradeTariffRequest.service = 'uk' }
+
+      it { expect(described_class.uk?).to be true }
+      it { expect(described_class.xi?).to be false }
+    end
+
+    context 'when service is xi' do
+      before { TradeTariffRequest.service = 'xi' }
+
+      it { expect(described_class.uk?).to be false }
+      it { expect(described_class.xi?).to be true }
+    end
+  end
+
   describe '.reindex_all' do
     let(:indexer) { double }
 


### PR DESCRIPTION
## Summary

- Adds `SetRequestedService` middleware that reads the URL prefix (`/uk/` or `/xi/`) and stores the service in `TradeTariffRequest.service` per request, making service selection request-scoped rather than process-wide
- Makes `TradeTariffBackend.service` fall back to `ENV['SERVICE']` only when no request-scoped service is set
- Mounts all API engines at both `/uk/` and `/xi/` prefixes unconditionally; removes boot-time `if TradeTariffBackend.uk?/xi?` guards from engine route blocks
- Adds `UkOnly` controller concern (mirrors existing `XiOnly`) to restrict exchange rates, news, and admin news/live issues endpoints to UK requests only
- Makes `MeasureTypeExclusion` and `rules_of_origin` caches per-service so both services can coexist in a single process

## Test plan

- [ ] Unit tests for `SetRequestedService` middleware (`spec/middleware/set_requested_service_spec.rb`)
- [ ] Integration tests confirming both `/uk/` and `/xi/` routes respond correctly in a single instance (`spec/requests/multi_service_spec.rb`)
- [ ] UK-only endpoints return 404 for XI requests, and XI-only endpoints return 404 for UK requests
- [ ] Service is reset to nil after each request (no cross-request leakage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)