### PR TITLE
Fix ~491 N+1 queries on commodities#show by merging eager load graphs

### DIFF
--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -14,31 +14,9 @@ class CachedCommodityService
     export_measures.measure_components.measurement_unit
   ]).freeze
 
-  # Single unified eager-load graph for all measures associations.
-  #
-  # IMPORTANT: Do not split this into two arrays and concatenate them.
-  # Sequel's eager_options_for_associations builds a flat hash from the array
-  # via opts.merge!(association). If the same association key appears twice —
-  # even as a bare symbol vs a nested hash — the later entry silently overwrites
-  # the earlier one, dropping all nested sub-associations from the first entry.
-  # This was the root cause of ~491 N+1 queries on commodities#show:
-  #
-  #   :geographical_area  appeared in both arrays → geographical_area_descriptions dropped
-  #   :measure_type       appeared in both arrays → measure_type_series_description dropped
-  #   :measure_components appeared in both arrays → duty_expression sub-load dropped
-  #   :additional_code    appeared in both arrays → additional_code_descriptions dropped
-  #
-  # Every association that is needed for both payload serialisation and measure
-  # filtering/metadata is listed once here, with the union of all nested
-  # associations required by either use.
   MEASURES_EAGER_LOAD_GRAPH = [
     { footnotes: :footnote_descriptions },
-    # Load both description associations so the serializer can access
-    # measure_type_series_description without a per-measure lazy query.
-    # measure_type is also used by MeasureCollection filter logic.
     { measure_type: %i[measure_type_description measure_type_series_description] },
-    # measure_components is used by MeasureCollection filter logic AND serialised
-    # via MeasureComponentSerializer. The nested associations cover both.
     {
       measure_components: [
         { duty_expression: :duty_expression_description },
@@ -50,10 +28,6 @@ class CachedCommodityService
     {
       measure_conditions: [
         { measure_action: :measure_action_description },
-        # exempting_certificate_override is accessed in
-        # MeasureCondition#is_exempting_certificate_overridden? (called by the
-        # condition permutations calculator). Without it, every condition that
-        # has a certificate fires a separate query.
         { certificate: %i[certificate_descriptions exempting_certificate_override] },
         { certificate_type: :certificate_type_description },
         { measurement_unit: %i[measurement_unit_description measurement_unit_abbreviations] },
@@ -81,11 +55,6 @@ class CachedCommodityService
         ],
       },
     },
-    # geographical_area_descriptions is needed by GeographicalAreaSerializer.
-    # contained_geographical_areas (with descriptions) is needed by the
-    # serializer for group members. referenced + its contained_geographical_areas
-    # is needed by GeographicalRelevance#contained_area_ids to resolve
-    # area-group references without per-measure lazy queries.
     {
       geographical_area: [
         :geographical_area_descriptions,
@@ -93,7 +62,6 @@ class CachedCommodityService
         { referenced: :contained_geographical_areas },
       ],
     },
-    # excluded_geographical_areas are used by MeasureCollection filter logic.
     {
       excluded_geographical_areas: [
         :geographical_area_descriptions,
@@ -101,16 +69,9 @@ class CachedCommodityService
         { referenced: :contained_geographical_areas },
       ],
     },
-    # additional_code is used by MeasureCollection filter logic AND serialised.
     { additional_code: :additional_code_descriptions },
     :base_regulation,
-    # Measure#legal_acts appends generating_regulation.base_regulation for
-    # modification-regulation-backed measures (to include the parent base
-    # regulation in the legal acts list). Loading it nested here means a single
-    # batch query instead of one per such measure.
     { modification_regulation: :base_regulation },
-    # Batch-load both directions of the justification regulation so
-    # Measure#justification_regulation uses the cache instead of a raw .find.
     :justification_base_regulation,
     :justification_modification_regulation,
     :full_temporary_stop_regulations,
@@ -162,14 +123,8 @@ class CachedCommodityService
       .with_leaf_column
       .where(goods_nomenclatures__goods_nomenclature_sid: @commodity_sid)
       .eager(
-        # Descriptions are delegated through goods_nomenclature_descriptions.first;
-        # without this the commodity's own description triggers a lazy load.
         goods_nomenclature_descriptions: {},
-        # CommodityPresenter combines commodity.footnotes + heading.footnotes.
-        # Without the nested :footnotes the heading is loaded separately.
         heading: :footnotes,
-        # ChapterSerializer renders chapter_note; section comes via
-        # chapter.sections.first and SectionSerializer renders section_note.
         chapter: [:chapter_note, { sections: :section_note }],
         ancestors: { measures: MEASURES_EAGER_LOAD_GRAPH,
                      goods_nomenclature_descriptions: {} },

--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -1,7 +1,7 @@
 class CachedCommodityService
   include DeclarableSerialization
 
-  CACHE_VERSION = 4
+  CACHE_VERSION = 5
 
   DEFAULT_INCLUDES = (DECLARABLE_INCLUDES + %w[
     heading
@@ -14,11 +14,31 @@ class CachedCommodityService
     export_measures.measure_components.measurement_unit
   ]).freeze
 
-  MEASURES_PAYLOAD_EAGER_LOAD_GRAPH = [
+  # Single unified eager-load graph for all measures associations.
+  #
+  # IMPORTANT: Do not split this into two arrays and concatenate them.
+  # Sequel's eager_options_for_associations builds a flat hash from the array
+  # via opts.merge!(association). If the same association key appears twice —
+  # even as a bare symbol vs a nested hash — the later entry silently overwrites
+  # the earlier one, dropping all nested sub-associations from the first entry.
+  # This was the root cause of ~491 N+1 queries on commodities#show:
+  #
+  #   :geographical_area  appeared in both arrays → geographical_area_descriptions dropped
+  #   :measure_type       appeared in both arrays → measure_type_series_description dropped
+  #   :measure_components appeared in both arrays → duty_expression sub-load dropped
+  #   :additional_code    appeared in both arrays → additional_code_descriptions dropped
+  #
+  # Every association that is needed for both payload serialisation and measure
+  # filtering/metadata is listed once here, with the union of all nested
+  # associations required by either use.
+  MEASURES_EAGER_LOAD_GRAPH = [
     { footnotes: :footnote_descriptions },
     # Load both description associations so the serializer can access
     # measure_type_series_description without a per-measure lazy query.
+    # measure_type is also used by MeasureCollection filter logic.
     { measure_type: %i[measure_type_description measure_type_series_description] },
+    # measure_components is used by MeasureCollection filter logic AND serialised
+    # via MeasureComponentSerializer. The nested associations cover both.
     {
       measure_components: [
         { duty_expression: :duty_expression_description },
@@ -61,10 +81,27 @@ class CachedCommodityService
         ],
       },
     },
+    # geographical_area_descriptions is needed by GeographicalAreaSerializer.
+    # contained_geographical_areas (with descriptions) is needed by the
+    # serializer for group members. referenced + its contained_geographical_areas
+    # is needed by GeographicalRelevance#contained_area_ids to resolve
+    # area-group references without per-measure lazy queries.
     {
-      geographical_area: [:geographical_area_descriptions,
-                          { contained_geographical_areas: :geographical_area_descriptions }],
+      geographical_area: [
+        :geographical_area_descriptions,
+        { contained_geographical_areas: :geographical_area_descriptions },
+        { referenced: :contained_geographical_areas },
+      ],
     },
+    # excluded_geographical_areas are used by MeasureCollection filter logic.
+    {
+      excluded_geographical_areas: [
+        :geographical_area_descriptions,
+        :contained_geographical_areas,
+        { referenced: :contained_geographical_areas },
+      ],
+    },
+    # additional_code is used by MeasureCollection filter logic AND serialised.
     { additional_code: :additional_code_descriptions },
     :base_regulation,
     # Measure#legal_acts appends generating_regulation.base_regulation for
@@ -79,29 +116,6 @@ class CachedCommodityService
     :full_temporary_stop_regulations,
     :measure_partial_temporary_stops,
   ].freeze
-
-  MEASURES_FILTER_META_EAGER_LOAD_GRAPH = [
-    {
-      excluded_geographical_areas: [
-        :geographical_area_descriptions,
-        :contained_geographical_areas,
-        { referenced: :contained_geographical_areas },
-      ],
-    },
-    # GeographicalRelevance#contained_area_ids calls
-    # geographical_area.referenced.contained_geographical_areas to resolve
-    # area-group references. Without referenced, each reference-backed area
-    # fires two extra queries (one for the referenced area, one for its members).
-    { geographical_area: [:contained_geographical_areas,
-                          { referenced: :contained_geographical_areas }] },
-    :measure_type,
-    :additional_code,
-    :measure_components,
-  ].freeze
-
-  MEASURES_EAGER_LOAD_GRAPH = (
-    MEASURES_PAYLOAD_EAGER_LOAD_GRAPH + MEASURES_FILTER_META_EAGER_LOAD_GRAPH
-  ).freeze
 
   TTL = 24.hours
 

--- a/spec/services/cached_commodity_service_spec.rb
+++ b/spec/services/cached_commodity_service_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe CachedCommodityService do
 
       it 'does not include geographical_area_id' do
         service.call
-        expected_key = "_commodity-v4-#{commodity.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}-"
+        expected_key = "_commodity-v#{CachedCommodityService::CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}-"
         expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 24.hours)
       end
 
@@ -102,7 +102,7 @@ RSpec.describe CachedCommodityService do
 
         it 'uses the same cache key regardless of country' do
           service.call
-          expected_key = "_commodity-v4-#{commodity.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}-"
+          expected_key = "_commodity-v#{CachedCommodityService::CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}-"
           expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 24.hours)
         end
       end
@@ -112,7 +112,7 @@ RSpec.describe CachedCommodityService do
 
         it 'includes meursing code in cache key' do
           service.call
-          expected_key = "_commodity-v4-#{commodity.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}-foo"
+          expected_key = "_commodity-v#{CachedCommodityService::CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}-foo"
           expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 24.hours)
         end
       end
@@ -124,7 +124,7 @@ RSpec.describe CachedCommodityService do
         ro_service.call
         de_service.call
 
-        expected_key = "_commodity-v4-#{commodity.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}-"
+        expected_key = "_commodity-v#{CachedCommodityService::CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}-"
         expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 24.hours).twice
       end
     end


### PR DESCRIPTION
## Summary

- `MEASURES_EAGER_LOAD_GRAPH` was previously built by concatenating two separate arrays. Sequel's `eager_options_for_associations` builds a flat hash from the array via `opts.merge!`, so when the same association key appeared in both arrays the later (filter meta) entry silently overwrote the earlier (payload) entry — dropping all nested sub-associations.
- Four associations were affected, causing a lazy DB query per measure for each one:
  - `:geographical_area` — `geographical_area_descriptions` dropped → `GeographicalAreaSerializer#description` lazy-loaded
  - `:measure_type` — `measure_type_series_description` dropped → `MeasureTypeSerializer` lazy-loaded
  - `:measure_components` — `duty_expression` + `duty_expression_description` dropped → `MeasureComponentSerializer` lazy-loaded
  - `:additional_code` — `additional_code_descriptions` dropped
- Fix: replace the two separate constants and their concatenation with a single `MEASURES_EAGER_LOAD_GRAPH` that lists every association once, with the union of all nested associations required by both serialisation and filter logic.
- `CACHE_VERSION` bumped to 5 to evict cached entries built with the incomplete eager load (which may be missing description fields in the serialised hash).
