### PR TITLE
Add composite indexes to speed up commodities#show measure queries

### DIFF
--- a/db/migrate/20260421120000_add_commodity_show_performance_indexes.rb
+++ b/db/migrate/20260421120000_add_commodity_show_performance_indexes.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Both `measures` and `measure_excluded_geographical_areas` are materialized
+# views, so we use raw SQL rather than alter_table.
+#
+# Index 1: measures(goods_nomenclature_sid, validity_start_date, validity_end_date)
+#
+#   The time-machine filter on the measures view is:
+#     goods_nomenclature_sid IN (...) AND validity_start_date <= :date
+#       AND (validity_end_date >= :date OR validity_end_date IS NULL)
+#
+#   Before this migration, PostgreSQL resolves that with a BitmapAnd across
+#   three separate single-column indexes. A composite index covering all three
+#   columns in access order lets the planner do a single index range scan —
+#   particularly valuable on commodities#show, which eagerly loads measures for
+#   the commodity and all its ancestors (typically 4–6 goods_nomenclature_sids).
+#
+# Index 2: measure_excluded_geographical_areas(measure_sid)
+#
+#   The excluded geographical areas CTE query joins
+#   measure_excluded_geographical_areas on measure_sid. The existing composite
+#   index (measure_sid, excluded_geographical_area, geographical_area_sid) has
+#   measure_sid as its leading column, but a narrower dedicated index is smaller,
+#   fits in cache more easily, and is more reliably chosen by the planner when
+#   measure_sid is the only predicate column (e.g. for hash joins against the
+#   CTE filter_ids set).
+
+Sequel.migration do
+  up do
+    run <<-SQL
+      CREATE INDEX IF NOT EXISTS measures_goods_nomenclature_sid_validity_composite_index
+        ON measures (goods_nomenclature_sid, validity_start_date, validity_end_date);
+
+      CREATE INDEX IF NOT EXISTS measure_excluded_geographical_areas_measure_sid_index
+        ON measure_excluded_geographical_areas (measure_sid);
+    SQL
+  end
+
+  down do
+    run <<-SQL
+      DROP INDEX IF EXISTS measures_goods_nomenclature_sid_validity_composite_index;
+      DROP INDEX IF EXISTS measure_excluded_geographical_areas_measure_sid_index;
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -12345,6 +12345,13 @@ CREATE INDEX measure_excluded_geographical_areas_measure_sid_excluded_geogra ON 
 
 
 --
+-- Name: measure_excluded_geographical_areas_measure_sid_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX measure_excluded_geographical_areas_measure_sid_index ON uk.measure_excluded_geographical_areas USING btree (measure_sid);
+
+
+--
 -- Name: measure_excluded_geographical_areas_oid_index; Type: INDEX; Schema: uk; Owner: -
 --
 
@@ -12433,6 +12440,13 @@ CREATE INDEX measures_goods_nomenclature_item_id_index ON uk.measures_oplog USIN
 --
 
 CREATE INDEX measures_goods_nomenclature_sid_index ON uk.measures USING btree (goods_nomenclature_sid);
+
+
+--
+-- Name: measures_goods_nomenclature_sid_validity_composite_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX measures_goods_nomenclature_sid_validity_composite_index ON uk.measures USING btree (goods_nomenclature_sid, validity_start_date, validity_end_date);
 
 
 --


### PR DESCRIPTION
## Summary

- Adds a composite index on `measures(goods_nomenclature_sid, validity_start_date, validity_end_date)` to replace the BitmapAnd of three separate single-column indexes that PostgreSQL currently uses for the time-machine filter on the measures materialized view
- Adds a standalone index on `measure_excluded_geographical_areas(measure_sid)` to improve planner reliability for hash joins in the excluded geographical areas CTE query

## Detail

### `measures` composite index

The time-machine filter applied on every `commodities#show` load is:

```sql
goods_nomenclature_sid IN (...) 
  AND validity_start_date <= :date
  AND (validity_end_date >= :date OR validity_end_date IS NULL)
```

Before this change, PostgreSQL resolves that with a BitmapAnd across `measures_goods_nomenclature_sid_index`, `measures_validity_start_date_index`, and `measures_validity_end_date_index`. A composite index covering all three columns in access order lets the planner do a single index range scan. The gain is multiplied because `commodities#show` eagerly loads measures for the commodity and all its ancestors (typically 4–6 `goods_nomenclature_sid` values).

### `measure_excluded_geographical_areas` standalone index

The excluded geographical areas CTE (generated by the `use_optimized: true` many_to_many plugin) joins `measure_excluded_geographical_areas` on `measure_sid`. The existing composite index `(measure_sid, excluded_geographical_area, geographical_area_sid)` already has `measure_sid` as its leading column, but a narrower dedicated index is smaller, stays in cache more easily, and is more reliably chosen by the planner when `measure_sid` is the only predicate column in a hash join against the CTE filter set.
