### PR TITLE
Fix N+1 queries from GeographicalArea#referenced by adding a custom eager_loader

### DIFF
--- a/app/models/geographical_area.rb
+++ b/app/models/geographical_area.rb
@@ -25,9 +25,29 @@ class GeographicalArea < Sequel::Model
       .order(Sequel.desc(:geographical_area_description_periods__validity_start_date))
   end
 
-  many_to_one :referenced, class: 'GeographicalArea',
-                           primary_key: :geographical_area_id,
-                           key: :referenced_id do |ds|
+  many_to_one :referenced,
+              class: 'GeographicalArea',
+              primary_key: :geographical_area_id,
+              key: :referenced_id,
+              eager_loader: (lambda do |eo|
+                eo[:rows].each { |ga| ga.associations[:referenced] = nil }
+
+                rows_with_refs = eo[:rows].select { |ga| REFERENCED_GEOGRAPHICAL_AREAS.key?(ga.geographical_area_id) }
+                return if rows_with_refs.empty?
+
+                ref_ids = rows_with_refs.map { |ga| REFERENCED_GEOGRAPHICAL_AREAS[ga.geographical_area_id] }.uniq
+
+                referenced_by_id = GeographicalArea.actual
+                  .where(geographical_area_id: ref_ids)
+                  .eager(eo[:associations])
+                  .all
+                  .index_by(&:geographical_area_id)
+
+                rows_with_refs.each do |ga|
+                  ref_id = REFERENCED_GEOGRAPHICAL_AREAS[ga.geographical_area_id]
+                  ga.associations[:referenced] = referenced_by_id[ref_id]
+                end
+              end) do |ds|
     ds.with_actual(GeographicalArea)
   end
 


### PR DESCRIPTION
## Summary

- `GeographicalArea#referenced` uses `key: :referenced_id` where `referenced_id` is a private Ruby method (not a DB column) that looks up the area's ID in `REFERENCED_GEOGRAPHICAL_AREAS = { 'EU' => '1013' }`.
- Sequel's standard many_to_one eager loader builds its batch `IN` query from the column values it reads from the SELECT result. Since `referenced_id` is not in the SELECT, Sequel cannot build the batch query and silently falls back to one lazy `SELECT ... WHERE geographical_area_id = '1013' LIMIT 1` per EU-area measure.
- EU is a very common measure geographical area, so this fired many times on every `commodities#show` cache miss.
- A second cascading N+1 followed: the freshly-lazy-loaded referenced objects had no preloaded associations, so each call to `referenced.contained_geographical_areas` also fired its own join query through `geographical_area_memberships`.
- Fix: add a custom `eager_loader:` lambda to the `referenced` association. It reads `REFERENCED_GEOGRAPHICAL_AREAS` in Ruby, issues **one** batch query for all referenced area IDs, and assigns results to each parent area's `associations` cache. Nested eager loads (`eo[:associations]`, e.g. `contained_geographical_areas`) are forwarded to the batch query so they are preloaded too. Areas without a reference mapping get `associations[:referenced] = nil` so Sequel skips the lazy load for them as well.
