### PR TITLE
Fix commodity cache fragmentation from meursing additional code

### DIFF
--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -148,7 +148,33 @@ class CachedCommodityService
     TradeTariffRequest.meursing_additional_code_id
   end
 
+  # Only fragment the cache by meursing code when the commodity actually has
+  # meursing measures (types 672, 673, 674 — agricultural duty add-ons).
+  # Most commodities (e.g. vehicles, electronics) never have these, so
+  # including the code in the key would create N identical cache entries —
+  # one per distinct meursing code seen in requests — for no benefit.
+  def effective_meursing_code
+    return nil if meursing_additional_code_id.blank?
+
+    commodity_has_meursing_measures? ? meursing_additional_code_id : nil
+  end
+
+  # Cached per commodity+date so we pay at most one DB query per commodity
+  # per day. The result is stable within a trading day; the 24-hour TTL
+  # matches the commodity response TTL for today's date.
+  def commodity_has_meursing_measures?
+    Rails.cache.fetch(
+      "commodity-has-meursing-#{@commodity_sid}-#{actual_date}",
+      expires_in: 24.hours,
+    ) do
+      Measure.actual
+             .where(goods_nomenclature_sid: @commodity_sid)
+             .where(measure_type_id: MeasureType::MEURSING_MEASURES)
+             .any?
+    end
+  end
+
   def cache_key
-    "_commodity-v#{CACHE_VERSION}-#{@commodity_sid}-#{actual_date}-#{meursing_additional_code_id}"
+    "_commodity-v#{CACHE_VERSION}-#{@commodity_sid}-#{actual_date}-#{effective_meursing_code}"
   end
 end

--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -165,7 +165,7 @@ class CachedCommodityService
   def commodity_has_meursing_measures?
     Rails.cache.fetch(
       "commodity-has-meursing-#{@commodity_sid}-#{actual_date}",
-      expires_in: 24.hours,
+      expires_in: ttl,
     ) do
       Measure.actual
              .where(goods_nomenclature_sid: @commodity_sid)

--- a/spec/services/cached_commodity_service_spec.rb
+++ b/spec/services/cached_commodity_service_spec.rb
@@ -124,10 +124,33 @@ RSpec.describe CachedCommodityService do
       context 'with meursing_additional_code_id' do
         include_context 'with meursing additional code id', 'foo'
 
-        it 'includes meursing code in cache key' do
-          service.call
-          expected_key = "_commodity-v#{CachedCommodityService::CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-foo"
-          expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 24.hours)
+        context 'when the commodity has no meursing measures' do
+          it 'uses the canonical cache key (no meursing code) to prevent fragmentation' do
+            service.call
+            expected_key = "_commodity-v#{CachedCommodityService::CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-"
+            expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 24.hours)
+          end
+        end
+
+        context 'when the commodity has meursing measures' do
+          before do
+            create(:measure_type, measure_type_id: '672', trade_movement_code: 0)
+            create(
+              :measure,
+              :with_base_regulation,
+              measure_type_id: '672',
+              goods_nomenclature: commodity,
+              goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+              goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+              for_geo_area: erga_omnes_area,
+            ).tap(&:reload)
+          end
+
+          it 'includes the meursing code in the cache key' do
+            service.call
+            expected_key = "_commodity-v#{CachedCommodityService::CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-foo"
+            expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 24.hours)
+          end
         end
       end
 


### PR DESCRIPTION
## What:
Only include `meursing_additional_code_id` in the `CachedCommodityService` cache key when the commodity actually has meursing measures (measure types 672, 673, 674 — agricultural duty add-ons for the XI tariff).

## Why:
The cache key previously included the meursing code unconditionally. Meursing codes only change the serialized response for compound agricultural products (those with measures of type 672/673/674). For all other commodities — vehicles, electronics, clothing — the response is identical regardless of what meursing code the client sends.

This meant every distinct meursing code seen in a request produced a separate cache entry for the same commodity, even though those entries were byte-for-byte identical. With ~200 valid meursing codes in the XI tariff, a popular commodity like `8703331900` (cars) could accumulate hundreds of redundant `Cache::RedisCacheStore/generate` events — exactly the symptom seen in APM.

The fix introduces `effective_meursing_code`: if the commodity has no meursing measures, the effective code is `nil` and all requests collapse to the canonical cache entry. The `commodity_has_meursing_measures?` check is itself cached for 24 hours per commodity+date (one Redis lookup per request, one DB query ever), so the overhead is minimal.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:** Pure cache key change. Correct meursing substitution still happens for commodities that need it (agricultural products); no data is suppressed. The worst case on deploy is a brief burst of cache misses while entries warm under the canonical key.