### PR TITLE
Fix sync age metric not appearing in NR: switch to record_custom_event

### DIFF
--- a/app/workers/synchronizer_check_worker.rb
+++ b/app/workers/synchronizer_check_worker.rb
@@ -9,7 +9,7 @@ class SynchronizerCheckWorker
     last_applied_at = TariffSynchronizer::BaseUpdate.most_recent_applied&.applied_at
     age_minutes = age_in_minutes(last_applied_at)
 
-    NewRelic::Agent.record_custom_event("TariffSyncAge", service: service, age_minutes: age_minutes)
+    NewRelic::Agent.record_custom_event('TariffSyncAge', service: service, age_minutes: age_minutes)
   end
 
 private

--- a/app/workers/synchronizer_check_worker.rb
+++ b/app/workers/synchronizer_check_worker.rb
@@ -9,7 +9,7 @@ class SynchronizerCheckWorker
     last_applied_at = TariffSynchronizer::BaseUpdate.most_recent_applied&.applied_at
     age_minutes = age_in_minutes(last_applied_at)
 
-    NewRelic::Agent.record_metric("Custom/TariffSync/#{service}/AgeMinutes", age_minutes)
+    NewRelic::Agent.record_custom_event("TariffSyncAge", service: service, age_minutes: age_minutes)
   end
 
 private

--- a/spec/workers/synchronizer_check_worker_spec.rb
+++ b/spec/workers/synchronizer_check_worker_spec.rb
@@ -2,14 +2,14 @@ RSpec.describe SynchronizerCheckWorker, type: :worker do
   describe '#perform' do
     subject(:perform) { described_class.new.perform }
 
-    before { allow(NewRelic::Agent).to receive(:record_metric) }
+    before { allow(NewRelic::Agent).to receive(:record_custom_event) }
 
     context 'when there are no applied updates' do
       before { perform }
 
-      it 'records the sentinel age metric' do
-        expect(NewRelic::Agent).to have_received(:record_metric)
-          .with('Custom/TariffSync/uk/AgeMinutes', SynchronizerCheckWorker::NO_SYNC_SENTINEL_MINUTES)
+      it 'records the sentinel age event' do
+        expect(NewRelic::Agent).to have_received(:record_custom_event)
+          .with('TariffSyncAge', service: 'uk', age_minutes: SynchronizerCheckWorker::NO_SYNC_SENTINEL_MINUTES)
       end
     end
 
@@ -19,9 +19,9 @@ RSpec.describe SynchronizerCheckWorker, type: :worker do
         perform
       end
 
-      it 'records an age metric close to 120 minutes' do
-        expect(NewRelic::Agent).to have_received(:record_metric)
-          .with('Custom/TariffSync/uk/AgeMinutes', be_within(2).of(120))
+      it 'records an age event close to 120 minutes' do
+        expect(NewRelic::Agent).to have_received(:record_custom_event)
+          .with('TariffSyncAge', service: 'uk', age_minutes: be_within(2).of(120))
       end
     end
 
@@ -31,9 +31,9 @@ RSpec.describe SynchronizerCheckWorker, type: :worker do
         perform
       end
 
-      it 'records an age metric over 24 hours' do
-        expect(NewRelic::Agent).to have_received(:record_metric)
-          .with('Custom/TariffSync/uk/AgeMinutes', be > 1440)
+      it 'records an age event over 24 hours' do
+        expect(NewRelic::Agent).to have_received(:record_custom_event)
+          .with('TariffSyncAge', service: 'uk', age_minutes: be > 1440)
       end
     end
   end


### PR DESCRIPTION
## Problem

`record_metric` writes an APM timeslice metric. These only appear in NRQL (`FROM Metric WHERE metricTimesliceName = '...'`) if the NR account has the "APM timeslice data as dimensional metrics" feature enabled — which is not the default and is the reason the metric from #2988 was not appearing after deploy.

## Fix

Replace `record_metric` with `record_custom_event`, which goes through the event pipeline and is immediately queryable via NRQL with no account-level configuration required.

## Updated NRQL

Alert conditions and dashboards should use `FROM TariffSyncAge` instead of `FROM Metric`:

```sql
-- Alert condition (one per service)
SELECT latest(age_minutes) FROM TariffSyncAge WHERE service = 'uk'

-- Dashboard time series
SELECT latest(age_minutes) FROM TariffSyncAge
FACET service
TIMESERIES 30 minutes
SINCE 2 days ago

-- Confirm data is arriving
SELECT uniques(service), latest(age_minutes) FROM TariffSyncAge SINCE 1 hour ago
```

The alert threshold logic is unchanged: fire when `age_minutes > 480`.