### PR TITLE
Preload descriptions and children on contained_geographical_areas in show

### DIFF
--- a/app/controllers/api/v2/geographical_areas_controller.rb
+++ b/app/controllers/api/v2/geographical_areas_controller.rb
@@ -23,7 +23,13 @@ module Api
       end
 
       def geographical_area
-        GeographicalArea.actual.by_id(params[:id]).eager(:geographical_area_descriptions, :contained_geographical_areas).take
+        GeographicalArea.actual
+          .by_id(params[:id])
+          .eager(
+            :geographical_area_descriptions,
+            contained_geographical_areas: %i[geographical_area_descriptions contained_geographical_areas],
+          )
+          .take
       end
 
       def exclude_none


### PR DESCRIPTION
## Summary

`geographical_areas#show` eagerly loaded `:contained_geographical_areas` on the top-level area but not the associations needed by the serializer on each of those members.

`GeographicalAreaTreeSerializer` accesses two things on every contained area:
- `description` → lazy-loads `geographical_area_descriptions` per member
- `contained_geographical_areas` → lazy-loads memberships per member

Fix: nest both one level deeper in the eager load so Sequel fetches them in two batch queries rather than 2N individual ones.
