### PR TITLE
AI-626: Add expired generated content filtering

### DIFF
--- a/app/controllers/api/admin/goods_nomenclature_labels_controller.rb
+++ b/app/controllers/api/admin/goods_nomenclature_labels_controller.rb
@@ -31,7 +31,7 @@ module Api
 
       def filtered_dataset
         dataset = GoodsNomenclatureLabel
-          .admin_listing
+          .admin_listing(include_expired: expired_listing?)
           .search(params[:q])
           .for_nomenclature_type(params[:type])
           .for_status(params[:status])
@@ -44,6 +44,10 @@ module Api
 
       def normal_review_listing?
         params[:status].blank? && !search_query?
+      end
+
+      def expired_listing?
+        params[:status] == 'expired'
       end
 
       def search_query?

--- a/app/controllers/api/admin/goods_nomenclature_self_texts_controller.rb
+++ b/app/controllers/api/admin/goods_nomenclature_self_texts_controller.rb
@@ -31,7 +31,7 @@ module Api
 
       def filtered_dataset
         dataset = GoodsNomenclatureSelfText
-          .admin_listing
+          .admin_listing(include_expired: expired_listing?)
           .search(params[:q])
           .for_nomenclature_type(params[:type])
           .for_status(params[:status])
@@ -44,6 +44,10 @@ module Api
 
       def normal_review_listing?
         params[:status].blank? && !search_query?
+      end
+
+      def expired_listing?
+        params[:status] == 'expired'
       end
 
       def search_query?

--- a/app/models/goods_nomenclature_label.rb
+++ b/app/models/goods_nomenclature_label.rb
@@ -34,18 +34,18 @@ class GoodsNomenclatureLabel < Sequel::Model
       where(stale: true, manually_edited: false)
     end
 
-    def admin_listing
+    def admin_listing(include_expired: false)
       lbl = Sequel[:goods_nomenclature_labels]
 
       TimeMachine.now do
-        join(:goods_nomenclatures, { Sequel[:gn][:goods_nomenclature_sid] => lbl[:goods_nomenclature_sid] }, table_alias: :gn)
-          .where(GoodsNomenclature.validity_dates_filter(:gn))
+        dataset = join(:goods_nomenclatures, { Sequel[:gn][:goods_nomenclature_sid] => lbl[:goods_nomenclature_sid] }, table_alias: :gn)
           .select_all(:goods_nomenclature_labels)
           .select_append(
             nomenclature_type_expression.as(:nomenclature_type),
             score_expression.as(:score),
           )
-          .where(lbl[:expired] => false)
+
+        include_expired ? dataset : dataset.where(GoodsNomenclature.validity_dates_filter(:gn)).where(lbl[:expired] => false)
       end
     end
 
@@ -82,6 +82,8 @@ class GoodsNomenclatureLabel < Sequel::Model
         where(lbl[:stale] => true)
       when 'manually_edited'
         where(lbl[:manually_edited] => true)
+      when 'expired'
+        where(lbl[:expired] => true)
       else
         self
       end

--- a/app/models/goods_nomenclature_self_text.rb
+++ b/app/models/goods_nomenclature_self_text.rb
@@ -23,17 +23,18 @@ class GoodsNomenclatureSelfText < Sequel::Model
       where(needs_review: true)
     end
 
-    def admin_listing
+    def admin_listing(include_expired: false)
       st = Sequel[:goods_nomenclature_self_texts]
 
-      join(:goods_nomenclatures, { Sequel[:gn][:goods_nomenclature_sid] => st[:goods_nomenclature_sid] }, table_alias: :gn)
+      dataset = join(:goods_nomenclatures, { Sequel[:gn][:goods_nomenclature_sid] => st[:goods_nomenclature_sid] }, table_alias: :gn)
         .select_all(:goods_nomenclature_self_texts)
         .select_append(
           nomenclature_type_expression.as(:nomenclature_type),
           score_expression.as(:score),
         )
         .where(st[:generation_type] => %w[ai ai_non_other])
-        .where(st[:expired] => false)
+
+      include_expired ? dataset : dataset.where(st[:expired] => false)
     end
 
     def search(query)
@@ -67,6 +68,8 @@ class GoodsNomenclatureSelfText < Sequel::Model
         where(st[:stale] => true)
       when 'manually_edited'
         where(st[:manually_edited] => true)
+      when 'expired'
+        where(st[:expired] => true)
       else
         self
       end

--- a/spec/controllers/api/admin/goods_nomenclature_labels_controller_spec.rb
+++ b/spec/controllers/api/admin/goods_nomenclature_labels_controller_spec.rb
@@ -81,6 +81,38 @@ RSpec.describe Api::Admin::GoodsNomenclatureLabelsController do
       end
     end
 
+    context 'with expired records' do
+      let!(:expired_commodity) do
+        create(:commodity, :expired, producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX).tap do |gn|
+          create(:goods_nomenclature_label,
+                 goods_nomenclature: gn,
+                 description: 'Expired label',
+                 description_score: 0.4,
+                 known_brands: Sequel.pg_array([], :text),
+                 synonyms: Sequel.pg_array([], :text),
+                 colloquial_terms: Sequel.pg_array([], :text),
+                 expired: true,
+                 labels: { 'description' => 'Expired label' })
+        end
+      end
+
+      it 'excludes expired labels from normal listing by default' do
+        get :index, format: :json
+
+        json = JSON.parse(response.body)
+        sids = json['data'].map { |d| d.dig('attributes', 'goods_nomenclature_sid') }
+        expect(sids).not_to include(expired_commodity.goods_nomenclature_sid)
+      end
+
+      it 'returns expired labels when explicitly filtered' do
+        get :index, params: { status: 'expired' }, format: :json
+
+        json = JSON.parse(response.body)
+        expect(json['data'].length).to eq(1)
+        expect(json['data'].first.dig('attributes', 'expired')).to be true
+      end
+    end
+
     context 'with approved records' do
       let!(:approved_commodity) do
         create(:goods_nomenclature, producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX).tap do |gn|

--- a/spec/controllers/api/admin/goods_nomenclature_self_texts_controller_spec.rb
+++ b/spec/controllers/api/admin/goods_nomenclature_self_texts_controller_spec.rb
@@ -132,6 +132,33 @@ RSpec.describe Api::Admin::GoodsNomenclatureSelfTextsController do
       end
     end
 
+    context 'with expired records' do
+      let!(:expired_commodity) do
+        create(:commodity, :expired, producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX).tap do |gn|
+          create(:goods_nomenclature_self_text,
+                 goods_nomenclature: gn,
+                 generation_type: 'ai',
+                 expired: true)
+        end
+      end
+
+      it 'excludes expired self texts from normal listing by default' do
+        get :index, format: :json
+
+        json = JSON.parse(response.body)
+        sids = json['data'].map { |d| d.dig('attributes', 'goods_nomenclature_sid') }
+        expect(sids).not_to include(expired_commodity.goods_nomenclature_sid)
+      end
+
+      it 'returns expired self texts when explicitly filtered' do
+        get :index, params: { status: 'expired' }, format: :json
+
+        json = JSON.parse(response.body)
+        expect(json['data'].length).to eq(1)
+        expect(json['data'].first.dig('attributes', 'expired')).to be true
+      end
+    end
+
     context 'with approved records' do
       let!(:approved_commodity) do
         create(:goods_nomenclature, producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX).tap do |gn|


### PR DESCRIPTION
### Jira link

[AI-626](https://transformuk.atlassian.net/browse/AI-626)

### What?

- [x] Support explicit `status=expired` for self-text admin listings
- [x] Support explicit `status=expired` for label admin listings
- [x] Keep expired generated content excluded from normal listings
- [x] Allow expired labels attached to expired goods nomenclature records to be listed when explicitly filtered

### Why?

Admin can now filter expired generated content, so the backend needs to honour that explicit filter while keeping expired rows out of normal review listings.