### PR TITLE
AI-554: Add description intercept schema validation

### DIFF
--- a/app/models/description_intercept.rb
+++ b/app/models/description_intercept.rb
@@ -8,9 +8,29 @@ class DescriptionIntercept < Sequel::Model
     validates_presence :term
     validates_presence :sources
     validates_includes [true, false], :excluded
+    validates_includes [true, false], :escalate_to_webchat
 
     if Array(sources).empty?
       errors.add(:sources, 'is not present')
     end
+
+    validate_filter_prefixes
+    validate_guidance_dependencies
+  end
+
+  private
+
+  def validate_filter_prefixes
+    prefixes = Array(filter_prefixes)
+    return if prefixes.empty?
+
+    errors.add(:filter_prefixes, 'cannot be set when excluded') if excluded
+    errors.add(:filter_prefixes, 'cannot contain blank prefixes') if prefixes.any?(&:blank?)
+    errors.add(:filter_prefixes, 'must contain only numeric prefixes') if prefixes.any? { |prefix| prefix.present? && !/\A\d+\z/.match?(prefix) }
+  end
+
+  def validate_guidance_dependencies
+    errors.add(:guidance_level, 'requires message') if guidance_level.present? && message.blank?
+    errors.add(:guidance_location, 'requires message') if guidance_location.present? && message.blank?
   end
 end

--- a/config/initializers/sequel.rb
+++ b/config/initializers/sequel.rb
@@ -2,7 +2,6 @@ Sequel.default_timezone = :utc
 Sequel.extension :pg_json
 Sequel.split_symbols = true
 
-
 # TimeMachine is incompatible with caching of associations dataset objects. This
 # is due to the cached dataset object including the TimeMachine date in it,
 # which may change between queries.

--- a/db/migrate/20260415120000_add_guidance_fields_to_description_intercepts.rb
+++ b/db/migrate/20260415120000_add_guidance_fields_to_description_intercepts.rb
@@ -1,0 +1,19 @@
+Sequel.migration do
+  up do
+    alter_table :description_intercepts do
+      add_column :guidance_level, String
+      add_column :guidance_location, String
+      add_column :escalate_to_webchat, TrueClass, null: false, default: false
+      add_column :filter_prefixes, 'text[]'
+    end
+  end
+
+  down do
+    alter_table :description_intercepts do
+      drop_column :filter_prefixes
+      drop_column :escalate_to_webchat
+      drop_column :guidance_location
+      drop_column :guidance_level
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict BlqRmhNHc0IpOluROnbM6lczo1hATSck8GN6LPFq0w6uKXg5Gh4JLpWBkBFfdFH
+\restrict 4xXn0CQzIHYhRrgv2qlE8Idjmg9eMNwFPzYhYmOtHiGsA71Y1oTKhiObnChJBkm
 
 -- Dumped from database version 18.3
 -- Dumped by pg_dump version 18.3
@@ -1816,7 +1816,11 @@ CREATE TABLE uk.description_intercepts (
     message text,
     excluded boolean DEFAULT false NOT NULL,
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    guidance_level text,
+    guidance_location text,
+    escalate_to_webchat boolean DEFAULT false NOT NULL,
+    filter_prefixes text[]
 );
 
 
@@ -13612,7 +13616,7 @@ ALTER TABLE ONLY uk.news_collections_news_items
 -- PostgreSQL database dump complete
 --
 
-\unrestrict BlqRmhNHc0IpOluROnbM6lczo1hATSck8GN6LPFq0w6uKXg5Gh4JLpWBkBFfdFH
+\unrestrict 4xXn0CQzIHYhRrgv2qlE8Idjmg9eMNwFPzYhYmOtHiGsA71Y1oTKhiObnChJBkm
 
 SET search_path TO uk, public;
 INSERT INTO "schema_migrations" ("filename") VALUES ('1342519058_create_schema.rb');
@@ -13838,3 +13842,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20260401110000_create_desc
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260401110100_create_goods_nomenclature_intercepts.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260413120000_drop_tariff_update_conformance_errors.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260413120001_drop_tariff_update_cds_errors.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20260415120000_add_guidance_fields_to_description_intercepts.rb');

--- a/spec/factories/description_intercept_factory.rb
+++ b/spec/factories/description_intercept_factory.rb
@@ -3,6 +3,10 @@ FactoryBot.define do
     term { 'footwear' }
     sources { Sequel.pg_array(%w[guided_search], :text) }
     message { 'Please be more specific.' }
+    guidance_level { nil }
+    guidance_location { nil }
+    escalate_to_webchat { false }
+    filter_prefixes { nil }
     excluded { false }
   end
 end

--- a/spec/models/description_intercept_spec.rb
+++ b/spec/models/description_intercept_spec.rb
@@ -25,6 +25,90 @@ RSpec.describe DescriptionIntercept do
         expect(intercept.errors[:sources]).to be_present
       end
     end
+
+    context 'when using the new guidance and filtering fields' do
+      let(:attrs) do
+        {
+          message: 'Consult the footwear guidance.',
+          guidance_level: 'warning',
+          guidance_location: 'results',
+          escalate_to_webchat: true,
+          filter_prefixes: Sequel.pg_array(%w[6403 6404], :text),
+        }
+      end
+
+      it 'is valid' do
+        expect(intercept).to be_valid
+      end
+    end
+
+    context 'when excluded and filtering prefixes are both set' do
+      let(:attrs) do
+        {
+          excluded: true,
+          filter_prefixes: Sequel.pg_array(%w[6403], :text),
+        }
+      end
+
+      it 'is invalid' do
+        expect(intercept).not_to be_valid
+        expect(intercept.errors[:filter_prefixes]).to include('cannot be set when excluded')
+      end
+    end
+
+    context 'when guidance level is set without a message' do
+      let(:attrs) do
+        {
+          message: nil,
+          guidance_level: 'warning',
+        }
+      end
+
+      it 'is invalid' do
+        expect(intercept).not_to be_valid
+        expect(intercept.errors[:guidance_level]).to include('requires message')
+      end
+    end
+
+    context 'when guidance location is set without a message' do
+      let(:attrs) do
+        {
+          message: nil,
+          guidance_location: 'results',
+        }
+      end
+
+      it 'is invalid' do
+        expect(intercept).not_to be_valid
+        expect(intercept.errors[:guidance_location]).to include('requires message')
+      end
+    end
+
+    context 'when a filtering prefix is blank' do
+      let(:attrs) do
+        {
+          filter_prefixes: Sequel.pg_array(['6403', ''], :text),
+        }
+      end
+
+      it 'is invalid' do
+        expect(intercept).not_to be_valid
+        expect(intercept.errors[:filter_prefixes]).to include('cannot contain blank prefixes')
+      end
+    end
+
+    context 'when a filtering prefix is not numeric' do
+      let(:attrs) do
+        {
+          filter_prefixes: Sequel.pg_array(%w[64A3], :text),
+        }
+      end
+
+      it 'is invalid' do
+        expect(intercept).not_to be_valid
+        expect(intercept.errors[:filter_prefixes]).to include('must contain only numeric prefixes')
+      end
+    end
   end
 
   describe 'versioning' do


### PR DESCRIPTION
### Jira link

[AI-554](https://transformuk.atlassian.net/browse/AI-554)

### What?

- [x] Add description intercept columns for guidance level, guidance location, webchat escalation, and filter prefixes
- [x] Add backend validation for invalid description intercept combinations
- [x] Add model specs for the new schema and validation rules
- [x] Regenerate database structure for the new migration

### Why?

This is the first isolated backend slice for AI-554. It adds the schema and domain validation needed before wiring the new intercept behaviour into guided search and admin editing flows.

### Have you?

- [ ] Added documentation for new APIs
- [ ] Added new environment variables to all environments

### Deployment risks

- Includes a migratory schema change to `description_intercepts`
