### PR TITLE
AI-596: Exclude approved content from review listings

### DIFF
--- a/app/controllers/api/admin/goods_nomenclature_labels_controller.rb
+++ b/app/controllers/api/admin/goods_nomenclature_labels_controller.rb
@@ -37,7 +37,19 @@ module Api
           .for_status(params[:status])
           .for_score_category(params[:score_category])
 
+        dataset = dataset.exclude(Sequel[:goods_nomenclature_labels][:approved] => true) if normal_review_listing?
+
         apply_sorting(dataset)
+      end
+
+      def normal_review_listing?
+        params[:status].blank? && !search_query?
+      end
+
+      def search_query?
+        q = params[:q].to_s.strip
+
+        q.match?(/\A\d{2,10}\z/) || q.length >= 2
       end
 
       def apply_sorting(dataset)

--- a/app/controllers/api/admin/goods_nomenclature_self_texts_controller.rb
+++ b/app/controllers/api/admin/goods_nomenclature_self_texts_controller.rb
@@ -37,7 +37,19 @@ module Api
           .for_status(params[:status])
           .for_score_category(params[:score_category])
 
+        dataset = dataset.exclude(Sequel[:goods_nomenclature_self_texts][:approved] => true) if normal_review_listing?
+
         apply_sorting(dataset)
+      end
+
+      def normal_review_listing?
+        params[:status].blank? && !search_query?
+      end
+
+      def search_query?
+        q = params[:q].to_s.strip
+
+        q.match?(/\A\d{2,10}\z/) || q.length >= 2
       end
 
       def apply_sorting(dataset)

--- a/spec/controllers/api/admin/goods_nomenclature_labels_controller_spec.rb
+++ b/spec/controllers/api/admin/goods_nomenclature_labels_controller_spec.rb
@@ -81,6 +81,46 @@ RSpec.describe Api::Admin::GoodsNomenclatureLabelsController do
       end
     end
 
+    context 'with approved records' do
+      let!(:approved_commodity) do
+        create(:goods_nomenclature, producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX).tap do |gn|
+          create(:goods_nomenclature_label,
+                 goods_nomenclature: gn,
+                 description: 'Approved label for direct lookup',
+                 description_score: 0.4,
+                 known_brands: Sequel.pg_array([], :text),
+                 synonyms: Sequel.pg_array([], :text),
+                 colloquial_terms: Sequel.pg_array([], :text),
+                 approved: true,
+                 labels: { 'description' => 'Approved label for direct lookup' })
+        end
+      end
+
+      it 'excludes approved labels from normal listing by default' do
+        get :index, format: :json
+
+        json = JSON.parse(response.body)
+        sids = json['data'].map { |d| d.dig('attributes', 'goods_nomenclature_sid') }
+        expect(sids).not_to include(approved_commodity.goods_nomenclature_sid)
+      end
+
+      it 'returns approved labels when explicitly filtered' do
+        get :index, params: { status: 'approved' }, format: :json
+
+        json = JSON.parse(response.body)
+        expect(json['data'].length).to eq(1)
+        expect(json['data'].first.dig('attributes', 'approved')).to be true
+      end
+
+      it 'keeps approved labels searchable by text' do
+        get :index, params: { q: 'direct lookup' }, format: :json
+
+        json = JSON.parse(response.body)
+        sids = json['data'].map { |d| d.dig('attributes', 'goods_nomenclature_sid') }
+        expect(sids).to include(approved_commodity.goods_nomenclature_sid)
+      end
+    end
+
     context 'with score_category filter' do
       let!(:low_score) do # rubocop:disable RSpec/LetSetup
         create(:goods_nomenclature, producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX).tap do |gn|

--- a/spec/controllers/api/admin/goods_nomenclature_self_texts_controller_spec.rb
+++ b/spec/controllers/api/admin/goods_nomenclature_self_texts_controller_spec.rb
@@ -132,6 +132,44 @@ RSpec.describe Api::Admin::GoodsNomenclatureSelfTextsController do
       end
     end
 
+    context 'with approved records' do
+      let!(:approved_commodity) do
+        create(:goods_nomenclature, producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX).tap do |gn|
+          create(:goods_nomenclature_self_text,
+                 goods_nomenclature: gn,
+                 self_text: 'Approved widgets for direct lookup',
+                 similarity_score: 0.4,
+                 coherence_score: 0.4,
+                 generation_type: 'ai',
+                 approved: true)
+        end
+      end
+
+      it 'excludes approved self texts from normal listing by default' do
+        get :index, format: :json
+
+        json = JSON.parse(response.body)
+        sids = json['data'].map { |d| d.dig('attributes', 'goods_nomenclature_sid') }
+        expect(sids).not_to include(approved_commodity.goods_nomenclature_sid)
+      end
+
+      it 'returns approved self texts when explicitly filtered' do
+        get :index, params: { status: 'approved' }, format: :json
+
+        json = JSON.parse(response.body)
+        expect(json['data'].length).to eq(1)
+        expect(json['data'].first.dig('attributes', 'approved')).to be true
+      end
+
+      it 'keeps approved self texts searchable by text' do
+        get :index, params: { q: 'direct lookup' }, format: :json
+
+        json = JSON.parse(response.body)
+        sids = json['data'].map { |d| d.dig('attributes', 'goods_nomenclature_sid') }
+        expect(sids).to include(approved_commodity.goods_nomenclature_sid)
+      end
+    end
+
     context 'with score_category filter' do
       let!(:low_score) do # rubocop:disable RSpec/LetSetup
         create(:goods_nomenclature, producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX).tap do |gn|


### PR DESCRIPTION
### Jira link

[AI-596](https://transformuk.atlassian.net/browse/AI-596)

### What?

- [x] Exclude approved self-texts from normal generated-content listings by default
- [x] Exclude approved labels from normal generated-content listings by default
- [x] Preserve explicit `status=approved` filters for self-texts and labels
- [x] Keep approved self-texts and labels searchable by commodity code or text

### Why?

Approved generated content should not keep returning to normal review work. Operators can still inspect approved rows deliberately using the approved filter or search when investigating a specific commodity or query.