### PR TITLE
Scope update_type and failure checks to the calling synchronizer

### DIFF
--- a/app/lib/cds_synchronizer.rb
+++ b/app/lib/cds_synchronizer.rb
@@ -14,6 +14,10 @@ class CdsSynchronizer
   self.initial_update_date = Date.new(2020, 9, 1)
 
   class << self
+    def update_type
+      TariffSynchronizer::CdsUpdate
+    end
+
     def download
       unless sync_variables_set?
         TariffSynchronizer::Instrumentation.sync_run_failed(

--- a/app/lib/taric_synchronizer.rb
+++ b/app/lib/taric_synchronizer.rb
@@ -29,6 +29,10 @@ class TaricSynchronizer
   self.taric_update_url_template = '%{host}/taric/%{filename}'
 
   class << self
+    def update_type
+      TariffSynchronizer::TaricUpdate
+    end
+
     # Download pending updates for TARIC and CDS data
     # Gets latest downloaded file present in (inbox/failbox/processed) and tries
     # to download any further updates to current day.

--- a/app/lib/tariff_synchronizer.rb
+++ b/app/lib/tariff_synchronizer.rb
@@ -82,8 +82,9 @@ module TariffSynchronizer
   end
 
   def check_tariff_updates_failures
-    if BaseUpdate.failed.any?
-      Instrumentation.failed_updates_detected(filenames: BaseUpdate.failed.map(&:filename))
+    failed = update_type.failed
+    if failed.any?
+      Instrumentation.failed_updates_detected(filenames: failed.map(&:filename))
       raise FailedUpdatesError
     end
   rescue FailedUpdatesError => e

--- a/spec/unit/cds_synchronizer_spec.rb
+++ b/spec/unit/cds_synchronizer_spec.rb
@@ -1,4 +1,10 @@
 RSpec.describe CdsSynchronizer, :truncation do
+  describe '.update_type' do
+    it 'always returns CdsUpdate regardless of the SERVICE env var' do
+      expect(described_class.update_type).to eq(TariffSynchronizer::CdsUpdate)
+    end
+  end
+
   describe '.initial_update_date' do
     it 'returns initial update date' do
       expect(described_class.initial_update_date).to eq(Date.new(2020, 9, 1))
@@ -92,7 +98,7 @@ RSpec.describe CdsSynchronizer, :truncation do
       end
     end
 
-    context 'with failed updates present' do
+    context 'with failed CDS updates present' do
       let(:failed_update) { create(:cds_update, :failed, example_date: Time.zone.yesterday) }
 
       before do
@@ -118,6 +124,18 @@ RSpec.describe CdsSynchronizer, :truncation do
 
       it 'sends email with the error' do
         expect { described_class.apply }.to raise_error(TariffSynchronizer::FailedUpdatesError)
+      end
+    end
+
+    context 'with only TARIC failed updates present' do
+      before do
+        create(:taric_update, :failed, example_date: Time.zone.yesterday)
+        allow(TradeTariffBackend).to receive(:service).and_return('uk')
+        allow(TradeTariffBackend).to receive(:with_redis_lock)
+      end
+
+      it 'does not raise FailedUpdatesError' do
+        expect { described_class.apply }.not_to raise_error
       end
     end
   end

--- a/spec/unit/taric_synchronizer_spec.rb
+++ b/spec/unit/taric_synchronizer_spec.rb
@@ -1,5 +1,11 @@
 # rubocop:disable RSpec/AnyInstance
 RSpec.describe TaricSynchronizer, :truncation do
+  describe '.update_type' do
+    it 'always returns TaricUpdate regardless of the SERVICE env var' do
+      expect(described_class.update_type).to eq(TariffSynchronizer::TaricUpdate)
+    end
+  end
+
   describe '.initial_update_date' do
     it 'returns initial update date' do
       expect(described_class.initial_update_date).to eq(Date.new(2012, 6, 6))
@@ -153,7 +159,7 @@ RSpec.describe TaricSynchronizer, :truncation do
       end
     end
 
-    context 'with failed updates present' do
+    context 'with failed TARIC updates present' do
       let(:failed_update) { create(:taric_update, :failed, example_date: Time.zone.yesterday) }
 
       before do
@@ -178,6 +184,18 @@ RSpec.describe TaricSynchronizer, :truncation do
 
       it 'sends email with the error' do
         expect { described_class.apply }.to raise_error(TariffSynchronizer::FailedUpdatesError)
+      end
+    end
+
+    context 'with only CDS failed updates present' do
+      before do
+        create(:cds_update, :failed, example_date: Time.zone.yesterday)
+        allow(TradeTariffBackend).to receive(:service).and_return('xi')
+        allow(TradeTariffBackend).to receive(:with_redis_lock)
+      end
+
+      it 'does not raise FailedUpdatesError' do
+        expect { described_class.apply }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
## Summary

- `TariffSynchronizer#update_type` returned a type based on the global `SERVICE` env var, not the synchronizer calling it — so `TaricSynchronizer.update_type` returned `CdsUpdate` on a UK instance
- `check_tariff_updates_failures` queried `BaseUpdate.failed` across all types, meaning a stale failed record from a different synchronizer could block a healthy sync indefinitely
- Fixes by overriding `update_type` on `CdsSynchronizer` (always `CdsUpdate`) and `TaricSynchronizer` (always `TaricUpdate`), and changing `check_tariff_updates_failures` to use `update_type.failed` — scoped to the calling synchronizer
- `check_sequence` already delegates to `update_type` so it benefits automatically from the override

Resolves HMRC-2035
