### PR TITLE
Avoid N+1 tree queries by adding with_leaf_column at key load sites

### DIFF
--- a/app/controllers/api/v2/headings_controller.rb
+++ b/app/controllers/api/v2/headings_controller.rb
@@ -43,7 +43,7 @@ module Api
     private
 
       def heading_scope
-        Heading.actual.non_grouping.non_hidden.by_code(params[:id])
+        Heading.actual.non_grouping.non_hidden.by_code(params[:id]).with_leaf_column
       end
 
       def heading

--- a/app/controllers/api/v2/subheadings_controller.rb
+++ b/app/controllers/api/v2/subheadings_controller.rb
@@ -31,6 +31,7 @@ module Api
                   .non_hidden
                   .by_code(subheading_code)
                   .by_productline_suffix(productline_suffix)
+                  .with_leaf_column
                   .take
                   .tap { |sh| raise Sequel::RecordNotFound if sh.leaf? }
       end

--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -126,6 +126,7 @@ class CachedCommodityService
   def commodity
     @commodity ||= Commodity
       .actual
+      .with_leaf_column
       .where(goods_nomenclature_sid: @commodity_sid)
       .eager(ancestors: { measures: MEASURES_EAGER_LOAD_GRAPH,
                           goods_nomenclature_descriptions: {} },

--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -127,7 +127,7 @@ class CachedCommodityService
     @commodity ||= Commodity
       .actual
       .with_leaf_column
-      .where(goods_nomenclature_sid: @commodity_sid)
+      .where(goods_nomenclatures__goods_nomenclature_sid: @commodity_sid)
       .eager(ancestors: { measures: MEASURES_EAGER_LOAD_GRAPH,
                           goods_nomenclature_descriptions: {} },
              measures: MEASURES_EAGER_LOAD_GRAPH)


### PR DESCRIPTION
## Problem

`leaf?` in `GoodsNomenclatures::NestedSet` has two paths:

```ruby
def leaf?
  values.key?(:leaf) ? values[:leaf] : children.empty?
end
```

When `:leaf` is not in the model's `values` hash, it falls back to
`children.empty?`, which fires a tree-traversal query against
`goods_nomenclature_tree_nodes` for every call. `declarable?` delegates
to `leaf?`, so any call site that calls `declarable?` on a record loaded
without `with_leaf_column` generates an extra query.

Three production code paths had this problem:

| File | Call site | Impact |
|------|-----------|--------|
| `HeadingsController#heading_scope` | `heading.declarable?` in `HeadingSerializationService` (called twice — once for the cache key, once to pick the serializer) | 1–2 extra queries per heading page request before the NsNondeclarableService reload |
| `SubheadingsController#subheading` | `sh.leaf?` inline guard after `.take` | 1 extra query per subheading page request |
| `CachedCommodityService#commodity` | `commodity.declarable?` in the serializer's `attribute :declarable` | 1 extra query per cold-cache commodity request |

The subheading and commodity cases were observed in production contributing to the tree-traversal query load that causes slow responses on high-traffic commodity codes.

## Fix

Add `.with_leaf_column` to the dataset at each of the three load sites. This appends a computed `:leaf` column (whether `child_sid IS NULL`) via a single additional JOIN, so all downstream `declarable?`/`leaf?` calls use the pre-computed value with no extra queries.

