### PR TITLE
HMRC-2118: Review and optimise the quota search loading strategy

### DIFF
--- a/app/controllers/api/v2/quotas_controller.rb
+++ b/app/controllers/api/v2/quotas_controller.rb
@@ -53,7 +53,13 @@ module Api
       end
 
       def search_service
-        @search_service ||= QuotaSearchService.new(params, current_page, per_page, actual_date)
+        @search_service ||= QuotaSearchService.new(
+          params,
+          current_page,
+          per_page,
+          actual_date,
+          include_quota_balance_events: include_params.include?('quota_balance_events'),
+        )
       end
 
       def valid_includes

--- a/app/models/quota_definition.rb
+++ b/app/models/quota_definition.rb
@@ -54,6 +54,13 @@ class QuotaDefinition < Sequel::Model
               primary_key: :quota_definition_sid,
               order: Sequel.desc(:occurrence_timestamp)
 
+  one_to_one :latest_quota_balance_event, class_name: 'QuotaBalanceEvent',
+                                          key: :quota_definition_sid,
+                                          primary_key: :quota_definition_sid do |ds|
+    ds = ds.where('occurrence_timestamp <= ?', point_in_time) if point_in_time.present?
+    ds.order(Sequel.desc(:occurrence_timestamp))
+  end
+
   one_to_many :quota_suspension_periods, key: :quota_definition_sid,
                                          primary_key: :quota_definition_sid do |ds|
     ds.with_actual(QuotaSuspensionPeriod)
@@ -137,9 +144,13 @@ class QuotaDefinition < Sequel::Model
   end
 
   def last_balance_event
-    @last_balance_event ||= quota_balance_events.select { |quota_balance_event|
-      point_in_time.blank? || quota_balance_event.occurrence_timestamp <= point_in_time
-    }.max_by(&:occurrence_timestamp)
+    @last_balance_event ||= if associations.key?(:quota_balance_events)
+                              quota_balance_events.select { |quota_balance_event|
+                                point_in_time.blank? || quota_balance_event.occurrence_timestamp <= point_in_time
+                              }.max_by(&:occurrence_timestamp)
+                            else
+                              latest_quota_balance_event
+                            end
   end
 
   def balance

--- a/app/services/quota_search_service.rb
+++ b/app/services/quota_search_service.rb
@@ -8,7 +8,6 @@ class QuotaSearchService
       { measures: [{ geographical_area: :geographical_area_description }] },
       :quota_suspension_periods,
       :quota_blocking_periods,
-      :quota_balance_events,
       {
         quota_order_number: [
           {
@@ -27,9 +26,9 @@ class QuotaSearchService
   }.freeze
 
   attr_reader :scope, :goods_nomenclature_item_id, :geographical_area_id, :order_number,
-              :critical, :years, :status, :current_page, :per_page, :date
+              :critical, :years, :status, :current_page, :per_page, :date, :include_quota_balance_events
 
-  def initialize(attributes, current_page, per_page, date)
+  def initialize(attributes, current_page, per_page, date, include_quota_balance_events: false)
     @attributes = attributes
     status_value = attributes['status']&.gsub(/[+ ]/, '_')
     status_value = '' unless STATUS_VALUES.include?(status_value)
@@ -41,6 +40,7 @@ class QuotaSearchService
     @current_page = current_page
     @per_page = per_page
     @date = date
+    @include_quota_balance_events = include_quota_balance_events
   end
 
   def call
@@ -85,7 +85,10 @@ class QuotaSearchService
   end
 
   def eager_load_graph
-    eager_load = DEFAULT_EAGER_LOAD_GRAPH.dup
+    eager_load = DEFAULT_EAGER_LOAD_GRAPH.deep_dup
+
+    eager_load[:quota_definition] << :latest_quota_balance_event
+    eager_load[:quota_definition] << :quota_balance_events if include_quota_balance_events
 
     eager_load[:quota_definition] << :quota_exhaustion_events if status.exhausted? || status.not_exhausted?
 

--- a/spec/controllers/api/v2/quotas_controller_spec.rb
+++ b/spec/controllers/api/v2/quotas_controller_spec.rb
@@ -193,15 +193,17 @@ RSpec.describe Api::V2::QuotasController, type: :controller do
       end
 
       it 'does not request eager loading full quota balance events' do
-        expect(QuotaSearchService).to receive(:new).with(
+        allow(QuotaSearchService).to receive(:new).and_call_original
+
+        get :search, params:, format: :json
+
+        expect(QuotaSearchService).to have_received(:new).with(
           anything,
           anything,
           anything,
           anything,
           include_quota_balance_events: false,
-        ).and_call_original
-
-        get :search, params:, format: :json
+        )
       end
     end
 
@@ -289,15 +291,17 @@ RSpec.describe Api::V2::QuotasController, type: :controller do
         end
 
         it 'requests eager loading full quota balance events' do
-          expect(QuotaSearchService).to receive(:new).with(
+          allow(QuotaSearchService).to receive(:new).and_call_original
+
+          get :search, params:, format: :json
+
+          expect(QuotaSearchService).to have_received(:new).with(
             anything,
             anything,
             anything,
             anything,
             include_quota_balance_events: true,
-          ).and_call_original
-
-          get :search, params:, format: :json
+          )
         end
       end
 

--- a/spec/controllers/api/v2/quotas_controller_spec.rb
+++ b/spec/controllers/api/v2/quotas_controller_spec.rb
@@ -191,6 +191,18 @@ RSpec.describe Api::V2::QuotasController, type: :controller do
 
         expect(response.body).to match_json_expression pattern
       end
+
+      it 'does not request eager loading full quota balance events' do
+        expect(QuotaSearchService).to receive(:new).with(
+          anything,
+          anything,
+          anything,
+          anything,
+          include_quota_balance_events: false,
+        ).and_call_original
+
+        get :search, params:, format: :json
+      end
     end
 
     context 'when specifying an includes list in the query params' do
@@ -274,6 +286,18 @@ RSpec.describe Api::V2::QuotasController, type: :controller do
           get :search, params:, format: :json
 
           expect(response.body).to match_json_expression pattern
+        end
+
+        it 'requests eager loading full quota balance events' do
+          expect(QuotaSearchService).to receive(:new).with(
+            anything,
+            anything,
+            anything,
+            anything,
+            include_quota_balance_events: true,
+          ).and_call_original
+
+          get :search, params:, format: :json
         end
       end
 

--- a/spec/models/quota_definition_spec.rb
+++ b/spec/models/quota_definition_spec.rb
@@ -286,6 +286,20 @@ RSpec.describe QuotaDefinition do
     end
   end
 
+  describe '#last_balance_event' do
+    subject(:last_balance_event) { quota_definition.last_balance_event }
+
+    let(:quota_definition) { build(:quota_definition) }
+    let(:latest_event) { instance_double(QuotaBalanceEvent) }
+
+    it 'uses the latest quota balance event association when events are not preloaded' do
+      allow(quota_definition).to receive(:associations).and_return({})
+      allow(quota_definition).to receive(:latest_quota_balance_event).and_return(latest_event)
+
+      expect(last_balance_event).to eq(latest_event)
+    end
+  end
+
   describe '#incoming_quota_closed_and_transferred_event' do
     subject(:incoming_quota_closed_and_transferred_event) do
       quota_definition.incoming_quota_closed_and_transferred_event

--- a/spec/models/quota_definition_spec.rb
+++ b/spec/models/quota_definition_spec.rb
@@ -293,8 +293,7 @@ RSpec.describe QuotaDefinition do
     let(:latest_event) { instance_double(QuotaBalanceEvent) }
 
     it 'uses the latest quota balance event association when events are not preloaded' do
-      allow(quota_definition).to receive(:associations).and_return({})
-      allow(quota_definition).to receive(:latest_quota_balance_event).and_return(latest_event)
+      allow(quota_definition).to receive_messages(associations: {}, latest_quota_balance_event: latest_event)
 
       expect(last_balance_event).to eq(latest_event)
     end


### PR DESCRIPTION
### Jira link

[HMRC-2118](https://transformuk.atlassian.net/browse/HMRC-2118)

### What?

I have added/removed/altered:

- [ ] Quota search no longer eagerly loads full quota_balance_events by default.
- [ ] QuotaDefinition#last_balance_event no longer requires scanning the full association unless it is already loaded for includes.


### Why?

I am doing this because:

- QuotasController only allows quota_balance_events as an optional include, and default response does not include them.
- last_balance_event currently scans all loaded quota_balance_events, filters by point_in_time, then max_by timestamp.
