### PR TITLE
HMRC-2110: Run database migrations as part of ECS deployment

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -24,6 +24,17 @@ jobs:
       app-name: tariff-backend
       environment: development
       test-flavour: none
+      migrate: true
+      migration-task: backend-uk
+      migration-overrides: |
+        {
+          "containerOverrides": [
+            {
+              "name": "backend-uk",
+              "command": ["/bin/sh", "-c", "bundle exec rails db:migrate && bundle exec rails data:migrate"]
+            }
+          ]
+        }
     secrets:
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
       ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}


### PR DESCRIPTION
### Jira link

[HMRC-2110](https://transformuk.atlassian.net/browse/HMRC-2110)

### What?

I have added/removed/altered:

- Added migration configuration for ECS deployment workflow

### Why?

I am doing this because:

- We should run database migrations before deploying the backend service