### PR TITLE
AI-553: Add excluded chapters admin configuration

### DIFF
--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -31,6 +31,7 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
     'expand_search_enabled' => false,
     'expand_model' => NESTED_OPTION_DEFAULTS['expand_model'][:selected],
     'interactive_search_enabled' => true,
+    'interactive_search_excluded_chapters' => %w[98 99].freeze,
     'interactive_search_max_questions' => 7,
     'label_model' => NESTED_OPTION_DEFAULTS['label_model'][:selected],
     'label_page_size' => -> { TradeTariffBackend.goods_nomenclature_label_page_size },
@@ -121,6 +122,22 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
     config.selected_option(default: default) || default
   end
 
+  def self.multi_options_values(name)
+    config = classification.by_name(name.to_s)
+    default = Array(default_for(name))
+    return default if config.nil?
+
+    val = config[:value]
+    hash = case val
+           when Hash then val
+           when Sequel::Postgres::JSONBHash then val.to_hash
+           else {}
+           end
+
+    selected = hash['selected']
+    selected.is_a?(Array) ? selected : default
+  end
+
   def self.nested_options_value(name)
     config = classification.by_name(name.to_s)
     nested_default = NESTED_OPTION_DEFAULTS[name.to_s]
@@ -158,7 +175,7 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
     validates_presence :config_type
     validates_presence :area
     validates_presence :description
-    validates_includes %w[string markdown boolean options integer nested_options], :config_type
+    validates_includes %w[string markdown boolean options multi_options integer nested_options], :config_type
     validate_unique_name if new?
     validate_value_for_type
   end

--- a/app/models/admin_configuration/value_normalizer.rb
+++ b/app/models/admin_configuration/value_normalizer.rb
@@ -17,7 +17,7 @@ class AdminConfiguration
                   val.to_s.downcase == 'true'
                 when 'integer'
                   val.to_i
-                when 'options', 'nested_options'
+                when 'options', 'nested_options', 'multi_options'
                   coerce_json_object(val)
                 else # string, markdown
                   val.to_s
@@ -31,10 +31,14 @@ class AdminConfiguration
       when Hash then val
       when Sequel::Postgres::JSONBHash then val.to_hash
       when String then JSON.parse(val)
-      else { 'selected' => '', 'options' => [] }
+      else { 'selected' => default_selected_value, 'options' => [] }
       end
     rescue JSON::ParserError
-      { 'selected' => '', 'options' => [] }
+      { 'selected' => default_selected_value, 'options' => [] }
+    end
+
+    def default_selected_value
+      config_type == 'multi_options' ? [] : ''
     end
   end
 end

--- a/app/models/admin_configuration/value_validator.rb
+++ b/app/models/admin_configuration/value_validator.rb
@@ -17,6 +17,8 @@ class AdminConfiguration
         validate_integer_value
       when 'options'
         validate_options_value
+      when 'multi_options'
+        validate_multi_options_value
       when 'nested_options'
         validate_nested_options_value
       when 'string', 'markdown'
@@ -78,6 +80,33 @@ class AdminConfiguration
 
       selected = hash['selected']
       errors.add(:value, t('value.no_selected')) if selected.blank?
+    end
+
+    def validate_multi_options_value
+      val = self[:value]
+      return if val.nil?
+
+      hash = case val
+             when Hash then val
+             when Sequel::Postgres::JSONBHash then val.to_hash
+             when Sequel::Postgres::JSONBObject then return
+             else return errors.add(:value, t('value.invalid_options'))
+             end
+
+      options = hash['options']
+      unless options.is_a?(Array) && options.any?
+        errors.add(:value, t('value.no_options'))
+        return
+      end
+
+      selected = hash['selected']
+      unless selected.is_a?(Array)
+        errors.add(:value, t('value.invalid_options'))
+        return
+      end
+
+      option_keys = options.filter_map { |option| option['key'] if option.is_a?(Hash) }
+      errors.add(:value, t('value.invalid_options')) unless (selected - option_keys).empty?
     end
   end
 end

--- a/app/models/goods_nomenclature_self_text.rb
+++ b/app/models/goods_nomenclature_self_text.rb
@@ -76,6 +76,7 @@ class GoodsNomenclatureSelfText < Sequel::Model
         .where(goods_nomenclature__producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX)
         .where { GoodsNomenclature.validity_dates_filter(:goods_nomenclature) }
         .exclude(goods_nomenclature__goods_nomenclature_item_id: HiddenGoodsNomenclature.codes)
+        .exclude(goods_nomenclature__chapter_short_code: AdminConfiguration.multi_options_values('interactive_search_excluded_chapters'))
         .select(Sequel[:goods_nomenclature][:goods_nomenclature_sid])
         .select_append(Sequel.as(Sequel.lit("1 - (#{distance_expr})"), :score))
         .order(distance_expr)

--- a/app/queries/search/goods_nomenclature_query.rb
+++ b/app/queries/search/goods_nomenclature_query.rb
@@ -29,6 +29,7 @@ module Search
             bool: {
               must: [
                 hidden_goods_nomenclature_filter,
+                excluded_chapter_filter,
                 declarable_filter,
                 multi_match_clause,
                 validity_date_filter,
@@ -144,6 +145,18 @@ module Search
           must_not: {
             terms: {
               goods_nomenclature_item_id: HiddenGoodsNomenclature.codes,
+            },
+          },
+        },
+      }
+    end
+
+    def excluded_chapter_filter
+      {
+        bool: {
+          must_not: {
+            terms: {
+              chapter_short_code: AdminConfiguration.multi_options_values('interactive_search_excluded_chapters'),
             },
           },
         },

--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -174,7 +174,13 @@ module Api
       end
 
       def hidden?(goods_nomenclature)
-        ::HiddenGoodsNomenclature.codes.include?(goods_nomenclature.goods_nomenclature_item_id)
+        ::HiddenGoodsNomenclature.codes.include?(goods_nomenclature.goods_nomenclature_item_id) ||
+          excluded_chapter?(goods_nomenclature)
+      end
+
+      def excluded_chapter?(goods_nomenclature)
+        AdminConfiguration.multi_options_values('interactive_search_excluded_chapters')
+          .include?(goods_nomenclature.chapter_short_code.to_s)
       end
 
       def digits_only?(query)

--- a/lib/tasks/admin_configurations.rake
+++ b/lib/tasks/admin_configurations.rake
@@ -386,6 +386,13 @@ namespace :admin_configurations do
       }
     end
 
+    chapter_options = lambda do
+      (1..99).map do |chapter|
+        formatted = sprintf('%02d', chapter)
+        { 'key' => formatted, 'label' => "Chapter #{formatted}" }
+      end
+    end
+
     configs = [
       {
         name: 'expand_search_enabled',
@@ -410,6 +417,15 @@ namespace :admin_configurations do
         config_type: 'boolean',
         description: 'Enable interactive Q&A to help traders narrow down commodity codes through clarifying questions',
         value: AdminConfiguration.default_for('interactive_search_enabled'),
+      },
+      {
+        name: 'interactive_search_excluded_chapters',
+        config_type: 'multi_options',
+        description: 'Chapters excluded from guided search results',
+        value: {
+          'selected' => AdminConfiguration.default_for('interactive_search_excluded_chapters'),
+          'options' => chapter_options.call,
+        },
       },
       {
         name: 'interactive_search_max_questions',

--- a/spec/lib/tasks/admin_configurations_rake_spec.rb
+++ b/spec/lib/tasks/admin_configurations_rake_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe 'admin_configurations:seed' do
     Rake::Task['admin_configurations:seed'].reenable
   end
 
-  it 'creates all 35 admin configurations', :aggregate_failures do
-    expect { seed }.to change(AdminConfiguration, :count).by(35)
+  it 'creates all 36 admin configurations', :aggregate_failures do
+    expect { seed }.to change(AdminConfiguration, :count).by(36)
 
     names = AdminConfiguration.order(:name).select_map(:name)
     expect(names).to eq(%w[
@@ -19,6 +19,7 @@ RSpec.describe 'admin_configurations:seed' do
       input_sanitiser_enabled
       input_sanitiser_max_length
       interactive_search_enabled
+      interactive_search_excluded_chapters
       interactive_search_max_questions
       label_context
       label_model
@@ -162,6 +163,19 @@ RSpec.describe 'admin_configurations:seed' do
     expect(config.config_type).to eq('boolean')
     expect(config.area).to eq('classification')
     expect(config.value).to be(AdminConfiguration.default_for('interactive_search_enabled'))
+  end
+
+  it 'seeds interactive_search_excluded_chapters as a multi_options config defaulting to chapters 98 and 99', :aggregate_failures do
+    seed
+
+    config = AdminConfiguration.where(name: 'interactive_search_excluded_chapters').first
+    expect(config.config_type).to eq('multi_options')
+    expect(config.area).to eq('classification')
+    expect(config.value['selected']).to eq(%w[98 99])
+    expect(config.value['options']).to include(
+      { 'key' => '98', 'label' => 'Chapter 98' },
+      { 'key' => '99', 'label' => 'Chapter 99' },
+    )
   end
 
   it 'seeds search_result_limit as an integer config defaulting to 0', :aggregate_failures do

--- a/spec/models/admin_configuration_spec.rb
+++ b/spec/models/admin_configuration_spec.rb
@@ -260,6 +260,51 @@ RSpec.describe AdminConfiguration do
       end
     end
 
+    describe 'multi_options value validation' do
+      let(:attrs) { { config_type: 'multi_options', value: value } }
+
+      context 'with valid multi_options hash' do
+        let(:value) do
+          {
+            'selected' => %w[98 99],
+            'options' => [
+              { 'key' => '98', 'label' => 'Chapter 98' },
+              { 'key' => '99', 'label' => 'Chapter 99' },
+            ],
+          }
+        end
+
+        it 'is valid' do
+          expect(config).to be_valid
+        end
+      end
+
+      context 'with empty options array' do
+        let(:value) do
+          { 'selected' => %w[98 99], 'options' => [] }
+        end
+
+        it 'is invalid' do
+          expect(config).not_to be_valid
+          expect(config.errors[:value]).to be_present
+        end
+      end
+
+      context 'with selected that is not an array' do
+        let(:value) do
+          {
+            'selected' => '98',
+            'options' => [{ 'key' => '98', 'label' => 'Chapter 98' }],
+          }
+        end
+
+        it 'is invalid' do
+          expect(config).not_to be_valid
+          expect(config.errors[:value]).to be_present
+        end
+      end
+    end
+
     describe 'unique name' do
       before { create(:admin_configuration, name: 'taken_name') }
 
@@ -435,6 +480,34 @@ RSpec.describe AdminConfiguration do
 
       it 'returns the selected option' do
         expect(described_class.option_value('search_model')).to eq('gpt-4.1-mini-2025-04-14')
+      end
+    end
+  end
+
+  describe '.multi_options_values' do
+    context 'when config record is missing' do
+      it 'returns the default selected values' do
+        expect(described_class.multi_options_values('interactive_search_excluded_chapters')).to eq(%w[98 99])
+      end
+    end
+
+    context 'when config record exists' do
+      before do
+        create(:admin_configuration,
+               name: 'interactive_search_excluded_chapters',
+               config_type: 'multi_options',
+               area: 'classification',
+               value: {
+                 'selected' => %w[01 02],
+                 'options' => [
+                   { 'key' => '01', 'label' => 'Chapter 01' },
+                   { 'key' => '02', 'label' => 'Chapter 02' },
+                 ],
+               })
+      end
+
+      it 'returns the selected values' do
+        expect(described_class.multi_options_values('interactive_search_excluded_chapters')).to eq(%w[01 02])
       end
     end
   end

--- a/spec/queries/search/goods_nomenclature_query_spec.rb
+++ b/spec/queries/search/goods_nomenclature_query_spec.rb
@@ -461,10 +461,34 @@ RSpec.describe Search::GoodsNomenclatureQuery do
 
     it 'filters out hidden goods nomenclatures' do
       must_clauses = query.dig(:body, :query, :bool, :must)
-      hidden_filter = must_clauses.find { |c| c.dig(:bool, :must_not) }
+      hidden_filter = must_clauses.find do |clause|
+        clause.dig(:bool, :must_not, :terms, :goods_nomenclature_item_id)
+      end
 
       expect(hidden_filter).to be_present
       expect(hidden_filter.dig(:bool, :must_not, :terms, :goods_nomenclature_item_id)).to eq(HiddenGoodsNomenclature.codes)
+    end
+
+    it 'filters out configured excluded chapters' do
+      create(:admin_configuration,
+             name: 'interactive_search_excluded_chapters',
+             config_type: 'multi_options',
+             area: 'classification',
+             value: {
+               'selected' => %w[98 99],
+               'options' => [
+                 { 'key' => '98', 'label' => 'Chapter 98' },
+                 { 'key' => '99', 'label' => 'Chapter 99' },
+               ],
+             })
+
+      must_clauses = query.dig(:body, :query, :bool, :must)
+      chapter_filter = must_clauses.find do |clause|
+        clause.dig(:bool, :must_not, :terms, :chapter_short_code)
+      end
+
+      expect(chapter_filter).to be_present
+      expect(chapter_filter.dig(:bool, :must_not, :terms, :chapter_short_code)).to eq(%w[98 99])
     end
 
     it 'filters to only declarable goods nomenclatures' do

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -153,6 +153,35 @@ RSpec.describe Api::Internal::SearchService do
       end
     end
 
+    context 'when exact match is in a configured excluded chapter' do
+      let(:opensearch_response) { { 'hits' => { 'hits' => [] } } }
+
+      before do
+        create(:admin_configuration,
+               name: 'interactive_search_excluded_chapters',
+               config_type: 'multi_options',
+               area: 'classification',
+               value: {
+                 'selected' => %w[98],
+                 'options' => [
+                   { 'key' => '98', 'label' => 'Chapter 98' },
+                   { 'key' => '99', 'label' => 'Chapter 99' },
+                 ],
+               })
+        create(:chapter, :with_description,
+               goods_nomenclature_item_id: '9800000000',
+               description: 'special classifications')
+        allow(TradeTariffBackend.search_client).to receive(:search).and_return(opensearch_response)
+      end
+
+      it 'falls through to OpenSearch instead of returning exact match' do
+        result = described_class.new(q: '98').call
+
+        expect(result).to eq(data: [])
+        expect(TradeTariffBackend.search_client).to have_received(:search)
+      end
+    end
+
     context 'when suggestion exists but has no associated goods nomenclature' do
       let(:opensearch_response) { { 'hits' => { 'hits' => [] } } }
 

--- a/spec/services/version_diff_service_spec.rb
+++ b/spec/services/version_diff_service_spec.rb
@@ -189,6 +189,40 @@ RSpec.describe VersionDiffService do
         expect(result['changes']['reasoning_effort']).to eq('type' => 'simple', 'old' => 'low', 'new' => 'high')
       end
 
+      it 'extracts selected arrays for multi_options as an array diff' do
+        old_obj = {
+          'id' => 1,
+          'name' => 'interactive_search_excluded_chapters',
+          'config_type' => 'multi_options',
+          'area' => 'classification',
+          'description' => 'Excluded chapters',
+          'value' => {
+            'selected' => %w[98 99],
+            'options' => [
+              { 'key' => '98', 'label' => 'Chapter 98' },
+              { 'key' => '99', 'label' => 'Chapter 99' },
+              { 'key' => '97', 'label' => 'Chapter 97' },
+            ],
+          },
+        }
+        new_obj = old_obj.merge(
+          'value' => {
+            'selected' => %w[97 99],
+            'options' => old_obj['value']['options'],
+          },
+        )
+
+        result = described_class.new('AdminConfiguration', old_obj, new_obj).call
+
+        expect(result['changed_fields']).to eq(%w[selected])
+        expect(result['changes']['selected']).to eq(
+          'type' => 'array',
+          'added' => %w[97],
+          'removed' => %w[98],
+          'unchanged' => %w[99],
+        )
+      end
+
       it 'falls back to raw value for non-hash values' do
         old_obj = {
           'id' => 1,


### PR DESCRIPTION
### Jira link

[AI-553](https://transformuk.atlassian.net/browse/AI-553)

### What?

- [x] Add `multi_options` support to admin configuration validation and normalisation
- [x] Seed `interactive_search_excluded_chapters` with chapters 98 and 99
- [x] Apply excluded chapter filtering to guided search retrieval paths
- [x] Add focused model, service, query and rake spec coverage

### Why?

- This exposes the capability and default configurations for a multi options type in the admin configuration and enables dynamic changes as part of a requirement from HMRC
