### PR TITLE
BAU: Split search dashboard into overview, operations and quality views

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -25,6 +25,8 @@ Terraform to deploy the service into AWS.
 | <a name="module_backend_xi"></a> [backend\_xi](#module\_backend\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.21.0 |
 | <a name="module_label_generator_dashboard"></a> [label\_generator\_dashboard](#module\_label\_generator\_dashboard) | ./modules/label_generator_dashboard | n/a |
 | <a name="module_search_dashboard"></a> [search\_dashboard](#module\_search\_dashboard) | ./modules/search_dashboard | n/a |
+| <a name="module_search_operations_dashboard"></a> [search\_operations\_dashboard](#module\_search\_operations\_dashboard) | ./modules/search_operations_dashboard | n/a |
+| <a name="module_search_quality_dashboard"></a> [search\_quality\_dashboard](#module\_search\_quality\_dashboard) | ./modules/search_quality_dashboard | n/a |
 | <a name="module_self_text_generator_dashboard"></a> [self\_text\_generator\_dashboard](#module\_self\_text\_generator\_dashboard) | ./modules/self_text_generator_dashboard | n/a |
 | <a name="module_tariff_sync_dashboard"></a> [tariff\_sync\_dashboard](#module\_tariff\_sync\_dashboard) | ./modules/tariff_sync_dashboard | n/a |
 | <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.21.0 |
@@ -89,6 +91,8 @@ Terraform to deploy the service into AWS.
 |------|-------------|
 | <a name="output_label_generator_dashboard_url"></a> [label\_generator\_dashboard\_url](#output\_label\_generator\_dashboard\_url) | URL to the Label Generator CloudWatch dashboard |
 | <a name="output_search_dashboard_url"></a> [search\_dashboard\_url](#output\_search\_dashboard\_url) | URL to the Search CloudWatch dashboard |
+| <a name="output_search_operations_dashboard_url"></a> [search\_operations\_dashboard\_url](#output\_search\_operations\_dashboard\_url) | URL to the Search Operations CloudWatch dashboard |
+| <a name="output_search_quality_dashboard_url"></a> [search\_quality\_dashboard\_url](#output\_search\_quality\_dashboard\_url) | URL to the Search Quality CloudWatch dashboard |
 | <a name="output_self_text_generator_dashboard_url"></a> [self\_text\_generator\_dashboard\_url](#output\_self\_text\_generator\_dashboard\_url) | URL to the Self-Text Generator CloudWatch dashboard |
 | <a name="output_tariff_sync_dashboard_url"></a> [tariff\_sync\_dashboard\_url](#output\_tariff\_sync\_dashboard\_url) | URL to the Tariff Sync CloudWatch dashboard |
 <!-- END_TF_DOCS -->

--- a/terraform/dashboards.tf
+++ b/terraform/dashboards.tf
@@ -24,6 +24,32 @@ output "search_dashboard_url" {
   value       = module.search_dashboard.dashboard_url
 }
 
+module "search_operations_dashboard" {
+  source = "./modules/search_operations_dashboard"
+
+  environment    = var.environment
+  log_group_name = "platform-logs-${var.environment}"
+  region         = var.region
+}
+
+output "search_operations_dashboard_url" {
+  description = "URL to the Search Operations CloudWatch dashboard"
+  value       = module.search_operations_dashboard.dashboard_url
+}
+
+module "search_quality_dashboard" {
+  source = "./modules/search_quality_dashboard"
+
+  environment    = var.environment
+  log_group_name = "platform-logs-${var.environment}"
+  region         = var.region
+}
+
+output "search_quality_dashboard_url" {
+  description = "URL to the Search Quality CloudWatch dashboard"
+  value       = module.search_quality_dashboard.dashboard_url
+}
+
 module "self_text_generator_dashboard" {
   source = "./modules/self_text_generator_dashboard"
 

--- a/terraform/modules/search_dashboard/main.tf
+++ b/terraform/modules/search_dashboard/main.tf
@@ -3,8 +3,10 @@ locals {
   source         = "SOURCE '${var.log_group_name}'"
   service_filter = "filter service = \"search\""
 
-  label_dashboard_url     = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=LabelGenerator-${var.environment}"
-  self_text_dashboard_url = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=SelfTextGenerator-${var.environment}"
+  search_operations_dashboard_url = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=SearchOperations-${var.environment}"
+  search_quality_dashboard_url    = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=SearchQuality-${var.environment}"
+  label_dashboard_url             = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=LabelGenerator-${var.environment}"
+  self_text_dashboard_url         = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=SelfTextGenerator-${var.environment}"
 }
 
 resource "aws_cloudwatch_dashboard" "search" {
@@ -12,8 +14,6 @@ resource "aws_cloudwatch_dashboard" "search" {
 
   dashboard_body = jsonencode({
     widgets = concat(
-
-      # Row 0 (y=0): Documentation
       [
         {
           type   = "text"
@@ -23,17 +23,15 @@ resource "aws_cloudwatch_dashboard" "search" {
           height = 2
           properties = {
             markdown = join("\n", [
-              "## Trade Tariff Search",
-              "Monitors keyword, interactive AI, reference searches, and description intercept behaviour. Follows the RED method (Rate, Errors, Duration).",
-              "**Healthy:** p90 latency < 5s, error rate < 1%, zero-result rate < 10%, intercept matches consistent with configured terms.",
-              "**Start here:** check latency and error trends in the top row, then review description intercept matches and zero-result terms below.",
-              "**Related:** [Label Generator](${local.label_dashboard_url}) | [Self-Text Generator](${local.self_text_dashboard_url})",
+              "## Trade Tariff Search Overview",
+              "Long-range search health dashboard for quarter-scale trend viewing. Follows the RED method (Rate, Errors, Duration).",
+              "**Healthy:** p90 latency < 5s, hard failures stay low, zero-result trends stable, and selections broadly track search volume.",
+              "**Start here:** use this dashboard for 3-month trends. Open Operations for active troubleshooting and Quality for intercepts, zero-result terms, and result behaviour.",
+              "**Related:** [Search Operations](${local.search_operations_dashboard_url}) | [Search Quality](${local.search_quality_dashboard_url}) | [Label Generator](${local.label_dashboard_url}) | [Self-Text Generator](${local.self_text_dashboard_url})",
             ])
           }
         }
       ],
-
-      # Row 1 (y=2): Hero KPI Strip
       [
         {
           type   = "log"
@@ -42,13 +40,13 @@ resource "aws_cloudwatch_dashboard" "search" {
           width  = 6
           height = 6
           properties = {
-            title  = "Total Searches (Hourly)"
+            title  = "Total Searches"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "search_completed"
-              | stats count(*) as searches by bin(1h)
+              | stats count(*) as searches by bin(1d)
             EOT
           }
         },
@@ -59,13 +57,13 @@ resource "aws_cloudwatch_dashboard" "search" {
           width  = 6
           height = 6
           properties = {
-            title  = "Search Type Split"
+            title  = "Search Volume by Type"
             region = var.region
-            view   = "pie"
+            view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "search_completed"
-              | stats count(*) as searches by search_type
+              | stats count(*) as searches by search_type, bin(1d)
             EOT
           }
         },
@@ -76,13 +74,13 @@ resource "aws_cloudwatch_dashboard" "search" {
           width  = 6
           height = 6
           properties = {
-            title  = "Latency Overview (p50/p90)"
+            title  = "Completed vs Failed Searches"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
-              | ${local.service_filter} and event = "search_completed"
-              | stats pct(total_duration_ms, 50) as p50, pct(total_duration_ms, 90) as p90 by bin(1h)
+              | ${local.service_filter} and event in ["search_completed", "search_failed"]
+              | stats count(*) as count by event, bin(1d)
             EOT
           }
         },
@@ -91,399 +89,6 @@ resource "aws_cloudwatch_dashboard" "search" {
           x      = 18
           y      = 2
           width  = 6
-          height = 6
-          properties = {
-            title  = "Search Volume by Outcome"
-            region = var.region
-            view   = "timeSeries"
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event in ["search_failed", "search_completed"]
-              | stats count(*) as total by event, bin(1h)
-            EOT
-          }
-        },
-      ],
-
-      # Row 2 (y=8): Performance Deep Dive
-      [
-        {
-          type   = "log"
-          x      = 0
-          y      = 8
-          width  = 12
-          height = 6
-          properties = {
-            title  = "E2E Latency Percentiles"
-            region = var.region
-            view   = "timeSeries"
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "search_completed"
-              | stats pct(total_duration_ms, 50) as p50, pct(total_duration_ms, 90) as p90, pct(total_duration_ms, 99) as p99 by bin(1h)
-            EOT
-          }
-        },
-        {
-          type   = "log"
-          x      = 12
-          y      = 8
-          width  = 12
-          height = 6
-          properties = {
-            title  = "AI API Latency Percentiles"
-            region = var.region
-            view   = "timeSeries"
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "api_call_completed"
-              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90, pct(duration_ms, 99) as p99 by bin(1h)
-            EOT
-          }
-        },
-      ],
-
-      # Row 3 (y=14): Performance by Type + Query Expansion
-      [
-        {
-          type   = "log"
-          x      = 0
-          y      = 14
-          width  = 8
-          height = 6
-          properties = {
-            title  = "Latency by Search Type"
-            region = var.region
-            view   = "bar"
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "search_completed"
-              | stats avg(total_duration_ms) as avg_ms, pct(total_duration_ms, 50) as p50, pct(total_duration_ms, 90) as p90 by search_type
-            EOT
-          }
-        },
-        {
-          type   = "log"
-          x      = 8
-          y      = 14
-          width  = 8
-          height = 6
-          properties = {
-            title  = "Query Expansion Volume"
-            region = var.region
-            view   = "timeSeries"
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "query_expanded"
-              | stats count(*) as expansions, avg(duration_ms) as avg_duration_ms by bin(1h)
-            EOT
-          }
-        },
-        {
-          type   = "log"
-          x      = 16
-          y      = 14
-          width  = 8
-          height = 6
-          properties = {
-            title  = "Query Expansion Detail"
-            region = var.region
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "query_expanded"
-              | stats count(*) as expansions, avg(duration_ms) as avg_ms by reason
-              | sort expansions desc
-            EOT
-          }
-        },
-      ],
-
-      # Row 4 (y=20): Hybrid Retrieval
-      [
-        {
-          type   = "log"
-          x      = 0
-          y      = 20
-          width  = 8
-          height = 6
-          properties = {
-            title  = "Hybrid Leg Latency (p50/p90)"
-            region = var.region
-            view   = "timeSeries"
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "retrieval_leg_completed"
-              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90 by leg, bin(1h)
-            EOT
-          }
-        },
-        {
-          type   = "log"
-          x      = 8
-          y      = 20
-          width  = 8
-          height = 6
-          properties = {
-            title  = "Hybrid Leg Failures"
-            region = var.region
-            view   = "timeSeries"
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "retrieval_leg_completed" and status = "error"
-              | stats count(*) as failures by leg, bin(1h)
-            EOT
-          }
-        },
-        {
-          type   = "log"
-          x      = 16
-          y      = 20
-          width  = 8
-          height = 6
-          properties = {
-            title  = "Hybrid Leg Result Counts"
-            region = var.region
-            view   = "timeSeries"
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "retrieval_leg_completed" and status = "success"
-              | stats avg(result_count) as avg_results by leg, bin(1h)
-            EOT
-          }
-        },
-      ],
-
-      # Row 5 (y=26): Search Quality - Outcomes
-      [
-        {
-          type   = "log"
-          x      = 0
-          y      = 26
-          width  = 8
-          height = 6
-          properties = {
-            title  = "Final Result Type (Interactive)"
-            region = var.region
-            view   = "pie"
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "search_completed" and search_type = "interactive"
-              | stats count(*) as searches by final_result_type
-            EOT
-          }
-        },
-        {
-          type   = "log"
-          x      = 8
-          y      = 26
-          width  = 8
-          height = 6
-          properties = {
-            title  = "Results Type Breakdown"
-            region = var.region
-            view   = "pie"
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "search_completed"
-              | stats count(*) as searches by results_type
-            EOT
-          }
-        },
-        {
-          type   = "log"
-          x      = 16
-          y      = 26
-          width  = 8
-          height = 6
-          properties = {
-            title  = "Average Result Count"
-            region = var.region
-            view   = "timeSeries"
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "search_completed"
-              | stats avg(result_count) as avg_results, median(result_count) as median_results by bin(1h)
-            EOT
-          }
-        },
-      ],
-
-      # Row 6 (y=32): Description Intercepts
-      [
-        {
-          type   = "log"
-          x      = 0
-          y      = 32
-          width  = 8
-          height = 6
-          properties = {
-            title  = "Intercept Checks Over Time"
-            region = var.region
-            view   = "timeSeries"
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "description_intercept_checked"
-              | stats count(*) as checks by matched, bin(1h)
-            EOT
-          }
-        },
-        {
-          type   = "log"
-          x      = 8
-          y      = 32
-          width  = 8
-          height = 6
-          properties = {
-            title  = "Intercept Outcomes"
-            region = var.region
-            view   = "bar"
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "description_intercept_checked" and matched = true
-              | stats count(*) as matches by excluded, filtering, guidance_level, guidance_location, escalate_to_webchat
-              | sort matches desc
-            EOT
-          }
-        },
-        {
-          type   = "log"
-          x      = 16
-          y      = 32
-          width  = 8
-          height = 6
-          properties = {
-            title  = "Top Matched Intercept Terms"
-            region = var.region
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "description_intercept_checked" and matched = true
-              | stats count(*) as matches by term, excluded, filtering, guidance_level, guidance_location, escalate_to_webchat
-              | sort matches desc
-              | limit 30
-            EOT
-          }
-        },
-      ],
-
-      # Row 7 (y=38): Zero-Result Searches
-      [
-        {
-          type   = "log"
-          x      = 0
-          y      = 38
-          width  = 8
-          height = 6
-          properties = {
-            title  = "Zero-Result Searches by Type"
-            region = var.region
-            view   = "pie"
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "search_completed" and result_count = 0
-              | stats count(*) as searches by search_type
-            EOT
-          }
-        },
-        {
-          type   = "log"
-          x      = 8
-          y      = 38
-          width  = 8
-          height = 6
-          properties = {
-            title  = "Top 30 Zero-Result Search Terms"
-            region = var.region
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "search_completed" and result_count = 0
-              | stats count(*) as searches by query
-              | sort searches desc
-              | limit 30
-            EOT
-          }
-        },
-        {
-          type   = "log"
-          x      = 16
-          y      = 38
-          width  = 8
-          height = 6
-          properties = {
-            title  = "Recent Zero-Result Searches"
-            region = var.region
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "search_completed" and result_count = 0
-              | fields @timestamp, query, search_type, request_id
-              | sort @timestamp desc
-              | limit 30
-            EOT
-          }
-        },
-      ],
-
-      # Row 8 (y=44): Interactive Search - The AI Story
-      [
-        {
-          type   = "log"
-          x      = 0
-          y      = 44
-          width  = 12
-          height = 6
-          properties = {
-            title  = "AI Response Types Over Time"
-            region = var.region
-            view   = "timeSeries"
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "api_call_completed"
-              | stats count(*) as calls by response_type, bin(1h)
-            EOT
-          }
-        },
-        {
-          type   = "log"
-          x      = 12
-          y      = 44
-          width  = 6
-          height = 6
-          properties = {
-            title  = "Attempts Per Search"
-            region = var.region
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "search_completed" and search_type = "interactive"
-              | stats count(*) as searches by total_attempts
-              | sort total_attempts asc
-            EOT
-          }
-        },
-        {
-          type   = "log"
-          x      = 18
-          y      = 44
-          width  = 6
-          height = 6
-          properties = {
-            title  = "Questions Per Search"
-            region = var.region
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "search_completed" and search_type = "interactive"
-              | stats count(*) as searches by total_questions
-              | sort total_questions asc
-            EOT
-          }
-        },
-      ],
-
-      # Row 9 (y=50): User Journey - Result Selection
-      [
-        {
-          type   = "log"
-          x      = 0
-          y      = 50
-          width  = 8
           height = 6
           properties = {
             title  = "Searches vs Selections"
@@ -492,178 +97,96 @@ resource "aws_cloudwatch_dashboard" "search" {
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event in ["search_completed", "result_selected"]
-              | stats count(*) as count by event, bin(1h)
+              | stats count(*) as count by event, bin(1d)
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 8
+          width  = 8
+          height = 6
+          properties = {
+            title  = "E2E Latency (p50/p90)"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "search_completed"
+              | stats pct(total_duration_ms, 50) as p50, pct(total_duration_ms, 90) as p90 by bin(1d)
             EOT
           }
         },
         {
           type   = "log"
           x      = 8
-          y      = 50
+          y      = 8
           width  = 8
           height = 6
           properties = {
-            title  = "Selected Result Types"
+            title  = "AI API Latency (p50/p90)"
             region = var.region
-            view   = "pie"
+            view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
-              | ${local.service_filter} and event = "result_selected"
-              | stats count(*) as selections by goods_nomenclature_class
+              | ${local.service_filter} and event = "api_call_completed"
+              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90 by bin(1d)
             EOT
           }
         },
         {
           type   = "log"
           x      = 16
-          y      = 50
+          y      = 8
           width  = 8
           height = 6
           properties = {
-            title  = "Top Selected Codes"
+            title  = "Query Expansions"
             region = var.region
+            view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
-              | ${local.service_filter} and event = "result_selected"
-              | stats count(*) as selections by goods_nomenclature_item_id, goods_nomenclature_class
-              | sort selections desc
-              | limit 20
+              | ${local.service_filter} and event = "query_expanded"
+              | stats count(*) as expansions by bin(1d)
             EOT
           }
         },
       ],
-
-      # Row 10 (y=56): Errors and Reliability
       [
         {
           type   = "log"
           x      = 0
-          y      = 56
-          width  = 6
+          y      = 14
+          width  = 12
           height = 6
           properties = {
-            title  = "Interactive Search Errors"
+            title  = "Zero-Result Searches"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
-              | ${local.service_filter} and event = "search_completed" and search_type = "interactive" and final_result_type = "error"
-              | stats count(*) as errors by bin(1h)
-            EOT
-          }
-        },
-        {
-          type   = "log"
-          x      = 6
-          y      = 56
-          width  = 6
-          height = 6
-          properties = {
-            title  = "Hard Errors Over Time"
-            region = var.region
-            view   = "timeSeries"
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "search_failed"
-              | stats count(*) as errors by bin(1h)
+              | ${local.service_filter} and event = "search_completed" and result_count = 0
+              | stats count(*) as searches by search_type, bin(1d)
             EOT
           }
         },
         {
           type   = "log"
           x      = 12
-          y      = 56
-          width  = 6
-          height = 6
-          properties = {
-            title  = "Hard Errors by Type"
-            region = var.region
-            view   = "pie"
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "search_failed"
-              | stats count(*) as errors by error_type
-            EOT
-          }
-        },
-        {
-          type   = "log"
-          x      = 18
-          y      = 56
-          width  = 6
-          height = 6
-          properties = {
-            title  = "Recent Error Log"
-            region = var.region
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event in ["search_failed", "search_completed"]
-              | filter event = "search_failed" or final_result_type = "error"
-              | fields @timestamp, event, search_type, error_type, final_result_type, error_message, request_id
-              | sort @timestamp desc
-              | limit 20
-            EOT
-          }
-        },
-      ],
-
-      # Row 11 (y=62): Live Feed
-      [
-        {
-          type   = "log"
-          x      = 0
-          y      = 62
+          y      = 14
           width  = 12
           height = 6
           properties = {
-            title  = "Recent Searches"
+            title  = "Average Result Count"
             region = var.region
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "search_started"
-              | fields @timestamp, query, search_type, request_id
-              | sort @timestamp desc
-              | limit 30
-            EOT
-          }
-        },
-        {
-          type   = "log"
-          x      = 12
-          y      = 62
-          width  = 12
-          height = 6
-          properties = {
-            title  = "Recent Completions"
-            region = var.region
+            view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "search_completed"
-              | fields @timestamp, search_type, total_duration_ms, result_count, final_result_type, request_id
-              | sort @timestamp desc
-              | limit 30
-            EOT
-          }
-        },
-      ],
-
-      # Row 12 (y=68): Description Intercept Drill-Down
-      [
-        {
-          type   = "log"
-          x      = 0
-          y      = 68
-          width  = 24
-          height = 6
-          properties = {
-            title  = "Recent Intercept Matches"
-            region = var.region
-            query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "description_intercept_checked" and matched = true
-              | fields @timestamp, query, term, excluded, filtering, filter_prefix_count, guidance_level, guidance_location, escalate_to_webchat, request_id
-              | sort @timestamp desc
-              | limit 30
+              | stats avg(result_count) as avg_results, median(result_count) as median_results by bin(1d)
             EOT
           }
         },

--- a/terraform/modules/search_operations_dashboard/README.md
+++ b/terraform/modules/search_operations_dashboard/README.md
@@ -1,0 +1,43 @@
+# search_operations_dashboard
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.12.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_dashboard.search_operations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_dashboard) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_dashboard_name"></a> [dashboard\_name](#input\_dashboard\_name) | Name of the CloudWatch dashboard | `string` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (e.g., development, staging, production) | `string` | n/a | yes |
+| <a name="input_log_group_name"></a> [log\_group\_name](#input\_log\_group\_name) | CloudWatch Log Group name where search instrumentation logs are sent | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | `"eu-west-2"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_dashboard_arn"></a> [dashboard\_arn](#output\_dashboard\_arn) | ARN of the CloudWatch dashboard |
+| <a name="output_dashboard_name"></a> [dashboard\_name](#output\_dashboard\_name) | Name of the CloudWatch dashboard |
+| <a name="output_dashboard_url"></a> [dashboard\_url](#output\_dashboard\_url) | URL to the CloudWatch dashboard |
+<!-- END_TF_DOCS -->

--- a/terraform/modules/search_operations_dashboard/main.tf
+++ b/terraform/modules/search_operations_dashboard/main.tf
@@ -1,0 +1,287 @@
+locals {
+  dashboard_name = var.dashboard_name != null ? var.dashboard_name : "SearchOperations-${var.environment}"
+  source         = "SOURCE '${var.log_group_name}'"
+  service_filter = "filter service = \"search\""
+
+  search_dashboard_url         = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=Search-${var.environment}"
+  search_quality_dashboard_url = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=SearchQuality-${var.environment}"
+}
+
+resource "aws_cloudwatch_dashboard" "search_operations" {
+  dashboard_name = local.dashboard_name
+
+  dashboard_body = jsonencode({
+    widgets = concat(
+      [
+        {
+          type   = "text"
+          x      = 0
+          y      = 0
+          width  = 24
+          height = 2
+          properties = {
+            markdown = join("\n", [
+              "## Trade Tariff Search Operations",
+              "Recent operational troubleshooting dashboard for search. Use this for live incidents, latency spikes, and error investigation.",
+              "**Healthy:** p90 latency < 5s, API latency p90 < 5s, low hard-error volume, and hybrid retrieval failures near zero.",
+              "**Start here:** check completed vs failed searches and latency rows first, then drill into error and recent-event tables below.",
+              "**Related:** [Search Overview](${local.search_dashboard_url}) | [Search Quality](${local.search_quality_dashboard_url})",
+            ])
+          }
+        }
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 2
+          width  = 6
+          height = 6
+          properties = {
+            title  = "Completed vs Failed Searches"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event in ["search_completed", "search_failed"]
+              | stats count(*) as count by event, bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 6
+          y      = 2
+          width  = 6
+          height = 6
+          properties = {
+            title  = "E2E Latency (p50/p90/p99)"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "search_completed"
+              | stats pct(total_duration_ms, 50) as p50, pct(total_duration_ms, 90) as p90, pct(total_duration_ms, 99) as p99 by bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 12
+          y      = 2
+          width  = 6
+          height = 6
+          properties = {
+            title  = "AI API Latency (p50/p90/p99)"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "api_call_completed"
+              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90, pct(duration_ms, 99) as p99 by bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 18
+          y      = 2
+          width  = 6
+          height = 6
+          properties = {
+            title  = "Hard Errors"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "search_failed"
+              | stats count(*) as errors by bin(1h)
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 8
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Query Expansion Volume"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "query_expanded"
+              | stats count(*) as expansions, avg(duration_ms) as avg_duration_ms by bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 8
+          y      = 8
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Interactive Search Errors"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "search_completed" and search_type = "interactive" and final_result_type = "error"
+              | stats count(*) as errors by bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 16
+          y      = 8
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Hard Errors by Type"
+            region = var.region
+            view   = "pie"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "search_failed"
+              | stats count(*) as errors by error_type
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 14
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Hybrid Leg Latency (p50/p90)"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "retrieval_leg_completed"
+              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90 by leg, bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 8
+          y      = 14
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Hybrid Leg Failures"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "retrieval_leg_completed" and status = "error"
+              | stats count(*) as failures by leg, bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 16
+          y      = 14
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Hybrid Leg Result Counts"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "retrieval_leg_completed" and status = "success"
+              | stats avg(result_count) as avg_results by leg, bin(1h)
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 20
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Query Expansion Detail"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "query_expanded"
+              | stats count(*) as expansions, avg(duration_ms) as avg_ms by reason
+              | sort expansions desc
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 8
+          y      = 20
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Recent Error Log"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event in ["search_failed", "search_completed"]
+              | filter event = "search_failed" or final_result_type = "error"
+              | fields @timestamp, event, search_type, error_type, final_result_type, error_message, request_id
+              | sort @timestamp desc
+              | limit 20
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 16
+          y      = 20
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Recent Searches"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "search_started"
+              | fields @timestamp, query, search_type, request_id
+              | sort @timestamp desc
+              | limit 30
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 26
+          width  = 24
+          height = 6
+          properties = {
+            title  = "Recent Completions"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "search_completed"
+              | fields @timestamp, search_type, total_duration_ms, result_count, final_result_type, request_id
+              | sort @timestamp desc
+              | limit 30
+            EOT
+          }
+        },
+      ]
+    )
+  })
+}

--- a/terraform/modules/search_operations_dashboard/outputs.tf
+++ b/terraform/modules/search_operations_dashboard/outputs.tf
@@ -1,0 +1,14 @@
+output "dashboard_arn" {
+  description = "ARN of the CloudWatch dashboard"
+  value       = aws_cloudwatch_dashboard.search_operations.dashboard_arn
+}
+
+output "dashboard_name" {
+  description = "Name of the CloudWatch dashboard"
+  value       = aws_cloudwatch_dashboard.search_operations.dashboard_name
+}
+
+output "dashboard_url" {
+  description = "URL to the CloudWatch dashboard"
+  value       = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${local.dashboard_name}"
+}

--- a/terraform/modules/search_operations_dashboard/variables.tf
+++ b/terraform/modules/search_operations_dashboard/variables.tf
@@ -1,0 +1,21 @@
+variable "environment" {
+  description = "Environment name (e.g., development, staging, production)"
+  type        = string
+}
+
+variable "log_group_name" {
+  description = "CloudWatch Log Group name where search instrumentation logs are sent"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "eu-west-2"
+}
+
+variable "dashboard_name" {
+  description = "Name of the CloudWatch dashboard"
+  type        = string
+  default     = null
+}

--- a/terraform/modules/search_operations_dashboard/versions.tf
+++ b/terraform/modules/search_operations_dashboard/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">=1.12.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5"
+    }
+  }
+}

--- a/terraform/modules/search_quality_dashboard/README.md
+++ b/terraform/modules/search_quality_dashboard/README.md
@@ -1,0 +1,43 @@
+# search_quality_dashboard
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.12.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_dashboard.search_quality](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_dashboard) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_dashboard_name"></a> [dashboard\_name](#input\_dashboard\_name) | Name of the CloudWatch dashboard | `string` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (e.g., development, staging, production) | `string` | n/a | yes |
+| <a name="input_log_group_name"></a> [log\_group\_name](#input\_log\_group\_name) | CloudWatch Log Group name where search instrumentation logs are sent | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | `"eu-west-2"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_dashboard_arn"></a> [dashboard\_arn](#output\_dashboard\_arn) | ARN of the CloudWatch dashboard |
+| <a name="output_dashboard_name"></a> [dashboard\_name](#output\_dashboard\_name) | Name of the CloudWatch dashboard |
+| <a name="output_dashboard_url"></a> [dashboard\_url](#output\_dashboard\_url) | URL to the CloudWatch dashboard |
+<!-- END_TF_DOCS -->

--- a/terraform/modules/search_quality_dashboard/main.tf
+++ b/terraform/modules/search_quality_dashboard/main.tf
@@ -1,0 +1,325 @@
+locals {
+  dashboard_name = var.dashboard_name != null ? var.dashboard_name : "SearchQuality-${var.environment}"
+  source         = "SOURCE '${var.log_group_name}'"
+  service_filter = "filter service = \"search\""
+
+  search_dashboard_url            = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=Search-${var.environment}"
+  search_operations_dashboard_url = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=SearchOperations-${var.environment}"
+}
+
+resource "aws_cloudwatch_dashboard" "search_quality" {
+  dashboard_name = local.dashboard_name
+
+  dashboard_body = jsonencode({
+    widgets = concat(
+      [
+        {
+          type   = "text"
+          x      = 0
+          y      = 0
+          width  = 24
+          height = 2
+          properties = {
+            markdown = join("\n", [
+              "## Trade Tariff Search Quality",
+              "Behaviour and product-quality dashboard for search outcomes, zero-result terms, intercepts, and result selection patterns.",
+              "**Healthy:** zero-result terms stay stable, result types remain consistent, intercept matches track expected terms, and interactive outcomes do not skew towards errors.",
+              "**Start here:** check result-type and zero-result widgets first, then inspect intercept and selection drill-downs below.",
+              "**Related:** [Search Overview](${local.search_dashboard_url}) | [Search Operations](${local.search_operations_dashboard_url})",
+            ])
+          }
+        }
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 2
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Final Result Type (Interactive)"
+            region = var.region
+            view   = "pie"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "search_completed" and search_type = "interactive"
+              | stats count(*) as searches by final_result_type
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 8
+          y      = 2
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Results Type Breakdown"
+            region = var.region
+            view   = "pie"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "search_completed"
+              | stats count(*) as searches by results_type
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 16
+          y      = 2
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Average Result Count"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "search_completed"
+              | stats avg(result_count) as avg_results, median(result_count) as median_results by bin(1h)
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 8
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Zero-Result Searches by Type"
+            region = var.region
+            view   = "pie"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "search_completed" and result_count = 0
+              | stats count(*) as searches by search_type
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 8
+          y      = 8
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Top 30 Zero-Result Search Terms"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "search_completed" and result_count = 0
+              | stats count(*) as searches by query
+              | sort searches desc
+              | limit 30
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 16
+          y      = 8
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Recent Zero-Result Searches"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "search_completed" and result_count = 0
+              | fields @timestamp, query, search_type, request_id
+              | sort @timestamp desc
+              | limit 30
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 14
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Searches vs Selections"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event in ["search_completed", "result_selected"]
+              | stats count(*) as count by event, bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 8
+          y      = 14
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Selected Result Types"
+            region = var.region
+            view   = "pie"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "result_selected"
+              | stats count(*) as selections by goods_nomenclature_class
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 16
+          y      = 14
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Top Selected Codes"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "result_selected"
+              | stats count(*) as selections by goods_nomenclature_item_id, goods_nomenclature_class
+              | sort selections desc
+              | limit 20
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 20
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Intercept Checks Over Time"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "description_intercept_checked"
+              | stats count(*) as checks by matched, bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 8
+          y      = 20
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Intercept Outcomes"
+            region = var.region
+            view   = "bar"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "description_intercept_checked" and matched = true
+              | stats count(*) as matches by excluded, filtering, guidance_level, guidance_location, escalate_to_webchat
+              | sort matches desc
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 16
+          y      = 20
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Top Matched Intercept Terms"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "description_intercept_checked" and matched = true
+              | stats count(*) as matches by term, excluded, filtering, guidance_level, guidance_location, escalate_to_webchat
+              | sort matches desc
+              | limit 30
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 26
+          width  = 12
+          height = 6
+          properties = {
+            title  = "AI Response Types Over Time"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "api_call_completed"
+              | stats count(*) as calls by response_type, bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 12
+          y      = 26
+          width  = 6
+          height = 6
+          properties = {
+            title  = "Attempts Per Search"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "search_completed" and search_type = "interactive"
+              | stats count(*) as searches by total_attempts
+              | sort total_attempts asc
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 18
+          y      = 26
+          width  = 6
+          height = 6
+          properties = {
+            title  = "Questions Per Search"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "search_completed" and search_type = "interactive"
+              | stats count(*) as searches by total_questions
+              | sort total_questions asc
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 32
+          width  = 24
+          height = 6
+          properties = {
+            title  = "Recent Intercept Matches"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "description_intercept_checked" and matched = true
+              | fields @timestamp, query, term, excluded, filtering, filter_prefix_count, guidance_level, guidance_location, escalate_to_webchat, request_id
+              | sort @timestamp desc
+              | limit 30
+            EOT
+          }
+        },
+      ]
+    )
+  })
+}

--- a/terraform/modules/search_quality_dashboard/outputs.tf
+++ b/terraform/modules/search_quality_dashboard/outputs.tf
@@ -1,0 +1,14 @@
+output "dashboard_arn" {
+  description = "ARN of the CloudWatch dashboard"
+  value       = aws_cloudwatch_dashboard.search_quality.dashboard_arn
+}
+
+output "dashboard_name" {
+  description = "Name of the CloudWatch dashboard"
+  value       = aws_cloudwatch_dashboard.search_quality.dashboard_name
+}
+
+output "dashboard_url" {
+  description = "URL to the CloudWatch dashboard"
+  value       = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${local.dashboard_name}"
+}

--- a/terraform/modules/search_quality_dashboard/variables.tf
+++ b/terraform/modules/search_quality_dashboard/variables.tf
@@ -1,0 +1,21 @@
+variable "environment" {
+  description = "Environment name (e.g., development, staging, production)"
+  type        = string
+}
+
+variable "log_group_name" {
+  description = "CloudWatch Log Group name where search instrumentation logs are sent"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "eu-west-2"
+}
+
+variable "dashboard_name" {
+  description = "Name of the CloudWatch dashboard"
+  type        = string
+  default     = null
+}

--- a/terraform/modules/search_quality_dashboard/versions.tf
+++ b/terraform/modules/search_quality_dashboard/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">=1.12.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5"
+    }
+  }
+}


### PR DESCRIPTION
### Jira link
BAU

### What?
- [x] Split the search CloudWatch dashboard into overview, operations, and quality dashboards
- [x] Keep the main Search dashboard focused on quarter-scale trend widgets with lower-cost daily bins
- [x] Add dedicated operations and quality dashboards for drill-downs, recent logs, intercepts, and zero-result analysis
- [x] Expose the new dashboard URLs from root Terraform and regenerate Terraform docs

### Why?
The existing Search dashboard ran too many CloudWatch Logs Insights widgets at once, which made long-range views such as 3 months hit CloudWatch query and rate limits quickly. Splitting the dashboard keeps the landing view cheap enough for trend analysis while preserving the detailed investigative views separately.
