### PR TITLE
HMRC-2116: Reduce repeated serialisation work in commodity, heading and subheading responses

### DIFF
--- a/app/presenters/api/v2/headings/commodity_presenter.rb
+++ b/app/presenters/api/v2/headings/commodity_presenter.rb
@@ -9,7 +9,7 @@ module Api
         end
 
         def overview_measures
-          @overview_measure_presenters ||= applicable_overview_measures.map do |measure|
+          @overview_measures ||= applicable_overview_measures.map do |measure|
             Api::V2::Measures::MeasurePresenter.new(measure, self)
           end
         end

--- a/app/presenters/api/v2/headings/commodity_presenter.rb
+++ b/app/presenters/api/v2/headings/commodity_presenter.rb
@@ -9,13 +9,13 @@ module Api
         end
 
         def overview_measures
-          applicable_overview_measures.map do |measure|
+          @overview_measure_presenters ||= applicable_overview_measures.map do |measure|
             Api::V2::Measures::MeasurePresenter.new(measure, self)
           end
         end
 
         def overview_measure_ids
-          applicable_overview_measures.map(&:measure_sid)
+          overview_measures.map(&:measure_sid)
         end
 
         def leaf

--- a/app/presenters/api/v2/measures/measure_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_presenter.rb
@@ -61,7 +61,7 @@ module Api
         end
 
         def measure_conditions
-          @measure_condition_presenter ||= MeasureConditionPresenter.wrap(super, measure)
+          @measure_conditions ||= MeasureConditionPresenter.wrap(super, measure)
         end
 
         def measure_condition_ids
@@ -89,7 +89,7 @@ module Api
         end
 
         def legal_acts
-          @legal_acts_presenters ||= super.map do |legal_act|
+          @legal_acts ||= super.map do |legal_act|
             Api::V2::Measures::MeasureLegalActPresenter.new legal_act, self
           end
         end

--- a/app/presenters/api/v2/measures/measure_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_presenter.rb
@@ -61,7 +61,7 @@ module Api
         end
 
         def measure_conditions
-          MeasureConditionPresenter.wrap(super, measure)
+          @measure_condition_presenter ||= MeasureConditionPresenter.wrap(super, measure)
         end
 
         def measure_condition_ids
@@ -89,7 +89,7 @@ module Api
         end
 
         def legal_acts
-          super.map do |legal_act|
+          @legal_acts_presenters ||= super.map do |legal_act|
             Api::V2::Measures::MeasureLegalActPresenter.new legal_act, self
           end
         end
@@ -113,7 +113,7 @@ module Api
         end
 
         def measure_condition_permutation_groups
-          @measure_condition_permutation_groups = \
+          @measure_condition_permutation_groups ||= \
             MeasureConditionPermutations::Calculator.new(measure)
                                                     .permutation_groups
         end

--- a/spec/presenters/api/v2/headings/commodity_presenter_spec.rb
+++ b/spec/presenters/api/v2/headings/commodity_presenter_spec.rb
@@ -79,10 +79,12 @@ RSpec.describe Api::V2::Headings::CommodityPresenter do
     it { is_expected.to have_attributes overview_measure_ids: measures.map(&:measure_sid) }
 
     it 'memoizes overview measure builders for ids access' do
+      allow(commodity).to receive(:applicable_overview_measures).and_call_original
+
       presenter.overview_measures
       presenter.overview_measure_ids
 
-      expect(commodity).to have_received(:applicable_overview_measures).once.and_call_original
+      expect(commodity).to have_received(:applicable_overview_measures).once
     end
   end
 end

--- a/spec/presenters/api/v2/headings/commodity_presenter_spec.rb
+++ b/spec/presenters/api/v2/headings/commodity_presenter_spec.rb
@@ -77,5 +77,12 @@ RSpec.describe Api::V2::Headings::CommodityPresenter do
     end
 
     it { is_expected.to have_attributes overview_measure_ids: measures.map(&:measure_sid) }
+
+    it 'memoizes overview measure builders for ids access' do
+      expect(commodity).to receive(:applicable_overview_measures).once.and_call_original
+
+      presenter.overview_measures
+      presenter.overview_measure_ids
+    end
   end
 end

--- a/spec/presenters/api/v2/headings/commodity_presenter_spec.rb
+++ b/spec/presenters/api/v2/headings/commodity_presenter_spec.rb
@@ -79,10 +79,10 @@ RSpec.describe Api::V2::Headings::CommodityPresenter do
     it { is_expected.to have_attributes overview_measure_ids: measures.map(&:measure_sid) }
 
     it 'memoizes overview measure builders for ids access' do
-      expect(commodity).to receive(:applicable_overview_measures).once.and_call_original
-
       presenter.overview_measures
       presenter.overview_measure_ids
+
+      expect(commodity).to have_received(:applicable_overview_measures).once.and_call_original
     end
   end
 end

--- a/spec/presenters/api/v2/measures/measure_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_presenter_spec.rb
@@ -5,12 +5,32 @@ RSpec.describe Api::V2::Measures::MeasurePresenter do
 
   describe '#measure_conditions' do
     it { expect(presenter.measure_conditions).to all(be_a(Api::V2::Measures::MeasureConditionPresenter)) }
+
+    it 'memoizes wrapped conditions for id access' do
+      expect(Api::V2::Measures::MeasureConditionPresenter)
+        .to receive(:wrap)
+        .once
+        .and_call_original
+
+      presenter.measure_conditions
+      presenter.measure_condition_ids
+    end
   end
 
   describe '#legal_acts' do
     it 'is mapped through the MeasureLegalActPresenter' do
       expect(presenter.legal_acts.first).to \
         be_instance_of(Api::V2::Measures::MeasureLegalActPresenter)
+    end
+
+    it 'memoizes legal act presenters for id access' do
+      expect(Api::V2::Measures::MeasureLegalActPresenter)
+        .to receive(:new)
+        .once
+        .and_call_original
+
+      presenter.legal_acts
+      presenter.legal_act_ids
     end
   end
 
@@ -184,6 +204,19 @@ RSpec.describe Api::V2::Measures::MeasurePresenter do
 
     it { is_expected.not_to be_empty }
     it { is_expected.to all be_instance_of MeasureConditionPermutations::Group }
+
+    it 'memoizes permutation calculation for relationship and ids access' do
+      calculator = instance_double(MeasureConditionPermutations::Calculator, permutation_groups: [])
+
+      expect(MeasureConditionPermutations::Calculator)
+        .to receive(:new)
+        .with(measure)
+        .once
+        .and_return(calculator)
+
+      presenter.measure_condition_permutation_groups
+      presenter.measure_condition_permutation_group_ids
+    end
   end
 
   describe '#special_nature?' do

--- a/spec/presenters/api/v2/measures/measure_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_presenter_spec.rb
@@ -7,13 +7,14 @@ RSpec.describe Api::V2::Measures::MeasurePresenter do
     it { expect(presenter.measure_conditions).to all(be_a(Api::V2::Measures::MeasureConditionPresenter)) }
 
     it 'memoizes wrapped conditions for id access' do
-      expect(Api::V2::Measures::MeasureConditionPresenter)
+      allow(Api::V2::Measures::MeasureConditionPresenter)
         .to receive(:wrap)
-        .once
         .and_call_original
 
       presenter.measure_conditions
       presenter.measure_condition_ids
+
+      expect(Api::V2::Measures::MeasureConditionPresenter).to have_received(:wrap).once
     end
   end
 
@@ -24,13 +25,14 @@ RSpec.describe Api::V2::Measures::MeasurePresenter do
     end
 
     it 'memoizes legal act presenters for id access' do
-      expect(Api::V2::Measures::MeasureLegalActPresenter)
+      allow(Api::V2::Measures::MeasureLegalActPresenter)
         .to receive(:new)
-        .once
         .and_call_original
 
       presenter.legal_acts
       presenter.legal_act_ids
+
+      expect(Api::V2::Measures::MeasureLegalActPresenter).to have_received(:new).once
     end
   end
 
@@ -208,14 +210,15 @@ RSpec.describe Api::V2::Measures::MeasurePresenter do
     it 'memoizes permutation calculation for relationship and ids access' do
       calculator = instance_double(MeasureConditionPermutations::Calculator, permutation_groups: [])
 
-      expect(MeasureConditionPermutations::Calculator)
+      allow(MeasureConditionPermutations::Calculator)
         .to receive(:new)
         .with(measure)
-        .once
         .and_return(calculator)
 
       presenter.measure_condition_permutation_groups
       presenter.measure_condition_permutation_group_ids
+
+      expect(MeasureConditionPermutations::Calculator).to have_received(:new).once
     end
   end
 


### PR DESCRIPTION
### Jira link

[HMRC-2116](https://transformuk.atlassian.net/browse/HMRC-2116)

### What?

I have added/removed/altered:

- [ ] Optimized/memoized repeated derived-data construction

### Why?

I am doing this because:

- Commodity, heading and subheading responses avoid recalculating the same derived structures multiple times within one request.
