### PR TITLE
Dataset methods refactor

### DIFF
--- a/app/controllers/api/admin/chapters/chapter_notes_controller.rb
+++ b/app/controllers/api/admin/chapters/chapter_notes_controller.rb
@@ -49,13 +49,11 @@ module Api
         end
 
         def chapter
-          @chapter ||= Chapter.find(goods_nomenclature_item_id: chapter_id)
+          @chapter ||= Chapter.by_code(chapter_id).take
         end
 
         def chapter_id
-          # Converts 8 to 0800000000, 18 to 1800000000
-          # May result in 0000000000 but there is no such chapter
-          params[:chapter_id].to_s.rjust(2, '0').ljust(10, '0')
+          params[:chapter_id]
         end
       end
     end

--- a/app/controllers/api/admin/chapters/search_references_controller.rb
+++ b/app/controllers/api/admin/chapters/search_references_controller.rb
@@ -17,13 +17,11 @@ module Api
         end
 
         def chapter
-          @chapter ||= Chapter.find(goods_nomenclature_item_id: chapter_id)
+          @chapter ||= Chapter.by_code(chapter_id).take
         end
 
         def chapter_id
-          # Converts 8 to 0800000000, 18 to 1800000000
-          # May result in 0000000000 but there is no such chapter
-          params[:chapter_id].to_s.rjust(2, '0').ljust(10, '0')
+          params[:chapter_id]
         end
       end
     end

--- a/app/controllers/api/admin/commodities_controller.rb
+++ b/app/controllers/api/admin/commodities_controller.rb
@@ -13,10 +13,8 @@ module Api
         @commodity = GoodsNomenclature
           .actual
           .with_leaf_column
-          .where(
-            goods_nomenclatures__goods_nomenclature_item_id: commodity_code,
-            goods_nomenclatures__producline_suffix: productline_suffix,
-          )
+          .by_code(commodity_code)
+          .by_productline_suffix(productline_suffix)
           .take
 
         raise Sequel::RecordNotFound if @commodity.goods_nomenclature_item_id.in? HiddenGoodsNomenclature.codes

--- a/app/controllers/api/admin/goods_nomenclatures/goods_nomenclature_self_texts_controller.rb
+++ b/app/controllers/api/admin/goods_nomenclatures/goods_nomenclature_self_texts_controller.rb
@@ -47,7 +47,7 @@ module Api
 
           raise Sequel::RecordNotFound unless gn
 
-          chapter = TimeMachine.now { Chapter.actual.by_code(gn.goods_nomenclature_item_id[0..1]).take }
+          chapter = TimeMachine.now { Chapter.actual.by_code(gn.goods_nomenclature_item_id).take }
           raise Sequel::RecordNotFound unless chapter
 
           # Force regeneration by invalidating context hash so context_stale? returns true

--- a/app/controllers/api/admin/green_lanes/measures_controller.rb
+++ b/app/controllers/api/admin/green_lanes/measures_controller.rb
@@ -25,21 +25,19 @@ module Api
         end
 
         def create
-          gn = GoodsNomenclature.actual.where(goods_nomenclature_item_id: measure_params[:goods_nomenclature_item_id],
-                                              producline_suffix: measure_params[:productline_suffix])
+          GoodsNomenclature.actual
+                           .by_code(measure_params[:goods_nomenclature_item_id])
+                           .by_productline_suffix(measure_params[:productline_suffix])
+                           .take # will raise if not found
 
-          if gn.present?
-            measure = ::GreenLanes::Measure.new(measure_params)
+          measure = ::GreenLanes::Measure.new(measure_params)
 
-            if gn.present? && measure.valid? && measure.save
-              render json: serialize(measure),
-                     status: :created
-            else
-              render json: serialize_errors(measure),
-                     status: :unprocessable_content
-            end
+          if measure.valid? && measure.save
+            render json: serialize(measure),
+                   status: :created
           else
-            raise Sequel::RecordNotFound
+            render json: serialize_errors(measure),
+                   status: :unprocessable_content
           end
         end
 

--- a/app/controllers/api/admin/headings/search_references_controller.rb
+++ b/app/controllers/api/admin/headings/search_references_controller.rb
@@ -20,7 +20,7 @@ module Api
           @heading ||= begin
             heading = Heading.actual
                    .non_grouping
-                   .where(goods_nomenclatures__goods_nomenclature_item_id: heading_id)
+                   .by_code(heading_id)
                    .take
 
             raise Sequel::RecordNotFound if heading.goods_nomenclature_item_id.in?(HiddenGoodsNomenclature.codes)
@@ -30,7 +30,7 @@ module Api
         end
 
         def heading_id
-          "#{params[:heading_id]}000000"
+          params[:heading_id]
         end
       end
     end

--- a/app/controllers/api/v2/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/goods_nomenclatures_controller.rb
@@ -19,7 +19,7 @@ module Api
         gn = GoodsNomenclature
                .actual
                .association_inner_join(:goods_nomenclature_indents)
-               .where(Sequel[:goods_nomenclatures][:goods_nomenclature_item_id] => params[:id])
+               .by_code(params[:id])
                .order(Sequel[:goods_nomenclatures][:producline_suffix], Sequel[:goods_nomenclature_indents][:number_indents])
                .last
 

--- a/app/lib/tariff_synchronizer/base_update.rb
+++ b/app/lib/tariff_synchronizer/base_update.rb
@@ -40,7 +40,7 @@ module TariffSynchronizer
       end
 
       def applied
-        filter(state: APPLIED_STATE)
+        where(state: APPLIED_STATE)
       end
 
       def pending

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -1,5 +1,5 @@
 class Chapter < GoodsNomenclature
-  set_dataset filter('goods_nomenclatures.goods_nomenclature_item_id LIKE ?', GoodsNomenclature.sql_pattern_for(CHAPTER_SUFFIX))
+  set_dataset where('goods_nomenclatures.goods_nomenclature_item_id LIKE ?', GoodsNomenclature.sql_pattern_for(CHAPTER_SUFFIX))
               .order(
                 Sequel.asc(:goods_nomenclature_item_id),
                 Sequel.asc(:goods_nomenclatures__producline_suffix),
@@ -38,7 +38,7 @@ class Chapter < GoodsNomenclature
 
   dataset_module do
     def by_code(code = '')
-      filter(goods_nomenclatures__goods_nomenclature_item_id: "#{code.to_s.first(2)}00000000")
+      where(goods_nomenclatures__goods_nomenclature_item_id: "#{code.to_s.first(2)}#{CHAPTER_SUFFIX}")
     end
   end
 

--- a/app/models/concerns/ten_digit_goods_nomenclature.rb
+++ b/app/models/concerns/ten_digit_goods_nomenclature.rb
@@ -4,10 +4,10 @@ module TenDigitGoodsNomenclature
   included do
     plugin :oplog, primary_key: :goods_nomenclature_sid, materialized: true
 
-    set_dataset filter('goods_nomenclatures.goods_nomenclature_item_id NOT LIKE ?', GoodsNomenclature.sql_pattern_for(GoodsNomenclature::HEADING_SUFFIX))
-      .order(Sequel.asc(:goods_nomenclatures__goods_nomenclature_item_id),
-             Sequel.asc(:goods_nomenclatures__producline_suffix),
-             Sequel.asc(:goods_nomenclatures__goods_nomenclature_sid))
+    set_dataset where('goods_nomenclatures.goods_nomenclature_item_id NOT LIKE ?', GoodsNomenclature.sql_pattern_for(GoodsNomenclature::HEADING_SUFFIX))
+                .order(Sequel.asc(:goods_nomenclatures__goods_nomenclature_item_id),
+                       Sequel.asc(:goods_nomenclatures__producline_suffix),
+                       Sequel.asc(:goods_nomenclatures__goods_nomenclature_sid))
 
     set_primary_key [:goods_nomenclature_sid]
 

--- a/app/models/concerns/ten_digit_goods_nomenclature.rb
+++ b/app/models/concerns/ten_digit_goods_nomenclature.rb
@@ -29,16 +29,6 @@ module TenDigitGoodsNomenclature
 
     delegate :section, :section_id, to: :chapter, allow_nil: true
 
-    dataset_module do
-      def by_code(code = '')
-        filter(goods_nomenclatures__goods_nomenclature_item_id: code.to_s.first(10))
-      end
-
-      def by_productline_suffix(productline_suffix)
-        filter(producline_suffix: productline_suffix)
-      end
-    end
-
     # See oplog sequel plugin
     def operation=(operation)
       self[:operation] = operation.to_s.first.upcase

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -150,6 +150,18 @@ class GoodsNomenclature < Sequel::Model
                                      reciprocal: :goods_nomenclature
 
   dataset_module do
+    def by_codes(codes)
+      where(goods_nomenclatures__goods_nomenclature_item_id: codes)
+    end
+
+    def by_code(code = '')
+      where(goods_nomenclatures__goods_nomenclature_item_id: code.to_s.first(10))
+    end
+
+    def by_productline_suffix(productline_suffix)
+      where(goods_nomenclatures__producline_suffix: productline_suffix)
+    end
+
     def non_hidden
       filter(Sequel.~(goods_nomenclatures__goods_nomenclature_item_id: HiddenGoodsNomenclature.codes))
     end

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -163,7 +163,7 @@ class GoodsNomenclature < Sequel::Model
     end
 
     def non_hidden
-      filter(Sequel.~(goods_nomenclatures__goods_nomenclature_item_id: HiddenGoodsNomenclature.codes))
+      where(Sequel.~(goods_nomenclatures__goods_nomenclature_item_id: HiddenGoodsNomenclature.codes))
     end
 
     def non_classifieds
@@ -171,7 +171,7 @@ class GoodsNomenclature < Sequel::Model
     end
 
     def non_grouping
-      where(producline_suffix: NON_GROUPING_PRODUCTLINE_SUFFIX)
+      where(goods_nomenclatures__producline_suffix: NON_GROUPING_PRODUCTLINE_SUFFIX)
     end
 
     def join_footnotes

--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -154,9 +154,8 @@ module GoodsNomenclatures
 
         def declarable
           with_leaf_column
-            .where(tree_node__child_sid: nil,
-                   goods_nomenclatures__producline_suffix:
-                     GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX)
+            .non_grouping
+            .where(tree_node__child_sid: nil)
         end
       end
     end

--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -1,6 +1,6 @@
 class Heading < GoodsNomenclature
-  set_dataset filter('goods_nomenclatures.goods_nomenclature_item_id LIKE ?', GoodsNomenclature.sql_pattern_for(HEADING_SUFFIX))
-              .filter('goods_nomenclatures.goods_nomenclature_item_id NOT LIKE ?', GoodsNomenclature.sql_pattern_for(CHAPTER_SUFFIX))
+  set_dataset where('goods_nomenclatures.goods_nomenclature_item_id LIKE ?', GoodsNomenclature.sql_pattern_for(HEADING_SUFFIX))
+              .where('goods_nomenclatures.goods_nomenclature_item_id NOT LIKE ?', GoodsNomenclature.sql_pattern_for(CHAPTER_SUFFIX))
               .order(
                 Sequel.asc(:goods_nomenclature_item_id),
                 Sequel.asc(:goods_nomenclatures__producline_suffix),
@@ -22,7 +22,7 @@ class Heading < GoodsNomenclature
 
   dataset_module do
     def by_code(code = '')
-      filter(goods_nomenclatures__goods_nomenclature_item_id: "#{code.to_s.first(4)}000000")
+      where(goods_nomenclatures__goods_nomenclature_item_id: "#{code.to_s.first(4)}#{HEADING_SUFFIX}")
     end
   end
 

--- a/app/models/meursing_measure.rb
+++ b/app/models/meursing_measure.rb
@@ -1,7 +1,7 @@
 class MeursingMeasure < Measure
-  initial_dataset = filter(goods_nomenclature_item_id: nil)
-    .filter(measure_type_id: MeasureType::MEURSING_MEASURES)
-    .filter(additional_code_type_id: AdditionalCode::MEURSING_TYPE_IDS)
+  initial_dataset = where(goods_nomenclature_item_id: nil)
+    .where(measure_type_id: MeasureType::MEURSING_MEASURES)
+    .where(additional_code_type_id: AdditionalCode::MEURSING_TYPE_IDS)
 
   set_dataset(initial_dataset, inherited: true)
 

--- a/app/models/monetary_exchange_rate.rb
+++ b/app/models/monetary_exchange_rate.rb
@@ -9,7 +9,7 @@ class MonetaryExchangeRate < Sequel::Model
 
   dataset_module do
     def currency(currency)
-      filter(child_monetary_unit_code: currency)
+      where(child_monetary_unit_code: currency)
     end
   end
 

--- a/app/models/tariff_change.rb
+++ b/app/models/tariff_change.rb
@@ -19,6 +19,14 @@ class TariffChange < Sequel::Model
   end
 
   dataset_module do
+    def on_date(date)
+      where(operation_date: date)
+    end
+
+    def for_goods_nomenclature_sids(goods_nomenclature_sids)
+      where(goods_nomenclature_sid: goods_nomenclature_sids)
+    end
+
     def measures
       where(type: 'Measure')
     end

--- a/app/models/tariff_changes/grouped_measure_commodity_change.rb
+++ b/app/models/tariff_changes/grouped_measure_commodity_change.rb
@@ -75,8 +75,8 @@ module TariffChanges
     end
 
     def set_commodity
-      @commodity = Commodity.where(goods_nomenclature_item_id: goods_nomenclature_item_id)
-                            .where(producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX)
+      @commodity = Commodity.non_grouping
+                            .by_code(goods_nomenclature_item_id)
                             .last
     end
   end

--- a/app/services/api/user/active_commodities_service.rb
+++ b/app/services/api/user/active_commodities_service.rb
@@ -42,13 +42,10 @@ module Api
 
       def self.generate_fresh_expired_commodities(target_sids: nil)
         expired_candidates = TimeMachine.no_time_machine do
-          query = GoodsNomenclature
-            .where(producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX)
-
+          query = GoodsNomenclature.non_grouping
           query = query.where(goods_nomenclature_sid: target_sids) if target_sids
 
           active_sids = generate_fresh_active_commodities.map(&:first).to_set
-
           query.pluck(:goods_nomenclature_sid, :goods_nomenclature_item_id)
             .reject { |sid, _| active_sids.include?(sid) }
         end

--- a/app/services/api/user/batcher_service/my_commodities_batcher_service.rb
+++ b/app/services/api/user/batcher_service/my_commodities_batcher_service.rb
@@ -7,7 +7,7 @@ module Api
 
           user_subscription = user.subscriptions_dataset.with_subscription_type(Subscriptions::Type.my_commodities).first
           user_subscription.set_metadata_key('commodity_codes', targets)
-          commodity_targets = GoodsNomenclature.where(goods_nomenclature_item_id: targets)
+          commodity_targets = GoodsNomenclature.by_codes(targets)
 
           user_subscription.add_targets(targets: commodity_targets, target_type: 'commodity')
 

--- a/app/services/api/user/commodity_changes_service.rb
+++ b/app/services/api/user/commodity_changes_service.rb
@@ -31,8 +31,8 @@ module Api
 
       def ending(with_records: false)
         changes = TariffChange.commodities
-                              .where(operation_date: date)
-                              .where(goods_nomenclature_sid: user_commodity_code_sids)
+                              .on_date(date)
+                              .for_goods_nomenclature_sids(user_commodity_code_sids)
                               .where(action: TariffChangesService::BaseChanges::ENDING)
 
         count = changes.count
@@ -49,8 +49,8 @@ module Api
 
       def classification(with_records: false)
         changes = TariffChange.commodity_descriptions
-                              .where(operation_date: date)
-                              .where(goods_nomenclature_sid: user_commodity_code_sids)
+                              .on_date(date)
+                              .for_goods_nomenclature_sids(user_commodity_code_sids)
                               .where(action: TariffChangesService::BaseChanges::UPDATE)
         count = changes.count
 

--- a/app/services/api/user/grouped_measure_changes_service.rb
+++ b/app/services/api/user/grouped_measure_changes_service.rb
@@ -39,8 +39,8 @@ module Api
                       geographical_area: grouped_measure_change.geographical_area_id,
                       excluded_areas: excluded_areas_sorted,
                     )
-                    .where(operation_date: date)
-                    .where(goods_nomenclature_sid: user_commodity_code_sids)
+                    .on_date(date)
+                    .for_goods_nomenclature_sids(user_commodity_code_sids)
                     .group(:goods_nomenclature_item_id)
                     .order(:goods_nomenclature_item_id)
                     .select(
@@ -75,7 +75,7 @@ module Api
 
       def load_commodities(commodity_ids)
         if commodity_ids.any?
-          GoodsNomenclature.where(goods_nomenclature_item_id: commodity_ids)
+          GoodsNomenclature.by_codes(commodity_ids)
                            .index_by(&:goods_nomenclature_item_id)
         else
           {}
@@ -96,8 +96,8 @@ module Api
         return [] if user_commodity_code_sids.blank?
 
         TariffChange.measures
-                    .where(operation_date: @date)
-                    .where(goods_nomenclature_sid: user_commodity_code_sids)
+                    .on_date(@date)
+                    .for_goods_nomenclature_sids(user_commodity_code_sids)
                     .group(
                       Sequel.lit("metadata->'measure'->>'trade_movement_code'"),
                       Sequel.lit("metadata->'measure'->>'geographical_area_id'"),

--- a/spec/services/api/user/active_commodities_service_spec.rb
+++ b/spec/services/api/user/active_commodities_service_spec.rb
@@ -77,14 +77,19 @@ RSpec.describe Api::User::ActiveCommoditiesService do
       Rails.cache.delete('myott_all_expired_commodities')
       described_class.instance_variable_set(:@all_expired_commodities, nil)
 
-      allow(GoodsNomenclature).to receive_message_chain(:where, :pluck).and_return([])
+      non_grouping_query = instance_double(Sequel::Dataset, pluck: [])
+      allow(GoodsNomenclature).to receive(:non_grouping).and_return(non_grouping_query)
 
       result = described_class.all_expired_commodities
       expect(result).to eq([])
     end
 
     it 'returns empty array when no expired candidates exist with target filtering' do
-      allow(GoodsNomenclature).to receive_message_chain(:where, :where, :pluck).and_return([])
+      filtered_query = instance_double(Sequel::Dataset, pluck: [])
+      non_grouping_query = instance_double(Sequel::Dataset)
+
+      allow(non_grouping_query).to receive(:where).with(goods_nomenclature_sid: [999]).and_return(filtered_query)
+      allow(GoodsNomenclature).to receive(:non_grouping).and_return(non_grouping_query)
 
       result = described_class.all_expired_commodities(target_sids: [999])
       expect(result).to eq([])

--- a/spec/services/api/user/commodity_changes_service_spec.rb
+++ b/spec/services/api/user/commodity_changes_service_spec.rb
@@ -1,99 +1,131 @@
-RSpec.describe Api::User::CommodityChangesService do
-  subject(:service) { described_class.new(user, nil, date) }
+class CommodityChangesQueryStub
+  attr_reader :count
 
+  def initialize(count:, records: nil)
+    @count = count
+    @records = records
+  end
+
+  def on_date(_date)
+    self
+  end
+
+  def for_goods_nomenclature_sids(_goods_nomenclature_sids)
+    self
+  end
+
+  def where(*_args)
+    self
+  end
+
+  def all
+    @records
+  end
+end
+
+RSpec.describe Api::User::CommodityChangesService do
+  subject(:service) { described_class.new(user, id, date) }
+
+  let(:id) { nil }
   let(:date) { Date.yesterday }
   let(:user) { create(:public_user) }
   let(:user_commodity_code_sids) { [123_456, 987_654] }
 
   before do
-    allow(Time.zone).to receive(:yesterday).and_return(date)
     allow(user).to receive(:target_ids_for_my_commodities).and_return(user_commodity_code_sids)
   end
 
-  describe '#call when id is not allowed' do
-    let(:user_commodity_code_sids) { [123_456, 987_654] }
-    let(:user) { create(:public_user) }
-    let(:date) { Date.yesterday }
-    let(:service_with_invalid_id) { described_class.new(user, 'not_allowed', date) }
-
-    before do
-      allow(Time.zone).to receive(:yesterday).and_return(date)
-      allow(user).to receive(:target_ids_for_my_commodities).and_return(user_commodity_code_sids)
-      allow(TariffChange).to receive_message_chain(:commodities, :where, :where, :where, :count).and_return(5)
-      allow(TariffChange).to receive_message_chain(:commodity_descriptions, :where, :where, :where, :count).and_return(3)
-    end
-
-    it 'returns all changes (array) when id is not in allowed list' do
-      result = service_with_invalid_id.call
-      expect(result).to be_an(Array)
-      expect(result.first.id).to eq('ending')
-      expect(result.last.id).to eq('classification')
-    end
+  def stub_tariff_change_scope(scope, count:, records: nil)
+    allow(TariffChange).to receive(scope).and_return(
+      CommodityChangesQueryStub.new(count: count, records: records),
+    )
   end
 
-  describe '#call when id is nil' do
-    before do
-      allow(TariffChange).to receive_message_chain(:commodities, :where, :where, :where, :count).and_return(5)
-      allow(TariffChange).to receive_message_chain(:commodity_descriptions, :where, :where, :where, :count).and_return(3)
+  describe '#call' do
+    context 'when id is nil' do
+      before do
+        stub_tariff_change_scope(:commodities, count: 5)
+        stub_tariff_change_scope(:commodity_descriptions, count: 3)
+      end
+
+      it 'returns both grouped changes' do
+        expect(service.call.map(&:id)).to eq(%w[ending classification])
+      end
+
+      it 'returns the expected counts' do
+        result = service.call
+
+        expect(result.map(&:count)).to eq([5, 3])
+      end
     end
 
-    it 'returns the correct structure' do
-      result = service.call
-      expect(result).to be_an(Array)
-      expect(result.first.id).to eq('ending')
-      expect(result.first.count).to eq(5)
-      expect(result.last.id).to eq('classification')
-      expect(result.last.count).to eq(3)
+    context 'when id is not allowed' do
+      let(:id) { 'not_allowed' }
+
+      before do
+        stub_tariff_change_scope(:commodities, count: 5)
+        stub_tariff_change_scope(:commodity_descriptions, count: 3)
+      end
+
+      it 'falls back to all changes' do
+        expect(service.call.map(&:id)).to eq(%w[ending classification])
+      end
     end
 
     context 'when there are no commodity endings' do
       before do
-        allow(TariffChange).to receive_message_chain(:commodities, :where, :where, :where, :count).and_return(0)
+        stub_tariff_change_scope(:commodities, count: 0)
+        stub_tariff_change_scope(:commodity_descriptions, count: 3)
       end
 
-      it 'omits commodity endings from the result' do
-        result = service.call
-        expect(result).not_to(be_any { |change| change.id == 'ending' })
+      it 'omits ending changes' do
+        expect(service.call.map(&:id)).to eq(%w[classification])
       end
     end
 
     context 'when there are no classification changes' do
       before do
-        allow(TariffChange).to receive_message_chain(:commodity_descriptions, :where, :where, :where, :count).and_return(0)
+        stub_tariff_change_scope(:commodities, count: 5)
+        stub_tariff_change_scope(:commodity_descriptions, count: 0)
       end
 
-      it 'omits classification changes from the result' do
+      it 'omits classification changes' do
+        expect(service.call.map(&:id)).to eq(%w[ending])
+      end
+    end
+
+    context 'when id is ending' do
+      let(:id) { 'ending' }
+
+      before do
+        stub_tariff_change_scope(:commodities, count: 2, records: %i[ending1 ending2])
+      end
+
+      it 'returns the ending group with records' do
         result = service.call
-        expect(result).not_to(be_any { |change| change.id == 'classification' })
+
+        expect(result).to be_a(TariffChanges::GroupedCommodityChange)
+        expect(result.id).to eq('ending')
+        expect(result.count).to eq(2)
+        expect(result.tariff_changes).to eq(%i[ending1 ending2])
       end
     end
-  end
 
-  describe '#call when id is specified' do
-    let(:service_with_id_ending) { described_class.new(user, 'ending', date) }
-    let(:service_with_id_classification) { described_class.new(user, 'classification', date) }
+    context 'when id is classification' do
+      let(:id) { 'classification' }
 
-    before do
-      allow(TariffChange).to receive_message_chain(:commodities, :where, :where, :where, :all).and_return(%i[ending1 ending2])
-      allow(TariffChange).to receive_message_chain(:commodities, :where, :where, :where, :count).and_return(2)
-      allow(TariffChange).to receive_message_chain(:commodity_descriptions, :where, :where, :where, :all).and_return([:desc1])
-      allow(TariffChange).to receive_message_chain(:commodity_descriptions, :where, :where, :where, :count).and_return(1)
-    end
+      before do
+        stub_tariff_change_scope(:commodity_descriptions, count: 1, records: [:desc1])
+      end
 
-    it 'returns a GroupedCommodityChange with correct attributes when id is ending' do
-      result = service_with_id_ending.call
-      expect(result).to be_a(TariffChanges::GroupedCommodityChange)
-      expect(result.id).to eq('ending')
-      expect(result.count).to eq(2)
-      expect(result.tariff_changes).to eq(%i[ending1 ending2])
-    end
+      it 'returns the classification group with records' do
+        result = service.call
 
-    it 'returns a GroupedCommodityChange with correct attributes when id is classification' do
-      result = service_with_id_classification.call
-      expect(result).to be_a(TariffChanges::GroupedCommodityChange)
-      expect(result.id).to eq('classification')
-      expect(result.count).to eq(1)
-      expect(result.tariff_changes).to eq([:desc1])
+        expect(result).to be_a(TariffChanges::GroupedCommodityChange)
+        expect(result.id).to eq('classification')
+        expect(result.count).to eq(1)
+        expect(result.tariff_changes).to eq([:desc1])
+      end
     end
   end
 end


### PR DESCRIPTION
### What?

- Moves by_code and by_productline_suffix methods to GoodsNomenclature and adds by_codes method
- Makes use of these added methods in place of raw queries
- Uses `where` over `filter` for consistency
- Adds dataset methods to TariffChange