### PR TITLE
Eliminate N+1 queries on api/v2/commodities#show

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -170,6 +170,22 @@ class Measure < Sequel::Model
                                         measure_generating_regulation_role],
                                 conditions: { approved_flag: true }
 
+  # The justification regulation is a separate regulation from the generating
+  # one: it records the legal act that justifies the measure ending. Both
+  # association directions are defined so they can be batch-eager-loaded in the
+  # commodity serialization path, avoiding a raw `.find` per measure.
+  many_to_one :justification_modification_regulation,
+              class: 'ModificationRegulation',
+              primary_key: %i[modification_regulation_id modification_regulation_role],
+              key: %i[justification_regulation_id justification_regulation_role],
+              conditions: { approved_flag: true }
+
+  many_to_one :justification_base_regulation,
+              class: 'BaseRegulation',
+              primary_key: %i[base_regulation_id base_regulation_role],
+              key: %i[justification_regulation_id justification_regulation_role],
+              conditions: { approved_flag: true }
+
   def validity_start_date
     self[:validity_start_date].presence || generating_regulation.validity_start_date
   end
@@ -188,11 +204,9 @@ class Measure < Sequel::Model
 
   def justification_regulation
     @justification_regulation ||= if justification_regulation_role == MODIFICATION_REGULATION_ROLE
-                                    ModificationRegulation.find(modification_regulation_id: justification_regulation_id,
-                                                                modification_regulation_role: justification_regulation_role)
+                                    justification_modification_regulation
                                   else
-                                    BaseRegulation.find(base_regulation_id: justification_regulation_id,
-                                                        base_regulation_role: justification_regulation_role)
+                                    justification_base_regulation
                                   end
   end
 

--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -16,7 +16,9 @@ class CachedCommodityService
 
   MEASURES_PAYLOAD_EAGER_LOAD_GRAPH = [
     { footnotes: :footnote_descriptions },
-    { measure_type: :measure_type_description },
+    # Load both description associations so the serializer can access
+    # measure_type_series_description without a per-measure lazy query.
+    { measure_type: %i[measure_type_description measure_type_series_description] },
     {
       measure_components: [
         { duty_expression: :duty_expression_description },
@@ -62,6 +64,10 @@ class CachedCommodityService
     { additional_code: :additional_code_descriptions },
     :base_regulation,
     :modification_regulation,
+    # Batch-load both directions of the justification regulation so
+    # Measure#justification_regulation uses the cache instead of a raw .find.
+    :justification_base_regulation,
+    :justification_modification_regulation,
     :full_temporary_stop_regulations,
     :measure_partial_temporary_stops,
   ].freeze
@@ -128,9 +134,20 @@ class CachedCommodityService
       .actual
       .with_leaf_column
       .where(goods_nomenclatures__goods_nomenclature_sid: @commodity_sid)
-      .eager(ancestors: { measures: MEASURES_EAGER_LOAD_GRAPH,
-                          goods_nomenclature_descriptions: {} },
-             measures: MEASURES_EAGER_LOAD_GRAPH)
+      .eager(
+        # Descriptions are delegated through goods_nomenclature_descriptions.first;
+        # without this the commodity's own description triggers a lazy load.
+        goods_nomenclature_descriptions: {},
+        # CommodityPresenter combines commodity.footnotes + heading.footnotes.
+        # Without the nested :footnotes the heading is loaded separately.
+        heading: :footnotes,
+        # ChapterSerializer renders chapter_note; section comes via
+        # chapter.sections.first and SectionSerializer renders section_note.
+        chapter: [:chapter_note, { sections: :section_note }],
+        ancestors: { measures: MEASURES_EAGER_LOAD_GRAPH,
+                     goods_nomenclature_descriptions: {} },
+        measures: MEASURES_EAGER_LOAD_GRAPH,
+      )
       .take
   end
 


### PR DESCRIPTION
## Summary

Six sources of lazy queries eliminated from the commodity show serialization path. On a commodity with ~50 measures these were producing ~100-300 extra queries per cache miss.

## Changes

### `app/models/measure.rb`

**`Measure#justification_regulation` was firing a raw `.find` per measure** — `ModificationRegulation.find(...)` or `BaseRegulation.find(...)` bypasses Sequel's association cache entirely. Two new `many_to_one` associations are added to mirror the existing `base_regulation` / `modification_regulation` pattern:

```ruby
many_to_one :justification_modification_regulation, class: 'ModificationRegulation', ...
many_to_one :justification_base_regulation,         class: 'BaseRegulation', ...
```

`justification_regulation` now reads from whichever cached association is appropriate.

### `app/services/cached_commodity_service.rb`

| Fix | Root cause |
|-----|-----------|
| `{ measure_type: %i[measure_type_description measure_type_series_description] }` | `MeasureTypeSerializer` renders `measure_type_series_description` but only `measure_type_description` was in the eager graph — 1 query per measure |
| `:justification_base_regulation`, `:justification_modification_regulation` in `MEASURES_PAYLOAD_EAGER_LOAD_GRAPH` | Enables batch loading for the new associations above |
| `goods_nomenclature_descriptions: {}` at the commodity level | `description`, `formatted_description`, etc. delegate through `goods_nomenclature_descriptions.first` — ancestor descriptions were eager-loaded, the commodity's own were not |
| `heading: :footnotes` | `CommodityPresenter` combines `commodity.footnotes + heading.footnotes`; heading was loaded but its footnotes were not |
| `chapter: [:chapter_note, { sections: :section_note }]` | `ChapterSerializer` renders `chapter_note`; `SectionSerializer` renders `section_note` (reached via `chapter.sections.first`) — neither was in any eager load |

## What remains

`MeasureTypeExclusion#find_geographical_areas` can still issue a `GeographicalArea.where(...)` per measure when the CSV file has an exclusion entry matching the measure's `(measure_type_id, geographical_area_id)`. Fixing that requires either pre-loading all referenced GeographicalArea rows at CSV parse time or restructuring the exclusion lookup. Tracked separately.

## Test plan

- [ ] CI passes (existing `justification_legal_act` presenter spec covers the model change)
- [ ] Verify query count in dev with `bullet` or `rack-mini-profiler` — expect significant reduction from ~500 to low double-digits on a commodity with many measures