### PR TITLE
Replace blocking sleep retry with Sidekiq rescheduling

### DIFF
--- a/app/lib/cds_synchronizer.rb
+++ b/app/lib/cds_synchronizer.rb
@@ -32,12 +32,7 @@ class CdsSynchronizer
         TariffSynchronizer::Instrumentation.lock_acquired(phase: 'download')
 
         start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-        begin
-          TariffSynchronizer::CdsUpdate.sync(initial_date: initial_update_date)
-        rescue TariffUpdatesRequester::DownloadException => e
-          TariffLogger.failed_download(exception: e)
-          raise e.original
-        end
+        TariffSynchronizer::CdsUpdate.sync(initial_date: initial_update_date)
 
         duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
         TariffSynchronizer::Instrumentation.download_completed(

--- a/app/lib/taric_synchronizer.rb
+++ b/app/lib/taric_synchronizer.rb
@@ -50,12 +50,7 @@ class TaricSynchronizer
         TariffSynchronizer::Instrumentation.lock_acquired(phase: 'download')
 
         start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-        begin
-          TradeTariffBackend.patch_broken_taric_downloads? ? TariffSynchronizer::TaricUpdate.sync_patched : TariffSynchronizer::TaricUpdate.sync(initial_date: initial_update_date)
-        rescue TariffSynchronizer::TariffUpdatesRequester::DownloadException => e
-          TariffLogger.failed_download(exception: e)
-          raise e.original
-        end
+        TradeTariffBackend.patch_broken_taric_downloads? ? TariffSynchronizer::TaricUpdate.sync_patched : TariffSynchronizer::TaricUpdate.sync(initial_date: initial_update_date)
 
         duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
         TariffSynchronizer::Instrumentation.download_completed(

--- a/app/lib/tariff_synchronizer/tariff_downloader.rb
+++ b/app/lib/tariff_synchronizer/tariff_downloader.rb
@@ -24,6 +24,9 @@ module TariffSynchronizer
       else
         download_and_create_entry
       end
+    rescue TariffUpdatesRequester::RetriableDownloadError => e
+      persist_exception_for_review(e)
+      raise
     rescue StandardError => e
       persist_exception_for_review(e)
     end

--- a/app/lib/tariff_synchronizer/tariff_updates_requester.rb
+++ b/app/lib/tariff_synchronizer/tariff_updates_requester.rb
@@ -1,6 +1,7 @@
 module TariffSynchronizer
-  # The server in question may respond with 403 from time to time so keep retrying
-  # until it returns either 200 or 404 or retry count limit is reached
+  # The server in question may respond with 403 from time to time. Rather than
+  # sleeping in-thread, callers should catch RetriableDownloadError and
+  # reschedule via Sidekiq so worker threads are not held while waiting.
   class TariffUpdatesRequester
     class DownloadException < StandardError
       attr_reader :url, :original
@@ -13,10 +14,18 @@ module TariffSynchronizer
       end
     end
 
+    class RetriableDownloadError < StandardError
+      attr_reader :url
+
+      def initialize(url)
+        super('TariffSynchronizer::TariffUpdatesRequester::RetriableDownloadError')
+
+        @url = url
+      end
+    end
+
     def initialize(url)
       @url = url
-      @retry_count = TariffSynchronizer.retry_count
-      @exception_retry_count = TariffSynchronizer.exception_retry_count
     end
 
     def self.perform(url)
@@ -24,37 +33,23 @@ module TariffSynchronizer
     end
 
     def perform
-      loop do
-        response = send_request
+      response = send_request
 
-        if response.terminated?
-          return response
-        elsif @retry_count.zero?
-          response.retry_count_exceeded!
-          return response
-        else
-          @retry_count -= 1
-          Instrumentation.download_retried(
-            url: @url,
-            attempt: TariffSynchronizer.retry_count - @retry_count,
-            reason: "response_code_#{response.response_code}",
-          )
-          sleep TariffSynchronizer.request_throttle
-        end
-      rescue DownloadException => e
-        if @exception_retry_count.zero?
-          Instrumentation.download_retry_exhausted(url: @url)
-          raise
-        else
-          @exception_retry_count -= 1
-          Instrumentation.download_retried(
-            url: @url,
-            attempt: TariffSynchronizer.exception_retry_count - @exception_retry_count,
-            reason: e.original.class.name,
-          )
-          sleep TariffSynchronizer.request_throttle
-        end
-      end
+      return response if response.terminated?
+
+      Instrumentation.download_retried(
+        url: @url,
+        attempt: 1,
+        reason: "response_code_#{response.response_code}",
+      )
+      raise RetriableDownloadError, @url
+    rescue DownloadException => e
+      Instrumentation.download_retried(
+        url: @url,
+        attempt: 1,
+        reason: e.original.class.name,
+      )
+      raise RetriableDownloadError, @url
     end
 
     private

--- a/app/workers/cds_updates_synchronizer_worker.rb
+++ b/app/workers/cds_updates_synchronizer_worker.rb
@@ -3,10 +3,11 @@ class CdsUpdatesSynchronizerWorker
 
   TRY_AGAIN_IN = 20.minutes
   CUT_OFF_TIME = '10:00'.freeze
+  DOWNLOAD_MAX_RETRIES = TariffSynchronizer.retry_count
 
   sidekiq_options queue: :sync, retry: false
 
-  def perform(check_for_todays_file = true, reapply_data_migrations = false)
+  def perform(check_for_todays_file = true, reapply_data_migrations = false, download_retry_count = 0)
     return unless TradeTariffBackend.uk?
 
     Thread.current[:tariff_sync_run_id] = SecureRandom.uuid
@@ -39,6 +40,8 @@ class CdsUpdatesSynchronizerWorker
     )
 
     emit_sync_run_completed(start_time)
+  rescue TariffSynchronizer::TariffUpdatesRequester::RetriableDownloadError
+    attempt_reschedule_download!(download_retry_count, check_for_todays_file, reapply_data_migrations)
   rescue TariffSynchronizer::CdsUpdateDownloader::ListDownloadFailedError => e
     TariffSynchronizer::Instrumentation.sync_run_failed(
       phase: 'download',
@@ -87,6 +90,17 @@ private
       true
     else
       false
+    end
+  end
+
+  def attempt_reschedule_download!(download_retry_count, check_for_todays_file, reapply_data_migrations)
+    delay = TariffSynchronizer.request_throttle.seconds
+
+    if download_retry_count < DOWNLOAD_MAX_RETRIES
+      self.class.perform_in(delay, check_for_todays_file, reapply_data_migrations, download_retry_count + 1)
+      TariffSynchronizer::Instrumentation.download_delayed(retry_at: delay.from_now.iso8601)
+    else
+      TariffSynchronizer::Instrumentation.download_retry_exhausted(url: 'cds')
     end
   end
 end

--- a/app/workers/taric_updates_synchronizer_worker.rb
+++ b/app/workers/taric_updates_synchronizer_worker.rb
@@ -1,9 +1,11 @@
 class TaricUpdatesSynchronizerWorker
   include Sidekiq::Worker
 
+  DOWNLOAD_MAX_RETRIES = TariffSynchronizer.retry_count
+
   sidekiq_options queue: :sync, retry: false
 
-  def perform(reapply_data_migrations = false)
+  def perform(reapply_data_migrations = false, download_retry_count = 0)
     return unless TradeTariffBackend.xi?
 
     Thread.current[:tariff_sync_run_id] = SecureRandom.uuid
@@ -33,6 +35,8 @@ class TaricUpdatesSynchronizerWorker
     )
 
     emit_sync_run_completed(start_time)
+  rescue TariffSynchronizer::TariffUpdatesRequester::RetriableDownloadError
+    attempt_reschedule_download!(download_retry_count, reapply_data_migrations)
   rescue StandardError => e
     TariffSynchronizer::Instrumentation.sync_run_failed(
       phase: 'sync',
@@ -56,5 +60,16 @@ private
 
     require 'data_migrator' unless defined?(DataMigrator)
     DataMigrator.migrate_up!(nil)
+  end
+
+  def attempt_reschedule_download!(download_retry_count, reapply_data_migrations)
+    delay = TariffSynchronizer.request_throttle.seconds
+
+    if download_retry_count < DOWNLOAD_MAX_RETRIES
+      self.class.perform_in(delay, reapply_data_migrations, download_retry_count + 1)
+      TariffSynchronizer::Instrumentation.download_delayed(retry_at: delay.from_now.iso8601)
+    else
+      TariffSynchronizer::Instrumentation.download_retry_exhausted(url: 'taric')
+    end
   end
 end

--- a/spec/unit/cds_synchronizer_spec.rb
+++ b/spec/unit/cds_synchronizer_spec.rb
@@ -58,25 +58,14 @@ RSpec.describe CdsSynchronizer, :truncation do
     end
 
     context 'when a download exception' do
-      let(:exception) { StandardError.new 'Something went wrong' }
-
       before do
         allow(described_class).to receive(:sync_variables_set?).and_return(true)
-        allow(exception).to receive(:backtrace).and_return([])
-        allow(TariffSynchronizer::CdsUpdate).to receive(:sync).and_raise(TariffSynchronizer::TariffUpdatesRequester::DownloadException.new('url', exception))
+        allow(TariffSynchronizer::CdsUpdate).to receive(:sync)
+          .and_raise(TariffSynchronizer::TariffUpdatesRequester::RetriableDownloadError.new('url'))
       end
 
-      it 'raises original exception ending the process and logs an error event' do
-        expect { described_class.download }.to raise_error StandardError
-      end
-
-      it 'sends an email with the exception error', :aggregate_failures do
-        ActionMailer::Base.deliveries.clear
-        expect { described_class.download }.to raise_error(StandardError)
-
-        expect(ActionMailer::Base.deliveries).not_to be_empty
-        expect(ActionMailer::Base.deliveries.last.encoded).to match(/Backtrace/)
-        expect(ActionMailer::Base.deliveries.last.encoded).to match(/Trade Tariff download failure/)
+      it 'raises a retriable download error ending the process' do
+        expect { described_class.download }.to raise_error TariffSynchronizer::TariffUpdatesRequester::RetriableDownloadError
       end
     end
   end

--- a/spec/unit/taric_synchronizer_spec.rb
+++ b/spec/unit/taric_synchronizer_spec.rb
@@ -78,20 +78,11 @@ RSpec.describe TaricSynchronizer, :truncation do
         allow_any_instance_of(Faraday::Connection).to receive(:get).and_raise(Faraday::Error, 'Foo')
       end
 
-      it 'raises original exception ending the process and emits a download_failed event' do
-        allow(TariffSynchronizer::Instrumentation).to receive(:download_failed)
+      it 'raises a retriable download error and emits a download_retried event' do
+        allow(TariffSynchronizer::Instrumentation).to receive(:download_retried)
 
-        expect { described_class.download }.to raise_error Faraday::Error
-        expect(TariffSynchronizer::Instrumentation).to have_received(:download_failed)
-      end
-
-      it 'sends an email with the exception error' do
-        ActionMailer::Base.deliveries.clear
-        expect { described_class.download }.to raise_error(Faraday::Error)
-
-        expect(ActionMailer::Base.deliveries).not_to be_empty
-        expect(ActionMailer::Base.deliveries.last.encoded).to match(/Backtrace/)
-        expect(ActionMailer::Base.deliveries.last.encoded).to match(/Trade Tariff download failure/)
+        expect { described_class.download }.to raise_error TariffSynchronizer::TariffUpdatesRequester::RetriableDownloadError
+        expect(TariffSynchronizer::Instrumentation).to have_received(:download_retried)
       end
     end
   end

--- a/spec/unit/tariff_synchronizer/tariff_updates_requester_spec.rb
+++ b/spec/unit/tariff_synchronizer/tariff_updates_requester_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe TariffSynchronizer::TariffUpdatesRequester do
         it { expect(response.response_code).to eq(200) }
       end
 
-      context 'when a Faraday:Error is propagated' do
+      context 'when a Faraday::Error is propagated' do
         before do
           stub_request(:get, url).to_raise(Faraday::Error)
         end
 
-        it { expect { described_class.perform('http://example/test') }.to raise_error TariffSynchronizer::TariffUpdatesRequester::DownloadException }
+        it { expect { described_class.perform('http://example/test') }.to raise_error TariffSynchronizer::TariffUpdatesRequester::RetriableDownloadError }
       end
 
       context 'when a 401 response is returned' do
@@ -27,12 +27,12 @@ RSpec.describe TariffSynchronizer::TariffUpdatesRequester do
           stub_request(:get, url).to_return(status: 401)
         end
 
-        it { expect(response).to be_retry_count_exceeded }
+        it { expect { response }.to raise_error TariffSynchronizer::TariffUpdatesRequester::RetriableDownloadError }
 
         it 'emits a download_retried instrumentation event' do
           allow(TariffSynchronizer::Instrumentation).to receive(:download_retried)
 
-          response
+          expect { response }.to raise_error TariffSynchronizer::TariffUpdatesRequester::RetriableDownloadError
 
           expect(TariffSynchronizer::Instrumentation).to have_received(:download_retried)
         end

--- a/spec/workers/cds_updates_synchronizer_worker_spec.rb
+++ b/spec/workers/cds_updates_synchronizer_worker_spec.rb
@@ -186,5 +186,34 @@ RSpec.describe CdsUpdatesSynchronizerWorker, type: :worker do
 
       it { expect(described_class.jobs).to have_attributes length: 1 }
     end
+
+    context 'when a retriable download error is raised' do
+      before do
+        allow(TariffSynchronizer::CdsUpdate).to receive(:downloaded_todays_file?).and_return(true)
+        allow(CdsSynchronizer).to receive(:download)
+          .and_raise(TariffSynchronizer::TariffUpdatesRequester::RetriableDownloadError, 'http://example/file')
+      end
+
+      context 'when retry budget remains' do
+        subject(:perform) { described_class.new.perform(true, false, 0) }
+
+        it 'reschedules the job with an incremented retry count' do
+          perform
+
+          expect(described_class.jobs).to have_attributes length: 1
+          expect(described_class.jobs.first).to include('args' => [true, false, 1])
+        end
+      end
+
+      context 'when retry budget is exhausted' do
+        subject(:perform) { described_class.new.perform(true, false, described_class::DOWNLOAD_MAX_RETRIES) }
+
+        it 'does not reschedule the job' do
+          perform
+
+          expect(described_class.jobs).to be_empty
+        end
+      end
+    end
   end
 end

--- a/spec/workers/taric_updates_synchronizer_worker_spec.rb
+++ b/spec/workers/taric_updates_synchronizer_worker_spec.rb
@@ -82,5 +82,31 @@ RSpec.describe TaricUpdatesSynchronizerWorker, type: :worker do
         end
       end
     end
+
+    context 'when a retriable download error is raised' do
+      let(:service) { 'xi' }
+
+      before do
+        allow(TaricSynchronizer).to receive(:download)
+          .and_raise(TariffSynchronizer::TariffUpdatesRequester::RetriableDownloadError, 'http://example/file')
+      end
+
+      context 'when retry budget remains' do
+        it 'reschedules the job with an incremented retry count' do
+          described_class.new.perform(false, 0)
+
+          expect(described_class.jobs).to have_attributes length: 1
+          expect(described_class.jobs.first).to include('args' => [false, 1])
+        end
+      end
+
+      context 'when retry budget is exhausted' do
+        it 'does not reschedule the job' do
+          described_class.new.perform(false, described_class::DOWNLOAD_MAX_RETRIES)
+
+          expect(described_class.jobs).to be_empty
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Removes the `loop { sleep }` pattern in `TariffUpdatesRequester` that could block a Sidekiq worker thread for up to 20 minutes (20 retries × 60 seconds), risking thread-pool starvation with concurrency 10
- Introduces `RetriableDownloadError` — raised instead of sleeping when a non-terminated HTTP response or network error occurs
- Both sync workers (`TaricUpdatesSynchronizerWorker`, `CdsUpdatesSynchronizerWorker`) catch `RetriableDownloadError` and reschedule via `perform_in` with an incremented `download_retry_count` argument, up to `TariffSynchronizer.retry_count` (20) times at `TariffSynchronizer.request_throttle` (60s) intervals
- `TariffDownloader` marks the update FAILED before re-raising, preserving the existing FAILED-state semantics; the FAILED record is reset to PENDING if a retry succeeds
- Removes the now-dead `rescue DownloadException` blocks from `TaricSynchronizer` and `CdsSynchronizer` (DownloadException no longer escapes `TariffUpdatesRequester`)

Closes HMRC-2039
