### PR TITLE
Fix flaky rake test

### DIFF
--- a/spec/lib/tasks/paper_trail_rake_spec.rb
+++ b/spec/lib/tasks/paper_trail_rake_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe 'paper_trail:reset_initial_versions' do
 
   let(:service) { instance_spy(PaperTrail::ResetInitialVersions, call: true) }
 
+  before do
+    Rake::Task['paper_trail:reset_initial_versions'].reenable
+    Rake::Task['class_eager_load'].reenable
+  end
+
   after do
     Rake::Task['paper_trail:reset_initial_versions'].reenable
     Rake::Task['class_eager_load'].reenable


### PR DESCRIPTION
### What?

The test "eager loads classes and runs the reset service when confirmed" was failing sometimes e.g.
`bundle exec rspec spec/lib/tasks/tariff_sync_tooling_rake_spec.rb spec/lib/tasks/paper_trail_rake_spec.rb --seed 5793`
because a previous test had already set the class_eager_load as done.

The state is now reset before the test.

