### PR TITLE
AI-556: Add V2 description intercepts endpoint

### DIFF
--- a/app/controllers/api/v2/description_intercepts_controller.rb
+++ b/app/controllers/api/v2/description_intercepts_controller.rb
@@ -1,0 +1,19 @@
+module Api
+  module V2
+    class DescriptionInterceptsController < ApiController
+      def index
+        render json: Api::V2::DescriptionInterceptSerializer.new(description_intercepts).serializable_hash
+      end
+
+      private
+
+      def description_intercepts
+        DescriptionIntercept
+          .for_source(params[:source])
+          .matching_excluded(params[:excluded])
+          .order(Sequel.asc(:term), Sequel.asc(:id))
+          .all
+      end
+    end
+  end
+end

--- a/app/engines/v2_api.rb
+++ b/app/engines/v2_api.rb
@@ -61,6 +61,7 @@ V2Api.routes.draw do
 
       resources :chemical_substances, only: %i[index]
       resources :simplified_procedural_code_measures, only: %i[index]
+      resources :description_intercepts, only: %i[index]
 
       resources :preference_codes, only: %i[index show]
 

--- a/app/models/description_intercept.rb
+++ b/app/models/description_intercept.rb
@@ -20,6 +20,12 @@ class DescriptionIntercept < Sequel::Model
       where(Sequel.lit('? = ANY(sources)', source))
     end
 
+    def matching_excluded(value)
+      return self if value.nil? || value == ''
+
+      where(excluded: ActiveModel::Type::Boolean.new.cast(value))
+    end
+
     def with_filtering(enabled)
       return self unless boolean_filter_enabled?(enabled)
 

--- a/app/models/description_intercept.rb
+++ b/app/models/description_intercept.rb
@@ -21,7 +21,7 @@ class DescriptionIntercept < Sequel::Model
     end
 
     def matching_excluded(value)
-      return self if value.nil? || value == ''
+      return self if value.blank?
 
       where(excluded: ActiveModel::Type::Boolean.new.cast(value))
     end

--- a/app/serializers/api/v2/description_intercept_serializer.rb
+++ b/app/serializers/api/v2/description_intercept_serializer.rb
@@ -1,0 +1,21 @@
+module Api
+  module V2
+    class DescriptionInterceptSerializer
+      include JSONAPI::Serializer
+
+      set_type :description_intercept
+      set_id :id
+
+      attributes :term,
+                 :sources,
+                 :message,
+                 :excluded,
+                 :created_at,
+                 :updated_at,
+                 :guidance_level,
+                 :guidance_location,
+                 :escalate_to_webchat,
+                 :filter_prefixes
+    end
+  end
+end

--- a/spec/requests/api/v2/description_intercepts_controller_spec.rb
+++ b/spec/requests/api/v2/description_intercepts_controller_spec.rb
@@ -1,0 +1,96 @@
+RSpec.describe Api::V2::DescriptionInterceptsController, :v2 do
+  describe 'GET #index' do
+    let!(:guided_excluded) do
+      create(
+        :description_intercept,
+        term: 'alpha',
+        sources: Sequel.pg_array(%w[guided_search], :text),
+        message: 'Alpha guidance',
+        excluded: true,
+        guidance_level: 'warning',
+        guidance_location: 'results',
+        escalate_to_webchat: true,
+      )
+    end
+
+    let!(:fpo_excluded) do
+      create(
+        :description_intercept,
+        term: 'beta',
+        sources: Sequel.pg_array(%w[fpo_search], :text),
+        message: 'Beta guidance',
+        excluded: true,
+        guidance_level: 'info',
+        guidance_location: 'question',
+        escalate_to_webchat: false,
+      )
+    end
+
+    let!(:fpo_included) do
+      create(
+        :description_intercept,
+        term: 'gamma',
+        sources: Sequel.pg_array(%w[fpo_search], :text),
+        message: 'Gamma guidance',
+        excluded: false,
+        guidance_level: nil,
+        guidance_location: nil,
+        escalate_to_webchat: false,
+        filter_prefixes: Sequel.pg_array(%w[0201], :text),
+      )
+    end
+
+    it 'returns all description intercepts ordered by term then id' do
+      api_get api_description_intercepts_path
+
+      body = JSON.parse(response.body)
+
+      expect(response).to be_successful
+      expect(body.fetch('data').map { |row| row.fetch('id') }).to eq([guided_excluded.id.to_s, fpo_excluded.id.to_s, fpo_included.id.to_s])
+      expect(body.fetch('data').first.fetch('attributes').keys).to match_array(%w[
+        term
+        sources
+        message
+        excluded
+        created_at
+        updated_at
+        guidance_level
+        guidance_location
+        escalate_to_webchat
+        filter_prefixes
+      ])
+    end
+
+    it 'filters by source' do
+      api_get api_description_intercepts_path, params: { source: 'fpo_search' }
+
+      body = JSON.parse(response.body)
+
+      expect(body.fetch('data').map { |row| row.fetch('id') }).to eq([fpo_excluded.id.to_s, fpo_included.id.to_s])
+    end
+
+    it 'filters by excluded=true' do
+      api_get api_description_intercepts_path, params: { excluded: true }
+
+      body = JSON.parse(response.body)
+
+      expect(body.fetch('data').map { |row| row.fetch('id') }).to eq([guided_excluded.id.to_s, fpo_excluded.id.to_s])
+    end
+
+    it 'filters by excluded=false' do
+      api_get api_description_intercepts_path, params: { excluded: false }
+
+      body = JSON.parse(response.body)
+
+      expect(body.fetch('data').map { |row| row.fetch('id') }).to eq([fpo_included.id.to_s])
+    end
+
+    it 'combines source and excluded filters' do
+      api_get api_description_intercepts_path, params: { source: 'fpo_search', excluded: true }
+
+      body = JSON.parse(response.body)
+
+      expect(body.fetch('data').map { |row| row.fetch('id') }).to eq([fpo_excluded.id.to_s])
+    end
+  end
+end

--- a/spec/swagger/api/v2/description_intercepts_spec.rb
+++ b/spec/swagger/api/v2/description_intercepts_spec.rb
@@ -1,0 +1,60 @@
+require 'swagger_helper'
+
+RSpec.describe 'Description Intercepts', swagger_doc: 'v2/swagger.json', type: :request do
+  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+
+  path '/api/description_intercepts' do
+    parameter name: :Accept, in: :header, required: true,
+              schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
+              description: 'API version negotiation header'
+    parameter name: :source, in: :query, required: false,
+              schema: { type: :string },
+              description: 'Filter by an enabled description intercept source'
+    parameter name: :excluded, in: :query, required: false,
+              schema: { type: :boolean },
+              description: 'Filter by whether the intercept excludes the term'
+
+    get 'List description intercepts' do
+      tags 'Description Intercepts'
+      produces 'application/json'
+      description 'Returns description intercepts, optionally filtered by source and excluded state.'
+      operationId 'listDescriptionIntercepts'
+
+      response '200', 'description intercepts listed' do
+        schema type: :object,
+               required: %w[data],
+               properties: {
+                 data: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       id: { type: :string },
+                       type: { type: :string, enum: %w[description_intercept] },
+                       attributes: {
+                         type: :object,
+                         properties: {
+                           term: { type: :string, nullable: true },
+                           sources: { type: :array, items: { type: :string }, nullable: true },
+                           message: { type: :string, nullable: true },
+                           excluded: { type: :boolean, nullable: true },
+                           created_at: { type: :string, format: :'date-time', nullable: true },
+                           updated_at: { type: :string, format: :'date-time', nullable: true },
+                           guidance_level: { type: :string, nullable: true },
+                           guidance_location: { type: :string, nullable: true },
+                           escalate_to_webchat: { type: :boolean, nullable: true },
+                           filter_prefixes: { type: :array, items: { type: :string }, nullable: true },
+                         },
+                       },
+                     },
+                   },
+                 },
+               }
+
+        before { create(:description_intercept, sources: Sequel.pg_array(%w[fpo_search], :text), excluded: true) }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/swagger/v2/swagger.json
+++ b/swagger/v2/swagger.json
@@ -1861,6 +1861,135 @@
         }
       }
     },
+    "/api/description_intercepts": {
+      "parameters": [
+        {
+          "name": "Accept",
+          "in": "header",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "enum": [
+              "application/vnd.hmrc.2.0+json"
+            ]
+          },
+          "description": "API version negotiation header"
+        },
+        {
+          "name": "source",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "string"
+          },
+          "description": "Filter by an enabled description intercept source"
+        },
+        {
+          "name": "excluded",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          },
+          "description": "Filter by whether the intercept excludes the term"
+        }
+      ],
+      "get": {
+        "summary": "List description intercepts",
+        "tags": [
+          "Description Intercepts"
+        ],
+        "description": "Returns description intercepts, optionally filtered by source and excluded state.",
+        "operationId": "listDescriptionIntercepts",
+        "responses": {
+          "200": {
+            "description": "description intercepts listed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "description_intercept"
+                            ]
+                          },
+                          "attributes": {
+                            "type": "object",
+                            "properties": {
+                              "term": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "sources": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "nullable": true
+                              },
+                              "message": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "excluded": {
+                                "type": "boolean",
+                                "nullable": true
+                              },
+                              "created_at": {
+                                "type": "string",
+                                "format": "date-time",
+                                "nullable": true
+                              },
+                              "updated_at": {
+                                "type": "string",
+                                "format": "date-time",
+                                "nullable": true
+                              },
+                              "guidance_level": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "guidance_location": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "escalate_to_webchat": {
+                                "type": "boolean",
+                                "nullable": true
+                              },
+                              "filter_prefixes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "nullable": true
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/exchange_rates/period_lists/{year}": {
       "parameters": [
         {


### PR DESCRIPTION
## What
- add a new V2 `description_intercepts#index` endpoint
- support `source` and `excluded` filters for public API consumers
- add a dedicated V2 serializer that exposes the full description intercept attribute set
- add request and Swagger coverage for the new endpoint

## Why
FPO needs a V2 description intercepts endpoint with a stable JSON:API response, without coupling consumers to the admin API or guided-search flow.