### PR TITLE
Fix three slow queries on commodities#show

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -300,7 +300,11 @@ class GoodsNomenclature < Sequel::Model
   end
 
   def has_chemicals
-    @has_chemicals ||= full_chemicals_dataset.limit(1).any?
+    if associations.key?(:full_chemicals)
+      full_chemicals.any?
+    else
+      @has_chemicals ||= full_chemicals_dataset.limit(1).any?
+    end
   end
 
   def to_admin_param

--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -129,6 +129,7 @@ class CachedCommodityService
         ancestors: { measures: MEASURES_EAGER_LOAD_GRAPH,
                      goods_nomenclature_descriptions: {} },
         measures: MEASURES_EAGER_LOAD_GRAPH,
+        full_chemicals: {},
       )
       .take
   end

--- a/db/migrate/20260423120000_add_regulation_and_fts_performance_indexes.rb
+++ b/db/migrate/20260423120000_add_regulation_and_fts_performance_indexes.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Three targeted index additions for commodities#show:
+#
+# Index 1 & 2: partial indexes on base_regulations and modification_regulations
+#   for the approved composite-key lookup pattern.
+#
+#   The eager-load queries for :base_regulation, :justification_base_regulation
+#   and :modification_regulation all take the form:
+#
+#     WHERE approved_flag IS TRUE
+#       AND (base_regulation_id, base_regulation_role) IN ((v1, v2), ...)
+#
+#   With separate single-column indexes, PostgreSQL may BitmapAnd the
+#   approved_flag index (large) with the composite-key index (small) rather
+#   than doing a direct index lookup. A partial index that covers only
+#   approved rows collapses this into a single index scan.
+#
+# Index 3: fts_regulation_actions(stopped_regulation_id)
+#
+#   The full_temporary_stop_regulations eager-load joins fts_regulation_actions
+#   and filters by stopped_regulation_id IN (...). The only existing index is a
+#   four-column composite with stopped_regulation_id as the third column, which
+#   cannot be used for this single-column predicate. Without an index the join
+#   table is fully scanned.
+
+Sequel.migration do
+  up do
+    run <<-SQL
+      CREATE INDEX IF NOT EXISTS base_regulations_approved_composite_index
+        ON base_regulations (base_regulation_id, base_regulation_role)
+        WHERE approved_flag IS TRUE;
+
+      CREATE INDEX IF NOT EXISTS modification_regulations_approved_composite_index
+        ON modification_regulations (modification_regulation_id, modification_regulation_role)
+        WHERE approved_flag IS TRUE;
+
+      CREATE INDEX IF NOT EXISTS fts_regulation_actions_stopped_regulation_id_index
+        ON fts_regulation_actions (stopped_regulation_id);
+    SQL
+  end
+
+  down do
+    run <<-SQL
+      DROP INDEX IF EXISTS base_regulations_approved_composite_index;
+      DROP INDEX IF EXISTS modification_regulations_approved_composite_index;
+      DROP INDEX IF EXISTS fts_regulation_actions_stopped_regulation_id_index;
+    SQL
+  end
+end


### PR DESCRIPTION
## Summary

Three independent slow queries on `commodities#show`:

**`base_regulations` / `modification_regulations` — partial indexes**

The batch eager-load for `:base_regulation`, `:justification_base_regulation`, and `{ modification_regulation: :base_regulation }` all generate:

```sql
WHERE approved_flag IS TRUE
  AND (base_regulation_id, base_regulation_role) IN ((v1, v2), ...)
```

With separate single-column indexes, PostgreSQL can end up BitmapAnding the `approved_flag` index (large result set) with the composite-key index (2–4 rows) rather than doing a direct targeted lookup. A partial index that covers only `approved_flag IS TRUE` rows collapses this into a single index scan on the approved-regulation subset.

**`fts_regulation_actions.stopped_regulation_id` — missing index**

The `full_temporary_stop_regulations` many-to-many eager-load joins `fts_regulation_actions` and filters by `stopped_regulation_id IN (...)`. The only existing index is a four-column composite with `stopped_regulation_id` as the third column — it cannot serve this single-column predicate alone, so the join table is fully scanned. A dedicated index on `stopped_regulation_id` gives the planner the access path it needs.

**`full_chemicals` — eager load + association-aware `has_chemicals`**

`GoodsNomenclature#has_chemicals` called `full_chemicals_dataset.limit(1).any?`, which always creates a new dataset and fires a DB query even when `full_chemicals` was already loaded. Changed to check `full_chemicals.any?` when the association is in memory, with a fallback to the dataset query for other call sites. Added `:full_chemicals` to the commodity eager load in `CachedCommodityService` so `has_chemicals` incurs zero DB queries during serialization.
