### PR TITLE
[HMRC-2187] Improve performance of quota search

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -14,6 +14,11 @@ module Api
       render json: serializer.serialized_errors({ error: exception.message, url: request.url }), status: :unprocessable_content
     end
 
+    rescue_from ActionController::BadRequest do |exception|
+      serializer = TradeTariffBackend.error_serializer(request)
+      render json: serializer.serialized_errors({ error: exception.message, url: request.url }), status: :bad_request
+    end
+
     protected
 
     def current_page

--- a/app/controllers/api/v2/quotas_controller.rb
+++ b/app/controllers/api/v2/quotas_controller.rb
@@ -26,7 +26,7 @@ module Api
 
       def validate_order_number
         return if params[:order_number].blank?
-        raise NotImplementedError, params[:order_number] unless params[:order_number].match?(/\A\d{6}\z/)
+        raise ActionController::BadRequest, params[:order_number] unless params[:order_number].match?(/\A\d{6}\z/)
       end
 
       def serialized_quota_definitions

--- a/app/controllers/api/v2/quotas_controller.rb
+++ b/app/controllers/api/v2/quotas_controller.rb
@@ -16,11 +16,18 @@ module Api
 
       ALLOWED_INCLUDES = %w[quota_balance_events].freeze
 
+      before_action :validate_order_number, only: :search
+
       def search
         render json: serialized_quota_definitions
       end
 
       private
+
+      def validate_order_number
+        return if params[:order_number].blank?
+        raise NotImplementedError, params[:order_number] unless params[:order_number].match?(/\A\d{6}\z/)
+      end
 
       def serialized_quota_definitions
         Api::V2::Quotas::QuotaDefinitionSerializer.new(

--- a/app/services/quota_search_service.rb
+++ b/app/services/quota_search_service.rb
@@ -110,7 +110,7 @@ class QuotaSearchService
   end
 
   def apply_order_number_filter
-    @scope = scope.where(Sequel.like(:measures__ordernumber, "#{order_number}%"))
+    @scope = scope.where(measures__ordernumber: order_number)
   end
 
   def apply_quota_definition

--- a/spec/controllers/api/v2/quotas_controller_spec.rb
+++ b/spec/controllers/api/v2/quotas_controller_spec.rb
@@ -287,5 +287,15 @@ RSpec.describe Api::V2::QuotasController, type: :controller do
         end
       end
     end
+
+    context 'when order_number is not 6 digits' do
+      let(:params) { { year: [Time.zone.today.year.to_s], order_number: '0500' } }
+
+      it 'returns 422' do
+        get :search, params:, format: :json
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
   end
 end

--- a/spec/controllers/api/v2/quotas_controller_spec.rb
+++ b/spec/controllers/api/v2/quotas_controller_spec.rb
@@ -291,10 +291,10 @@ RSpec.describe Api::V2::QuotasController, type: :controller do
     context 'when order_number is not 6 digits' do
       let(:params) { { year: [Time.zone.today.year.to_s], order_number: '0500' } }
 
-      it 'returns 422' do
+      it 'returns 400' do
         get :search, params:, format: :json
 
-        expect(response).to have_http_status(:unprocessable_content)
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end


### PR DESCRIPTION
### Jira link

[HMRC-2187](https://transformuk.atlassian.net/browse/HMRC-2187)

### What?

The /quotas/search endpoint has a high average db time when searching with an order number and no other filters.

The existing index is a standard btree on (ordernumber, validity_start_date). Postgres cannot make use of this index for LIKE queries, and falls back to scanning all index entries and filters them out row by row, causing a high average db time.

Since we don't need to search partial order numbers, and an order number will always be 6 digits, we can remove the offending LIKE, and refactor this for a direct search instead.

This PR:

- refactors to remove the LIKE in favour of a direct where
- adds validation to raise an error for requests where the order number is not 6 digits
- adds test

### Why?

This endpoint was identified as having a high average db time and a high number of requests. Improving this helps us reduce db load, deliver results faster and keep users happy.

### Testing

Run the following on main vs this branch to see the difference in query time

```
Sequel::Model.db.loggers << Logger.new($stdout)
start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
QuotaSearchService.new({'order_number' => '050001'}, 1, 10, Date.today).call
elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
puts "Time: #{(elapsed * 1000).round}ms"
```
