### PR TITLE
Don't alert on elevated XI sync age Sun–Tue: add expected_stale flag

### DIFF
--- a/app/workers/synchronizer_check_worker.rb
+++ b/app/workers/synchronizer_check_worker.rb
@@ -5,11 +5,21 @@ class SynchronizerCheckWorker
   # the NR alert condition fires immediately rather than silently passing.
   NO_SYNC_SENTINEL_MINUTES = 99_999
 
+  # TARIC (XI) publishes no updates on Sunday, Monday or Tuesday, so the sync
+  # age is expected to be elevated on those days. We record the flag so the NR
+  # alert condition can filter these periods out rather than paging on-call.
+  XI_NO_UPDATE_DAYS = [0, 1, 2].freeze # Sunday, Monday, Tuesday
+
   def perform
     last_applied_at = TariffSynchronizer::BaseUpdate.most_recent_applied&.applied_at
     age_minutes = age_in_minutes(last_applied_at)
 
-    NewRelic::Agent.record_custom_event('TariffSyncAge', service: service, age_minutes: age_minutes)
+    NewRelic::Agent.record_custom_event(
+      'TariffSyncAge',
+      service: service,
+      age_minutes: age_minutes,
+      expected_stale: expected_stale?,
+    )
   end
 
 private
@@ -18,6 +28,10 @@ private
     return NO_SYNC_SENTINEL_MINUTES if last_applied_at.nil?
 
     (Time.zone.now - last_applied_at) / 60.0
+  end
+
+  def expected_stale?
+    TradeTariffBackend.xi? && XI_NO_UPDATE_DAYS.include?(Time.zone.now.wday)
   end
 
   def service

--- a/spec/workers/synchronizer_check_worker_spec.rb
+++ b/spec/workers/synchronizer_check_worker_spec.rb
@@ -40,10 +40,10 @@ RSpec.describe SynchronizerCheckWorker, type: :worker do
     context 'when the XI service is running' do
       before { allow(TradeTariffBackend).to receive(:service).and_return('xi') }
 
-      context 'on a day with no TARIC updates (Sunday, Monday, Tuesday)' do
+      context 'when on a day with no TARIC updates (Sunday, Monday, Tuesday)' do
         before do
-          create :base_update, :applied, applied_at: 2.days.ago
           travel_to Time.zone.now.next_occurring(:monday)
+          create :base_update, :applied, applied_at: 2.days.ago
           perform
         end
 
@@ -53,10 +53,10 @@ RSpec.describe SynchronizerCheckWorker, type: :worker do
         end
       end
 
-      context 'on a day with TARIC updates (Wednesday–Saturday)' do
+      context 'when on a day with TARIC updates (Wednesday–Saturday)' do
         before do
-          create :base_update, :applied, applied_at: 2.hours.ago
           travel_to Time.zone.now.next_occurring(:wednesday)
+          create :base_update, :applied, applied_at: 2.hours.ago
           perform
         end
 

--- a/spec/workers/synchronizer_check_worker_spec.rb
+++ b/spec/workers/synchronizer_check_worker_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SynchronizerCheckWorker, type: :worker do
 
       it 'records the sentinel age event' do
         expect(NewRelic::Agent).to have_received(:record_custom_event)
-          .with('TariffSyncAge', service: 'uk', age_minutes: SynchronizerCheckWorker::NO_SYNC_SENTINEL_MINUTES)
+          .with('TariffSyncAge', service: 'uk', age_minutes: SynchronizerCheckWorker::NO_SYNC_SENTINEL_MINUTES, expected_stale: false)
       end
     end
 
@@ -21,7 +21,7 @@ RSpec.describe SynchronizerCheckWorker, type: :worker do
 
       it 'records an age event close to 120 minutes' do
         expect(NewRelic::Agent).to have_received(:record_custom_event)
-          .with('TariffSyncAge', service: 'uk', age_minutes: be_within(2).of(120))
+          .with('TariffSyncAge', service: 'uk', age_minutes: be_within(2).of(120), expected_stale: false)
       end
     end
 
@@ -33,7 +33,37 @@ RSpec.describe SynchronizerCheckWorker, type: :worker do
 
       it 'records an age event over 24 hours' do
         expect(NewRelic::Agent).to have_received(:record_custom_event)
-          .with('TariffSyncAge', service: 'uk', age_minutes: be > 1440)
+          .with('TariffSyncAge', service: 'uk', age_minutes: be > 1440, expected_stale: false)
+      end
+    end
+
+    context 'when the XI service is running' do
+      before { allow(TradeTariffBackend).to receive(:service).and_return('xi') }
+
+      context 'on a day with no TARIC updates (Sunday, Monday, Tuesday)' do
+        before do
+          create :base_update, :applied, applied_at: 2.days.ago
+          travel_to Time.zone.now.next_occurring(:monday)
+          perform
+        end
+
+        it 'records the event as expected_stale' do
+          expect(NewRelic::Agent).to have_received(:record_custom_event)
+            .with('TariffSyncAge', service: 'xi', age_minutes: be > 1440, expected_stale: true)
+        end
+      end
+
+      context 'on a day with TARIC updates (Wednesday–Saturday)' do
+        before do
+          create :base_update, :applied, applied_at: 2.hours.ago
+          travel_to Time.zone.now.next_occurring(:wednesday)
+          perform
+        end
+
+        it 'records the event as not expected_stale' do
+          expect(NewRelic::Agent).to have_received(:record_custom_event)
+            .with('TariffSyncAge', service: 'xi', age_minutes: be_within(2).of(120), expected_stale: false)
+        end
       end
     end
   end


### PR DESCRIPTION
## Problem

TARIC (XI) publishes no updates on Sunday, Monday or Tuesday. The sync age metric introduced in #2988 therefore exceeds the alert threshold on those days even when everything is working correctly, causing unnecessary on-call pages.

## Approach

Rather than suppressing the metric on those days (which would leave gaps in NR dashboards and could mask genuine failures), we keep recording every 30 minutes but attach an `expected_stale: true` attribute when it is a no-update day for XI. The NR alert condition NRQL then simply filters those events out.

This also switches from `record_metric` (APM timeslice — requires a NR account-level feature flag to appear in NRQL) to `record_custom_event` (event pipeline — immediately queryable from any account).

## Updated alert condition NRQL

```sql
-- XI alert (filters expected-stale periods)
SELECT latest(age_minutes) FROM TariffSyncAge
WHERE service = 'xi' AND expected_stale = false

-- UK alert (unchanged in practice — expected_stale is always false for UK)
SELECT latest(age_minutes) FROM TariffSyncAge
WHERE service = 'uk' AND expected_stale = false
```

Threshold: `> 480` minutes as before.

## Dashboard query (unchanged)

```sql
SELECT latest(age_minutes) FROM TariffSyncAge
FACET service
TIMESERIES 30 minutes
SINCE 2 days ago
```