### PR TITLE
BAU: Disable Rails event log forwarding

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -36,6 +36,9 @@ common: &default_settings # Required license key associated with your New Relic 
   # Logging level for log/newrelic_agent.log
   log_level: info
 
+  # Disable New Relic's Rails.event forwarding to avoid duplicating Rails request lifecycle logs.
+  instrumentation.rails_event_logger: false
+
   application_logging:
     # If `true`, all logging-related features for the agent can be enabled or disabled
     # independently. If `false`, all logging-related features are disabled.


### PR DESCRIPTION
### Jira link

[BAU](https://transformuk.atlassian.net/browse/BAU)

### What?

- [x] Disable New Relic Rails.event log forwarding.
- [x] Keep normal New Relic application log forwarding enabled.

### Why?

New Relic 10.4.0 started subscribing to Rails.event when application logging is enabled. Rails 8.1 emits structured ActionController request lifecycle events through that path, which duplicates the request telemetry we already get from Lograge and New Relic APM.

Disabling only `instrumentation.rails_event_logger` stops the noisy `ActionController::StructuredEventSubscriber` entries without changing normal application logs.