### PR TITLE
Return object from subscription methods

### DIFF
--- a/app/models/public_users/user.rb
+++ b/app/models/public_users/user.rb
@@ -61,15 +61,11 @@ module PublicUsers
     end
 
     def stop_press_subscription
-      subscription_for(Subscriptions::Type.stop_press)&.uuid || false
+      subscription_for(Subscriptions::Type.stop_press)
     end
 
     def my_commodities_subscription
-      subscription_for(Subscriptions::Type.my_commodities)&.uuid || false
-    end
-
-    def subscription_for(type)
-      subscriptions_dataset.where(subscription_type: type, active: true).first
+      subscription_for(Subscriptions::Type.my_commodities)
     end
 
     def stop_press_subscription=(active)
@@ -97,8 +93,7 @@ module PublicUsers
     end
 
     def target_ids_for_my_commodities
-      subscription = subscription_for(Subscriptions::Type.my_commodities)
-      subscription&.subscription_targets_dataset&.map(&:target_id) || []
+      my_commodities_subscription&.subscription_targets_dataset&.map(&:target_id) || []
     end
 
     def invalidate!
@@ -123,6 +118,10 @@ module PublicUsers
       super
       PublicUsers::Preferences.create(user_id: id)
       PublicUsers::ActionLog.create(user_id: id, action: PublicUsers::ActionLog::REGISTERED)
+    end
+
+    def subscription_for(type)
+      subscriptions_dataset.where(subscription_type: type, active: true).first
     end
   end
 end

--- a/app/services/api/user/batcher_service/my_commodities_batcher_service.rb
+++ b/app/services/api/user/batcher_service/my_commodities_batcher_service.rb
@@ -3,7 +3,7 @@ module Api
     module BatcherService
       class MyCommoditiesBatcherService
         def self.call(targets, user)
-          raise ArgumentError, 'my commodities subscription must be present' unless user.my_commodities_subscription
+          raise ArgumentError, 'my commodities subscription must be present' if user.my_commodities_subscription.blank?
 
           user_subscription = user.subscriptions_dataset.with_subscription_type(Subscriptions::Type.my_commodities).first
           user_subscription.set_metadata_key('commodity_codes', targets)

--- a/app/workers/my_commodities_email_worker.rb
+++ b/app/workers/my_commodities_email_worker.rb
@@ -10,7 +10,9 @@ class MyCommoditiesEmailWorker
     return if date.nil?
     return if user.nil?
     return if user.email.blank?
-    return if user.deleted
+
+    subscription = user.my_commodities_subscription
+    return if subscription.nil?
 
     as_of_date = Date.parse(date).strftime('%Y-%m-%d')
     tracking_params = 'utm_source=private+beta&utm_medium=email&utm_campaign=commodity+watchlist'
@@ -19,7 +21,7 @@ class MyCommoditiesEmailWorker
       changes_count:,
       published_date: date,
       site_url: "#{URI.join(TradeTariffBackend.frontend_host, 'subscriptions/mycommodities')}?as_of=#{as_of_date}&#{tracking_params}",
-      unsubscribe_url: "#{URI.join(TradeTariffBackend.frontend_host, 'subscriptions/unsubscribe/', user.my_commodities_subscription)}?#{tracking_params}",
+      unsubscribe_url: "#{URI.join(TradeTariffBackend.frontend_host, 'subscriptions/unsubscribe/', subscription.uuid)}?#{tracking_params}",
     }
 
     response = client.send_email(user.email, TEMPLATE_ID, personalisation, REPLY_TO_ID, nil)

--- a/app/workers/stop_press_email_worker.rb
+++ b/app/workers/stop_press_email_worker.rb
@@ -10,7 +10,10 @@ class StopPressEmailWorker
 
     return if stop_press.nil?
     return if user.nil?
-    return unless user.email
+    return if user.email.blank?
+
+    subscription = user.stop_press_subscription
+    return if subscription.nil?
 
     tracking_params = 'utm_source=private+beta&utm_medium=email&utm_campaign=stop+press+notification'
 
@@ -19,7 +22,7 @@ class StopPressEmailWorker
       stop_press_link: "#{stop_press.public_url}?#{tracking_params}",
       subscription_reason: subscription_reason(stop_press, user),
       site_url: "#{URI.join(TradeTariffBackend.frontend_host, 'subscriptions/')}?#{tracking_params}",
-      unsubscribe_url: "#{URI.join(TradeTariffBackend.frontend_host, 'subscriptions/unsubscribe/', user.stop_press_subscription)}?#{tracking_params}",
+      unsubscribe_url: "#{URI.join(TradeTariffBackend.frontend_host, 'subscriptions/unsubscribe/', subscription.uuid)}?#{tracking_params}",
     }
 
     response = client.send_email(user.email, TEMPLATE_ID, personalisation, REPLY_TO_ID, nil)

--- a/spec/models/public_users/user_spec.rb
+++ b/spec/models/public_users/user_spec.rb
@@ -39,34 +39,34 @@ RSpec.describe PublicUsers::User do
   end
 
   describe '#stop_press_subscription' do
-    it 'returns id when user has an active subscription' do
+    it 'returns subscription when user has an active subscription' do
       user.add_subscription(subscription_type_id: Subscriptions::Type.stop_press.id, active: true)
-      expect(user.stop_press_subscription).to be_a(String)
+      expect(user.stop_press_subscription).to be_a(PublicUsers::Subscription)
     end
 
-    it 'returns false when user has an inactive subscription' do
+    it 'returns nil when user has an inactive subscription' do
       user.add_subscription(subscription_type_id: Subscriptions::Type.stop_press.id, active: false)
-      expect(user.stop_press_subscription).to be false
+      expect(user.stop_press_subscription).to be_nil
     end
 
-    it 'returns false when user does not have a subscription' do
-      expect(user.stop_press_subscription).to be false
+    it 'returns nil when user does not have a subscription' do
+      expect(user.stop_press_subscription).to be_nil
     end
   end
 
   describe '#my_commodities_subscription' do
-    it 'returns id when user has an active subscription' do
+    it 'returns subscription when user has an active subscription' do
       user.add_subscription(subscription_type_id: Subscriptions::Type.my_commodities.id, active: true)
-      expect(user.my_commodities_subscription).to be_a(String)
+      expect(user.my_commodities_subscription).to be_a(PublicUsers::Subscription)
     end
 
-    it 'returns false when user has an inactive subscription' do
+    it 'returns nil when user has an inactive subscription' do
       user.add_subscription(subscription_type_id: Subscriptions::Type.my_commodities.id, active: false)
-      expect(user.my_commodities_subscription).to be false
+      expect(user.my_commodities_subscription).to be_nil
     end
 
-    it 'returns false when user does not have a subscription' do
-      expect(user.my_commodities_subscription).to be false
+    it 'returns nil when user does not have a subscription' do
+      expect(user.my_commodities_subscription).to be_nil
     end
   end
 

--- a/spec/support/shared_examples/a_user_controller_subscription_type_update.rb
+++ b/spec/support/shared_examples/a_user_controller_subscription_type_update.rb
@@ -28,7 +28,7 @@ RSpec.shared_examples_for 'a user controller subscription type update' do |subsc
 
       it 'activates the subscription' do
         api_response
-        expect(user.public_send(subscription_type)).to be_a(String)
+        expect(user.reload.public_send(subscription_type)).to be_a(PublicUsers::Subscription)
       end
 
       it 'responds with updated subscription details' do
@@ -48,7 +48,7 @@ RSpec.shared_examples_for 'a user controller subscription type update' do |subsc
 
       it 'deactivates the subscription' do
         api_response
-        expect(user.public_send(subscription_type)).to be(false)
+        expect(user.reload.public_send(subscription_type)).to be_nil
       end
 
       it 'responds with updated subscription details' do

--- a/spec/workers/my_commodities_email_worker_spec.rb
+++ b/spec/workers/my_commodities_email_worker_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe MyCommoditiesEmailWorker, type: :worker do
             changes_count: count,
             published_date: date,
             site_url: "#{TradeTariffBackend.frontend_host}/subscriptions/mycommodities?as_of=2025-12-08&utm_source=private+beta&utm_medium=email&utm_campaign=commodity+watchlist",
-            unsubscribe_url: "#{URI.join(TradeTariffBackend.frontend_host, 'subscriptions/unsubscribe/', user.my_commodities_subscription)}?utm_source=private+beta&utm_medium=email&utm_campaign=commodity+watchlist",
+            unsubscribe_url: "#{URI.join(TradeTariffBackend.frontend_host, 'subscriptions/unsubscribe/', user.my_commodities_subscription.uuid)}?utm_source=private+beta&utm_medium=email&utm_campaign=commodity+watchlist",
           },
           described_class::REPLY_TO_ID,
           nil,

--- a/spec/workers/stop_press_email_worker_spec.rb
+++ b/spec/workers/stop_press_email_worker_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe StopPressEmailWorker, type: :worker do
         stop_press_link: "#{stop_press.public_url}?utm_source=private+beta&utm_medium=email&utm_campaign=stop+press+notification",
         subscription_reason: 'This is a non-chapter specific update from the UK Trade Tariff Service',
         site_url: "#{URI.join(TradeTariffBackend.frontend_host, 'subscriptions/')}?utm_source=private+beta&utm_medium=email&utm_campaign=stop+press+notification",
-        unsubscribe_url: "#{URI.join(TradeTariffBackend.frontend_host, 'subscriptions/unsubscribe/', user.stop_press_subscription)}?utm_source=private+beta&utm_medium=email&utm_campaign=stop+press+notification",
+        unsubscribe_url: "#{URI.join(TradeTariffBackend.frontend_host, 'subscriptions/unsubscribe/', user.stop_press_subscription.uuid)}?utm_source=private+beta&utm_medium=email&utm_campaign=stop+press+notification",
       }
     end
 


### PR DESCRIPTION
### What?

The subscription methods on User could return the subscription identifier or false. This is confusing so they now return the subscription object.
