### PR TITLE
Restore flaky excess query spec fix accidentally dropped by revert

### DIFF
--- a/app/helpers/materialize_view_helper.rb
+++ b/app/helpers/materialize_view_helper.rb
@@ -1,5 +1,7 @@
 module MaterializeViewHelper
   def refresh_materialized_view(concurrently: false)
+    eager_load_materialized_view_models
+
     Sequel::Plugins::Oplog.models.each do |model|
       if model.materialized?
         model.refresh!(concurrently:)
@@ -9,5 +11,13 @@ module MaterializeViewHelper
     GoodsNomenclatures::TreeNode.refresh!(concurrently:)
   end
 
+  def eager_load_materialized_view_models
+    return if Rails.application.config.x.materialized_view_models_loaded
+
+    Rails.application.eager_load!
+    Rails.application.config.x.materialized_view_models_loaded = true
+  end
+
   module_function :refresh_materialized_view
+  module_function :eager_load_materialized_view_models
 end

--- a/spec/requests/excess_query_spec.rb
+++ b/spec/requests/excess_query_spec.rb
@@ -1,10 +1,16 @@
 RSpec.describe 'excess query counts', :v2 do
   before do
     allow(NewRelic::Agent).to receive(:notice_error).and_return true
-    allow(TradeTariffBackend).to receive(:check_query_count?).and_return true
+    allow(TradeTariffBackend).to receive_messages(
+      check_query_count?: true,
+      excess_query_threshold: 20,
+    )
   end
 
-  let(:get_page) { api_get api_heading_path(heading, format: :json) }
+  let :get_page do
+    MaterializeViewHelper.refresh_materialized_view
+    api_get api_heading_path(heading, format: :json)
+  end
 
   let :heading do
     create(:commodity,
@@ -34,12 +40,7 @@ RSpec.describe 'excess query counts', :v2 do
     before { allow(::SequelRails::Railties::LogSubscriber).to receive(:count).and_return 21 }
 
     context 'with exceptions mode' do
-      before do
-        allow(QueryCountChecker).to receive(:new).and_return \
-          QueryCountChecker.new(20, raise_exception: true)
-
-        get_page
-      end
+      before { get_page }
 
       it { expect(response).to have_http_status :internal_server_error }
     end


### PR DESCRIPTION
## What

Re-applies Will's fix from 70c7c2309 ("BAU: Fix flaky excess query request spec"), which was accidentally reverted by 3c228cbda.

## Why it was lost

3c228cbda reverted "BAU: Removes automatic releases after a successful staging deployment", but that revert was generated against a branch that also contained 70c7c2309's changes. Git's revert included the spec/helper changes as collateral, even though the intent was only to undo the deployment workflow change.

## What the fix does

- `MaterializeViewHelper`: adds `eager_load_materialized_view_models` which ensures all Sequel models are loaded before refreshing materialized views. Without this, the `Sequel::Plugins::Oplog.models` set is incomplete when the spec runs in a lazy-load environment, causing the heading request to 500.
- `excess_query_spec.rb`: calls `refresh_materialized_view` before the heading request so the views exist; also stubs `excess_query_threshold` alongside `check_query_count?` so the checker uses a known threshold rather than whatever the default returns.