### PR TITLE
Replace sync staleness proxy with New Relic metric

### DIFF
--- a/app/workers/cds_updates_synchronizer_worker.rb
+++ b/app/workers/cds_updates_synchronizer_worker.rb
@@ -86,8 +86,6 @@ private
       TariffSynchronizer::Instrumentation.download_delayed(retry_at: TRY_AGAIN_IN.from_now.iso8601)
       true
     else
-      SlackNotifierService.call \
-        'Daily CDS file missing, max retry time passed - continuing without todays file'
       false
     end
   end

--- a/app/workers/synchronizer_check_worker.rb
+++ b/app/workers/synchronizer_check_worker.rb
@@ -1,26 +1,26 @@
 class SynchronizerCheckWorker
   include Sidekiq::Worker
 
-  RECENCY_THRESHOLD = 4 # days ago
+  # Sentinel value recorded when no applied updates exist at all, ensuring
+  # the NR alert condition fires immediately rather than silently passing.
+  NO_SYNC_SENTINEL_MINUTES = 99_999
 
-  def perform(check_since = RECENCY_THRESHOLD)
-    latest_qbe = QuotaBalanceEvent::Operation.order_by(Sequel.desc(:oid)).first
+  def perform
+    last_applied_at = TariffSynchronizer::BaseUpdate.most_recent_applied&.applied_at
+    age_minutes = age_in_minutes(last_applied_at)
 
-    return true if latest_qbe && latest_qbe.created_at > check_since.days.ago
-
-    msg = <<~EOMSG
-      #{sync_service_name} sync problem - last update to Quota Balance Events was over #{check_since} days ago
-
-      Last update was at #{latest_qbe&.created_at}. Please investigate promptly.
-    EOMSG
-
-    NewRelic::Agent.notice_error(msg)
-    Rails.logger.warn(msg)
+    NewRelic::Agent.record_metric("Custom/TariffSync/#{service}/AgeMinutes", age_minutes)
   end
 
-  private
+private
 
-  def sync_service_name
-    TradeTariffBackend.uk? ? 'CDS' : 'Taric'
+  def age_in_minutes(last_applied_at)
+    return NO_SYNC_SENTINEL_MINUTES if last_applied_at.nil?
+
+    (Time.zone.now - last_applied_at) / 60.0
+  end
+
+  def service
+    TradeTariffBackend.uk? ? 'uk' : 'xi'
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -69,8 +69,8 @@
       description: Creates average rates from downloaded data and uploads file to S3
       enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' %>
     SynchronizerCheckWorker:
-      cron: "30 08 * * *"
-      description: Checks we have recent Quota Balance Events - this is an early warning that our sync process has a potential issue
+      cron: "*/30 * * * *"
+      description: Records sync age as a New Relic custom metric every 30 minutes — NR alert conditions on Custom/TariffSync/{service}/AgeMinutes trigger PagerDuty when age exceeds threshold
     CheckDifferencesReportHasRun:
       cron: "0 1 * * 2"  # 1am every Tuesday
       description: "Checks if the differences report has run"

--- a/spec/workers/cds_updates_synchronizer_worker_spec.rb
+++ b/spec/workers/cds_updates_synchronizer_worker_spec.rb
@@ -97,8 +97,8 @@ RSpec.describe CdsUpdatesSynchronizerWorker, type: :worker do
           it { expect(DataMigrator).to have_received(:migrate_up!).with(nil) }
         end
 
-        it 'notifies Slack ETL channel' do
-          expect(SlackNotifierService).to have_received(:call).with(/CDS file missing/)
+        it 'does not notify Slack' do
+          expect(SlackNotifierService).not_to have_received(:call)
         end
       end
 

--- a/spec/workers/synchronizer_check_worker_spec.rb
+++ b/spec/workers/synchronizer_check_worker_spec.rb
@@ -1,38 +1,39 @@
 RSpec.describe SynchronizerCheckWorker, type: :worker do
   describe '#perform' do
-    before { allow(::NewRelic::Agent).to receive(:notice_error) }
+    subject(:perform) { described_class.new.perform }
 
-    context 'with data' do
-      before do
-        QuotaBalanceEvent::Operation.where(oid: qbe.oid).update(created_at:)
+    before { allow(NewRelic::Agent).to receive(:record_metric) }
 
-        described_class.new.perform
-      end
+    context 'when there are no applied updates' do
+      before { perform }
 
-      let(:qbe) { create :quota_balance_event }
-
-      context 'when it is up to date' do
-        let(:created_at) { 1.day.ago }
-
-        it 'takes no action' do
-          expect(NewRelic::Agent).not_to have_received(:notice_error)
-        end
-      end
-
-      context 'when it is outdated' do
-        let(:created_at) { 10.days.ago }
-
-        it 'alerts with the failing service' do
-          expect(NewRelic::Agent).to have_received(:notice_error).with %r{CDS sync problem}
-        end
+      it 'records the sentinel age metric' do
+        expect(NewRelic::Agent).to have_received(:record_metric)
+          .with('Custom/TariffSync/uk/AgeMinutes', SynchronizerCheckWorker::NO_SYNC_SENTINEL_MINUTES)
       end
     end
 
-    context 'with no data' do
-      before { described_class.new.perform }
+    context 'when the most recent applied update is recent' do
+      before do
+        create :base_update, :applied, applied_at: 2.hours.ago
+        perform
+      end
 
-      it 'alerts with the failing service' do
-        expect(NewRelic::Agent).to have_received(:notice_error).with %r{CDS sync problem}
+      it 'records an age metric close to 120 minutes' do
+        expect(NewRelic::Agent).to have_received(:record_metric)
+          .with('Custom/TariffSync/uk/AgeMinutes', be_within(2).of(120))
+      end
+    end
+
+    context 'when the most recent applied update is stale' do
+      before do
+        create :base_update, :applied, applied_at: 25.hours.ago
+        perform
+      end
+
+      it 'records an age metric over 24 hours' do
+        expect(NewRelic::Agent).to have_received(:record_metric)
+          .with('Custom/TariffSync/uk/AgeMinutes', be > 1440)
       end
     end
   end


### PR DESCRIPTION
## Summary

- Replaces `SynchronizerCheckWorker`'s `QuotaBalanceEvent` proxy (4-day threshold, `notice_error`) with a continuous `Custom/TariffSync/{service}/AgeMinutes` metric recorded to New Relic every 30 minutes
- Removes the Slack cutoff alert from `CdsUpdatesSynchronizerWorker` (fired at 10:00 UTC when the daily file was missing) — the NR metric covers this with better escalation
- Changes the worker schedule from once-daily at 08:30 → every 30 minutes, which is required for NR to see a time series it can evaluate threshold alert conditions against and auto-resolve

The previous approach had two structural problems: `notice_error` has no resolve concept (incidents stay open until manually closed), and a single daily data point cannot drive an NR alert condition that auto-resolves. A continuously recorded metric fixes both.

## Ops setup required before this is fully active

This PR ships the app-side work. The alerting won't reach PagerDuty until the following NR configuration is done:

### 1. Create NR alert conditions

In New Relic, create alert conditions on the two new metrics:

| Metric | Service |
|--------|---------|
| `Custom/TariffSync/uk/AgeMinutes` | UK (CDS) |
| `Custom/TariffSync/xi/AgeMinutes` | XI (TARIC) |

Suggested configuration:
- **Threshold**: `> 480` minutes (8 hours) to start — tighten once you've observed normal completion times in NR dashboards after a week in production
- **Evaluation periods**: 1 (alert on first breach)
- **Auto-resolve**: yes — when metric returns below threshold NR closes the incident automatically

### 2. Create a PagerDuty notification channel in NR

Add a PagerDuty notification channel to the alert policy that owns the above conditions. NR docs: [Connect PagerDuty to New Relic alerts](https://docs.newrelic.com/docs/alerts-applied-intelligence/notifications/notification-integrations/#pagerduty-simple).

### 3. Tune the threshold

The `Custom/TariffSync/{service}/AgeMinutes` metric will be visible in NR dashboards from the first deployment. After ~1 week you'll have a baseline for typical sync completion times (CDS runs at 00:30 UTC; look for the daily trough in the metric). Tighten the threshold to catch failures earlier.

## Test plan

- [x] `spec/workers/synchronizer_check_worker_spec.rb` — rewritten: no applied updates (sentinel), recent (within 2 min of 120), stale (over 1440)
- [x] `spec/workers/cds_updates_synchronizer_worker_spec.rb` — updated: post-cutoff context now asserts no Slack notification
- [x] 44 examples, 0 failures