### PR TITLE
BAU: Fix max length handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ tariff_data_basic_*.csv
 
 .claude/
 terraform/modules/*/.terraform.lock.hcl
+.gitnexus
+
+AGENTS.md
+.codex

--- a/app/services/api/internal/input_sanitiser.rb
+++ b/app/services/api/internal/input_sanitiser.rb
@@ -1,6 +1,7 @@
 module Api
   module Internal
     class InputSanitiser
+      MAX_QUERY_LENGTH = 500
       NON_PRINTABLE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F\u200B\u200C\u200D\uFEFF]/
 
       def initialize(query)
@@ -34,7 +35,7 @@ module Api
       end
 
       def max_length
-        AdminConfiguration.integer_value('input_sanitiser_max_length')
+        [AdminConfiguration.integer_value('input_sanitiser_max_length'), MAX_QUERY_LENGTH].min
       end
 
       def strip_html(text)

--- a/app/services/api/internal/query_processing.rb
+++ b/app/services/api/internal/query_processing.rb
@@ -8,7 +8,7 @@ module Api
       def process_query(term)
         return '' if term.blank?
 
-        term = term.to_s.first(100)
+        term = term.to_s
 
         if (m = cas_number_regex.match(term))
           m[1]

--- a/spec/services/api/internal/input_sanitiser_spec.rb
+++ b/spec/services/api/internal/input_sanitiser_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Api::Internal::InputSanitiser do
       it 'returns an error' do
         expect(result[:errors]).to be_present
         expect(result[:errors].first[:status]).to eq('422')
-        expect(result[:errors].first[:detail]).to include('exceeds maximum length')
+        expect(result[:errors].first[:detail]).to eq('Query exceeds maximum length of 500 characters')
       end
     end
 
@@ -87,6 +87,19 @@ RSpec.describe Api::Internal::InputSanitiser do
       it 'uses the configured max length' do
         expect(result[:errors]).to be_present
         expect(result[:errors].first[:detail]).to include('10 characters')
+      end
+    end
+
+    context 'when max length is configured above 500' do
+      let(:query) { 'a' * 501 }
+
+      before do
+        create(:admin_configuration, :integer, name: 'input_sanitiser_max_length', value: 600)
+      end
+
+      it 'caps validation at 500 characters' do
+        expect(result[:errors]).to be_present
+        expect(result[:errors].first[:detail]).to eq('Query exceeds maximum length of 500 characters')
       end
     end
 

--- a/spec/services/api/internal/query_processing_spec.rb
+++ b/spec/services/api/internal/query_processing_spec.rb
@@ -14,9 +14,10 @@ RSpec.describe Api::Internal::QueryProcessing do
       expect(instance.process_query('')).to eq('')
     end
 
-    it 'truncates to 100 characters' do
+    it 'does not truncate long queries' do
       long_query = 'a' * 200
-      expect(instance.process_query(long_query).length).to eq(100)
+
+      expect(instance.process_query(long_query)).to eq(long_query)
     end
 
     it 'extracts CAS number from query' do


### PR DESCRIPTION
### Jira link

BAU

### What?

- [x] Cap the input sanitiser maximum query length at 500 characters.
- [x] Stop query processing from truncating terms before sanitiser validation.
- [x] Add specs for the 500 character cap and long query handling.
- [x] Ignore local Codex/GitNexus files.

### Why?

Search input length handling should be consistent: long queries are validated by the input sanitiser with a clear 422 error instead of being truncated earlier in query processing.

## Risk: 
**Risk level:** 🟢 

**Reason for rating:**
Full unit tests
Not changing the behaviour other than a specific edge case
