### PR TITLE
BAU: Remove init containers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
         args: ["--severity=warning"]
 
   - repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.93.6
+    rev: v3.95.2
     hooks:
       - id: trufflehog
 
@@ -43,6 +43,6 @@ repos:
 
 
   - repo: https://github.com/rhysd/actionlint.git
-    rev: v1.7.11
+    rev: v1.7.12
     hooks:
       - id: actionlint-docker

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -7,6 +7,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   hashes = [
     "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
     "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
     "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
     "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
@@ -30,6 +31,7 @@ provider "registry.terraform.io/hashicorp/random" {
   hashes = [
     "h1:BYpqK2+ZHqNF9sauVugKJSeFWMCx11I/z/1lMplwUC0=",
     "h1:SqwYP3u2T4rNxWvcrUc693VLY1V7DJPusZR9nn5NqSo=",
+    "h1:a6J4v7/4LbNCr8boUAJ7+xyVILRECYlRHicm543y+uU=",
     "zh:0e71891d8f25564e8d0b61654ed2ca52101862b9a2a07d736395193ae07b134b",
     "zh:1c56852d094161997df5fd8a6cbca7c6c979b3f8c3c00fbcc374a59305d117b1",
     "zh:20698fb8a2eaa7e23c4f8e3d22250368862f578cf618be0281d5b61496cbef13",

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -2,7 +2,6 @@ locals {
   has_autoscaler = var.environment == "development" ? false : true
   account_id     = data.aws_caller_identity.current.account_id
   worker_command = ["/bin/sh", "-c", "export DB_POOL=$${DB_POOL:-$${SIDEKIQ_CONCURRENCY:-10}} && bundle exec sidekiq -C ./config/sidekiq.yml"]
-  init_command   = ["/bin/sh", "-c", "bundle exec rails db:migrate && bundle exec rails data:migrate"]
   job_command    = ["/bin/sh", "-c", "bin/null-service"]
 
   tls_secret = jsondecode(data.aws_secretsmanager_secret_version.ecs_tls_certificate.secret_string)

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -28,9 +28,6 @@ module "worker_uk" {
   container_entrypoint = [""]
   container_command    = local.worker_command
 
-  init_container_entrypoint = [""]
-  init_container_command    = local.init_command
-
   service_environment_config = local.worker_uk_secret_env_vars
 
   has_autoscaler = local.has_autoscaler

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -28,9 +28,6 @@ module "worker_xi" {
   container_entrypoint = [""]
   container_command    = local.worker_command
 
-  init_container_entrypoint = [""]
-  init_container_command    = local.init_command
-
   service_environment_config = local.worker_xi_secret_env_vars
 
   has_autoscaler = local.has_autoscaler


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Removed init containers from Terraform ECS services
- Bumped pre-commit hooks

### Why?

I am doing this because:

- Now that database migrations for the backend run in the deployment pipeline, the init containers are effectively a no-op, and can be removed. This should speed up application deployment.

### Deployment risks

- Removing the init containers should be a no-op as schema migrations are run in the pipeline, however we should continue doing best practices for safe schema changes; that is, removing code before removing tables such that there is less chance of deploying a broken application.