### PR TITLE
AI-628: Consolidate generated content admin listings

### DIFF
--- a/app/controllers/api/admin/goods_nomenclature_self_texts_controller.rb
+++ b/app/controllers/api/admin/goods_nomenclature_self_texts_controller.rb
@@ -1,79 +1,20 @@
 module Api
   module Admin
     class GoodsNomenclatureSelfTextsController < AdminController
-      def index
-        render json: serialized_collection
-      end
+      include GeneratedContentListing
 
       private
 
-      def serialized_collection
-        GoodsNomenclatures::GoodsNomenclatureSelfTextSerializer.new(
-          paginated_dataset.all,
-          is_collection: true,
-          meta: pagination_meta,
-        ).serializable_hash
+      def model_class
+        GoodsNomenclatureSelfText
       end
 
-      def pagination_meta
-        {
-          pagination: {
-            page: current_page,
-            per_page:,
-            total_count: paginated_dataset.pagination_record_count,
-          },
-        }
+      def serializer_class
+        GoodsNomenclatures::GoodsNomenclatureSelfTextSerializer
       end
 
-      def paginated_dataset
-        @paginated_dataset ||= filtered_dataset.paginate(current_page, per_page)
-      end
-
-      def filtered_dataset
-        dataset = GoodsNomenclatureSelfText
-          .admin_listing(include_expired: expired_listing?)
-          .search(params[:q])
-          .for_nomenclature_type(params[:type])
-          .for_status(params[:status])
-          .for_score_category(params[:score_category])
-
-        dataset = dataset.exclude(Sequel[:goods_nomenclature_self_texts][:approved] => true) if normal_review_listing?
-
-        apply_sorting(dataset)
-      end
-
-      def normal_review_listing?
-        params[:status].blank? && !search_query?
-      end
-
-      def expired_listing?
-        params[:status] == 'expired'
-      end
-
-      def search_query?
-        q = params[:q].to_s.strip
-
-        q.match?(/\A\d{2,10}\z/) || q.length >= 2
-      end
-
-      def apply_sorting(dataset)
-        col = sort_column
-        dir = sort_direction == 'desc' ? :desc : :asc
-
-        dataset.order(Sequel.public_send(dir, col, nulls: :last))
-      end
-
-      def sort_column
-        allowed = {
-          'score' => Sequel.lit('score'),
-          'goods_nomenclature_item_id' => Sequel[:goods_nomenclature_self_texts][:goods_nomenclature_item_id],
-        }
-
-        allowed[params[:sort]] || Sequel.lit('score')
-      end
-
-      def sort_direction
-        %w[asc desc].include?(params[:direction]) ? params[:direction] : 'asc'
+      def listing_table
+        Sequel[:goods_nomenclature_self_texts]
       end
     end
   end

--- a/app/controllers/concerns/api/admin/generated_content_listing.rb
+++ b/app/controllers/concerns/api/admin/generated_content_listing.rb
@@ -1,0 +1,93 @@
+module Api
+  module Admin
+    module GeneratedContentListing
+      extend ActiveSupport::Concern
+
+      def index
+        render json: serialized_collection
+      end
+
+      private
+
+      def serialized_collection
+        serializer_class.new(
+          paginated_dataset.all,
+          is_collection: true,
+          meta: pagination_meta,
+        ).serializable_hash
+      end
+
+      def pagination_meta
+        {
+          pagination: {
+            page: current_page,
+            per_page:,
+            total_count: paginated_dataset.pagination_record_count,
+          },
+        }
+      end
+
+      def paginated_dataset
+        @paginated_dataset ||= filtered_dataset.paginate(current_page, per_page)
+      end
+
+      def filtered_dataset
+        dataset = model_class
+          .admin_listing(include_expired: expired_listing?)
+          .search(params[:q])
+          .for_nomenclature_type(params[:type])
+          .for_status(params[:status])
+          .for_score_category(params[:score_category])
+
+        dataset = dataset.exclude(listing_table[:approved] => true) if normal_review_listing?
+
+        apply_sorting(dataset)
+      end
+
+      def normal_review_listing?
+        params[:status].blank? && !search_query?
+      end
+
+      def expired_listing?
+        params[:status] == 'expired'
+      end
+
+      def search_query?
+        q = params[:q].to_s.strip
+
+        q.match?(/\A\d{2,10}\z/) || q.length >= 2
+      end
+
+      def apply_sorting(dataset)
+        dir = sort_direction == 'desc' ? :desc : :asc
+
+        dataset.order(Sequel.public_send(dir, sort_column, nulls: :last))
+      end
+
+      def sort_column
+        allowed = {
+          'score' => Sequel.lit('score'),
+          'goods_nomenclature_item_id' => listing_table[:goods_nomenclature_item_id],
+        }
+
+        allowed[params[:sort]] || Sequel.lit('score')
+      end
+
+      def sort_direction
+        %w[asc desc].include?(params[:direction]) ? params[:direction] : 'asc'
+      end
+
+      def model_class
+        raise NotImplementedError, "#{self.class} must define #model_class"
+      end
+
+      def serializer_class
+        raise NotImplementedError, "#{self.class} must define #serializer_class"
+      end
+
+      def listing_table
+        raise NotImplementedError, "#{self.class} must define #listing_table"
+      end
+    end
+  end
+end

--- a/app/models/concerns/admin_listing_dataset.rb
+++ b/app/models/concerns/admin_listing_dataset.rb
@@ -1,8 +1,22 @@
 module AdminListingDataset
+  GENERATED_CONTENT_STATUSES = %w[
+    needs_review
+    approved
+    stale
+    manually_edited
+    expired
+  ].freeze
+
   def for_nomenclature_type(type)
     return self unless %w[commodity heading subheading].include?(type)
 
     where(Sequel.lit("(#{nomenclature_type_sql}) = ?", type))
+  end
+
+  def for_status(status)
+    return self unless GENERATED_CONTENT_STATUSES.include?(status)
+
+    where(generated_content_table[status.to_sym] => true)
   end
 
   def for_score_category(category)
@@ -25,6 +39,10 @@ module AdminListingDataset
   end
 
   private
+
+  def generated_content_table
+    raise NotImplementedError, "#{self.class} must define #generated_content_table"
+  end
 
   def score_expression
     Sequel.lit(score_sql)

--- a/app/models/goods_nomenclature_label.rb
+++ b/app/models/goods_nomenclature_label.rb
@@ -70,26 +70,11 @@ class GoodsNomenclatureLabel < Sequel::Model
       end
     end
 
-    def for_status(status)
-      lbl = Sequel[:goods_nomenclature_labels]
-
-      case status
-      when 'needs_review'
-        where(lbl[:needs_review] => true)
-      when 'approved'
-        where(lbl[:approved] => true)
-      when 'stale'
-        where(lbl[:stale] => true)
-      when 'manually_edited'
-        where(lbl[:manually_edited] => true)
-      when 'expired'
-        where(lbl[:expired] => true)
-      else
-        self
-      end
-    end
-
     private
+
+    def generated_content_table
+      Sequel[:goods_nomenclature_labels]
+    end
 
     def score_sql
       lbl = '"goods_nomenclature_labels"'

--- a/app/models/goods_nomenclature_self_text.rb
+++ b/app/models/goods_nomenclature_self_text.rb
@@ -56,25 +56,6 @@ class GoodsNomenclatureSelfText < Sequel::Model
       end
     end
 
-    def for_status(status)
-      st = Sequel[:goods_nomenclature_self_texts]
-
-      case status
-      when 'needs_review'
-        where(st[:needs_review] => true)
-      when 'approved'
-        where(st[:approved] => true)
-      when 'stale'
-        where(st[:stale] => true)
-      when 'manually_edited'
-        where(st[:manually_edited] => true)
-      when 'expired'
-        where(st[:expired] => true)
-      else
-        self
-      end
-    end
-
     def vector_search(vector_literal, limit:)
       distance_expr = Sequel.lit("goods_nomenclature_self_texts.search_embedding <=> #{vector_literal}")
 
@@ -91,6 +72,10 @@ class GoodsNomenclatureSelfText < Sequel::Model
     end
 
     private
+
+    def generated_content_table
+      Sequel[:goods_nomenclature_self_texts]
+    end
 
     def score_expression
       st = Sequel[:goods_nomenclature_self_texts]


### PR DESCRIPTION
### Jira link

[AI-628](https://transformuk.atlassian.net/browse/AI-628)

### What?

- [x] Move shared generated-content status filtering into the admin listing concern
- [x] Extract shared admin generated-content listing controller behaviour
- [x] Keep label and self-text specific dataset logic explicit
- [x] Preserve approved and expired listing behaviour on the consolidated path

### Why?

Self-texts and labels now share the same admin listing lifecycle mechanics. Keeping that logic in separate controllers and models makes it easy for the two paths to drift over time. This consolidates the shared behaviour without changing the admin API contract.
