### PR TITLE
Reintroduce RAILS_ENV=production to worker and job ECS tasks

### DIFF
--- a/terraform/backend_job.tf
+++ b/terraform/backend_job.tf
@@ -20,7 +20,7 @@ module "backend-job" {
 
   task_role_policy_arns = [aws_iam_policy.task.arn]
 
-  service_environment_config = local.backend_job_secret_env_vars
+  service_environment_config = local.backend_job_env_vars
 
   enable_ecs_exec = true
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -70,4 +70,15 @@ locals {
     }
   ]
   ecr_repo = "382373577178.dkr.ecr.eu-west-2.amazonaws.com/tariff-backend-production"
+
+  worker_static_env_vars = [
+    {
+      name  = "RAILS_ENV"
+      value = "production"
+    }
+  ]
+
+  worker_uk_env_vars   = concat(local.worker_uk_secret_env_vars, local.worker_static_env_vars)
+  worker_xi_env_vars   = concat(local.worker_xi_secret_env_vars, local.worker_static_env_vars)
+  backend_job_env_vars = concat(local.backend_job_secret_env_vars, local.worker_static_env_vars)
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -74,7 +74,7 @@ locals {
   worker_static_env_vars = [
     {
       name  = "RAILS_ENV"
-      value = "production"
+      value = var.environment
     }
   ]
 

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -31,7 +31,7 @@ module "worker_uk" {
   init_container_entrypoint = [""]
   init_container_command    = local.init_command
 
-  service_environment_config = local.worker_uk_secret_env_vars
+  service_environment_config = local.worker_uk_env_vars
 
   has_autoscaler = local.has_autoscaler
   min_capacity   = 1

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -31,7 +31,7 @@ module "worker_xi" {
   init_container_entrypoint = [""]
   init_container_command    = local.init_command
 
-  service_environment_config = local.worker_xi_secret_env_vars
+  service_environment_config = local.worker_xi_env_vars
 
   has_autoscaler = local.has_autoscaler
   min_capacity   = 1


### PR DESCRIPTION
## Problem

`RAILS_ENV=production` was missing from the ECS task environment for `worker-uk`, `worker-xi`, and `backend-job`. Without it, Rails boots in the default environment and the New Relic agent runs with `monitor_mode: false` (the `common:` default in `newrelic.yml`), silently dropping all metrics, events, and traces.

This is why the sync age metric introduced in #2988 was not appearing in New Relic after deploy.

## Change

`RAILS_ENV` is not a secret, so it is added as a static env var in `locals.tf` (`worker_static_env_vars`) and concatenated with the Secrets Manager env vars for each task:

| Task | Local |
|------|-------|
| `worker-uk` | `worker_uk_env_vars` |
| `worker-xi` | `worker_xi_env_vars` |
| `backend-job` | `backend_job_env_vars` |

## Ops note

After this is applied via Terraform, the ECS tasks will need to be redeployed (new task definition registered) for the change to take effect. A standard deploy is sufficient.