### PR TITLE
Fix ActionLogReportWorker querying entire history on every run

### DIFF
--- a/app/workers/action_log_report_worker.rb
+++ b/app/workers/action_log_report_worker.rb
@@ -3,13 +3,11 @@ require 'csv'
 class ActionLogReportWorker
   include Sidekiq::Worker
 
-  START_DATE = Date.new(2025, 6, 19).freeze
-
   def perform
     return unless TradeTariffBackend.uk?
 
     yesterday = Time.zone.yesterday
-    start_date = START_DATE.beginning_of_day
+    start_date = 1.month.ago.beginning_of_day
     end_date = yesterday.end_of_day
 
     action_logs = PublicUsers::ActionLog

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -80,6 +80,6 @@
       description: "Removes failed myott subscribers"
       enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' %>
     ActionLogReportWorker:
-      cron: "0 6 * * *" # 6am every day
+      cron: "0 23 * * 0" # 11pm UTC every Sunday
       description: Generates and emails a CSV report of the previous day's user action logs
       enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' %>

--- a/spec/workers/action_log_report_worker_spec.rb
+++ b/spec/workers/action_log_report_worker_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe ActionLogReportWorker do
     subject(:worker) { described_class.new }
 
     let(:yesterday) { Time.zone.yesterday }
-    let(:start_date) { described_class::START_DATE.beginning_of_day }
+    let(:start_date) { 1.month.ago.beginning_of_day }
     let(:end_date) { yesterday.end_of_day }
 
     context 'when there are action logs from yesterday' do


### PR DESCRIPTION
## What:
Changed \`ActionLogReportWorker\` to query a rolling month of action logs instead of the entire history since \`START_DATE\` (2025-06-19)

## Why:

- The worker used a hardcoded \`START_DATE\` as the lower bound of its query, so every daily run loaded the full action log history from that date to yesterday into memory, generated a CSV from it, and emailed it
- The window grew by one day per run — by the time this was caught (~10 months in) the job was pulling a large and ever-growing result set at 6am every day, causing a measurable performance dip
- The report should cover a rolling window, not accumulate unboundedly — changed to \`1.month.ago\` as the lower bound

## Ticket:
N/A

## Risk: 
**Risk level:** 🟢 
**Reason for rating:**
query scope is narrowed, not widened

───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.

───────────────────────────────────────────────────

🟢 GREEN – things that are typically low risk:
───────────────────────────────────────────────────
- Dependency bumps with no API changes (e.g. minor/patch gems, npm packages)
- Copy or content changes in GOV.UK-style UI components
- Adding or updating CloudWatch alarms or dashboards (read-only observability)
- New tests or improved test coverage with no production code changes
- Config/env var additions that are purely additive and have safe defaults
- Refactors with full test coverage and no behaviour change
- Terraform formatting or variable renaming with no resource recreation
- S3 lifecycle rule additions (non-destructive, time-delayed effect)

🟠 AMBER – things that need a team conversation first:
───────────────────────────────────────────────────
- Changes to commodity code lookups, measure type logic, or duty calculation
- Modifications to the search indexing pipeline (OpenSearch mappings, synonyms, stop words)
- Changes to declarable goods or quota logic
- New or modified API endpoints that other services (backend, frontend, admin) consume
- Adding or changing feature flags that affect live user journeys
- Infrastructure changes that alter networking, security groups, or IAM permissions in non-production first
- Terraform changes that will cause a resource replacement (check plan output carefully)
- Changes to CI/CD pipeline steps or deployment order dependencies
- S3 bucket policy or access control changes
- Removing or deprecating an endpoint or field that may still be consumed

🔴 RED – requires explicit approval from Thor or Neil:
───────────────────────────────────────────────────
- Dangeorous database migrations, especially destructive ones (dropping columns/tables, removing indexes)
- Modifications to how measures, conditions, or footnotes are processed or surfaced
- Changes to the synchronisation mechanism from CDS or HMRC upstream data feeds
- Any change to production AWS infrastructure that cannot be easily rolled back (e.g. RDS parameter groups, KMS key policy, removal of resources)
- Secrets rotation or changes to how credentials are stored, scoped, or accessed
- Changes that affect trader-facing regulatory content or legally significant data (e.g. trade remedies, licensing, prohibitions)
- Significant architectural shifts (e.g. new service boundaries, queue/event topology changes)
