### PR TITLE
fix: N+1 on geographical_area_descriptions in PrecacheHeadingsWorker

### DIFF
--- a/app/services/heading_service/serialization/ns_nondeclarable_service.rb
+++ b/app/services/heading_service/serialization/ns_nondeclarable_service.rb
@@ -17,6 +17,7 @@ module HeadingService
       }.freeze
 
       MEASURES_EAGER_LOAD = {
+        geographical_area: :geographical_area_descriptions,
         measure_components: {
           duty_expression: :duty_expression_description,
           measurement_unit: %i[measurement_unit_description

--- a/spec/services/heading_service/serialization/ns_nondeclarable_service_spec.rb
+++ b/spec/services/heading_service/serialization/ns_nondeclarable_service_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe HeadingService::Serialization::NsNondeclarableService do
+  describe 'MEASURES_EAGER_LOAD' do
+    # geographical_area_descriptions must be eagerly loaded alongside geographical_area.
+    # Without it, serialising a measure's geographical area fires one JOIN query per
+    # measure — the source of the N+1 observed after the nightly TARIC sync triggers
+    # PrecacheHeadingsWorker across all headings.
+    it 'includes geographical_area_descriptions nested under geographical_area' do
+      expect(described_class::MEASURES_EAGER_LOAD).to include(
+        geographical_area: :geographical_area_descriptions,
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Problem

After the nightly TARIC sync completes (~3am UTC / 4am BST), the `TARIFF_UPDATES_APPLIED` event triggers `ClearCacheWorker`, which enqueues `PrecacheHeadingsWorker`. That worker serialises every heading via `NsNondeclarableService`.

`MEASURES_EAGER_LOAD` fetches `overview_measures` but does not include `geographical_area_descriptions` nested inside each measure's `geographical_area`. At serialisation time, `GeographicalArea#geographical_area_description` calls `geographical_area_descriptions.first`, which fires a separate JOIN query per measure across every heading in the tariff — the source of the spike of slow `geographical_area_descriptions` queries observed at 4am BST.

## Fix

Add `geographical_area: :geographical_area_descriptions` to `MEASURES_EAGER_LOAD` in `NsNondeclarableService`. This constant is used for `overview_measures` on the heading itself, its ancestors, and its descendants, so a single change covers all three nodes.

