### PR TITLE
OTTIMP-530 Refactor duty expression formatters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,7 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.6.3)
+    pg (1.6.3-arm64-darwin)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -477,6 +478,7 @@ GEM
     zeitwerk (2.7.5)
 
 PLATFORMS
+  arm64-darwin-24
   arm64-darwin-25
   x86_64-linux
 

--- a/app/formatters/duty_expression_formatter.rb
+++ b/app/formatters/duty_expression_formatter.rb
@@ -10,122 +10,16 @@ class DutyExpressionFormatter
     end
 
     def format(opts = {})
-      duty_expression_id = opts[:duty_expression_id]
-      duty_expression_description = opts[:duty_expression_description]
-      duty_expression_abbreviation = opts[:duty_expression_abbreviation]
-      duty_amount = opts[:duty_amount]
-      monetary_unit = opts[:monetary_unit_abbreviation].presence || opts[:monetary_unit]
-      measurement_unit = opts[:measurement_unit]
-      measurement_unit_qualifier = opts[:measurement_unit_qualifier]
-      measurement_unit_abbreviation = measurement_unit.try(:abbreviation,
-                                                           measurement_unit_qualifier:)
-      resolved_meursing_component = opts[:resolved_meursing]
-      formatted = opts[:formatted]
-      verbose = opts[:verbose]
-
-      if verbose
-        measurement_unit_expansion = measurement_unit.try(
-          :expansion,
-          measurement_unit_qualifier:,
-        )
-        monetary_unit_to_symbol = Currency.new(monetary_unit).try(
-          :format,
-          prettify(duty_amount).to_s,
-        )
-      else
-        measurement_unit_expansion = nil
-        monetary_unit_to_symbol = nil
-      end
-
-      output = []
-      case duty_expression_id
-      when '99'
-        output << if formatted
-                    "<abbr title='#{measurement_unit.description}'>#{measurement_unit_abbreviation}</abbr>"
-                  elsif verbose && measurement_unit_expansion
-                    measurement_unit_expansion
-                  else
-                    measurement_unit_abbreviation.to_s
-                  end
-      when '12', '14', '37', '40', '41', '42', '43', '44', '21', '25', '27', '29'
-        if duty_expression_abbreviation.present?
-          output << duty_expression_abbreviation
-        elsif duty_expression_description.present?
-          output << duty_expression_description
-        end
-      when '02', '04', '15', '17', '19', '20', '36'
-        if duty_expression_abbreviation.present?
-          output << duty_expression_abbreviation
-        elsif duty_expression_description.present?
-          output << duty_expression_description
-        end
-        if duty_amount.present?
-          output << if formatted
-                      html_formatted_duty_expression(duty_amount)
-                    elsif verbose && monetary_unit
-                      monetary_unit_to_symbol
-                    else
-                      prettify(duty_amount).to_s
-                    end
-        end
-        output << if monetary_unit.present? && !verbose
-                    monetary_unit
-                  else
-                    '%' unless monetary_unit
-                  end
-        if measurement_unit_abbreviation.present?
-          output << if formatted
-                      "/ <abbr title='#{measurement_unit.description}'>#{measurement_unit_abbreviation}</abbr>"
-                    elsif verbose && measurement_unit_expansion
-                      "/ #{measurement_unit_expansion}"
-                    else
-                      "/ #{measurement_unit_abbreviation}"
-                    end
-        end
-      else
-        if duty_amount.present?
-          output << if formatted
-                      html_formatted_duty_expression(duty_amount)
-                    elsif verbose && monetary_unit
-                      monetary_unit_to_symbol
-                    else
-                      prettify(duty_amount).to_s
-                    end
-        end
-        if duty_expression_abbreviation.present? && monetary_unit.blank?
-          output << duty_expression_abbreviation
-        elsif duty_expression_description.present? && monetary_unit.blank?
-          output << duty_expression_description
-        elsif duty_expression_description.blank?
-          output << '%'
-        end
-        if monetary_unit.present? && !verbose
-          output << monetary_unit
-        end
-        if measurement_unit_abbreviation.present?
-          output << if formatted
-                      "/ <abbr title='#{measurement_unit.description}'>#{measurement_unit_abbreviation}</abbr>"
-                    elsif verbose && measurement_unit_expansion
-                      "/ #{measurement_unit_expansion}"
-                    else
-                      "/ #{measurement_unit_abbreviation}"
-                    end
-        end
-      end
+      context = Context.build(opts)
+      output = OutputBuilder.call(context)
 
       result = output.join(' ').html_safe
 
-      if resolved_meursing_component
+      if context.resolved_meursing_component
         "<strong>#{result}</strong>"
       else
         result
       end
-    end
-
-    private
-
-    def html_formatted_duty_expression(duty_amount)
-      "<span>#{prettify(duty_amount)}</span>"
     end
   end
 end

--- a/app/formatters/duty_expression_formatter.rb
+++ b/app/formatters/duty_expression_formatter.rb
@@ -1,14 +1,7 @@
 class DutyExpressionFormatter
-  class << self
-    def prettify(float)
-      TradeTariffBackend.number_formatter.number_with_precision(
-        float,
-        minimum_decimal_points: 2,
-        precision: 4,
-        strip_insignificant_zeros: true,
-      )
-    end
+  extend DutyExpressionPrettifier
 
+  class << self
     def format(opts = {})
       context = Context.build(opts)
       output = OutputBuilder.call(context)

--- a/app/formatters/duty_expression_formatter/context.rb
+++ b/app/formatters/duty_expression_formatter/context.rb
@@ -1,0 +1,70 @@
+DutyExpressionFormatter::Context = Struct.new(
+  :duty_expression_id,
+  :duty_expression_description,
+  :duty_expression_abbreviation,
+  :duty_amount,
+  :monetary_unit,
+  :measurement_unit,
+  :measurement_unit_qualifier,
+  :measurement_unit_abbreviation,
+  :measurement_unit_expansion,
+  :monetary_unit_to_symbol,
+  :resolved_meursing_component,
+  :formatted,
+  :verbose,
+  keyword_init: true,
+) do
+  class << self
+    def build(opts)
+      monetary_unit = opts[:monetary_unit_abbreviation].presence || opts[:monetary_unit]
+      measurement_unit = opts[:measurement_unit]
+      measurement_unit_qualifier = opts[:measurement_unit_qualifier]
+      measurement_unit_abbreviation = measurement_unit.try(
+        :abbreviation,
+        measurement_unit_qualifier:,
+      )
+      verbose = opts[:verbose]
+
+      measurement_unit_expansion, monetary_unit_to_symbol = verbose_context_values(
+        verbose,
+        measurement_unit,
+        measurement_unit_qualifier,
+        monetary_unit,
+        opts[:duty_amount],
+      )
+
+      new(
+        duty_expression_id: opts[:duty_expression_id],
+        duty_expression_description: opts[:duty_expression_description],
+        duty_expression_abbreviation: opts[:duty_expression_abbreviation],
+        duty_amount: opts[:duty_amount],
+        monetary_unit: monetary_unit,
+        measurement_unit: measurement_unit,
+        measurement_unit_qualifier: measurement_unit_qualifier,
+        measurement_unit_abbreviation: measurement_unit_abbreviation,
+        measurement_unit_expansion: measurement_unit_expansion,
+        monetary_unit_to_symbol: monetary_unit_to_symbol,
+        resolved_meursing_component: opts[:resolved_meursing],
+        formatted: opts[:formatted],
+        verbose: verbose,
+      )
+    end
+
+    private
+
+    def verbose_context_values(verbose, measurement_unit, measurement_unit_qualifier, monetary_unit, duty_amount)
+      return [nil, nil] unless verbose
+
+      measurement_unit_expansion = measurement_unit.try(
+        :expansion,
+        measurement_unit_qualifier:,
+      )
+      monetary_unit_to_symbol = Currency.new(monetary_unit).try(
+        :format,
+        DutyExpressionFormatter.prettify(duty_amount).to_s,
+      )
+
+      [measurement_unit_expansion, monetary_unit_to_symbol]
+    end
+  end
+end

--- a/app/formatters/duty_expression_formatter/output_builder.rb
+++ b/app/formatters/duty_expression_formatter/output_builder.rb
@@ -1,0 +1,34 @@
+class DutyExpressionFormatter::OutputBuilder
+  DESCRIPTION_ONLY_EXPRESSION_IDS = %w[12 14 37 40 41 42 43 44 21 25 27 29].freeze
+  DESCRIPTION_AMOUNT_EXPRESSION_IDS = %w[02 04 15 17 19 20 36].freeze
+
+  class << self
+    def call(context)
+      new(context).call
+    end
+  end
+
+  def initialize(context)
+    @context = context
+  end
+
+  def call
+    strategy_for(context).call
+  end
+
+  private
+
+  attr_reader :context
+
+  def strategy_for(context)
+    if context.duty_expression_id == '99'
+      DutyExpressionFormatter::Strategies::UnitOnly.new(context)
+    elsif DESCRIPTION_ONLY_EXPRESSION_IDS.include?(context.duty_expression_id)
+      DutyExpressionFormatter::Strategies::DescriptionOnly.new(context)
+    elsif DESCRIPTION_AMOUNT_EXPRESSION_IDS.include?(context.duty_expression_id)
+      DutyExpressionFormatter::Strategies::DescriptionAmount.new(context)
+    else
+      DutyExpressionFormatter::Strategies::Default.new(context)
+    end
+  end
+end

--- a/app/formatters/duty_expression_formatter/strategies/base.rb
+++ b/app/formatters/duty_expression_formatter/strategies/base.rb
@@ -1,0 +1,75 @@
+class DutyExpressionFormatter::Strategies::Base
+  include FormatterOutputHelpers
+
+  def initialize(context)
+    @context = context
+  end
+
+  private
+
+  attr_reader :context
+
+  def duty_expression_text_fragment
+    if context.duty_expression_abbreviation.present?
+      context.duty_expression_abbreviation
+    elsif context.duty_expression_description.present?
+      context.duty_expression_description
+    end
+  end
+
+  def duty_amount_fragment
+    return if context.duty_amount.blank?
+
+    if context.formatted
+      formatted_amount_fragment(DutyExpressionFormatter, context.duty_amount, formatted: true)
+    elsif context.verbose && context.monetary_unit
+      context.monetary_unit_to_symbol
+    else
+      DutyExpressionFormatter.prettify(context.duty_amount).to_s
+    end
+  end
+
+  def monetary_or_percent_fragment
+    if context.monetary_unit.present? && !context.verbose
+      context.monetary_unit
+    else
+      '%' unless context.monetary_unit
+    end
+  end
+
+  def default_expression_or_percent_fragment
+    if context.duty_expression_abbreviation.present? && context.monetary_unit.blank?
+      context.duty_expression_abbreviation
+    elsif context.duty_expression_description.present? && context.monetary_unit.blank?
+      context.duty_expression_description
+    elsif context.duty_expression_description.blank?
+      '%'
+    end
+  end
+
+  def default_monetary_unit_fragment
+    context.monetary_unit if context.monetary_unit.present? && !context.verbose
+  end
+
+  def measurement_unit_fragment
+    if context.formatted
+      measurement_unit_abbr_tag(context.measurement_unit, context.measurement_unit_abbreviation)
+    elsif context.verbose && context.measurement_unit_expansion
+      context.measurement_unit_expansion
+    else
+      context.measurement_unit_abbreviation.to_s
+    end
+  end
+
+  def per_measurement_unit_fragment
+    return if context.measurement_unit_abbreviation.blank?
+
+    if context.formatted
+      "/ #{measurement_unit_abbr_tag(context.measurement_unit, context.measurement_unit_abbreviation)}"
+    elsif context.verbose && context.measurement_unit_expansion
+      "/ #{context.measurement_unit_expansion}"
+    else
+      "/ #{context.measurement_unit_abbreviation}"
+    end
+  end
+end

--- a/app/formatters/duty_expression_formatter/strategies/base.rb
+++ b/app/formatters/duty_expression_formatter/strategies/base.rb
@@ -52,24 +52,27 @@ class DutyExpressionFormatter::Strategies::Base
   end
 
   def measurement_unit_fragment
-    if context.formatted
-      measurement_unit_abbr_tag(context.measurement_unit, context.measurement_unit_abbreviation)
-    elsif context.verbose && context.measurement_unit_expansion
-      context.measurement_unit_expansion
-    else
-      context.measurement_unit_abbreviation.to_s
-    end
+    render_measurement_unit_fragment(
+      measurement_unit: context.measurement_unit,
+      abbreviation: context.measurement_unit_abbreviation,
+      formatted: context.formatted,
+      unformatted: context.measurement_unit_abbreviation.to_s,
+      verbose: context.verbose,
+      expansion: context.measurement_unit_expansion,
+    )
   end
 
   def per_measurement_unit_fragment
     return if context.measurement_unit_abbreviation.blank?
 
-    if context.formatted
-      "/ #{measurement_unit_abbr_tag(context.measurement_unit, context.measurement_unit_abbreviation)}"
-    elsif context.verbose && context.measurement_unit_expansion
-      "/ #{context.measurement_unit_expansion}"
-    else
-      "/ #{context.measurement_unit_abbreviation}"
-    end
+    render_prefixed_measurement_unit_fragment(
+      prefix: '/ ',
+      measurement_unit: context.measurement_unit,
+      abbreviation: context.measurement_unit_abbreviation,
+      formatted: context.formatted,
+      unformatted: context.measurement_unit_abbreviation,
+      verbose: context.verbose,
+      expansion: context.measurement_unit_expansion,
+    )
   end
 end

--- a/app/formatters/duty_expression_formatter/strategies/base.rb
+++ b/app/formatters/duty_expression_formatter/strategies/base.rb
@@ -53,12 +53,7 @@ class DutyExpressionFormatter::Strategies::Base
 
   def measurement_unit_fragment
     render_measurement_unit_fragment(
-      measurement_unit: context.measurement_unit,
-      abbreviation: context.measurement_unit_abbreviation,
-      formatted: context.formatted,
-      unformatted: context.measurement_unit_abbreviation.to_s,
-      verbose: context.verbose,
-      expansion: context.measurement_unit_expansion,
+      **measurement_unit_render_options,
     )
   end
 
@@ -67,12 +62,18 @@ class DutyExpressionFormatter::Strategies::Base
 
     render_prefixed_measurement_unit_fragment(
       prefix: '/ ',
+      **measurement_unit_render_options,
+    )
+  end
+
+  def measurement_unit_render_options
+    {
       measurement_unit: context.measurement_unit,
       abbreviation: context.measurement_unit_abbreviation,
       formatted: context.formatted,
       unformatted: context.measurement_unit_abbreviation,
       verbose: context.verbose,
       expansion: context.measurement_unit_expansion,
-    )
+    }
   end
 end

--- a/app/formatters/duty_expression_formatter/strategies/default.rb
+++ b/app/formatters/duty_expression_formatter/strategies/default.rb
@@ -1,0 +1,10 @@
+class DutyExpressionFormatter::Strategies::Default < DutyExpressionFormatter::Strategies::Base
+  def call
+    [
+      duty_amount_fragment,
+      default_expression_or_percent_fragment,
+      default_monetary_unit_fragment,
+      per_measurement_unit_fragment,
+    ].compact
+  end
+end

--- a/app/formatters/duty_expression_formatter/strategies/description_amount.rb
+++ b/app/formatters/duty_expression_formatter/strategies/description_amount.rb
@@ -1,0 +1,10 @@
+class DutyExpressionFormatter::Strategies::DescriptionAmount < DutyExpressionFormatter::Strategies::Base
+  def call
+    [
+      duty_expression_text_fragment,
+      duty_amount_fragment,
+      monetary_or_percent_fragment,
+      per_measurement_unit_fragment,
+    ].compact
+  end
+end

--- a/app/formatters/duty_expression_formatter/strategies/description_only.rb
+++ b/app/formatters/duty_expression_formatter/strategies/description_only.rb
@@ -1,0 +1,5 @@
+class DutyExpressionFormatter::Strategies::DescriptionOnly < DutyExpressionFormatter::Strategies::Base
+  def call
+    [duty_expression_text_fragment].compact
+  end
+end

--- a/app/formatters/duty_expression_formatter/strategies/unit_only.rb
+++ b/app/formatters/duty_expression_formatter/strategies/unit_only.rb
@@ -1,0 +1,5 @@
+class DutyExpressionFormatter::Strategies::UnitOnly < DutyExpressionFormatter::Strategies::Base
+  def call
+    [measurement_unit_fragment].compact
+  end
+end

--- a/app/formatters/duty_expression_prettifier.rb
+++ b/app/formatters/duty_expression_prettifier.rb
@@ -1,0 +1,10 @@
+module DutyExpressionPrettifier
+  def prettify(float)
+    TradeTariffBackend.number_formatter.number_with_precision(
+      float,
+      minimum_decimal_points: 2,
+      precision: 4,
+      strip_insignificant_zeros: true,
+    )
+  end
+end

--- a/app/formatters/formatter_output_helpers.rb
+++ b/app/formatters/formatter_output_helpers.rb
@@ -11,4 +11,25 @@ module FormatterOutputHelpers
   def measurement_unit_abbr_tag(measurement_unit, abbreviation)
     "<abbr title='#{measurement_unit.description}'>#{abbreviation}</abbr>"
   end
+
+  def render_measurement_unit_fragment(measurement_unit:, abbreviation:, formatted:, unformatted:, verbose: false, expansion: nil)
+    if formatted
+      measurement_unit_abbr_tag(measurement_unit, abbreviation)
+    elsif verbose && expansion.present?
+      expansion
+    else
+      unformatted
+    end
+  end
+
+  def render_prefixed_measurement_unit_fragment(prefix:, measurement_unit:, abbreviation:, formatted:, unformatted:, verbose: false, expansion: nil)
+    "#{prefix}#{render_measurement_unit_fragment(
+      measurement_unit: measurement_unit,
+      abbreviation: abbreviation,
+      formatted: formatted,
+      unformatted: unformatted,
+      verbose: verbose,
+      expansion: expansion,
+    )}"
+  end
 end

--- a/app/formatters/formatter_output_helpers.rb
+++ b/app/formatters/formatter_output_helpers.rb
@@ -1,0 +1,14 @@
+module FormatterOutputHelpers
+  private
+
+  def formatted_amount_fragment(formatter_class, amount, formatted:)
+    prettified_amount = formatter_class.prettify(amount).to_s
+    return prettified_amount unless formatted
+
+    "<span>#{prettified_amount}</span>"
+  end
+
+  def measurement_unit_abbr_tag(measurement_unit, abbreviation)
+    "<abbr title='#{measurement_unit.description}'>#{abbreviation}</abbr>"
+  end
+end

--- a/app/formatters/requirement_duty_expression_formatter.rb
+++ b/app/formatters/requirement_duty_expression_formatter.rb
@@ -10,49 +10,9 @@ class RequirementDutyExpressionFormatter
     end
 
     def format(opts = {})
-      duty_amount = opts[:duty_amount]
-      monetary_unit = opts[:monetary_unit_abbreviation].presence || opts[:monetary_unit]
-      measurement_unit = opts[:measurement_unit]
-      measurement_unit_qualifier = opts[:formatted_measurement_unit_qualifier]
-      measurement_unit_abbreviation = measurement_unit.try(:abbreviation,
-                                                           measurement_unit_qualifier:)
+      context = Context.build(opts)
 
-      output = []
-
-      if duty_amount.present?
-        output << if opts[:formatted]
-                    "<span>#{prettify(duty_amount)}</span>"
-                  else
-                    prettify(duty_amount).to_s
-                  end
-      end
-
-      if monetary_unit.present? && measurement_unit_abbreviation.present? && measurement_unit_qualifier.present?
-        output << if opts[:formatted]
-                    "#{monetary_unit} / (<abbr title='#{measurement_unit.description}'>#{measurement_unit_abbreviation}</abbr> / #{measurement_unit_qualifier})"
-                  else
-                    "#{monetary_unit} / (#{measurement_unit} / #{measurement_unit_qualifier})"
-                  end
-      elsif monetary_unit.present? && measurement_unit_abbreviation.present?
-        output << if opts[:formatted]
-                    "#{monetary_unit} / <abbr title='#{measurement_unit.description}'>#{measurement_unit_abbreviation}</abbr>"
-                  else
-                    "#{monetary_unit} / #{measurement_unit}"
-                  end
-      elsif measurement_unit_abbreviation.present?
-        output << if opts[:formatted]
-                    "<abbr title='#{measurement_unit.description}'>#{measurement_unit_abbreviation}</abbr>"
-                  else
-                    measurement_unit
-                  end
-      elsif monetary_unit.present?
-        output << if opts[:formatted]
-                    monetary_unit.to_s
-                  else
-                    monetary_unit
-                  end
-      end
-      output.join(' ').html_safe
+      OutputBuilder.call(context).join(' ').html_safe
     end
   end
 end

--- a/app/formatters/requirement_duty_expression_formatter.rb
+++ b/app/formatters/requirement_duty_expression_formatter.rb
@@ -1,14 +1,7 @@
 class RequirementDutyExpressionFormatter
-  class << self
-    def prettify(float)
-      TradeTariffBackend.number_formatter.number_with_precision(
-        float,
-        precision: 4,
-        minimum_decimal_points: 2,
-        strip_insignificant_zeros: true,
-      )
-    end
+  extend DutyExpressionPrettifier
 
+  class << self
     def format(opts = {})
       context = Context.build(opts)
 

--- a/app/formatters/requirement_duty_expression_formatter/context.rb
+++ b/app/formatters/requirement_duty_expression_formatter/context.rb
@@ -1,0 +1,28 @@
+RequirementDutyExpressionFormatter::Context = Struct.new(
+  :duty_amount,
+  :monetary_unit,
+  :measurement_unit,
+  :measurement_unit_qualifier,
+  :measurement_unit_abbreviation,
+  :formatted,
+  keyword_init: true,
+) do
+  class << self
+    def build(opts)
+      measurement_unit = opts[:measurement_unit]
+      measurement_unit_qualifier = opts[:formatted_measurement_unit_qualifier]
+
+      new(
+        duty_amount: opts[:duty_amount],
+        monetary_unit: opts[:monetary_unit_abbreviation].presence || opts[:monetary_unit],
+        measurement_unit: measurement_unit,
+        measurement_unit_qualifier: measurement_unit_qualifier,
+        measurement_unit_abbreviation: measurement_unit.try(
+          :abbreviation,
+          measurement_unit_qualifier:,
+        ),
+        formatted: opts[:formatted],
+      )
+    end
+  end
+end

--- a/app/formatters/requirement_duty_expression_formatter/output_builder.rb
+++ b/app/formatters/requirement_duty_expression_formatter/output_builder.rb
@@ -1,0 +1,83 @@
+class RequirementDutyExpressionFormatter::OutputBuilder
+  include FormatterOutputHelpers
+
+  class << self
+    def call(context)
+      new(context).call
+    end
+  end
+
+  def initialize(context)
+    @context = context
+  end
+
+  def call
+    [amount_fragment, unit_fragment].compact
+  end
+
+  private
+
+  attr_reader :context
+
+  def amount_fragment
+    return if context.duty_amount.blank?
+
+    formatted_amount_fragment(
+      RequirementDutyExpressionFormatter,
+      context.duty_amount,
+      formatted: context.formatted,
+    )
+  end
+
+  def unit_fragment
+    if monetary_measurement_qualifier?
+      monetary_measurement_qualifier_fragment
+    elsif monetary_measurement?
+      monetary_measurement_fragment
+    elsif measurement_only?
+      measurement_fragment
+    elsif monetary_only?
+      context.monetary_unit.to_s
+    end
+  end
+
+  def monetary_measurement_qualifier?
+    context.monetary_unit.present? && context.measurement_unit_abbreviation.present? && context.measurement_unit_qualifier.present?
+  end
+
+  def monetary_measurement?
+    context.monetary_unit.present? && context.measurement_unit_abbreviation.present?
+  end
+
+  def measurement_only?
+    context.measurement_unit_abbreviation.present?
+  end
+
+  def monetary_only?
+    context.monetary_unit.present?
+  end
+
+  def monetary_measurement_qualifier_fragment
+    if context.formatted
+      "#{context.monetary_unit} / (#{measurement_unit_abbr_tag(context.measurement_unit, context.measurement_unit_abbreviation)} / #{context.measurement_unit_qualifier})"
+    else
+      "#{context.monetary_unit} / (#{context.measurement_unit} / #{context.measurement_unit_qualifier})"
+    end
+  end
+
+  def monetary_measurement_fragment
+    if context.formatted
+      "#{context.monetary_unit} / #{measurement_unit_abbr_tag(context.measurement_unit, context.measurement_unit_abbreviation)}"
+    else
+      "#{context.monetary_unit} / #{context.measurement_unit}"
+    end
+  end
+
+  def measurement_fragment
+    if context.formatted
+      measurement_unit_abbr_tag(context.measurement_unit, context.measurement_unit_abbreviation)
+    else
+      context.measurement_unit
+    end
+  end
+end

--- a/app/formatters/requirement_duty_expression_formatter/output_builder.rb
+++ b/app/formatters/requirement_duty_expression_formatter/output_builder.rb
@@ -58,26 +58,29 @@ class RequirementDutyExpressionFormatter::OutputBuilder
   end
 
   def monetary_measurement_qualifier_fragment
-    if context.formatted
-      "#{context.monetary_unit} / (#{measurement_unit_abbr_tag(context.measurement_unit, context.measurement_unit_abbreviation)} / #{context.measurement_unit_qualifier})"
-    else
-      "#{context.monetary_unit} / (#{context.measurement_unit} / #{context.measurement_unit_qualifier})"
-    end
+    "#{context.monetary_unit} / (#{render_measurement_unit_fragment(
+      measurement_unit: context.measurement_unit,
+      abbreviation: context.measurement_unit_abbreviation,
+      formatted: context.formatted,
+      unformatted: context.measurement_unit,
+    )} / #{context.measurement_unit_qualifier})"
   end
 
   def monetary_measurement_fragment
-    if context.formatted
-      "#{context.monetary_unit} / #{measurement_unit_abbr_tag(context.measurement_unit, context.measurement_unit_abbreviation)}"
-    else
-      "#{context.monetary_unit} / #{context.measurement_unit}"
-    end
+    "#{context.monetary_unit} / #{render_measurement_unit_fragment(
+      measurement_unit: context.measurement_unit,
+      abbreviation: context.measurement_unit_abbreviation,
+      formatted: context.formatted,
+      unformatted: context.measurement_unit,
+    )}"
   end
 
   def measurement_fragment
-    if context.formatted
-      measurement_unit_abbr_tag(context.measurement_unit, context.measurement_unit_abbreviation)
-    else
-      context.measurement_unit
-    end
+    render_measurement_unit_fragment(
+      measurement_unit: context.measurement_unit,
+      abbreviation: context.measurement_unit_abbreviation,
+      formatted: context.formatted,
+      unformatted: context.measurement_unit,
+    )
   end
 end

--- a/app/formatters/requirement_duty_expression_formatter/output_builder.rb
+++ b/app/formatters/requirement_duty_expression_formatter/output_builder.rb
@@ -58,24 +58,18 @@ class RequirementDutyExpressionFormatter::OutputBuilder
   end
 
   def monetary_measurement_qualifier_fragment
-    "#{context.monetary_unit} / (#{render_measurement_unit_fragment(
-      measurement_unit: context.measurement_unit,
-      abbreviation: context.measurement_unit_abbreviation,
-      formatted: context.formatted,
-      unformatted: context.measurement_unit,
-    )} / #{context.measurement_unit_qualifier})"
+    "#{context.monetary_unit} / (#{measurement_unit_fragment} / #{context.measurement_unit_qualifier})"
   end
 
   def monetary_measurement_fragment
-    "#{context.monetary_unit} / #{render_measurement_unit_fragment(
-      measurement_unit: context.measurement_unit,
-      abbreviation: context.measurement_unit_abbreviation,
-      formatted: context.formatted,
-      unformatted: context.measurement_unit,
-    )}"
+    "#{context.monetary_unit} / #{measurement_unit_fragment}"
   end
 
   def measurement_fragment
+    measurement_unit_fragment
+  end
+
+  def measurement_unit_fragment
     render_measurement_unit_fragment(
       measurement_unit: context.measurement_unit,
       abbreviation: context.measurement_unit_abbreviation,

--- a/app/formatters/spq_duty_expression_formatter.rb
+++ b/app/formatters/spq_duty_expression_formatter.rb
@@ -1,18 +1,11 @@
 class SpqDutyExpressionFormatter
+  extend DutyExpressionPrettifier
+
   class << self
     def format(component)
       duty_amount = prettify(component.duty_amount)
 
       "(£#{duty_amount} - SPR discount) / vol% / hl"
-    end
-
-    def prettify(float)
-      TradeTariffBackend.number_formatter.number_with_precision(
-        float,
-        minimum_decimal_points: 2,
-        precision: 4,
-        strip_insignificant_zeros: true,
-      )
     end
   end
 end

--- a/app/models/concerns/componentable.rb
+++ b/app/models/concerns/componentable.rb
@@ -1,4 +1,6 @@
 module Componentable
+  include DutyExpressionFormattable
+
   SMALL_PRODUCERS_QUOTIENT = 'SPQ'.freeze
   LITERS_OF_PURE_ALCOHOL_QUALIFIER = 'LPA'.freeze
   LITERS_QUALIFIER = 'LTR'.freeze
@@ -106,31 +108,6 @@ module Componentable
 
     def meursing?
       duty_expression_id.in?(DutyExpression::MEURSING_DUTY_EXPRESSION_IDS)
-    end
-
-    def duty_expression_formatter_options
-      {
-        duty_expression_id:,
-        duty_expression_description:,
-        duty_expression_abbreviation:,
-        duty_amount:,
-        monetary_unit: monetary_unit_code,
-        monetary_unit_abbreviation:,
-        measurement_unit:,
-        measurement_unit_qualifier:,
-      }
-    end
-
-    def formatted_duty_expression
-      DutyExpressionFormatter.format(duty_expression_formatter_options.merge(formatted: true))
-    end
-
-    def verbose_duty_expression
-      DutyExpressionFormatter.format(duty_expression_formatter_options.merge(verbose: true))
-    end
-
-    def duty_expression_str
-      DutyExpressionFormatter.format(duty_expression_formatter_options)
     end
   end
 end

--- a/app/models/concerns/duty_expression_formattable.rb
+++ b/app/models/concerns/duty_expression_formattable.rb
@@ -1,0 +1,26 @@
+module DutyExpressionFormattable
+  def duty_expression_formatter_options
+    {
+      duty_expression_id:,
+      duty_expression_description:,
+      duty_expression_abbreviation:,
+      duty_amount:,
+      monetary_unit: monetary_unit_code,
+      monetary_unit_abbreviation:,
+      measurement_unit:,
+      measurement_unit_qualifier:,
+    }
+  end
+
+  def formatted_duty_expression
+    DutyExpressionFormatter.format(duty_expression_formatter_options.merge(formatted: true))
+  end
+
+  def verbose_duty_expression
+    DutyExpressionFormatter.format(duty_expression_formatter_options.merge(verbose: true))
+  end
+
+  def duty_expression_str
+    DutyExpressionFormatter.format(duty_expression_formatter_options)
+  end
+end

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -103,7 +103,6 @@ class MeasureCondition < Sequel::Model
       monetary_unit_abbreviation:,
       measurement_unit:,
       formatted_measurement_unit_qualifier:,
-      currency: TradeTariffBackend.currency,
       formatted: true,
     )
   end

--- a/app/presenters/api/v2/measures/measure_condition_component_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_condition_component_presenter.rb
@@ -2,6 +2,8 @@ module Api
   module V2
     module Measures
       class MeasureConditionComponentPresenter < WrapDelegator
+        include DutyExpressionFormattable
+
         delegate :excise_alcohol_coercian_starts_from, to: TradeTariffBackend
 
         # Rather than just creating a new measurement unit,
@@ -38,18 +40,6 @@ module Api
           end
         end
 
-        def formatted_duty_expression
-          DutyExpressionFormatter.format(duty_expression_formatter_options.merge(formatted: true))
-        end
-
-        def verbose_duty_expression
-          DutyExpressionFormatter.format(duty_expression_formatter_options.merge(verbose: true))
-        end
-
-        def duty_expression_str
-          DutyExpressionFormatter.format(duty_expression_formatter_options)
-        end
-
         private
 
         attr_reader :measure
@@ -58,19 +48,6 @@ module Api
           return false if point_in_time.present? && point_in_time < excise_alcohol_coercian_starts_from
 
           measure.excise? && percentage_alcohol_and_volume_per_hl?
-        end
-
-        def duty_expression_formatter_options
-          {
-            duty_expression_id:,
-            duty_expression_description:,
-            duty_expression_abbreviation:,
-            duty_amount:,
-            monetary_unit: monetary_unit_code,
-            monetary_unit_abbreviation:,
-            measurement_unit:,
-            measurement_unit_qualifier:,
-          }
         end
       end
     end

--- a/spec/formatters/duty_expression_formatter/context_spec.rb
+++ b/spec/formatters/duty_expression_formatter/context_spec.rb
@@ -1,0 +1,58 @@
+RSpec.describe DutyExpressionFormatter::Context do
+  describe '.build' do
+    let(:measurement_unit_abbreviation) do
+      create(:measurement_unit_abbreviation, :with_measurement_unit, :include_qualifier)
+    end
+    let(:measurement_unit) do
+      measurement_unit_abbreviation.measurement_unit
+    end
+    let(:measurement_unit_qualifier) do
+      create(:measurement_unit_qualifier, measurement_unit_qualifier_code: measurement_unit_abbreviation.measurement_unit_qualifier)
+    end
+
+    it 'prefers the monetary unit abbreviation when both values are provided' do
+      context = described_class.build(
+        duty_expression_id: '12',
+        monetary_unit: 'Euro',
+        monetary_unit_abbreviation: 'EUR',
+      )
+
+      expect(context.monetary_unit).to eq('EUR')
+    end
+
+    it 'populates derived verbose fields when verbose output is requested' do
+      context = described_class.build(
+        duty_expression_id: '66',
+        duty_amount: 0.52,
+        monetary_unit: 'EUR',
+        measurement_unit: measurement_unit,
+        measurement_unit_qualifier: measurement_unit_qualifier,
+        verbose: true,
+      )
+
+      expect(context.measurement_unit_abbreviation).to eq(
+        measurement_unit.abbreviation(measurement_unit_qualifier: measurement_unit_qualifier),
+      )
+      expect(context.measurement_unit_expansion).to eq(
+        measurement_unit.expansion(measurement_unit_qualifier: measurement_unit_qualifier),
+      )
+      expect(context.monetary_unit_to_symbol).to eq(
+        Currency.new('EUR').format(DutyExpressionFormatter.prettify(0.52).to_s),
+      )
+    end
+
+    it 'leaves verbose-only fields unset when verbose output is disabled' do
+      context = described_class.build(
+        duty_expression_id: '66',
+        duty_amount: 0.52,
+        monetary_unit: 'EUR',
+        measurement_unit: measurement_unit,
+        measurement_unit_qualifier: measurement_unit_qualifier,
+        verbose: false,
+      )
+
+      expect(context.measurement_unit_expansion).to be_nil
+      expect(context.monetary_unit_to_symbol).to be_nil
+    end
+  end
+end

--- a/spec/formatters/duty_expression_formatter/output_builder_spec.rb
+++ b/spec/formatters/duty_expression_formatter/output_builder_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe DutyExpressionFormatter::OutputBuilder do
+  subject(:output) { described_class.call(context) }
+
+  let(:strategy) { instance_spy(Proc, call: %w[result]) }
+  let(:context) { instance_double(DutyExpressionFormatter::Context, duty_expression_id: duty_expression_id) }
+
+  context 'when the duty expression is unit only' do
+    let(:duty_expression_id) { '99' }
+
+    it 'dispatches to the unit-only strategy' do
+      allow(DutyExpressionFormatter::Strategies::UnitOnly).to receive(:new).with(context).and_return(strategy)
+
+      expect(output).to eq(%w[result])
+      expect(DutyExpressionFormatter::Strategies::UnitOnly).to have_received(:new).with(context)
+    end
+  end
+
+  context 'when the duty expression is description only' do
+    let(:duty_expression_id) { '12' }
+
+    it 'dispatches to the description-only strategy' do
+      allow(DutyExpressionFormatter::Strategies::DescriptionOnly).to receive(:new).with(context).and_return(strategy)
+
+      expect(output).to eq(%w[result])
+      expect(DutyExpressionFormatter::Strategies::DescriptionOnly).to have_received(:new).with(context)
+    end
+  end
+
+  context 'when the duty expression includes a description and amount' do
+    let(:duty_expression_id) { '15' }
+
+    it 'dispatches to the description-amount strategy' do
+      allow(DutyExpressionFormatter::Strategies::DescriptionAmount).to receive(:new).with(context).and_return(strategy)
+
+      expect(output).to eq(%w[result])
+      expect(DutyExpressionFormatter::Strategies::DescriptionAmount).to have_received(:new).with(context)
+    end
+  end
+
+  context 'when the duty expression falls through to the default path' do
+    let(:duty_expression_id) { '66' }
+
+    it 'dispatches to the default strategy' do
+      allow(DutyExpressionFormatter::Strategies::Default).to receive(:new).with(context).and_return(strategy)
+
+      expect(output).to eq(%w[result])
+      expect(DutyExpressionFormatter::Strategies::Default).to have_received(:new).with(context)
+    end
+  end
+end

--- a/spec/formatters/duty_expression_formatter/strategies_spec.rb
+++ b/spec/formatters/duty_expression_formatter/strategies_spec.rb
@@ -1,0 +1,100 @@
+RSpec.shared_context 'with duty expression formatter strategy helpers' do
+  let(:measurement_unit) { instance_double(MeasurementUnit, description: 'kilogram') }
+
+  def build_context(overrides = {})
+    DutyExpressionFormatter::Context.new(
+      {
+        duty_expression_id: '66',
+        duty_expression_description: nil,
+        duty_expression_abbreviation: nil,
+        duty_amount: nil,
+        monetary_unit: nil,
+        measurement_unit: measurement_unit,
+        measurement_unit_qualifier: nil,
+        measurement_unit_abbreviation: nil,
+        measurement_unit_expansion: nil,
+        monetary_unit_to_symbol: nil,
+        resolved_meursing_component: false,
+        formatted: false,
+        verbose: false,
+      }.merge(overrides),
+    )
+  end
+end
+
+RSpec.describe DutyExpressionFormatter::Strategies::Base do
+  include_context 'with duty expression formatter strategy helpers'
+
+  describe DutyExpressionFormatter::Strategies::UnitOnly do
+    it 'returns the measurement unit fragment' do
+      context = build_context(
+        duty_expression_id: '99',
+        measurement_unit_abbreviation: 'kg',
+      )
+
+      expect(described_class.new(context).call).to eq(%w[kg])
+    end
+  end
+
+  describe DutyExpressionFormatter::Strategies::DescriptionOnly do
+    it 'prefers the duty expression abbreviation' do
+      context = build_context(
+        duty_expression_id: '12',
+        duty_expression_abbreviation: 'MAX',
+        duty_expression_description: 'Maximum duty',
+      )
+
+      expect(described_class.new(context).call).to eq(%w[MAX])
+    end
+  end
+
+  describe DutyExpressionFormatter::Strategies::DescriptionAmount do
+    it 'assembles description, amount, percent, and measurement unit fragments' do
+      context = build_context(
+        duty_expression_id: '15',
+        duty_expression_description: 'MIN',
+        duty_amount: 0.52,
+        measurement_unit_abbreviation: 'kg',
+      )
+
+      expect(described_class.new(context).call).to eq(['MIN', '0.52', '%', '/ kg'])
+    end
+
+    it 'renders formatted measurement unit fragments when requested' do
+      context = build_context(
+        duty_expression_id: '15',
+        duty_expression_description: 'MIN',
+        duty_amount: 0.52,
+        measurement_unit_abbreviation: 'kg',
+        formatted: true,
+      )
+
+      expect(described_class.new(context).call).to eq([
+        'MIN',
+        '<span>0.52</span>',
+        '%',
+        "/ <abbr title='kilogram'>kg</abbr>",
+      ])
+    end
+  end
+
+  describe DutyExpressionFormatter::Strategies::Default do
+    it 'returns the monetary symbol when verbose output is enabled' do
+      context = build_context(
+        duty_expression_description: 'Standard duty',
+        duty_amount: 0.52,
+        monetary_unit: 'EUR',
+        monetary_unit_to_symbol: '€0.52',
+        verbose: true,
+      )
+
+      expect(described_class.new(context).call).to eq(['€0.52'])
+    end
+
+    it 'falls back to a percent sign when no description is present' do
+      context = build_context(duty_amount: 0.52)
+
+      expect(described_class.new(context).call).to eq(['0.52', '%'])
+    end
+  end
+end

--- a/spec/formatters/duty_expression_formatter/strategies_spec.rb
+++ b/spec/formatters/duty_expression_formatter/strategies_spec.rb
@@ -97,4 +97,160 @@ RSpec.describe DutyExpressionFormatter::Strategies::Base do
       expect(described_class.new(context).call).to eq(['0.52', '%'])
     end
   end
+
+  describe '.format integration' do
+    let(:measurement_unit) do
+      instance_double(
+        MeasurementUnit,
+        description: 'kilogram',
+        abbreviation: 'kg',
+        expansion: 'kilogram (kg)',
+      ).tap do |dbl|
+        allow(dbl).to receive(:abbreviation).with(measurement_unit_qualifier: nil).and_return('kg')
+        allow(dbl).to receive(:expansion).with(measurement_unit_qualifier: nil).and_return('kilogram (kg)')
+      end
+    end
+
+    describe 'UnitOnly strategy (duty_expression_id 99)' do
+      it 'returns the plain measurement unit abbreviation' do
+        result = DutyExpressionFormatter.format(
+          duty_expression_id: '99',
+          measurement_unit:,
+          measurement_unit_qualifier: nil,
+        )
+
+        expect(result).to eq('kg')
+      end
+
+      it 'returns a formatted abbr tag when formatted: true' do
+        result = DutyExpressionFormatter.format(
+          duty_expression_id: '99',
+          measurement_unit:,
+          measurement_unit_qualifier: nil,
+          formatted: true,
+        )
+
+        expect(result).to eq("<abbr title='kilogram'>kg</abbr>")
+      end
+
+      it 'returns the expanded unit when verbose: true' do
+        result = DutyExpressionFormatter.format(
+          duty_expression_id: '99',
+          measurement_unit:,
+          measurement_unit_qualifier: nil,
+          verbose: true,
+        )
+
+        expect(result).to eq('kilogram (kg)')
+      end
+    end
+
+    describe 'DescriptionOnly strategy (duty_expression_id 12)' do
+      it 'returns the duty expression abbreviation when present' do
+        result = DutyExpressionFormatter.format(
+          duty_expression_id: '12',
+          duty_expression_abbreviation: 'MAX',
+          duty_expression_description: 'Maximum',
+        )
+
+        expect(result).to eq('MAX')
+      end
+
+      it 'falls back to description when abbreviation is absent' do
+        result = DutyExpressionFormatter.format(
+          duty_expression_id: '12',
+          duty_expression_description: 'Maximum',
+        )
+
+        expect(result).to eq('Maximum')
+      end
+    end
+
+    describe 'DescriptionAmount strategy (duty_expression_id 02)' do
+      it 'returns plain description, amount and percent for a simple case' do
+        result = DutyExpressionFormatter.format(
+          duty_expression_id: '02',
+          duty_expression_abbreviation: 'MIN',
+          duty_amount: 1.5,
+        )
+
+        expect(result).to eq('MIN 1.50 %')
+      end
+
+      it 'returns formatted HTML fragments when formatted: true' do
+        result = DutyExpressionFormatter.format(
+          duty_expression_id: '02',
+          duty_expression_abbreviation: 'MIN',
+          duty_amount: 1.5,
+          formatted: true,
+        )
+
+        expect(result).to eq('MIN <span>1.50</span> %')
+      end
+
+      it 'includes the measurement unit when present' do
+        result = DutyExpressionFormatter.format(
+          duty_expression_id: '02',
+          duty_expression_abbreviation: 'MIN',
+          duty_amount: 1.5,
+          measurement_unit:,
+          measurement_unit_qualifier: nil,
+        )
+
+        expect(result).to eq('MIN 1.50 % / kg')
+      end
+    end
+
+    describe 'Default strategy (other duty expression ids)' do
+      it 'returns amount and percent for a simple case' do
+        result = DutyExpressionFormatter.format(
+          duty_expression_id: '66',
+          duty_amount: 4.0,
+        )
+
+        expect(result).to eq('4.00 %')
+      end
+
+      it 'returns amount and monetary unit when monetary unit is present' do
+        result = DutyExpressionFormatter.format(
+          duty_expression_id: '66',
+          duty_amount: 4.0,
+          monetary_unit: 'GBP',
+        )
+
+        expect(result).to eq('4.00 % GBP')
+      end
+
+      it 'returns formatted HTML when formatted: true' do
+        result = DutyExpressionFormatter.format(
+          duty_expression_id: '66',
+          duty_amount: 4.0,
+          formatted: true,
+        )
+
+        expect(result).to eq('<span>4.00</span> %')
+      end
+
+      it 'includes a measurement unit when present' do
+        result = DutyExpressionFormatter.format(
+          duty_expression_id: '66',
+          duty_amount: 4.0,
+          measurement_unit:,
+          measurement_unit_qualifier: nil,
+        )
+
+        expect(result).to eq('4.00 % / kg')
+      end
+
+      it 'wraps output in strong tags when resolved_meursing: true' do
+        result = DutyExpressionFormatter.format(
+          duty_expression_id: '66',
+          duty_amount: 4.0,
+          resolved_meursing: true,
+        )
+
+        expect(result).to eq('<strong>4.00 %</strong>')
+      end
+    end
+  end
 end

--- a/spec/formatters/requirement_duty_expression_formatter/context_spec.rb
+++ b/spec/formatters/requirement_duty_expression_formatter/context_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe RequirementDutyExpressionFormatter::Context do
+  describe '.build' do
+    let(:measurement_unit_abbreviation) do
+      create(:measurement_unit_abbreviation, :with_measurement_unit, :include_qualifier)
+    end
+    let(:measurement_unit) do
+      measurement_unit_abbreviation.measurement_unit
+    end
+
+    it 'prefers the monetary unit abbreviation when it is present' do
+      context = described_class.build(
+        monetary_unit: 'Euro',
+        monetary_unit_abbreviation: 'EUR',
+      )
+
+      expect(context.monetary_unit).to eq('EUR')
+    end
+
+    it 'stores the formatted measurement unit qualifier and derived abbreviation' do
+      context = described_class.build(
+        measurement_unit: measurement_unit,
+        formatted_measurement_unit_qualifier: 'L',
+      )
+
+      expect(context.measurement_unit_qualifier).to eq('L')
+      expect(context.measurement_unit_abbreviation).to eq(
+        measurement_unit.abbreviation(measurement_unit_qualifier: 'L'),
+      )
+    end
+  end
+end

--- a/spec/formatters/requirement_duty_expression_formatter/output_builder_spec.rb
+++ b/spec/formatters/requirement_duty_expression_formatter/output_builder_spec.rb
@@ -1,0 +1,78 @@
+RSpec.describe RequirementDutyExpressionFormatter::OutputBuilder do
+  subject(:output) { described_class.call(context) }
+
+  let(:measurement_unit) { instance_double(MeasurementUnit, description: 'kilogram', to_s: 'kilogram') }
+  let(:context) do
+    RequirementDutyExpressionFormatter::Context.new(
+      duty_amount: duty_amount,
+      monetary_unit: monetary_unit,
+      measurement_unit: measurement_unit,
+      measurement_unit_qualifier: measurement_unit_qualifier,
+      measurement_unit_abbreviation: measurement_unit_abbreviation,
+      formatted: formatted,
+    )
+  end
+  let(:duty_amount) { nil }
+  let(:monetary_unit) { nil }
+  let(:measurement_unit_qualifier) { nil }
+  let(:measurement_unit_abbreviation) { nil }
+  let(:formatted) { false }
+
+  context 'when a duty amount is present' do
+    let(:duty_amount) { 3.5 }
+
+    it 'renders the numeric amount' do
+      expect(output).to eq(['3.50'])
+    end
+
+    context 'when formatted output is requested' do
+      let(:formatted) { true }
+
+      it 'wraps the amount in a span' do
+        expect(output).to eq(['<span>3.50</span>'])
+      end
+    end
+  end
+
+  context 'when monetary unit, measurement unit, and qualifier are present' do
+    let(:monetary_unit) { 'EUR' }
+    let(:measurement_unit_qualifier) { 'L' }
+    let(:measurement_unit_abbreviation) { 'kg' }
+
+    it 'renders the combined qualifier fragment' do
+      expect(output).to eq(['EUR / (kilogram / L)'])
+    end
+
+    context 'when formatted output is requested' do
+      let(:formatted) { true }
+
+      it 'renders the qualifier fragment with an abbreviation tag' do
+        expect(output).to eq(["EUR / (<abbr title='kilogram'>kg</abbr> / L)"])
+      end
+    end
+  end
+
+  context 'when only a measurement unit is present' do
+    let(:measurement_unit_abbreviation) { 'kg' }
+
+    it 'returns the measurement unit object for plain output' do
+      expect(output).to eq([measurement_unit])
+    end
+
+    context 'when formatted output is requested' do
+      let(:formatted) { true }
+
+      it 'renders the measurement unit abbreviation tag' do
+        expect(output).to eq(["<abbr title='kilogram'>kg</abbr>"])
+      end
+    end
+  end
+
+  context 'when only a monetary unit is present' do
+    let(:monetary_unit) { 'EUR' }
+
+    it 'returns the monetary unit fragment' do
+      expect(output).to eq(%w[EUR])
+    end
+  end
+end

--- a/spec/formatters/requirement_duty_expression_formatter_spec.rb
+++ b/spec/formatters/requirement_duty_expression_formatter_spec.rb
@@ -96,6 +96,20 @@ RSpec.describe RequirementDutyExpressionFormatter do
           expect(output).to eq('<span>3.50</span> EUR')
         end
       end
+
+      context 'when the monetary unit abbreviation is also present' do
+        subject(:output) do
+          described_class.format(
+            duty_amount: 3.50,
+            monetary_unit: 'Euro',
+            monetary_unit_abbreviation: 'EUR',
+          )
+        end
+
+        it 'prefers the monetary unit abbreviation' do
+          expect(output).to eq('3.50 EUR')
+        end
+      end
     end
 
     context 'when measurement unit is present' do
@@ -105,6 +119,16 @@ RSpec.describe RequirementDutyExpressionFormatter do
 
       it 'properly formats output' do
         expect(output).to match Regexp.new(measurement_unit.description)
+      end
+
+      context 'when formatted in html' do
+        subject(:output) do
+          described_class.format(measurement_unit:, formatted: true)
+        end
+
+        it 'renders an abbreviation tag' do
+          expect(output).to eq("<abbr title='#{measurement_unit.description}'>#{measurement_unit.description}</abbr>")
+        end
       end
     end
   end

--- a/spec/presenters/api/v2/measures/measure_condition_component_presenter_spec.rb
+++ b/spec/presenters/api/v2/measures/measure_condition_component_presenter_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe Api::V2::Measures::MeasureConditionComponentPresenter do
         )
       end
 
-      it { expect(presenter.presented_duty_expression).to eq('- £1.00  / for each litre of pure alcohol, multiplied by the SPR discount') }
+      it { expect(presenter.presented_duty_expression).to eq('- £1.00 / for each litre of pure alcohol, multiplied by the SPR discount') }
     end
 
     context 'when the component is not a Small Producers Quotient component' do


### PR DESCRIPTION
Splits the monolithic `DutyExpressionFormatter` and `RequirementDutyExpressionFormatter` classes into smaller, focused collaborator objects and extracts shared logic into reusable modules.

### What changed

#### Structural decomposition
Each formatter is now split into three collaborators:
- **`Context`** — builds and validates input data
- **`OutputBuilder`** — assembles output fragments
- **`Strategies`** — one class per duty expression type

This replaces the original single-class implementations.

#### Shared modules extracted
- **`DutyExpressionPrettifier`** — `prettify(float)` was duplicated across all three formatters; now a single shared module
- **`FormatterOutputHelpers`** — HTML fragment helpers (`formatted_amount_fragment`, `measurement_unit_abbr_tag`, `render_measurement_unit_fragment`, `render_prefixed_measurement_unit_fragment`) were duplicated; now shared
- **`DutyExpressionFormattable`** — `duty_expression_formatter_options`, `formatted_duty_expression`, `verbose_duty_expression`, and `duty_expression_str` were duplicated between `Componentable` and `MeasureConditionComponentPresenter`; extracted into a concern included by both

#### Caller clean-up
- Removed a redundant `currency:` kwarg from `RequirementDutyExpressionFormatter.format(...)` in `MeasureCondition`

#### Collaborator specs added
- `DutyExpressionFormatter::Context`, `OutputBuilder`, and `Strategies`
- `RequirementDutyExpressionFormatter::Context` and `OutputBuilder`

## Ticket
https://transformuk.atlassian.net/browse/OTTIMP-530

## Risk: 
**Risk level:** 🟢 

**Reason for rating:**
Refactor with full test coverage and no behaviour change
