### PR TITLE
Materialise footnote and measure hot-path plain views

### DIFF
--- a/app/models/footnote.rb
+++ b/app/models/footnote.rb
@@ -1,6 +1,6 @@
 class Footnote < Sequel::Model
   plugin :time_machine
-  plugin :oplog, primary_key: %i[footnote_type_id footnote_id]
+  plugin :oplog, primary_key: %i[footnote_type_id footnote_id], materialized: true
 
   set_primary_key %i[footnote_type_id footnote_id]
 

--- a/app/models/footnote_description.rb
+++ b/app/models/footnote_description.rb
@@ -4,7 +4,7 @@ class FootnoteDescription < Sequel::Model
   plugin :time_machine
   plugin :oplog, primary_key: %i[footnote_description_period_sid
                                  footnote_id
-                                 footnote_type_id]
+                                 footnote_type_id], materialized: true
 
   set_primary_key %i[footnote_description_period_sid footnote_id footnote_type_id]
 

--- a/app/models/footnote_description_period.rb
+++ b/app/models/footnote_description_period.rb
@@ -2,7 +2,7 @@ class FootnoteDescriptionPeriod < Sequel::Model
   plugin :time_machine
   plugin :oplog, primary_key: %i[footnote_id
                                  footnote_type_id
-                                 footnote_description_period_sid]
+                                 footnote_description_period_sid], materialized: true
 
   set_primary_key %i[footnote_id footnote_type_id footnote_description_period_sid]
 

--- a/app/models/measure_component.rb
+++ b/app/models/measure_component.rb
@@ -1,5 +1,5 @@
 class MeasureComponent < Sequel::Model
-  plugin :oplog, primary_key: %i[measure_sid duty_expression_id]
+  plugin :oplog, primary_key: %i[measure_sid duty_expression_id], materialized: true
 
   set_primary_key %i[measure_sid duty_expression_id]
 

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -4,7 +4,7 @@ class MeasureCondition < Sequel::Model
 
   plugin :time_machine
   plugin :national
-  plugin :oplog, primary_key: :measure_condition_sid
+  plugin :oplog, primary_key: :measure_condition_sid, materialized: true
 
   set_primary_key [:measure_condition_sid]
 

--- a/db/migrate/20260424120000_materialise_hot_path_footnote_and_measure_views.rb
+++ b/db/migrate/20260424120000_materialise_hot_path_footnote_and_measure_views.rb
@@ -1,0 +1,353 @@
+# frozen_string_literal: true
+
+# Converts five high-traffic plain views to materialized views.
+#
+# All five are queried on every commodity/heading/subheading show request:
+#
+#   footnotes                  — eager-loaded on goods nomenclatures and measures
+#   footnote_description_periods — join table for footnote description loading
+#   footnote_descriptions      — loaded alongside footnote_description_periods
+#   measure_conditions         — eager-loaded for every measure
+#   measure_components         — eager-loaded for every measure (duty components)
+#
+# As plain views each row evaluation triggers a correlated MAX(oid) subquery
+# against the underlying oplog table. Materializing pre-computes the
+# deduplicated rows and allows PostgreSQL to use conventional indexes for all
+# subsequent queries.
+#
+# Refresh is handled automatically: MaterializeViewHelper#refresh_materialized_view
+# iterates all oplog models with materialized: true and is called at the end of
+# both TaricUpdatesSynchronizerWorker and CdsUpdatesSynchronizerWorker, as well
+# as ApplyWorker and RollbackWorker.
+#
+# simplified_procedural_code_measures is a plain view that JOINs
+# measure_components by name. PostgreSQL tracks this as a dependency and will
+# refuse DROP VIEW measure_components unless we drop the dependent view first.
+# It is recreated after the measure_components conversion.
+
+Sequel.migration do
+  up do
+    # --- footnotes -----------------------------------------------------------
+
+    drop_view :footnotes
+
+    create_view :footnotes, <<~SQL, materialized: true
+      SELECT footnote_id,
+             footnote_type_id,
+             validity_start_date,
+             validity_end_date,
+             "national",
+             oid,
+             operation,
+             operation_date,
+             filename
+      FROM uk.footnotes_oplog footnotes1
+      WHERE oid IN (
+        SELECT max(footnotes2.oid)
+        FROM uk.footnotes_oplog footnotes2
+        WHERE footnotes1.footnote_type_id::text = footnotes2.footnote_type_id::text
+          AND footnotes1.footnote_id::text = footnotes2.footnote_id::text
+      )
+      AND operation::text <> 'D'
+    SQL
+
+    # Unique OID index is required by the oplog plugin's refresh! path and
+    # allows REFRESH MATERIALIZED VIEW CONCURRENTLY in future.
+    add_index :footnotes, :oid, unique: true
+    # Covers (footnote_type_id, footnote_id) IN (...) batched eager loads.
+    add_index :footnotes, %i[footnote_type_id footnote_id]
+    # Covers the time_machine validity date filter.
+    add_index :footnotes, %i[validity_start_date validity_end_date]
+
+    # --- footnote_description_periods ----------------------------------------
+
+    drop_view :footnote_description_periods
+
+    create_view :footnote_description_periods, <<~SQL, materialized: true
+      SELECT footnote_description_period_sid,
+             footnote_type_id,
+             footnote_id,
+             validity_start_date,
+             validity_end_date,
+             "national",
+             oid,
+             operation,
+             operation_date,
+             filename
+      FROM uk.footnote_description_periods_oplog footnote_description_periods1
+      WHERE oid IN (
+        SELECT max(footnote_description_periods2.oid)
+        FROM uk.footnote_description_periods_oplog footnote_description_periods2
+        WHERE footnote_description_periods1.footnote_id::text = footnote_description_periods2.footnote_id::text
+          AND footnote_description_periods1.footnote_type_id::text = footnote_description_periods2.footnote_type_id::text
+          AND footnote_description_periods1.footnote_description_period_sid = footnote_description_periods2.footnote_description_period_sid
+      )
+      AND operation::text <> 'D'
+    SQL
+
+    add_index :footnote_description_periods, :oid, unique: true
+    # Covers (footnote_type_id, footnote_id) IN (...) + validity_start_date <= ?
+    # in a single index range scan.
+    add_index :footnote_description_periods, %i[footnote_type_id footnote_id validity_start_date]
+
+    # --- footnote_descriptions -----------------------------------------------
+
+    drop_view :footnote_descriptions
+
+    create_view :footnote_descriptions, <<~SQL, materialized: true
+      SELECT footnote_description_period_sid,
+             footnote_type_id,
+             footnote_id,
+             language_id,
+             description,
+             "national",
+             oid,
+             operation,
+             operation_date,
+             filename
+      FROM uk.footnote_descriptions_oplog footnote_descriptions1
+      WHERE oid IN (
+        SELECT max(footnote_descriptions2.oid)
+        FROM uk.footnote_descriptions_oplog footnote_descriptions2
+        WHERE footnote_descriptions1.footnote_description_period_sid = footnote_descriptions2.footnote_description_period_sid
+          AND footnote_descriptions1.footnote_id::text = footnote_descriptions2.footnote_id::text
+          AND footnote_descriptions1.footnote_type_id::text = footnote_descriptions2.footnote_type_id::text
+      )
+      AND operation::text <> 'D'
+    SQL
+
+    add_index :footnote_descriptions, :oid, unique: true
+    # Covers the three-column join key used by the many_to_many association.
+    add_index :footnote_descriptions, %i[footnote_description_period_sid footnote_type_id footnote_id]
+
+    # --- measure_conditions --------------------------------------------------
+
+    drop_view :measure_conditions
+
+    create_view :measure_conditions, <<~SQL, materialized: true
+      SELECT measure_condition_sid,
+             measure_sid,
+             condition_code,
+             component_sequence_number,
+             condition_duty_amount,
+             condition_monetary_unit_code,
+             condition_measurement_unit_code,
+             condition_measurement_unit_qualifier_code,
+             action_code,
+             certificate_type_code,
+             certificate_code,
+             oid,
+             operation,
+             operation_date,
+             filename
+      FROM uk.measure_conditions_oplog measure_conditions1
+      WHERE oid IN (
+        SELECT max(measure_conditions2.oid)
+        FROM uk.measure_conditions_oplog measure_conditions2
+        WHERE measure_conditions1.measure_condition_sid = measure_conditions2.measure_condition_sid
+      )
+      AND operation::text <> 'D'
+    SQL
+
+    add_index :measure_conditions, :oid, unique: true
+    # Covers the primary eager-load pattern: measure_sid IN (...).
+    add_index :measure_conditions, :measure_sid
+    add_index :measure_conditions, :measure_condition_sid
+
+    # --- measure_components --------------------------------------------------
+    # Drop the dependent view first; recreated at the end of this migration.
+
+    drop_view :simplified_procedural_code_measures
+    drop_view :measure_components
+
+    create_view :measure_components, <<~SQL, materialized: true
+      SELECT measure_sid,
+             duty_expression_id,
+             duty_amount,
+             monetary_unit_code,
+             measurement_unit_code,
+             measurement_unit_qualifier_code,
+             oid,
+             operation,
+             operation_date,
+             filename
+      FROM uk.measure_components_oplog measure_components1
+      WHERE oid IN (
+        SELECT max(measure_components2.oid)
+        FROM uk.measure_components_oplog measure_components2
+        WHERE measure_components1.measure_sid = measure_components2.measure_sid
+          AND measure_components1.duty_expression_id::text = measure_components2.duty_expression_id::text
+      )
+      AND operation::text <> 'D'
+    SQL
+
+    add_index :measure_components, :oid, unique: true
+    # Covers measure_sid IN (...) eager loads.
+    add_index :measure_components, :measure_sid
+
+    # Recreate the dependent view now that measure_components is materialized.
+    create_or_replace_view :simplified_procedural_code_measures, <<~SQL
+      SELECT simplified_procedural_codes.simplified_procedural_code,
+             measures.validity_start_date,
+             measures.validity_end_date,
+             string_agg(DISTINCT simplified_procedural_codes.goods_nomenclature_item_id, ', ') AS goods_nomenclature_item_ids,
+             max(measure_components.duty_amount) AS duty_amount,
+             max(measure_components.monetary_unit_code::text) AS monetary_unit_code,
+             max(measure_components.measurement_unit_code::text) AS measurement_unit_code,
+             max(measure_components.measurement_unit_qualifier_code::text) AS measurement_unit_qualifier_code,
+             max(simplified_procedural_codes.goods_nomenclature_label) AS goods_nomenclature_label
+      FROM uk.measures
+        JOIN uk.measure_components ON measures.measure_sid = measure_components.measure_sid
+        RIGHT JOIN uk.simplified_procedural_codes
+          ON measures.goods_nomenclature_item_id::text = simplified_procedural_codes.goods_nomenclature_item_id
+         AND measures.measure_type_id::text = '488'
+         AND measures.validity_end_date > '2021-01-01'
+         AND measures.geographical_area_id::text = '1011'
+      GROUP BY simplified_procedural_codes.simplified_procedural_code,
+               measures.validity_start_date,
+               measures.validity_end_date
+    SQL
+  end
+
+  down do
+    drop_view :simplified_procedural_code_measures
+
+    drop_view(:measure_components, materialized: true) if MeasureComponent.actually_materialized?
+    drop_view(:measure_conditions, materialized: true) if MeasureCondition.actually_materialized?
+    drop_view(:footnote_descriptions, materialized: true) if FootnoteDescription.actually_materialized?
+    drop_view(:footnote_description_periods, materialized: true) if FootnoteDescriptionPeriod.actually_materialized?
+    drop_view(:footnotes, materialized: true) if Footnote.actually_materialized?
+
+    create_or_replace_view :footnotes, <<~SQL
+      SELECT footnote_id,
+             footnote_type_id,
+             validity_start_date,
+             validity_end_date,
+             "national",
+             oid,
+             operation,
+             operation_date,
+             filename
+      FROM uk.footnotes_oplog footnotes1
+      WHERE oid IN (
+        SELECT max(footnotes2.oid)
+        FROM uk.footnotes_oplog footnotes2
+        WHERE footnotes1.footnote_type_id::text = footnotes2.footnote_type_id::text
+          AND footnotes1.footnote_id::text = footnotes2.footnote_id::text
+      )
+      AND operation::text <> 'D'
+    SQL
+
+    create_or_replace_view :footnote_description_periods, <<~SQL
+      SELECT footnote_description_period_sid,
+             footnote_type_id,
+             footnote_id,
+             validity_start_date,
+             validity_end_date,
+             "national",
+             oid,
+             operation,
+             operation_date,
+             filename
+      FROM uk.footnote_description_periods_oplog footnote_description_periods1
+      WHERE oid IN (
+        SELECT max(footnote_description_periods2.oid)
+        FROM uk.footnote_description_periods_oplog footnote_description_periods2
+        WHERE footnote_description_periods1.footnote_id::text = footnote_description_periods2.footnote_id::text
+          AND footnote_description_periods1.footnote_type_id::text = footnote_description_periods2.footnote_type_id::text
+          AND footnote_description_periods1.footnote_description_period_sid = footnote_description_periods2.footnote_description_period_sid
+      )
+      AND operation::text <> 'D'
+    SQL
+
+    create_or_replace_view :footnote_descriptions, <<~SQL
+      SELECT footnote_description_period_sid,
+             footnote_type_id,
+             footnote_id,
+             language_id,
+             description,
+             "national",
+             oid,
+             operation,
+             operation_date,
+             filename
+      FROM uk.footnote_descriptions_oplog footnote_descriptions1
+      WHERE oid IN (
+        SELECT max(footnote_descriptions2.oid)
+        FROM uk.footnote_descriptions_oplog footnote_descriptions2
+        WHERE footnote_descriptions1.footnote_description_period_sid = footnote_descriptions2.footnote_description_period_sid
+          AND footnote_descriptions1.footnote_id::text = footnote_descriptions2.footnote_id::text
+          AND footnote_descriptions1.footnote_type_id::text = footnote_descriptions2.footnote_type_id::text
+      )
+      AND operation::text <> 'D'
+    SQL
+
+    create_or_replace_view :measure_conditions, <<~SQL
+      SELECT measure_condition_sid,
+             measure_sid,
+             condition_code,
+             component_sequence_number,
+             condition_duty_amount,
+             condition_monetary_unit_code,
+             condition_measurement_unit_code,
+             condition_measurement_unit_qualifier_code,
+             action_code,
+             certificate_type_code,
+             certificate_code,
+             oid,
+             operation,
+             operation_date,
+             filename
+      FROM uk.measure_conditions_oplog measure_conditions1
+      WHERE oid IN (
+        SELECT max(measure_conditions2.oid)
+        FROM uk.measure_conditions_oplog measure_conditions2
+        WHERE measure_conditions1.measure_condition_sid = measure_conditions2.measure_condition_sid
+      )
+      AND operation::text <> 'D'
+    SQL
+
+    create_or_replace_view :measure_components, <<~SQL
+      SELECT measure_sid,
+             duty_expression_id,
+             duty_amount,
+             monetary_unit_code,
+             measurement_unit_code,
+             measurement_unit_qualifier_code,
+             oid,
+             operation,
+             operation_date,
+             filename
+      FROM uk.measure_components_oplog measure_components1
+      WHERE oid IN (
+        SELECT max(measure_components2.oid)
+        FROM uk.measure_components_oplog measure_components2
+        WHERE measure_components1.measure_sid = measure_components2.measure_sid
+          AND measure_components1.duty_expression_id::text = measure_components2.duty_expression_id::text
+      )
+      AND operation::text <> 'D'
+    SQL
+
+    create_or_replace_view :simplified_procedural_code_measures, <<~SQL
+      SELECT simplified_procedural_codes.simplified_procedural_code,
+             measures.validity_start_date,
+             measures.validity_end_date,
+             string_agg(DISTINCT simplified_procedural_codes.goods_nomenclature_item_id, ', ') AS goods_nomenclature_item_ids,
+             max(measure_components.duty_amount) AS duty_amount,
+             max(measure_components.monetary_unit_code::text) AS monetary_unit_code,
+             max(measure_components.measurement_unit_code::text) AS measurement_unit_code,
+             max(measure_components.measurement_unit_qualifier_code::text) AS measurement_unit_qualifier_code,
+             max(simplified_procedural_codes.goods_nomenclature_label) AS goods_nomenclature_label
+      FROM uk.measures
+        JOIN uk.measure_components ON measures.measure_sid = measure_components.measure_sid
+        RIGHT JOIN uk.simplified_procedural_codes
+          ON measures.goods_nomenclature_item_id::text = simplified_procedural_codes.goods_nomenclature_item_id
+         AND measures.measure_type_id::text = '488'
+         AND measures.validity_end_date > '2021-01-01'
+         AND measures.geographical_area_id::text = '1011'
+      GROUP BY simplified_procedural_codes.simplified_procedural_code,
+               measures.validity_start_date,
+               measures.validity_end_date
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict 4xXn0CQzIHYhRrgv2qlE8Idjmg9eMNwFPzYhYmOtHiGsA71Y1oTKhiObnChJBkm
+\restrict LdWMLXxWAQmYyPnk0MXJZNNoeKQ11UM6A1vB8Ml2abPnJASuWl25cIEWkreFVm6
 
 -- Dumped from database version 18.3
 -- Dumped by pg_dump version 18.3
@@ -2756,10 +2756,10 @@ CREATE TABLE uk.footnote_description_periods_oplog (
 
 
 --
--- Name: footnote_description_periods; Type: VIEW; Schema: uk; Owner: -
+-- Name: footnote_description_periods; Type: MATERIALIZED VIEW; Schema: uk; Owner: -
 --
 
-CREATE VIEW uk.footnote_description_periods AS
+CREATE MATERIALIZED VIEW uk.footnote_description_periods AS
  SELECT footnote_description_period_sid,
     footnote_type_id,
     footnote_id,
@@ -2773,7 +2773,8 @@ CREATE VIEW uk.footnote_description_periods AS
    FROM uk.footnote_description_periods_oplog footnote_description_periods1
   WHERE ((oid IN ( SELECT max(footnote_description_periods2.oid) AS max
            FROM uk.footnote_description_periods_oplog footnote_description_periods2
-          WHERE (((footnote_description_periods1.footnote_id)::text = (footnote_description_periods2.footnote_id)::text) AND ((footnote_description_periods1.footnote_type_id)::text = (footnote_description_periods2.footnote_type_id)::text) AND (footnote_description_periods1.footnote_description_period_sid = footnote_description_periods2.footnote_description_period_sid)))) AND ((operation)::text <> 'D'::text));
+          WHERE (((footnote_description_periods1.footnote_id)::text = (footnote_description_periods2.footnote_id)::text) AND ((footnote_description_periods1.footnote_type_id)::text = (footnote_description_periods2.footnote_type_id)::text) AND (footnote_description_periods1.footnote_description_period_sid = footnote_description_periods2.footnote_description_period_sid)))) AND ((operation)::text <> 'D'::text))
+  WITH NO DATA;
 
 
 --
@@ -2815,10 +2816,10 @@ CREATE TABLE uk.footnote_descriptions_oplog (
 
 
 --
--- Name: footnote_descriptions; Type: VIEW; Schema: uk; Owner: -
+-- Name: footnote_descriptions; Type: MATERIALIZED VIEW; Schema: uk; Owner: -
 --
 
-CREATE VIEW uk.footnote_descriptions AS
+CREATE MATERIALIZED VIEW uk.footnote_descriptions AS
  SELECT footnote_description_period_sid,
     footnote_type_id,
     footnote_id,
@@ -2832,7 +2833,8 @@ CREATE VIEW uk.footnote_descriptions AS
    FROM uk.footnote_descriptions_oplog footnote_descriptions1
   WHERE ((oid IN ( SELECT max(footnote_descriptions2.oid) AS max
            FROM uk.footnote_descriptions_oplog footnote_descriptions2
-          WHERE ((footnote_descriptions1.footnote_description_period_sid = footnote_descriptions2.footnote_description_period_sid) AND ((footnote_descriptions1.footnote_id)::text = (footnote_descriptions2.footnote_id)::text) AND ((footnote_descriptions1.footnote_type_id)::text = (footnote_descriptions2.footnote_type_id)::text)))) AND ((operation)::text <> 'D'::text));
+          WHERE ((footnote_descriptions1.footnote_description_period_sid = footnote_descriptions2.footnote_description_period_sid) AND ((footnote_descriptions1.footnote_id)::text = (footnote_descriptions2.footnote_id)::text) AND ((footnote_descriptions1.footnote_type_id)::text = (footnote_descriptions2.footnote_type_id)::text)))) AND ((operation)::text <> 'D'::text))
+  WITH NO DATA;
 
 
 --
@@ -2985,10 +2987,10 @@ CREATE TABLE uk.footnotes_oplog (
 
 
 --
--- Name: footnotes; Type: VIEW; Schema: uk; Owner: -
+-- Name: footnotes; Type: MATERIALIZED VIEW; Schema: uk; Owner: -
 --
 
-CREATE VIEW uk.footnotes AS
+CREATE MATERIALIZED VIEW uk.footnotes AS
  SELECT footnote_id,
     footnote_type_id,
     validity_start_date,
@@ -3001,7 +3003,8 @@ CREATE VIEW uk.footnotes AS
    FROM uk.footnotes_oplog footnotes1
   WHERE ((oid IN ( SELECT max(footnotes2.oid) AS max
            FROM uk.footnotes_oplog footnotes2
-          WHERE (((footnotes1.footnote_type_id)::text = (footnotes2.footnote_type_id)::text) AND ((footnotes1.footnote_id)::text = (footnotes2.footnote_id)::text)))) AND ((operation)::text <> 'D'::text));
+          WHERE (((footnotes1.footnote_type_id)::text = (footnotes2.footnote_type_id)::text) AND ((footnotes1.footnote_id)::text = (footnotes2.footnote_id)::text)))) AND ((operation)::text <> 'D'::text))
+  WITH NO DATA;
 
 
 --
@@ -4607,10 +4610,10 @@ CREATE TABLE uk.measure_components_oplog (
 
 
 --
--- Name: measure_components; Type: VIEW; Schema: uk; Owner: -
+-- Name: measure_components; Type: MATERIALIZED VIEW; Schema: uk; Owner: -
 --
 
-CREATE VIEW uk.measure_components AS
+CREATE MATERIALIZED VIEW uk.measure_components AS
  SELECT measure_sid,
     duty_expression_id,
     duty_amount,
@@ -4624,7 +4627,8 @@ CREATE VIEW uk.measure_components AS
    FROM uk.measure_components_oplog measure_components1
   WHERE ((oid IN ( SELECT max(measure_components2.oid) AS max
            FROM uk.measure_components_oplog measure_components2
-          WHERE ((measure_components1.measure_sid = measure_components2.measure_sid) AND ((measure_components1.duty_expression_id)::text = (measure_components2.duty_expression_id)::text)))) AND ((operation)::text <> 'D'::text));
+          WHERE ((measure_components1.measure_sid = measure_components2.measure_sid) AND ((measure_components1.duty_expression_id)::text = (measure_components2.duty_expression_id)::text)))) AND ((operation)::text <> 'D'::text))
+  WITH NO DATA;
 
 
 --
@@ -4836,10 +4840,10 @@ CREATE TABLE uk.measure_conditions_oplog (
 
 
 --
--- Name: measure_conditions; Type: VIEW; Schema: uk; Owner: -
+-- Name: measure_conditions; Type: MATERIALIZED VIEW; Schema: uk; Owner: -
 --
 
-CREATE VIEW uk.measure_conditions AS
+CREATE MATERIALIZED VIEW uk.measure_conditions AS
  SELECT measure_condition_sid,
     measure_sid,
     condition_code,
@@ -4858,7 +4862,8 @@ CREATE VIEW uk.measure_conditions AS
    FROM uk.measure_conditions_oplog measure_conditions1
   WHERE ((oid IN ( SELECT max(measure_conditions2.oid) AS max
            FROM uk.measure_conditions_oplog measure_conditions2
-          WHERE (measure_conditions1.measure_condition_sid = measure_conditions2.measure_condition_sid))) AND ((operation)::text <> 'D'::text));
+          WHERE (measure_conditions1.measure_condition_sid = measure_conditions2.measure_condition_sid))) AND ((operation)::text <> 'D'::text))
+  WITH NO DATA;
 
 
 --
@@ -7683,7 +7688,7 @@ CREATE VIEW uk.simplified_procedural_code_measures AS
     max(simplified_procedural_codes.goods_nomenclature_label) AS goods_nomenclature_label
    FROM ((uk.measures
      JOIN uk.measure_components ON ((measures.measure_sid = measure_components.measure_sid)))
-     RIGHT JOIN uk.simplified_procedural_codes ON ((((measures.goods_nomenclature_item_id)::text = simplified_procedural_codes.goods_nomenclature_item_id) AND ((measures.measure_type_id)::text = '488'::text) AND (measures.validity_end_date > '2021-01-01'::date) AND ((measures.geographical_area_id)::text = '1011'::text))))
+     RIGHT JOIN uk.simplified_procedural_codes ON ((((measures.goods_nomenclature_item_id)::text = simplified_procedural_codes.goods_nomenclature_item_id) AND ((measures.measure_type_id)::text = '488'::text) AND (measures.validity_end_date > '2021-01-01 00:00:00'::timestamp without time zone) AND ((measures.geographical_area_id)::text = '1011'::text))))
   GROUP BY simplified_procedural_codes.simplified_procedural_code, measures.validity_start_date, measures.validity_end_date;
 
 
@@ -7758,11 +7763,25 @@ ALTER SEQUENCE uk.tariff_update_presence_errors_id_seq OWNED BY uk.tariff_update
 --
 
 CREATE TABLE uk.tariff_update_state_changes (
-    id integer GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY,
+    id integer NOT NULL,
     tariff_update_filename text NOT NULL,
-    from_state character(1),
-    to_state character(1) NOT NULL,
+    from_state character varying(1),
+    to_state character varying(1) NOT NULL,
     created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: tariff_update_state_changes_id_seq; Type: SEQUENCE; Schema: uk; Owner: -
+--
+
+ALTER TABLE uk.tariff_update_state_changes ALTER COLUMN id ADD GENERATED BY DEFAULT AS IDENTITY (
+    SEQUENCE NAME uk.tariff_update_state_changes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1
 );
 
 
@@ -10041,6 +10060,14 @@ ALTER TABLE ONLY uk.tariff_update_presence_errors
 
 
 --
+-- Name: tariff_update_state_changes tariff_update_state_changes_pkey; Type: CONSTRAINT; Schema: uk; Owner: -
+--
+
+ALTER TABLE ONLY uk.tariff_update_state_changes
+    ADD CONSTRAINT tariff_update_state_changes_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: tariff_updates tariff_updates_pkey; Type: CONSTRAINT; Schema: uk; Owner: -
 --
 
@@ -11034,6 +11061,20 @@ CREATE INDEX footnote_association_measures_oplog_footnote_type_id_index ON uk.fo
 
 
 --
+-- Name: footnote_description_periods_footnote_type_id_footnote_id_valid; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX footnote_description_periods_footnote_type_id_footnote_id_valid ON uk.footnote_description_periods USING btree (footnote_type_id, footnote_id, validity_start_date);
+
+
+--
+-- Name: footnote_description_periods_oid_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE UNIQUE INDEX footnote_description_periods_oid_index ON uk.footnote_description_periods USING btree (oid);
+
+
+--
 -- Name: footnote_descriptions_description_trgm_idx; Type: INDEX; Schema: uk; Owner: -
 --
 
@@ -11041,10 +11082,45 @@ CREATE INDEX footnote_descriptions_description_trgm_idx ON uk.footnote_descripti
 
 
 --
+-- Name: footnote_descriptions_footnote_description_period_sid_footnote_; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX footnote_descriptions_footnote_description_period_sid_footnote_ ON uk.footnote_descriptions USING btree (footnote_description_period_sid, footnote_type_id, footnote_id);
+
+
+--
+-- Name: footnote_descriptions_oid_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE UNIQUE INDEX footnote_descriptions_oid_index ON uk.footnote_descriptions USING btree (oid);
+
+
+--
 -- Name: footnote_id; Type: INDEX; Schema: uk; Owner: -
 --
 
 CREATE INDEX footnote_id ON uk.footnote_association_measures_oplog USING btree (footnote_id);
+
+
+--
+-- Name: footnotes_footnote_type_id_footnote_id_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX footnotes_footnote_type_id_footnote_id_index ON uk.footnotes USING btree (footnote_type_id, footnote_id);
+
+
+--
+-- Name: footnotes_oid_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE UNIQUE INDEX footnotes_oid_index ON uk.footnotes USING btree (oid);
+
+
+--
+-- Name: footnotes_validity_start_date_validity_end_date_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX footnotes_validity_start_date_validity_end_date_index ON uk.footnotes USING btree (validity_start_date, validity_end_date);
 
 
 --
@@ -11433,6 +11509,20 @@ CREATE INDEX gnso_goonomsucopl_odsureorslog_operation_date ON uk.goods_nomenclat
 
 
 --
+-- Name: gono_desc_oid_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX gono_desc_oid_index ON uk.goods_nomenclature_descriptions_oplog USING btree (goods_nomenclature_sid, goods_nomenclature_description_period_sid, oid DESC);
+
+
+--
+-- Name: gono_desc_periods_oid_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX gono_desc_periods_oid_index ON uk.goods_nomenclature_description_periods_oplog USING btree (goods_nomenclature_description_period_sid, oid DESC);
+
+
+--
 -- Name: gono_desc_periods_pk; Type: INDEX; Schema: uk; Owner: -
 --
 
@@ -11443,21 +11533,7 @@ CREATE INDEX gono_desc_periods_pk ON uk.goods_nomenclature_description_periods_o
 -- Name: gono_desc_pk; Type: INDEX; Schema: uk; Owner: -
 --
 
-CREATE INDEX gono_desc_oid_index ON uk.goods_nomenclature_descriptions_oplog USING btree (goods_nomenclature_sid, goods_nomenclature_description_period_sid, oid DESC);
-
-
---
--- Name: gono_desc_pk; Type: INDEX; Schema: uk; Owner: -
---
-
 CREATE INDEX gono_desc_pk ON uk.goods_nomenclature_descriptions_oplog USING btree (goods_nomenclature_sid, goods_nomenclature_description_period_sid);
-
-
---
--- Name: gono_desc_periods_oid_index; Type: INDEX; Schema: uk; Owner: -
---
-
-CREATE INDEX gono_desc_periods_oid_index ON uk.goods_nomenclature_description_periods_oplog USING btree (goods_nomenclature_description_period_sid, oid DESC);
 
 
 --
@@ -12389,6 +12465,41 @@ CREATE INDEX meas_unit_qual_pk ON uk.measurement_unit_qualifiers_oplog USING btr
 --
 
 CREATE INDEX measrm_pk ON uk.measurements_oplog USING btree (measurement_unit_code, measurement_unit_qualifier_code);
+
+
+--
+-- Name: measure_components_measure_sid_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX measure_components_measure_sid_index ON uk.measure_components USING btree (measure_sid);
+
+
+--
+-- Name: measure_components_oid_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE UNIQUE INDEX measure_components_oid_index ON uk.measure_components USING btree (oid);
+
+
+--
+-- Name: measure_conditions_measure_condition_sid_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX measure_conditions_measure_condition_sid_index ON uk.measure_conditions USING btree (measure_condition_sid);
+
+
+--
+-- Name: measure_conditions_measure_sid_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX measure_conditions_measure_sid_index ON uk.measure_conditions USING btree (measure_sid);
+
+
+--
+-- Name: measure_conditions_oid_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE UNIQUE INDEX measure_conditions_oid_index ON uk.measure_conditions USING btree (oid);
 
 
 --
@@ -13739,7 +13850,7 @@ ALTER TABLE ONLY uk.news_collections_news_items
 -- PostgreSQL database dump complete
 --
 
-\unrestrict 4xXn0CQzIHYhRrgv2qlE8Idjmg9eMNwFPzYhYmOtHiGsA71Y1oTKhiObnChJBkm
+\unrestrict LdWMLXxWAQmYyPnk0MXJZNNoeKQ11UM6A1vB8Ml2abPnJASuWl25cIEWkreFVm6
 
 SET search_path TO uk, public;
 INSERT INTO "schema_migrations" ("filename") VALUES ('1342519058_create_schema.rb');
@@ -13967,5 +14078,9 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20260413120000_drop_tariff
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260413120001_drop_tariff_update_cds_errors.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260415120000_add_guidance_fields_to_description_intercepts.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260415120001_create_tariff_update_state_changes.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20260420115159_add_validity_date_indexes_to_geographical_area_description_periods.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20260421120000_add_commodity_show_performance_indexes.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20260421120001_add_oid_covering_indexes_to_goods_nomenclature_description_oplogs.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260422143000_add_lifecycle_flags_to_generated_classification_content.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260423120000_add_regulation_and_fts_performance_indexes.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20260424120000_materialise_hot_path_footnote_and_measure_views.rb');

--- a/spec/controllers/api/admin/footnotes_controller_spec.rb
+++ b/spec/controllers/api/admin/footnotes_controller_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe Api::Admin::FootnotesController do
     specify 'updates national footnote' do
       expect {
         put :update, params: { id: national_footnote.pk.join, data: { type: :footnote, attributes: { description: 'new description' } } }, format: :json
+        FootnoteDescription.refresh!
       }.to change { national_footnote.reload.description }.to('new description')
     end
 

--- a/spec/integration/cds_importer/cds_importer_spec.rb
+++ b/spec/integration/cds_importer/cds_importer_spec.rb
@@ -47,6 +47,10 @@ RSpec.describe CdsImporter do
 
       it 'creates a footnote with a large description' do
         importer.import
+        Footnote.refresh!
+        FootnoteDescriptionPeriod.refresh!
+        FootnoteDescription.refresh!
+
         expect(Footnote.last.description.bytesize).to eq(5985)
       end
     end


### PR DESCRIPTION
## Summary

- Converts five high-traffic plain views to materialized views: `footnotes`, `footnote_description_periods`, `footnote_descriptions`, `measure_conditions`, `measure_components`
- As plain views, every row evaluation triggered a correlated `MAX(oid)` subquery against the backing oplog table — this happened on every commodity, heading, and subheading show request via `MEASURES_EAGER_LOAD_GRAPH`
- Materializing pre-computes the deduplicated rows so all subsequent reads use conventional index scans with no subquery overhead
- Adds targeted indexes to each view covering the primary eager-load query patterns (FK `IN`-list lookups and time-machine validity date filters)
- Handles the `simplified_procedural_code_measures` plain view which depends on `measure_components` — dropped and recreated around the conversion

Refresh is already fully wired: `MaterializeViewHelper#refresh_materialized_view` iterates all `materialized: true` oplog models and is called at the end of `TaricUpdatesSynchronizerWorker`, `CdsUpdatesSynchronizerWorker`, `ApplyWorker`, and `RollbackWorker`. No changes to the sync pipeline are needed.
