### PR TITLE
Fix three more N+1 query sources on commodities#show

### DIFF
--- a/app/models/measure_type_exclusion.rb
+++ b/app/models/measure_type_exclusion.rb
@@ -8,12 +8,18 @@ class MeasureTypeExclusion
 
   class << self
     def load_from_file(file = SOURCES.fetch(TradeTariffBackend.service))
-      exclusions_by_service[TradeTariffBackend.service] = parse_file(file)
+      service = TradeTariffBackend.service
+      exclusions_by_service[service] = parse_file(file)
+      # Clear the geo area cache so it is rebuilt lazily on the next
+      # find_geographical_areas call. We cannot preload here because
+      # load_from_file may run before DB records exist (e.g. in tests).
+      geographical_areas_by_service.delete(service)
       self
     end
 
     def reset_data
       @exclusions_by_service = nil
+      @geographical_areas_by_service = nil
       self
     end
 
@@ -21,11 +27,17 @@ class MeasureTypeExclusion
       exclusions[[measure_type_id.to_s, geographical_area_id.to_s]] || []
     end
 
+    # Replaces the previous per-call GeographicalArea.where query.
+    #
+    # On first call after load (or reset), preloads ALL country codes referenced
+    # in the exclusions CSV into a hash keyed by geographical_area_id. Subsequent
+    # calls look up in that hash — no DB query.
     def find_geographical_areas(measure_type_id, geographical_area_id)
       country_codes = find(measure_type_id, geographical_area_id)
       return [] if country_codes.empty?
 
-      GeographicalArea.where(geographical_area_id: country_codes).order(:geographical_area_id).all
+      country_codes.filter_map { |code| geographical_areas[code] }
+                   .sort_by(&:geographical_area_id)
     end
 
     # Returns the exclusion hash for the current service, loading from disk on
@@ -36,6 +48,23 @@ class MeasureTypeExclusion
     end
 
     private
+
+    # Returns a hash of geographical_area_id => GeographicalArea for every
+    # country code that appears in the CSV, loaded in a single DB query.
+    def geographical_areas
+      service = TradeTariffBackend.service
+      geographical_areas_by_service[service] ||= preload_geographical_areas(exclusions)
+    end
+
+    def preload_geographical_areas(exclusions_data)
+      all_codes = exclusions_data.values.flatten.uniq
+      return {} if all_codes.empty?
+
+      GeographicalArea
+        .where(geographical_area_id: all_codes)
+        .all
+        .index_by(&:geographical_area_id)
+    end
 
     def parse_file(file)
       data = {}
@@ -49,6 +78,10 @@ class MeasureTypeExclusion
 
     def exclusions_by_service
       @exclusions_by_service ||= {}
+    end
+
+    def geographical_areas_by_service
+      @geographical_areas_by_service ||= {}
     end
   end
 end

--- a/app/models/measure_type_exclusion.rb
+++ b/app/models/measure_type_exclusion.rb
@@ -8,18 +8,12 @@ class MeasureTypeExclusion
 
   class << self
     def load_from_file(file = SOURCES.fetch(TradeTariffBackend.service))
-      service = TradeTariffBackend.service
-      exclusions_by_service[service] = parse_file(file)
-      # Clear the geo area cache so it is rebuilt lazily on the next
-      # find_geographical_areas call. We cannot preload here because
-      # load_from_file may run before DB records exist (e.g. in tests).
-      geographical_areas_by_service.delete(service)
+      exclusions_by_service[TradeTariffBackend.service] = parse_file(file)
       self
     end
 
     def reset_data
       @exclusions_by_service = nil
-      @geographical_areas_by_service = nil
       self
     end
 
@@ -27,17 +21,11 @@ class MeasureTypeExclusion
       exclusions[[measure_type_id.to_s, geographical_area_id.to_s]] || []
     end
 
-    # Replaces the previous per-call GeographicalArea.where query.
-    #
-    # On first call after load (or reset), preloads ALL country codes referenced
-    # in the exclusions CSV into a hash keyed by geographical_area_id. Subsequent
-    # calls look up in that hash — no DB query.
     def find_geographical_areas(measure_type_id, geographical_area_id)
       country_codes = find(measure_type_id, geographical_area_id)
       return [] if country_codes.empty?
 
-      country_codes.filter_map { |code| geographical_areas[code] }
-                   .sort_by(&:geographical_area_id)
+      GeographicalArea.where(geographical_area_id: country_codes).order(:geographical_area_id).all
     end
 
     # Returns the exclusion hash for the current service, loading from disk on
@@ -48,23 +36,6 @@ class MeasureTypeExclusion
     end
 
     private
-
-    # Returns a hash of geographical_area_id => GeographicalArea for every
-    # country code that appears in the CSV, loaded in a single DB query.
-    def geographical_areas
-      service = TradeTariffBackend.service
-      geographical_areas_by_service[service] ||= preload_geographical_areas(exclusions)
-    end
-
-    def preload_geographical_areas(exclusions_data)
-      all_codes = exclusions_data.values.flatten.uniq
-      return {} if all_codes.empty?
-
-      GeographicalArea
-        .where(geographical_area_id: all_codes)
-        .all
-        .index_by(&:geographical_area_id)
-    end
 
     def parse_file(file)
       data = {}
@@ -78,10 +49,6 @@ class MeasureTypeExclusion
 
     def exclusions_by_service
       @exclusions_by_service ||= {}
-    end
-
-    def geographical_areas_by_service
-      @geographical_areas_by_service ||= {}
     end
   end
 end

--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -30,7 +30,11 @@ class CachedCommodityService
     {
       measure_conditions: [
         { measure_action: :measure_action_description },
-        { certificate: :certificate_descriptions },
+        # exempting_certificate_override is accessed in
+        # MeasureCondition#is_exempting_certificate_overridden? (called by the
+        # condition permutations calculator). Without it, every condition that
+        # has a certificate fires a separate query.
+        { certificate: %i[certificate_descriptions exempting_certificate_override] },
         { certificate_type: :certificate_type_description },
         { measurement_unit: %i[measurement_unit_description measurement_unit_abbreviations] },
         :appendix_5a,
@@ -63,7 +67,11 @@ class CachedCommodityService
     },
     { additional_code: :additional_code_descriptions },
     :base_regulation,
-    :modification_regulation,
+    # Measure#legal_acts appends generating_regulation.base_regulation for
+    # modification-regulation-backed measures (to include the parent base
+    # regulation in the legal acts list). Loading it nested here means a single
+    # batch query instead of one per such measure.
+    { modification_regulation: :base_regulation },
     # Batch-load both directions of the justification regulation so
     # Measure#justification_regulation uses the cache instead of a raw .find.
     :justification_base_regulation,
@@ -80,7 +88,12 @@ class CachedCommodityService
         { referenced: :contained_geographical_areas },
       ],
     },
-    { geographical_area: :contained_geographical_areas },
+    # GeographicalRelevance#contained_area_ids calls
+    # geographical_area.referenced.contained_geographical_areas to resolve
+    # area-group references. Without referenced, each reference-backed area
+    # fires two extra queries (one for the referenced area, one for its members).
+    { geographical_area: [:contained_geographical_areas,
+                          { referenced: :contained_geographical_areas }] },
     :measure_type,
     :additional_code,
     :measure_components,


### PR DESCRIPTION
## Summary

Three more lazy-load sources eliminated from the commodity show serialization path, on top of PR #3058.

## Changes (all in `MEASURES_PAYLOAD_EAGER_LOAD_GRAPH` / `MEASURES_FILTER_META_EAGER_LOAD_GRAPH`)

### `modification_regulation: :base_regulation` (was `:modification_regulation`)

`Measure#legal_acts` appends `generating_regulation.base_regulation` when the generating regulation is a modification regulation — this includes the parent base regulation in the legal acts list rendered by `MeasureLegalActSerializer`. `modification_regulation` was already batch-loaded, but its `one_to_one :base_regulation` (on `ModificationRegulation`) was not. Every modification-regulation-backed measure fired one extra query. Most preference measures are backed by modification regulations.

### `certificate: %i[certificate_descriptions exempting_certificate_override]`

`MeasureCondition#is_exempting_certificate_overridden?` accesses `certificate.exempting_certificate_override`. This is called from `MeasureConditionPermutations::Calculator` for every condition in a measure. The existing eager load had `{ certificate: :certificate_descriptions }` but not `exempting_certificate_override`. Every condition with a certificate fired a separate lookup. `GreenLanes::FetchGoodsNomenclatureService` already loads this correctly — this brings the commodity path in line.

### `geographical_area: [:contained_geographical_areas, { referenced: :contained_geographical_areas }]`

`Measure::GeographicalRelevance#contained_area_ids` resolves:

```ruby
(measure.geographical_area.referenced.presence || measure.geographical_area)
  .contained_geographical_areas
  .pluck(:geographical_area_id)
```

The filter meta graph previously loaded `geographical_area: :contained_geographical_areas` but not `referenced`. For any measure whose geographical area is a reference to another area (common for UK regional preference groups like `1011`, `1013` etc.), this fired two extra queries per measure — one for the `referenced` GeographicalArea and one for its `contained_geographical_areas`.
