### PR TITLE
Disable MultiJSON in json-schema to fix deprecation warning

### DIFF
--- a/config/initializers/json_schema.rb
+++ b/config/initializers/json_schema.rb
@@ -1,0 +1,3 @@
+# json-schema dropped MultiJSON support. Disable it explicitly to silence
+# the deprecation warning and use the standard JSON backend directly.
+JSON::Validator.use_multi_json = false


### PR DESCRIPTION
## What:

Add `config/initializers/json_schema.rb` setting `JSON::Validator.use_multi_json = false`.

## Why:

json-schema logs a deprecation warning on every boot:

```
[DEPRECATION NOTICE] json-schema support for MultiJSON is deprecated and will be removed
in a future version. To stop using MultiJSON, add `JSON::Validator.use_multi_json = false`
to your application's initialization code.
```

The fix is exactly what the notice prescribes.

## Ticket:

N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:** Single initializer line, no behaviour change — json-schema already uses the standard JSON backend in practice.