### PR TITLE
BAU: Restore commodity show performance fixes

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -300,7 +300,11 @@ class GoodsNomenclature < Sequel::Model
   end
 
   def has_chemicals
-    @has_chemicals ||= full_chemicals_dataset.limit(1).any?
+    if associations.key?(:full_chemicals)
+      full_chemicals.any?
+    else
+      @has_chemicals ||= full_chemicals_dataset.limit(1).any?
+    end
   end
 
   def to_admin_param

--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -129,6 +129,7 @@ class CachedCommodityService
         ancestors: { measures: MEASURES_EAGER_LOAD_GRAPH,
                      goods_nomenclature_descriptions: {} },
         measures: MEASURES_EAGER_LOAD_GRAPH,
+        full_chemicals: {},
       )
       .take
   end

--- a/db/migrate/20260423120000_add_regulation_and_fts_performance_indexes.rb
+++ b/db/migrate/20260423120000_add_regulation_and_fts_performance_indexes.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Three targeted index additions for commodities#show:
+#
+# Index 1 & 2: partial indexes on base_regulations and modification_regulations
+#   for the approved composite-key lookup pattern.
+#
+#   The eager-load queries for :base_regulation, :justification_base_regulation
+#   and :modification_regulation all take the form:
+#
+#     WHERE approved_flag IS TRUE
+#       AND (base_regulation_id, base_regulation_role) IN ((v1, v2), ...)
+#
+#   With separate single-column indexes, PostgreSQL may BitmapAnd the
+#   approved_flag index (large) with the composite-key index (small) rather
+#   than doing a direct index lookup. A partial index that covers only
+#   approved rows collapses this into a single index scan.
+#
+# Index 3: fts_regulation_actions_oplog(stopped_regulation_id)
+#
+#   The full_temporary_stop_regulations eager-load joins the
+#   fts_regulation_actions view and filters by stopped_regulation_id IN (...).
+#   Because fts_regulation_actions is a view, the supporting index has to live
+#   on the underlying fts_regulation_actions_oplog table. The only existing
+#   index there is a four-column composite with stopped_regulation_id as the
+#   third column, which cannot be used for this single-column predicate.
+
+Sequel.migration do
+  up do
+    run <<-SQL
+      CREATE INDEX IF NOT EXISTS base_regulations_approved_composite_index
+        ON base_regulations (base_regulation_id, base_regulation_role)
+        WHERE approved_flag IS TRUE;
+
+      CREATE INDEX IF NOT EXISTS modification_regulations_approved_composite_index
+        ON modification_regulations (modification_regulation_id, modification_regulation_role)
+        WHERE approved_flag IS TRUE;
+
+      CREATE INDEX IF NOT EXISTS fts_regulation_actions_stopped_regulation_id_index
+        ON fts_regulation_actions_oplog (stopped_regulation_id);
+    SQL
+  end
+
+  down do
+    run <<-SQL
+      DROP INDEX IF EXISTS base_regulations_approved_composite_index;
+      DROP INDEX IF EXISTS modification_regulations_approved_composite_index;
+      DROP INDEX IF EXISTS fts_regulation_actions_stopped_regulation_id_index;
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10425,6 +10425,13 @@ CREATE INDEX base_regulations_antidumping_regulation_role_related_antidumpin ON 
 
 
 --
+-- Name: base_regulations_approved_composite_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX base_regulations_approved_composite_index ON uk.base_regulations USING btree (base_regulation_id, base_regulation_role) WHERE (approved_flag IS TRUE);
+
+
+--
 -- Name: base_regulations_approved_flag_index; Type: INDEX; Schema: uk; Owner: -
 --
 
@@ -11136,6 +11143,13 @@ CREATE INDEX fto_footypopl_otepeslog_operation_date ON uk.footnote_types_oplog U
 --
 
 CREATE INDEX fts_reg_act_pk ON uk.fts_regulation_actions_oplog USING btree (fts_regulation_id, fts_regulation_role, stopped_regulation_id, stopped_regulation_role);
+
+
+--
+-- Name: fts_regulation_actions_stopped_regulation_id_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX fts_regulation_actions_stopped_regulation_id_index ON uk.fts_regulation_actions_oplog USING btree (stopped_regulation_id);
 
 
 --
@@ -12742,6 +12756,13 @@ CREATE INDEX mod_reg_pk ON uk.modification_regulations_oplog USING btree (modifi
 
 
 --
+-- Name: modification_regulations_approved_composite_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX modification_regulations_approved_composite_index ON uk.modification_regulations USING btree (modification_regulation_id, modification_regulation_role) WHERE (approved_flag IS TRUE);
+
+
+--
 -- Name: modification_regulations_approved_flag_index; Type: INDEX; Schema: uk; Owner: -
 --
 
@@ -13947,3 +13968,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20260413120001_drop_tariff
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260415120000_add_guidance_fields_to_description_intercepts.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260415120001_create_tariff_update_state_changes.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260422143000_add_lifecycle_flags_to_generated_classification_content.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20260423120000_add_regulation_and_fts_performance_indexes.rb');

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -270,6 +270,19 @@ RSpec.describe GoodsNomenclature do
 
       it { is_expected.to be(true) }
     end
+
+    context 'when the full_chemicals association is already loaded' do
+      subject(:has_chemicals) { goods_nomenclature.has_chemicals }
+
+      let(:goods_nomenclature) { create(:goods_nomenclature, :with_full_chemicals) }
+
+      before do
+        goods_nomenclature.full_chemicals
+        allow(goods_nomenclature).to receive(:full_chemicals_dataset).and_raise('should not query dataset')
+      end
+
+      it { is_expected.to be(true) }
+    end
   end
 
   describe '#non_grouping?' do

--- a/spec/services/cached_commodity_service_spec.rb
+++ b/spec/services/cached_commodity_service_spec.rb
@@ -31,18 +31,32 @@ RSpec.describe CachedCommodityService do
   end
 
   describe '#call' do
-    # MeasureType records must be created before measures because FactoryBot
-    # skips the measure_type association block when measure_type_id is overridden
-    before do
-      create(:duty_expression, :with_description, duty_expression_id: '01')
-      create(:measure_type, measure_type_id: '103', trade_movement_code: 0)
-      create(:measure_type, measure_type_id: '142', trade_movement_code: 0)
+    let!(:de_measure) do
+      create(
+        :measure,
+        :with_measure_components,
+        :with_base_regulation,
+        measure_type_id: '142',
+        goods_nomenclature: commodity,
+        goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+        goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+        for_geo_area: de_area,
+        duty_amount: 2.5,
+      ).tap(&:reload)
     end
-
-    let!(:ro_area) { create(:geographical_area, :country, :with_description, geographical_area_id: 'RO') }
-    let!(:de_area) { create(:geographical_area, :country, :with_description, geographical_area_id: 'DE') }
-    let!(:erga_omnes_area) { create(:geographical_area, :erga_omnes, :with_description) }
-
+    let!(:ro_measure) do
+      create(
+        :measure,
+        :with_measure_components,
+        :with_base_regulation,
+        measure_type_id: '142',
+        goods_nomenclature: commodity,
+        goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+        goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+        for_geo_area: ro_area,
+        duty_amount: 0.0,
+      ).tap(&:reload)
+    end
     let!(:erga_omnes_measure) do
       create(
         :measure,
@@ -57,33 +71,33 @@ RSpec.describe CachedCommodityService do
         duty_amount: 4.0,
       ).tap(&:reload)
     end
+    let!(:erga_omnes_area) { create(:geographical_area, :erga_omnes, :with_description) }
+    let!(:de_area) { create(:geographical_area, :country, :with_description, geographical_area_id: 'DE') }
+    let!(:ro_area) { create(:geographical_area, :country, :with_description, geographical_area_id: 'RO') }
 
-    let!(:ro_measure) do
-      create(
-        :measure,
-        :with_measure_components,
-        :with_base_regulation,
-        measure_type_id: '142',
-        goods_nomenclature: commodity,
-        goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
-        goods_nomenclature_sid: commodity.goods_nomenclature_sid,
-        for_geo_area: ro_area,
-        duty_amount: 0.0,
-      ).tap(&:reload)
+    # MeasureType records must be created before measures because FactoryBot
+    # skips the measure_type association block when measure_type_id is overridden
+    before do
+      create(:duty_expression, :with_description, duty_expression_id: '01')
+      create(:measure_type, measure_type_id: '103', trade_movement_code: 0)
+      create(:measure_type, measure_type_id: '142', trade_movement_code: 0)
     end
 
-    let!(:de_measure) do
-      create(
-        :measure,
-        :with_measure_components,
-        :with_base_regulation,
-        measure_type_id: '142',
-        goods_nomenclature: commodity,
-        goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
-        goods_nomenclature_sid: commodity.goods_nomenclature_sid,
-        for_geo_area: de_area,
-        duty_amount: 2.5,
-      ).tap(&:reload)
+    context 'when loading the commodity for serialization' do
+      let(:commodity) { create(:commodity, :with_chapter_and_heading, :with_full_chemicals) }
+
+      it 'loads full chemicals on the commodity' do
+        loaded_commodity = nil
+
+        allow(Api::V2::Commodities::CommodityPresenter).to receive(:new).and_wrap_original do |original, commodity, measures|
+          loaded_commodity = commodity
+          original.call(commodity, measures)
+        end
+
+        described_class.new(commodity.reload, actual_date).call
+
+        expect(loaded_commodity.associations).to include(full_chemicals: be_present)
+      end
     end
 
     describe 'cache key' do


### PR DESCRIPTION
### What?

- [x] restore the approved `has_chemicals` association-aware check
- [x] restore `full_chemicals` eager loading in `CachedCommodityService`
- [x] restore the two approved regulation partial indexes
- [x] replace the broken FTS view index with a valid index on `fts_regulation_actions_oplog`
- [x] add regression coverage for the chemical-loading path

### Why?

PR #3072 was approved and merged, then reverted by PR #3076 after staging deploy failed.

The failure was caused by trying to create an index on `fts_regulation_actions`, which is a view in this schema. This PR restores the approved runtime changes and keeps the intended FTS optimisation, but applies that index to the underlying `fts_regulation_actions_oplog` table so the migration can run in staging.
