### PR TITLE
BAU: Fix intermittent paper trail rake spec

### DIFF
--- a/lib/tasks/paper_trail.rake
+++ b/lib/tasks/paper_trail.rake
@@ -1,11 +1,13 @@
 namespace :paper_trail do
   desc 'DANGER: Truncate versions and rebuild create snapshots from the current database state. Set CONFIRM=true.'
-  task reset_initial_versions: :class_eager_load do
+  task reset_initial_versions: :environment do
     unless ENV['CONFIRM'] == 'true'
       puts 'WARNING: This will truncate all versions and rebuild create snapshots from current records.'
       puts 'Set CONFIRM=true to proceed.'
       exit 1
     end
+
+    Rails.application.eager_load!
 
     puts 'Resetting PaperTrail versions...'
     PaperTrail::ResetInitialVersions.new.call

--- a/spec/lib/tasks/paper_trail_rake_spec.rb
+++ b/spec/lib/tasks/paper_trail_rake_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe 'paper_trail:reset_initial_versions' do
     expect { Rake::Task['paper_trail:reset_initial_versions'].invoke }.to raise_error(SystemExit)
   end
 
+  it 'does not eager load classes without confirmation' do
+    allow(Rails.application).to receive(:eager_load!).and_return(true)
+
+    expect { Rake::Task['paper_trail:reset_initial_versions'].invoke }.to raise_error(SystemExit)
+
+    expect(Rails.application).not_to have_received(:eager_load!)
+  end
+
   it 'eager loads classes and runs the reset service when confirmed' do
     allow(Rails.application).to receive(:eager_load!).and_return(true)
     allow(PaperTrail::ResetInitialVersions).to receive(:new).and_return(service)


### PR DESCRIPTION
### Jira link

BAU

### What?

- [x] Stop `paper_trail:reset_initial_versions` using the shared `class_eager_load` prerequisite.
- [x] Eager load classes inside the task after the `CONFIRM=true` guard.
- [x] Add coverage that the dangerous task does not eager load when confirmation is missing.

### Why?

The failing CI run showed `paper_trail:reset_initial_versions eager loads classes and runs the reset service when confirmed` receiving no call to `Rails.application.eager_load!`.

That spec was asserting behaviour through the shared `class_eager_load` rake prerequisite. Rake task invocation state is process-global and several rake specs use the same prerequisite, which makes this order-sensitive in the full suite.

Calling `Rails.application.eager_load!` directly inside the confirmed branch makes the behaviour deterministic and avoids eager loading before the safety confirmation has passed.