### PR TITLE
HMRC-2012: Cap commodity cache TTL for non-current tariff dates

### DIFF
--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -78,16 +78,18 @@ class CachedCommodityService
     :measure_partial_temporary_stops,
   ].freeze
 
-  TTL = 24.hours
-
   def initialize(commodity, actual_date, filters = {})
     @commodity_sid = commodity.goods_nomenclature_sid
     @actual_date = actual_date
     @filters = filters
   end
 
+  def ttl
+    actual_date.to_date == Time.zone.today ? 24.hours : 2.hours
+  end
+
   def call
-    cached_data = Rails.cache.fetch(cache_key, expires_in: TTL) do
+    cached_data = Rails.cache.fetch(cache_key, expires_in: ttl) do
       presenter = presented_commodity
       hash = Api::V2::Commodities::CommoditySerializer.new(presenter, options).serializable_hash
       measure_meta = MeasureMetadataBuilder.new(presenter).build

--- a/spec/services/cached_commodity_service_spec.rb
+++ b/spec/services/cached_commodity_service_spec.rb
@@ -141,6 +141,16 @@ RSpec.describe CachedCommodityService do
         expected_key = "_commodity-v#{CachedCommodityService::CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-"
         expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 24.hours).twice
       end
+
+      context 'with a non-current tariff date' do
+        let(:actual_date) { Time.zone.tomorrow }
+
+        it 'caches with a 2-hour ttl' do
+          service.call
+          expected_key = "_commodity-v#{CachedCommodityService::CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-"
+          expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 2.hours)
+        end
+      end
     end
 
     describe 'measure filtering' do


### PR DESCRIPTION
### Jira link

[HMRC-2012](https://transformuk.atlassian.net/browse/HMRC-2012)

### What?

I have added/removed/altered:

- Set commodity cache TTL based on Tariff date
- Added test case for short TTL

### Why?

I am doing this because:

- This will reduce memory pressure on the Valkey instances

### Deployment risks (optional)

- Commodity lookups with non-current dates will be slower outside of the 2-hour cache 
