### PR TITLE
HMRC-2015: Remove currency from commodity cache key

### DIFF
--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -1,7 +1,7 @@
 class CachedCommodityService
   include DeclarableSerialization
 
-  CACHE_VERSION = 5
+  CACHE_VERSION = 6
 
   DEFAULT_INCLUDES = (DECLARABLE_INCLUDES + %w[
     heading
@@ -146,6 +146,6 @@ class CachedCommodityService
   end
 
   def cache_key
-    "_commodity-v#{CACHE_VERSION}-#{@commodity_sid}-#{actual_date}-#{TradeTariffBackend.currency}-#{meursing_additional_code_id}"
+    "_commodity-v#{CACHE_VERSION}-#{@commodity_sid}-#{actual_date}-#{meursing_additional_code_id}"
   end
 end

--- a/spec/services/cached_commodity_service_spec.rb
+++ b/spec/services/cached_commodity_service_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe CachedCommodityService do
 
       it 'does not include geographical_area_id' do
         service.call
-        expected_key = "_commodity-v#{CachedCommodityService::CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}-"
+        expected_key = "_commodity-v#{CachedCommodityService::CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-"
         expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 24.hours)
       end
 
@@ -102,7 +102,7 @@ RSpec.describe CachedCommodityService do
 
         it 'uses the same cache key regardless of country' do
           service.call
-          expected_key = "_commodity-v#{CachedCommodityService::CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}-"
+          expected_key = "_commodity-v#{CachedCommodityService::CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-"
           expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 24.hours)
         end
       end
@@ -112,7 +112,7 @@ RSpec.describe CachedCommodityService do
 
         it 'includes meursing code in cache key' do
           service.call
-          expected_key = "_commodity-v#{CachedCommodityService::CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}-foo"
+          expected_key = "_commodity-v#{CachedCommodityService::CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-foo"
           expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 24.hours)
         end
       end
@@ -124,7 +124,7 @@ RSpec.describe CachedCommodityService do
         ro_service.call
         de_service.call
 
-        expected_key = "_commodity-v#{CachedCommodityService::CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-#{TradeTariffBackend.currency}-"
+        expected_key = "_commodity-v#{CachedCommodityService::CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-"
         expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 24.hours).twice
       end
     end


### PR DESCRIPTION
### Jira link

[HMRC-2015](https://transformuk.atlassian.net/browse/HMRC-2015)

### What?

I have added/removed/altered:

- Removed `TradeTariffBackend.currency` from commodity cache key
- Bumped `CACHE_VERSION` to 6

### Why?

I am doing this because:

- Currency filtering is no longer supported on measures, so this does not need to be in the cache key; removing it decreases the size of the cache.