### PR TITLE
fix: add validity date indexes to geographical_area_description_periods

### DIFF
--- a/db/migrate/20260420115159_add_validity_date_indexes_to_geographical_area_description_periods.rb
+++ b/db/migrate/20260420115159_add_validity_date_indexes_to_geographical_area_description_periods.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table :geographical_area_description_periods do
+      add_index :validity_start_date
+      add_index :validity_end_date
+    end
+  end
+
+  down do
+    alter_table :geographical_area_description_periods do
+      drop_index :validity_start_date
+      drop_index :validity_end_date
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -11260,6 +11260,20 @@ CREATE INDEX geographical_area_description_periods_operation_date_index ON uk.ge
 
 
 --
+-- Name: geographical_area_description_periods_validity_end_date_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX geographical_area_description_periods_validity_end_date_index ON uk.geographical_area_description_periods USING btree (validity_end_date);
+
+
+--
+-- Name: geographical_area_description_periods_validity_start_date_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX geographical_area_description_periods_validity_start_date_index ON uk.geographical_area_description_periods USING btree (validity_start_date);
+
+
+--
 -- Name: geographical_area_descriptions_geographical_area_description_pe; Type: INDEX; Schema: uk; Owner: -
 --
 


### PR DESCRIPTION
## Problem

The `with_actual` filter applied to `geographical_area_description_periods` (used by the `geographical_area_descriptions` many-to-many association on `GeographicalArea`) filters on `validity_start_date` and `validity_end_date`. Neither column is indexed, so after the JOIN on the composite PK is resolved, Postgres falls back to a sequential scan of the period rows to apply the validity filter.

This shows up as a spike of slow `geographical_area_descriptions` JOIN queries at ~4am BST, when `PrecacheHeadingsWorker` runs after the nightly TARIC sync completes.

## Fix

Add btree indexes on `validity_start_date` and `validity_end_date` on the `geographical_area_description_periods` materialized view. These mirror the pattern already used on other validity-filtered tables (`base_regulations`, `modification_regulations`, `measures`, etc.).

## Related

PR #3046 fixes the N+1 in `PrecacheHeadingsWorker` that causes the volume of these queries. This PR reduces the cost of each individual query.