### PR TITLE
Fix TypeError in SearchReferencesController when query param is a scalar

### DIFF
--- a/app/controllers/api/v2/search_references_controller.rb
+++ b/app/controllers/api/v2/search_references_controller.rb
@@ -21,7 +21,10 @@ module Api
       end
 
       def letter
-        params.dig(:query, :letter) || ''
+        query = params[:query]
+        return '' unless query.is_a?(ActionController::Parameters)
+
+        query[:letter] || ''
       end
     end
   end

--- a/spec/requests/api/v2/search_references_controller_spec.rb
+++ b/spec/requests/api/v2/search_references_controller_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe Api::V2::SearchReferencesController do
+  before do
+    TradeTariffRequest.time_machine_now = Time.current
+    create :search_reference, referenced: create(:heading), title: 'aa'
+    create :search_reference, referenced: create(:chapter), title: 'bb'
+  end
+
+  describe 'GET #index' do
+    context 'when a valid query[letter] param is provided' do
+      it 'returns a successful response' do
+        api_get '/uk/api/search_references', params: { query: { letter: 'a' } }
+
+        expect(response).to be_successful
+      end
+
+      it 'filters results by letter' do
+        api_get '/uk/api/search_references', params: { query: { letter: 'a' } }
+
+        data = JSON.parse(response.body)['data']
+        expect(data.count).to eq(1)
+      end
+    end
+
+    context 'when no query param is provided' do
+      it 'returns a successful response' do
+        api_get '/uk/api/search_references'
+
+        expect(response).to be_successful
+      end
+    end
+
+    context 'when query is a scalar rather than a hash (e.g. ?query=foo)' do
+      it 'returns a successful response without raising' do
+        api_get '/uk/api/search_references', params: { query: 'foo' }
+
+        expect(response).to be_successful
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Bug

`GET /uk/api/search_references?query=foo` raises a `TypeError` with the message _"String does not have #dig method"_.

`params.dig(:query, :letter)` delegates to `ActionController::Parameters#dig` → `Hash#dig`, which requires every intermediate value to respond to `#dig`. When `params[:query]` is a plain string (scalar) rather than a nested hash, `Hash#dig` raises `TypeError` rather than returning `nil`.

This would have been silently swallowed in older Rails versions but surfaces as a 500 in Rails 8.

## Fix

Check that `params[:query]` is an `ActionController::Parameters` instance before accessing `:letter`. Any other value (scalar, missing) falls through to the `''` default, which returns all search references — the same behaviour as sending no `query` param at all.

## Test

Added `spec/requests/api/v2/search_references_controller_spec.rb` covering the happy path, missing param, and the scalar-param edge case that triggered the bug.