### PR TITLE
OTTIMP-501 Remove usage of unprocessable entity

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -10,10 +10,10 @@ class ErrorsController < ActionController::Base
     respond_to_error :not_found, 'Not Found'
   end
 
-  def unprocessable_entity
+  def unprocessable_content
     respond_to_error \
       :unprocessable_content,
-      'Unprocessable entity: API documentation is available at https://api.trade-tariff.service.gov.uk/'
+      'Unprocessable content: API documentation is available at https://api.trade-tariff.service.gov.uk/'
   end
 
   def internal_server_error

--- a/app/engines/v1_api.rb
+++ b/app/engines/v1_api.rb
@@ -41,7 +41,7 @@ V1Api.routes.draw do
       match '/404', to: 'errors#not_found', via: :all
       match '/405', to: 'errors#method_not_allowed', via: :all
       match '/406', to: 'errors#not_acceptable', via: :all
-      match '/422', to: 'errors#unprocessable_entity', via: :all
+      match '/422', to: 'errors#unprocessable_content', via: :all
       match '/500', to: 'errors#internal_server_error', via: :all
       match '/501', to: 'errors#not_implemented', via: :all
       match '/503', to: 'errors#maintenance', via: :all

--- a/app/engines/v2_api.rb
+++ b/app/engines/v2_api.rb
@@ -160,7 +160,7 @@ V2Api.routes.draw do
       match '/404', to: 'errors#not_found', via: :all
       match '/405', to: 'errors#method_not_allowed', via: :all
       match '/406', to: 'errors#not_acceptable', via: :all
-      match '/422', to: 'errors#unprocessable_entity', via: :all
+      match '/422', to: 'errors#unprocessable_content', via: :all
       match '/500', to: 'errors#internal_server_error', via: :all
       match '/501', to: 'errors#not_implemented', via: :all
       match '/503', to: 'errors#maintenance', via: :all

--- a/app/services/api/admin/error_serialization_service.rb
+++ b/app/services/api/admin/error_serialization_service.rb
@@ -1,7 +1,7 @@
 module Api
   module Admin
     class ErrorSerializationService
-      DEFAULT_ERROR_STATUS_CODE = 422 # Unprocessable_entity
+      DEFAULT_ERROR_STATUS_CODE = 422 # Unprocessable_content
       STATUS_CODES_FOR_ERRORS = {
         'is already taken' => 409, # Conflict
       }.freeze

--- a/app/services/api/search/error_serialization_service.rb
+++ b/app/services/api/search/error_serialization_service.rb
@@ -1,7 +1,7 @@
 module Api
   module Search
     class ErrorSerializationService
-      DEFAULT_ERROR_STATUS_CODE = 422 # Unprocessable_entity
+      DEFAULT_ERROR_STATUS_CODE = 422 # Unprocessable_content
 
       def initialize(records)
         @records = Array.wrap(records)

--- a/app/services/api/v2/active_model_error_serialization_service.rb
+++ b/app/services/api/v2/active_model_error_serialization_service.rb
@@ -1,7 +1,7 @@
 module Api
   module V2
     class ActiveModelErrorSerializationService
-      DEFAULT_ERROR_STATUS_CODE = 422 # Unprocessable_entity
+      DEFAULT_ERROR_STATUS_CODE = 422 # Unprocessable_content
       STATUS_CODES_FOR_ERRORS = {
         'is already taken' => 409, # Conflict
       }.freeze

--- a/config/routes/errors.rb
+++ b/config/routes/errors.rb
@@ -2,7 +2,7 @@ match '/400', to: 'errors#bad_request', via: :all
 match '/404', to: 'errors#not_found', via: :all
 match '/405', to: 'errors#method_not_allowed', via: :all
 match '/406', to: 'errors#not_acceptable', via: :all
-match '/422', to: 'errors#unprocessable_entity', via: :all
+match '/422', to: 'errors#unprocessable_content', via: :all
 match '/500', to: 'errors#internal_server_error', via: :all
 match '/501', to: 'errors#not_implemented', via: :all
 match '/503', to: 'errors#maintenance', via: :all

--- a/spec/requests/api/v2/notifications_spec.rb
+++ b/spec/requests/api/v2/notifications_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Api::V2::NotificationsController, :v2 do
         }
       end
 
-      it 'returns a 422 Unprocessable Entity response with validation errors' do
+      it 'returns a 422 Unprocessable Content response with validation errors' do
         do_request
         expect(response).to have_http_status(:unprocessable_content)
         expect(JSON.parse(response.body)).to eq(expected_errors)

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ApplicationController, type: :request do
         {
           "errors": [
             {
-              "detail": '422 - Unprocessable entity: API documentation is available at https://api.trade-tariff.service.gov.uk/',
+              "detail": '422 - Unprocessable content: API documentation is available at https://api.trade-tariff.service.gov.uk/',
             },
           ],
         }.to_json

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -51,10 +51,10 @@ RSpec.describe ErrorsController do
     it_behaves_like 'a csv or json error response', 404, 'Not Found'
   end
 
-  describe 'GET #unprocessable_entity' do
+  describe 'GET #unprocessable_content' do
     it_behaves_like 'a csv or json error response',
                     422,
-                    'Unprocessable entity: API documentation is available at https://api.trade-tariff.service.gov.uk/'
+                    'Unprocessable content: API documentation is available at https://api.trade-tariff.service.gov.uk/'
   end
 
   describe 'GET #internal_server_error' do


### PR DESCRIPTION
### Jira link

[OTTIMP-501](https://transformuk.atlassian.net/browse/OTTIMP-501)

### What?

Rake has removed the unprocessable_entity symbol to represent 422 status. The correct unprocessable_content symbol is already in use, but the related methods and descriptions have now been updated to use the current term.

### Why?

I am doing this to be consistent across apps.
