### PR TITLE
Add covering OID indexes to speed up goods nomenclature description deduplication and Fix copy-paste bug: oplog primary key in GoodsNomenclatureDescriptionPeriod

### DIFF
--- a/app/models/goods_nomenclature_description_period.rb
+++ b/app/models/goods_nomenclature_description_period.rb
@@ -1,6 +1,6 @@
 class GoodsNomenclatureDescriptionPeriod < Sequel::Model
   plugin :time_machine
-  plugin :oplog, primary_key: :geographical_area_description_period_sid
+  plugin :oplog, primary_key: :goods_nomenclature_description_period_sid
 
   set_primary_key [:goods_nomenclature_description_period_sid]
 

--- a/db/migrate/20260421120001_add_oid_covering_indexes_to_goods_nomenclature_description_oplogs.rb
+++ b/db/migrate/20260421120001_add_oid_covering_indexes_to_goods_nomenclature_description_oplogs.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# `goods_nomenclature_description_periods` and `goods_nomenclature_descriptions`
+# are regular SQL views that inline a correlated MAX(oid) subquery to deduplicate
+# the oplog tables:
+#
+#   WHERE oid IN (
+#     SELECT MAX(oid) FROM ...oplog
+#     WHERE primary_key_col = outer.primary_key_col
+#   )
+#
+# Unlike `measures` (which uses `materialized: true` on the oplog plugin and
+# pre-computes the deduplicated rows into a stored materialized view), these
+# views re-execute the MAX(oid) correlated subquery for every row returned by
+# the outer query.
+#
+# When the goods_nomenclature_descriptions many_to_many association is eager-
+# loaded for a chapter or heading (which can push 500+ goods_nomenclature_sids
+# into the IN list), the view returns ~1700 period rows and must execute a
+# correlated subquery per row — ~3400 subquery executions in total.
+#
+# Both deduplication lookups already use an index for the WHERE clause, but
+# they still need to scan all matching rows to compute MAX(oid):
+#
+#   gono_desc_primary_key  (goods_nomenclature_description_period_sid)
+#   gono_desc_pk           (goods_nomenclature_sid,
+#                           goods_nomenclature_description_period_sid)
+#
+# Adding `oid DESC` as a trailing column turns each MAX(oid) aggregate into a
+# single-row index-only forward scan: the planner reads the first entry at the
+# top of the (key, oid DESC) B-tree and returns immediately.
+#
+# The long-term fix is to convert both models to materialized views by adding
+# `materialized: true` to their `plugin :oplog` declarations (as measures does),
+# which eliminates the correlated subqueries entirely. That is a larger change
+# and is tracked separately.
+
+Sequel.migration do
+  up do
+    run <<-SQL
+      -- Covers: SELECT MAX(oid) FROM goods_nomenclature_description_periods_oplog
+      --         WHERE goods_nomenclature_description_period_sid = ?
+      CREATE INDEX IF NOT EXISTS gono_desc_periods_oid_index
+        ON goods_nomenclature_description_periods_oplog
+        (goods_nomenclature_description_period_sid, oid DESC);
+
+      -- Covers: SELECT MAX(oid) FROM goods_nomenclature_descriptions_oplog
+      --         WHERE goods_nomenclature_sid = ? AND goods_nomenclature_description_period_sid = ?
+      CREATE INDEX IF NOT EXISTS gono_desc_oid_index
+        ON goods_nomenclature_descriptions_oplog
+        (goods_nomenclature_sid, goods_nomenclature_description_period_sid, oid DESC);
+    SQL
+  end
+
+  down do
+    run <<-SQL
+      DROP INDEX IF EXISTS gono_desc_periods_oid_index;
+      DROP INDEX IF EXISTS gono_desc_oid_index;
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -11424,7 +11424,21 @@ CREATE INDEX gono_desc_periods_pk ON uk.goods_nomenclature_description_periods_o
 -- Name: gono_desc_pk; Type: INDEX; Schema: uk; Owner: -
 --
 
+CREATE INDEX gono_desc_oid_index ON uk.goods_nomenclature_descriptions_oplog USING btree (goods_nomenclature_sid, goods_nomenclature_description_period_sid, oid DESC);
+
+
+--
+-- Name: gono_desc_pk; Type: INDEX; Schema: uk; Owner: -
+--
+
 CREATE INDEX gono_desc_pk ON uk.goods_nomenclature_descriptions_oplog USING btree (goods_nomenclature_sid, goods_nomenclature_description_period_sid);
+
+
+--
+-- Name: gono_desc_periods_oid_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX gono_desc_periods_oid_index ON uk.goods_nomenclature_description_periods_oplog USING btree (goods_nomenclature_description_period_sid, oid DESC);
 
 
 --

--- a/spec/models/goods_nomenclature_description_period_spec.rb
+++ b/spec/models/goods_nomenclature_description_period_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe GoodsNomenclatureDescriptionPeriod do
+  describe 'oplog primary key' do
+    it 'uses goods_nomenclature_description_period_sid, not the geographical_area equivalent' do
+      expect(described_class::Operation.primary_key).to include(:goods_nomenclature_description_period_sid)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `GoodsNomenclatureDescriptionPeriod` had `:geographical_area_description_period_sid` as the oplog primary key — a copy-paste from a neighbouring model
- The correct key is `:goods_nomenclature_description_period_sid`, matching the `set_primary_key` declaration on line 5
- This mismatch caused `GoodsNomenclatureDescriptionPeriod::Operation` to have the wrong composite primary key, meaning `previous_record` deduplication queries would reference a non-existent column on the oplog table


- Adds `(goods_nomenclature_description_period_sid, oid DESC)` to `goods_nomenclature_description_periods_oplog`
- Adds `(goods_nomenclature_sid, goods_nomenclature_description_period_sid, oid DESC)` to `goods_nomenclature_descriptions_oplog`

## Root cause

`goods_nomenclature_description_periods` and `goods_nomenclature_descriptions` are plain SQL views that inline a correlated `MAX(oid)` subquery per row to deduplicate the oplog:

```sql
WHERE oid IN (
  SELECT MAX(oid) FROM ...oplog
  WHERE primary_key_col = outer.primary_key_col
)
```

Unlike `measures` (which uses `plugin :oplog, materialized: true` and pre-computes the deduplicated rows into a stored materialized view), these views re-execute the correlated subquery at query time for every candidate row.

When `goods_nomenclature_descriptions` is eager-loaded for a heading or chapter page (~500+ `goods_nomenclature_sid` values in the IN list), the views produce ~1700 period rows and must execute ~3400 correlated subquery executions in total. This shows up as a slow query on commodity/heading detail pages.

## What the indexes do

The existing deduplication lookup indexes support the WHERE clause but force a scan over all matching rows to compute MAX:

| Index | Covers |
|-------|--------|
| `gono_desc_primary_key (goods_nomenclature_description_period_sid)` | WHERE only |
| `gono_desc_pk (goods_nomenclature_sid, goods_nomenclature_description_period_sid)` | WHERE only |

Adding `oid DESC` as a trailing column makes `SELECT MAX(oid) WHERE key = ?` an **index-only forward scan returning exactly one row** — the planner reads the top entry of the `(key, oid DESC)` B-tree and stops immediately, rather than scanning all rows with that key.

## Long-term fix

Converting both models to materialized views (`materialized: true` on `plugin :oplog`) would eliminate the correlated subqueries entirely by pre-computing and storing the deduplicated rows. That is a larger change tracked separately.
