### PR TITLE
AI-563: Add PaperTrail coverage for bulk regeneration writes

### DIFF
--- a/app/lib/sequel/plugins/has_paper_trail.rb
+++ b/app/lib/sequel/plugins/has_paper_trail.rb
@@ -1,6 +1,53 @@
 module Sequel
   module Plugins
     module HasPaperTrail
+      @tracked_models = []
+
+      class << self
+        def apply(model, *_args)
+          register_model(model)
+        end
+
+        def tracked_models
+          @tracked_models.sort_by(&:name)
+        end
+
+        def version_item_id_for(record)
+          id = record.pk
+          id.is_a?(Array) ? id.first.to_s : id.to_s
+        end
+
+        def version_exists_for?(record)
+          Version.where(item_type: record.model.name, item_id: version_item_id_for(record)).any?
+        end
+
+        def record_current_version!(record, whodunnit: TradeTariffRequest.whodunnit, created_at: Time.current)
+          event = version_exists_for?(record) ? 'update' : 'create'
+          record_version!(record, event:, whodunnit:, created_at:)
+        end
+
+        def record_version!(record, event:, whodunnit: TradeTariffRequest.whodunnit, created_at: Time.current)
+          return false if record.nil?
+
+          Version.create(
+            item_type: record.model.name,
+            item_id: version_item_id_for(record),
+            event: event,
+            object: Sequel.pg_jsonb_wrap(record.values.transform_keys(&:to_s)),
+            whodunnit: whodunnit,
+            created_at: created_at,
+          )
+
+          true
+        end
+
+        private
+
+        def register_model(model)
+          @tracked_models |= [model]
+        end
+      end
+
       module ClassMethods
         def without_paper_trail
           previous = Thread.current[paper_trail_disabled_key]
@@ -58,8 +105,7 @@ module Sequel
         end
 
         def item_id_for_version
-          id = pk
-          id.is_a?(Array) ? id.first.to_s : id.to_s
+          HasPaperTrail.version_item_id_for(self)
         end
 
         def values_for_version

--- a/app/models/goods_nomenclature_self_text.rb
+++ b/app/models/goods_nomenclature_self_text.rb
@@ -168,6 +168,11 @@ class GoodsNomenclatureSelfText < Sequel::Model
         FROM (VALUES #{values}) AS v(goods_nomenclature_sid, search_text, search_embedding)
         WHERE t.goods_nomenclature_sid = v.goods_nomenclature_sid
       SQL
+
+      PaperTrail::BulkVersioning.record_current_versions_for_item_ids!(
+        model: GoodsNomenclatureSelfText,
+        item_ids: batch.map(&:goods_nomenclature_sid),
+      )
     end
   end
 

--- a/app/services/generate_self_text/base_self_text_builder.rb
+++ b/app/services/generate_self_text/base_self_text_builder.rb
@@ -228,7 +228,7 @@ module GenerateSelfText
         updated_at: now,
       }
 
-      GoodsNomenclatureSelfText.dataset.insert_conflict(
+      result = GoodsNomenclatureSelfText.dataset.insert_conflict(
         constraint: :goods_nomenclature_self_texts_pkey,
         update: {
           self_text: Sequel[:excluded][:self_text],
@@ -243,7 +243,12 @@ module GenerateSelfText
           { Sequel[:goods_nomenclature_self_texts][:manually_edited] => false },
           Sequel.~(Sequel[:goods_nomenclature_self_texts][:context_hash] => context_hash),
         ),
-      ).insert(values)
+      ).returning(:goods_nomenclature_sid).insert(values)
+
+      return if result.empty?
+
+      record = GoodsNomenclatureSelfText[node[:sid]]
+      Sequel::Plugins::HasPaperTrail.record_current_version!(record, created_at: now)
     end
 
     def system_prompt

--- a/app/services/paper_trail/bulk_versioning.rb
+++ b/app/services/paper_trail/bulk_versioning.rb
@@ -1,0 +1,24 @@
+module PaperTrail
+  class BulkVersioning
+    class << self
+      def record_current_versions_for_dataset!(model:, dataset:)
+        item_ids = dataset.select_map(model.primary_key)
+        record_current_versions_for_item_ids!(model:, item_ids:)
+      end
+
+      def record_current_versions_for_item_ids!(model:, item_ids:)
+        return 0 if item_ids.empty?
+
+        model.where(model.primary_key => item_ids).all.count do |record|
+          Sequel::Plugins::HasPaperTrail.record_current_version!(record)
+        end
+      end
+
+      def record_destroy_versions_for_dataset!(dataset:)
+        dataset.all.count do |record|
+          Sequel::Plugins::HasPaperTrail.record_version!(record, event: 'destroy')
+        end
+      end
+    end
+  end
+end

--- a/app/services/paper_trail/reset_initial_versions.rb
+++ b/app/services/paper_trail/reset_initial_versions.rb
@@ -1,0 +1,33 @@
+module PaperTrail
+  class ResetInitialVersions
+    def call
+      Sequel::Model.db.transaction do
+        Version.dataset.truncate(restart: true)
+        tracked_models.each { |model| reset_model_versions(model) }
+      end
+    end
+
+    private
+
+    def tracked_models
+      Sequel::Plugins::HasPaperTrail.tracked_models
+    end
+
+    def reset_model_versions(model)
+      model.each do |record|
+        Version.insert(
+          item_type: model.name,
+          item_id: Sequel::Plugins::HasPaperTrail.version_item_id_for(record),
+          event: 'create',
+          object: Sequel.pg_jsonb_wrap(record.values.transform_keys(&:to_s)),
+          whodunnit: nil,
+          created_at: version_created_at_for(record),
+        )
+      end
+    end
+
+    def version_created_at_for(record)
+      record.values[:created_at] || record.values[:updated_at] || Time.current
+    end
+  end
+end

--- a/app/workers/goods_nomenclature_reconciliation_worker.rb
+++ b/app/workers/goods_nomenclature_reconciliation_worker.rb
@@ -105,10 +105,13 @@ class GoodsNomenclatureReconciliationWorker
   end
 
   def mark_self_texts_stale(sids)
-    GoodsNomenclatureSelfText
+    dataset = GoodsNomenclatureSelfText
       .where(goods_nomenclature_sid: sids)
       .where(stale: false)
-      .update(stale: true, search_embedding_stale: true, updated_at: Time.zone.now)
+
+    item_ids = dataset.select_map(:goods_nomenclature_sid)
+    updated = dataset.update(stale: true, search_embedding_stale: true, updated_at: Time.zone.now)
+    PaperTrail::BulkVersioning.record_current_versions_for_item_ids!(model: GoodsNomenclatureSelfText, item_ids:) if updated.positive?
   end
 
   def regenerate_self_texts(chapter_code)
@@ -122,10 +125,13 @@ class GoodsNomenclatureReconciliationWorker
   def mark_labels_stale(sids)
     return if sids.empty?
 
-    GoodsNomenclatureLabel
+    dataset = GoodsNomenclatureLabel
       .where(goods_nomenclature_sid: sids)
       .where(stale: false)
-      .update(stale: true, updated_at: Time.zone.now)
+
+    item_ids = dataset.select_map(:goods_nomenclature_sid)
+    updated = dataset.update(stale: true, updated_at: Time.zone.now)
+    PaperTrail::BulkVersioning.record_current_versions_for_item_ids!(model: GoodsNomenclatureLabel, item_ids:) if updated.positive?
 
     RelabelGoodsNomenclatureWorker.perform_async
   end

--- a/app/workers/relabel_goods_nomenclature_page_worker.rb
+++ b/app/workers/relabel_goods_nomenclature_page_worker.rb
@@ -76,7 +76,7 @@ class RelabelGoodsNomenclaturePageWorker
 
   def upsert_label(label)
     now = Time.zone.now
-    GoodsNomenclatureLabel.dataset.insert_conflict(
+    result = GoodsNomenclatureLabel.dataset.insert_conflict(
       target: :goods_nomenclature_sid,
       update: {
         labels: label.labels,
@@ -90,7 +90,7 @@ class RelabelGoodsNomenclaturePageWorker
         updated_at: now,
       },
       update_where: { Sequel[:goods_nomenclature_labels][:manually_edited] => false },
-    ).insert(
+    ).returning(:goods_nomenclature_sid).insert(
       goods_nomenclature_sid: label.goods_nomenclature_sid,
       goods_nomenclature_type: label.goods_nomenclature_type,
       goods_nomenclature_item_id: label.goods_nomenclature_item_id,
@@ -107,5 +107,10 @@ class RelabelGoodsNomenclaturePageWorker
       created_at: now,
       updated_at: now,
     )
+
+    return false if result.empty?
+
+    persisted_label = GoodsNomenclatureLabel[label.goods_nomenclature_sid]
+    Sequel::Plugins::HasPaperTrail.record_current_version!(persisted_label, created_at: now)
   end
 end

--- a/lib/tasks/labels.rake
+++ b/lib/tasks/labels.rake
@@ -56,7 +56,9 @@ namespace :labels do
       scope = scope.where(Sequel.like(:goods_nomenclature_item_id, "#{ENV['CHAPTER']}%"))
     end
 
+    label_sids = scope.select_map(:goods_nomenclature_sid)
     updated = scope.update(stale: true, updated_at: Time.zone.now)
+    PaperTrail::BulkVersioning.record_current_versions_for_item_ids!(model: GoodsNomenclatureLabel, item_ids: label_sids) if updated.positive?
     puts "Marked #{updated} labels as stale"
 
     unlabeled = GoodsNomenclatureLabel.goods_nomenclatures_dataset.count
@@ -285,8 +287,10 @@ namespace :labels do
     end
 
     puts "\nDeleting all labels..."
-    deleted_count = GoodsNomenclatureLabel.count
-    GoodsNomenclatureLabel.dataset.delete
+    label_dataset = GoodsNomenclatureLabel.dataset
+    deleted_count = label_dataset.count
+    PaperTrail::BulkVersioning.record_destroy_versions_for_dataset!(dataset: label_dataset) if deleted_count.positive?
+    label_dataset.delete
     puts "Deleted #{deleted_count} labels"
 
     puts "\nEnqueuing label generation..."

--- a/lib/tasks/paper_trail.rake
+++ b/lib/tasks/paper_trail.rake
@@ -1,0 +1,14 @@
+namespace :paper_trail do
+  desc 'DANGER: Truncate versions and rebuild create snapshots from the current database state. Set CONFIRM=true.'
+  task reset_initial_versions: :class_eager_load do
+    unless ENV['CONFIRM'] == 'true'
+      puts 'WARNING: This will truncate all versions and rebuild create snapshots from current records.'
+      puts 'Set CONFIRM=true to proceed.'
+      exit 1
+    end
+
+    puts 'Resetting PaperTrail versions...'
+    PaperTrail::ResetInitialVersions.new.call
+    puts 'Done.'
+  end
+end

--- a/lib/tasks/self_texts.rake
+++ b/lib/tasks/self_texts.rake
@@ -30,7 +30,10 @@ namespace :self_texts do
 
   desc 'Regenerate all self-texts by marking them stale and re-enqueuing'
   task regenerate: :environment do
-    count = GoodsNomenclatureSelfText.where(stale: false, manually_edited: false).update(stale: true)
+    dataset = GoodsNomenclatureSelfText.where(stale: false, manually_edited: false)
+    item_ids = dataset.select_map(:goods_nomenclature_sid)
+    count = dataset.update(stale: true)
+    PaperTrail::BulkVersioning.record_current_versions_for_item_ids!(model: GoodsNomenclatureSelfText, item_ids:) if count.positive?
     puts "Marked #{count} self-texts as stale."
 
     GenerateSelfTextWorker.perform_async
@@ -76,13 +79,16 @@ namespace :self_texts do
 
       normalized = code.gsub(/\s/, '').ljust(10, '0')
 
-      count = GoodsNomenclatureSelfText
+      dataset = GoodsNomenclatureSelfText
         .where(goods_nomenclature_item_id: normalized)
         .where(Sequel.|(
                  { eu_self_text: nil },
                  Sequel.~(eu_self_text: eu_text),
                ))
-        .update(eu_self_text: eu_text, eu_embedding: nil)
+      item_ids = dataset.select_map(:goods_nomenclature_sid)
+      count = dataset.update(eu_self_text: eu_text, eu_embedding: nil)
+
+      PaperTrail::BulkVersioning.record_current_versions_for_item_ids!(model: GoodsNomenclatureSelfText, item_ids:) if count.positive?
 
       if count.positive?
         stats[:updated] += count
@@ -113,9 +119,9 @@ namespace :self_texts do
       embeddings = service.embed_batch(texts)
 
       batch.zip(embeddings).each do |record, embedding|
-        GoodsNomenclatureSelfText
-          .where(goods_nomenclature_sid: record.goods_nomenclature_sid)
-          .update(embedding: Sequel.lit("'[#{embedding.join(',')}]'::vector"))
+        update_dataset = GoodsNomenclatureSelfText.where(goods_nomenclature_sid: record.goods_nomenclature_sid)
+        update_dataset.update(embedding: Sequel.lit("'[#{embedding.join(',')}]'::vector"))
+        PaperTrail::BulkVersioning.record_current_versions_for_dataset!(model: GoodsNomenclatureSelfText, dataset: update_dataset)
       end
 
       processed = [(i + 1) * EmbeddingService::BATCH_SIZE, generate_texts.size].min
@@ -136,9 +142,9 @@ namespace :self_texts do
       embeddings = service.embed_batch(texts)
 
       batch.zip(embeddings).each do |record, embedding|
-        GoodsNomenclatureSelfText
-          .where(goods_nomenclature_sid: record.goods_nomenclature_sid)
-          .update(eu_embedding: Sequel.lit("'[#{embedding.join(',')}]'::vector"))
+        update_dataset = GoodsNomenclatureSelfText.where(goods_nomenclature_sid: record.goods_nomenclature_sid)
+        update_dataset.update(eu_embedding: Sequel.lit("'[#{embedding.join(',')}]'::vector"))
+        PaperTrail::BulkVersioning.record_current_versions_for_dataset!(model: GoodsNomenclatureSelfText, dataset: update_dataset)
       end
 
       processed = [(i + 1) * EmbeddingService::BATCH_SIZE, eu_texts.size].min

--- a/spec/lib/sequel/plugins/has_paper_trail_spec.rb
+++ b/spec/lib/sequel/plugins/has_paper_trail_spec.rb
@@ -75,6 +75,23 @@ RSpec.describe Sequel::Plugins::HasPaperTrail do
     end
   end
 
+  describe '.tracked_models' do
+    it 'registers all models using has_paper_trail in sorted order without duplicates' do
+      Rails.application.eager_load!
+
+      expect(described_class.tracked_models.map(&:name)).to eq(%w[
+        AdminConfiguration
+        ChapterNote
+        DescriptionIntercept
+        GoodsNomenclatureIntercept
+        GoodsNomenclatureLabel
+        GoodsNomenclatureSelfText
+        SearchReference
+        SectionNote
+      ])
+    end
+  end
+
   describe '.without_paper_trail' do
     it 'suppresses version creation within the block' do
       model_with_plugin

--- a/spec/lib/tasks/labels_rake_spec.rb
+++ b/spec/lib/tasks/labels_rake_spec.rb
@@ -1,0 +1,20 @@
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'labels:relabel' do
+  subject(:relabel) { suppress_output { Rake::Task['labels:relabel'].invoke } }
+
+  after do
+    Rake::Task['labels:relabel'].reenable
+    ENV.delete('CHAPTER')
+  end
+
+  it 'marks labels stale and records an update version' do
+    label = create(:goods_nomenclature_label, stale: false)
+    allow(RelabelGoodsNomenclatureWorker).to receive(:perform_async)
+
+    expect { relabel }.to change(Version, :count).by(1)
+
+    expect(label.reload.stale).to be true
+    expect(label.versions.order(:id).last.event).to eq('update')
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/lib/tasks/paper_trail_rake_spec.rb
+++ b/spec/lib/tasks/paper_trail_rake_spec.rb
@@ -1,0 +1,29 @@
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'paper_trail:reset_initial_versions' do
+  subject(:run_task) { suppress_output { Rake::Task['paper_trail:reset_initial_versions'].invoke } }
+
+  let(:service) { instance_spy(PaperTrail::ResetInitialVersions, call: true) }
+
+  after do
+    Rake::Task['paper_trail:reset_initial_versions'].reenable
+    Rake::Task['class_eager_load'].reenable
+    ENV.delete('CONFIRM')
+  end
+
+  it 'aborts unless CONFIRM=true' do
+    expect { Rake::Task['paper_trail:reset_initial_versions'].invoke }.to raise_error(SystemExit)
+  end
+
+  it 'eager loads classes and runs the reset service when confirmed' do
+    allow(Rails.application).to receive(:eager_load!).and_return(true)
+    allow(PaperTrail::ResetInitialVersions).to receive(:new).and_return(service)
+    ENV['CONFIRM'] = 'true'
+
+    run_task
+
+    expect(Rails.application).to have_received(:eager_load!)
+    expect(PaperTrail::ResetInitialVersions).to have_received(:new)
+    expect(service).to have_received(:call)
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/services/generate_self_text/base_self_text_builder_spec.rb
+++ b/spec/services/generate_self_text/base_self_text_builder_spec.rb
@@ -100,6 +100,42 @@ RSpec.describe GenerateSelfText::BaseSelfTextBuilder do
       end
     end
 
+    describe 'paper trail' do
+      it 'creates a create version for a newly generated self-text' do
+        result
+
+        version = GoodsNomenclatureSelfText[other_commodity.goods_nomenclature_sid].versions.order(:id).last
+        expect(version.event).to eq('create')
+      end
+
+      it 'creates an update version when regeneration changes an existing self-text' do
+        result
+        GoodsNomenclatureSelfText[other_commodity.goods_nomenclature_sid].update(stale: true)
+        create(:commodity, :with_description, description: 'Ponies', parent: heading)
+
+        allow(ai_client).to receive(:call).and_return({
+          'descriptions' => [{
+            'sid' => other_commodity.goods_nomenclature_sid,
+            'contextualised_description' => 'Updated generated text',
+          }],
+        }.to_json)
+
+        expect { builder_class.call(chapter) }.to change(Version, :count).by(1)
+        expect(GoodsNomenclatureSelfText[other_commodity.goods_nomenclature_sid].versions.order(:id).last.event).to eq('update')
+      end
+
+      it 'does not create a version when a manually edited record is skipped' do
+        result
+        record = GoodsNomenclatureSelfText[other_commodity.goods_nomenclature_sid]
+        existing_version_count = record.versions.count
+        record.update(manually_edited: true, self_text: 'Custom text')
+
+        builder_class.call(chapter)
+
+        expect(record.reload.versions.count).to eq(existing_version_count + 1)
+      end
+    end
+
     describe 'failed count' do
       context 'when the AI returns an empty response' do
         before { allow(ai_client).to receive(:call).and_return('') }

--- a/spec/services/paper_trail/reset_initial_versions_spec.rb
+++ b/spec/services/paper_trail/reset_initial_versions_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe PaperTrail::ResetInitialVersions do
+  describe '#call' do
+    around do |example|
+      Rails.application.eager_load!
+      travel_to(Time.zone.parse('2026-04-14 12:00:00')) { example.run }
+    end
+
+    it 'truncates existing versions and recreates one create snapshot per tracked record', :aggregate_failures do
+      note = create(:section_note, content: 'before')
+      note.update(content: 'after')
+      config = create(:admin_configuration, name: 'reset_test_config')
+      create(:description_intercept, term: 'boots')
+      create(:goods_nomenclature_intercept)
+      create(:goods_nomenclature_label)
+      create(:goods_nomenclature_self_text)
+      create(:search_reference)
+
+      Version.create(
+        item_type: 'GhostRecord',
+        item_id: '123',
+        event: 'update',
+        object: Sequel.pg_jsonb_wrap('ghost' => true),
+        whodunnit: 'user-1',
+        created_at: 2.days.ago,
+      )
+
+      expect(Version.where(event: 'update').count).to be > 0
+
+      described_class.new.call
+
+      expect(Version.count).to eq(Sequel::Plugins::HasPaperTrail.tracked_models.sum(&:count))
+      expect(Version.select_map(:event).uniq).to eq(%w[create])
+      expect(Version.where(item_type: 'GhostRecord').count).to eq(0)
+
+      note_version = Version.where(item_type: 'SectionNote', item_id: note.id.to_s).first
+      expect(note_version.object['content']).to eq('after')
+
+      config_version = Version.where(item_type: 'AdminConfiguration', item_id: config.name).first
+      expect(config_version).not_to be_nil
+    end
+
+    it 'uses the current time when the tracked record has no timestamps' do
+      note = create(:section_note)
+
+      described_class.new.call
+
+      version = Version.where(item_type: 'SectionNote', item_id: note.id.to_s).first
+      expect(version.created_at).to eq(Time.zone.parse('2026-04-14 12:00:00'))
+    end
+  end
+end

--- a/spec/workers/relabel_goods_nomenclature_page_worker_spec.rb
+++ b/spec/workers/relabel_goods_nomenclature_page_worker_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe RelabelGoodsNomenclaturePageWorker, type: :worker do
       let(:invalid_label) do
         GoodsNomenclatureLabel.new(
           goods_nomenclature: commodity,
-          labels: nil, # missing required field
+          labels: nil,
         )
       end
 
@@ -215,6 +215,50 @@ RSpec.describe RelabelGoodsNomenclaturePageWorker, type: :worker do
         expect(LabelGenerator::Instrumentation).to have_received(:label_saved).once
         expect(LabelGenerator::Instrumentation).to have_received(:label_save_failed).once
       end
+    end
+  end
+
+  describe '#upsert_label' do
+    subject(:upsert_label) { described_class.new.send(:upsert_label, label) }
+
+    let(:commodity) { create(:commodity) }
+    let(:label) do
+      build(
+        :goods_nomenclature_label,
+        goods_nomenclature: commodity,
+        description: 'Fresh label text',
+        labels: { 'description' => 'Fresh label text' },
+      )
+    end
+
+    it 'creates a create version when inserting a new label' do
+      expect { upsert_label }.to change(Version, :count).by(1)
+
+      version = Version.last
+      expect(version.item_type).to eq('GoodsNomenclatureLabel')
+      expect(version.event).to eq('create')
+      expect(version.object['description']).to eq('Fresh label text')
+    end
+
+    it 'creates an update version when updating an existing label' do
+      create(:goods_nomenclature_label, goods_nomenclature: commodity, description: 'Old text')
+
+      expect { upsert_label }.to change(Version, :count).by(1)
+
+      version = Version.last
+      expect(version.event).to eq('update')
+      expect(version.object['description']).to eq('Fresh label text')
+    end
+
+    it 'does not create a version when a manually edited label is protected from overwrite' do
+      create(
+        :goods_nomenclature_label,
+        goods_nomenclature: commodity,
+        description: 'Manual text',
+        manually_edited: true,
+      )
+
+      expect { upsert_label }.not_to change(Version, :count)
     end
   end
 end


### PR DESCRIPTION
### Jira link

[AI-563](https://transformuk.atlassian.net/browse/AI-563)

### What?

- [x] Add a PaperTrail model registry and a `paper_trail:reset_initial_versions` task to truncate and reseed baseline `create` versions from current DB state
- [x] Add bulk version recording helpers and wire them into label/self-text bulk upsert/update/delete paths that previously bypassed callbacks
- [x] Keep existing high-throughput upsert paths in place, but record versions only when writes actually occur (including manual-edit skip paths)
- [x] Add coverage for reset task behaviour and bulk label/self-text versioning create/update/skip cases

### Why?

Bulk label and self-text regeneration paths were writing directly via dataset upserts/updates, so PaperTrail callbacks did not fire and history became incomplete. This closes that gap while preserving existing write strategy and throughput characteristics.