### PR TITLE
Remove stale memoization from SimplifiedProceduralCode.all_null_measures

### DIFF
--- a/app/models/simplified_procedural_code.rb
+++ b/app/models/simplified_procedural_code.rb
@@ -4,15 +4,13 @@ class SimplifiedProceduralCode < Sequel::Model
 
   class << self
     def all_null_measures
-      @all_null_measures ||= select(
+      select(
         :simplified_procedural_code,
         :goods_nomenclature_label,
         Sequel.lit('ARRAY_AGG(goods_nomenclature_item_id) AS goods_nomenclature_item_ids'),
       )
-                               .group(:simplified_procedural_code, :goods_nomenclature_label)
-                               .map do |record|
-                                 to_null_measure(record)
-      end
+        .group(:simplified_procedural_code, :goods_nomenclature_label)
+        .map { |record| to_null_measure(record) }
     end
 
     def populate

--- a/spec/lib/tasks/paper_trail_rake_spec.rb
+++ b/spec/lib/tasks/paper_trail_rake_spec.rb
@@ -4,9 +4,12 @@ RSpec.describe 'paper_trail:reset_initial_versions' do
 
   let(:service) { instance_spy(PaperTrail::ResetInitialVersions, call: true) }
 
-  after do
+  before do
     Rake::Task['paper_trail:reset_initial_versions'].reenable
     Rake::Task['class_eager_load'].reenable
+  end
+
+  after do
     ENV.delete('CONFIRM')
   end
 


### PR DESCRIPTION
## Summary

- Removes `@all_null_measures ||=` class-level memoization from `SimplifiedProceduralCode.all_null_measures`
- The cached result persisted for the lifetime of the Ruby process, making it stale after `populate` re-seeds the table in production, and causing 3 intermittent test failures in CI

## Why this is a bug

The memoization means:

- **In production**: after `SimplifiedProceduralCode.populate` runs (which truncates and re-inserts all rows), the controller continues serving the old cached result until the process restarts
- **In tests**: database cleaner truncates the table between examples; if any earlier spec triggers `all_null_measures` with an empty table, that empty array is cached and the `simplified_procedural_code_spec.rb` examples all fail

The query itself is a simple `GROUP BY` with `ARRAY_AGG` over a small reference table — hitting the DB fresh on each call is both correct and cheap.
