### PR TITLE
BAU_ : Move connection_validator into Sequel’s after_connect hook

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -55,6 +55,10 @@ module TradeTariffBackend
       Sequel::Model.plugin :validation_class_methods
       Sequel::Model.plugin :optimized_many_to_many
 
+      # Validate long-idle pooled connections before reuse.
+      Sequel::Model.db.extension :connection_validator
+      Sequel::Model.db.pool.connection_validation_timeout = 60 # seconds
+
       Sequel::Model.db.extension :pagination
       Sequel::Model.db.extension :server_block
       Sequel::Model.db.extension :auto_literal_strings

--- a/config/initializers/sequel.rb
+++ b/config/initializers/sequel.rb
@@ -2,11 +2,6 @@ Sequel.default_timezone = :utc
 Sequel.extension :pg_json
 Sequel.split_symbols = true
 
-# Validate long-idle pooled connections before reuse. This is especially
-# important for low-traffic Sidekiq queues such as within_1_hour, where a
-# thread can hold a stale PostgreSQL connection for a long time between jobs.
-Sequel::Model.db.extension(:connection_validator)
-Sequel::Model.db.pool.connection_validation_timeout = 60 # seconds
 
 # TimeMachine is incompatible with caching of associations dataset objects. This
 # is due to the cached dataset object including the TimeMachine date in it,


### PR DESCRIPTION
### Jira link

[BAU_](https://transformuk.atlassian.net/browse/BAU_)

### What?

I have added/removed/altered:

- [ ] Moved connection_validator into Sequel’s after_connect hook

### Why?

I am doing this because:

- config/initializers/sequel.rb eagerly calling Sequel::Model.db before Sequel has attached a DB during db:test:prepare
- it cause sequel::Error: No database associated with Sequel::Model: have you called Sequel.connect or Sequel::Model.db= ? (Sequel::Error)
-

### Have you? (optional)

- [ ] Added documentation for new apis
- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical data
- Changes an api that is used in production
