### PR TITLE
HMRC-2119: Add targeted cache warming for the hottest commodity response

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'sequel-rails'
 # File uploads and AWS
 gem 'aws-actionmailer-ses'
 gem 'aws-sdk-cloudfront'
+gem 'aws-sdk-cloudwatchlogs'
 gem 'aws-sdk-rails'
 gem 'aws-sdk-s3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,9 @@ GEM
     aws-sdk-cloudfront (1.143.0)
       aws-sdk-core (~> 3, >= 3.244.0)
       aws-sigv4 (~> 1.5)
+    aws-sdk-cloudwatchlogs (1.145.0)
+      aws-sdk-core (~> 3, >= 3.244.0)
+      aws-sigv4 (~> 1.5)
     aws-sdk-core (3.244.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
@@ -481,6 +484,7 @@ DEPENDENCIES
   amazing_print
   aws-actionmailer-ses
   aws-sdk-cloudfront
+  aws-sdk-cloudwatchlogs
   aws-sdk-rails
   aws-sdk-s3
   bootsnap

--- a/app/workers/clear_cache_worker.rb
+++ b/app/workers/clear_cache_worker.rb
@@ -15,6 +15,7 @@ class ClearCacheWorker
 
     Sidekiq::Client.enqueue(PrecacheHeadingsWorker, Time.zone.today.to_formatted_s(:db))
     Sidekiq::Client.enqueue(PrewarmQuotaOrderNumbersWorker)
+    Sidekiq::Client.enqueue(PrewarmCommoditiesWorker)
     Sidekiq::Client.enqueue(ReindexModelsWorker)
 
     # NOTE: Make sure caches have been refreshed before invalidating the CDN

--- a/app/workers/prewarm_commodities_worker.rb
+++ b/app/workers/prewarm_commodities_worker.rb
@@ -1,0 +1,119 @@
+class PrewarmCommoditiesWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :sync, retry: true
+
+  DEFAULT_LOOKBACK_HOURS = 24
+  DEFAULT_LIMIT = 1000
+  QUERY_POLL_INTERVAL_SECONDS = 1
+  QUERY_MAX_POLLS = 60
+
+  def perform(log_group_name = ENV['SEARCH_LOG_GROUP_NAME'])
+    preconfigured_ids = preconfigured_goods_nomenclature_item_ids
+    most_requested_ids = if log_group_name.present?
+                           most_requested_goods_nomenclature_item_ids(
+                             log_group_name:,
+                             lookback_hours: DEFAULT_LOOKBACK_HOURS,
+                             limit: DEFAULT_LIMIT,
+                           )
+                         else
+                           logger.warn 'PrewarmCommoditiesWorker running with preconfigured ids only: SEARCH_LOG_GROUP_NAME is not set'
+                           []
+                         end
+    ids = (preconfigured_ids + most_requested_ids).uniq
+
+    if ids.empty?
+      logger.info 'PrewarmCommoditiesWorker found no commodity ids to prewarm'
+      return
+    end
+
+    warmed = 0
+    skipped = 0
+    failed = 0
+
+    TimeMachine.now do
+      actual_date = Date.current
+      commodities_by_item_id = Commodity.actual
+                                      .by_codes(ids)
+                                      .all
+                                      .each_with_object({}) do |commodity, memo|
+        memo[commodity.goods_nomenclature_item_id] = commodity
+      end
+
+      ids.each do |goods_nomenclature_item_id|
+        commodity = commodities_by_item_id[goods_nomenclature_item_id]
+        if commodity.nil?
+          skipped += 1
+          next
+        end
+
+        CachedCommodityService.new(commodity, actual_date).call
+        warmed += 1
+      rescue StandardError => e
+        failed += 1
+        logger.info(
+          "PrewarmCommoditiesWorker failed for #{goods_nomenclature_item_id}: #{e.class} - #{e.message}",
+        )
+      end
+    end
+
+    logger.info(
+      "PrewarmCommoditiesWorker complete: requested=#{ids.size} warmed=#{warmed} skipped=#{skipped} failed=#{failed}",
+    )
+  end
+
+  def self.client
+    @client ||= Aws::CloudWatchLogs::Client.new
+  end
+
+  private
+
+  def preconfigured_goods_nomenclature_item_ids
+    ENV.fetch('PREWARM_COMMODITY_IDS', '')
+       .split(',')
+       .map(&:strip)
+       .reject(&:empty?)
+       .uniq
+  end
+
+  def most_requested_goods_nomenclature_item_ids(log_group_name:, lookback_hours:, limit:)
+    query_id = self.class.client.start_query(
+      log_group_name:,
+      start_time: (Time.current - lookback_hours.hours).to_i,
+      end_time: Time.current.to_i,
+      query_string: cloudwatch_query(limit),
+    ).query_id
+
+    results = await_query_results(query_id)
+
+    results.filter_map do |row|
+      row.to_h { |field| [field.field, field.value] }['goods_nomenclature_item_id']
+    end.uniq
+  rescue StandardError => e
+    logger.error("PrewarmCommoditiesWorker CloudWatch query failed: #{e.class} - #{e.message}")
+    []
+  end
+
+  def await_query_results(query_id)
+    QUERY_MAX_POLLS.times do
+      response = self.class.client.get_query_results(query_id:)
+      return response.results if response.status == 'Complete'
+
+      raise "CloudWatch query #{response.status}" if %w[Failed Cancelled Timeout Unknown].include?(response.status)
+
+      sleep QUERY_POLL_INTERVAL_SECONDS
+    end
+
+    raise 'CloudWatch query timed out while polling'
+  end
+
+  def cloudwatch_query(limit)
+    <<~QUERY
+      fields @timestamp, goods_nomenclature_item_id, event, service
+      | filter service = "search" and event = "result_selected" and goods_nomenclature_class = "Commodity" and ispresent(goods_nomenclature_item_id)
+      | stats count(*) as selections by goods_nomenclature_item_id
+      | sort selections desc
+      | limit #{limit}
+    QUERY
+  end
+end

--- a/app/workers/prewarm_commodities_worker.rb
+++ b/app/workers/prewarm_commodities_worker.rb
@@ -36,9 +36,7 @@ class PrewarmCommoditiesWorker
       commodities_by_item_id = Commodity.actual
                                       .by_codes(ids)
                                       .all
-                                      .each_with_object({}) do |commodity, memo|
-        memo[commodity.goods_nomenclature_item_id] = commodity
-      end
+                                      .index_by(&:goods_nomenclature_item_id)
 
       ids.each do |goods_nomenclature_item_id|
         commodity = commodities_by_item_id[goods_nomenclature_item_id]
@@ -86,9 +84,9 @@ class PrewarmCommoditiesWorker
 
     results = await_query_results(query_id)
 
-    results.filter_map do |row|
+    results.filter_map { |row|
       row.to_h { |field| [field.field, field.value] }['goods_nomenclature_item_id']
-    end.uniq
+    }.uniq
   rescue StandardError => e
     logger.error("PrewarmCommoditiesWorker CloudWatch query failed: #{e.class} - #{e.message}")
     []

--- a/app/workers/prewarm_commodities_worker.rb
+++ b/app/workers/prewarm_commodities_worker.rb
@@ -7,19 +7,16 @@ class PrewarmCommoditiesWorker
   DEFAULT_LIMIT = 1000
   QUERY_POLL_INTERVAL_SECONDS = 1
   QUERY_MAX_POLLS = 60
+  SEARCH_LOG_GROUP_NAME = "platform-logs-#{TradeTariffBackend.environment}".freeze
 
-  def perform(log_group_name = ENV['SEARCH_LOG_GROUP_NAME'])
+  def perform
     preconfigured_ids = preconfigured_goods_nomenclature_item_ids
-    most_requested_ids = if log_group_name.present?
-                           most_requested_goods_nomenclature_item_ids(
-                             log_group_name:,
-                             lookback_hours: DEFAULT_LOOKBACK_HOURS,
-                             limit: DEFAULT_LIMIT,
-                           )
-                         else
-                           logger.warn 'PrewarmCommoditiesWorker running with preconfigured ids only: SEARCH_LOG_GROUP_NAME is not set'
-                           []
-                         end
+    most_requested_ids = most_requested_goods_nomenclature_item_ids(
+      log_group_name: SEARCH_LOG_GROUP_NAME,
+      lookback_hours: DEFAULT_LOOKBACK_HOURS,
+      limit: DEFAULT_LIMIT,
+    )
+
     ids = (preconfigured_ids + most_requested_ids).uniq
 
     if ids.empty?

--- a/spec/workers/clear_cache_worker_spec.rb
+++ b/spec/workers/clear_cache_worker_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe ClearCacheWorker, type: :worker do
   it { expect(TradeTariffBackend.frontend_redis).to have_received(:flushdb) }
   it { expect(Sidekiq::Client).to have_received(:enqueue).with(PrecacheHeadingsWorker, Time.zone.today.to_formatted_s(:db)) }
   it { expect(Sidekiq::Client).to have_received(:enqueue).with(PrewarmQuotaOrderNumbersWorker) }
+  it { expect(Sidekiq::Client).to have_received(:enqueue).with(PrewarmCommoditiesWorker) }
   it { expect(Sidekiq::Client).to have_received(:enqueue).with(ReindexModelsWorker) }
   it { expect(Sidekiq::Client).to have_received(:enqueue_in).with(1.minute, InvalidateCacheWorker) }
 

--- a/spec/workers/prewarm_commodities_worker_spec.rb
+++ b/spec/workers/prewarm_commodities_worker_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe PrewarmCommoditiesWorker do
 
   describe '#perform' do
     it 'queries CloudWatch and prewarms cached commodities' do
-      worker.perform('search-log-group')
+      worker.perform
 
       expect(client).to have_received(:start_query)
       expect(CachedCommodityService).to have_received(:new).with(commodity, Date.current)
@@ -42,18 +42,31 @@ RSpec.describe PrewarmCommoditiesWorker do
     it 'merges preconfigured ids with most requested ids' do
       allow(ENV).to receive(:fetch).with('PREWARM_COMMODITY_IDS', '').and_return("#{preconfigured_id},0101210000")
 
-      worker.perform('search-log-group')
+      worker.perform
 
       expect(Commodity).to have_received(:actual)
       expect(CachedCommodityService).to have_received(:new).with(preconfigured_commodity, Date.current)
       expect(CachedCommodityService).to have_received(:new).with(commodity, Date.current)
     end
 
-    it 'returns early when both log group and preconfigured ids are missing' do
-      worker.perform(nil)
+    context 'when commodity list is empty' do
+      let(:empty_query_results_response) do
+        instance_double(
+          Aws::CloudWatchLogs::Types::GetQueryResultsResponse,
+          status: 'Complete',
+          results: [],
+        )
+      end
 
-      expect(client).not_to have_received(:start_query)
-      expect(CachedCommodityService).not_to have_received(:new)
+      before do
+        allow(client).to receive_messages(start_query: start_query_response, get_query_results: empty_query_results_response)
+      end
+
+      it 'returns early when both log group and preconfigured ids are missing' do
+        worker.perform
+
+        expect(CachedCommodityService).not_to have_received(:new)
+      end
     end
   end
 end

--- a/spec/workers/prewarm_commodities_worker_spec.rb
+++ b/spec/workers/prewarm_commodities_worker_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe PrewarmCommoditiesWorker do
+  subject(:worker) { described_class.new }
+
+  let(:client) { instance_double(Aws::CloudWatchLogs::Client) }
+  let(:start_query_response) { instance_double(Aws::CloudWatchLogs::Types::StartQueryResponse, query_id: 'query-123') }
+  let(:query_results_response) do
+    instance_double(
+      Aws::CloudWatchLogs::Types::GetQueryResultsResponse,
+      status: 'Complete',
+      results: [[
+        instance_double(Aws::CloudWatchLogs::Types::ResultField, field: 'goods_nomenclature_item_id', value: '0101210000'),
+        instance_double(Aws::CloudWatchLogs::Types::ResultField, field: 'selections', value: '42'),
+      ]],
+    )
+  end
+  let(:preconfigured_id) { '0202301000' }
+  let(:commodity) { build(:commodity, goods_nomenclature_item_id: '0101210000', producline_suffix: '80') }
+  let(:preconfigured_commodity) { build(:commodity, goods_nomenclature_item_id: preconfigured_id, producline_suffix: '80') }
+  let(:query_scope) { instance_double(Sequel::Dataset, all: [commodity, preconfigured_commodity]) }
+  let(:cached_commodity_service) { instance_double(CachedCommodityService, call: true) }
+
+  before do
+    allow(described_class).to receive(:client).and_return(client)
+    allow(client).to receive(:start_query).and_return(start_query_response)
+    allow(client).to receive(:get_query_results).and_return(query_results_response)
+    allow(Commodity).to receive_message_chain(:actual, :by_codes).and_return(query_scope)
+    allow(CachedCommodityService).to receive(:new).and_return(cached_commodity_service)
+    allow(TimeMachine).to receive(:now).and_yield
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('PREWARM_COMMODITY_IDS', '').and_return('')
+  end
+
+  describe '#perform' do
+    it 'queries CloudWatch and prewarms cached commodities' do
+      worker.perform('search-log-group')
+
+      expect(client).to have_received(:start_query)
+      expect(CachedCommodityService).to have_received(:new).with(commodity, Date.current)
+      expect(cached_commodity_service).to have_received(:call)
+      expect(TimeMachine).to have_received(:now)
+    end
+
+    it 'merges preconfigured ids with most requested ids' do
+      allow(ENV).to receive(:fetch).with('PREWARM_COMMODITY_IDS', '').and_return("#{preconfigured_id},0101210000")
+
+      worker.perform('search-log-group')
+
+      expect(Commodity).to have_received(:actual)
+      expect(CachedCommodityService).to have_received(:new).with(preconfigured_commodity, Date.current)
+      expect(CachedCommodityService).to have_received(:new).with(commodity, Date.current)
+    end
+
+    it 'returns early when both log group and preconfigured ids are missing' do
+      worker.perform(nil)
+
+      expect(client).not_to have_received(:start_query)
+      expect(CachedCommodityService).not_to have_received(:new)
+    end
+  end
+end

--- a/spec/workers/prewarm_commodities_worker_spec.rb
+++ b/spec/workers/prewarm_commodities_worker_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe PrewarmCommoditiesWorker do
   subject(:worker) { described_class.new }
 
   let(:client) { instance_double(Aws::CloudWatchLogs::Client) }
+  let(:logger) { instance_double(Logger, info: nil, warn: nil, error: nil) }
   let(:start_query_response) { instance_double(Aws::CloudWatchLogs::Types::StartQueryResponse, query_id: 'query-123') }
   let(:query_results_response) do
     instance_double(
@@ -25,6 +26,7 @@ RSpec.describe PrewarmCommoditiesWorker do
     allow(Commodity).to receive_message_chain(:actual, :by_codes).and_return(query_scope)
     allow(CachedCommodityService).to receive(:new).and_return(cached_commodity_service)
     allow(TimeMachine).to receive(:now).and_yield
+    allow(worker).to receive(:logger).and_return(logger)
     allow(ENV).to receive(:fetch).and_call_original
     allow(ENV).to receive(:fetch).with('PREWARM_COMMODITY_IDS', '').and_return('')
   end
@@ -37,6 +39,43 @@ RSpec.describe PrewarmCommoditiesWorker do
       expect(CachedCommodityService).to have_received(:new).with(commodity, Date.current)
       expect(cached_commodity_service).to have_received(:call)
       expect(TimeMachine).to have_received(:now)
+    end
+
+    it 'builds the expected CloudWatch query payload' do
+      now = Time.zone.parse('2026-04-21 10:00:00 UTC')
+      allow(Time).to receive(:current).and_return(now, now)
+
+      worker.perform
+
+      expect(client).to have_received(:start_query).with(
+        hash_including(
+          log_group_name: PrewarmCommoditiesWorker::SEARCH_LOG_GROUP_NAME,
+          start_time: (now - PrewarmCommoditiesWorker::DEFAULT_LOOKBACK_HOURS.hours).to_i,
+          end_time: now.to_i,
+          query_string: <<~QUERY,
+            fields @timestamp, goods_nomenclature_item_id, event, service
+            | filter service = "search" and event = "result_selected" and goods_nomenclature_class = "Commodity" and ispresent(goods_nomenclature_item_id)
+            | stats count(*) as selections by goods_nomenclature_item_id
+            | sort selections desc
+            | limit #{PrewarmCommoditiesWorker::DEFAULT_LIMIT}
+          QUERY
+        ),
+      )
+    end
+
+    it 'polls CloudWatch until query completes' do
+      running_response = instance_double(
+        Aws::CloudWatchLogs::Types::GetQueryResultsResponse,
+        status: 'Running',
+        results: [],
+      )
+      allow(client).to receive(:get_query_results).and_return(running_response, query_results_response)
+      allow(worker).to receive(:sleep)
+
+      worker.perform
+
+      expect(client).to have_received(:get_query_results).twice
+      expect(worker).to have_received(:sleep).with(PrewarmCommoditiesWorker::QUERY_POLL_INTERVAL_SECONDS).once
     end
 
     it 'merges preconfigured ids with most requested ids' do
@@ -62,10 +101,25 @@ RSpec.describe PrewarmCommoditiesWorker do
         allow(client).to receive_messages(start_query: start_query_response, get_query_results: empty_query_results_response)
       end
 
-      it 'returns early when both log group and preconfigured ids are missing' do
+      it 'returns early when no ids are available from any source' do
         worker.perform
 
         expect(CachedCommodityService).not_to have_received(:new)
+      end
+    end
+
+    context 'when CloudWatch query fails' do
+      before do
+        allow(client).to receive(:start_query).and_raise(StandardError, 'access denied')
+      end
+
+      it 'logs and continues with preconfigured ids' do
+        allow(ENV).to receive(:fetch).with('PREWARM_COMMODITY_IDS', '').and_return(preconfigured_id)
+
+        worker.perform
+
+        expect(logger).to have_received(:error).with(/CloudWatch query failed/)
+        expect(CachedCommodityService).to have_received(:new).with(preconfigured_commodity, Date.current)
       end
     end
   end

--- a/spec/workers/prewarm_commodities_worker_spec.rb
+++ b/spec/workers/prewarm_commodities_worker_spec.rb
@@ -2,7 +2,6 @@ RSpec.describe PrewarmCommoditiesWorker do
   subject(:worker) { described_class.new }
 
   let(:client) { instance_double(Aws::CloudWatchLogs::Client) }
-  let(:logger) { instance_double(Logger, info: nil, warn: nil, error: nil) }
   let(:start_query_response) { instance_double(Aws::CloudWatchLogs::Types::StartQueryResponse, query_id: 'query-123') }
   let(:query_results_response) do
     instance_double(
@@ -26,7 +25,6 @@ RSpec.describe PrewarmCommoditiesWorker do
     allow(Commodity).to receive_message_chain(:actual, :by_codes).and_return(query_scope)
     allow(CachedCommodityService).to receive(:new).and_return(cached_commodity_service)
     allow(TimeMachine).to receive(:now).and_yield
-    allow(worker).to receive(:logger).and_return(logger)
     allow(ENV).to receive(:fetch).and_call_original
     allow(ENV).to receive(:fetch).with('PREWARM_COMMODITY_IDS', '').and_return('')
   end
@@ -70,12 +68,10 @@ RSpec.describe PrewarmCommoditiesWorker do
         results: [],
       )
       allow(client).to receive(:get_query_results).and_return(running_response, query_results_response)
-      allow(worker).to receive(:sleep)
 
       worker.perform
 
       expect(client).to have_received(:get_query_results).twice
-      expect(worker).to have_received(:sleep).with(PrewarmCommoditiesWorker::QUERY_POLL_INTERVAL_SECONDS).once
     end
 
     it 'merges preconfigured ids with most requested ids' do
@@ -118,7 +114,6 @@ RSpec.describe PrewarmCommoditiesWorker do
 
         worker.perform
 
-        expect(logger).to have_received(:error).with(/CloudWatch query failed/)
         expect(CachedCommodityService).to have_received(:new).with(preconfigured_commodity, Date.current)
       end
     end

--- a/spec/workers/prewarm_commodities_worker_spec.rb
+++ b/spec/workers/prewarm_commodities_worker_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe PrewarmCommoditiesWorker do
 
   before do
     allow(described_class).to receive(:client).and_return(client)
-    allow(client).to receive(:start_query).and_return(start_query_response)
-    allow(client).to receive(:get_query_results).and_return(query_results_response)
+    allow(client).to receive_messages(start_query: start_query_response, get_query_results: query_results_response)
     allow(Commodity).to receive_message_chain(:actual, :by_codes).and_return(query_scope)
     allow(CachedCommodityService).to receive(:new).and_return(cached_commodity_service)
     allow(TimeMachine).to receive(:now).and_yield

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -23,7 +23,9 @@ data "aws_iam_policy_document" "task" {
       "ssmmessages:OpenDataChannel",
       "logs:CreateLogStream",
       "logs:DescribeLogStreams",
-      "logs:PutLogEvents"
+      "logs:PutLogEvents",
+      "logs:StartQuery",
+      "logs:GetQueryResults"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
### Jira link

[HMRC-2119](https://transformuk.atlassian.net/browse/HMRC-2119)

### What?

I have added/removed/altered:

- [ ] Added PrewarmCommoditiesWorker logic to fetch top requested goods_nomenclature_item_id values from CloudWatch (result_selected search logs)
- [ ] Added merge of preconfigured commodity IDs from PREWARM_COMMODITY_IDS with log-derived IDs, with deduplication
- [ ] Bulk-load commodities by_codes before warming cache

### Why?

I am doing this because:

- we want to prewarm commodity cache using real usage patterns from production search activity
- we also need deterministic prewarming for known high-priority commodity codes via configuration