### PR TITLE
AI-554: Add description intercept admin API

### DIFF
--- a/app/controllers/api/admin/description_intercepts_controller.rb
+++ b/app/controllers/api/admin/description_intercepts_controller.rb
@@ -1,0 +1,124 @@
+module Api
+  module Admin
+    class DescriptionInterceptsController < AdminController
+      include Api::Admin::VersionBrowsing
+
+      def index
+        render json: serialize(paginated_dataset.all, is_collection: true, meta: pagination_meta)
+      end
+
+      def show
+        render json: serialize(description_intercept, serializer_options)
+      end
+
+      def create
+        description_intercept = DescriptionIntercept.new(description_intercept_params)
+
+        if description_intercept.save(raise_on_failure: false)
+          render json: serialize(description_intercept.reload, serializer_options), status: :created
+        else
+          render json: serialize_errors(description_intercept), status: :unprocessable_content
+        end
+      end
+
+      def update
+        description_intercept.set(description_intercept_params)
+
+        if description_intercept.save(raise_on_failure: false)
+          render json: serialize(description_intercept.reload, serializer_options), status: :ok
+        else
+          render json: serialize_errors(description_intercept), status: :unprocessable_content
+        end
+      end
+
+      def versions
+        versions = description_intercept.versions.all
+        Version.preload_predecessors(versions)
+        render json: Api::Admin::VersionSerializer.new(versions).serializable_hash
+      end
+
+      private
+
+      def serializer_class
+        Api::Admin::DescriptionInterceptSerializer
+      end
+
+      def pagination_meta
+        {
+          pagination: {
+            page: current_page,
+            per_page:,
+            total_count: paginated_dataset.pagination_record_count,
+          },
+        }
+      end
+
+      def paginated_dataset
+        @paginated_dataset ||= filtered_dataset.paginate(current_page, per_page)
+      end
+
+      def filtered_dataset
+        DescriptionIntercept
+          .search(params[:q])
+          .for_source(params[:source])
+          .with_filtering(params[:filtering])
+          .with_escalation(params[:escalates])
+          .with_guidance(params[:guidance])
+          .with_excluded(params[:excluded])
+          .order(Sequel.asc(:term), Sequel.asc(:id))
+      end
+
+      def description_intercept
+        @description_intercept ||= find_description_intercept
+      end
+
+      def find_description_intercept
+        if filter_version_id.present? && !current_version?
+          find_historical_description_intercept
+        else
+          find_current_description_intercept
+        end
+      end
+
+      def find_current_description_intercept
+        DescriptionIntercept.where(id: params[:id].to_i).first || raise(Sequel::RecordNotFound)
+      end
+
+      def find_historical_description_intercept
+        version = versions_for_item.where(id: filter_version_id).first
+        raise Sequel::RecordNotFound if version.blank?
+
+        version.reify
+      end
+
+      def versions_for_item
+        Version.where(item_type: 'DescriptionIntercept', item_id: params[:id].to_s)
+      end
+
+      def description_intercept_params
+        attrs = params.require(:data).require(:attributes)
+        permitted = attrs.permit(
+          :term,
+          :message,
+          :excluded,
+          :guidance_level,
+          :guidance_location,
+          :escalate_to_webchat,
+          sources: [],
+          filter_prefixes: [],
+        )
+
+        {}.tap do |result|
+          result[:term] = permitted[:term] if permitted.key?(:term)
+          result[:message] = permitted[:message] if permitted.key?(:message)
+          result[:excluded] = permitted[:excluded] if permitted.key?(:excluded)
+          result[:guidance_level] = permitted[:guidance_level] if permitted.key?(:guidance_level)
+          result[:guidance_location] = permitted[:guidance_location] if permitted.key?(:guidance_location)
+          result[:escalate_to_webchat] = permitted[:escalate_to_webchat] if permitted.key?(:escalate_to_webchat)
+          result[:sources] = Sequel.pg_array(Array(permitted[:sources]), :text) if permitted.key?(:sources)
+          result[:filter_prefixes] = Sequel.pg_array(Array(permitted[:filter_prefixes]), :text) if permitted.key?(:filter_prefixes)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/goods_nomenclature_autocomplete_controller.rb
+++ b/app/controllers/api/admin/goods_nomenclature_autocomplete_controller.rb
@@ -1,0 +1,25 @@
+module Api
+  module Admin
+    class GoodsNomenclatureAutocompleteController < AdminController
+      def index
+        render json: Api::Admin::GoodsNomenclatureAutocompleteSerializer.new(results).serializable_hash
+      end
+
+      private
+
+      def results
+        @results ||= SearchSuggestion
+          .goods_nomenclature_autocomplete_with_filters(params[:q], autocomplete_filters)
+          .all
+          .select { |suggestion| suggestion.goods_nomenclature.present? }
+      end
+
+      def autocomplete_filters
+        goods_nomenclature_class = params.dig(:filter, :goods_nomenclature_class) ||
+          params.dig(:filter, 'goods_nomenclature_class')
+
+        { goods_nomenclature_class: }
+      end
+    end
+  end
+end

--- a/app/engines/admin_api.rb
+++ b/app/engines/admin_api.rb
@@ -90,6 +90,12 @@ AdminApi.routes.draw do
 
         resources :live_issues, only: %i[index show create update destroy]
         resources :admin_configurations, only: %i[index show update]
+        resources :description_intercepts, only: %i[index show create update] do
+          member do
+            get :versions
+          end
+        end
+        resources :goods_nomenclature_autocomplete, only: [:index]
       end
 
       namespace :green_lanes do

--- a/app/models/description_intercept.rb
+++ b/app/models/description_intercept.rb
@@ -1,18 +1,61 @@
 class DescriptionIntercept < Sequel::Model
+  GUIDANCE_LEVELS = %w[info warning error].freeze
+  GUIDANCE_LOCATIONS = %w[interstitial results question].freeze
+
   plugin :timestamps, update_on_create: true
   plugin :auto_validations, not_null: :presence
   plugin :has_paper_trail
+  skip_auto_validations(:not_null)
+
+  dataset_module do
+    def search(query)
+      return self if query.blank?
+
+      where(Sequel.ilike(:term, "%#{query}%"))
+    end
+
+    def for_source(source)
+      return self if source.blank?
+
+      where(Sequel.lit('? = ANY(sources)', source))
+    end
+
+    def with_filtering(enabled)
+      return self unless boolean_filter_enabled?(enabled)
+
+      where(Sequel.lit('COALESCE(array_length(filter_prefixes, 1), 0) > 0'))
+    end
+
+    def with_escalation(enabled)
+      return self unless boolean_filter_enabled?(enabled)
+
+      where(escalate_to_webchat: true)
+    end
+
+    def with_guidance(enabled)
+      return self unless boolean_filter_enabled?(enabled)
+
+      where(Sequel.lit("COALESCE(message, '') <> ''"))
+    end
+
+    def with_excluded(enabled)
+      return self unless boolean_filter_enabled?(enabled)
+
+      where(excluded: true)
+    end
+
+    def boolean_filter_enabled?(value)
+      ActiveModel::Type::Boolean.new.cast(value)
+    end
+  end
 
   def validate
     super
     validates_presence :term
-    validates_presence :sources
     validates_includes [true, false], :excluded
     validates_includes [true, false], :escalate_to_webchat
-
-    if Array(sources).empty?
-      errors.add(:sources, 'is not present')
-    end
+    validates_includes GUIDANCE_LEVELS, :guidance_level, allow_nil: true
+    validates_includes GUIDANCE_LOCATIONS, :guidance_location, allow_nil: true
 
     validate_filter_prefixes
     validate_guidance_dependencies

--- a/app/models/search_suggestion.rb
+++ b/app/models/search_suggestion.rb
@@ -123,6 +123,36 @@ class SearchSuggestion < Sequel::Model
       where(type: 'goods_nomenclature')
     end
 
+    def goods_nomenclature_autocomplete(query)
+      goods_nomenclature_autocomplete_with_filters(query)
+    end
+
+    def goods_nomenclature_autocomplete_with_filters(query, filters = {})
+      dataset = goods_nomenclature_type
+      dataset = dataset.where(Sequel.ilike(:value, "#{query}%")) if query.present?
+      dataset = dataset.exclude_hidden_goods_nomenclatures
+      dataset = dataset.for_goods_nomenclature_classes(filters[:goods_nomenclature_class])
+
+      dataset
+        .eager(:goods_nomenclature)
+        .order(Sequel.asc(:value), Sequel.asc(:goods_nomenclature_sid))
+        .limit(20)
+    end
+
+    def for_goods_nomenclature_classes(classes)
+      normalised_classes = Array(classes).flat_map { |value| value.to_s.split(',') }.map(&:strip).reject(&:blank?)
+      return self if normalised_classes.empty?
+
+      where(goods_nomenclature_class: normalised_classes)
+    end
+
+    def exclude_hidden_goods_nomenclatures
+      excluded_chapters = AdminConfiguration.multi_options_values('interactive_search_excluded_chapters')
+      return self if excluded_chapters.empty?
+
+      exclude(Sequel.function(:substring, :value, 1, 2) => excluded_chapters)
+    end
+
     def text_type
       where(
         type: [

--- a/app/serializers/api/admin/description_intercept_serializer.rb
+++ b/app/serializers/api/admin/description_intercept_serializer.rb
@@ -1,0 +1,19 @@
+module Api
+  module Admin
+    class DescriptionInterceptSerializer
+      include JSONAPI::Serializer
+
+      set_type :description_intercept
+
+      attributes :term,
+                 :sources,
+                 :message,
+                 :excluded,
+                 :created_at,
+                 :guidance_level,
+                 :guidance_location,
+                 :escalate_to_webchat,
+                 :filter_prefixes
+    end
+  end
+end

--- a/app/serializers/api/admin/goods_nomenclature_autocomplete_serializer.rb
+++ b/app/serializers/api/admin/goods_nomenclature_autocomplete_serializer.rb
@@ -1,0 +1,21 @@
+module Api
+  module Admin
+    class GoodsNomenclatureAutocompleteSerializer
+      include JSONAPI::Serializer
+
+      set_type :goods_nomenclature_autocomplete
+      set_id :goods_nomenclature_sid
+
+      attribute :goods_nomenclature_sid, &:goods_nomenclature_sid
+      attribute :goods_nomenclature_item_id, &:value
+
+      attribute :producline_suffix do |record|
+        record.goods_nomenclature&.producline_suffix
+      end
+
+      attribute :description do |record|
+        record.goods_nomenclature&.description
+      end
+    end
+  end
+end

--- a/spec/controllers/api/admin/description_intercepts_controller_spec.rb
+++ b/spec/controllers/api/admin/description_intercepts_controller_spec.rb
@@ -1,0 +1,281 @@
+RSpec.describe Api::Admin::DescriptionInterceptsController do
+  routes { AdminApi.routes }
+
+  describe '#index' do
+    before do
+      guided_search_intercept
+      fpo_intercept
+    end
+
+    let!(:guided_search_intercept) do
+      create(
+        :description_intercept,
+        term: 'footwear',
+        sources: Sequel.pg_array(%w[guided_search], :text),
+        guidance_level: 'warning',
+        guidance_location: 'results',
+        escalate_to_webchat: true,
+        filter_prefixes: Sequel.pg_array(%w[6403 6404], :text),
+      )
+    end
+
+    let!(:fpo_intercept) do
+      create(
+        :description_intercept,
+        term: 'gift',
+        sources: Sequel.pg_array(%w[fpo_search], :text),
+        excluded: true,
+        message: nil,
+      )
+    end
+
+    it 'returns all description intercepts' do
+      get :index, format: :json
+
+      json = JSON.parse(response.body)
+      expect(json['data'].length).to eq(2)
+      expect(json['data'].map { |row| row['type'] }.uniq).to eq(%w[description_intercept])
+    end
+
+    it 'includes pagination meta' do
+      get :index, format: :json
+
+      json = JSON.parse(response.body)
+      expect(json.dig('meta', 'pagination')).to include(
+        'page' => 1,
+        'per_page' => Integer,
+        'total_count' => 2,
+      )
+    end
+
+    it 'filters by search term' do
+      get :index, params: { q: 'foot' }, format: :json
+
+      json = JSON.parse(response.body)
+      expect(json['data'].length).to eq(1)
+      expect(json.dig('data', 0, 'attributes', 'term')).to eq('footwear')
+    end
+
+    it 'filters by source' do
+      get :index, params: { source: 'fpo_search' }, format: :json
+
+      json = JSON.parse(response.body)
+      expect(json['data'].length).to eq(1)
+      expect(json.dig('data', 0, 'attributes', 'term')).to eq('gift')
+    end
+
+    it 'filters to rows with filtering enabled' do
+      get :index, params: { filtering: 'true' }, format: :json
+
+      json = JSON.parse(response.body)
+      expect(json['data'].length).to eq(1)
+      expect(json.dig('data', 0, 'attributes', 'term')).to eq('footwear')
+    end
+
+    it 'filters to rows with escalation enabled' do
+      get :index, params: { escalates: 'true' }, format: :json
+
+      json = JSON.parse(response.body)
+      expect(json['data'].length).to eq(1)
+      expect(json.dig('data', 0, 'attributes', 'term')).to eq('footwear')
+    end
+
+    it 'filters to rows with guidance' do
+      get :index, params: { guidance: 'true' }, format: :json
+
+      json = JSON.parse(response.body)
+      expect(json['data'].length).to eq(1)
+      expect(json.dig('data', 0, 'attributes', 'term')).to eq('footwear')
+    end
+
+    it 'filters to rows that are excluded' do
+      get :index, params: { excluded: 'true' }, format: :json
+
+      json = JSON.parse(response.body)
+      expect(json['data'].length).to eq(1)
+      expect(json.dig('data', 0, 'attributes', 'term')).to eq('gift')
+    end
+  end
+
+  describe '#show' do
+    let!(:intercept) do
+      create(
+        :description_intercept,
+        term: 'footwear',
+        guidance_level: 'warning',
+        guidance_location: 'results',
+        escalate_to_webchat: true,
+        filter_prefixes: Sequel.pg_array(%w[6403 6404], :text),
+      )
+    end
+
+    it 'returns the description intercept' do
+      get :show, params: { id: intercept.id }, format: :json
+
+      json = JSON.parse(response.body)
+      expect(json).to match_json_expression(
+        data: {
+          id: intercept.id.to_s,
+          type: 'description_intercept',
+          attributes: {
+            term: 'footwear',
+            sources: %w[guided_search],
+            message: 'Please be more specific.',
+            excluded: false,
+            created_at: wildcard_matcher,
+            guidance_level: 'warning',
+            guidance_location: 'results',
+            escalate_to_webchat: true,
+            filter_prefixes: %w[6403 6404],
+          },
+        },
+        meta: {
+          version: {
+            current: wildcard_matcher,
+            oid: wildcard_matcher,
+            previous_oid: wildcard_matcher,
+            has_previous_version: wildcard_matcher,
+            latest_event: wildcard_matcher,
+          },
+        },
+      )
+    end
+
+    it 'returns 404 when not found' do
+      get :show, params: { id: 999_999 }, format: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    context 'when viewing a historical version' do
+      before { intercept.update(message: 'Updated guidance') }
+
+      it 'returns the historical version data' do
+        version = intercept.versions.order(:id).first
+
+        get :show, params: { id: intercept.id, filter: { oid: version.id } }, format: :json
+
+        json = JSON.parse(response.body)
+        expect(json.dig('data', 'attributes', 'message')).to eq('Please be more specific.')
+        expect(json.dig('meta', 'version', 'current')).to be false
+      end
+    end
+  end
+
+  describe '#create' do
+    it 'creates a description intercept' do
+      expect {
+        post :create, params: {
+          data: {
+            type: 'description_intercept',
+            attributes: {
+              term: 'bicycles',
+              message: 'Read the bicycle guidance.',
+              guidance_level: 'info',
+              guidance_location: 'results',
+              escalate_to_webchat: true,
+              filter_prefixes: %w[8712 9503],
+              sources: %w[guided_search fpo_search],
+              excluded: false,
+            },
+          },
+        }, format: :json
+      }.to change(DescriptionIntercept, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+
+      intercept = DescriptionIntercept.order(Sequel.desc(:id)).first
+      expect(intercept.term).to eq('bicycles')
+      expect(intercept.message).to eq('Read the bicycle guidance.')
+      expect(intercept.guidance_level).to eq('info')
+      expect(intercept.guidance_location).to eq('results')
+      expect(intercept.escalate_to_webchat).to be true
+      expect(intercept.filter_prefixes).to eq(%w[8712 9503])
+      expect(intercept.sources).to eq(%w[guided_search fpo_search])
+      expect(intercept.excluded).to be false
+    end
+
+    it 'returns validation errors for invalid attributes' do
+      expect {
+        post :create, params: {
+          data: {
+            type: 'description_intercept',
+            attributes: {
+              term: 'bicycles',
+              excluded: true,
+              filter_prefixes: %w[8712],
+              sources: %w[guided_search],
+              escalate_to_webchat: false,
+            },
+          },
+        }, format: :json
+      }.not_to change(DescriptionIntercept, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      json = JSON.parse(response.body)
+      expect(json['errors'].first.dig('source', 'pointer')).to eq('/data/attributes/filter_prefixes')
+    end
+  end
+
+  describe '#update' do
+    let!(:intercept) { create(:description_intercept, term: 'footwear') }
+
+    it 'updates the description intercept fields' do
+      put :update, params: {
+        id: intercept.id,
+        data: {
+          type: 'description_intercept',
+          attributes: {
+            message: 'Read the footwear guidance.',
+            guidance_level: 'warning',
+            guidance_location: 'results',
+            escalate_to_webchat: true,
+            filter_prefixes: %w[6403 6404],
+            sources: %w[guided_search fpo_search],
+          },
+        },
+      }, format: :json
+
+      expect(response).to have_http_status(:ok)
+
+      intercept.reload
+      expect(intercept.message).to eq('Read the footwear guidance.')
+      expect(intercept.guidance_level).to eq('warning')
+      expect(intercept.guidance_location).to eq('results')
+      expect(intercept.escalate_to_webchat).to be true
+      expect(intercept.filter_prefixes).to eq(%w[6403 6404])
+      expect(intercept.sources).to eq(%w[guided_search fpo_search])
+    end
+
+    it 'returns validation errors for invalid combinations' do
+      put :update, params: {
+        id: intercept.id,
+        data: {
+          type: 'description_intercept',
+          attributes: {
+            excluded: true,
+            filter_prefixes: %w[6403],
+          },
+        },
+      }, format: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+      json = JSON.parse(response.body)
+      expect(json['errors'].first.dig('source', 'pointer')).to eq('/data/attributes/filter_prefixes')
+    end
+  end
+
+  describe '#versions' do
+    let!(:intercept) { create(:description_intercept, term: 'footwear') }
+
+    before { intercept.update(message: 'Updated guidance') }
+
+    it 'returns the intercept versions' do
+      get :versions, params: { id: intercept.id }, format: :json
+
+      json = JSON.parse(response.body)
+      expect(json['data'].length).to eq(2)
+      expect(json['data'].map { |row| row['type'] }.uniq).to eq(%w[version])
+    end
+  end
+end

--- a/spec/controllers/api/admin/goods_nomenclature_autocomplete_controller_spec.rb
+++ b/spec/controllers/api/admin/goods_nomenclature_autocomplete_controller_spec.rb
@@ -1,0 +1,159 @@
+RSpec.describe Api::Admin::GoodsNomenclatureAutocompleteController do
+  routes { AdminApi.routes }
+
+  describe '#index' do
+    before do
+      first_match
+      second_match
+      commodity_match
+      non_current_match
+      hidden_match
+    end
+
+    let!(:first_match) do
+      create(
+        :goods_nomenclature,
+        :with_description,
+        :without_indent,
+        goods_nomenclature_item_id: '6403000000',
+        producline_suffix: '80',
+        description: 'Footwear with uppers of leather',
+      ).tap do |goods_nomenclature|
+        create(
+          :search_suggestion,
+          :goods_nomenclature,
+          goods_nomenclature:,
+          value: goods_nomenclature.goods_nomenclature_item_id,
+          goods_nomenclature_class: 'Chapter',
+        )
+      end
+    end
+
+    let!(:second_match) do
+      create(
+        :goods_nomenclature,
+        :with_description,
+        :without_indent,
+        goods_nomenclature_item_id: '6404000000',
+        producline_suffix: '10',
+        description: 'Footwear with uppers of textile materials',
+      ).tap do |goods_nomenclature|
+        create(
+          :search_suggestion,
+          :goods_nomenclature,
+          goods_nomenclature:,
+          value: goods_nomenclature.goods_nomenclature_item_id,
+          goods_nomenclature_class: 'Heading',
+        )
+      end
+    end
+
+    let(:commodity_match) do
+      create(
+        :goods_nomenclature,
+        :with_description,
+        :without_indent,
+        goods_nomenclature_item_id: '6406100000',
+        producline_suffix: '80',
+        description: 'Parts of footwear',
+      ).tap do |goods_nomenclature|
+        create(
+          :search_suggestion,
+          :goods_nomenclature,
+          goods_nomenclature:,
+          value: goods_nomenclature.goods_nomenclature_item_id,
+          goods_nomenclature_class: 'Commodity',
+        )
+      end
+    end
+
+    let!(:non_current_match) do
+      create(
+        :goods_nomenclature,
+        :with_description,
+        :without_indent,
+        :non_current,
+        goods_nomenclature_item_id: '6405000000',
+        description: 'Old footwear record',
+      ).tap do |goods_nomenclature|
+        create(:search_suggestion, :goods_nomenclature, goods_nomenclature:, value: goods_nomenclature.goods_nomenclature_item_id)
+      end
+    end
+
+    let(:hidden_match) do
+      create(
+        :goods_nomenclature,
+        :with_description,
+        :without_indent,
+        goods_nomenclature_item_id: '6407000000',
+        description: 'Hidden footwear record',
+      ).tap do |goods_nomenclature|
+        create(
+          :search_suggestion,
+          :goods_nomenclature,
+          goods_nomenclature:,
+          value: goods_nomenclature.goods_nomenclature_item_id,
+          goods_nomenclature_class: 'Heading',
+        )
+        create(:hidden_goods_nomenclature, goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id)
+      end
+    end
+
+    it 'returns active goods nomenclatures ordered by item id and producline suffix' do
+      get :index, params: { q: '640' }, format: :json
+
+      json = JSON.parse(response.body)
+      expect(json['data'].map { |row| row.dig('attributes', 'goods_nomenclature_item_id') }).to eq(%w[6403000000 6404000000 6406100000 6407000000])
+    end
+
+    it 'includes the description in the response' do
+      get :index, params: { q: '6403' }, format: :json
+
+      json = JSON.parse(response.body)
+      expect(json.dig('data', 0, 'attributes')).to include(
+        'goods_nomenclature_item_id' => '6403000000',
+        'description' => 'Footwear with uppers of leather',
+      )
+    end
+
+    it 'excludes non-current goods nomenclatures' do
+      get :index, params: { q: '640' }, format: :json
+
+      json = JSON.parse(response.body)
+      expect(json['data'].map { |row| row.dig('attributes', 'goods_nomenclature_item_id') }).not_to include('6405000000')
+    end
+
+    it 'does not exclude hidden goods nomenclatures by exact code' do
+      get :index, params: { q: '6407' }, format: :json
+
+      json = JSON.parse(response.body)
+      expect(json['data'].map { |row| row.dig('attributes', 'goods_nomenclature_item_id') }).to eq(%w[6407000000])
+    end
+
+    it 'excludes chapters hidden by admin configuration' do
+      create(
+        :admin_configuration,
+        name: 'interactive_search_excluded_chapters',
+        config_type: 'multi_options',
+        value: {
+          'selected' => %w[64],
+          'options' => [
+            { 'key' => '64', 'label' => '64' },
+          ],
+        },
+      )
+
+      get :index, params: { q: '640' }, format: :json
+
+      json = JSON.parse(response.body)
+      expect(json['data']).to be_empty
+    end
+
+    it 'filters by goods nomenclature class when requested' do
+      get :index, params: { q: '640', filter: { goods_nomenclature_class: %w[Chapter Heading] } }, format: :json
+
+      json = JSON.parse(response.body)
+      expect(json['data'].map { |row| row.dig('attributes', 'goods_nomenclature_item_id') }).to eq(%w[6403000000 6404000000 6407000000])
+    end
+  end
+end

--- a/spec/models/description_intercept_spec.rb
+++ b/spec/models/description_intercept_spec.rb
@@ -20,9 +20,8 @@ RSpec.describe DescriptionIntercept do
     context 'when sources is blank' do
       let(:attrs) { { sources: [] } }
 
-      it 'is invalid' do
-        expect(intercept).not_to be_valid
-        expect(intercept.errors[:sources]).to be_present
+      it 'is valid' do
+        expect(intercept).to be_valid
       end
     end
 
@@ -81,6 +80,34 @@ RSpec.describe DescriptionIntercept do
       it 'is invalid' do
         expect(intercept).not_to be_valid
         expect(intercept.errors[:guidance_location]).to include('requires message')
+      end
+    end
+
+    context 'when guidance level is not one of the allowed values' do
+      let(:attrs) do
+        {
+          message: 'Consult the footwear guidance.',
+          guidance_level: 'urgent',
+        }
+      end
+
+      it 'is invalid' do
+        expect(intercept).not_to be_valid
+        expect(intercept.errors[:guidance_level]).to include('is not in range or set: ["info", "warning", "error"]')
+      end
+    end
+
+    context 'when guidance location is not one of the allowed values' do
+      let(:attrs) do
+        {
+          message: 'Consult the footwear guidance.',
+          guidance_location: 'sidebar',
+        }
+      end
+
+      it 'is invalid' do
+        expect(intercept).not_to be_valid
+        expect(intercept.errors[:guidance_location]).to include('is not in range or set: ["interstitial", "results", "question"]')
       end
     end
 


### PR DESCRIPTION
### Jira link

[AI-554](https://transformuk.atlassian.net/browse/AI-554)

### What?

- [x] Add admin API endpoints for listing, showing, creating, updating, and version-browsing description intercepts
- [x] Add a generic goods nomenclature autocomplete endpoint with class filtering and hidden-goods exclusions

### Why?

This gives the admin UI the backend capabilities it needs to manage description intercepts safely.

### Have you?

- [ ] Added documentation for new APIs
- [ ] Added new environment variables to all environments
