### PR TITLE
Prewarm base_regulations after materialized view refresh

### DIFF
--- a/app/helpers/materialize_view_helper.rb
+++ b/app/helpers/materialize_view_helper.rb
@@ -1,4 +1,12 @@
 module MaterializeViewHelper
+  # Tables the commodity query plan always seq-scans via Hash Left Join.
+  # Loading them into shared_buffers here means they are warm before
+  # PrewarmCommoditiesWorker fires HTTP requests that hit them concurrently.
+  VIEWS_TO_PREWARM = %w[
+    BaseRegulation
+    ModificationRegulation
+  ].freeze
+
   def refresh_materialized_view(concurrently: false)
     eager_load_materialized_view_models
 
@@ -9,6 +17,8 @@ module MaterializeViewHelper
     end
 
     GoodsNomenclatures::TreeNode.refresh!(concurrently:)
+
+    prewarm_views
   end
 
   def eager_load_materialized_view_models
@@ -18,6 +28,13 @@ module MaterializeViewHelper
     Rails.application.config.x.materialized_view_models_loaded = true
   end
 
+  def prewarm_views
+    VIEWS_TO_PREWARM.each do |model_name|
+      model_name.constantize.count
+    end
+  end
+
   module_function :refresh_materialized_view
   module_function :eager_load_materialized_view_models
+  module_function :prewarm_views
 end


### PR DESCRIPTION
## Summary

The commodity query plan always executes a Hash Left Join over `base_regulations`, requiring a full sequential scan of ~5,600 rows on every request. After a nightly sync refreshes the materialized view, those pages are cold. `PrewarmCommoditiesWorker` then fires many concurrent commodity requests that all seq-scan `base_regulations` from disk simultaneously, causing I/O contention — observed as queries taking up to 11 seconds.

Adding a `prewarm_views` step at the end of `refresh_materialized_view` runs `count(*)` on `base_regulations` and `modification_regulations` immediately after refresh. This is a single sequential read of each view that loads all pages into PostgreSQL's `shared_buffers` before any application traffic hits them.

The cost is negligible (~5ms per view in the sync worker, which already takes seconds).
