### PR TITLE
Align ApplyWorker post-processing with scheduled sync

### DIFF
--- a/app/workers/apply_worker.rb
+++ b/app/workers/apply_worker.rb
@@ -7,6 +7,8 @@ class ApplyWorker
     Thread.current[:tariff_sync_run_id] = SecureRandom.uuid
     start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
+    oldest_pending_date = TariffSynchronizer::BaseUpdate.oldest_pending&.issue_date || Time.zone.today
+
     TariffSynchronizer::Instrumentation.sync_run_started(triggered_by: self.class.name)
     TariffSynchronizer::Instrumentation.apply_started(pending_count: TariffSynchronizer::BaseUpdate.pending.count)
 
@@ -14,7 +16,11 @@ class ApplyWorker
 
     MaterializeViewHelper.refresh_materialized_view
 
-    ClearCacheWorker.perform_async
+    ActiveSupport::Notifications.instrument(
+      TradeTariffBackend::TariffUpdateEventListener::TARIFF_UPDATES_APPLIED,
+      service: TradeTariffBackend.service,
+      oldest_pending_date: oldest_pending_date.iso8601,
+    )
 
     duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
     TariffSynchronizer::Instrumentation.sync_run_completed(duration_ms:)

--- a/spec/workers/apply_worker_spec.rb
+++ b/spec/workers/apply_worker_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe ApplyWorker, type: :worker do
       allow(CdsSynchronizer).to receive(:apply)
       allow(TaricSynchronizer).to receive(:apply)
       allow(MaterializeViewHelper).to receive(:refresh_materialized_view)
-      allow(ClearCacheWorker).to receive(:perform_async)
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+      allow(TariffSynchronizer::BaseUpdate).to receive(:oldest_pending).and_return(nil)
       allow(TradeTariffBackend).to receive(:service).and_return(service)
     end
 
@@ -17,7 +18,14 @@ RSpec.describe ApplyWorker, type: :worker do
 
       it { expect(CdsSynchronizer).to have_received(:apply) }
       it { expect(MaterializeViewHelper).to have_received(:refresh_materialized_view) }
-      it { expect(ClearCacheWorker).to have_received(:perform_async) }
+
+      it 'fires the tariff updates applied event with service and oldest_pending_date' do
+        expect(ActiveSupport::Notifications).to have_received(:instrument)
+          .with(
+            TradeTariffBackend::TariffUpdateEventListener::TARIFF_UPDATES_APPLIED,
+            hash_including(service: 'uk', oldest_pending_date: Time.zone.today.iso8601),
+          )
+      end
     end
 
     context 'when on the xi service' do
@@ -27,7 +35,32 @@ RSpec.describe ApplyWorker, type: :worker do
 
       it { expect(TaricSynchronizer).to have_received(:apply) }
       it { expect(MaterializeViewHelper).to have_received(:refresh_materialized_view) }
-      it { expect(ClearCacheWorker).to have_received(:perform_async) }
+
+      it 'fires the tariff updates applied event with service and oldest_pending_date' do
+        expect(ActiveSupport::Notifications).to have_received(:instrument)
+          .with(
+            TradeTariffBackend::TariffUpdateEventListener::TARIFF_UPDATES_APPLIED,
+            hash_including(service: 'xi', oldest_pending_date: Time.zone.today.iso8601),
+          )
+      end
+    end
+
+    context 'when pending updates exist' do
+      let(:service) { 'uk' }
+      let(:pending_update) { instance_double(TariffSynchronizer::BaseUpdate, issue_date: Date.new(2024, 1, 15)) }
+
+      before do
+        allow(TariffSynchronizer::BaseUpdate).to receive(:oldest_pending).and_return(pending_update)
+        perform
+      end
+
+      it 'uses the oldest pending date in the event payload' do
+        expect(ActiveSupport::Notifications).to have_received(:instrument)
+          .with(
+            TradeTariffBackend::TariffUpdateEventListener::TARIFF_UPDATES_APPLIED,
+            hash_including(oldest_pending_date: '2024-01-15'),
+          )
+      end
     end
 
     context 'when an error is raised' do

--- a/spec/workers/apply_worker_spec.rb
+++ b/spec/workers/apply_worker_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ApplyWorker, type: :worker do
       allow(TaricSynchronizer).to receive(:apply)
       allow(MaterializeViewHelper).to receive(:refresh_materialized_view)
       allow(ActiveSupport::Notifications).to receive(:instrument)
-      allow(TariffSynchronizer::BaseUpdate).to receive(:oldest_pending).and_return(nil)
+      allow(TariffSynchronizer::BaseUpdate).to receive_messages(oldest_pending: nil, pending: double(count: 0))
       allow(TradeTariffBackend).to receive(:service).and_return(service)
     end
 


### PR DESCRIPTION
## Summary

- `ApplyWorker` was directly calling `ClearCacheWorker.perform_async`, skipping `ClearInvalidSearchReferences`, `TreeIntegrityCheckWorker`, `PopulateChangesTableWorker`, and `GreenLanesUpdatesWorker`
- Fixes by firing `TARIFF_UPDATES_APPLIED` via `ActiveSupport::Notifications` — the same event the CDS and TARIC sync workers emit — so the full `TariffUpdateEventListener` downstream chain runs for manual applies too
- Also captures `oldest_pending_date` before `apply` runs (matching `TaricUpdatesSynchronizerWorker`), so XI's `GreenLanesUpdatesWorker` receives the correct date

Resolves HMRC-2034