### PR TITLE
HMRC-2110: Enable database migration step in deployments

### DIFF
--- a/.github/workflows/deploy-to-development-full.yml
+++ b/.github/workflows/deploy-to-development-full.yml
@@ -45,6 +45,7 @@ jobs:
           }
         ]
       test-flavour: tariff
+      migrate: true
     secrets:
       ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -24,6 +24,7 @@ jobs:
       app-name: tariff-backend
       environment: development
       test-flavour: none
+      migrate: true
     secrets:
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
       ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -21,6 +21,7 @@ jobs:
     with:
       app-name: tariff-backend
       environment: production
+      migrate: true
     secrets:
       basic-password: ${{ secrets.BASIC_PASSWORD }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -16,6 +16,7 @@ jobs:
     with:
       app-name: tariff-backend
       environment: staging
+      migrate: true
     secrets:
       basic-password: ${{ secrets.BASIC_PASSWORD }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Jira link

[HMRC-2110](https://transformuk.atlassian.net/browse/HMRC-2110)

### What?

I have added/removed/altered:

- Enabled `migrate` in deployment actions

### Why?

I am doing this because:

- This workflow has been tested in development and runs database migrations as an explicit pre-deployment task.
