### PR TITLE
Fix two bugs in OptimizedManyToMany eager loader

### DIFF
--- a/app/lib/sequel/plugins/optimized_many_to_many.rb
+++ b/app/lib/sequel/plugins/optimized_many_to_many.rb
@@ -119,51 +119,53 @@ module Sequel
             target_table = associated_class.table_name
             right_pks = Array(refl[:right_primary_key])
             order = refl[:order]
-            cte_name = 'filter_ids'
 
-            # Build join conditions for right-hand side
             join_conditions = OptimizedManyToMany.join_conditions(right_keys, right_pks, join_table, target_table)
             order_sql = OptimizedManyToMany.qualify_order(order, target_table, associated_class)
+            fk_selects = left_keys.map { |lk| "#{join_table}.#{lk} AS x_fk_#{lk}" }.join(', ')
 
-            # Build the CTE for composite keys
-            cte_columns = left_pks.map(&:to_s).join(', ')
-            unnest_args = left_pks.each_with_index.map { |_, _i| 'unnest(?)' }.join(', ')
-            fk_selects = left_keys.each_with_index.map { |lk, _i|
-              "#{join_table}.#{lk} AS x_fk_#{lk}"
-            }.join(', ')
+            if left_pks.size == 1
+              sql = <<~SQL.strip
+                SELECT #{target_table}.*, #{fk_selects}
+                FROM #{OptimizedManyToMany.table_ref(join_table)}
+                JOIN #{target_table} ON #{join_conditions}
+                WHERE #{join_table}.#{left_keys.first} = ANY(?)
+                #{order_sql ? "ORDER BY #{order_sql}" : ''}
+              SQL
 
-            sql = <<~SQL.strip
-              WITH #{cte_name} (#{cte_columns}) AS (
-                SELECT #{unnest_args}
-              )
-              SELECT #{target_table}.*, #{fk_selects}
-              FROM #{target_table}
-              JOIN #{OptimizedManyToMany.table_ref(join_table)} ON #{join_conditions}
-              JOIN #{cte_name} fm ON #{left_keys.zip(left_pks).map { |lk, pk| "fm.#{pk} = #{join_table}.#{lk}" }.join(' AND ')}
-              #{order_sql ? "ORDER BY #{order_sql}" : ''}
-            SQL
+              bind_args = [Sequel.pg_array(ids)]
+            else
+              cte_name = 'filter_ids'
+              cte_columns = left_pks.map(&:to_s).join(', ')
+              unnest_args = left_pks.map { 'unnest(?)' }.join(', ')
 
-            # Build bind arguments for unnest
-            bind_args = left_pks.map.with_index do |_pk, i|
-              Sequel.pg_array(ids.map { |k| Array(k)[i] })
+              sql = <<~SQL.strip
+                WITH #{cte_name} (#{cte_columns}) AS (
+                  SELECT #{unnest_args}
+                )
+                SELECT #{target_table}.*, #{fk_selects}
+                FROM #{target_table}
+                JOIN #{OptimizedManyToMany.table_ref(join_table)} ON #{join_conditions}
+                JOIN #{cte_name} fm ON #{left_keys.zip(left_pks).map { |lk, pk| "fm.#{pk} = #{join_table}.#{lk}" }.join(' AND ')}
+                #{order_sql ? "ORDER BY #{order_sql}" : ''}
+              SQL
+
+              bind_args = left_pks.map.with_index do |_pk, i|
+                Sequel.pg_array(ids.map { |k| Array(k)[i] })
+              end
             end
 
             dataset = associated_class.with_sql(sql, *bind_args)
             records = dataset.all
 
-            # Load nested associations if requested
-            if eo[:associations]
-              associated_class.eager(eo[:associations])
-            end
+            associated_class.eager(eo[:associations]).send(:eager_load, records) if eo[:associations] && records.any?
 
-            # Group by composite key (tuples)
             grouped = Hash.new { |h, k| h[k] = [] }
             records.each do |rec|
               key_values = left_keys.map { |lk| rec.values.delete("x_fk_#{lk}".to_sym) }
               grouped[key_values] << rec
             end
 
-            # Assign back to parent objects
             eo[:rows].each do |parent|
               parent_key = Array(left_pks).map { |pk| parent.send(pk) }
               parent.associations[assoc_name] = grouped[parent_key] || []

--- a/spec/lib/sequel/plugins/optimized_many_to_many_spec.rb
+++ b/spec/lib/sequel/plugins/optimized_many_to_many_spec.rb
@@ -222,9 +222,11 @@ RSpec.describe Sequel::Plugins::OptimizedManyToMany do
                           use_optimized: true
     end
 
-    it 'eager loads nested associations (children → grandchildren)' do
+    it 'eager loads nested associations (cte_children → grandchildren)' do
       parents = Parent.eager(cte_children: :grandchildren).all
-      expect(parents.first.children.first.grandchildren.map(&:name)).to eq(%w[G1])
+      p1 = parents.find { |p| p.id == @p1.id }
+      c1 = p1.cte_children.find { |c| c.id == @c1.id }
+      expect(c1.grandchildren.map(&:name)).to eq(%w[G1])
     end
   end
 


### PR DESCRIPTION
## Summary

Two independent bugs in `app/lib/sequel/plugins/optimized_many_to_many.rb`:

**Bug 1 — nested associations never loaded (dead code)**

```ruby
# before: creates a dataset but never calls .all — does nothing
if eo[:associations]
  associated_class.eager(eo[:associations])
end

# after: calls eager_load on already-fetched records in-place
associated_class.eager(eo[:associations]).send(:eager_load, records) if eo[:associations] && records.any?
```

Every association that uses `use_optimized: true` and has nested eager options specified would silently skip loading those nested associations. On `commodities#show`, `excluded_geographical_areas` is loaded with `[: geographical_area_descriptions, :contained_geographical_areas, { referenced: :contained_geographical_areas }]` nested — all three were lazy-loading on every record.

**Bug 2 — CTE prevents index use for single-key associations**

The previous query started `FROM target_table JOIN join_table JOIN filter_ids_cte`. Because `unnest()` is volatile, PostgreSQL materialises the CTE, which can force a hash join against the full join table rather than using the index on the left-key column.

For single-key associations the CTE is replaced with a `WHERE left_key = ANY(?)` that leads from the join table:

```sql
-- before
WITH filter_ids (measure_sid) AS (SELECT unnest(?))
SELECT geographical_areas.*, ...
FROM geographical_areas
JOIN measure_excluded_geographical_areas ON ...
JOIN filter_ids fm ON fm.measure_sid = measure_excluded_geographical_areas.measure_sid

-- after
SELECT geographical_areas.*, ...
FROM measure_excluded_geographical_areas
JOIN geographical_areas ON ...
WHERE measure_excluded_geographical_areas.measure_sid = ANY(?)
```

The planner can now do an index scan on `measure_excluded_geographical_areas.measure_sid` followed by a nested-loop join into `geographical_areas` — the access pattern the index was built for.

Composite-key associations keep the CTE approach.

**Spec fix**

The existing nested-association spec with `use_optimized: true` tested `parents.first.children` (the non-optimised association) instead of `cte_children`, so it passed even with the dead code. Fixed to test `cte_children`.

## Test plan

- [ ] CI passes
- [ ] Verify on a commodity with excluded geographical areas — repeated `geographical_area_descriptions` / `contained_geographical_areas` queries for excluded areas should collapse to single batch queries