### PR TITLE
Preload contained_geographical_areas one level deeper to prevent N+1

### DIFF
--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -58,8 +58,8 @@ class CachedCommodityService
     {
       geographical_area: [
         :geographical_area_descriptions,
-        { contained_geographical_areas: :geographical_area_descriptions },
-        { referenced: :contained_geographical_areas },
+        { contained_geographical_areas: %i[geographical_area_descriptions contained_geographical_areas] },
+        { referenced: { contained_geographical_areas: :contained_geographical_areas } },
       ],
     },
     {


### PR DESCRIPTION
## Summary

- `GeographicalAreaSerializer` declares `has_many :contained_geographical_areas` (surfaced as `children_geographical_areas`). When member countries of a group area are sideloaded, `jsonapi-serializer` accesses that relationship on each member country to build the `relationships` section — one query per country.
- Fix: nest `:contained_geographical_areas` inside itself in the `MEASURES_EAGER_LOAD_GRAPH` so Sequel preloads it in a single batch for all member countries.
- Also applied one level deeper on the `:referenced` path so the EU → 1013 mapping is covered.
