### PR TITLE
Remove active model plugin

### DIFF
--- a/app/models/chapter_note.rb
+++ b/app/models/chapter_note.rb
@@ -1,6 +1,5 @@
 class ChapterNote < Sequel::Model
   plugin :json_serializer
-  plugin :active_model
   plugin :has_paper_trail
 
   many_to_one :chapter, dataset: lambda {

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -1,19 +1,22 @@
 class GoodsNomenclature < Sequel::Model
+  extend ActiveModel::Naming
+
+  include AncestorChainDescription
+  include ClassificationDescription
+  include Formatter
+
   CLASSIFICATION_CHAPTER = '98'.freeze
   CHAPTER_SUFFIX = '00000000'.freeze
   HEADING_SUFFIX = '000000'.freeze
   NON_GROUPING_PRODUCTLINE_SUFFIX = '80'.freeze
 
-  def self.sql_pattern_for(suffix)
-    '_' * (10 - suffix.length) + suffix
-  end
-
   set_dataset order(Sequel.asc(:goods_nomenclatures__goods_nomenclature_item_id), Sequel.asc(:goods_nomenclatures__producline_suffix))
   set_primary_key [:goods_nomenclature_sid]
 
+  include GoodsNomenclatures::NestedSet # must be after set_dataset and set_primary_key
+
   plugin :time_machine
   plugin :oplog, primary_key: :goods_nomenclature_sid, materialized: true
-  plugin :active_model
 
   plugin :sti, class_determinator: lambda { |record|
     gono_id = record[:goods_nomenclature_item_id].to_s
@@ -30,13 +33,6 @@ class GoodsNomenclature < Sequel::Model
       record[:producline_suffix] != NON_GROUPING_PRODUCTLINE_SUFFIX || record[:leaf].is_a?(FalseClass) ? 'Subheading' : 'Commodity'
     end
   }
-
-  extend ActiveModel::Naming
-
-  include AncestorChainDescription
-  include ClassificationDescription
-  include Formatter
-  include GoodsNomenclatures::NestedSet
 
   one_to_one :chapter,
              key: :goods_nomenclature_item_id,
@@ -93,26 +89,6 @@ class GoodsNomenclature < Sequel::Model
     ds.with_actual(FootnoteAssociationGoodsNomenclature)
   end
 
-  def number_indents
-    if values.key?(:number_indents)
-      values[:number_indents]
-    elsif goods_nomenclature_indent.present?
-      goods_nomenclature_indent.number_indents
-    else
-      reload && goods_nomenclature_indent&.number_indents
-    end
-  end
-
-  delegate :description,
-           :description_html,
-           :description_indexed,
-           :description_plain,
-           :formatted_description,
-           :csv_formatted_description,
-           :consigned_from,
-           to: :goods_nomenclature_description,
-           allow_nil: true
-
   # Find goods nomenclature where I am the origin (e.g. who succeed me)
   one_to_many :deriving_goods_nomenclature_origins, key: %i[derived_goods_nomenclature_item_id derived_productline_suffix],
                                                     primary_key: %i[goods_nomenclature_item_id producline_suffix],
@@ -146,6 +122,20 @@ class GoodsNomenclature < Sequel::Model
                                      key: %i[goods_nomenclature_item_id productline_suffix],
                                      primary_key: %i[goods_nomenclature_item_id producline_suffix],
                                      reciprocal: :goods_nomenclature
+
+  delegate :description,
+           :description_html,
+           :description_indexed,
+           :description_plain,
+           :formatted_description,
+           :csv_formatted_description,
+           :consigned_from,
+           to: :goods_nomenclature_description,
+           allow_nil: true
+
+  def self.sql_pattern_for(suffix)
+    '_' * (10 - suffix.length) + suffix
+  end
 
   dataset_module do
     def by_codes(codes)
@@ -198,6 +188,16 @@ class GoodsNomenclature < Sequel::Model
       combined_conditions = conditions.reduce(:|)
 
       where(combined_conditions)
+    end
+  end
+
+  def number_indents
+    if values.key?(:number_indents)
+      values[:number_indents]
+    elsif goods_nomenclature_indent.present?
+      goods_nomenclature_indent.number_indents
+    else
+      reload && goods_nomenclature_indent&.number_indents
     end
   end
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,6 +1,5 @@
 class Notification
   include ActiveModel::Model
-  include ActiveModel::Validations
 
   attr_accessor :email,
                 :template_id,

--- a/app/models/search_reference.rb
+++ b/app/models/search_reference.rb
@@ -8,7 +8,6 @@ class SearchReference < Sequel::Model
     Commodity
   ].freeze
 
-  plugin :active_model
   plugin :has_paper_trail
 
   referenced_setter = proc do |referenced|

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -5,7 +5,6 @@ class Section < Sequel::Model
   set_dataset order(Sequel.asc(:position))
 
   plugin :timestamps
-  plugin :active_model
 
   many_to_many :chapters,
                join_table: :chapters_sections,

--- a/app/models/section_note.rb
+++ b/app/models/section_note.rb
@@ -1,6 +1,5 @@
 class SectionNote < Sequel::Model
   plugin :json_serializer
-  plugin :active_model
   plugin :has_paper_trail
 
   many_to_one :section


### PR DESCRIPTION
### What?

Removed use of the active_model sequel plugin from `GoodsNomenclature`, `SearchReference`, `Section`, `SectionNote` and `ChapterNote` as it is not required.

The methods that the plugin adds are either not required, or are defined elsewhere (to_param is defined on subclasses of GoodsNomenclature).

Section, SearchReference and GoodsNomenclature all extend ActiveModel::Naming so `model_name` method still works.

---
There has been some rearrangement of code on GoodsNomenclature to follow the standard pattern.
