### PR TITLE
AI-554: Add description intercept search capabilities

### DIFF
--- a/app/controllers/api/admin/description_intercepts_controller.rb
+++ b/app/controllers/api/admin/description_intercepts_controller.rb
@@ -115,8 +115,8 @@ module Api
           result[:guidance_level] = permitted[:guidance_level] if permitted.key?(:guidance_level)
           result[:guidance_location] = permitted[:guidance_location] if permitted.key?(:guidance_location)
           result[:escalate_to_webchat] = permitted[:escalate_to_webchat] if permitted.key?(:escalate_to_webchat)
-          result[:sources] = Sequel.pg_array(Array(permitted[:sources]), :text) if permitted.key?(:sources)
-          result[:filter_prefixes] = Sequel.pg_array(Array(permitted[:filter_prefixes]), :text) if permitted.key?(:filter_prefixes)
+          result[:sources] = Sequel.pg_array(Array(permitted[:sources]).compact_blank, :text) if permitted.key?(:sources)
+          result[:filter_prefixes] = Sequel.pg_array(Array(permitted[:filter_prefixes]).compact_blank, :text) if permitted.key?(:filter_prefixes)
         end
       end
     end

--- a/app/lib/search/instrumentation.rb
+++ b/app/lib/search/instrumentation.rb
@@ -87,7 +87,7 @@ module Search
       instrument('answer_returned', request_id:, answer_count:, confidence_levels:, attempt_number:)
     end
 
-    def search_completed(request_id:, search_type:, total_duration_ms:, result_count:, query: nil, total_attempts: nil, total_questions: nil, final_result_type: nil, results_type: nil, max_score: nil, error_message: nil)
+    def search_completed(request_id:, search_type:, total_duration_ms:, result_count:, query: nil, total_attempts: nil, total_questions: nil, final_result_type: nil, results_type: nil, max_score: nil, error_message: nil, description_intercept: nil)
       payload = {
         request_id:,
         query:,
@@ -100,8 +100,16 @@ module Search
       }
       payload[:results_type] = results_type if results_type
       payload[:max_score] = max_score if max_score
+      payload.merge!(description_intercept_payload(description_intercept, prefix: :description_intercept))
       payload.merge!(truncate_error_payload(error_message))
       instrument('search_completed', payload)
+    end
+
+    def description_intercept_checked(request_id:, query:, description_intercept:)
+      instrument(
+        'description_intercept_checked',
+        { request_id:, query: }.merge(description_intercept_payload(description_intercept)),
+      )
     end
 
     def retrieval_leg_completed(request_id:, leg:, duration_ms:, result_count:, status:, error_message: nil)
@@ -130,6 +138,27 @@ module Search
           search_type:,
         }.merge(truncate_error_payload(error_message)),
       )
+    end
+
+    def description_intercept_payload(description_intercept, prefix: nil)
+      payload = if description_intercept
+                  {
+                    matched: true,
+                    term: description_intercept.term,
+                    excluded: description_intercept.excluded,
+                    filtering: description_intercept.filtering?,
+                    filter_prefix_count: description_intercept.filter_prefixes_array.size,
+                    guidance_level: description_intercept.guidance_level,
+                    guidance_location: description_intercept.guidance_location,
+                    escalate_to_webchat: description_intercept.escalate_to_webchat,
+                  }
+                else
+                  { matched: false }
+                end
+
+      return payload unless prefix
+
+      payload.transform_keys { |key| [prefix, key].join('_').to_sym }
     end
 
     def determine_response_type(result)

--- a/app/lib/search/logger.rb
+++ b/app/lib/search/logger.rb
@@ -54,6 +54,14 @@ module Search
       )
     end
 
+    def description_intercept_checked(event)
+      info log_entry(description_intercept_fields(event).merge(
+                       event: 'description_intercept_checked',
+                       request_id: event.payload[:request_id],
+                       query: event.payload[:query],
+                     ))
+    end
+
     def search_completed(event)
       data = {
         event: 'search_completed',
@@ -68,6 +76,7 @@ module Search
       }
       data[:results_type] = event.payload[:results_type] if event.payload[:results_type]
       data[:max_score] = event.payload[:max_score] if event.payload[:max_score]
+      add_description_intercept_fields!(data, event)
       add_error_fields!(data, event)
       info log_entry(data)
     end
@@ -112,6 +121,21 @@ module Search
         service: 'search',
         timestamp: Time.current.iso8601,
       ).to_json
+    end
+
+    def add_description_intercept_fields!(data, event)
+      description_intercept_fields(event, prefix: :description_intercept).each do |key, value|
+        data[key] = value
+      end
+    end
+
+    def description_intercept_fields(event, prefix: nil)
+      keys = %i[matched term excluded filtering filter_prefix_count guidance_level guidance_location escalate_to_webchat]
+
+      keys.each_with_object({}) do |key, fields|
+        payload_key = prefix ? [prefix, key].join('_').to_sym : key
+        fields[payload_key] = event.payload[payload_key] if event.payload.key?(payload_key)
+      end
     end
 
     def add_error_fields!(data, event)

--- a/app/models/description_intercept.rb
+++ b/app/models/description_intercept.rb
@@ -49,6 +49,33 @@ class DescriptionIntercept < Sequel::Model
     end
   end
 
+  def self.for_search(query, source:)
+    return nil if query.blank?
+
+    for_source(source).where(Sequel.ilike(:term, query)).first
+  end
+
+  def filter_prefixes_array
+    Array(filter_prefixes).compact_blank
+  end
+
+  def filtering?
+    filter_prefixes_array.present?
+  end
+
+  def search_metadata
+    {
+      term: term,
+      excluded: excluded,
+      filtering: filtering?,
+      filter_prefixes: filter_prefixes_array,
+      message: message,
+      guidance_level: guidance_level,
+      guidance_location: guidance_location,
+      escalate_to_webchat: escalate_to_webchat,
+    }
+  end
+
   def validate
     super
     validates_presence :term

--- a/app/queries/search/goods_nomenclature_query.rb
+++ b/app/queries/search/goods_nomenclature_query.rb
@@ -3,7 +3,7 @@ module Search
     NOISE_TAGS = %w[cc dt det in to prp prp$ md ex pdt wp wp$ wdt wrb].freeze
 
     attr_reader :query_string, :date, :expanded_query, :pos_search, :size,
-                :noun_boost, :qualifier_boost
+                :noun_boost, :qualifier_boost, :filter_prefixes
 
     class << self
       def tagger
@@ -11,7 +11,7 @@ module Search
       end
     end
 
-    def initialize(query_string, date, size:, noun_boost:, qualifier_boost:, expanded_query: nil, pos_search: true)
+    def initialize(query_string, date, size:, noun_boost:, qualifier_boost:, expanded_query: nil, pos_search: true, filter_prefixes: [])
       @query_string = query_string
       @date = date
       @expanded_query = expanded_query
@@ -19,6 +19,7 @@ module Search
       @size = size
       @noun_boost = noun_boost
       @qualifier_boost = qualifier_boost
+      @filter_prefixes = Array(filter_prefixes).compact_blank
     end
 
     def query
@@ -33,7 +34,8 @@ module Search
                 declarable_filter,
                 multi_match_clause,
                 validity_date_filter,
-              ],
+                filter_prefixes_clause,
+              ].compact,
             },
           },
           size: size,
@@ -196,6 +198,19 @@ module Search
               },
             },
           ],
+        },
+      }
+    end
+
+    def filter_prefixes_clause
+      return nil if filter_prefixes.empty?
+
+      {
+        bool: {
+          should: filter_prefixes.map do |prefix|
+            { prefix: { goods_nomenclature_item_id: prefix } }
+          end,
+          minimum_should_match: 1,
         },
       }
     end

--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -5,7 +5,7 @@ module Api
 
       RetrievalResult = Struct.new(:goods_nomenclatures, :max_score, :expanded_query, :results_type, keyword_init: true)
 
-      attr_reader :q, :as_of, :answers, :request_id
+      attr_reader :q, :as_of, :answers, :request_id, :description_intercept
 
       def initialize(params = {})
         sanitiser_result = InputSanitiser.new(params[:q]).call
@@ -25,21 +25,27 @@ module Api
       def call
         return @sanitiser_errors if @sanitiser_errors
 
-        if q.blank? || ::SearchService::RogueSearchService.call(q)
-          return { data: [] }
-        end
+        return { data: [] } if q.blank?
+
+        @description_intercept = DescriptionIntercept.for_search(q, source: 'guided_search')
+        ::Search::Instrumentation.description_intercept_checked(
+          request_id:,
+          query: q,
+          description_intercept:,
+        )
+        return empty_response if description_intercept&.excluded
 
         ::Search::Instrumentation.search(request_id:, query: q, search_type: 'interactive') do
           exact = find_exact_match
           if exact
-            next [GoodsNomenclatureSearchSerializer.serialize([exact]),
-                  { result_count: 1, results_type: 'exact_match' }]
+            next [with_description_intercept_meta(GoodsNomenclatureSearchSerializer.serialize([exact])),
+                  completion_payload(result_count: 1, results_type: 'exact_match')]
           end
 
           retrieval = retrieve_short_list
 
           if retrieval.goods_nomenclatures.empty?
-            next [{ data: [] }, { result_count: 0, results_type: retrieval.results_type }]
+            next [empty_response, completion_payload(result_count: 0, results_type: retrieval.results_type)]
           end
 
           interactive_result = run_interactive_search(
@@ -52,7 +58,7 @@ module Api
             interactive_result,
             retrieval.expanded_query,
           )
-          completion = {
+          completion = completion_payload(
             result_count: response[:data]&.size || 0,
             total_attempts: interactive_result&.attempt,
             total_questions: answers.size,
@@ -60,13 +66,19 @@ module Api
             results_type: retrieval.results_type,
             max_score: retrieval.max_score,
             error_message: interactive_result&.type == :error ? interactive_result.data[:message] : nil,
-          }
+          )
 
           [response, completion]
         end
       end
 
       private
+
+      def completion_payload(**payload)
+        return payload unless description_intercept
+
+        payload.merge(description_intercept:)
+      end
 
       def retrieve_short_list
         case retrieval_method
@@ -84,6 +96,7 @@ module Api
         goods_nomenclatures = VectorRetrievalService.call(
           query: q,
           limit: opensearch_result_limit,
+          filter_prefixes: filter_prefixes,
         )
 
         RetrievalResult.new(
@@ -96,6 +109,7 @@ module Api
       def opensearch_short_list
         result = OpensearchRetrievalService.call(
           query: q, as_of: as_of, request_id: request_id, limit: opensearch_result_limit,
+          filter_prefixes: filter_prefixes
         )
 
         RetrievalResult.new(
@@ -109,6 +123,7 @@ module Api
       def hybrid_short_list
         result = HybridRetrievalService.call(
           query: q, as_of: as_of, request_id: request_id, limit: opensearch_result_limit,
+          filter_prefixes: filter_prefixes
         )
 
         RetrievalResult.new(
@@ -134,6 +149,7 @@ module Api
 
         return nil unless gn
         return nil if hidden?(gn)
+        return nil unless allowed_by_description_intercept_filter?(gn)
 
         build_exact_result(gn)
       end
@@ -274,6 +290,7 @@ module Api
 
       def build_meta(interactive_result, expanded_query)
         meta = {}
+        meta[:description_intercept] = description_intercept.search_metadata if description_intercept
 
         if interactive_result
           interactive_meta = {
@@ -297,6 +314,26 @@ module Api
         end
 
         meta.presence
+      end
+
+      def empty_response
+        with_description_intercept_meta({ data: [] })
+      end
+
+      def with_description_intercept_meta(response)
+        return response unless description_intercept
+
+        response.merge(meta: (response[:meta] || {}).merge(description_intercept: description_intercept.search_metadata))
+      end
+
+      def filter_prefixes
+        description_intercept&.filter_prefixes_array || []
+      end
+
+      def allowed_by_description_intercept_filter?(goods_nomenclature)
+        return true if filter_prefixes.empty?
+
+        filter_prefixes.any? { |prefix| goods_nomenclature.goods_nomenclature_item_id.to_s.start_with?(prefix) }
       end
 
       def normalize_answers(answers_param)

--- a/app/services/hybrid_retrieval_service.rb
+++ b/app/services/hybrid_retrieval_service.rb
@@ -1,15 +1,16 @@
 class HybridRetrievalService
   Result = Struct.new(:results, :expanded_query, keyword_init: true)
 
-  def self.call(query:, as_of:, request_id: nil, limit: 30)
-    new(query:, as_of:, request_id:, limit:).call
+  def self.call(query:, as_of:, request_id: nil, limit: 30, filter_prefixes: [])
+    new(query:, as_of:, request_id:, limit:, filter_prefixes:).call
   end
 
-  def initialize(query:, as_of:, request_id: nil, limit: 30)
+  def initialize(query:, as_of:, request_id: nil, limit: 30, filter_prefixes: [])
     @query = query
     @as_of = as_of
     @request_id = request_id
     @limit = limit
+    @filter_prefixes = Array(filter_prefixes).compact_blank
   end
 
   def call
@@ -39,11 +40,9 @@ class HybridRetrievalService
     result = TimeMachine.at(@as_of) do
       case leg
       when :opensearch
-        OpensearchRetrievalService.call(
-          query: @query, as_of: @as_of, request_id: @request_id, limit: @limit,
-        )
+        OpensearchRetrievalService.call(**opensearch_args)
       when :vector
-        VectorRetrievalService.call(query: @query, limit: @limit)
+        VectorRetrievalService.call(**vector_args)
       end
     end
 
@@ -65,6 +64,18 @@ class HybridRetrievalService
 
     Rails.logger.error("HybridRetrievalService #{leg} leg failed: #{e.message}")
     nil
+  end
+
+  def opensearch_args
+    args = { query: @query, as_of: @as_of, request_id: @request_id, limit: @limit }
+    args[:filter_prefixes] = @filter_prefixes if @filter_prefixes.present?
+    args
+  end
+
+  def vector_args
+    args = { query: @query, limit: @limit }
+    args[:filter_prefixes] = @filter_prefixes if @filter_prefixes.present?
+    args
   end
 
   def rrf_merge(opensearch_items, vector_items)

--- a/app/services/opensearch_retrieval_service.rb
+++ b/app/services/opensearch_retrieval_service.rb
@@ -1,15 +1,16 @@
 class OpensearchRetrievalService
   Result = Struct.new(:results, :expanded_query, keyword_init: true)
 
-  def self.call(query:, as_of:, request_id: nil, limit: 30)
-    new(query:, as_of:, request_id:, limit:).call
+  def self.call(query:, as_of:, request_id: nil, limit: 30, filter_prefixes: [])
+    new(query:, as_of:, request_id:, limit:, filter_prefixes:).call
   end
 
-  def initialize(query:, as_of:, request_id: nil, limit: 30)
+  def initialize(query:, as_of:, request_id: nil, limit: 30, filter_prefixes: [])
     @query = query
     @as_of = as_of
     @request_id = request_id
     @limit = limit
+    @filter_prefixes = Array(filter_prefixes).compact_blank
   end
 
   def call
@@ -31,6 +32,7 @@ class OpensearchRetrievalService
           size: @limit,
           noun_boost: pos_noun_boost,
           qualifier_boost: pos_qualifier_boost,
+          filter_prefixes: @filter_prefixes,
         ).query,
       )
     end

--- a/app/services/vector_retrieval_service.rb
+++ b/app/services/vector_retrieval_service.rb
@@ -1,11 +1,12 @@
 class VectorRetrievalService
-  def self.call(query:, limit: 80)
-    new(query:, limit:).call
+  def self.call(query:, limit: 80, filter_prefixes: [])
+    new(query:, limit:, filter_prefixes:).call
   end
 
-  def initialize(query:, limit: 80)
+  def initialize(query:, limit: 80, filter_prefixes: [])
     @query = query
     @limit = limit
+    @filter_prefixes = Array(filter_prefixes).compact_blank
   end
 
   def call
@@ -45,6 +46,7 @@ class VectorRetrievalService
 
       GoodsNomenclatureSelfText
         .vector_search(vector_literal, limit: @limit)
+        .then { |dataset| apply_filter_prefixes(dataset, Sequel[:goods_nomenclature][:goods_nomenclature_item_id]) }
         .all
     end
   end
@@ -54,9 +56,16 @@ class VectorRetrievalService
       .actual
       .with_leaf_column
       .where(goods_nomenclatures__goods_nomenclature_sid: sids)
+      .then { |dataset| apply_filter_prefixes(dataset, Sequel[:goods_nomenclatures][:goods_nomenclature_item_id]) }
       .eager(:goods_nomenclature_descriptions, :goods_nomenclature_self_text, :heading)
       .all
       .index_by(&:goods_nomenclature_sid)
+  end
+
+  def apply_filter_prefixes(dataset, column)
+    return dataset if @filter_prefixes.empty?
+
+    dataset.where(Sequel.|(*@filter_prefixes.map { |prefix| Sequel.like(column, "#{prefix}%") }))
   end
 
   def build_result(goods_nomenclature, score)

--- a/spec/controllers/api/admin/description_intercepts_controller_spec.rb
+++ b/spec/controllers/api/admin/description_intercepts_controller_spec.rb
@@ -247,6 +247,30 @@ RSpec.describe Api::Admin::DescriptionInterceptsController do
       expect(intercept.sources).to eq(%w[guided_search fpo_search])
     end
 
+    it 'clears array fields when blank values are submitted' do
+      intercept.update(
+        filter_prefixes: Sequel.pg_array(%w[6403 6404], :text),
+        sources: Sequel.pg_array(%w[guided_search fpo_search], :text),
+      )
+
+      put :update, params: {
+        id: intercept.id,
+        data: {
+          type: 'description_intercept',
+          attributes: {
+            filter_prefixes: [''],
+            sources: [''],
+          },
+        },
+      }, format: :json
+
+      expect(response).to have_http_status(:ok)
+
+      intercept.reload
+      expect(intercept.filter_prefixes).to eq([])
+      expect(intercept.sources).to eq([])
+    end
+
     it 'returns validation errors for invalid combinations' do
       put :update, params: {
         id: intercept.id,

--- a/spec/lib/search/instrumentation_spec.rb
+++ b/spec/lib/search/instrumentation_spec.rb
@@ -203,9 +203,71 @@ RSpec.describe Search::Instrumentation do
     end
   end
 
+  describe '.description_intercept_checked' do
+    it 'instruments an unmatched description intercept check' do
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+
+      described_class.description_intercept_checked(
+        request_id: 'req-1',
+        query: 'horses',
+        description_intercept: nil,
+      )
+
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'description_intercept_checked.search',
+        request_id: 'req-1',
+        query: 'horses',
+        matched: false,
+      )
+    end
+
+    it 'instruments a matched description intercept check with low-cardinality fields' do
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+      intercept = double(
+        term: 'gift',
+        excluded: true,
+        filtering?: true,
+        filter_prefixes_array: %w[9503 9504],
+        guidance_level: 'warning',
+        guidance_location: 'interstitial',
+        escalate_to_webchat: true,
+      )
+
+      described_class.description_intercept_checked(
+        request_id: 'req-1',
+        query: 'gift',
+        description_intercept: intercept,
+      )
+
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'description_intercept_checked.search',
+        request_id: 'req-1',
+        query: 'gift',
+        matched: true,
+        term: 'gift',
+        excluded: true,
+        filtering: true,
+        filter_prefix_count: 2,
+        guidance_level: 'warning',
+        guidance_location: 'interstitial',
+        escalate_to_webchat: true,
+      )
+    end
+  end
+
   describe '.search_completed' do
     it 'instruments the search_completed event' do
       allow(ActiveSupport::Notifications).to receive(:instrument)
+
+      intercept = double(
+        term: 'gift',
+        excluded: false,
+        filtering?: true,
+        filter_prefixes_array: %w[9503 9504],
+        guidance_level: 'info',
+        guidance_location: 'results',
+        escalate_to_webchat: false,
+      )
 
       described_class.search_completed(
         request_id: 'req-1',
@@ -216,6 +278,7 @@ RSpec.describe Search::Instrumentation do
         final_result_type: 'answers',
         total_duration_ms: 1500.0,
         result_count: 3,
+        description_intercept: intercept,
       )
 
       expect(ActiveSupport::Notifications).to have_received(:instrument).with(
@@ -228,6 +291,14 @@ RSpec.describe Search::Instrumentation do
         final_result_type: 'answers',
         total_duration_ms: 1500.0,
         result_count: 3,
+        description_intercept_matched: true,
+        description_intercept_term: 'gift',
+        description_intercept_excluded: false,
+        description_intercept_filtering: true,
+        description_intercept_filter_prefix_count: 2,
+        description_intercept_guidance_level: 'info',
+        description_intercept_guidance_location: 'results',
+        description_intercept_escalate_to_webchat: false,
       )
     end
 

--- a/spec/lib/search/logger_spec.rb
+++ b/spec/lib/search/logger_spec.rb
@@ -148,6 +148,43 @@ RSpec.describe Search::Logger do
     end
   end
 
+  describe '#description_intercept_checked' do
+    let(:payload) do
+      {
+        request_id: 'req-1',
+        query: 'gift',
+        matched: true,
+        term: 'gift',
+        excluded: true,
+        filtering: false,
+        filter_prefix_count: 0,
+        guidance_level: 'warning',
+        guidance_location: 'interstitial',
+        escalate_to_webchat: true,
+      }
+    end
+
+    it_behaves_like 'a search log entry', :description_intercept_checked, 'description_intercept_checked',
+                    { request_id: 'req-1', query: 'gift', matched: true }
+
+    it 'logs correct fields' do
+      logger_instance.description_intercept_checked(build_event('description_intercept_checked', payload))
+      json = parsed_log_output
+
+      expect(json['event']).to eq('description_intercept_checked')
+      expect(json['request_id']).to eq('req-1')
+      expect(json['query']).to eq('gift')
+      expect(json['matched']).to be(true)
+      expect(json['term']).to eq('gift')
+      expect(json['excluded']).to be(true)
+      expect(json['filtering']).to be(false)
+      expect(json['filter_prefix_count']).to eq(0)
+      expect(json['guidance_level']).to eq('warning')
+      expect(json['guidance_location']).to eq('interstitial')
+      expect(json['escalate_to_webchat']).to be(true)
+    end
+  end
+
   describe '#search_completed' do
     let(:payload) do
       { request_id: 'req-1',
@@ -179,6 +216,30 @@ RSpec.describe Search::Logger do
       expect(json['total_duration_ms']).to eq(3000.0)
       expect(json['result_count']).to eq(5)
       expect(json['total_attempts']).to eq(2)
+    end
+
+    it 'logs description intercept fields when present' do
+      payload.merge!(
+        description_intercept_matched: true,
+        description_intercept_term: 'gift',
+        description_intercept_excluded: false,
+        description_intercept_filtering: true,
+        description_intercept_filter_prefix_count: 2,
+        description_intercept_guidance_level: 'info',
+        description_intercept_guidance_location: 'results',
+        description_intercept_escalate_to_webchat: false,
+      )
+
+      logger_instance.search_completed(build_event('search_completed', payload))
+      json = parsed_log_output
+
+      expect(json['description_intercept_matched']).to be(true)
+      expect(json['description_intercept_term']).to eq('gift')
+      expect(json['description_intercept_filtering']).to be(true)
+      expect(json['description_intercept_filter_prefix_count']).to eq(2)
+      expect(json['description_intercept_guidance_level']).to eq('info')
+      expect(json['description_intercept_guidance_location']).to eq('results')
+      expect(json['description_intercept_escalate_to_webchat']).to be(false)
     end
 
     it 'logs error details when present' do

--- a/spec/requests/api/internal/search_controller_spec.rb
+++ b/spec/requests/api/internal/search_controller_spec.rb
@@ -168,13 +168,37 @@ RSpec.describe Api::Internal::SearchController, :internal do
       end
     end
 
-    context 'when rogue query' do
-      let(:pattern) do
-        { 'data' => [] }
+    context 'when description intercept matches' do
+      before do
+        create(:description_intercept,
+               term: 'gift',
+               excluded: true,
+               message: 'Gift is too vague.',
+               guidance_level: 'warning',
+               guidance_location: 'interstitial',
+               escalate_to_webchat: true)
       end
 
-      it 'returns an empty data array' do
-        post api_search_path(format: :json), params: { q: 'gif' }
+      let(:pattern) do
+        {
+          'data' => [],
+          'meta' => {
+            'description_intercept' => {
+              'term' => 'gift',
+              'excluded' => true,
+              'filtering' => false,
+              'filter_prefixes' => [],
+              'message' => 'Gift is too vague.',
+              'guidance_level' => 'warning',
+              'guidance_location' => 'interstitial',
+              'escalate_to_webchat' => true,
+            },
+          },
+        }
+      end
+
+      it 'returns intercept metadata' do
+        post api_search_path(format: :json), params: { q: 'gift' }
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to match_json_expression(pattern)

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Api::Internal::SearchService do
     allow(InteractiveSearchService).to receive(:call).and_return(nil)
     allow(Search::Instrumentation).to receive(:search) { |**_kwargs, &block| block.call&.first }
     allow(Search::Instrumentation).to receive(:query_expanded).and_yield
+    allow(Search::Instrumentation).to receive(:description_intercept_checked)
   end
 
   describe '#call' do
@@ -21,13 +22,6 @@ RSpec.describe Api::Internal::SearchService do
     context 'when nil query' do
       it 'returns empty data' do
         result = described_class.new(q: nil).call
-        expect(result).to eq(data: [])
-      end
-    end
-
-    context 'when rogue query' do
-      it 'returns empty data' do
-        result = described_class.new(q: 'gif').call
         expect(result).to eq(data: [])
       end
     end
@@ -254,6 +248,176 @@ RSpec.describe Api::Internal::SearchService do
 
         expect(TradeTariffBackend.search_client).to have_received(:search).with(
           hash_including(index: Search::GoodsNomenclatureIndex.new.name),
+        )
+      end
+
+      it 'instruments the lack of a description intercept match' do
+        described_class.new(q: 'animals', as_of: Time.zone.today.iso8601, request_id: 'req-1').call
+
+        expect(Search::Instrumentation).to have_received(:description_intercept_checked).with(
+          request_id: 'req-1',
+          query: 'animals',
+          description_intercept: nil,
+        )
+      end
+    end
+
+    context 'when description intercept excludes the query' do
+      before do
+        create(:description_intercept,
+               term: 'gift',
+               excluded: true,
+               message: 'Gift is too vague.',
+               guidance_level: 'warning',
+               guidance_location: 'interstitial',
+               escalate_to_webchat: true)
+        allow(TradeTariffBackend.search_client).to receive(:search)
+      end
+
+      it 'returns no results with intercept meta without querying retrieval' do
+        result = described_class.new(q: 'gift', request_id: 'req-1').call
+
+        expect(result).to include(data: [])
+        expect(result[:meta][:description_intercept]).to include(
+          term: 'gift',
+          excluded: true,
+          filtering: false,
+          filter_prefixes: [],
+          message: 'Gift is too vague.',
+          guidance_level: 'warning',
+          guidance_location: 'interstitial',
+          escalate_to_webchat: true,
+        )
+        expect(TradeTariffBackend.search_client).not_to have_received(:search)
+        expect(Search::Instrumentation).to have_received(:description_intercept_checked).with(
+          request_id: 'req-1',
+          query: 'gift',
+          description_intercept: an_instance_of(DescriptionIntercept),
+        )
+      end
+    end
+
+    context 'when description intercept provides guidance' do
+      let(:opensearch_response) do
+        {
+          'hits' => {
+            'hits' => [
+              {
+                '_score' => 12.5,
+                '_source' => {
+                  'goods_nomenclature_sid' => 1,
+                  'goods_nomenclature_item_id' => '0100000000',
+                  'producline_suffix' => '80',
+                  'goods_nomenclature_class' => 'Chapter',
+                  'description' => 'live animals',
+                  'formatted_description' => 'Live animals',
+                  'declarable' => false,
+                },
+              },
+            ],
+          },
+        }
+      end
+
+      before do
+        create(:description_intercept,
+               term: 'animals',
+               message: 'Use a more specific animal term.',
+               guidance_level: 'info',
+               guidance_location: 'results',
+               escalate_to_webchat: true)
+        allow(TradeTariffBackend.search_client).to receive(:search).and_return(opensearch_response)
+      end
+
+      it 'keeps results and adds intercept meta' do
+        result = described_class.new(q: 'animals').call
+
+        expect(result[:data].length).to eq(1)
+        expect(result[:meta][:description_intercept]).to include(
+          term: 'animals',
+          excluded: false,
+          filtering: false,
+          message: 'Use a more specific animal term.',
+          guidance_level: 'info',
+          guidance_location: 'results',
+          escalate_to_webchat: true,
+        )
+      end
+
+      it 'adds description intercept fields to search completion instrumentation' do
+        completion_payload = nil
+        allow(Search::Instrumentation).to receive(:search) do |**_kwargs, &block|
+          result, completion_payload = block.call
+          result
+        end
+
+        described_class.new(q: 'animals').call
+
+        expect(completion_payload[:description_intercept]).to have_attributes(
+          term: 'animals',
+          excluded: false,
+          filtering?: false,
+          filter_prefixes_array: [],
+          guidance_level: 'info',
+          guidance_location: 'results',
+          escalate_to_webchat: true,
+        )
+      end
+    end
+
+    context 'when description intercept filters the query' do
+      before do
+        create(:description_intercept,
+               term: 'toy',
+               message: nil,
+               guidance_level: nil,
+               guidance_location: nil,
+               filter_prefixes: Sequel.pg_array(%w[9503 9504], :text))
+        allow(OpensearchRetrievalService).to receive(:call).and_return(
+          OpensearchRetrievalService::Result.new(results: [], expanded_query: 'toy'),
+        )
+      end
+
+      it 'passes prefixes to retrieval and adds filtering meta' do
+        result = described_class.new(q: 'toy').call
+
+        expect(OpensearchRetrievalService).to have_received(:call).with(
+          hash_including(filter_prefixes: %w[9503 9504]),
+        )
+        expect(result[:meta][:description_intercept]).to include(
+          term: 'toy',
+          filtering: true,
+          filter_prefixes: %w[9503 9504],
+        )
+      end
+    end
+
+    context 'when filtered description intercept has an exact match outside prefixes' do
+      let!(:chapter) do
+        create(:chapter, :with_description,
+               goods_nomenclature_item_id: '0100000000',
+               description: 'live animals')
+      end
+
+      before do
+        create(:description_intercept,
+               term: 'animals',
+               filter_prefixes: Sequel.pg_array(%w[9503], :text))
+        create(:search_suggestion, :goods_nomenclature,
+               goods_nomenclature: chapter,
+               value: 'animals',
+               declarable: true)
+        allow(OpensearchRetrievalService).to receive(:call).and_return(
+          OpensearchRetrievalService::Result.new(results: [], expanded_query: 'animals'),
+        )
+      end
+
+      it 'does not let the exact match bypass filtering' do
+        result = described_class.new(q: 'animals').call
+
+        expect(result[:data]).to be_empty
+        expect(OpensearchRetrievalService).to have_received(:call).with(
+          hash_including(filter_prefixes: %w[9503]),
         )
       end
     end
@@ -745,6 +909,22 @@ RSpec.describe Api::Internal::SearchService do
         expect(result[:data].length).to eq(1)
         expect(result[:data][0][:attributes][:goods_nomenclature_item_id]).to eq('0101210000')
       end
+
+      context 'with a filtering description intercept' do
+        before do
+          create(:description_intercept,
+                 term: 'horses',
+                 filter_prefixes: Sequel.pg_array(%w[0101], :text))
+        end
+
+        it 'passes prefixes to VectorRetrievalService' do
+          described_class.new(q: 'horses').call
+
+          expect(VectorRetrievalService).to have_received(:call).with(
+            hash_including(filter_prefixes: %w[0101]),
+          )
+        end
+      end
     end
 
     context 'when retrieval_method is hybrid' do
@@ -803,6 +983,22 @@ RSpec.describe Api::Internal::SearchService do
 
         expect(result[:data].length).to eq(1)
         expect(result[:data][0][:attributes][:goods_nomenclature_item_id]).to eq('0101210000')
+      end
+
+      context 'with a filtering description intercept' do
+        before do
+          create(:description_intercept,
+                 term: 'horses',
+                 filter_prefixes: Sequel.pg_array(%w[0101], :text))
+        end
+
+        it 'passes prefixes to HybridRetrievalService' do
+          described_class.new(q: 'horses').call
+
+          expect(HybridRetrievalService).to have_received(:call).with(
+            hash_including(filter_prefixes: %w[0101]),
+          )
+        end
       end
     end
 

--- a/spec/services/hybrid_retrieval_service_spec.rb
+++ b/spec/services/hybrid_retrieval_service_spec.rb
@@ -63,6 +63,19 @@ RSpec.describe HybridRetrievalService do
       expect(VectorRetrievalService).to have_received(:call).with(query: 'horses', limit: 30)
     end
 
+    it 'passes filter prefixes to both retrieval legs' do
+      as_of = Time.zone.today
+
+      described_class.call(query: 'horses', as_of: as_of, filter_prefixes: %w[0101])
+
+      expect(OpensearchRetrievalService).to have_received(:call).with(
+        query: 'horses', as_of: as_of, request_id: nil, limit: 30, filter_prefixes: %w[0101],
+      )
+      expect(VectorRetrievalService).to have_received(:call).with(
+        query: 'horses', limit: 30, filter_prefixes: %w[0101],
+      )
+    end
+
     it 'returns items from both lists ranked by RRF score' do
       result = described_class.call(query: 'horses', as_of: Time.zone.today)
 

--- a/spec/services/opensearch_retrieval_service_spec.rb
+++ b/spec/services/opensearch_retrieval_service_spec.rb
@@ -68,5 +68,33 @@ RSpec.describe OpensearchRetrievalService do
         expect(result.results).to be_empty
       end
     end
+
+    context 'with filter prefixes' do
+      let(:opensearch_response) { { 'hits' => { 'hits' => [] } } }
+
+      it 'adds prefix filters to the query' do
+        described_class.call(query: 'toys', as_of: Time.zone.today, filter_prefixes: %w[9503 9504])
+
+        expect(TradeTariffBackend.search_client).to have_received(:search).with(
+          hash_including(
+            body: hash_including(
+              query: hash_including(
+                bool: hash_including(
+                  must: include(
+                    bool: hash_including(
+                      minimum_should_match: 1,
+                      should: contain_exactly(
+                        { prefix: { goods_nomenclature_item_id: '9503' } },
+                        { prefix: { goods_nomenclature_item_id: '9504' } },
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        )
+      end
+    end
   end
 end

--- a/spec/services/vector_retrieval_service_spec.rb
+++ b/spec/services/vector_retrieval_service_spec.rb
@@ -202,6 +202,29 @@ RSpec.describe VectorRetrievalService do
 
       expect(results.size).to eq(2)
     end
+
+    context 'with filter prefixes' do
+      subject(:service) { described_class.new(query: 'live horses', limit: 10, filter_prefixes: %w[0101]) }
+
+      it 'only returns goods nomenclatures matching the prefixes' do
+        matching = create(:commodity, :with_description, :declarable,
+                          goods_nomenclature_item_id: '0101210000',
+                          producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX)
+        non_matching = create(:commodity, :with_description, :declarable,
+                              goods_nomenclature_item_id: '0201210000',
+                              producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX)
+
+        [matching, non_matching].each do |commodity|
+          create(:goods_nomenclature_self_text,
+                 goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+                 goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+                 self_text: 'Pure-bred breeding horses')
+          populate_search_embedding(commodity.goods_nomenclature_sid, query_embedding)
+        end
+
+        expect(service.call.map(&:goods_nomenclature_item_id)).to eq(%w[0101210000])
+      end
+    end
   end
 
   private

--- a/terraform/modules/search_dashboard/main.tf
+++ b/terraform/modules/search_dashboard/main.tf
@@ -24,9 +24,9 @@ resource "aws_cloudwatch_dashboard" "search" {
           properties = {
             markdown = join("\n", [
               "## Trade Tariff Search",
-              "Monitors keyword, interactive AI, and reference searches. Follows the RED method (Rate, Errors, Duration).",
-              "**Healthy:** p90 latency < 5s, error rate < 1%, zero-result rate < 10%.",
-              "**Start here:** check latency and error trends in the top row, then drill into search quality and zero-result terms below.",
+              "Monitors keyword, interactive AI, reference searches, and description intercept behaviour. Follows the RED method (Rate, Errors, Duration).",
+              "**Healthy:** p90 latency < 5s, error rate < 1%, zero-result rate < 10%, intercept matches consistent with configured terms.",
+              "**Start here:** check latency and error trends in the top row, then review description intercept matches and zero-result terms below.",
               "**Related:** [Label Generator](${local.label_dashboard_url}) | [Self-Text Generator](${local.self_text_dashboard_url})",
             ])
           }
@@ -308,12 +308,69 @@ resource "aws_cloudwatch_dashboard" "search" {
         },
       ],
 
-      # Row 6 (y=32): Zero-Result Searches
+      # Row 6 (y=32): Description Intercepts
       [
         {
           type   = "log"
           x      = 0
           y      = 32
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Intercept Checks Over Time"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "description_intercept_checked"
+              | stats count(*) as checks by matched, bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 8
+          y      = 32
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Intercept Outcomes"
+            region = var.region
+            view   = "bar"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "description_intercept_checked" and matched = true
+              | stats count(*) as matches by excluded, filtering, guidance_level, guidance_location, escalate_to_webchat
+              | sort matches desc
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 16
+          y      = 32
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Top Matched Intercept Terms"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "description_intercept_checked" and matched = true
+              | stats count(*) as matches by term, excluded, filtering, guidance_level, guidance_location, escalate_to_webchat
+              | sort matches desc
+              | limit 30
+            EOT
+          }
+        },
+      ],
+
+      # Row 7 (y=38): Zero-Result Searches
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 38
           width  = 8
           height = 6
           properties = {
@@ -330,7 +387,7 @@ resource "aws_cloudwatch_dashboard" "search" {
         {
           type   = "log"
           x      = 8
-          y      = 32
+          y      = 38
           width  = 8
           height = 6
           properties = {
@@ -348,7 +405,7 @@ resource "aws_cloudwatch_dashboard" "search" {
         {
           type   = "log"
           x      = 16
-          y      = 32
+          y      = 38
           width  = 8
           height = 6
           properties = {
@@ -365,12 +422,12 @@ resource "aws_cloudwatch_dashboard" "search" {
         },
       ],
 
-      # Row 7 (y=38): Interactive Search - The AI Story
+      # Row 8 (y=44): Interactive Search - The AI Story
       [
         {
           type   = "log"
           x      = 0
-          y      = 38
+          y      = 44
           width  = 12
           height = 6
           properties = {
@@ -387,7 +444,7 @@ resource "aws_cloudwatch_dashboard" "search" {
         {
           type   = "log"
           x      = 12
-          y      = 38
+          y      = 44
           width  = 6
           height = 6
           properties = {
@@ -404,7 +461,7 @@ resource "aws_cloudwatch_dashboard" "search" {
         {
           type   = "log"
           x      = 18
-          y      = 38
+          y      = 44
           width  = 6
           height = 6
           properties = {
@@ -420,12 +477,12 @@ resource "aws_cloudwatch_dashboard" "search" {
         },
       ],
 
-      # Row 8 (y=44): User Journey - Result Selection
+      # Row 9 (y=50): User Journey - Result Selection
       [
         {
           type   = "log"
           x      = 0
-          y      = 44
+          y      = 50
           width  = 8
           height = 6
           properties = {
@@ -442,7 +499,7 @@ resource "aws_cloudwatch_dashboard" "search" {
         {
           type   = "log"
           x      = 8
-          y      = 44
+          y      = 50
           width  = 8
           height = 6
           properties = {
@@ -459,7 +516,7 @@ resource "aws_cloudwatch_dashboard" "search" {
         {
           type   = "log"
           x      = 16
-          y      = 44
+          y      = 50
           width  = 8
           height = 6
           properties = {
@@ -476,12 +533,12 @@ resource "aws_cloudwatch_dashboard" "search" {
         },
       ],
 
-      # Row 9 (y=50): Errors and Reliability
+      # Row 10 (y=56): Errors and Reliability
       [
         {
           type   = "log"
           x      = 0
-          y      = 50
+          y      = 56
           width  = 6
           height = 6
           properties = {
@@ -498,7 +555,7 @@ resource "aws_cloudwatch_dashboard" "search" {
         {
           type   = "log"
           x      = 6
-          y      = 50
+          y      = 56
           width  = 6
           height = 6
           properties = {
@@ -515,7 +572,7 @@ resource "aws_cloudwatch_dashboard" "search" {
         {
           type   = "log"
           x      = 12
-          y      = 50
+          y      = 56
           width  = 6
           height = 6
           properties = {
@@ -532,7 +589,7 @@ resource "aws_cloudwatch_dashboard" "search" {
         {
           type   = "log"
           x      = 18
-          y      = 50
+          y      = 56
           width  = 6
           height = 6
           properties = {
@@ -550,12 +607,12 @@ resource "aws_cloudwatch_dashboard" "search" {
         },
       ],
 
-      # Row 10 (y=56): Live Feed
+      # Row 11 (y=62): Live Feed
       [
         {
           type   = "log"
           x      = 0
-          y      = 56
+          y      = 62
           width  = 12
           height = 6
           properties = {
@@ -573,7 +630,7 @@ resource "aws_cloudwatch_dashboard" "search" {
         {
           type   = "log"
           x      = 12
-          y      = 56
+          y      = 62
           width  = 12
           height = 6
           properties = {
@@ -583,6 +640,28 @@ resource "aws_cloudwatch_dashboard" "search" {
               ${local.source}
               | ${local.service_filter} and event = "search_completed"
               | fields @timestamp, search_type, total_duration_ms, result_count, final_result_type, request_id
+              | sort @timestamp desc
+              | limit 30
+            EOT
+          }
+        },
+      ],
+
+      # Row 12 (y=68): Description Intercept Drill-Down
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 68
+          width  = 24
+          height = 6
+          properties = {
+            title  = "Recent Intercept Matches"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "description_intercept_checked" and matched = true
+              | fields @timestamp, query, term, excluded, filtering, filter_prefix_count, guidance_level, guidance_location, escalate_to_webchat, request_id
               | sort @timestamp desc
               | limit 30
             EOT


### PR DESCRIPTION
### Jira link

[AI-554](https://transformuk.atlassian.net/browse/AI-554)

```mermaid
flowchart TB
    A[Internal guided search request] --> B{Description intercept matched?}
    B -->|Excluded| C[Return empty results with intercept metadata]
    B -->|Filtering| D[Apply prefixes to exact match, OpenSearch and vector retrieval]
    B -->|Guidance or escalation| E[Return results with intercept metadata]
    B --> F[Emit intercept match instrumentation]
    F --> G[Search dashboard intercept widgets]
    D --> E
```

### What?

- [x] Match description intercepts during internal guided search.
- [x] Return empty results when an intercept excludes the search.
- [x] Surface guidance, location, level and escalation metadata in search responses.
- [x] Apply filter prefixes across exact match, OpenSearch, vector and hybrid retrieval paths.
- [x] Instrument description intercept matches and misses in search logs.
- [x] Extend the search dashboard with intercept match, outcome, top term and recent match widgets.
- [x] Add request, service, retrieval, instrumentation and logger coverage for excluded, filtering, guidance and escalation behaviour.

### Why?

Description intercepts are now configured by the admin APIs, but guided search still needs to act on them. Search needs to stop excluded terms before retrieval, restrict filtered terms consistently across both retrieval paths, and return enough metadata for the frontend to decide how to render guidance or HMRC support escalation.

The dashboard also needs a reliable denominator for intercept usage. Excluded intercepts short-circuit before normal search completion, so a dedicated intercept check event records both matches and misses before the search path branches.