### PR TITLE
HMRC-2204: Restore spelling correction corpus loaders

### DIFF
--- a/app/lib/spelling_corrector/loaders/descriptions.rb
+++ b/app/lib/spelling_corrector/loaders/descriptions.rb
@@ -1,0 +1,31 @@
+module SpellingCorrector
+  module Loaders
+    class Descriptions
+      def load
+        TimeMachine.now do
+          each_term do |term|
+            terms[term] += 1
+          end
+        end
+
+        terms
+      end
+
+      def terms
+        @terms ||= Hash.new(0)
+      end
+
+      private
+
+      def each_term
+        GoodsNomenclature.actual.eager(:goods_nomenclature_descriptions).each do |goods_nomenclature|
+          goods_nomenclature.description.scan(/\w+/).map do |term|
+            normalised_term = SpellingCorrector::TermHandlerService.new(term).call
+
+            yield normalised_term if normalised_term.present?
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/spelling_corrector/loaders/initial.rb
+++ b/app/lib/spelling_corrector/loaders/initial.rb
@@ -1,0 +1,31 @@
+module SpellingCorrector
+  module Loaders
+    class Initial
+      INITIAL_SPELLING_MODEL_PATH = 'spelling-corrector/initial-spelling-model.txt'.freeze
+
+      def load
+        each_term do |line|
+          term, count = line.split(' ')
+          normalised_term = SpellingCorrector::TermHandlerService.new(term).call
+          terms[normalised_term] = count.to_i if normalised_term.present?
+        end
+
+        terms
+      end
+
+      def terms
+        @terms ||= Hash.new(0)
+      end
+
+      private
+
+      def each_term(&block)
+        bucket.object(INITIAL_SPELLING_MODEL_PATH).get.body.each_line(&block)
+      end
+
+      def bucket
+        Rails.application.config.spelling_corrector_s3_bucket
+      end
+    end
+  end
+end

--- a/app/lib/spelling_corrector/loaders/intercepts.rb
+++ b/app/lib/spelling_corrector/loaders/intercepts.rb
@@ -1,0 +1,39 @@
+module SpellingCorrector
+  module Loaders
+    class Intercepts
+      def load
+        each_term do |term|
+          terms[term] += 1
+        end
+
+        terms
+      end
+
+      def terms
+        @terms ||= Hash.new(0)
+      end
+
+      private
+
+      def each_term
+        intercept_terms.join(' ').scan(/\w+/).each do |term|
+          normalised_term = SpellingCorrector::TermHandlerService.new(term).call
+
+          yield normalised_term if normalised_term.present?
+        end
+      end
+
+      def intercept_terms
+        legacy_intercept_terms + description_intercept_terms
+      end
+
+      def legacy_intercept_terms
+        Rails.application.config.intercept_messages.keys
+      end
+
+      def description_intercept_terms
+        DescriptionIntercept.select_map(:term)
+      end
+    end
+  end
+end

--- a/app/lib/spelling_corrector/loaders/labels.rb
+++ b/app/lib/spelling_corrector/loaders/labels.rb
@@ -1,0 +1,37 @@
+module SpellingCorrector
+  module Loaders
+    class Labels
+      LABEL_FIELDS = %i[description known_brands colloquial_terms synonyms].freeze
+
+      def load
+        TimeMachine.now do
+          each_term do |term|
+            terms[term] += 1
+          end
+        end
+
+        terms
+      end
+
+      def terms
+        @terms ||= Hash.new(0)
+      end
+
+      private
+
+      def each_term
+        GoodsNomenclatureLabel.exclude(expired: true).each do |label|
+          label_terms(label).join(' ').scan(/\w+/) do |term|
+            normalised_term = SpellingCorrector::TermHandlerService.new(term).call
+
+            yield normalised_term if normalised_term.present?
+          end
+        end
+      end
+
+      def label_terms(label)
+        LABEL_FIELDS.flat_map { |field| Array(label.public_send(field)) }.compact
+      end
+    end
+  end
+end

--- a/app/lib/spelling_corrector/loaders/origin_reference.rb
+++ b/app/lib/spelling_corrector/loaders/origin_reference.rb
@@ -1,0 +1,47 @@
+module SpellingCorrector
+  module Loaders
+    class OriginReference
+      ORIGIN_REFERENCE_OBJECTS_PREFIX_PATH = 'spelling-corrector/origin-reference/'.freeze
+
+      def load
+        each_term do |term|
+          terms[term] += 1
+        end
+
+        terms
+      end
+
+      def terms
+        @terms ||= Hash.new(0)
+      end
+
+      private
+
+      def each_term
+        each_file do |io|
+          io.each_line do |line|
+            line.scan(/\w+/).map do |term|
+              normalised_term = SpellingCorrector::TermHandlerService.new(term).call
+
+              yield normalised_term if normalised_term.present?
+            end
+          end
+        end
+      end
+
+      def each_file
+        object_summaries.each do |object_summary|
+          yield object_summary.get.body
+        end
+      end
+
+      def object_summaries
+        bucket.objects(prefix: ORIGIN_REFERENCE_OBJECTS_PREFIX_PATH)
+      end
+
+      def bucket
+        Rails.application.config.spelling_corrector_s3_bucket
+      end
+    end
+  end
+end

--- a/app/lib/spelling_corrector/loaders/references.rb
+++ b/app/lib/spelling_corrector/loaders/references.rb
@@ -1,0 +1,27 @@
+module SpellingCorrector
+  module Loaders
+    class References
+      def load
+        each_term do |term|
+          terms[term] += 1
+        end
+
+        terms
+      end
+
+      def terms
+        @terms ||= Hash.new(0)
+      end
+
+      private
+
+      def each_term
+        SearchReference.pluck(:title).join(' ').scan(/\w+/).map do |term|
+          normalised_term = SpellingCorrector::TermHandlerService.new(term).call
+
+          yield normalised_term if normalised_term.present?
+        end
+      end
+    end
+  end
+end

--- a/app/lib/spelling_corrector/loaders/self_texts.rb
+++ b/app/lib/spelling_corrector/loaders/self_texts.rb
@@ -1,0 +1,34 @@
+module SpellingCorrector
+  module Loaders
+    class SelfTexts
+      def load
+        TimeMachine.now do
+          each_term do |term|
+            terms[term] += 1
+          end
+        end
+
+        terms
+      end
+
+      def terms
+        @terms ||= Hash.new(0)
+      end
+
+      private
+
+      def each_term
+        GoodsNomenclatureSelfText
+          .exclude(expired: true)
+          .exclude(self_text: nil)
+          .select_map(:self_text)
+          .join(' ')
+          .scan(/\w+/) do |term|
+            normalised_term = SpellingCorrector::TermHandlerService.new(term).call
+
+            yield normalised_term if normalised_term.present?
+          end
+      end
+    end
+  end
+end

--- a/app/lib/spelling_corrector/loaders/stop_words.rb
+++ b/app/lib/spelling_corrector/loaders/stop_words.rb
@@ -1,0 +1,27 @@
+module SpellingCorrector
+  module Loaders
+    class StopWords
+      def load
+        each_term do |term|
+          terms[term] += 1
+        end
+
+        terms
+      end
+
+      def terms
+        @terms ||= Hash.new(0)
+      end
+
+      private
+
+      def each_term
+        TradeTariffBackend.stop_words.each do |term|
+          normalised_term = SpellingCorrector::TermHandlerService.new(term).call
+
+          yield normalised_term if normalised_term.present?
+        end
+      end
+    end
+  end
+end

--- a/app/lib/spelling_corrector/loaders/synonyms.rb
+++ b/app/lib/spelling_corrector/loaders/synonyms.rb
@@ -1,0 +1,33 @@
+module SpellingCorrector
+  module Loaders
+    class Synonyms
+      SYNONYMS_PATH = Rails.root.join('config/opensearch/synonyms_all.txt')
+
+      def load
+        each_term do |term|
+          terms[term] += 1
+        end
+
+        terms
+      end
+
+      def terms
+        @terms ||= Hash.new(0)
+      end
+
+      private
+
+      def each_term
+        Pathname.new(SYNONYMS_PATH).each_line do |line|
+          terms = line.scan(/\w+/)
+
+          terms.each do |term|
+            normalised_term = SpellingCorrector::TermHandlerService.new(term).call
+
+            yield normalised_term if normalised_term.present?
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/spelling_corrector/file_updater_service.rb
+++ b/app/services/spelling_corrector/file_updater_service.rb
@@ -1,0 +1,49 @@
+module SpellingCorrector
+  class FileUpdaterService
+    LOADERS = [
+      SpellingCorrector::Loaders::Initial,
+      SpellingCorrector::Loaders::Synonyms,
+      SpellingCorrector::Loaders::Descriptions,
+      SpellingCorrector::Loaders::References,
+      SpellingCorrector::Loaders::SelfTexts,
+      SpellingCorrector::Loaders::Labels,
+      SpellingCorrector::Loaders::Intercepts,
+      SpellingCorrector::Loaders::StopWords,
+      SpellingCorrector::Loaders::OriginReference,
+    ].freeze
+
+    SPELLING_MODEL_PATH = 'spelling-corrector/spelling-model.txt'.freeze
+
+    def call
+      if bucket.blank?
+        Rails.logger.warn('Cannot update. Have you configured your bucket and credentials?')
+      else
+        loaders = LOADERS.map { |loader| loader.new.tap(&:load) }
+        spelling_model_content = spelling_model_content_for(loaders)
+
+        bucket.put_object(key: SPELLING_MODEL_PATH, body: spelling_model_content_for(loaders))
+
+        spelling_model_content
+      end
+    end
+
+    private
+
+    def spelling_model_content_for(loaders)
+      all_terms = loaders.each_with_object({}) do |loader, acc|
+        acc.merge!(loader.terms) do |_term, original_count, additional_count|
+          original_count + additional_count
+        end
+      end
+
+      all_terms = all_terms.sort_by { |_term, count| -count }
+      all_terms = all_terms.map { |term, count| "#{term} #{count}" }
+
+      StringIO.new(all_terms.join("\n"))
+    end
+
+    def bucket
+      Rails.application.config.spelling_corrector_s3_bucket
+    end
+  end
+end

--- a/app/services/spelling_corrector/term_handler_service.rb
+++ b/app/services/spelling_corrector/term_handler_service.rb
@@ -1,0 +1,18 @@
+module SpellingCorrector
+  class TermHandlerService
+    def initialize(term)
+      @term = term
+    end
+
+    def call
+      term = @term.downcase
+
+      has_digits = term.match(/\d/)
+      too_small = term.length < 3
+
+      return nil if has_digits || too_small
+
+      term
+    end
+  end
+end

--- a/app/workers/spelling_file_uploader_worker.rb
+++ b/app/workers/spelling_file_uploader_worker.rb
@@ -1,0 +1,9 @@
+class SpellingFileUploaderWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :default, retry: false
+
+  def perform
+    SpellingCorrector::FileUpdaterService.new.call
+  end
+end

--- a/config/initializers/spelling_corrector_bucket.rb
+++ b/config/initializers/spelling_corrector_bucket.rb
@@ -1,0 +1,12 @@
+s3_bucket_name = ENV['SPELLING_CORRECTOR_BUCKET_NAME']
+ecs_credentials_loaded = ENV['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'].present?
+local_credentials_loaded = ENV['AWS_PROFILE'].present? || (ENV['AWS_SECRET_ACCESS_KEY'].present? && ENV['AWS_ACCESS_KEY_ID'].present?)
+credentials_loaded = ecs_credentials_loaded || local_credentials_loaded
+
+s3_bucket = if Rails.env.test?
+              Aws::S3::Resource.new(stub_responses: true).bucket(s3_bucket_name || 'test-spelling-corrector')
+            elsif s3_bucket_name.present? && credentials_loaded
+              Aws::S3::Resource.new.bucket(s3_bucket_name)
+            end
+
+Rails.application.config.spelling_corrector_s3_bucket = s3_bucket

--- a/config/opensearch/synonyms_all.txt
+++ b/config/opensearch/synonyms_all.txt
@@ -1,0 +1,8485 @@
+cherry tomatoes => tomatoes
+tea bags => teabags
+red kite=>bird
+0106190000,hedgehog,wildcat,badger,otter,stoat,weasel,polecat
+0106390000,sparrow,robin,magpie,jay,blackbird,bluebird
+0106490000,birdwing,bookworm,cockchafer,cockroach,cutworm,damselfly,dragonfly,glowworm,gnat,grasshopper,housefly,midge,sandfly,toktokkies,twig-borer,twigborer,waxworm,wētā,woodworm,yellowjacket
+0203219000,babirusa,warthog,bushpig,boar
+1000,chiliad,grand,thou,thousand,yard
+10000,myriad
+100000,lakh
+1000000,million
+1000000000,billion
+1000000000000,billion
+1000000000000,trillion
+2202000000,redbull
+8471607000,lightpen,trackpad,trackball
+aave,ebonics
+abamp,abampere
+abasement,abjection,degradation
+abatement,hiatus,reprieve,respite,suspension
+abatis,abattis
+abattoir,butchery,shambles,slaughterhouse
+abdias,obadiah
+abdomen,belly,stomach,venter
+abducens,abducent
+aberrance,aberrancy,aberration,deviance
+aberration,distortion
+abertam => cheese
+abetment,abettal,instigation
+abeyance,suspension
+abies => tree
+abila,abyla
+abilify,aripiprazole
+abiogenesis,autogenesis,autogeny
+abjuration,recantation,retraction
+abkhas,abkhaz
+abkhasian,abkhazian
+abkhaz,abkhazia
+abnormalcy,abnormality
+abode,domicile,dwelling,habitation,home,residence
+abondance => cheese
+abor,dafla,miri,mirish
+aborticide,abortifacient
+abortion,miscarriage
+aboulia,abulia
+abrasion,attrition,corrasion,detrition,grinding
+abraxane,paclitaxel
+abridgement,abridgment,capsule,condensation
+absinth,absinthe
+abstract,outline,precis,synopsis
+absurdity,absurdness,ridiculousness
+abuse,contumely,insult,revilement,vilification
+abysm,abyss
+abyssinia,ethiopia,yaltopya
+abyssinian => cat,abyssinian
+academe,academia
+acamol,acet,acetalgin,adol,aeknil,aldolor,alvedon,apap,apiretal,apiretal flas,atamel,atasol,benuron,biogesic,biogesic-kiddielets,buscapina,calonal,calpol,captin,cemol,cetamol,coldex,coldrex,co-tipol,cotibin,crocin,dolo,dafalgan,daleron,depon,dexamol,dolex,dolgesic,doliprane,dolorol,dolprone,dolyc,efferalgan,endopain,enelfa,europain,excedrin,febrectal,febricet,febridol,fensum,gelocatil,gripin,gesic,hedex,hedanol,herron,influbene,kafa,kitadol,lekadol,lupocet,metacin,mexalen,milidon,minoset,momentum,napa,napadol,niko,neo-kiddielets,pacol,pamol,parol,panado,panadol,panamax,panda,panodil,paracet,paracitol,paralen,paramax,paramed,paratabs,paramol,paracetol,parol,perdolan,perfalgan,pinex,piretanyl,plicet,pyrenol,pyrigesic,reliv,revanin,rokamol,rubophen,sara,scanol,tachipirin,tachipirina,tafirol,tapsin,termalgin,tempra,thomapyrin,tipol,treuphadol,triaminic,tylenol,uphamol,vermidon,vitamol,xumadol,zolben => paracetamol
+acantha,spine,spur
+acanthisittidae,xenicidae
+acanthus => flower
+acapnia,hypocapnia
+acaracide,acaricide
+acariasis,acaridiasis,acariosis
+acaryote,akaryocyte,akaryote
+accelerator,throttle
+access,approach
+accessory,accouterment,accoutrement,appurtenance,supplement
+accho,acre,akka,akko
+acciaccatura,appoggiatura
+accident,fortuity,stroke
+acclaim,acclamation,eclat,plaudit,plaudits
+acclimation,acclimatisation,acclimatization
+acclivity,ascent,climb,raise,rise,upgrade
+accolade,award,honor,honour,laurels
+accouchement,childbearing,childbirth
+accoutre,accoutrement,accouter,accouterment
+accretion,accumulation
+accumulation,aggregation,assemblage,collection
+accumulator => battery,accumulator
+accupril,quinapril,accuretic
+accusal,accusation
+acebutolol,sectral
+acephalia,acephalism,acephaly
+acetamide,ethanamide
+acetaminophen,datril,panadol,phenaphen,tempra,tylenol
+acetanilid,acetanilide,phenylacetamide
+acetate,ethanoate
+acetic,vinegar
+acetone,propanone
+acetonemia,ketonemia,ketosis
+acetonuria,ketoaciduria,ketonuria
+acetophenetidin,acetphenetidin,phenacetin
+acetylene,alkyne,ethyne
+ache,aching
+achievability,attainability,attainableness
+achira,arrowroot
+acholia,cholestasis
+achondroplasia,achondroplasty,chondrodystrophy
+achromycin,tetracycline
+acid,dose,elvis,pane,superman
+acidophil,acidophile
+ackawi => cheese
+ackee,akee
+acocanthera,acokanthera
+acores,azores
+acousticophobia,phonophobia
+acquaintance,acquaintanceship
+acquiescence,assent
+acragas,agrigento
+acres,demesne,estate,land
+acrididae,locustidae
+acrilan,polypropenonitrile
+acroanaesthesia,acroanesthesia
+acrocephaly,oxycephaly
+acrolein,propenal
+acromegalia,acromegaly
+acromicria,acromikria
+acronym,initialism
+acrylate,propenoate
+acrylonitrile,propenonitrile
+actemra,tocilizumab
+acth,adrenocorticotrophin,adrenocorticotropin,corticotrophin,corticotropin
+actimmune,interferon
+actinaria,actiniaria
+actinia,actinian,actiniarian
+actinide,actinoid,actinon
+actinozoa,anthozoa
+actinozoan,anthozoan
+action,activity
+actiprofen,actron,adagin,addaprin,adex,advifen,advil,aktren,alaxan,,algifor,algoflex,algofren,alivium,arinac,arthrofen,artofen,betagesic,betaprofen,blokmax,bonifen,brufen,bufen,bugesic,buplex,buprovil,burana,caldolor,calprofen,combiflam,dalsy,dismenol,diverin,dolgit,dolofort,doloraz,dolormin,dolo-spedifen,dorival,easofen,ebufac,emuprofen,espidifen,eve,faspic,fenbid,fenpaed,feverfen,finalflex,galprofen,gelofen,genpril,haltran,hedafen,hedex,i-prin,i-profen,ibalgin,ibrofen,ibu,ibu,ibufen,íbúfen,ibugan,ibugel,ibuflam,ibugesic,ibuhexal,ibuleve,ibum,ibumax,ibumetin,ibumidol,ibupain,ibupirac,ibuprofen,ibuprofene,ibuprohm,ibuprom,ibuprox,ibuprosyn,ibu-ratiopharm,ibustar,ibutabs,ibutab,ibu-vivimed,ibux,ibuxin,ipren,irfen,kratalgin,lotem,medicol,midol,moment,motrin,mypaid,myprodol,narfen,neobrufen,neofen,norvectan,nuprin,nureflex,nurofen,orbifen,paduden,panafen,perifar,profin,proprinal,proris,q-profen,ranfen,rapidol,ratiodolor,rimafen,salvarina,sarixell,solpaflex,spedifen,spidifen,tefin,unafen,upfen => ibuprofen
+activase,alteplase
+activewear,sportswear
+acular,toradol
+acute,ague
+acyclovir,zovirax
+acylglycerol,glyceride
+adactylia,adactylism,adactyly
+adage,byword,proverb
+adakveo,crizanlizumab
+adalia,antalya
+adam,cristal,ecstasy
+adamant,diamond
+adana,seyhan
+adansonia => tree
+adapin,doxepin,sinequan
+adapter,adaptor,charger
+adbry,tralokinumab-idrm
+adcetris,brentuximab
+adcirca,tadalafil
+addendum,postscript,supplement
+addiction,dependance,dependence,dependency,habituation
+adelost => cheese
+adempas,riociguat
+adenomyosarcoma,nephroblastoma
+adenomyosis,endometriosis
+adermin,pyridoxal,pyridoxamine,pyridoxine
+adieu,adios,arrivederci,cheerio,goodby,goodbye,sayonara
+adjustment,allowance
+administration,brass,establishment,governance,organisation,organization
+admixture,alloy,intermixture
+admonishment,admonition,monition
+admonition,monition,warning
+adnexa,annexa
+adrenalin,adrenaline,epinephrin,epinephrine
+adrianople,adrianopolis,edirne
+adulterant,adulterator
+adulteration,debasement
+advate,antihemophilic,adynovate
+advent,parousia
+adventitia,tunic,tunica
+adversity,hardship
+advert,advertisement,advertising,advertizement,advertizing
+advil,ibuprofen,motrin,nuprin
+adze,adz
+adzhar,adzharia
+aegean => cat,aegean
+aegina,aigina
+aegir,bore,eager,eagre
+aegis,breastplate,egis
+aegospotami,aegospotamos
+aemcolo,rifamycin
+aeolia,aeolis
+aeolic,eolic
+aerial,antenna
+aerie,aery,eyrie,eyry
+aerodrome,airdrome,airport,drome
+aeroembolism,bends
+aerofoil,airfoil,surface
+aerogenerator,windmill
+aerogram,aerogramme
+aerophyte,epiphyte
+aether,ether
+aetiology,etiology
+affenpinscher => dog,affenpinscher
+affiliation,association
+affinity,kinship
+affray,altercation,fracas
+affricate,affricative
+afinitor,everolimus
+aflaxen,aleve,anaprox
+afrasian,afroasiatic
+afrocarpus => tree
+afters,dessert,sweet
+agalactia,agalactosis
+agathis => tree
+aged,elderly
+ageratum,mistflower
+aggeus,haggai
+agglomerate,cumulation,cumulus,heap,mound,pile
+agio,agiotage,premium
+agitation,ferment,fermentation,tempestuousness,unrest
+agkistrodon,ancistrodon
+aglet,aiglet,aiguilette
+agnation,patrilineage
+agony,excruciation,suffering
+agranulocytosis,agranulosis,granulocytopenia
+agraphia,anorthography,logagraphia
+agriculture,usda
+agrimonia,agrimony
+aguacate,avocado
+agueweed,boneset,thoroughwort
+aidi => dog,aidi
+aigret,aigrette
+ailanthus => tree
+ailment,complaint
+aimovig,erenumab
+air-conditioning,aircon
+airag => cheese
+airdock,hangar
+airing,dissemination,spreading
+airline,airway
+airmail,airpost
+airplane,aeroplane,aircraft
+airscrew,prop
+airship,dirigible
+airstream,backwash,race,slipstream,wash
+airway,skyway
+aisle,gangway
+aizoaceae,tetragoniaceae
+ajovy,fremanezumab
+akaba,aqaba
+akbash => dog,akbash
+akha,hani
+akinesia,akinesis
+akita => dog,akita
+akmola,astana
+akume => tree
+akvavit,aquavit
+alar,daminozide
+alarm,alarum,alert
+alastrim,pseudosmallpox,pseudovariola
+albatross,mollymawk
+albigenses,cathari,cathars
+albumen,albumin,ovalbumin
+albuminoid,scleroprotein
+albuminuria,proteinuria
+albuterol,proventil,ventolin
+alcahest,alkahest
+alcapton,alkapton
+alcaptonuria,alkaptonuria
+alchemy,chemistry
+alcohol,inebriant,intoxicant
+alcoholism,drunkenness,inebriation
+aldactazide,spironolactone,hydrochlorothiazide
+aldactone,spironolactone
+aldara,imiquimod
+aldomet,methyldopa
+aldosteronism,hyperaldosteronism
+ale,beer,lager
+alecensa,alectinib
+alecost,costmary
+alendronate,fosamax
+alep,aleppo,halab
+alerce => tree
+alert,alerting
+alerting,alertness
+alexander,alexanders
+alfilaria,alfileria,clocks,filaree,filaria
+alga,algae
+algonkian,algonkin
+algonquian,algonquin
+alibi,exculpation,excuse
+alidad,alidade
+alienation,estrangement
+aliment,alimentation,nourishment,nutriment,nutrition,sustenance,victuals
+alimony,maintenance
+alimta,pemetrexed
+aliqopa,copanlisib
+alir,interahamwe
+alismales,naiadales
+aliveness,animation,life,living
+alizarin,alizarine
+alkalinuria,alkaluria
+alkaliser,alkalizer,antacid,antiacid
+alkane,paraffin
+alkanet,bugloss
+alkene,olefin,olefine
+alkeran,melphalan
+allegation,allegement
+allegra,fexofenadine
+allele,allelomorph
+alleviant,alleviator,palliative
+alley,alleyway
+allice,allis
+alligator => reptile
+alligator,gator
+allioniaceae,nyctaginaceae
+allmouth,angler,anglerfish,goosefish,lotte,monkfish
+alloantibody,isoantibody
+allocation,allotment
+allograft,homograft
+allopurinol,zyloprim
+allosaur,allosaurus
+allotropism,allotropy
+alluviation,deposit,sedimentation
+almandine,almandite
+aloha,ciao
+alopekis => dog,alopekis
+alprazolam,xanax
+alsace,alsatia,elsass
+altace,ramipril
+altarpiece,reredos
+alteration,change,modification
+althaea,althea,hollyhock
+altitude,elevation
+alula,calypter
+alumbloom,alumroot
+aluminium,aluminum
+alunbrig,brigatinib
+alupag => tree
+alupent,metaproterenol
+alveolar,dental
+alverca => cheese
+alyssum,madwort
+alzheimer's,alzheimers
+amadavat,avadavat
+amaranth => flower
+ambage,circumlocution,periphrasis
+amberfish,amberjack
+ambergris,ambergrease
+ambert => cheese
+ambo,dais,podium,pulpit,rostrum,soapbox,stump
+amboyna,padauk,padouk
+ambrosia,nectar
+ameba,amoeba
+amebiasis,amebiosis,amoebiasis,amoebiosis
+amelanchier => tree
+amends,damages,indemnification,indemnity,redress,restitution
+amenia,amenorrhea,amenorrhoea
+amenities,comforts,conveniences
+ament,catkin
+amentotaxus => tree
+amercement,fine,mulct
+americanisation,americanization
+amerind,indian
+amethopterin,methotrexate
+amex,curb
+amidopyrine,aminopyrine
+amine,aminoalkane
+aminobenzine,aniline,phenylamine
+aminopherase,aminotransferase,transaminase
+amiodarone,cordarone
+amitiza,lubiprostone
+amitriptyline,elavil
+ammo,ammunition
+ammonite,ammonoid
+amnesty,pardon
+amnion,amnios
+amoebida,amoebina
+amondys,casimersen
+amount,measure,quantity
+amoxicillin,amoxil,augmentin,larotid,polymox,trimox
+amoy,fukien,fukkianese,hokkianese,taiwanese
+amphetamine,speed,upper
+amphibology,amphiboly
+amphicarpa,amphicarpaea
+amphioxidae,branchiostomidae
+amphioxus,lancelet
+amphisbaena,amphisbaenia
+amphitheater,amphitheatre,coliseum
+amphitheatre,amphitheater
+ampicillin,polycillin,principen
+ampoule,ampul,ampule,phial,vial
+ampyra,dalfampridine
+amrinone,inocor
+amulet,talisman
+amur,heilong
+amvuttra,vutrisiran
+amylum,starch
+amyotonia,atonia,atonicity,atony
+amyotrophia,amyotrophy
+anacardium => tree
+anacoluthia,anacoluthon
+anadiplosis,reduplication
+anaemia,anemia
+anaesthesia,anesthesia
+anaesthetic,anesthetic
+analecta,analects
+analgesic,anodyne,painkiller
+analyser,analyzer
+ananas,pineapple
+anapaest,anapest
+anaphora,epanaphora
+anapurna,annapurna
+anarchy,lawlessness
+anastomosis,inosculation
+anastrophe,inversion
+anatoxin,toxoid
+anchylosis,ankylosis
+ancobon,flucytosine
+andalucia,andalusia
+andelmin,angelim
+andiron,firedog
+andrena,andrenid
+androgenesis,androgeny
+android,humanoid
+anemone,windflower
+anencephalia,anencephaly
+anestrum,anestrus,anoestrum,anoestrus
+aneurin,thiamin,thiamine
+aneurism,aneurysm
+angara,tunguska
+angelica,angelique
+angeliq,drospirenone,estradiol
+anger,angriness
+angioedema,atrophedema
+angiospermae,anthophyta,magnoliophyta
+angiotensin,angiotonin,hypertensin
+anglesea,anglesey,mona
+angleworm,crawler,earthworm,fishworm,nightcrawler,nightwalker,wiggler
+anglicisation,anglicization
+anglicism,briticism,britishism
+angora,ankara
+anguillula,turbatrix
+anhidrosis,anhydrosis
+anhinga,darter,snakebird
+anhydrite,caso4
+anil,indigo,indigotin
+animadversion,censure
+animal,beast,brute,creature,fauna
+animalcule,animalculum
+anis,anise,aniseed
+anklebone,astragal,astragalus,talus
+anklet,anklets,bobbysock,bobbysocks
+ankylosaur,ankylosaurus
+anlage,primordium
+annamese,annamite,vietnamese
+annex,annexe,extension
+annihilation,disintegration
+annon,sweetsop
+annotation,notation,note
+annoyance,botheration,irritation,vexation
+annual,yearbook,yearly
+annuity,rente
+annulet,bandelet,bandelette,bandlet
+annulment,revocation
+anomalousness,anomaly
+anomie,anomy
+anonym,pseudonym
+anonymity,namelessness
+anorak,parka,windbreaker,windcheater
+anorchia,anorchidism,anorchism
+anovulant,pill
+ansaid,flurbiprofen
+antabuse,disulfiram
+antagonism,enmity,hostility
+antakiya,antakya,antioch
+anteater,echidna,aardvark,numbat,pangolin
+antecedent,forerunner
+antechamber,anteroom,foyer,hall,lobby,vestibule
+antenna,feeler
+antepenult,antepenultima,antepenultimate
+anthelminthic,anthelmintic,helminthic,vermifuge
+anthem,hymn
+anthericum => flower
+antherozoid,spermatozoid
+anthesis,blossoming,efflorescence,florescence,flowering,inflorescence
+anthill,formicary
+anthoriro => cheese
+anthropogenesis,anthropogeny
+anthurium,tailflower
+antiaircraft,flack,flak
+antibacterial,bactericide
+anticipation,expectation
+anticlimax,bathos
+anticlockwise,counterclockwise
+anticoagulant,decoagulant
+anticonvulsant,antiepileptic
+antidote,counterpoison
+antielectron,positron
+antifungal,antimycotic,fungicide
+antilog,antilogarithm
+antimicrobial,antimicrobic,disinfectant,germicide
+antiphon,antiphony
+antiphonal,antiphonary
+antipsychotic,neuroleptic
+antipyretic,febrifuge
+antispasmodic,spasmolytic
+antivenene,antivenin
+antivert,meclizine
+antlion,doodlebug
+antonym,opposite
+antwerp,antwerpen,anvers
+anura,batrachia,salientia
+anuran,batrachian,frog,salientian,toad
+anuresis,anuria
+anvil,incus
+anxiety,anxiousness
+aoudad,arui,audad
+apanage,appanage
+apatosaur,apatosaurus,brontosaur,brontosaurus
+aperient,cathartic,physic,purgative
+aphaeresis,apheresis
+aphonia,voicelessness
+aphorism,apophthegm,apothegm
+apiaceae,umbelliferae
+aplacophora,solenogastres
+aplacophoran,solenogaster
+aplysia,tethys
+aplysiidae,tethyidae
+apocalypse,revelation
+apologia,apology
+apolune,aposelene
+apoplexy,stroke
+apostasy,defection,renunciation
+appal,appall
+apparatus,setup
+apparel,clothes,clothing
+appellation,appellative,denomination,designation
+appetiser,appetizer,starter
+applause,clapping
+applesauce,codswallop,folderol,rubbish,trash,tripe,trumpery
+appliance,contraption,contrivance,convenience,gadget,gismo,gizmo,widget
+applicability,pertinence,pertinency
+application,lotion
+applicator,applier
+appraisal,estimate,estimation
+apprisal,notification,telling
+approach,approaching
+approval,commendation
+apresoline,hydralazine
+apretude,cabotegravir
+apron,pinafore,pinnafore,pinny
+apse,apsis
+apteryx,kiwi
+aptivus,tipranavir
+apulia,puglia
+aqualung,scuba
+aquila,l'aquila
+aquilege,aquilegia,columbine
+aquitaine,aquitania
+arab,arabian
+araçá => tree
+arachnid,arachnoid
+aragon => cheese
+araguaia,araguaya
+arak,arrack
+aranea,araneus
+araneae,araneida
+arapaho,arapahoe
+araroba,chrysarobin
+aras,araxes
+araucaria => tree
+arava,leflunomide
+arawak,arawakan
+araza => tree
+arazlo,tazarotene
+arbalest,arbalist,ballista,bricole,catapult,mangonel,onager,trebuchet,trebucket
+arborvirus,arbovirus
+arborvitae => tree
+arbutus => tree
+arcade,colonnade
+arcanum,secret
+arccos,arccosine
+arcdegree,degree
+arch,archway
+archaebacteria,archaebacterium,archaeobacteria,archeobacteria
+archaeopteryx,archeopteryx
+archaicism,archaism
+archer,sagittarius
+archespore,archesporium
+archipallium,paleocortex
+archontophoenix => tree
+archosaur,archosaurian
+arcminute,minute
+arcsec,arcsecant
+arcsecond,second
+arcsin,arcsine
+arctan,arctangent
+ardisia => tree
+ardour,ardor
+ardrahan => cheese
+arecaceae => tree
+arecaceae,palmaceae,palmae
+arena,stadium
+arenga => tree
+arere,obeche,obechi,samba
+arestin,minocycline
+argal,argali
+argan => tree
+argantree => tree
+argonaut,nautilus
+argot,cant,jargon,lingo,patois,slang,vernacular
+argyle,argyll
+aricara,arikara
+aridity,aridness,thirstiness
+ariegeois => dog,ariegeois
+arishth,margosa,neem
+aristocort,aristopak,kenalog,triamcinolone
+armant => dog,armant
+armenia,hayastan
+armguard,bracer
+armistice,truce
+armorer,armourer
+armory,armoury,arsenal
+armour,armor
+armpit,axilla
+arms,munition,weaponry
+aroid,arum
+aromasin,exemestane
+arquebus,hackbut,hagbut,harquebus
+arranon,nelarabine
+arras,tapestry
+arrow,pointer
+arrowworm,chaetognath
+arsenic,ratsbane
+arsenopyrite,mispickel
+artefact,artifact
+artemia,chirocephalus
+arteria,artery
+arteriectasia,arteriectasis
+arteriola,arteriole
+article,clause
+artillery,artilery,ordnance
+artwork,graphics
+arugula,rocket,roquette
+arum => flower
+arytaenoid,arytenoid
+asadero => cheese
+asafetida,asafoetida
+asamiya,assamese
+ascendance,ascendancy,ascendence,ascendency,control,dominance
+ascendant,ascendent
+ascension,ascent,rise,rising
+aschelminthes,nematoda
+ascomycota,ascomycotina
+asdic,sonar
+ashbin,ashcan,dustbin,wastebin
+ashur,assur,asur
+aside,digression,divagation,excursus,parenthesis
+asimina => tree
+asking,request
+asmara,asmera
+aspadana,esfahan,isfahan
+asparaginase,elspar
+aspergill,aspersorium
+aspergillales,eurotiales
+aspersion,slur
+asphalt,bitumen
+asphyxiation,suffocation
+asphyxiator,extinguisher
+aspinwall,colon
+aspirin,bayer,empirin
+assagai,assegai
+assassination,blackwash
+assembly,forum
+assertion,asseveration,averment
+assibilation,sibilation
+assignment,grant
+assortment,miscellanea,miscellany,mixture,motley,potpourri,salmagundi,smorgasbord,variety
+assouan,assuan,aswan
+assumption,premise,premiss
+assurance,pledge
+astacidae,astacura
+aster => flower
+asteraceae,compositae
+asterope,sterope
+asthenia,astheny
+asthenopia,eyestrain
+astigmatism,astigmia
+astragal,bead,beading,beadwork
+astrantia,masterwort
+astringent,styptic
+astroglia,macroglia
+asynchronism,asynchrony,desynchronisation,desynchronization,desynchronizing
+asynclitism,obliquity
+asynergia,asynergy
+atabrine,mepacrine,quinacrine
+atakapa,atakapan,attacapa,attacapan
+atar,athar,attar,ottar
+ataractic,tranquilizer,tranquilliser,tranquillizer
+atarax,hydroxyzine,vistaril
+atavism,reversion,throwback
+ataxia,ataxy,dyssynergia
+atayalic,tayalic
+ateleiosis,ateliosis
+atemoya => tree
+atenolol,tenormin
+athabascan,athabaskan,athapascan,athapaskan
+atherodyde,athodyd,ramjet
+athrotaxis => tree
+athyriaceae,dryopteridaceae
+ativan,lorazepam
+atlas,telamon
+atmometer,evaporometer
+atmospherics,static
+atom,corpuscle,molecule,mote,particle,speck
+atomiser,atomizer,nebuliser,nebulizer,spray,sprayer
+atonalism,atonality
+atonement,expiation,satisfaction
+atopiclair,nonsteroidal
+atopognosia,atopognosis
+atorvastatin,lipitor
+attachment,bond
+attack,blast,fire,flack,flak
+attenuation,fading
+aubagio,teriflunomide
+auberge,hostel,hostelry,lodge
+aubergine,brinjal,eggplant
+audio,sound
+audiometer,sonometer
+auger,gimlet,wimble
+aureomycin,chlortetracycline
+auricle,pinna
+auriga,charioteer
+auriscope,auroscope,otoscope
+austedo,deutetrabenazine
+austria,oesterreich
+autacoid,autocoid
+authentication,hallmark
+authorisation,authorization,mandate
+authorities,government,regime
+automobile,motorcar,car
+autobus,bus,charabanc,coach,jitney,motorbus,motorcoach,omnibus
+autoclave,steriliser,sterilizer
+autocue,prompter
+autogiro,autogyro,gyroplane
+autograft,autoplasty
+automaker,carmaker
+automaton,golem,robot
+autonomy,liberty
+autophyte,autotroph
+autun => cheese
+auvi-q,epinephrine
+avastin,bevacizumab
+avaxtskyr => cheese
+aveloz => tree
+aventail,camail,ventail
+aventurine,sunstone
+avenue,boulevard
+avestan,zend
+aviary,volary
+avitaminosis,hypovitaminosis
+avycaz,ceftazidime,avibactam
+award,prize
+awning,sunblind,sunshade
+axe,ax
+axiom,maxim
+axis,bloc
+axlewood => tree
+axon,axone
+ayvakit,avapritnib
+azactam,aztreonam
+azathioprine,imuran
+azawakh => dog,azawakh
+azedarach,azederach,chinaberry
+azedra,iobenguane
+azerbaijan,azerbajdzhan
+azithromycin,zithromax
+azotaemia,azotemia,uraemia,uremia
+babble,babbling,lallation
+babbler,cackler
+babiroussa,babirusa,babirussa
+babybel => cheese
+babyhood,infancy
+babylonia,chaldaea,chaldea
+babytalk,motherese
+baccharis => tree
+baccy,tobacco
+bacillariophyceae,diatomophyceae
+bacitracin,bacitracin
+backbone,spine
+backchat,banter,raillery
+backcloth,backdrop,background
+backdown,withdrawal
+backfire,blowback
+backflow,backflowing
+backing,mount
+backlash,rebound,recoil,repercussion
+backlog,reserve,stockpile
+backpack,haversack,knapsack,packsack,rucksack
+backsheesh,baksheesh,bakshis,bakshish,gratuity,pourboire
+backspace,backspacer
+backstage,offstage,wing
+backsword,singlestick
+backtalk,mouth,sass,sassing
+backwash,wake
+backwoods,boondocks,hinterland
+bacteremia,bacteriaemia,bacteriemia
+bacteria,bacterium
+bacteriacide,bactericide
+bacteriophage,phage
+bactris => tree
+bael => tree
+bagascosis,bagassosis
+bagatelle,fluff,frippery,frivolity
+bagdad,baghdad
+bagel,beigel
+baggage,luggage
+bagging,sacking
+baguet,baguette
+bahasa,indonesian
+baht,tical
+baikal,baykal
+bail,bond
+bairiki,tarawa
+baisa,baiza
+bait,decoy,lure
+bakeapple,cloudberry,salmonberry
+bakehouse,bakery,bakeshop
+baladi => cheese
+balance,counterbalance,counterpoise,counterweight,equaliser,equalizer
+balancer,halter,haltere
+balata,beefwood
+balaton => cheese
+balderdash,piffle
+baldness,phalacrosis
+baldric,baldrick
+baleen,whalebone
+balefire,bonfire
+balibago,mahagua,mahoe,majagua,purau
+balinese => cat,balinese
+balk,baulk
+ballast,barretter
+ballistocardiograph,cardiograph
+ballpen,ballpoint,biro
+balm,ointment,salve,unction,unguent
+balminess,softness
+balmoral,bluebonnet
+balochi,baluchi
+baloney,bilgewater,boloney,bosh,drool,humbug,taradiddle,tarradiddle,tommyrot,tosh,twaddle
+balusters,balustrade,banister,bannister,handrail
+balversa,erdafitinib
+bambino => cat,bambino
+banality,bromide,cliche,commonplace,platitude
+bandage,patch
+bandal => cheese
+bandana,bandanna
+bandeau,brassiere
+bandoleer,bandolier
+bandstand,stand
+bandyleg,bowleg
+bane,curse,nemesis,scourge
+baneberry,cohosh
+banger,cracker,firecracker
+bangla,bengali
+bangle,bauble,fallal,gaud,gewgaw,trinket,bracelet
+bangtail,racehorse
+banian,banyan
+banishment,coventry,ostracism
+bankbook,passbook
+banknote,bill,greenback,note
+bankroll,roll
+bankruptcy,failure
+banner,streamer
+banning,forbiddance,forbidding
+banon => cheese
+banquet,feast
+banteng,banting,tsine
+baobab => tree
+baptistery,baptistry,font
+baqsimi,glucagon
+baraclude,entecavir
+baranduki,baronduki,barunduki,burunduki
+barbacan,barbican
+barbasco,joewood
+barbecue,barbeque
+barbel,feeler
+barberry => flower
+barbet => dog,barbet
+barbital,barbitone,diethylmalonylurea,veronal
+barcarole,barcarolle
+bareness,bleakness,desolation,nakedness
+barf,puke,vomit,vomitus
+barge,flatboat,lighter
+barilla,glasswort,kali,kelpwort,saltwort
+barite,barytes
+bark,barque
+barker,doggie,doggy,pooch
+barley,barleycorn
+barm,yeast
+barnacle,cirriped,cirripede
+baronage,peerage
+baronetcy,barony
+barosaur,barosaurus
+barracouta,snoek
+barrage,bombardment,onslaught,outpouring
+barrel,cask
+barren,waste,wasteland
+barricade,roadblock
+barroom,ginmill,saloon,taproom
+barrow,wheelbarrow
+barye,microbar
+baseboard,mopboard
+basement,cellar
+basenji => dog,basenji
+bash,brawl
+basia,basra
+basidiomycota,basidiomycotina
+basilicata,lucania
+basing => cheese
+basis,footing,ground
+basket,handbasket
+basophil,basophile
+bass,basso
+bassarisk,cacomistle,cacomixle,ringtail
+bassia,kochia
+basswood,lime,linden
+bast,phloem
+baste,basting,tacking
+bastion,citadel
+bastnaesite,bastnasite
+basuto,sesotho
+basutoland,lesotho
+bath,bathtub
+batholite,batholith,pluton
+bathometer,bathymeter
+lavatory,privy,toilet,wc
+bathyscape,bathyscaph,bathyscaphe
+batoidei,rajiformes
+baton,billy,billystick,nightstick,truncheon,wand
+batten,batting
+battercake,flapcake,flapjack,griddlecake,hotcake,pancake
+bauhinia => tree
+bavencio,avelumab
+bawdry,bawdy
+bayahonda => tree
+bayberry,candleberry,waxberry
+baycol,cerivastatin
+bayleaf => tree
+baylough => cheese
+bayrut,beirut
+bazaar,bazar
+bazillion,billion,gazillion,jillion,million,trillion,zillion
+bbq,barbecue,barbeque
+beacon,lighthouse,pharos
+beading,beadwork
+beagle => dog,beagle
+beagle-harrier => dog,beagle-harrier
+beam,irradiation,shaft
+beanie,beany
+bearberry,bearwood,chittamwood,chittimwood,winterberry
+bearcat,binturong
+bearskin,busby,shako
+beatification,beatitude,blessedness
+beatniks,beats
+beaucarnea => tree
+beauceron => dog,beauceron
+beaufort => cheese
+beauvoorde => cheese
+bedbug,chinch
+bedclothes,bedding
+bedcover,bedspread,counterpane
+bedding,litter
+bedevils,bedevilled,bedevilling,bedevils,bedeviled,bedeviling
+bedframe,bedstead
+beech,beechwood
+beef,boeuf
+beefalo,cattalo
+beefburger,burger,hamburger
+beefwood => tree
+beehive,hive
+beep,bleep
+beeper,pager
+beetleweed,coltsfoot,galax,galaxy,wandflower
+behavior,behaviour
+behove,behoove
+beijing,peiping,peking
+belabour,belabor
+belarus,belorussia,byelarus,byelorussia
+belarusian,byelorussian
+belau,palau,pelew
+belgique,belgium
+belgrade,beograd
+bellarmine,greybeard,longbeard
+bellflower,campanula => flower
+belly,paunch
+bellyache,gastralgia,stomachache
+bellybutton,navel,omphalos,omphalus,umbilicus
+belsomra,suvorexant
+beluga,hausen
+bema,chancel,sanctuary
+benadryl,diphenhydramine
+bend,curve
+bendeka,bendamustine
+bendopa,brocadopa,larodopa,levodopa
+benediction,blessing
+benefix,recombinant
+bengal => cat,bengal
+benin,dahomey
+benjamin,benzoin
+benlysta,belimumab
+bennie,benzedrine
+benweed,ragweed,ragwort
+benzene,benzine,benzol
+benzofuran,coumarone,cumarone
+benzol,benzole
+benzoquinone,quinone
+bergader => cheese
+bergall,cunner
+berkswell => cheese
+berm,shoulder
+berretta,biretta,birretta
+beryllium,glucinium
+betrothal,engagement,troth
+bevel,cant,chamfer
+beverage,drink
+bextra,valdecoxib
+bezant,bezzant,byzant,solidus
+bhagavadgita,gita
+bharat,india
+bialy,bialystoker
+bias,diagonal
+bible,book,scripture,word
+bichloride,dichloride
+bichromate,dichromate
+bicker,bickering,fuss,pettifoggery,spat,squabble,tiff
+bicorn,bicorne
+bicuspid,premolar
+bicycle,bike
+bida,doha
+biddy,chick
+bierkase => cheese
+bighorn,cimarron,dall,argali,mouflon
+bilberry,blaeberry,whinberry,whortleberry
+bile,gall
+bilestone,gallstone
+bilharzia,bilharziasis,schistosomiasis
+bilirubin,haematoidin,hematoidin
+billboard,hoarding
+billfish,garfish,garpike,needlefish,saury
+billfold,notecase,pocketbook,wallet
+billingsgate,scurrility
+billow,surge
+billy => dog,billy
+billyo,billyoh
+biltricide,praziquantel
+bimli,kanaf,kenaf
+binder,ligature
+bindinga => tree
+bindweed => flower
+bioarm,bioweapon
+bioflavinoid,citrin
+biogenesis,biosynthesis
+biography,life
+biology,biota
+biquadrate,biquadratic,quartic
+bird,birdie,bird,fowl
+birdcall,birdsong,call,song
+biriani,biryani
+birman => cat,birman
+birr,whir,whirr,whirring
+biscuit,cookie
+bise,bize
+bishkek,biskek,frunze
+bishopric,diocese,episcopate
+bison,buffalo,wisent
+bister,bistre
+bisulphate,bisulfate
+bitstock,brace
+bitt,bollard
+bittersweet,waxwork
+bitterweed,bugloss,oxtongue
+bitterwood,quassia
+bivalve,lamellibranch,pelecypod
+bivalvia,lamellibranchia
+bivouac,camp,cantonment,encampment
+blackbird,merl,merle,ousel,ouzel
+blackboard,chalkboard
+blackcap,pewit
+blackdamp,chokedamp
+blackfish,tautog
+blackhaw => tree
+blackhead,comedo
+blackjack,cosh
+blackout,brownout,dimout
+blackthorn => flower
+blacktop,blacktopping
+bladder,vesica
+bladderwrack,tang
+blah,bombast,claptrap,fustian,rant
+blame,incrimination,inculpation
+blameable,blamable
+blanket,cover
+blanquillo,tilefish
+blare,blaring,cacophony,clamor
+blast,blow,gust
+blastocele,blastocoel,blastocoele
+blastocytoma,blastoma
+blastoderm,blastodisc
+blastosphere,blastula
+blather,blatherskite
+blattaria,blattodea
+bleach,whitener
+bleb,blister,bulla
+bleeding,haemorrhage,hemorrhage
+bleeper,beeper
+blend,portmanteau
+blende,sphalerite
+blender,liquidiser,liquidizer
+blether,prate,prattle
+blincyto,blinatumomab
+blinder,blinker,winker
+blindness,cecity,sightlessness
+blini,bliny
+blintz,blintze
+bliss,blissfulness
+blistering,vesication,vesiculation
+blocadren,timolol
+blockage,obstruction
+bloodberry,rougeberry
+bloodhound => dog,bloodhound
+bloodhound,sleuthhound
+bloodroot,puccoon,redroot,tetterwort
+bloodstone,heliotrope
+bloodsucker,hirudinean,leech
+bloom,blooming
+bloomers,drawers,knickers,pants
+blouson => jacket
+blowball,dandelion
+blower,cetacean
+blowfish,globefish,puffer,pufferfish
+blowgun,blowpipe,blowtube
+blowhole,vent,venthole
+blowlamp,blowtorch,torch
+blowout,laugher,romp,runaway,walkaway
+blowpipe,blowtube
+bluebell,harebell
+bluebill,broadbill,scaup
+blusher,paint,rouge
+boab => tree
+boaboa => tree
+boatbill,broadbill
+bobbin,reel,spool
+bobolink,reedbird,ricebird
+bobsleigh,bobsled
+bobtail,dock
+bobwhite,partridge
+bocconcini => cheese
+bodensee,constance
+bodkin,poniard
+bodoni,modern
+body => body,corselette
+bodysuit,body
+boerboel => dog,boerboel
+bogbean,buckbean
+bogey,bogie,bogy
+boil,furuncle
+boiler,kettle
+boilersuit,overall
+bokkos,daffo
+bokmaal,bokmal
+bola,bolo
+bolanci,bole
+bole,trunk
+bolide,fireball
+bologram,bolograph
+bolt,deadbolt
+bombard,bombardon
+bombardon,helicon
+bombax => tree
+bombay => cat,bombay
+bombay,mumbai
+bomber,grinder,hero,hoagie,hoagy,submarine,torpedo,wedge
+bombilation,bombination,buzz
+bombshell,thunderbolt,thunderclap
+bonanza,boom,bunce,godsend,gravy,windfall
+bonchester => cheese
+bond,hamper,shackle,trammel
+bondage,slavery,thraldom,thrall,thralldom
+bonduc,chicot
+bonelet,ossicle,ossiculum
+bones,castanets,clappers
+bonnet,cowl,cowling,hood
+bonnethead,shovelhead
+bonus,incentive
+bonxie,skua
+boodle,bread,cabbage,clams,dinero,dough,gelt,kale,lettuce,lolly,loot,lucre,moolah,pelf,scratch,shekels,simoleons,sugar,wampum
+booklet,brochure,folder,leaflet,pamphlet
+booklouse,deathwatch
+bookmark,bookmarker
+bookshop,bookstall,bookstore
+boom,roar,roaring,thunder
+boot,trunk
+bootboys,skinheads
+bootee,bootie
+booth,cubicle,kiosk,stall
+bootleg,moonshine
+booty,loot,pillage,plunder,prize,swag
+booze,liquor,spirits
+borage => flower
+borassus => tree
+borderland,march,marchland
+boreas,norther,northerly
+borecole,cole,colewort,kail,kale
+borer,woodborer
+borneo,kalimantan
+borsch,borscht,borsh,borshch,borsht,bortsch
+borzoi => dog,borzoi
+boss,knob
+bosulif,bosutinib
+bosworth => cheese
+botany,flora,vegetation
+bother,fuss,hassle,trouble
+bottle,bottleful
+bottleneck,chokepoint,constriction
+bottletree => tree
+botulin,botulismotoxin
+botulinum,botulinus
+bougon => cheese
+boulder,bowlder
+boule,boulle,buhl
+bounce,bouncing
+bounty,premium
+bouquet,corsage,nosegay,posy
+bourbon,daniels
+bourdon,drone
+bourgogne,burgundy
+bourn,bourne
+bourreria => tree
+boursault => cheese
+boursin => cheese
+bourtree,elderberry
+bouyei,buyi
+bouyssou => cheese
+bovine,cow,cattle
+bowel,intestine
+bowerbird,catbird
+bowfin,dogfish,grindle
+bowing,obeisance
+bowler,derby
+boxberry,checkerberry,spiceberry,teaberry,wintergreen,partridgeberry,twinberry
+boxelder => tree
+boxer => dog,boxer
+boxers,boxershorts,drawers,shorts,underdrawers
+boxfish,trunkfish
+boxwood => tree
+bra,bras,brassiere,brassière,brassieres,brassières,bustiers,bralette
+brace,bracing
+brachiopod,lampshell
+brachydactylia,brachydactyly
+brachylaena => tree
+bracken,brake
+bracteole,bractlet
+bradawl,pricker
+braftovi,encorafenib
+brahea => tree
+brahma,brahman,brahmin
+braid,braiding,plait,tress,twist
+bramble => flower
+branchia,gill
+branchiopod,branchiopodan
+branchlet,sprig,twig
+brandish,flourish
+brant,brent
+brasier,brazier
+brasil,brazil
+brassicaceae,cruciferae
+bratislava,pozsony,pressburg
+braudostur => cheese
+braunschweig,brunswick
+brazilwood => tree
+breach,break,rift,rupture,severance
+breadbasket,stomach,tummy
+breadnut => tree
+breakax,breakaxe
+breaker,breakers,surf
+breakstone,rockfoil,saxifrage
+breast,chest
+breastbone,sternum
+breastpin,broach,brooch
+breastwork,parapet
+breath,hint,intimation
+breathalyser,breathalyzer
+breather,schnorchel,schnorkel,snorkel
+breechcloth,breechclout,loincloth
+breeches,knickerbockers,knickers
+breed,stock,strain
+breeze,zephyr
+breeziness,windiness
+breiz,bretagne,brittany
+breslau,wroclaw
+brevibloc,esmolol
+brevicipitidae,microhylidae
+brew,brewage
+briar,brier,bullbrier,catbrier,greenbrier
+briard => dog,briard
+briarwood,brierwood
+bribe,payoff
+brickfield,brickyard
+brilinta,ticagrelor
+brin => cheese
+brine,saltwater,seawater
+brink,threshold,verge
+briny,main
+briony,bryony
+briquet,briquette
+brisling,sprat
+brit,britt
+brittanic,brythonic
+brittany => dog,brittany
+brittle,toffee,toffy
+brittlebush,incienso
+briviact,brivaracetam
+brno,brunn
+broadax,broadaxe
+broadbill,shoveler,shoveller
+broadcast,program,programme
+broadcaster,spreader
+broadening,widening
+broadside,philippic,tirade
+broadtail,caracul,karakul
+broccio => cheese
+brogan,brogue,clodhopper
+broholmer => dog,broholmer
+brolly,gamp
+bromberg,bydgoszcz
+brome,bromegrass
+bromeosin,eosin
+bromoform,tribromomethane
+bronc,broncho,bronco
+brooder,incubator
+brooding,incubation
+broody,sitter
+brook,creek
+broom,heather,ling
+broomrape => flower
+broth,stock
+brow,forehead
+browse,browsing
+bruise,contusion
+brukinsa,zanubrutinib
+brusa,bursa
+brush,brushwood,coppice,copse,thicket
+brussels,bruxelles
+brutalisation,brutalization
+bryndza => cheese
+bryony => flower
+bryopsida,musci
+bryozoa,polyzoa
+bryozoan,polyzoan
+bubbly,champagne
+bubinga => tree
+bucharest,bucharesti,bucuresti
+bucida => tree
+buck,horse,sawbuck,sawhorse
+bucket,pail
+buckeye,conker
+buckle,warp
+buckler,shield
+buckminsterfullerene,buckyball
+buckthorn,ribgrass,ribwort
+bucolic,eclogue,idyl,idyll
+budgereegah,budgerigar,budgerygah,budgie,lovebird
+buff,buffer
+buffet,counter,sideboard
+buffeting,pounding
+bufflehead,butterball,dipper
+buggy,roadster
+bugle,bugleweed
+bugloss => flower
+building,edifice
+bujumbura,usumbura
+bulb,lightbulb
+bulbil,bulblet
+bulge,bump,excrescence,extrusion,gibbosity,gibbousness,hump,prominence,protrusion,protuberance,swelling
+bulghur,bulgur
+bull,taurus
+bullbat,nighthawk
+bulldog => dog,bulldog
+bulldozer,dozer
+bullet,slug
+bullfight,corrida
+bullmastiff => dog,bullmastiff
+bullock,steer
+bullrush,bulrush,nailrod,reedmace
+bulwark,rampart,wall
+bumblebee,humblebee
+bumf,bumph
+bunchberry,crackerberry
+buncombe,bunk,bunkum,guff,hogwash
+bundle,sheaf
+bung,spile
+bungalow,cottage
+bunk,hokum,meaninglessness,nonsense,nonsensicality
+bunsen,etna
+bura,pabir
+burbot,cusk,eelpout,ling
+burdock => flower
+bureau,chest,dresser
+bureaucracy,bureaucratism
+bureaux,bureaus
+buret,burette
+burgoo,oatmeal
+burgos => cheese
+burial,entombment,inhumation,interment,sepulture
+burka,burqa
+burlap,gunny
+burlesque,lampoon,mockery,parody,pasquinade,sendup,spoof,takeoff,travesty
+burma,myanmar
+burmese => cat,burmese
+burmilla => cat,burmilla
+burning,combustion
+burnoose,burnous,burnouse
+burnside,sideburn
+burro => donkey
+burrow,tunnel
+burst,outburst
+bushbaby,galago
+bushbuck,guib
+buspar,buspirone
+bust,fizzle,flop
+butat,butut
+butazolidin,phenylbutazone
+butch,flattop
+butene,butylene
+butia => tree
+butte => cheese
+buttercup,butterflower,crowfoot,goldcup,kingcup
+butterfish,stromateid
+butterfruit => tree
+butterkase => cheese
+butterweed,ragwort
+buttery,larder,pantry
+buttock,cheekbutton,clit,clitoris
+button,push
+buttonbush => tree
+buttonwood => tree
+buttress,buttressing
+buxus => tree
+buzzword,cant
+byetta,exenatide
+bylvay,odevixibat
+byname,cognomen,moniker,nickname,sobriquet,soubriquet
+bypass,shunt
+bypath,byroad,byway
+byre,cowbarn,cowhouse,cowshed
+byrnie,hauberk
+byrsonima => tree
+bystolic,nebivolol
+c.p.u.,mainframe,processor
+c2h6,ethane
+caaba,kaaba
+cabal,camarilla,faction,junto
+cabala,cabbala,cabbalah,kabala,kabbala,kabbalah,qabala,qabalah
+cabaret,club,nightclub,nightspot
+cabasset,morion
+cabassous,tatouay
+cabbage,chou
+cabecou => cheese
+cabenuva,cabotegravir,rilpivirine
+cabinet,console,cupboard
+caboc => cheese
+caboose,cookhouse,galley
+cabrales => cheese
+cabstand,taxistand
+cacahuatl => tree
+cacao => tree
+cacatua,kakatoe
+cachaille => cheese
+cache,hoard,stash
+cachet,seal
+cachexia,cachexy,wasting
+caciotta => cheese
+cacique,cazique
+cackle,chatter,yack
+cacodyl,tetramethyldiarsine
+cacography,scratch,scrawl,scribble
+cadaster,cadastre
+cadaver,clay,corpse,remains,stiff
+caddisworm,strawworm
+caddo,caddoan
+cadre,cell
+caeciliadae,caeciliidae
+caecum,cecum
+caenogenesis,cainogenesis,cenogenesis,kainogenesis,kenogenesis
+caerphilly => cheese
+caesalpinia => tree
+caesium,cesium
+cafe,coffeehouse
+caffein,caffeine
+caftan,kaftan
+caiman,cayman
+caimitillo,satinleaf
+cairnsmore => cheese
+cajeput => tree
+calabash,gourd
+calabura,silkwood
+calamari,calamary,squid
+calamine,hemimorphite
+calamity,cataclysm,catastrophe,disaster,tragedy
+calamus,quill,shaft
+calan,isoptin,verapamil
+calcaneus,heelbone
+calcedony,chalcedony
+calceolaria,slipperwort
+calciferol,cholecalciferol,ergocalciferol,viosterol
+calcitonin,thyrocalcitonin
+calculus,tartar,tophus
+calcutta,kolkata
+caldron,cauldron
+calean,chicha,hookah,kalian,narghile,nargileh,sheesha,shisha
+calenzana => cheese
+calf => cattle
+calf,sura
+calibre,caliber
+caliche,hardpan
+caliculus,calycle,calyculus
+caliper,calliper
+calk,calkin
+callathump,callithump
+callback,recall
+calligraphy,chirography,penmanship
+calliophis,callophis
+callipers,calipers
+callistemon => tree
+callisthenics,calisthenics
+callosity,callus
+callowness,jejuneness,juvenility
+calocedrus => tree
+calophyllum => tree
+calorie,kilocalorie
+calpac,calpack,kalpac
+calpe,gibraltar
+calquence,acalabrutinib
+calumniation,calumny,defamation,obloquy,traducement
+calvaria,skullcap
+calves => cattle
+calx,lime,quicklime
+calycle,calyculus,epicalyx
+calyptranthes => tree
+camachile,huamachil
+camas,camash,camass,camosh,quamash
+camassia,quamassia
+cambazola => cheese
+cambodia,kampuchea
+cambria,cymru,wales
+camcevi,leuprolide
+camelia,camellia
+camelid,dromedary,llama,guanaco,alpaca,vicuña
+camelopard,giraffe
+cameroon,cameroun
+camion,dray
+camisole,underbodice
+camo,camouflage
+camomile,chamomile
+camp,clique,coterie,ingroup,pack
+campeachy,logwood
+camphorweed,vinegarweed
+campion,catchfly,silene
+campong,kampong
+camptosar,irinotecan
+campylorhynchus,heleodytes
+camzyos,mavacamten
+canaan,palestine
+canafistola,canafistula
+canagliflozin,metformin
+canal,channel,duct
+cananga,canangium
+canara,kanara
+canarywood => tree
+canasa,mesalamine
+cancel,natural
+cancels,cancelled,cancelling,cancels,canceled,canceling
+cancer,crab
+candela,candle
+candelabra,candelabrum
+candidiasis,moniliasis
+candle,taper
+candleberry => tree
+candlewood => tree
+candour,candor
+candy,confect
+canestrato => cheese
+canicula,sirius,sothis
+canid,canine
+canine,cuspid,dogtooth,eyetooth
+caning,wicker,wickerwork
+canistel,eggfruit
+canister,cannister
+cannabis,ganja,marihuana,marijuana,hemp
+canoe,kayak
+cantala,maguey
+cantaloup,cantaloupe
+cantata,oratorio
+canton,guangzhou,kuangchou,kwangchow
+canvas,canvass
+canvassing,electioneering
+caoutchouc,rubber
+caparison,housing,trapping
+cape,ness
+capelan,capelin,caplin
+capella,gallinago
+capercaillie,capercailzie
+capeweed,gosmore
+capibara,capybara
+capitalisation,capitalization
+caplyta,lumateperone
+capoten,captopril
+cappelletti,ravioli
+caprelsa,vandetanib
+capricorn,goat
+caprimulgid,goatsucker,nightjar
+capsicum,pepper
+capsid,mirid
+capsidae,miridae
+capstone,copestone,stretcher
+captivation,fascination
+capuchin,ringtail
+car,automobile,automotive
+carabiner,karabiner
+carac,fluorouracil
+carack,carrack
+carafate,sucralfate
+carafe,decanter
+caragana => tree
+carageen,carrageen,carragheen
+caranda,caranday
+carapace,cuticle,shell,shield
+carat,karat
+caravane => cheese
+caravansary,caravanserai,khan
+caravanserai,caravanserais,caravansary,caravansaries
+carbamide,urea
+carbatrol,carbamazepine
+carbohydrate,saccharide,sugar
+carbohydride,cementite,heterodiamond,tantalcarbide => 2849909000
+carbonisation,carbonization
+carburettor,carburetor
+carcajou,wolverine
+carcass,carcas,carcases,carcasses
+carcharias,odontaspis
+carchariidae,odontaspididae
+cardamom,cardamon,cardamum
+cardcastle,cardhouse
+cardigan,cardy,cardie
+cardinal,redbird
+cardiogram,electrocardiogram
+cardiograph,electrocardiograph
+cardiomegaly,megacardia,megalocardia
+cardiomyopathy,myocardiopathy
+cardizem,diltiazem
+cardura,doxazosin
+carelian,karelian
+cargo,consignment,freight,lading,load,loading,payload,shipment
+caribe,pirana,piranha
+caribou,reindeer
+caricature,imitation,impersonation
+caries,cavity
+carnation,gillyflower
+carnelian,cornelian
+carols,carolling,caroller,carols,caroling,caroler
+carom,ricochet
+carotene,carotin
+carotenemia,xanthemia
+carousel,carrousel,roundabout,whirligig
+carpet,carpeting
+carpinus => tree
+carpus,wrist
+carrageenan,carrageenin
+carrefour,crossing,crossroad,crossway,intersection
+carrel,carrell,cubicle,stall
+carriage,coach
+carrier,flattop
+carryall,holdall,tote
+carthorse,drayhorse
+cartilage,gristle
+carton,cartonful
+cartoon,sketch
+cartouch,cartouche
+cartroad,track
+caruncle,caruncula
+caryophyllales,chenopodiales
+caryota => tree
+casbah,kasbah
+cascade,shower
+cashbox,till
+cashmere,kashmir
+cask,caskful
+casket,coffin
+casquet,casquetel
+cassava,manioc,casava,manioca
+cassia => tree
+cassie,huisache
+cassite,kassite
+castelleno => cheese
+castelmagno => cheese
+caster,castor
+castigation,earful,upbraiding
+castigliano => cheese
+castile,castilla
+castilleia,castilleja
+castle,palace
+casuarina => tree
+cat => 0106190000,cat
+cat => cat,pet
+catabolism,dissimilation,katabolism
+cataclysm,catastrophe
+catalog,catalogue
+catalpa => tree
+catamenia,flow,menses,menstruation,menstruum,period
+catamount,cougar,painter,panther,puma,lynx
+cataphoresis,dielectrolysis,electrophoresis,ionophoresis
+cataplasm,plaster,poultice
+catapres,clonidine
+catapult,slingshot
+catastrophe,disaster
+catawba => tree
+catchfly,lychnis
+catchweed,cleavers,clivers
+catclaw => tree
+categorem,categoreme
+categorisation,categorization,classification
+category,class,family
+catfish,mudcat,wolffish
+cathay,china
+cathedral,duomo
+cathelain => cheese
+cathflo,alteplase
+catholicon,nostrum,panacea
+catmint,catnip
+catsup,cetchup,ketchup
+cattie,catty
+cattle,bovine,cow,oxen
+caucasia,caucasus
+caudata,urodella
+caudate,urodele
+caudex,stock
+caul,veil
+caulk,caulking
+cause,grounds,reason
+causerie,chitchat,gabfest,gossip
+cauterant,cautery
+caution,caveat
+cautious,timid
+cavalla,cero
+cavalry,horse
+caverject,alprostadil
+caviar,caviare
+cavity,cavum
+cayenne,jalapeno
+cayman => reptile
+cebuan,cebuano
+cecropia => tree
+cedar,cedarwood
+cedrela => tree
+cedrus => tree
+cefadroxil,ultracef
+cefobid,cefoperazone
+cefotaxime,claforan
+ceftazidime,fortaz,tazicef
+ceftin,cefuroxime,zinacef
+ceftriaxone,rocephin
+ceiba => tree
+ceiling,roof
+celandine,jewelweed,swallowwort
+celebes,sulawesi
+celebration,jubilation
+celebrex,celecoxib
+celebrity,fame,renown
+cell,cubicle
+cellaret,minibar
+cellblock,ward
+cello,violoncello
+celluloid,cinema,film
+celom,celoma,coelom
+celontin,methsuximide
+cembalo,harpsichord
+cement,cementum
+cemetery,graveyard,necropolis
+censer,thurible
+censure,exclusion,excommunication
+cent,centime,penny
+cental,centner,hundredweight,quintal
+centaur,centaurus
+center,centre,midpoint
+centerboard,centreboard
+centerfold,centrefold
+centerpiece,centrepiece
+centilitre,centiliter
+centimetre,centimeter
+centner,doppelzentner,hundredweight
+central,exchange
+centrarchid,sunfish
+centre,centres,centred,center,centers,centered
+centrifuge,extractor,separator
+centring,centreboard,centrefold,centrepiece,centering,centerboard,centerfold,centerpiece
+centromere,kinetochore
+century,hundred
+cephalalgia,headache
+cephalaspid,osteostracan
+cephalaspida,osteostraci
+cephalexin,keflex,keflin,keftab
+cephalhematoma,cephalohematoma
+cephalitis,encephalitis,phrenitis
+cephaloglycin,kafocin
+cephalosporin,mefoxin
+cephalotaxus => tree
+ceratin,keratin
+ceratosaur,ceratosaurus
+cercis => tree
+cereal,grain
+cerebromeningitis,encephalomeningitis,meningoencephalitis
+cerement,pall,shroud
+ceremonial,ceremony,observance
+ceriman,monstera
+cerney => cheese
+cero,kingfish,pintado
+certificate,certification,credential,credentials
+certification,corroboration,documentation
+cerumen,earwax
+cervid,deer
+cervix,neck
+cessation,surcease
+cesspit,cesspool,sink,sump
+cestode,tapeworm
+ceylonite,pleonaste
+ch'ing,manchu,qing
+chabad,lubavitch
+chabasite,chabazite
+chabichou => cheese
+chaca => tree
+chachka,tchotchke,tsatske,tshatshke
+chad,chadic,tchad
+chadar,chaddar,chador,chuddar
+chadlock,charlock
+chaff,husk,shuck,stalk,straw,stubble
+chaga,chagga,kichaga
+chagatai,jagatai,jaghatai
+chahta,choctaw
+chairs,seats,seating
+chaise,daybed
+chalcedon,kadikoy
+chalcid,chalcidfly
+chalcidae,chalcididae
+chaldaea,chaldea
+chalice,goblet
+chalk,crank,deoxyephedrine,glass,meth,methamphetamine,methedrine,shabu
+chalkstone,tophus
+challah,hallah
+chalybite,siderite
+chamaecyparis => tree
+chamaeleon,chameleon
+chamberpot,potty
+chamfron,chanfron,frontstall,testiere
+chammy,chamois,shammy
+chanal,chanar
+chandelier,pendant,pendent
+chang,changjiang,yangtze
+changan,hsian,sian,singan,xian
+changeover,conversion,transition
+chantarelle,chanterelle
+chantey,chanty,shanty
+chantilly-tiffany => cat,chantilly-tiffany
+chantix,varenicline
+chaource => cheese
+chap,crack,cranny,crevice,fissure
+chapati,chapatti
+chapeau => hat
+chaplet,coronal,garland,wreath
+char,charr
+characid,characin
+charcoal,fusain
+chari,shari
+charm,spell
+charolais => cheese
+chart,graph
+chartreux => cat,chartreux
+chasidim,chassidim,hasidim,hasidism,hassidim
+chasteberry => tree
+chastening,chastisement,correction
+chastetree => tree
+chat,confab,confabulation,schmoose,schmooze
+chattel,movable
+chaulmoogra,chaulmugra
+chaumes => cheese
+chausie => cat,chausie
+chaw,chew,plug,quid
+chechenia,chechnya
+check,cheque
+checkbook,chequebook
+checker,chequer
+checkerberry,groundberry,teaberry,wintergreen
+cheek,impertinence,impudence
+cheekbone,malar,zygomatic
+cheep,peep
+cheering,shouting
+cheetah,chetah
+cheewink,chewink
+cheiloschisis,harelip
+cheilosis,perleche
+chela,claw,nipper,pincer
+cheloid,keloid
+chelonethida,pseudoscorpiones,pseudoscorpionida
+chelonia,testudinata,testudines
+chelonidae,cheloniidae
+chemet,succimer
+chemisorption,chemosorption
+chemist's,drugstore,pharmacy
+chemulpo,incheon,inchon
+chenfish,kingfish
+chennai,madras
+cheque,chequebook,chequer,chequered,chequers,check,checkbook,checker,checkered,checkers
+cheremis,cheremiss,mari
+cherimolla,cherimoya
+cherimoya => tree
+chermidae,psyllidae
+chest,pectus,thorax
+chevres => cheese
+chevron,stripe,stripes
+chiasm,chiasma,decussation
+chicken,hen,capon,poulet,ameraucana,andalusian,araucana,australorp,barnevelder,brahma,bresse,buckeye,cochin,crevecoeur,cubalaya,delaware,dominique,dorking,faverolles,frizzle,hamburg,houdan,minorca,onagadori,orpingtons,phoenix,sebright,serama,silkie,sussex,welsummer,wyandotte,poulet,volaille
+chickenpox,varicella
+chickpea,garbanzo
+chicory,succory
+chiding,objurgation,scolding
+chiffonier,commode
+chigetai,dziggetai
+chihuahua => dog,chihuahua
+chilblain,chilblains,pernio
+child,children,kid,juvenile,youngster,youth
+childbed,confinement,labor,labour,parturiency,travail
+childhood,puerility
+chili,chilli,chillies
+chill,shivering
+chilling,cooling
+chimneypiece,mantel,mantelpiece,mantle,mantlepiece
+chimp,chimpanzee
+china,chinaware
+chinaberry => tree
+chincapin,chinkapin,chinquapin
+chinchillon,viscacha
+chinchona,cinchona
+chine,meat,chop,rib,cutlet
+chingpo,jinghpaw,jinghpo
+chink,click,clink
+chinook => dog,chinook
+chinquapin => tree
+chionanthus => tree
+chios,khios
+chip,microchip
+chipboard,hardboard
+chipewyan,chippewaian,chippewyan
+chippewa,ojibwa,ojibway
+chippiparai => dog,chippiparai
+chipwood,chipboard
+chirrup,twitter
+chisels,chiselled,chisels,chiseled
+chisinau,kishinev
+chitlings,chitlins,chitterlings
+chiton,polyplacophore
+chittamwood,chittimwood,shittimwood
+chive,chives,cive,schnittlaugh
+chlamyphore,pichiciago,pichiciego
+chlamys,perianth,perigone,perigonium
+chloasma,melasma
+chlorambucil,leukeran
+chloramphenicol,chloromycetin
+chlordiazepoxide,libritabs,librium
+chlorocardium => tree
+chloroform,trichloromethane
+chlorophyl,chlorophyll
+chloropicrin,nitrochloroform
+chlorosis,greensickness
+chlorothiazide,diuril
+chlorpromazine,thorazine
+chlorthalidone,hygroton,thalidone
+chock,wedge
+chocolate,cocoa
+choir,consort
+choker,ruff,ruffle
+chokey,choky
+cholesterin,cholesterol
+chondriosome,mitochondrion
+chongqing,chungking
+chontaleno => cheese
+chophouse,steakhouse
+chopine,platform
+chopper,cleaver
+choppiness,roughness
+choral,chorale
+chordamesoderm,chordomesoderm
+chortai => dog,chortai
+chortle,chuckle
+chorus,refrain
+chosen,elect
+chou,chow,zhou
+chow,chuck,eats,grub
+christmas,xmas
+christmasberry,tollon,toyon
+chrysophyceae,heterokontae
+chuckhole,pothole
+chuddah,chuddar,chudder,chador => shawl
+chunga,seriema
+chymosin,rennin
+cialis,tadalafil
+cibinqo,abrocitinib
+cicada,cicala
+cicatrice,cicatrix,scar
+cider,cyder
+cigaret,cigarette
+cigarfish,quiaquia
+cilantro,coriander
+ciliata,ciliophora
+ciliate,ciliophoran
+cilioflagellata,dinoflagellata
+cilium,eyelash,lash
+cimetidine,tagamet
+cinch,girth
+cincture,girdle,sash,waistband,waistcloth
+cinder,clinker
+cinerarium,columbarium
+cinnamene,phenylethylene,styrene,vinylbenzene
+cinnamonbark => tree
+cinnamonwood => tree
+cinqair,reslizumab
+cinque,five,fivesome,pentad,phoebe,quint,quintet,quintuplet
+cinquefoil => flower
+cipro,ciprofloxacin
+circuit,circumference
+cirque,corrie
+cirrhus,cirrus
+cistern,cisterna
+cistron,factor,gene
+citellus,spermophilus
+cither,cithern,citole,cittern,gittern,zither,zithern
+citizenry,people
+citronwood,sandarac
+civies,civvies
+civray => cheese
+clack,clap
+cladding,facing
+cladode,cladophyll,phylloclad,phylloclade
+cladrastis => tree
+clamp,clinch
+clamshell,grapple
+clan,kindred,tribe
+clang,clangor,clangoring,clangour,clank,clash,crash
+clangour,clangor
+clarification,elucidation,illumination
+clarinettist,clarinetist
+classroom,schoolroom
+claudication,gameness,gimp,gimpiness,lameness,limping
+clavicle,collarbone
+clavier,fingerboard,klavier
+clavus,corn
+claxon,klaxon
+clayware,pottery
+cleaner,cleanser
+cleanup,killing
+clearance,headroom,headway
+clearing,glade
+clearstory,clerestory
+clearweed,richweed
+cleavage,segmentation
+cleft,crack,crevice,fissure,scissure
+cleg,clegg,horsefly
+cleistocarp,cleistothecium
+clemency,mildness
+clench,clinch
+cleome,spiderflower
+clerisy,intelligentsia
+clew,clue
+clianthus => flower
+click,detent,pawl
+client,guest,node
+cliff,drop
+climax,culmination
+climb,climbing,mounting
+climber,crampon,crampoon
+clincher,determiner
+cling,clingstone
+clink,gaol,jail,jailhouse,pokey,poky,slammer
+clinocephalism,clinocephaly
+clinometer,inclinometer
+clinoril,sulindac
+clioquinol,iodochlorhydroxyquin
+clipper,limiter
+clipping,cutting
+cloaca,sewer,sewerage
+cloakroom,coatroom
+clobber,stuff
+clog,geta,patten,sabot
+clomid,clomiphene
+clon,clone
+clone,knockoff
+clop,clopping,clumping,clunking
+closet,cupboard,wardrobe
+clostridia,clostridium
+closure,cloture
+clot,coagulum
+cloth,fabric,material,textile
+clotting,coagulation,curdling
+cloud,swarm
+cloudburst,deluge,downpour,pelter,soaker,torrent,waterspout
+cloudiness,overcast
+clover,trifolium,trefoil
+clowning,comedy,drollery,funniness
+clozapine,clozaril
+clubfoot,talipes
+cluck,clucking
+clue,hint
+clump,clunk,thud,thump,thumping
+clusia => tree
+clusiaceae,guttiferae
+clutchbag,handbag
+clutter,fuddle,jumble,muddle,smother,welter
+cnidaria,coelenterata
+cnidarian,coelenterate
+cnossos,cnossus,knossos
+coachwhip,ocotillo
+coagulant,coagulator
+coal,ember
+coalbin,coalhole
+coalition,fusion
+coarctation,constriction
+coarseness,saltiness
+coartem,artmether,lumefantrine
+coast,seacoast,seashore
+coatrack,hatrack
+cobalamin,cyanocobalamin
+cobble,cobblestone,sett
+cobnut,filbert
+cobweb,gossamer
+coca,pepsi
+cocain,cocaine
+cocci,coccus
+coccidioidomycosis,coccidiomycosis
+coccidium,eimeria
+coccothrinax => tree
+cock,rooster
+cockateel,cockatiel
+cocklebur,cockleburr
+cockroach,roach
+cockscomb,coxcomb
+cocksfoot,cockspur
+coco => tree
+coco,coconut
+cocoanut => tree
+cocoanut,coconut
+cocopa,cocopah
+cocoswood,cocuswood
+coda,finale
+code,codification
+coerebidae,dacninae
+coevals,contemporaries,generation
+coffea => tree
+coffee,java
+cogwheel,gear
+coherence,coherency,cohesion,cohesiveness
+coho,cohoe
+coif,coiffure,hairdo,hairstyle
+coign,coigne,quoin
+coinage,neologism,neology
+coincidence,happenstance
+cojack => cheese
+cola,dope
+colander,cullender
+colazal,balsalazide
+colcrys,colchicine
+cole,kail,kale
+coleslaw,slaw
+colestid,colestipol
+colic,gripes,griping
+colicwood => tree
+colin,pollock,pollack
+collage,montage
+collar,neckband
+collectable,collectible
+collection,compendium
+collembolan,springtail
+collet,ferrule
+colligation,conjugation,conjunction,junction
+collusion,connivance
+collyrium,eyewash
+cologne,koln
+colorcast,colourcast
+colorimeter,tintometer
+coloring,colouring
+colostrum,foremilk
+colour,coloured,colourfast,colourful,color,colored,colorfast,colorful,colorize
+colpocele,vaginocele
+colpocystocele,cystocele
+colter,coulter
+coltsfoot => flower
+columba,dove
+columbarium,columbary,dovecote
+columbine => flower
+columbite,niobite
+column,pillar
+colymbiformes,podicipediformes,podicipitiformes
+combine,combining
+combivir,lamivudine,ziovudine
+combretum => tree
+come,ejaculate,seed,semen
+comeback,counter,rejoinder,replication,retort,return,riposte
+comestible,eatable,edible,pabulum,victual,victuals
+comeupance,comeuppance
+comforter,pacifier
+comfrey,cumfrey
+command,instruction,statement
+commelinales,xyridales
+commencement,graduation
+commensurateness,correspondence,proportionateness
+comminuted,pulverised
+commiseration,condolence
+commissariat,provender,provisions,viands,victuals
+commitment,dedication
+commode,crapper,potty,stool,throne,toilet
+commodity,good
+common,commons,green,park
+commonality,commonalty,commons
+commonness,expectedness
+communicating,communication
+communion,sharing
+communique,despatch,dispatch
+comp,comprehensive
+compact,concordat,covenant
+compaction,compression,concretion,densification
+companionship,company,fellowship,society
+compartmentalisation,compartmentalization
+competition,contest
+compilation,digest
+complera,emtricitabine,rilpivirine
+complication,ramification
+compliments,regard,wish
+computer,laptop
+comte => cheese
+conakry,konakri
+concavity,incurvation,incurvature
+conceding,concession,yielding
+conceivability,conceivableness
+conception,creation
+conceptus,embryo
+concertina,bandoneon,squeezebox => accordion
+concession,grant
+conciseness,concision,pithiness,succinctness
+concoction,intermixture,mixture
+concourse,multitude,throng
+concurrence,concurrency
+condensate,condensation
+condescension,disdain,patronage
+condo,condominium
+condom,prophylactic,rubber
+conduction,conductivity
+conessi,kurchee,kurchi
+confection,sweet
+confectionary,confectionery
+confederacy,confederation,federation
+conference,league
+confidence,trust
+confirmation,ratification
+conflagration,inferno
+conflict,difference,dispute
+confluence,meeting
+confrontation,encounter,showdown
+conge,congee
+congealment,congelation
+congee,jook
+congenator,congener,congeneric,relative
+congius,gallon
+conglobation,conglomeration
+conglomerate,empire
+conglutination,union
+congo,congou,zaire
+congratulation,felicitation
+congratulations,extolment,kudos,praise
+congregation,faithful,fold
+conidiospore,conidium
+coniferophyta,coniferophytina,coniferopsida
+conjecture,guess,hypothesis,speculation,supposition,surmisal,surmise
+conjunctivitis,pinkeye
+conjuration,incantation
+connecter,connection,connective,connector,connexion
+connection,connexion,link
+conniption,scene,tantrum
+connotation,intension
+conodonta,conodontophorida
+consequence,effect,event,issue,outcome,result,upshot
+conservation,preservation
+conservatoire,conservatory
+conservatory,hothouse
+conserve,conserves,preserve,preserves
+consideration,retainer
+consortium,pool,syndicate
+constabulary,police
+constantan,eureka
+constantinople,istanbul,stamboul,stambul
+constipation,irregularity
+constraint,restraint
+consuetudinal,consuetudinary
+consumption,phthisis,usance
+contagion,infection
+contaminant,contamination
+contamination,taint
+contempt,scorn
+contingence,contingency,eventuality
+contingent,detail
+continuation,sequel
+contortion,crookedness,torsion,tortuosity,tortuousness
+contrabassoon,contrafagotto
+contraceptive,preventative,preventive
+contract,declaration
+contrary,opposite,reverse
+contribution,donation
+control,controller
+conundrum,enigma,riddle
+conurbation,sprawl
+convalescence,recovery,recuperation
+convenience,restroom
+conventicle,meetinghouse
+converter,convertor
+conveyer,conveyor,transporter
+coolea => cheese
+cooleney => cheese
+cooler,tank
+coolwart,foamflower
+coon,ringtail
+coop,hencoop,henhouse
+copal => tree
+copaline,copalite
+cope,coping,header
+copeck,kopeck,kopek
+copenhagen,kobenhavn
+copernicia => tree
+copey => tree
+copier,duplicator
+copperwood => tree
+copra,nucifera
+coprolith,faecalith,fecalith,stercolith
+copula,copulative
+copy,transcript
+coquetdale => cheese
+coracan,corakan,kurakkan,ragee,ragi
+coralberry,spiceberry
+coralroot,coralwort
+corbel,truss
+cord,corduroy
+cordia => tree
+cordial,liqueur
+cordoba,cordova
+cords,corduroys
+core,nucleus
+coreopsis,tickseed,tickweed
+corgard,nadolol
+corinth,korinthos
+corium,derma,dermis
+cork,phellem
+corlanor,ivabradine
+corleggy => cheese
+cornel,dogwood
+cornet,horn,trump,trumpet
+cornflour,cornstarch,maizeflour
+cornflower,strawflower
+cornice,pelmet,valance
+cornpone,pone
+cornus => tree
+corona,corposant
+coronach,dirge,lament,requiem,threnody
+coronation,enthronement,enthronisation,enthronization,investiture
+corozo => tree
+corp,corporation
+corporation,potbelly,tummy
+corpus,principal
+corrective,restorative
+correlation,correlativity
+corrodentia,psocoptera
+corroding,corrosion,erosion
+corruption,putrescence,putridness,rottenness
+corselet,corslet
+corset,girdle,stays
+cortef,cortisol,hydrocortisone,hydrocortone
+cortege,entourage,retinue,suite
+cortex,pallium
+cortices,cortexes
+corticoid,corticosteroid
+cortrophin,corticotropin
+corundom,corundum
+coruscation,glitter,sparkle
+corvus,crow
+corydalis,corydalus
+corymbia => tree
+corypha => tree
+corythosaur,corythosaurus
+coryza,rhinitis
+cosec,cosecant
+cosela,trilaciclib
+cosentyx,secukinumab
+cosiness,coziness,snugness
+cosmea,cosmos
+cosmegen,dactinomycin
+cosmos,creation,existence,macrocosm,universe,world
+costalgia,pleuralgia,pleurodynia
+cosy,cozy
+cotan,cotangent
+cotellic,cobimetinib
+cotherstone => cheese
+cothromboplastin,proconvertin
+cotija => cheese
+cotilion,cotillion
+cottar,cotter
+cottonwood => tree
+couch,lounge,sofa
+cough,coughing
+coulommiers => cheese
+coumadin,warfarin
+coumarouna,dipteryx
+councillor,councilor
+counsel,counseling,counselling,direction,guidance
+counsels,counselled,counselling,counsellor,counsels,counseled,counseling,counselor
+counter,tabulator
+counterbalance,offset
+counterbore,countersink
+countercurrent,crosscurrent,riptide
+counterfeit,forgery
+counterfoil,stub
+counterglow,gegenschein
+counterpart,similitude,twin
+coupler,coupling
+coupling,yoke
+coupon,voucher
+courgette,zucchini
+couroupita => tree
+courting,courtship,suit,wooing
+couscous,kuskus
+cover,covering
+coverage,reportage,reporting
+coverdale => cheese
+covertness,hiddenness
+coville,hediondilla
+cowberry,foxberry,lingberry,lingenberry,lingonberry
+cowhide,cowskin
+cowpox,vaccinia
+cowrie,cowry
+cowslip,kingcup,paigle
+coyo => tree
+coypu,nutria
+crab,crabmeat
+cracker,snapper
+crackerjack,jimdandy,jimhickey
+crackling,greaves
+cracow,krakau,krakow
+cradle,rocker
+cramp,spasm
+crampfish,numbfish,torpedo
+crampon,crampoon
+crane,grus
+craniata,vertebrata,vertebrate
+crank,starter
+crape,crepe
+crash,wreck
+crataegus => tree
+crate,crateful
+craw,crop
+crawdad,crawfish,crayfish,ecrevisse
+crayfish,langouste
+craze,delirium,frenzy,fury,hysteria
+craziness,daftness,flakiness
+crazyweed,locoweed
+creak,creaking
+creashak,mealberry,sandberry
+creatin,creatine
+credence,credenza
+credit,recognition
+creed,gospel
+crematorium,crematory
+crenation,crenature,crenel,crenelle,scallop
+crenel,crenelle
+crescenza => cheese
+crete,kriti
+crew,gang
+crewet,cruet
+crib,pony,trot
+crick,kink,rick,wrick
+crill,krill
+criminalism,criminality,criminalness
+crimper,curler,roller
+cringle,eyelet,grommet,grummet,loop
+crinion,trichion
+crinkleroot,toothwort
+crinoline,hoopskirt
+crinone,progesterone
+crit,criterium
+criterion,measure,standard,touchstone
+criticality,criticalness,cruciality
+critique,review
+crixivan,indinavir
+croak,croaking
+croatia,hrvatska
+crochet,crocheting
+crock,lampblack,smut,soot
+crockery,dishware
+crocodile => reptile
+crocodilia,crocodylia
+crocodilus,crocodylus
+croghan => cheese
+cromlech,dolmen
+cromorne,crumhorn,krummhorn
+crop,harvest
+crosier,crozier
+cross,crossbreed,hybrid
+crossbeam,crosspiece,trave,traverse
+crosscut,cutoff,shortcut
+crosshead,crossheading
+crossopterygian,lobefin
+crosstie,sleeper
+crotal,crottal,crottle
+crotalaria,rattlebox
+crotch,genitalia,genitals,privates
+crotchet,hook
+croup,croupe,hindquarters,rump
+crowdie => cheese
+crowfoot => flower
+crowley => cheese
+crown,diadem
+crucifix,rood
+crud,filth,skank
+crudeness,crudity,primitiveness,primitivism,rudeness
+crueller,cruellest,crueler,cruelest
+cruller,twister
+crush,press
+crust,encrustation,incrustation
+crustacean,shellfish
+cryaesthesia,cryesthesia
+cryoanaesthesia,cryoanesthesia
+cryopathy,frostbite
+cryptogram,cryptograph
+cryptomonad,cryptophyte
+cryptorchidism,cryptorchidy,cryptorchism
+crystallisation,crystallization,crystallizing
+crysvita,burosumab-twza
+cuajada => cheese
+cubby,cubbyhole,snug,snuggery
+cubbyhole,pigeonhole
+cubitus,elbow
+cucumber,cuke
+cudgels,cudgelled,cudgelling,cudgels,cudgeled,cudgeling
+cudweed,filago
+cuff,handcuff,handlock,manacle
+cultivation,culture,finish,polish,refinement
+cultivator,tiller
+cummerbund,kummerbund
+cumquat,kumquat
+cumulonimbus,thundercloud
+cuneus,wedge
+cunt,puss,pussy,slit,snatch,twat
+cuon,cyon
+cupflower,nierembergia
+cuppa,cupper
+cupressus => tree
+cuprimine,penicillamine
+cuquenan,kukenaam
+curacao,curacoa
+curare,tubocurarine
+curative,cure,remedy,therapeutic
+curb,curbing,kerb
+curbstone,kerbstone
+curet,curette
+curing,hardening,solidification,solidifying
+curio,curiosity,oddity,oddment,peculiarity,rarity
+curl,lock,ringlet,whorl
+curlicue,squiggle
+currajong,kurrajong
+curriculum,program,programme,syllabus
+cursinu => dog,cursinu
+cursive,longhand
+cursor,pointer
+curtain,drape,drapery,pall
+curtilage,grounds,yard
+curtsey,curtsy
+curworthy => cheese
+cusco,cuzco
+cushat,ringdove
+cushion,shock
+cushioning,padding
+cusk,torsk
+cusp,leaflet
+cuspidor,spittoon
+cussonia => tree
+custody,detainment,detention,hold
+custom,customs,impost
+customhouse,customshouse
+cutch,kutch
+cuticle,epidermis
+cutis,skin,tegument
+cutlas,cutlass
+cutlassfish,hairtail
+cutlery => cutlery,dinnerware
+cutlet,escallop,scallop,scollop
+cutter,pinnace,tender
+cutting,slip
+cuttle,cuttlefish
+cyanamid,cyanamide
+cyanide,nitril,nitrile
+cyanite,kyanite
+cyanuramide,melamine
+cyathea => tree
+cyberspace,internet
+cycadofilicales,lyginopteridales
+cycadophyta,cycadophytina,cycadopsida
+cyclades,kikladhes
+cycle,oscillation
+cyclobenzaprine,flexeril
+cyclopaedia,cyclopedia,encyclopaedia,encyclopedia
+cyclorama,diorama,panorama
+cyclosis,streaming
+cydippea,cydippida,cydippidea
+cylix,kylix
+cyma,cymatium
+cymbalta,duloxetine
+cymbid,cymbidium
+cymograph,kymograph
+cymric,welsh
+cypre,princewood,salmwood
+cypresses => tree
+cyproheptadine,periactin
+cyprus => cat,cyprus
+cyramza,ramucirumab
+cyrilla,leatherwood
+cyst,vesicle
+cystoparalysis,cystoplegia
+cytidine,deoxycytidine
+cytogenesis,cytogeny
+cytokinin,kinin
+cytol,cytoplasm
+cytosmear,smear
+cytotec,misoprostol
+d.p.r.k.,dprk
+daba,kola,musgoi
+dacca,dhaka
+dachshund,dachsie => dog,dachshund
+dacron,terylene
+dacryodes => tree
+dactyl,digit
+dada,dadaism
+dado,wainscot
+daffodil => flower
+dahl,dhal
+dahlia => flower
+daikon,radish
+dainty,delicacy,goody,kickshaw,treat
+dairen,dalian,talien
+daishiki,dashiki
+daisy => flower
+dalbergia => tree
+daliresp,roflumilast
+dallisgrass,paspalum
+dalmane,flurazepam
+dalmatian => dog,dalmatian
+daltonism,deuteranopia
+dalvance,dalbavancin
+damar,dammar
+damascus,dimash
+dammar => tree
+damp,dampness,moistness
+dampener,moistener
+damper,muffler
+damselfish,demoiselle
+danau,danube
+dandelion => flower
+dandy,yawl
+dangaleat,dangla
+danmark,denmark
+danzig,gdansk
+daralagjazsky => cheese
+daraprim,pyrimethamine
+dard,dardic
+dardanelles,hellespont
+dare,daring
+dari,durra,sorghum,sorgum,broomcorn
+daricon,oxyphencyclimine
+darmera,peltiphyllum
+darn,mend,patch
+darvon,propoxyphene
+darzalex,daratumumab
+dash,hyphen
+dashboard,fascia
+dasheen,taro,dasheen,edda,dalo,eddo
+data,information
+dauphin => cheese
+daurismo,glasdegib
+dawn,morning
+daybook,ledger
+dayflower,spiderwort
+dayfly,mayfly,shadfly
+daypro,oxaprozin
+daystar,lucifer,phosphorus
+dayvigo,lemborexant
+deadlock,impasse,stalemate,standstill
+dealership,franchise
+dealings,relations
+deamination,deaminization
+dearth,famine,shortage
+debilitation,enervation,enfeeblement,exhaustion
+debility,feebleness,frailness,frailty,infirmity,valetudinarianism
+debris,detritus,dust,junk,rubble
+decadence,decadency,degeneracy,degeneration
+decadron,dexamethasone,dexone,hexadrol,oradexon
+decagram,dekagram
+decal,decalcomania
+decaliter,decalitre,dekaliter,dekalitre
+decameter,decametre,dekameter,dekametre
+decametre,decameter
+deceit,deception,misrepresentation
+decentalisation,decentralization
+decilitre,deciliter
+decimetre,decimeter
+decolourise,decolorize
+decomposition,disintegration
+decoration,ornament,ornamentation
+decree,edict,fiat,order,rescript
+decrepitude,dilapidation
+dedication,inscription
+deduction,discount
+deed,title
+deedbox,strongbox
+deep,trench
+deepfreeze,freezer
+defeat,licking
+defeated,discomfited
+defecation,laxation,shitting
+defect,fault,flaw
+defectiveness,faultiness
+defence,defense
+deferral,recess
+deficiency,lack,want
+defile,gorge
+defining,shaping
+deformation,distortion
+deformity,malformation,misshapenness
+defroster,deicer
+defunctness,extinction
+degree,level,point,stage
+dejection,faeces,feces,ordure,stool
+dejeuner,lunch,luncheon,tiffin
+delavirdine,rescriptor
+deli,delicatessen
+delineation,depiction,limning
+deliquium,faint,swoon,syncope
+delivery,speech
+dell,dingle
+delstrigo,doravirine,lamivudine
+deltasone,meticorten,orasone,prednisone
+deluge,flood,inundation,torrent
+delzicol,mesalamine
+demagnetisation,demagnetization
+demagoguery,demagogy
+demarcation,limit
+demeanour,demeanor
+dementedness,dementia
+demerol,meperidine
+demineralisation,demineralization
+demo,demonstration
+demodulator,detector
+demolition,destruction,wipeout
+demonstration,monstrance
+demoralisation,demoralization
+demotic,romaic
+demser,metyrosine
+demur,demurral,demurrer
+demythologisation,demythologization
+denali,mckinley
+denavir,penciclovir
+dendraspis,dendroaspis
+denial,disaffirmation
+denim,jean,jeans
+denotation,indication
+denouncement,denunciation
+densimeter,densitometer
+dent,incision,prick,scratch,slit
+dentin,dentine
+dentition,teeth
+denture,plate
+deodorant,deodourant
+deoxyguanosine,guanosine
+deoxythymidine,thymidine
+depakote,divalproex
+department,section
+dependance,dependence,dependency
+depersonalisation,depersonalization
+depilation,hairlessness
+depilator,depilatory,epilator
+depolarisation,depolarization
+depreciation,derogation,disparagement
+depredation,ravage
+depressant,downer,sedative
+deprivation,neediness,privation,want
+derangement,unbalance
+derivation,deriving,etymologizing
+dermatomycosis,dermatophytosis
+dermatosclerosis,scleroderma
+desalination,desalinisation,desalinization
+descant,discant
+descendants,posterity
+descensus,prolapse,prolapsus
+desensitisation,desensitization
+deshabille,dishabille
+desiccant,drier,siccative
+design,figure,pattern
+desolation,devastation
+despair,desperation
+despatch,dispatch
+desquamation,peeling,shedding
+dessertspoon,dessertspoonful
+destalinisation,destalinization
+destination,finish,goal
+destiny,fate
+desyrel,trazodone
+detachment,insularism,insularity,insulation
+detail,item,particular
+detailing,particularisation,particularization
+detector,sensor
+deterioration,impairment
+determent,deterrence,intimidation
+determinant,epitope
+determinative,determiner
+detriment,hurt
+deuce,devil,dickens
+deuteromycota,deuteromycotina
+deutschland,germany
+deutschmark,mark
+devanagari,nagari
+developing,development
+devilfish,manta,octopus
+devon,devonshire
+dexilant,dexlansoprazole
+dextrous,dexterous
+dflp,pdflp
+dhak,palas
+dhau => tree
+dhava,dhawa
+dhawa => tree
+dhawra => tree
+dhodhekanisos,dodecanese
+diabeta,glyburide,micronase
+diacetylmorphine,heroin
+diaeresis,dieresis
+diaglyph,intaglio
+diagonal,separatrix,slash,solidus,stroke,virgule
+dialog,dialogue,duologue
+dialogue,negotiation,talks
+dials,dialled,dialler,dialling,dials,dialed,dialer,dialing
+diamante,sequin,spangle
+diaper,napkin,nappy
+diaphoresis,hidrosis,perspiration,sudation,sweating
+diaphragm,pessary
+diaphysis,shaft
+diarchy,dyarchy
+diarrhea,diarrhoea,looseness
+diatomite,kieselguhr
+diatribe,fulmination
+diazepam,valium
+diazoxide,hyperstat
+dibber,dibble
+dibrach,pyrrhic
+dibranch,dibranchiate
+dibranchia,dibranchiata
+dicamptodon,dicamptodontid
+dichotomy,duality
+dichromacy,dichromasy,dichromatism,dichromatopsia,dichromia
+dickey,dickie,dicky
+dickeybird,dickybird
+dicloxacillin,dynapen
+dicot,dicotyledon,exogen,magnoliopsid
+dicotyledonae,dicotyledones,magnoliopsida
+dicoumarol,dicumarol
+dictionary,lexicon
+dictum,pronouncement
+didanosine,dideoxyinosine
+diddley,diddly,diddlyshit,diddlysquat,jack,shit,squat
+dideoxycytosine,zalcitabine
+dielectric,insulator,nonconductor
+diestrum,diestrus
+diethylstilbesterol,stilbesterol
+diethylstilbestrol,diethylstilboestrol,stilbestrol,stilboestrol
+difference,remainder
+differentiation,specialisation,specialization
+diffuser,diffusor
+diflucan,fluconazole
+diflunisal,dolobid
+digenesis,metagenesis
+digger,excavator
+digit,figure
+digitalin,digitalis,foxglove
+digitiser,digitizer
+digoxin,lanoxin
+digram,digraph
+dihydroxyphenylalanine,dopa
+dike,dyke
+dilantin,diphenylhydantoin,phenytoin
+dilapidation,ruin
+dilatation,distension,distention
+dilater,dilator
+dilaudid,hydromorphone
+diluent,dilutant,thinner
+dimenhydrinate,dramamine
+dimness,duskiness
+dinge,dinginess
+dinghy,dory,rowboat
+dingo => dog,dingo
+dinkey,dinky
+dinoceras,uintathere
+diol,glycol
+diopter,dioptre
+diospyros => tree
+diovan,valsartan
+dipladenia,mandevilla
+diploma,sheepskin
+diplopoda,myriapoda
+dipper,plough,wagon,wain
+dippers,dunkers
+dipteran,dipteron
+direction,instruction
+dirtiness,uncleanness
+disability,disablement,handicap,impairment
+disabled,handicapped
+disagreement,dissension,dissonance
+disarrangement,disorganisation,disorganization
+disassociation,dissociation
+disavowal,disclaimer
+disbursal,disbursement,expense
+disc,disk,platter,record
+discharge,emission,expelling
+disclosure,revealing,revelation
+disco,discotheque
+discolour,discoloured,discolor,discolored
+discomfort,uncomfortableness
+disconnectedness,disconnection,disjunction,disjuncture
+discount,rebate
+discourtesy,disrespect
+discredit,disrepute
+discrepancy,variance,variant
+discreteness,distinctness,separateness,severalty
+discussion,word
+disembowels,disembowelled,disembowels,disemboweled
+disfavor,disfavour
+disfavour,disfavor
+disfunction,dysfunction
+disgrace,ignominy,shame
+dish,saucer
+dishcloth,dishrag
+dishevelled,disheveled
+diskette,floppy
+dislocation,disruption
+distillate,distillation,distillment
+distributer,distributor
+district,dominion,territory
+disulphide,disulfide
+disuse,neglect
+ditchmoss,elodea,pondweed
+dither,flap,fuss,pother,tizzy
+dittany => flower
+dittany,fraxinella
+divan,diwan
+diver,loon
+divertimento,serenade
+division,variance
+dizziness,giddiness,lightheadedness,vertigo
+djakarta,jakarta
+dmus,musd
+dnipropetrovsk,yekaterinoslav
+dobermann => dog,dobermann
+dobrich,tolbukhin
+docudrama,documentary,infotainment
+dodder => flower
+dodge,dodging,scheme
+dog => 0106190000,dog
+doggerel,jingle
+doghouse,kennel
+dogie,dogy,leppy
+dogma,tenet
+dogwood => tree
+doily,doyley,doyly
+dojolvi,triheptanoin
+dolcelatte => cheese
+doldrums,stagnancy,stagnation
+doll,dolly
+dollarfish,horsefish,horsehead,moonfish
+dolman,robe
+dolphin,dolphinfish,mahimahi
+dolphinfish,mahimahi
+domain,world
+domination,mastery,supremacy
+dominick,dominique
+dominion,rule
+donjon,dungeon,keep
+donut,doughnut,sinker
+doodle,scrabble,scribble
+doolin => cheese
+door,doorway,threshold
+doorcase,doorframe
+doorhandle,doorknob
+doorjamb,doorpost
+doorknocker,knocker,rapper
+doorsill,doorstep,threshold
+doorstop,doorstopper
+dopamine,dopastat,intropin
+doppelrhamstufel => cheese
+doptelet,avatrombopag
+doriden,glutethimide
+dorm,dormitory,hall
+dormancy,quiescence,quiescency
+dory,walleye
+dosage,dose
+dosemeter,dosimeter
+dossal,dossel
+dosshouse,flophouse
+dotrel,dotterel
+doukhobor,dukhobor
+doura,dourah,durra
+dovato,dolutegravir,lamivudine
+dove,squab
+dowdy,pandowdy
+dowel,joggle
+dower,dowery,dowry
+down,pile
+dowser,waterfinder
+doxycycline,vibramycin
+dozen,twelve
+dozens,gobs,heaps,lashings,loads,lots,oodles,piles,rafts,scads,scores,slews,stacks,tons,wads
+dracaena => tree
+dracaenaceae,dracenaceae
+draco,dragon
+draft,draught
+dragger,trawler
+dragnet,trawl
+drain,drainpipe
+drama,play
+dravidian,dravidic
+draw,standoff
+drawknife,drawshave
+drawstring,string
+dreadnaught,dreadnought
+dreck,schlock,shlock
+dregs,settlings
+dresser,vanity
+drever => dog,drever
+drib,driblet,drop
+drier,dryer
+drinkwear,drinkware,drinksware
+drip,dripping
+drippage,dripping
+dripstone,hoodmold,hoodmould
+drivel,garbage
+drizzle,mizzle
+drogue,sock,windsock
+drone,droning,monotone
+drop,fall
+dropline,stephead
+droppings,dung,muck
+dropsy,edema,hydrops,oedema
+droshky,drosky
+dross,scoria,slag
+drought,drouth
+drove,horde,swarm
+drowsiness,sleepiness,somnolence
+droxia,hydroxyurea
+drumbeat,rataplan
+drumhead,head
+drunkenness,inebriation,inebriety,insobriety,intoxication,tipsiness
+dryness,waterlessness,xerotes
+drypetes => tree
+drywall,wallboard
+duavee,bazedoxifene
+dubnium,hahnium
+dubrovnik,ragusa
+duchy,dukedom
+ductule,ductulus
+duddleswell => cheese
+duds,threads,togs
+duels,duelled,duelling,dueller,duellist,duels,dueled,dueling,dueler,duelist
+duet,duette
+duffel,duffle
+dugout,pirogue
+dumptruck => dumper,tipper
+dunbarra => cheese
+dunghill,midden,muckheap,muckhill
+dunker => dog,dunker
+dunkerque,dunkirk
+dunlop => cheese
+dunnock,sparrow
+duobrii,tazarotene
+duodecimal,twelfth
+duopa,carbidopa
+dupixent,dupilumab
+durabolin,kabolin,nandrolone
+duramen,heartwood
+durazzo,durres
+durham,shorthorn
+durian,durion
+durio => tree
+duroblando => cheese
+durrus => cheese
+dusanbe,dushanbe,dyushambe,stalinabad
+dustcloth,duster,dustrag
+dustman,dustmen
+dustpan,dustpanful
+dustup,quarrel,words,wrangle
+duty,tariff
+duvet,eiderdown
+dwarfism,nanism
+dwelf => cat,dwelf
+dyeweed,greenweed,whin,woadwaxen,woodwaxen
+dyirbal,jirrbal
+dynamometer,ergometer
+dysosmia,parosamia
+dyspepsia,indigestion
+dyspnea,dyspnoea
+dysport,abobotulinumtoxina
+eagle,secretarybird,osprey,milvus,milvus,lammergeier,bateleur,shikra,besra,buteo,buteo
+earache,otalgia
+eardrum,myringa,tympanum
+earflap,earlap
+earphones,headphones
+earreach,earshot,hearing
+earth,earth,globe,world,ground,land
+earthball,puffball
+earthnut,truffle
+earthquake,quake,seism,temblor
+ease,relief
+easing,moderation,relief
+eatage,forage,grass,pasturage,pasture
+eatery,restaurant
+ebbing,wane
+ebit,exabit
+ebonite,vulcanite
+ecclesiasticus,sirach
+eccyesis,metacyesis
+ecdysis,molt,molting,moult,moulting
+ecesis,establishment
+echinococcosis,hydatidosis
+echogram,sonogram
+ecigarettes,e-cigarettes
+eclipse,occultation
+eclipsis,ellipsis
+ecphonesis,exclamation
+ectasia,ectasis
+ectoblast,ectoderm,exoderm
+ectoparasite,ectozoan,ectozoon,epizoan,epizoon
+ectotherm,poikilotherm
+ecumenicalism,ecumenicism,ecumenism
+ecumenism,oecumenism
+edacity,esurience,ravenousness,voraciousness,voracity
+edarbyclor,chlorthalidone
+eddy,twist
+edelpilz => cheese
+eden,heaven,nirvana,paradise
+editing,redaction
+edronax,reboxetine
+edurant,rilpivirne
+eelpout,pout
+effigy,image,simulacrum
+efflorescence,rash,roseola
+effluence,efflux,outflow
+effluent,wastewater
+efudex,fluorouracil
+egalite,egality
+eggar,egger
+eggbeater,eggwhisk
+eggshell,shell
+eibit,exbibit
+eight,eighter,octad,octet,octonary,ogdoad,viii
+eighteen,xviii
+eightsome,octet,octette
+eighty,fourscore,lxxx
+eire,ireland
+ejaculation,interjection
+elaeagnus => tree
+elaeis => tree
+elam,susiana
+elamite,elamitic,susian
+elasmobranch,selachian
+elasmobranchii,selachii
+elater,elaterid
+elecare,elecare
+electricity,power
+electroencephalogram,encephalogram
+electron,negatron
+elegy,lament
+elevation,lift,raising
+elevator,lift
+elidel,pimecrolimus
+elimination,evacuation,excreting,excretion,voiding
+eliquis,apixaban
+elisabethville,lubumbashi
+elitek,rasburicase
+elixophyllin,theobid,theophylline
+ellas,greece
+ellence,epirubicin
+ellipse,oval
+elongation,extension
+eloquence,fluency,smoothness
+elzonris,tagraxofusp-erzs
+emanation,procession,rise
+embellishment,embroidery
+embiodea,embioptera
+embouchure,mouthpiece
+embrocation,liniment
+embroidery,fancywork
+embroilment,imbroglio
+emend,aprepitant
+emergence,growth,outgrowth
+emergency,exigency,pinch
+emeside,ethosuximide,zarontin
+emetic,nauseant,vomit,vomitive
+emflaza,deflazacort
+emgality,galcanezumab-gnlm
+eminence,tubercle,tuberosity
+emlett => cheese
+emmental,emmentaler,emmenthal,emmenthaler => cheese
+emmet,pismire
+empagliflozin,metformin
+empaveli,pegcetacoplan
+empennage,tail
+empire,imperium
+empliciti,elotuzumab
+employ,employment
+empyrean,firmament,heavens,sphere,welkin
+emtriva,emtricitabine
+emverm,mebendazole
+enalapril,vasotec
+enamel,enamels,enamelled,enamel,enamels,enameled
+enanthem,enanthema
+enantiomer,enantiomorph
+enbrel,etanercept
+encainide,enkaid
+encephalogram,pneumoencephalogram
+enchantment,spell,trance
+enchiridion,handbook
+enclosure,inclosure
+encomium,eulogy,paean,panegyric,pean
+encounter,meeting
+encroachment,intrusion,invasion
+encrustation,incrustation
+encyclopaedia,encyclopaedic,encyclopedia,encyclopedic
+endangerment,hazard,jeopardy,peril,risk
+endeavour,endeavor
+ending,termination
+endive,escarole,witloof
+endoblast,endoderm,entoblast,entoderm,hypoblast
+endocarp,stone
+endocrine,hormone
+endogamy,inmarriage,intermarriage
+endogen,liliopsid,monocot,monocotyledon
+endometritis,metritis
+endoparasite,endozoan,entoparasite,entozoan,entozoon
+endoprocta,entoprocta
+endpoint,termination,terminus
+endurance,survival
+energid,protoplast
+energiser,energizer
+energy,vitality
+enets,entsi,entsy,yenisei,yeniseian
+enflurane,ethrane
+engagement,interlocking,mesh,meshing
+enjambement,enjambment
+enjoining,enjoinment,injunction
+enlightened,initiate
+enlightenment,nirvana
+enlivener,invigorator,quickener
+ennead,nine,niner
+enough,sufficiency
+enrol,enrols,enrolled,enrolling,enroll,enrolls,enrolled,enrolling
+enrollment,registration
+ensilage,silage
+enspryng,satralizumab-mwge
+entellus,hanuman
+enterics,enterobacteria,entric
+entering,entrance
+enteroceptor,interoceptor
+enthral,enthrals,enthralled,enthrall,enthralls,enthralled
+entire,stallion
+entireness,entirety,integrality,totality
+entrails,innards,viscera
+entrance,entranceway,entree,entry,entryway
+entrenchment,intrenchment
+entresol,mezzanine
+entresto,sacubitril,valsartan
+entry,submission
+entyvio,vedolizumab
+enumeration,numbering
+envelope,gasbag
+environment,environs,surround,surroundings
+environs,purlieu
+envoi,envoy
+eosinophil,eosinophile
+eparchy,exarchate
+epaulet,epaulette
+epclusa,sofosbuvir,velpatasvir
+epha,ephah
+ephedra,gymnosperm
+ephemerid,ephemeropteran
+ephemerida,ephemeroptera
+epic,epos
+epicarp,exocarp
+epicenter,epicentre
+epidiolex,cannabidiol
+epigram,quip
+epilog,epilogue
+epipen,epinephrine
+epiphora,epistrophe
+episcopacy,episcopate
+episperm,testa
+epistasis,hypostasis
+epistaxis,nosebleed
+epithet,name
+epivir-hbv,lamivudine
+epivir,lamivudine
+epzicom,lamivudine
+equaliser,equalizer
+equality,equation,equivalence
+equals,equalled,equalling,equals,equaled,equaling
+equanil,meprin,meprobamate,miltown
+equetro,carbamazepine
+equid,equine
+equipage,materiel
+equisetatae,sphenopsida
+equivocation,evasion
+eradication,obliteration
+erbitux,cetuximab
+erica => tree
+eringo,eryngo
+eriobotrya => tree
+erivan,jerevan,yerevan
+erivedge,vismodegib
+erleada,apalutamide
+eroding,erosion,wearing
+eroticism,erotism
+erratum,literal,misprint,typo
+error,mistake
+erse,gaelic,goidelic
+eructation,eruption,extravasation
+eruption,irruption,outbreak
+erythrina => tree
+erythrocin,erythromycin,ethril,ilosone,pediamycin
+erythrocytolysin,erythrolysin,haemolysin,hemolysin
+erythroxylon,erythroxylum
+esbareich => cheese
+esbriet,pirfenidone
+escallop,scallop,scollop
+escape,leak,leakage,outflow
+escargot,snail
+escarp,escarpment,scarp
+escarpment,scarp
+eschalot,shallot
+escritoire,secretaire,secretary
+escutcheon,scutcheon
+esidrix,hydrochlorothiazide,hydrodiuril,microzide
+eskalith,lithane,lithonate
+eskimo,esquimau
+esophagitis,oesophagitis
+esophagoscope,oesophagoscope
+esophagus,gorge,gullet,oesophagus
+espana,spain
+esparcet,sainfoin,sanfoin
+essential,necessary,necessity,requirement,requisite
+essingang => tree
+essonite,hessonite
+establishment,institution
+estazolam,prosom
+esteem,regard,respect
+esthonia,estonia
+esthonian,estonian
+estradiol,oestradiol
+estragon,tarragon
+estriol,oestriol
+estrogen,oestrogen,oestrous,oestrus,estrous,estrous
+estrone,estronol,oestrone,theelin
+estrus,heat,oestrus
+etamin,etamine
+eternity,timelessness
+ethanal,acetaldehyde
+ethanediol,glycol
+ethchlorvynol,placidyl
+ethene,ethylene
+ether,ethoxyethane
+ethocaine,procaine
+etodolac,lodine
+etorki => cheese
+eubacteria,eubacterium
+eucalypt,eucalyptus
+eucarya,fusanus
+eucaryote,eukaryote
+eudaemonia,eudaimonia,upbeat,welfare,wellbeing
+euglenid,euglenoid,euglenophyte
+eulogium,eulogy
+euodia => tree
+euonymus => tree
+euphorbia => tree
+eurasier => dog,eurasier
+euronithopod,euronithopoda,ornithopoda
+europeanisation,europeanization
+eutherian,placental
+evangel,gospel,gospels
+eveningwear,formalwear
+evenity,romosozumab
+evenki,ewenki,tungus,tunguz
+everlasting => flower
+evil,eviller,evillest,evil,eviler,evilest
+evista,raloxifene
+evkeeza,evinacumab-dgnb
+evodia => tree
+evolution,phylogenesis,phylogeny
+evomela,melphalan
+evrysdi,risdiplam
+ewer,pitcher
+exabyte,exbibyte
+exam,examination,test
+examination,interrogation,interrogatory
+example,lesson
+exanthem,exanthema
+excerpt,excerption,extract,selection
+excess,overabundance,surfeit
+exchequer,treasury
+excitant,stimulant
+exclaiming,exclamation
+exclusive,scoop
+excrement,excreta,excretion
+exemplification,illustration
+exemption,freedom
+exfoliation,scale,scurf
+exhalation,halitus
+exhaust,fumes
+exhibition,expo,exposition
+exhortation,incitement
+exit,issue,outlet
+exjade,deferasirox
+exkivity,mobocertinib
+exogamy,intermarriage
+exopterygota,hemimetabola
+exotropia,walleye
+expectorant,expectorator
+expenditure,outgo,outlay,spending
+explanandum,explicandum
+explorateur => cheese
+explosion,plosion
+exponent,index,power
+export,exportation
+expose,unmasking
+exposition,expounding
+expostulation,objection,remonstrance,remonstration
+expressway,freeway,motorway,pike,superhighway,throughway,thruway
+extension,propagation
+extenuation,mitigation
+exterior,outside
+extermination,extinction
+extract,infusion
+extreme,extremum
+extremum,peak
+exudate,exudation
+exudation,transudation
+exultation,jubilation,rejoicing
+eyebath,eyecup
+eyeglass,monocle
+eyeglasses,glasses,specs,spectacles
+eyehole,eyelet
+eyelid,palpebra
+eyepatch,patch
+eyepiece,ocular
+eyeshot,view
+eylea,aflibercept
+eyra,jaguarondi,jaguarundi
+ezechiel,ezekiel
+ezed,izzard
+fabaceae,leguminosae
+facade,frontage,frontal
+facia,fascia
+facility,installation
+facing,veneer
+faction,sect
+factory,manufactory,mill
+faculty,staff
+fadeout,receding
+faeroes,faroes
+faeroese,faroese
+faggot,fagot
+faggoting,fagoting
+failing,weakness
+faisalabad,lyallpur
+faith,religion
+fake,postiche,sham
+falafel,felafel
+falderol,folderal,frill,gimcrack,gimcrackery,nonsense,trumpery
+falloff,slack,slump
+falls,waterfall
+falsehood,falsity,untruth
+falseness,falsity
+famishment,starvation
+famotidine,pepcid
+famvir,famciclovir
+fanjet,turbofan,turbojet
+fantasy,phantasy
+fanweed,stinkweed
+fare,transportation
+farkleberry,sparkleberry
+farmer => cheese
+farmland,ploughland,plowland,tillage,tilth
+farmplace,farmstead
+farrago,gallimaufry,hodgepodge,hotchpotch,melange,mishmash,oddments,ragbag
+farrow,farrowing
+farsi,persian
+farxiga,dapagliflozin
+fascioliasis,fasciolosis
+fasenra,benralizumab
+faslodex,fulvestrant
+fastener,fastening,fixing,holdfast
+fastness,stronghold
+fatherhood,paternity
+fatherland,homeland,motherland
+fatigue,tiredness,weariness
+fatiha,fatihah
+faucet,spigot,tap
+fauna,zoology
+favour,favourable,favor,favorable
+favourite,favorite,favoritism
+feast,fete,fiesta
+feather,plumage,plume
+febricity,febrility,fever,feverishness,pyrexia
+fecundation,fertilisation,fertilization,impregnation
+fecundity,fertility
+federalisation,federalization
+federita,feterita
+fedora,homburg,stetson,trilby
+feed,food,foodstuff
+feedbag,nosebag
+feist,fice
+felbatol,felbamate
+feldene,piroxicam
+feldspar,felspar
+felicity,happiness
+felid,feline
+fell,hide
+felloe,felly
+fellow,mate
+felon,whitlow
+feminisation,feminization
+femoris,femur,thighbone
+femtometer,femtometre,fermi
+fence,fencing
+fender,wing
+fenestella,lunette
+fengtien,moukden,mukden,shenyang
+fenland,marsh,marshland
+fennel,finocchio
+fennic,finnic
+fenoprofen,nalfon
+fentanyl,sublimaze
+feoff,fief
+feraheme,ferumoxytol
+ferment,fermentation,fermenting,zymolysis,zymosis
+ferriprox,deferiprone
+ferry,ferryboat
+fertiliser,fertilizer
+fervour,fervor
+fess,fesse
+festoon,festoonery
+fetich,fetish,hoodoo,juju,voodoo
+fetoprotein,foetoprotein
+fetoscope,foetoscope
+fetter,hobble
+fettuccine,fettuccini
+fetus,foetus
+fetzima,levomilnacipran
+fiascos,fiascoes
+fiber,fibre
+fiberboard,fibreboard
+fiberglass,fibreglass
+fiberoptics,fibreoptics
+fibril,filament,strand
+fibrinolysin,plasmin
+fictionalisation,fictionalization
+ficus => tree
+fiddle,violin
+fieldfare,snowbird
+fieldrush => flower
+figue => cheese
+figure,image,trope
+figurine,statue,statuette
+filagree,filigree,fillagree
+filament,filum
+filbert => tree
+filet,fillet
+filetta => cheese
+filicales,polypodiales
+filicinae,filicopsida
+filipino,philippine
+fill,filling
+film,flick,movie,picture
+filmdom,screen,screenland
+finances,funds
+finder,viewfinder
+fingerboard,fingerpost
+fingerflower,fingerroot
+finland,suomi
+finnish,suomi
+fintepla,fenfluramine
+fiord,fjord
+firdapse,amifampridine
+fire,flame,flaming
+firearm,piece
+firebell => tree
+firebird,hangbird,redbird
+firebomb,incendiary
+firebreak,fireguard
+firelock,flintlock
+firenze,florence
+fireplace,hearth
+fireplug,plug
+fireroom,stokehold,stokehole
+fireside,hearth
+firethorn,pyracanth,pyracantha
+fireweed,wickup
+firework,pyrotechnic
+firm,house
+firmware,microcode
+fish,pisces
+fisher,pekan
+fishery,piscary
+fishgig,fizgig,lance,spear
+fistful,handful
+fistula,sinus
+fitch,foulmart,foumart,polecat
+fivesome,quintet,quintette
+fixation,regression
+fixedness,immobility,stationariness
+fixer,methadon,methadone
+fizzle,hiss,hissing,hushing,sibilation
+flagellata,mastigophora
+flagellate,mastigophoran,mastigophore
+flagellum,scourge
+flageolet,haricot
+flagpole,flagstaff
+flagyl,metronidazole
+flake,snowflake
+flameflower,kniphofia,tritoma
+flank,wing
+flannel,gabardine,tweed,washcloth,washrag
+flare,flash
+flashboard,flashboarding
+flashlight,torch
+flashpoint,hotspot
+flask,flaskful
+flatfoot,splayfoot
+flatware,silver
+flatworm,platyhelminth
+flavour,flavouring,flavor,flavoring,flavorer,flavoring,flavourer,seasoner,seasoning
+flawlessness,perfection
+flaxedil,gallamine
+flaxseed,linseed
+fleabane,horseweed
+fleawort,psyllium
+flecainide,tambocor
+flection,flexion,flexure
+fledgeling,fledgling
+fleece,sheepskin,wool
+flexeril,cyclobenzaprine
+flexitime,flextime
+flicker,glint,spark
+flight,trajectory
+flindosa,flindosy
+floatation,flotation
+floater,spots
+floc,floccule
+flood,floodlight,photoflood
+floodgate,penstock,sluicegate
+floor,flooring
+flora,plant
+floret,floweret
+florilegium,garland,miscellany
+florin,guilder,gulden
+flotsam,jetsam
+flounce,frill,furbelow,ruffle
+flowering,unfolding
+fluctuation,variation
+flue,fluke
+fluegelhorn,flugelhorn
+fluke,trematode
+flume,gulch
+flummery,mummery
+flunitrazepan,rohypnol
+fluor,fluorite,fluorspar
+fluorescein,fluoresceine,resorcinolphthalein
+fluoroform,trifluoromethane
+fluoroscope,roentgenoscope
+fluoxetine,prozac,sarafem
+flush,gush,outpouring
+fluvastatin,lescol
+flux,fluxion
+flyover,overpass
+flyswat,flyswatter,swatter
+foal => horse
+foam,froth
+focalisation,focalization
+focus,nidus
+foehn,fohn
+fogginess,murk,murkiness
+foghorn,fogsignal
+folacin,folate
+fold,sheepcote,sheepfold
+foldex => cat,foldex
+foldout,gatefold
+foliage,leaf,leafage
+foliation,leafing
+folk,tribe
+folotyn,pralatrexate
+fomite,vehicle
+fondu,fondue
+fonio,findo,digitaria
+fontainebleau => cheese
+fontanel,fontanelle
+food,nutrient
+foodstuff,grocery
+footbridge,overcrossing
+footer,footnote
+footfall,footstep,step
+footgear,footwear
+foothold,footing
+footing,terms
+footlocker,locker
+footmark,footprint,step
+footpath,pathway
+footrest,footstool,ottoman,tuffet
+footstall,pedestal,plinth
+footstep,pace,step,stride
+foram,foraminifer
+foramen,hiatus
+force,personnel
+forebrain,prosencephalon
+forecast,prognosis
+forecasting,foretelling,prediction,prognostication
+forefinger,index
+forefront,head
+foreknowledge,precognition
+foreland,head,headland,promontory
+forelock,foretop
+forepart,front
+forerunner,harbinger,herald,precursor,predecessor
+foreskin,prepuce
+forewarning,premonition
+foreword,preface,prolusion
+forge,smithy
+forking,furcation
+formalin,formol
+formalities,formality
+format,formatting
+formosa,taiwan
+formula,recipe
+formulary,pharmacopeia
+formulation,preparation
+forteo,teriparatide
+forthcomingness,imminence,imminency,imminentness,impendence,impendency
+fortification,munition
+fortune,luck
+fosse,moat
+fossilisation,fossilization
+fosterage,fostering
+fotivda,tivozanib
+fougerus => cheese
+foundation,fundament,groundwork,substructure,understructure
+founder,laminitis
+foundry,metalworks
+fount,fountain
+fountain,outflow,outpouring,spring
+four,foursome,quadruplet,quartet,quatern,quaternary,quaternion,quaternity,tetrad
+fourpence,groat
+foursome,quartet,quartette
+foursquare,square
+fourth,quarter,quartern
+fowl,poultry
+foxglove => flower
+fradicin,neobiotic,neomycin
+fragment,shard,sherd
+frambesia,framboesia,yaws
+frangipani,frangipanni
+frank,frankfurter,hotdog,weenie,wiener,wienerwurst
+frankfort,frankfurt
+frankincense,olibanum,thus
+frat,fraternity
+fraxinus => tree
+freckle,lentigo
+freebee,freebie
+freemasonry,masonry
+freight,freightage
+fremontia,fremontodendron
+freshet,spate
+freshner,freshener
+freshness,glow
+fret,lather,stew,sweat,swither
+fretsaw,jigsaw
+fretwork,lattice,latticework
+fricative,spirant
+friction,rubbing
+frier,fryer,pullet
+friesekaas => cheese
+friesian,holstein
+friesla => cheese
+frijol,frijole
+frijolillo,frijolito
+frijolito => tree
+frill,ruff
+frinault => cheese
+fringepod,lacepod
+fringetree => tree
+friuli,friulian
+frock,dress
+frontal,frontlet
+frosting,icing
+frostweed,frostwort
+frown,scowl
+fructose,laevulose,levulose
+fruit,yield
+frypan,skillet
+fula,fulani,peul
+fulfilment,fulfillment
+fulphila,pegfilgrastim-jmdb
+fulsomeness,smarm,unction
+fulvicin,griseofulvin
+fume,smoke
+fumeroot,fumewort,fumitory
+functioning,operation,performance
+fund,stock,store
+funeral,obsequy
+funicle,funiculus
+funka,hosta
+funkaceae,hostaceae
+furan,furane,furfuran
+furfural,furfuraldehyde
+furnishing,trappings
+furosemide,lasix
+furze,gorse,whin
+fuse,fusee,fuze,fuzee
+fusion,merger,unification
+fuzeon,enfuvirtide
+fuzz,hair,tomentum
+fycompa,perampanel
+gabapentin,neurontin
+gabble,jabber,jabbering
+gabitril,tiagabine
+gabon,gabun
+gabriel => cheese
+gadolinite,ytterbite
+gage,gauge
+gaiter,spat
+galafold,migalastat
+galangal,galingale
+gallberry,inkberry
+gallery,veranda,verandah
+gallia,gaul
+gallinule,swamphen
+gallous,gibbet
+galvanisation,galvanization
+gambit,ploy
+gamboge => tree
+gambols,gambolled,gambolling,gambols,gamboled,gamboling
+gamifant,emapalumab-lzsg
+gammelost => cheese
+gammon,jambon
+gamunex-c,intravenous
+gand,gent,ghent
+gang,pack,ring
+gangboard,gangplank,gangway
+gangdom,gangland
+ganoin,ganoine
+gansu,kansu
+gantanol,sulfamethoxazole
+gantlet,gauntlet
+gantrisin,sulfisoxazole
+gantry,gauntry
+garamycin,gentamicin
+garboil,tumult,tumultuousness,uproar
+garcinia => tree
+garget,poke,scoke
+gargle,mouthwash
+gargoylism,lipochondrodystrophy
+garner,granary
+garotte,garrote,garrotte
+garrotxa => cheese
+garter,supporter
+gascogne,gascony
+gash,slash,slice
+gasmask,respirator
+gasolene,gasoline,petrol
+gastanberra => cheese
+gasteromycete,gastromycete
+gasteropoda,gastropoda
+gastropod,univalve
+gather,gathering
+gaudery,pomp
+gauffer,goffer
+gaussmeter,magnetometer
+gauze,netting,veiling
+gavels,gavelled,gavelling,gavels,gaveled,gaveling
+gavial => reptile
+gavreto,pralsetinib
+gayal,mithan
+gayfeather,snakeroot
+gazebo,summerhouse
+gazyva,obinutuzumab
+gbit,gigabit
+gean,mazzard
+gear,gearing,geartrain,train
+gearshift,gearstick,shifter
+geigertree => tree
+geitost => cheese
+gelatin,gelatine
+gelding => horse
+gelignite,gelly
+gemfibrozil,lopid
+gemini,twins
+gemmation,pullulation
+gemmology,gemology
+gemonil,metharbital
+gemsbok,gemsbuck
+gemstone,stone
+gendarmerie,gendarmery
+generation,genesis
+geneva,geneve,genf
+engraf,cyclosporine
+genip,ginep,mamoncillo
+genitive,possessive
+genoa,genova
+genotropin,somatropin
+gens,name
+genu,knee
+genuflection,genuflexion
+genvoya,elvitegravir,cobicistat,emtricitabine
+georgetown,stabroek
+georgia,sakartvelo
+geosphere,lithosphere
+gerbil,gerbille
+gerfalcon,gyrfalcon
+germ,microbe
+germination,sprouting
+gerreidae,gerridae
+gerridae,gerrididae
+gestation,maternity,pregnancy
+gesture,motion
+getup,outfit,turnout
+ghillie,gillie
+ghost,touch,trace
+ghostfish,wrymouth
+giant => tree
+giantism,gigantism,overgrowth
+gibber,gibberish
+gibibit,gibit
+gibibyte,gigabyte
+giblet,giblets
+gilding,gilt
+gilenya,fingolimod
+gilet,jerkin => waistcoat
+gill,lamella
+gilliflower => flower
+gilotrif,afatinib
+gimoti,metoclopramide
+ginger,gingerroot
+gingersnap,snap
+gingko,ginkgo
+ginkgophytina,ginkgopsida
+gipsywort,gypsywort
+girandola,girandole
+givlaari,givosiran
+giza,gizeh
+gizzard,ventriculus
+gjetost => cheese
+glabella,mesophyron
+glad,gladiola,gladiolus
+gladstone,portmanteau
+gland,secreter,secretor
+glare,limelight,spotlight
+glareole,pratincole
+glasshouse,greenhouse
+glassware,glasswork
+glasswort,samphire
+gleam,gleaming,glimmer
+gleditsia => tree
+gleostine,lomustine
+glia,neuroglia
+glide,semivowel
+glider,sailplane
+glioblastoma,spongioblastoma
+glipizide,glucotrol
+globalisation,globalization
+globin,haematohiston,hematohiston
+glochid,glochidium
+glop,mush,slop,treacle
+glorification,glory
+glossalgia,glossodynia
+glossina,tsetse,tzetze
+glossy,slick
+glove,mitt
+glucagon,glucagon
+glucophage,metformin
+glucose,dextrose,dextroglucose
+glucotrol,glipizide
+glue,mucilage
+glute,gluteus
+glutton,wolverine
+glycerin,glycerine,glycerol,glycerite,glycerole
+glycerogel,glycerogelatin
+glyoxaline,imidazole,iminazole
+glyptics,lithoglyptics
+glyset,miglitol
+glyxambi,empagliflozin,linagliptin
+gnarl,knot
+gnetophyta,gnetophytina,gnetopsida
+goad,goading,prod,prodding,spur,spurring,urging
+goat,kid
+goatfish,surmullet
+goby,gudgeon
+gocovri,amantadine;
+goeteborg,goteborg,gothenburg
+goethite,gothite
+gogi,goji
+goiter,goitre,struma,thyromegaly
+goldeneye,whistler
+goldfinch,yellowbird
+golliwog,golliwogg
+gomel,homel,homyel
+gommier => tree
+gomorrah,gomorrha
+gomuti,gumati
+gonadotrophin,gonadotropin
+gook,goop,guck,gunk,muck,ooze,slime,sludge
+gooney,goonie,goony
+goop,scoop,soap
+goosefoot => flower
+gopher,spermophile
+gordonia => tree
+gore,panel
+gorgerin,necking
+gorgonacea,gorgoniacea
+gorki,gorkiy,gorky
+gornyaltajski => cheese
+gossiping,gossipmongering
+gotterdammerung,ragnarok
+gotukola,centella
+goujon,mudcat
+goulash,gulyas
+gout,urarthritis
+goutu => cheese
+governor,regulator
+gown => gown,dress
+gown,robe
+gowrie => cheese
+grabetto => cheese
+gracilariidae,gracillariidae
+grad,grade
+graddost => cheese
+grade,level,tier
+graffiti,graffito
+graft,transplant
+grail,sangraal
+gram,gramme
+grama,gramma
+graminaceae,gramineae,poaceae
+grampus,killer,orca
+grandiloquence,grandiosity,magniloquence,ornateness,rhetoric
+grandness,importance
+granix,tbo-filgrastim
+grape,grapevine
+graphite,plumbago
+grasshopper,hopper
+grate,grating
+graticule,reticle,reticule
+gratification,satisfaction
+grave,tomb
+gravel,gravelled,gravel,graveled
+graver,pointel,pointrel
+gravestone,headstone,tombstone
+gravidation,gravidity,gravidness
+graviera => cheese
+gravimeter,hydrometer
+gravitation,gravity
+gray,grey
+grayback,greyback
+grayhen,greyhen
+graylag,greylag
+greatcoat,overcoat,topcoat
+greave,jambeau
+greegree,grigri
+greek,hellenic
+greenbelt,greenway
+greenery,verdure
+greenheart => tree
+greening,rejuvenation
+greenland,gronland
+greensward,sward,turf
+greeting,salutation
+grenadier,rattail
+greuilh => cheese
+greve => cheese
+greyhound => dog,greyhound
+grid,gridiron
+grill,grille,grillwork
+grillwork,wirework
+griminess,grubbiness
+grin,grinning,smile,smiling
+grinder,mill
+grippe,influenza
+grit,gritrock,gritstone
+grizzly,silvertip
+groan,moan
+grocery,market
+groin,inguen
+groove,vallecula
+grosbeak,grossbeak
+gross,receipts,revenue
+grot,grotto
+groundhog,woodchuck
+grove,orchard,plantation,woodlet
+grovels,grovelled,grovelling,grovels,groveled,groveling
+growl,growling
+growth,increase,increment
+grozny,groznyy
+gruelling,grueling
+grugru,macamba
+grunt,oink
+grunter,squealer
+gruyere => cheese
+guacharo,oilbird
+guaiac,guaiacum
+guanabana,soursop
+guanabenz,wytensin
+guanandi => tree
+guangdong,kwangtung
+guapinol => tree
+guard,safety
+guarumo => tree
+guavasteen => tree
+guayaba => tree
+gubbeen => cheese
+guerbigny => cheese
+guibourtia => tree
+guide,guidebook
+guidepost,signpost
+guilt,guiltiness
+gujarat,gujerat
+gujarati,gujerati
+gulfweed,sargasso,sargassum
+gull,seagull
+gulmohar => tree
+gumbo,okra
+gumshield,mouthpiece
+gumtree => tree
+gumweed,rosinweed,tarweed
+guncotton,nitrocellulose,nitrocotton
+gunnel,gunwale
+gunpoint,point
+gunpowder,powder
+gunstock,stock
+guomindang,kuomintang
+gutter,sewer,trough
+guttural,pharyngeal
+gymnanthes => tree
+gymnasium,lycee,lyceum
+gymnomycota,myxomycota
+gymnospermae,gymnospermophyta
+gynarchy,gynecocracy
+gypsum => gyproc,placo,rigips,gypcore,armstrong
+gypsy,romany
+gyration,revolution,rotation
+gyro,gyroscope
+gyrostabiliser,gyrostabilizer
+h.p.,horsepower
+ha'p'orth,halfpennyworth
+ha'penny,halfpenny
+habacuc,habakkuk
+habsburg,hapsburg
+hacek,wedge
+hackamore,halter
+hackberry => tree
+hackberry,sugarberry
+hackelia,lappula
+hackmatack,tacamahac
+hadrosaur,hadrosaurus
+haem,haemitin,hematin,heme,protoheme
+haemagglutination,hemagglutination
+haemangioma,hemangioma
+haematinic,hematinic
+haematite,hematite
+haematocele,haematocoele,hematocele,hematocoele
+haematochezia,hematochezia
+haematocolpometra,hematocolpometra
+haematocolpos,hematocolpos
+haematocrit,hematocrit
+haematocytopenia,hematocytopenia
+haematocyturia,hematocyturia
+haematogenesis,haematopoiesis,haemogenesis,haemopoiesis,hematogenesis,hematopoiesis,hemogenesis,hemopoiesis,sanguification
+haematolysis,haemolysis,hematolysis,hemolysis
+haematoma,hematoma
+haematoxylon,haematoxylum
+haematuria,hematuria
+haemoglobin,hemoglobin
+haemoglobinemia,hemoglobinemia
+haemoglobinopathy,hemoglobinopathy
+haemoglobinuria,hemoglobinuria
+haemophilia,hemophilia
+haemoprotein,hemoprotein
+haemoptysis,hemoptysis
+haemorrhoid,hemorrhoid,piles
+haemosiderin,hemosiderin
+haemosiderosis,hemosiderosis
+haemostat,hemostat
+haemothorax,hemothorax
+haft,helve
+haftarah,haftorah,haphtarah,haphtorah
+hagada,haggada,haggadah
+haggle,haggling,wrangle,wrangling
+hagiographa,ketubim,writings
+haick,haik
+haifa,hefa
+hairball,trichobezoar
+hairpiece,postiche
+haiti,hayti,hispaniola
+hakenkreuz,swastika
+halacha,halaka,halakah
+halcion,triazolam
+haldol,haloperidol
+haleness,wholeness
+haler,heller
+halesia => tree
+halftone,photoengraving
+halibut,holibut
+hall,manse,mansion,residence
+halliard,halyard
+halloumi => cheese
+halm,haulm
+halobacter,halobacteria,halobacterium
+halophil,halophile
+haloragaceae,haloragidaceae
+hamamelis => tree
+hamelin,hameln
+hamiltonstövare => dog,hamiltonstövare
+hamlet,village
+hammer,mallet
+handbag,purse
+handbasin,lavabo,washbowl,basin,washbasin,washbowl,washstand
+handbreadth,handsbreadth
+handclasp,handshake,handshaking,shake
+handcraft,handicraft,handiwork,handwork
+handful,smattering
+handgun,pistol
+handkerchief,hankey,hankie,hanky
+handmaid,handmaiden,servant
+hands,manpower,workforce
+hangchow,hangzhou
+hangout,haunt,repair,resort
+hangover,katzenjammer
+hannover,hanover
+haoma,soma
+happening,occurrence,occurrent
+harangue,rant,ranting
+harbor,harbour,haven,seaport,harborage,harbourage
+hardback,hardcover
+hardware,ironware
+hare,rabbit
+hareem,harem,seraglio,serail
+harm,hurt,injury,trauma
+harmonica,harp
+harmonisation,harmonization
+harmonium,organ
+harpullia => tree
+harrier => dog,harrier
+hart,stag
+harvester,reaper
+harvoni,ledipasvir,sofosbuvir
+haschisch,hash,hasheesh,hashish
+hassock,ottoman,pouf,pouffe,puff
+haste,hurry
+hatchel,heckle
+hatchet,tomahawk
+hatchway,opening,scuttle
+hausa,haussa
+hautbois,hautboy,oboe
+havanese => dog,havanese
+haven,oasis
+hawk,mortarboard
+hawkbill,hawksbill
+hawkmoth,sphingid
+hawse,hawsehole,hawsepipe
+hayfield,meadow
+hayloft,haymow
+hayrack,hayrig
+hayrick,haystack,rick
+hazardousness,perilousness
+hazel => tree
+hazelnut,cobnut,filbert,hazel
+hcfc,hydrochlorofluorocarbon
+headdress,headgear
+header,lintel
+headfish,mola,sunfish
+headgear,headwear
+headlamp,headlight
+headpiece,headstall
+headpin,kingpin
+headstone,keystone
+health,wellness
+heap,jalopy
+hearsay,rumor,rumour
+heart,pump,ticker
+heartburn,pyrosis
+heat,heating
+heater,warmer
+heath,heathland
+heating,warming
+heatproof,heat-proof
+heave,heaving
+hebei,hopeh,hopei
+hebraism,judaism
+hebrews,israelites
+hectograph,heliotype
+hectoliter,hectolitre
+hectometer,hectometre
+hedge,hedgerow,hedging
+hedgehog,porcupine
+hedjaz,hejaz,hijaz
+hedysarum => flower
+helenium => flower
+helianthemum,sunrose
+helianthus,sunflower
+heliopsis,oxeye
+helix,spiral
+hell,hellhole,inferno
+helleri,swordtail,topminnow
+hello,howdy,hullo
+helmetflower,monkshood,skullcap
+helping,portion,serving
+helsingfors,helsinki
+helxine,soleirolia
+hemabate,usp
+hemady,dexamethasone
+hemianopia,hemianopsia
+hemicrania,megrim,migraine
+hemicycle,semicircle
+hemiepiphyte,semiepiphyte
+hemimetabolism,hemimetaboly,hemimetamorphosis
+hemin,protohemin
+hemiparasite,semiparasite
+hemipteran,hemipteron
+hemlibra,emicizumab-kxwh
+hemstitch,hemstitching
+hen,chicken
+heparin,liquaemin
+hepatic,liverwort
+hepatica => flower
+hepatica,liverleaf
+hepaticae,hepaticopsida
+hepatocarcinoma,hepatoma
+hepatoflavin,lactoflavin,ovoflavin,riboflavin
+hepatomegaly,megalohepatia
+heptad,septenary,septet,seven,sevener
+herbage,pasturage
+herbicide,weedkiller
+herceptin,trastuzumab
+herd,ruck
+hereford,whiteface
+heritage,inheritance
+heritiera,terrietia
+hermaphrodism,hermaphroditism
+hernia,herniation
+herrerasaur,herrerasaurus
+herrgardsost => cheese
+herve => cheese
+herzuma,trastuzumab-pkrb
+hesperus,vesper
+hessian,jackboot,wellington
+heterocycle,heterocyclic
+heterogenesis,xenogenesis
+heterograft,xenograft
+heterometabolism,heterometaboly
+heterotaxy,transposition
+hetlioz,tasimelteon
+hexad,sestet,sextet,sextuplet,sise,sixer
+hexapoda,insecta
+hexenbesen,staghead
+hexoloy => 2849200000
+hezbollah,hizballah,hizbollah,hizbullah
+hibernia,ireland
+hibiscus => flower
+hibiscus => tree
+hiccough,hiccup,singultus
+hickey,pimple
+hide,pelt,skin
+hieroglyph,hieroglyphic
+high-heel,stiletto
+highboy,tallboy
+highland,upland
+highlander => cat,highlander
+higi,kapsiki
+hiking,walking
+hill,mound
+hilum,hilus
+himalaya,himalayas
+himalayan => cat,himalayan
+hindbrain,rhombencephalon
+hindooism,hinduism
+hindoostani,hindostani,hindustani
+hippies,hipsters
+hippo,hippopotamus
+histrionics,representation,theatrical
+hives,urticaria,urtication
+hivis,hi-vis,hiviz,hi-viz
+hmong,miao
+hoactzin,hoatzin,stinkbird
+hobby,hobbyhorse
+hock,rhenish
+hodometer,mileometer,milometer,odometer
+hogback,horseback
+hogbean => flower
+hogfish,pigfish
+hogg,hogget
+hoka,hokan
+hokkaido => dog,hokkaido
+hokkaido,yezo
+holdalls,hold-alls
+holland,nederland,netherlands
+holler,hollow
+holloware,hollowware
+hollyhock => flower
+holocephalan,holocephalian
+hologram,holograph
+holograph,manuscript
+holometabola,metabola
+holometabolism,holometaboly
+holy,sanctum
+home-made,homemade
+homeotherm,homoiotherm,homotherm
+homily,preachment
+hommos,hoummos,hummus,humous,humus
+homo,human
+homogenised,blended
+hondo,honshu
+honesty,satinpod
+honeymyrtle => tree
+honeysuckle => flower
+honor,honour,laurels
+hooch,hootch
+hoody,hoodie
+hooey,poppycock,stuff
+hooks,maulers
+hoop,wicket
+hoopoe,hoopoo
+hoopwood,ash,winterberry,ilex
+hooray,hurrah
+hoosegow,hoosgow
+hooter,horn
+hophornbeam => tree
+hopsack,hopsacking
+hordeolum,stye
+horizon,skyline
+hornbeam => flower
+hornfels,hornstone
+horniness,hotness
+hornpipe,pibgorn,stockhorn
+hornpout,pout
+horologe,timekeeper,timepiece
+horse,knight
+horseflesh,horsemeat
+horseweed,richweed,stoneroot
+hortensia => flower
+hose => hose,pantyhose
+hospital,infirmary
+hottentot,khoikhoi,khoikhoin
+houdah,howdah
+houhere,lacebark,ribbonwood
+hound => dog,hound
+house,mansion,sign
+housecoat,neglige,negligee,peignoir,wrapper
+housing,lodging
+hovawart => dog,hovawart
+hovel,hutch,shack,shanty
+howitzer,mortar
+howl,howling,ululation
+howler,riot,scream,sidesplitter
+hualapai,hualpai,walapai
+huarache,huaraches
+huck,huckaback
+huddle,powwow
+hudood,hudud
+huff,miff
+huisache => tree
+huitre,oyster
+humanity,humankind,humans,mankind,world
+humbleness,lowliness,obscureness,unimportance
+humidity,humidness
+humiliation,mortification
+humira,adalimumab
+humor,humour,witticism,wittiness
+humpback,hunchback,kyphosis
+hungarian,magyar
+hungary,magyarorszag
+hunger,hungriness
+hunk,lump
+huntaway => dog,huntaway
+hunter,orion
+hurdles,hurdling
+hurting,pain
+hushallsost => cheese
+hyacinth,jacinth
+hyaena,hyena
+hyalin,hyaline
+hyalinisation,hyalinization
+hyaluronidase,hyazyme
+hybrid,loanblend
+hycamtin,topotecan
+hydnocarpus,taraktagenos,taraktogenos
+hydra,snake
+hydrargyrum,mercury,quicksilver
+hydrocephalus,hydrocephaly
+hydrocharidaceae,hydrocharitaceae
+hydrofoil,hydroplane
+hydroid,hydrozoan
+hydrophobia,lyssa,madness,rabies
+hydroplane,seaplane
+hydroxybenzene,oxybenzene,phenol
+hydroxychloroquine,plaquenil
+hydroxytetracycline,oxytetracycline,terramycin
+hymen,maidenhead
+hymeneals,nuptials,wedding
+hymenopter,hymenopteran,hymenopteron
+hymnal,hymnary,hymnbook
+hyophorbe => tree
+hyoscine,scopolamine
+hyperacusia,hyperacusis
+hyperaemia,hyperemia
+hypercalcaemia,hypercalcemia
+hypercalcinuria,hypercalciuria
+hypercapnia,hypercarbia
+hypercholesteremia,hypercholesterolemia
+hyperdactyly,polydactyly
+hyperglycaemia,hyperglycemia
+hyperhidrosis,hyperidrosis,polyhidrosis
+hypericales,parietales
+hyperlipaemia,hyperlipemia,hyperlipidaemia,hyperlipidemia,hyperlipoidaemia,hyperlipoidemia,lipaemia,lipemia,lipidaemia,lipidemia,lipoidaemia,lipoidemia
+hypermenorrhea,menorrhagia
+hypernym,superordinate
+hypernymy,superordination
+hyperoartia,petromyzoniformes
+hyperodontidae,ziphiidae
+hyperotreta,myxiniformes,myxinoidea,myxinoidei
+hyperpiesia,hyperpiesis
+hyperthermia,hyperthermy
+hyperthyroidism,thyrotoxicosis
+hypertonia,hypertonicity,hypertonus
+hypervolaemia,hypervolemia
+hypesthesia,hypoesthesia
+hyphaene => tree
+hypnotic,soporific
+hypo,hypodermic
+hypoadrenalism,hypoadrenocorticism
+hypocalcaemia,hypocalcemia
+hypochaeris,hypochoeris
+hypochondria,hypochondriasis
+hypodermatidae,oestridae
+hypoglycaemia,hypoglycemia
+hyponym,subordinate
+hyponymy,subordination
+hypophysis,pituitary
+hypotonia,hypotonicity,hypotonus
+hypovolaemia,hypovolemia
+hytrin,terazosin
+iamb,iambus
+iberico => cheese
+ibrance,palbociclib
+icaco => tree
+icebox,refrigerator,fridge,frig
+iclusig,ponatinib
+icterus,jaundice
+ictus,raptus,seizure
+idamycin,idarubicin
+idealisation,idealization
+ideogram,ideograph
+idhifa,enasidenib
+idiazabal => cheese
+idocrase,vesuvian,vesuvianite
+idyl,idyll,pastoral,pastorale
+igloo,iglu
+igniter,ignitor
+iguania,iguanidae
+iguassu,iguazu
+ilaris,canakinumab
+ilion,ilium,troy
+illicium => tree
+illness,malady,sickness,unwellness
+ilumya,tildrakizumab-asmn
+imac,minicomputer,microcomputer => computer
+image,range
+imavate,imipramine,tofranil
+imbalance,instability,unbalance
+imbauba,trumpetwood
+imbruvica,ibrutinib
+imcivree,setmelanotide
+imfinzi,durvalumab
+immaculateness,spotlessness
+immanence,immanency
+immatureness,immaturity
+immovable,realty
+immunity,resistance
+immunity,unsusceptibility
+immunosuppressant,immunosuppressive,immunosuppressor
+impatience,restlessness
+impeachability,indictability
+impecuniousness,pennilessness,penuriousness
+impedance,resistance,resistivity
+impediment,impedimenta,obstructer,obstruction,obstructor
+imperativeness,insistence,insistency,press,pressure
+imperfect,progressive
+imperfection,imperfectness
+implantation,nidation
+importunity,urgency,urging
+impossibility,impossibleness
+impost,springer
+impotence,impotency
+impoverishment,poorness,poverty
+imprecation,malediction
+impregnability,invulnerability
+impregnation,saturation
+improvement,melioration
+impulse,pulsation,pulse,pulsing
+impureness,impurity
+inaction,inactiveness,inactivity
+inadequacy,insufficiency
+inca,inka
+inception,origin,origination
+inchworm,looper
+incisura,incisure
+incitement,provocation
+inclemency,inclementness
+incommodiousness,inconvenience
+incompatibility,inconsistency,repugnance
+incompleteness,rawness
+inconceivability,inconceivableness
+incontinence,incontinency
+increlex,mecasermin
+incubus,nightmare
+indapamide,lozal
+indemnity,insurance
+independence,independency
+inderal,propanolol
+index,indicant,indicator
+indicant,indication
+indigence,need,pauperism,pauperization,penury
+individual,mortal,person,somebody,someone,soul
+indocin,indomethacin
+indri,indris
+inductance,induction,inductor
+indument,indumentum
+induration,sclerosis
+inessential,nonessential
+infamy,opprobrium
+infant,baby
+infarct,infarction
+infed,infed
+inferior,subscript
+infertility,sterility
+infestation,plague
+infiltration,percolation
+infinite,space
+inflammation,redness,rubor
+inflater,inflator
+inflection,inflexion
+inflectra,infliximab-dyyb
+infliximab,remicade
+inflow,influx
+info,information
+infolding,introversion,intussusception,invagination
+infomercial,informercial
+informing,ratting
+infrastructure,substructure
+infrigidation,refrigeration
+ingrezza,valbenazine
+inhalant,inhalation
+inhalator,inhaler,respirator
+inherence,inherency
+initialisation,initialization
+initials,initialled,initialling,initials,initialed,initialing
+injectant,injection
+injury,wound
+inkstand,inkwell
+inlyta,axitinib
+innersole,insole
+innocence,pureness,purity,sinlessness,whiteness
+innovation,invention
+innuendo,insinuation
+inoculant,inoculum
+inpour,inpouring,inrush
+inqovi,decitabine,cedazuridine
+inquiring,questioning
+inrebic,fedratinib
+insaneness,lunacy,madness
+inscription,lettering
+insert,inset
+insertion,interpolation
+insessores,percher
+insistence,insisting
+insolation,siriasis,sunstroke
+inspra,eplerenone
+installment,instalment
+instrumentality,instrumentation
+insulant,insulation
+insurance,policy
+insurer,underwriter
+integrator,planimeter
+integrity,unity,wholeness
+intelence,etravirine
+intellectualisation,intellectualization
+intelligence,news,tidings,word
+intensifier,intensive
+intent,purport,spirit
+interconnectedness,interconnection
+interdependence,interdependency,mutuality
+interdict,interdiction
+interest,stake
+interference,intervention
+interlanguage,koine
+interrelatedness,interrelation,interrelationship
+interrogation,interrogative,question
+intersection,product
+intonation,modulation
+intoxication,poisoning
+intransitiveness,intransitivity
+intro,introduction,presentation
+introversion,invagination
+intumescence,intumescency,swelling
+intuniv,guanfacine
+invective,vitriol,vituperation
+inventory,stock
+inverse,opposite
+invertase,saccharase,sucrase
+invirase,saquinavir
+invocation,supplication
+invokamet,canagliflozin-metformin
+invokana,canagliflozin
+involvement,participation
+iodin,iodine
+iodoform,triiodomethane
+ionisation,ionization
+iota,scintilla,shred,smidge,smidgen,smidgeon,smidgin,tittle,whit
+iowa,ioway
+ipad => tablet,ipad
+ipidae,scolytidae
+irak,iraq
+iran,persia
+iressa,gefitinib
+iridosmine,osmiridium
+iris => flower
+ironweed,vernonia
+ironwood => tree
+irony,sarcasm,satire
+iroquoian,iroquois
+irrationality,unreason
+irreality,unreality
+irredenta,irridenta
+irregular,second
+irrelevance,irrelevancy
+irtish,irtysh
+isarithm,isogram,isopleth
+ischaemia,ischemia
+isentress,raltegravir
+isinglass,mica
+islam,muslimism
+isle,islet
+isocarboxazid,marplan
+isomerisation,isomerization
+isoniazid,nydrazid
+isoproterenol,isuprel
+isordil,isosorbide
+israel,sion,yisrael,zion
+istodax,romidepsin
+isturisa,osilodrostat
+italia,italy
+itch,scabies
+ithaca,ithaki
+itinerary,path,route
+itraconazole,sporanox
+ivory,tusk
+ivy => flower
+izmir,smyrna
+jabalpur,jubbulpore
+jabiru,saddlebill
+jacaranda => tree
+jackpot,kitty
+jackstraw,spillikin
+jade,jadestone
+jadenu,deferasirox
+jaffa,joppa,yafo
+jagdterrier => dog,jagdterrier
+jaggary,jaggery,jagghery
+jaguar,panther
+jakafi,ruxolitinib
+jakes,outhouse,privy
+jamberry,miltomate,tomatillo
+jamjar,jampot
+jangle,jingle
+janumet,sitagliptin,metformin
+japan,nihon,nippon
+jape,jest,joke,laugh
+jardiance,empagliflozin
+jargon,jargoon
+jasmine,jasmin
+jatoba => tree
+jatobá => tree
+javanese => cat,javanese
+jawbone,jowl,mandible,mandibula,submaxilla
+jazz,malarkey,malarky,nothingness,wind
+jed'dah,jeddah,jidda,jiddah
+jeep,landrover
+jeer,jeering,mockery,scoff,scoffing
+jelmyto,mitomycin
+jemmy,jimmy
+jemperl,dostarlimab
+jenever,hollands,genever,genièvre,peket
+jennet,jenny
+jentadueto,linagliptin,metformin
+jerk,jerky
+jersey,pullover,jumper,sweater
+jessamine => flower
+jevtana,cabazitaxel
+jewellery,jewelry,jewelery,jewllery
+jewfish,mulloway
+jicaro => tree
+jimmies,sprinkles
+jindo => dog,jindo
+jinrikisha,ricksha,rickshaw
+jive,swing
+jock,jockstrap,supporter,suspensor
+jocosity,jocularity
+jocote,mombin
+joggers,trousers
+johor,johore
+join,union
+jointworm,strawworm
+jolt,jounce,shock
+jonangi => dog,jonangi
+jook,juke
+joshua,josue
+journal,diary
+joust,tilt
+joystick,stick
+jublia,efinaconazole
+juda,judah
+judaea,judea
+jugoslavija,yugoslavia
+juice,succus
+juicer,reamer
+jukebox,nickelodeon
+juluca,dolutegravir,rilpivirine
+jumbal,jumble
+juncaginaceae,scheuchzeriaceae
+junco,snowbird
+juncture,occasion
+juneberry,saskatoon,serviceberry,shadberry
+juniper,raetam,retem
+juniperus => tree
+jupati,jupaty
+jurema => tree
+jury,panel
+jutish,kentish
+jutland,jylland
+juustoleipa => cheese
+jynarque,tolvaptan
+kabob,kebab
+kachin,kachinic
+kadchgall => cheese
+kaikadi => dog,kaikadi
+kakaw => tree
+kalapooian,kalapuyan
+kaletra,lopinavir,ritonavir
+kaliuresis,kaluresis
+kalka,khalka,khalkha
+kalmia => flower
+kalydeco,ivacaftor
+kanaani => cat,kanaani
+kanamycin,kantrex
+kananga,luluabourg
+kanarese,kannada
+kanchanjanga,kanchenjunga,kinchinjunga
+kandahar,qandahar
+kanjiniti,trastuzumab-anns
+kanni => dog,kanni
+kanooka => tree
+kansa,kansas
+kaochlor,klorvess
+kaolin,kaoline
+kapok => tree
+karakoram,mustagh
+karbala,kerbala,kerbela
+karen,karenic
+karnataka,mysore
+kars => dog,kars
+karyon,nucleus
+karyoplasm,nucleoplasm
+kaseri => cheese
+kashta => cheese
+katar,qatar
+kathmandu,katmandu
+kaunas,kovna,kovno
+kauri,kaury
+kava,kavakava
+kavrin,papaverine
+kazak,kazakh
+kazano,alogliptin,metformin
+kbit,kilobit
+keep,livelihood,living,support,sustenance
+keepsake,relic,souvenir,token
+keeshond => dog,keeshond
+kefalotyri => cheese
+kelter,kilter
+kemadrin,procyclidine
+kenafa => cheese
+kennedia,kennedya
+kennels,kennelled,kennels,kenneled
+kepivance,palifermin
+keratinisation,keratinization
+keratoderma,keratodermia
+kerb,kerbside,kerbstone,curb,curbside,curbstone
+kerendia,finerenone
+kernel,meat
+kerosene,kerosine
+kerugma,kerygma
+kesimpta,ofatumumab
+ketalar,ketamine
+ketembilla,kitambilla,kitembilla
+ketoprofen,orudis,oruvail
+ketorolac,torodal
+kevazingo => tree
+keveyis,dichlorphenamide
+kevzara,sarilumab
+keynote,tonic
+keytruda,pembrolizumab
+khaddar,khadi
+khala => dog,khala
+khanty,ostyak
+khapzory,levoleucovorin
+kharkiv,kharkov
+khat,quat
+khaya => tree
+khirghiz,kirghiz,kirgiz
+kibibit,kibit
+kibibyte,kilobyte
+kick,recoil
+kiev,kyyiv
+kikorangi => cheese
+kildeer,killdeer
+kiley,kylie
+kiliwa,kiliwi
+kilo,kilogram
+kiloliter,kilolitre
+kilometer,kilometre,klick
+kilometre,kilometer
+kimmtrak,tebentafusp-tebn
+kimshi,kimchi
+kimyrsa,oritavancin
+kindergartener,kindergartner
+kindling,punk,spunk,tinder,touchwood
+kineret,anakinra
+kingbolt,kingpin
+kink,twirl,twist
+kinkajou,potto
+kinkalow => cat,kinkalow
+kinshasa,leopoldville
+kinship,relationship
+kintamani => dog,kintamani
+kirghiz,kirghizia,kirghizstan,kirgiz,kirgizia,kirgizstan,kyrgyzstan
+kishu => dog,kishu
+kismat,kismet
+kisqali,ribociclib
+kitten => cat,kitten
+kitten => kitten,cat,pet
+kitten,kitty
+kittul,kitul
+kiwi,kiwifruit
+klaipeda,memel
+klosterkaese => cheese
+knackwurst,knockwurst
+knawe,knawel
+knee,stifle
+kneecap,kneepan,patella
+knesset,knesseth
+knit,knitting,knitwork
+knob,pommel
+knobkerrie,knobkerry
+knock,knocking
+knockalara => cheese
+knuckles,knucks
+koellia,pycnanthemum
+koelreuteria => tree
+kokio => tree
+kokoni => dog,kokoni
+kolea => tree
+kōlea => tree
+kombai => dog,kombai
+komi,zyrian
+komondor => dog,komondor
+koodoo,koudou,kudu
+kooikerhondje => dog,kooikerhondje
+koolie => dog,koolie
+kopje,koppie
+korat => cat,korat
+korlym,mifepristone
+koselugo,selumetinib
+kota,kotar
+kotow,kowtow
+koumiss,kumis
+koweit,kuwait
+koyamaki => tree
+kraftliner,corrugated
+kromfohrländer => dog,kromfohrländer
+kuchi => dog,kuchi
+kuenlun,kunlun
+kugelkase => cheese
+kulun,ulaanbaatar,urga
+kuripaka => tree
+kurus,piaster,piastre
+kuvasz => dog,kuvasz
+kwai,yuan
+kyprolis,carfilzomib
+laager,lager
+labdanum,ladanum
+label,lable
+labels,labelled,labelling,labels,labeled,labeling
+labetalol,normodyne,trandate
+labiatae,lamiaceae
+labor,labour
+labrocyte,mastocyte
+laburnum => tree
+labyrinth,maze
+labyrinthodonta,labyrinthodontia
+lace,lacing
+lacertilia,sauria
+lacewood,sycamore
+lachrymation,lacrimation,tearing,watering
+lachrymator,lacrimator,teargas
+lacklustre,lackluster
+laconicism,laconism
+lactaid,lactase
+lactobacillaceae,lactobacteriaceae
+ladder,ravel
+ladybeetle,ladybird,ladybug
+ladyfish,tenpounder
+lagan,lagend,ligan
+lagerstroemia => tree
+lagoon,laguna,lagune
+laguiole => cheese
+lahuan => tree
+laichi => tree
+lairobell => cheese
+laity,temporalty
+lajta => cheese
+lakeshore,lakeside
+lambkin => cat,lambkin
+lambskin,parchment,sheepskin
+lament,lamentation,plaint,wail
+lamictal,lamotrigine
+lamisil,terbinafine
+lamivudine,zidovudine)
+lammergeier,lammergeyer
+lamp,lantern
+lampit,nifurtimox
+lampshade,shade
+lance,shaft,spear
+lancetfish,wolffish
+lanchou,lanchow,lanzhou
+landmark,watershed
+landseer => dog,landseer
+landslide,landslip
+landsmaal,landsmal,nynorsk
+langoustine,scampo
+langres => cheese
+langsat,langset
+laniard,lanyard
+lansa,lansat,lanseh,lanset
+lansoprazole,prevacid
+lanthanide,lanthanoid,lanthanon
+laperm => cat,laperm
+lapin,rabbit
+lapland,lappland
+lapp,saame,saami,same,sami
+lappet,wattle
+lappi => cheese
+lappic,lappish
+lapwing,peewit,pewit
+larch => flower
+larches => tree
+largess,largesse
+lariat,lasso,reata,riata
+larium,mefloquine,mephaquine
+larix => tree
+lark,pipit,titlark
+larkspur => flower
+laruns => cheese
+lasagne,lasagna
+lash,thong
+lassa,lhasa
+lassitude,lethargy,sluggishness
+latania => tree
+lathee,lathi
+lather,soapsuds,suds
+latitude,parallel
+latium,lazio
+latuda,lurasidone
+latvian,lettish
+laugh,laughter
+launderette,laundromat
+laundrette,launderette
+laundry,wash,washables,washing
+laurel => flower
+laurestine => flower
+laurus => tree
+lavalier,lavaliere,lavalliere
+lavistown => cheese
+laws,pentateuch,torah
+laxity,laxness
+lazaret,lazarette,lazaretto,pesthouse
+lbf.,pound
+leach,leaching
+leaders,leadership
+leadtrees => tree
+leafield => cheese
+leafstalk,petiole
+leak,wetting
+lease,letting,rental
+leash,tercet,ternary,ternion,terzetto,three,threesome,tierce,trey,triad,trine,trinity,trio,triplet,troika
+leatherfish,leatherjacket
+leatherjack,leatherjacket
+leatherwood => tree
+leatherwood,moosewood,ropebark,wicopy
+leaven,leavening
+lebbene => cheese
+lecythis => tree
+led,leds
+ledge,shelf
+ledger,leger
+leechee => tree
+leechee,lichee,lichi,litchee,litchi,lychee
+leechi => tree
+leek,scallion
+leer,sneer
+leerdammer => cheese
+left,leftfield
+leftover,remnant
+leggin,legging,jegging,leging
+leicester => cheese
+leicester,leicestershire
+leiden,leyden
+leiopelma,liopelma
+leiopelmatidae,liopelmidae
+leipoa,lowan
+leishmaniasis,leishmaniosis
+leitmotif,leitmotiv
+lemanderin,rangpur
+lemnos,limnos
+lemon,stinker
+lemonade,7up,lilt,cariba,fanta
+lemtrada,alemtuzumab
+leningrad,peterburg,petrograd
+lens,lense
+lentia,linz
+lentisk,mastic
+lenvima,lenvatinib
+leonberger => dog,leonberger
+leoncita,tamarin
+leotard,unitard
+leotards,tights
+lepechinia,sphacele
+lepidopteran,lepidopteron
+leqvio,inclisiran
+lesbos,lesvos,mytilene
+lesion,wound
+lesson,moral
+letairis,ambrisentan
+letter,missive
+leucaemia,leukaemia,leukemia
+leucaena => tree
+leucocyte,leukocyte
+leucocytosis,leukocytosis
+leucocytozoan,leucocytozoon
+leucoma,leukoma
+leucopenia,leukopenia
+leucorrhea,leukorrhea
+leukaemia,leukemia
+leukine,sargramostim
+levallorphan,lorfan
+levels,levelled,levelling,levels,leveled,leveling
+leverage,purchase
+levi's,levis
+levitra,vardenafil
+levoxyl,levothyroxine
+lexicalisation,lexicalization
+lexiscan,regadenoson
+leyden => cheese
+liakoura,parnassus
+lialda,mesalamine
+libels,libelled,libelling,libeller,libellous,libel,libeled,libeling,libeler,libelous
+libtayo,cemiplimab-rwlc
+licaria => tree
+licence,license,permit
+lichee,litchi
+lichgate,lychgate
+lichu => tree
+licorice,liquorice
+licuala => tree
+lidocaine,xylocaine
+liege,luik
+lien,spleen
+lietuva,lithuania
+lifelessness,motionlessness,stillness
+lift,rise
+light,lighting
+likeness,semblance
+lilac => flower
+liliopsida,monocotyledonae,monocotyledones
+limbo,oblivion
+limburger => cheese
+limit,limitation
+limiting,modification,qualifying
+limo,limousine
+linchpin,lynchpin
+lincocin,lincomycin
+linden => tree
+lindesnes,naze
+lineation,outline
+liner,lining
+linguine,linguini
+linnet,lintwhite
+lino,linoleum
+linzess,linaclotide
+lioresal,baclofen
+liothyronine,triiodothyronine
+liparidae,liparididae
+lipid,lipide,lipoid
+lipizzan,lippizan,lippizaner
+liptauer => cheese
+liquid,liquidity,liquidness
+liquidambar => tree
+lisboa,lisbon
+lisinopril,prinival,zestril
+lissom,lissome
+list,listing
+lister,middlebreaker
+litchi => tree
+lithocarpus => tree
+lithops,stoneface
+litoral,littoral,sands
+litotes,meiosis
+litre,liter
+livalo,pitavastatin
+livarot => cheese
+liveable,liveability,livable,livability
+livelong,orpin,orpine
+liver,kidney,tripe => offal
+livestock,stock
+livistona => tree
+livtencity,maribavir
+lizardfish,snakefish
+lizhi => tree
+llanboidy => cheese
+lleuque => tree
+loadstar,lodestar
+loadstone,lodestone
+loan,loanword
+lobscouse,lobscuse,scouse
+lobworm,lugworm
+locale,locus,venue
+locality,neighborhood,neighbourhood,vicinity
+lockjaw,tetanus
+locule,loculus
+lodgement,lodgment
+logginess,loginess
+logo,logotype
+logogram,logograph
+loin,lumbus
+loins,pubes
+lollipop,lolly,popsicle,sucker
+lombardia,lombardy
+loneliness,solitariness
+longan,longanberry,lungen
+longhorn => cheese
+longlegs,stilt,stiltbird
+longyi,lungi,lungyi
+loniten,minoxidil,rogaine
+lonsurf,trifluridine,tipiracil
+lontar,palmyra
+loofa,loofah,luffa
+lookout,observatory
+lookup,search
+loosening,relaxation,slackening
+lophostemon => tree
+lopid,gemfibrozil
+lopper,pruner
+lopressor,metoprolol
+loquat => tree
+lorbrena,lorlatinib
+lorraine,lothringen
+losings,losses
+lotronex,alosetron
+loudspeaker,speaker
+lounger,recliner
+lour,lours,loured,louring,lower,lowers,lowered,lowering
+lousiness,pediculosis
+louver,louvre
+lovastatin,mevacor
+löwchen => dog,löwchen
+lowercase,minuscule
+lowliness,lowness
+loxapine,loxitane
+loxodrome,rhumb
+loyang,luoyang
+lozenge,pill,tablet
+ltte,tigers
+luba,tshiluba
+lube,lubricant,lubricator
+lucemyra,lofexidine
+lucentis,ranibizumab
+lucerne,alfalfa
+lucifer,match
+lucite,perspex
+luda,luta
+lues,syph,syphilis
+lull,quiet
+lumakras,sotorasib
+lumber,timber
+lumbermill,sawmill
+luminal,phenobarbital,phenobarbitone
+lumnitzera => tree
+lump,puffiness,swelling
+lunula,lunule
+lupin,lupine
+lupkynis,voclosporin
+luridness,sensationalism
+lusatian,sorbian
+lute,luting
+lutecium,lutetium
+lutefisk,lutfisk
+lutein,xanthophyl,xanthophyll
+luteotropin,prolactin
+luvian,luwian
+luxembourg,luxemburg
+luxuriousness,luxury,opulence,sumptuousness
+luzu,luliconazole
+lybalvi,olanzapone,samidorphan
+lycopersicon,lycopersicum
+lycopodiate,lycopsida
+lykoi => cat,lykoi
+lymphangiectasia,lymphangiectasis
+lymphocytopenia,lymphopenia
+lynparza,olaparib
+lyon,lyons
+lyonnais => cheese
+lyophilisation,lyophilization
+lyrica,pregabalin
+lysichiton,lysichitum
+lysiloma => tree
+lysogenicity,lysogeny
+lysogenisation,lysogenization
+lysozyme,muramidase
+lytgobi,futibatinib
+lyvispah,baclofen
+maarianhamina,mariehamn
+macacauba => tree
+macadam,tarmac,tarmacadam
+macao,macau
+macconais => cheese
+macedon,macedonia,makedonija
+machete,matchet,panga
+macintosh,mack,mackintosh
+macon,maconnais
+macrocephaly,megacephaly,megalocephaly
+macrocyte,megalocyte
+macrodantin,nitrofurantoin
+macromolecule,supermolecule
+macrosporangium,megasporangium
+macrospore,megaspore
+macrouridae,macruridae
+macula,macule,sunspot
+madder => flower
+madrasa,madrasah
+madrona,madrono,manzanita
+maelstrom,vortex,whirlpool
+maestri,maestro
+mafa,matakam
+maga => tree
+magasine,magazine,periodical,journal
+maghreb,mahgrib
+magilp,megilp
+magnesia,periclase
+magnetisation,magnetization
+mahabharata,mahabharatam,mahabharatum
+mahagua,mahoe,majagua
+mahican,mohican
+mahlstick,maulstick
+mahon => cheese
+mahratti,marathi
+maia,maja
+maidism,mayidism,pellagra
+maidu,pujunan
+maiger,maigre
+mailbag,postbag
+mailboat,packet
+mailbox,postbox
+maimed,wounded
+mainsheet,sheet,shroud,tack
+maiolica,majolica
+maisonette,maisonnette
+maize,corn
+make-up,makeup
+maker,manufacturer
+makomako,wineberry
+malachi,malachias
+malaise,unease,uneasiness
+malamute,malemute
+malanga,yautia,cocoyam
+malaprop,malapropism
+malarone,atovaquone,proguanil
+malawi,nyasaland
+malecite,maleseet
+malformation,miscreation
+malignance,malignancy
+malignment,smear,vilification
+mall,promenade
+malnourishment,undernourishment
+malodour,malodourous,malodor,malodorous
+malpighia => tree
+malt,malted
+maltese => dog,maltese
+maltese,malti
+malus => tree
+malvern => cheese
+māmane => tree
+mamilla,mammilla,nipple,teat
+mamirolle => cheese
+mammal,mammalian
+manchego => cheese
+manchineel => flower
+mandaean,mandean
+mandara,wandala
+mandate,mandatory
+mandelamine,methenamine,urex
+mandrake => flower
+maneto => dog,maneto
+manger,trough
+manifestation,materialisation,materialization
+manifesto,pronunciamento
+manila,manilla
+manjack => tree
+mannitol,osmitrol
+manoeuvre,manoeuvrable,manoeuvrability,maneuver,maneuverable,maneuverability
+manouri => cheese
+manroot,scammonyroot
+mansi,vogul
+manteau,cloak,mantle,cape
+manteidae,mantidae
+mantelet,mantilla,mantlet
+mantid,mantis
+manur => cheese
+manx => cat,manx
+manzanillo => tree
+marabou,marabout
+marche,marches
+marchpane,marzipan
+mare => horse
+mare,maria
+maredsous => cheese
+margarin,margarine,marge,oleo,oleomargarine
+margenza,margetuximab-cmkb
+marginalisation,marginalization
+marginocephalia,marginocephalian
+margotin => cheese
+marigold => flower
+marimba,xylophone
+marines,usmc
+marionette,puppet
+mariposan,yokuts
+market,marketplace,mart
+markhoor,markhor
+marlinespike,marlingspike,marlinspike
+marlite,marlstone
+marmara,marmora
+maroc,marruecos,morocco
+maroilles => cheese
+marquee,pavilion
+marqueterie,marquetry
+marrakech,marrakesh
+marriage,matrimony,union,wedlock
+marseille,marseilles
+marshals,marshalled,marshalling,marshals,marshaled,marshaling
+marshmallow => flower
+marvel,wonder
+marvels,marvelled,marvelling,marvellous,marvels,marveled,marveling,marvelous
+mascares => cheese
+mascarpone => cheese
+masculinisation,masculinization,virilisation,virilization
+mashhad,meshed
+masjid,musjid
+mask,masque,masquerade
+masora,masorah
+masqat,muscat
+mass,masses,multitude,people
+massachuset,massachusetts
+massicot,massicotite
+mastaba,mastabah
+mastigomycota,mastigomycotina
+mastodon,mastodont
+mastoid,mastoidal
+mastopathy,mazopathy
+matabele,ndebele
+matai => tree
+match,mate
+matchbush,matchweed
+matchwood,splinters
+mate,maté,himarrão,cimarrón
+material,stuff
+materialism,philistinism
+maternity,motherhood
+matocq => cheese
+matress,mattress
+matriarchate,matriarchy
+matronymic,metronymic
+matteuccia,pteretis
+maturation,maturement,ripening
+matureness,maturity
+matzah,matzo,matzoh
+maua => tree
+maul,sledge,sledgehammer
+mauritania,mauritanie,muritaniya
+mavenclad,cladribine
+mavik,trandolapril
+mavis,throstle
+mavyret,glecaprevir,pibrentasvir
+mawlamyine,moulmein
+maxilla,maxillary
+maya,mayan
+mayo,mayonnaise
+maytenus => tree
+mayzent,siponimod
+mbit,megabit
+mbundu,ovimbundu
+mdma,methylenedioxymethamphetamine
+meadowsweet => flower
+meagre,meagrely,meagreness,meager,meagerly,meagerness
+meal,repast
+means,substance
+mearstone,meerestone,merestone
+mebaral,mephobarbital
+mebibit,mibit
+mebibyte,megabyte
+mechanisation,mechanization
+mecholyl,methacholine
+meclofenamate,meclomen
+medic,medick,trefoil
+medicament,medication,medicine
+mediety,moiety
+medley,pastiche,potpourri
+medroxyprogesterone,provera
+medulla,myelin,myeline
+medusa,medusan,medusoid
+meerkat,mierkat
+meerschaum,sepiolite
+megaflop,mflop
+megalosaur,megalosaurus
+megatherian,megatheriid
+meiosis,miosis
+meira => cheese
+mekinist,trametinib
+melaena,melena
+melanism,melanosis
+melastomaceae,melastomataceae
+melia => tree
+melicocca,melicoccus
+melilot,melilotus
+mellaril,thioridazine
+melt,melting,thaw,thawing
+member,penis,phallus
+membership,rank
+mementoes,mementos
+memo,memoranda,memorandum
+memorial,monument
+memory,storage,store
+menace,threat
+menguilié => tree
+meninges,meninx
+menominee,menomini
+menonita => cheese
+menquadfi,meningococcal
+mention,reference
+meow,miaou,miaow,miaul
+mephenytoin,mesantoin
+mephyton,phytonadione
+merbatu => tree
+merbromine,mercurochrome
+mercaptopurine,purinethol
+merchandise,product,ware
+merganser,sawbill,sheldrake
+merling,whiting
+merthiolate,thimerosal
+meryta => tree
+mesa,table
+mescal,mezcal,peyote
+mescaline,peyote
+mesencephalon,midbrain
+mesh,meshing,meshwork,network
+mesoblast,mesoderm
+meson,mesotron
+mesost => cheese
+mesquit,mesquite
+mess,messiness,muss,mussiness
+metabolism,metamorphosis
+metamere,somite
+metempsychosis,rebirth
+meteor,meteoroid
+meterstick,metrestick
+methanal,formaldehyde
+methaqualone,quaalude
+methocarbamol,robaxin
+methylbenzene,toluene
+methylphenidate,ritalin
+metopium => tree
+metrazol,pentamethylenetetrazol,pentylenetetrazol
+metre,meter
+metro,subway,tube,underground
+metycaine,piperocaine
+mexiletine,mexitil
+mezereon => flower
+mezuza,mezuzah
+miacalcin,calcitonin-salmon
+miasm,miasma
+micah,micheas
+miconazole,monistat
+microcephalus,microcephaly,nanocephaly
+micrometeor,micrometeorite,micrometeoroid
+micrometer,micron
+micromicron,picometer,picometre
+micromillimeter,micromillimetre,millimicron,nanometer,nanometre
+micropenis,microphallus
+microphone,mike
+microprocessor => processor,microprocessor
+microseism,tremor
+micturition,urination
+midazolam,versed
+middle,midriff,midsection
+midline,midplane
+midrib,midvein
+midst,thick
+milan,milano
+milcher,milker
+mildew,mold,mould
+milepost,milestone
+milfoil => flower
+milfoil,yarrow
+milieu,surroundings
+militia,reserves
+milium,whitehead
+milkshake,shake
+milktree => tree
+milkweed,silkweed
+milkwort => flower
+milleens => cheese
+millepede,milliped,millipede
+millettia => tree
+milliliter,millilitre
+millilitre,milliliter
+millimeter,millimetre
+millimetre,millimeter
+millirem,mrem
+millrace,millrun
+milontin,phensuximide
+miltown,equanil => meprobamate
+mimeo,mimeograph,roneo,roneograph
+mimolette => cheese
+mimosa => tree
+mina,minah,myna,mynah
+minibike,motorbike
+minimalism,reductivism
+minipress,prazosin
+minisub,minisubmarine
+minocin,minocycline
+minskin => cat,minskin
+minuet => cat,minuet
+minutes,proceedings,transactions
+miotic,myotic
+mire,morass,quag,quagmire
+misadventure,mischance,mishap
+misbehaviour,misbehavior
+mischance,mishap
+misconstrual,misconstruction
+misdemeanour,misdemeanor
+miserableness,misery,wretchedness
+misfire,miss
+mishna,mishnah
+mishpachah,mishpocha
+misinterpretation,mistaking,misunderstanding
+misjudgement,misjudgment
+mislabels,mislabelled,mislabelling,mislabels,mislabeled,mislabeling
+misquotation,misquote
+missile,projectile
+mistletoe => flower
+miter,mitre
+miterwort,mitrewort
+mithracin,mithramycin
+mitomycin,mutamycin
+mitre,miter
+miwok,moquelumnan
+mixer,sociable,social
+mixte => cheese
+mizen,mizenmast,mizzen,mizzenmast
+moban,molindone
+mobocracy,ochlocracy
+mocambique,mozambique
+mocassin,moccasin
+mocker,mockingbird
+modality,mode
+model,simulation
+modeling,mold,molding,mould,moulding
+models,modelled,modelling,modeller,models,modeled,modeling,modeler
+modifier,qualifier
+modulation,transition
+mogadiscio,mogadishu
+mohave,mojave
+molbo => cheese
+moldavia,moldova
+moldboard,mouldboard
+molding,moulding
+mollie,molly
+mollusc,mollusk,shellfish
+molotov,perm
+molter,moulter
+momot,motmot
+monad,monas
+monal,monaul
+mondseer => cheese
+monera,prokayotae
+moneran,moneron
+monggo,moong,mung,munggo
+mongolian,mongolic
+mongolianism,mongolism
+mongrel,mutt
+monitor,varan
+monja => tree
+monjuvi,tafasitamab-cxix
+monkeypod,saman,zaman,zamang
+mono,mononucleosis
+monochromacy,monochromasy,monochromatism,monochromia
+monocycle,unicycle
+monody,monophony
+monogamousness,monogamy
+monogenesis,sporulation
+monologue,soliloquy
+monorchidism,monorchism
+monosaccharide,monosaccharose
+monster,teras
+monstrance,ostensorium
+monument,repository
+moonfish,opah
+moor,moorland
+moorbird,moorfowl,moorgame
+moralisation,moralization,moralizing
+morbier => cheese
+mordva,mordvin,mordvinian
+morgue,mortuary
+morphia,morphine
+mortice,mortise
+morus => tree
+mosaic,photomosaic
+motegrity,prucalopride
+motherwort => flower
+motif,motive
+motion,movement
+motivation,motive,need
+motorboat,powerboat
+moue,pout
+moufflon,mouflon
+mould,mouldings,mouldable,moulder,mouldy,mold,moldings,moldable,molder,moldy
+moult,molt
+mountainside,versant
+mounties,rcmp
+mouse,shiner
+moustache,mustache
+moustachio,mustachio
+mouthful,taste
+mouton,mutton
+movantik,naloxegol
+mozobil,plerixafor
+mucuchies => dog,mucuchies
+muddiness,sloppiness,wateriness
+mudi => dog,mudi
+mudskipper,mudspringer
+muenchen,munich
+muenster => cheese
+muesli,musli,müsli,alpen
+muffler,silencer
+mugwort => flower
+muhuhu => tree
+mujahadeen,mujahadein,mujahadin,mujahedeen,mujahedin,mujahideen,mujahidin
+mule,scuff
+muliebrity,womanhood
+muller,pestle,pounder
+multaq,dronedarone
+multicolour,multicolor
+multivalence,multivalency,polyvalence,polyvalency
+mulwi,munjuk,musgu
+mùmián => tree
+munchkin => cat,munchkin
+munition,ordnance
+munj,munja
+murmur,murmuration,murmuring,mussitation,mutter,muttering
+murol => cheese
+murphy,potato,spud,tater
+muscadel,muscadelle,muscat,muscatel,muskat
+muscle,musculus
+muse,alprostadil
+musengera => tree
+mush,pulp
+muskhogean,muskogean
+muskrat,musquash
+mustang => horse
+mustelid,musteline
+mutawa,mutawa'een
+muteness,mutism
+mutton => 0204230019
+mutton => 0204230099
+mutualism,symbiosis
+mutuality,mutualness
+muztag,muztagh
+mvasi,bevacizumab-awwb
+myalgia,myodynia
+mycapssa,octreotide
+mycella => cheese
+mycobacteria,mycobacterium
+mycobutin,rifabutin
+mycostatin,nystan,nystatin
+myelinisation,myelinization
+myfembree,relugolix,estradiol
+mylotarg,gemtuzumab
+myobloc,rimabotulinumtoxinb
+myofibril,myofibrilla,sarcostyle
+myopia,nearsightedness,shortsightedness
+myoporum => tree
+myrbetriq,mirabegron
+myrcia,myrciaria
+myriameter,myriametre
+myrica => tree
+myrsine => tree
+myrtales,thymelaeales
+myrtle => tree
+myrtle,blueberry,bilberry
+mysoline,primidone
+mystery,whodunit
+mystifier,puzzle,puzzler,teaser
+mytesi,delayed-release,crofelemer
+mythologisation,mythologization
+myxedema,myxoedema
+myxobacter,myxobacteria,myxobacterium
+myxobacterales,myxobacteriales
+myxobacteriaceae,polyangiaceae
+myxophyceae,schizophyceae
+myzithra => cheese
+n'djamena,ndjamena
+naboulsi => cheese
+nabumetone,relafen
+nafcil,nafcillin
+naglazyme,galsulfase
+naiadaceae,najadaceae
+naias,najas
+najd,nejd
+nakedness,nudeness,nudity
+nalline,nalorphine
+naloxone,narcan
+namenda,memantine
+nammad,numdah
+nan,naan
+nandu,rhea
+nanjing,nanking
+nantais => cheese
+nape,nucha,scruff
+naphazoline,privine,sudafed
+napkin,serviette
+naples,napoli
+nappies,diapers,huggies,pampers,peaudouce
+naprosyn,naproxen
+naqua,trichlormethiazide
+narcissus => flower
+nard,spikenard
+nardil,phenelzine
+nardo,nardoo
+narwal,narwhal,narwhale
+nasalisation,nasalization
+natazia,dienogest
+naturalism,realism
+naumachia,naumachy
+naupathia,seasickness
+nausea,sickness
+navaho,navajo
+navane,thiothixene
+nayzilam,midazolam
+naziism,nazism
+neandertal,neanderthal
+neatness,spruceness
+nebcin,tobramycin
+nebelung => cat,nebelung
+nebiim,prophets
+neckcloth,stock
+necklace,pendant
+necrology,obit,obituary
+nectandra => tree
+need,want
+needlecraft,needlework
+needlefish,pipefish
+neencephalon,neoencephalon
+nefazodone,serzone
+negativeness,negativity
+negligee,neglige
+neigh,nicker,whicker,whinny
+nelfinavir,viracept
+nematode,roundworm
+nembutal,pentobarbital
+nemertea,nemertina
+nemertean,nemertine
+nenets,nentsi,nentsy
+neocortex,neopallium
+neoplasm,tumor,tumour
+neostigmine,prostigmin
+nepheline,nephelite
+nephroangiosclerosis,nephrosclerosis
+nephropathy,nephrosis
+nephroptosia,nephroptosis
+nerve,nervus
+nerves,nervousness
+nervure,vein
+nesina,alogliptin
+nettle => flower
+neufchatel => cheese
+neulasta,pegfilgrastim
+neupogen,filgrastim
+neuralgia,neuralgy
+neurilemma,neurolemma
+neurilemoma,neurofibroma
+neurolysin,neurotoxin
+neurone,neurones,neuron,neurons
+neuropil,neuropile
+neuropteran,neuropteron
+neurosis,neuroticism,psychoneurosis
+neutralisation,neutralization
+neutrophil,neutrophile
+nevirapine,viramune
+newfoundland => dog,newfoundland
+newsletter,gazette,bulletin
+newspaper,newsprint
+newt,triton
+nexavar,sorafenib
+ngaio => tree
+nibble,nybble
+nicety,nuance,refinement,shade,subtlety
+niche,recess
+nicotrol,nicotine
+nidaros,trondheim
+nifedipine,procardia
+nightclothes,nightwear,sleepwear
+nightdress,nightgown,nightie,peignoir
+nightshade => flower
+nilgai,nylghai,nylghau
+nimtree => tree
+ninepin,skittle
+ninlaro,ixazomib
+niolo => cheese
+nipa,nypa
+niter,nitre,saltpeter,saltpetre
+nitramine,tetryl
+nitre,niter
+nitroglycerin,nitroglycerine,nitrospan,nitrostat,trinitroglycerin
+nitrospan,nitrostat
+nitrostat,nitroglycerin
+nitweed,pineweed
+nityr,nitisinone
+nivestym,filgrastim-aafi
+nobility,noblesse
+nocturia,nycturia
+nocturne,notturno
+nodule,tubercle
+nokkelost => cheese
+nomogram,nomograph
+nonalignment,nonalinement
+nonentity,nonexistence
+noninterference,nonintervention
+nonplus,nonplusses,nonplussed,nonplussing,nonplus,nonpluses,nonplused,nonplusing
+nonsteroid,nonsteroidal
+noose,snare
+noradrenaline,norepinephrine
+nordic,norse,scandinavian
+noreaster,northeaster
+noreg,norge,norway
+norethandrolone,norethindrone,norlutin
+norflex,orphenadrine
+noritate,metronidazole
+normalcy,normality
+normandie,normandy
+norpace,disopyramide
+norrbottenspets => dog,norrbottenspets
+north,northward
+northeast,northeastward
+northumberland => cheese
+northwest,northwestward
+nortriptyline,pamelor
+norvir,ritonavir
+nose,nozzle
+noseband,nosepiece
+nosegay => flower
+notch,pass
+note,tone
+notepad,notebook
+nothofagus => tree
+notice,notification
+notornis,takahe
+nourianz,istradefylline
+novelette,novella
+noviciate,novitiate
+novocain,novocaine
+noxafil,posaconazole
+nplate,romiplostim
+nsafu => tree
+nubeqa,darolutamide
+nucala,mepolizumab
+nucleole,nucleolus
+nulibry,fosdenopterin
+nulojix,belatacept
+number,numeral
+numididae,numidinae
+nuplazid,pimavanserin
+nuremberg,nurnberg
+nurseling,nursling
+nushield,woundessing
+nutcracker,nuthatch
+nutgrass,nutsedge
+nuvigil,armodafinil
+nuzyra,omadacycline
+nylons,rayons
+nyssa => tree
+nyvepria,pegfilgrastim-apgf
+o.k.,okay,okeh,okey
+oarfish,ribbonfish
+oarlock,rowlock,thole,tholepin
+oath,swearing
+oaxaca => cheese
+obbligato,obligato
+obloquy,opprobrium
+obscureness,obscurity
+observation,reflection,reflexion
+occitan,provencal
+occlusive,plosive,stop
+oceania,oceanica
+ocellus,stemma
+ocher,ochre
+ocicat => cat,ocicat
+ocrevus,ocrelizumab
+octet,octette
+octoberfest,oktoberfest
+oculus,optic
+oddment,remainder,remnant
+odefsey,emtricitabine,rilpivirine
+odesa,odessa
+odomzo,sonidegib
+odontalgia,toothache
+odour,odor
+oedema,oedematous,edema,edematous
+oesophagus,oesophagi,oesophageal,esophagus,esophagi,esophageal
+oeuvre,work
+ofev,nintedanib
+offbeat,upbeat
+offence,offense
+offer,offering
+office,power
+offprint,reprint,separate
+offspring,young
+ogalala,oglala
+ogivri,trastuzumab-dkst
+oiler,tanker
+oilskin,slicker
+oldwench,oldwife
+oleaster => tree
+olein,triolein
+oleostearin,oleostearine
+olicuáhuitl => tree
+oligo,oligonucleotide
+oligoclase,plagioclase
+oligodendria,oligodendroglia
+olimbos,olympus
+olumiant,baricitinib
+olux-e,clobetasol
+olympiad,olympics
+omasum,psalterium
+omayyad,ommiad,umayyad
+omelet,omelette
+omelette,omelet
+omen,portent,presage,prodigy,prognostic,prognostication
+omeprazole,prilosec
+omnipresence,ubiquitousness,ubiquity
+oncaspar,pegaspargase
+oncoming,onset
+oncosperma => tree
+oncovin,vincristine
+onfi,clobazam
+ongentys,opicapone
+onglyza,saxagliptin
+onopordon,onopordum
+onpattro,patisiran
+ontruzant,trastuzumab-dttb,iv
+onureg,azacitidine
+onychophoran,peripatus
+ooze,oozing,seepage
+opdivo,nivolumab
+opdualag,nivolumab,relatlimab-rmbw
+open,outdoors
+opening,orifice,porta
+ophidia,serpentes
+ophidian,serpent,snake
+ophthalmia,ophthalmitis
+opiliones,phalangida
+opinion,view
+oporto,porto
+opossum,phalanger,possum
+oppositeness,opposition
+opsonisation,opsonization
+opsumit,macitentan
+opzelura,ruxolitinib,topical
+orach,orache
+orang,orangutan,orangutang
+orbactiv,oritavancin
+orbiter,satellite
+ordinance,regulation
+oreide,oroide
+orencia,abatacept
+orenitram;,treprostinil
+orfadin,nitisinone
+organdie,organdy
+organisation,organization
+organiser,organizer
+orgovyx,relugolix
+oriahnn,elagolix,estradiol,elagolix
+orilissa,elagolix
+orinase,tolbutamide
+orison,petition,prayer
+orkambi,lumacaftor,ivacaftor
+orla => cheese
+orladeyo,berotralstat
+ornithopter,orthopter
+ornithosis,psittacosis
+orphanage,orphanhood
+orris,orrisroot
+orthoepy,pronunciation
+orthogonality,perpendicularity
+orthopaedic,orthopaedist,orthopedic,orthopedist
+orthophosphate,phosphate
+orthopteran,orthopteron
+orthovisc,hyaluronan
+orumiyeh,urmia
+oryx,pasang
+oscheocele,oscheocoele
+oschtjepka => cheese
+oscillation,vibration
+oscilloscope,scope
+oscines,passeres
+oscitance,oscitancy
+oseni,alogliptin,pioglitazone
+osmunda => flower
+ostrya => tree
+oszczypek => cheese
+otezla,apremilast
+ottawa,outaouais
+otterhound => dog,otterhound
+outcome,result,resultant,termination
+outcrop,outcropping
+outerwear,overclothes
+outpost,outstation
+outrage,scandal
+ovang => tree
+overalls,dungarees
+overappraisal,overestimate,overestimation,overvaluation
+overbid,overcall
+overburden,overload
+overcast,overcasting
+overcoat,overcoating
+overflow,overspill,runoff
+overhead,viewgraph
+overlay,overlayer,sheathing
+overprint,surprint
+oversimplification,simplism
+overture,preliminary,prelude
+ovine,sheep,lamb,mutton
+ovolo,thumb
+oxalacetate,oxaloacetate
+oxalis,sorrel
+oxazepam,serax
+oxbryta,voxelotor
+oxidant,oxidiser,oxidizer
+oxidation,oxidisation,oxidization
+oxidoreduction,redox
+oxlip,paigle
+oxlumo,lumasiran
+oxyhaemoglobin,oxyhemoglobin
+oxyphenbutazone,tandearil
+oxytocin,pitocin
+ozaena,ozena
+ozempic,semaglutide
+ozocerite,ozokerite
+pace,yard
+pacemaker,pacer,pacesetter
+pachouli,patchouli,patchouly
+pachycephalosaur,pachycephalosaurus
+pachypodium => tree
+pacification,peace
+package,parcel,software
+packaging,promo,promotion,publicity
+packing,wadding
+paddymelon,pademelon
+padova,padua,patavium
+paean,pean
+paediatric,paediatrician,pediatric,pediatrician
+paedophile,paedophilia,paedophiliac,pedophile,pedophilia,pedophiliac
+paeony,peony
+pageant,pageantry
+pahlavi,pehlevi
+pail,pailful
+paillasse,palliasse
+paint,pigment
+painting,picture
+pajamas,pyjamas,pjs,jammies
+palaeencephalon,paleencephalon,paleoencephalon
+palaeontology,palaeontologist,paleontology,paleontologist
+palaestra,palestra
+palankeen,palanquin
+palaquium => tree
+palatinate,pfalz
+palaver,rhetoric
+pale,picket
+paleostriatum,pallidum
+palette,pallet
+palingenesis,recapitulation
+palm,thenar
+palmaceae => tree
+palmae => tree
+palpitation,quiver,quivering,shakiness,shaking,trembling,vibration
+palsy,paralysis
+palynziq,pegvaliase-pqpz
+pamphlet,tract
+pamplemousse => tree
+panamica,panamiga
+panatela,panetela,panetella
+panchayat,panchayet,punchayet
+pane,paneling,panelling
+paneer => cheese
+panel,venire
+panela => cheese
+panelled,panelling,panellist,paneled,paneling,panelist
+pang,sting
+pangaea,pangea
+panhematin,hemin
+panic,scare
+panjabi,punjabi
+pannerone => cheese
+panocha,panoche,penoche,penuche
+panpipe,syrinx
+pansy => flower
+pantie,panty,scanty
+panting,trousering
+papacy,pontificate
+papaia,papaya,pawpaw
+papaverales,rhoeadales
+paperback,softback
+paperbark => tree
+paperboard,posterboard
+paperwork,documents
+papilloma,villoma
+papillon => dog,papillon
+papooseroot,squawroot
+paprika,pimento,pimiento
+papulovesicle,vesicopapule
+paraesthesia,paresthesia
+parakeet,paraquet,paroquet,parrakeet,parroket,parroquet
+paraleipsis,paralepsis,paralipsis,preterition
+parallelepiped,parallelepipedon,parallelopiped,parallelopipedon
+paramecia,paramecium
+paraphrase,paraphrasis
+parasitaemia,parasitemia
+parasol,sunshade
+parasoltree => tree
+parazoan,poriferan,sponge
+parcel,tract
+parcels,parcelled,parcelling,parcels,parceled,parceling
+parentage,parenthood
+parget,pargeting,pargetting
+pargeting,pargetry,pargetting
+parhelion,sundog
+paries,wall
+paring,shaving,sliver
+park,parkland
+parkinson's,parkinsonism
+parlour,parlor
+parmesan => cheese
+parnahiba,parnaiba
+parole,word
+paronomasia,punning,wordplay
+paroxetime,paxil
+parqueterie,parquetry
+parrotfish,pollyfish
+parsabiv,etelcalcetide
+parsec,secpar
+parsonage,rectory,vicarage
+parthenogenesis,parthenogeny
+participial,participle
+partisan,partizan
+partridge,tinamou
+parvo,parvovirus
+pashmina,shawl
+pashtun,pathan
+pass,passport
+passementerie,trim,trimming
+passendale => cheese
+passion,rage
+paster,sticker
+pastil,pastille,troche
+pasture,pastureland
+patchboard,plugboard,switchboard
+pathway,tract
+patio,terrace
+patrai,patras
+patriarchate,patriarchy
+patristics,patrology
+patronym,patronymic
+patter,spiel
+paulownia => tree
+pavan,pavane
+pavement,paving,sidewalk
+pavior,paviour
+pavis,pavise
+paygrade,rating
+payoff,reward,wages
+payroll,paysheet
+pbit,petabit
+pc => computer
+peaceableness,peacefulness
+peag,wampum,wampumpeag
+peak,point
+peal,pealing,roll,rolling
+peanut,groundnut,goober,pindar,monkeynut,earthnut
+pearlweed,pearlwort
+peavey,peavy
+pebibit,pibit
+pebibyte,petabyte
+pecker,peckerwood,woodpecker
+pecs,pectoral,pectoralis
+pedal,treadle
+pedals,pedalled,pedalling,pedals,pedaled,pedaling
+pediapred,prednisolone,prelone
+pediasure,pediasure
+pedicel,pedicle
+pedipalpi,uropygi
+peeing,piss,pissing
+peel,skin
+peepul,pipal,pipul
+peewee,peewit,pewee,pewit
+pehuén => tree
+peireskia,pereskia
+peke,pekinese,pekingese
+pekingese => dog,pekingese
+peliosis,purpura
+pellet,shot
+peloponnese,peloponnesus
+peltogyne => tree
+pelú => tree
+peludo,poyou
+pemazyre,pemigatinib
+pemican,pemmican
+penamellera => cheese
+penbryn => cheese
+pencarreg => cheese
+pendant,pendent
+peneplain,peneplane
+penn,pennsylvania
+penn'orth,pennyworth
+pennant,pennon,streamer,waft
+pennon,pinion
+pennoncel,pennoncelle,penoncel
+pennywhistle,whistle
+penstock,sluice,sluiceway
+pentacel,diptheria
+pentacle,pentagram,pentangle
+pentaerythritol,peritrate
+pentasa,mesalamine
+pentazocine,talwin
+pentothal,thiopental
+pentoxifylline,trental
+penult,penultima,penultimate
+peony => flower
+peplos,peplum,peplus
+pepper,peppercorn
+pepperwood => tree
+peptidase,protease,proteinase
+peptisation,peptization
+perambulator,pram,pushchair,pusher,stroller
+perative,perative
+percent,percentage
+perchloromethane,tetrachloromethane
+perciformes,percomorphi
+percoid,percoidean
+percussor,plessor,plexor
+perdicidae,perdicinae
+perfect,perfective
+perfume,cologne,essence
+peril,riskiness
+perilune,periselene
+period,point,stop
+peripeteia,peripetia,peripety
+periquiteira => tree
+perishable,spoilable
+peristalsis,vermiculation
+periwig,peruke
+periwinkle => flower
+periwinkle,winkle
+perjeta,pertuzumab
+perk,perquisite
+perm,permanent
+permeation,pervasion,suffusion
+permutation,replacement,substitution,switch,transposition
+pernambuco,recife
+perphenazine,triavil
+persea => tree
+persian => cat,persian
+personification,prosopopoeia
+perspiration,sudor,sweat
+persuasion,suasion
+pertzye,amylase,lipase,pancrelipase,protease
+perusal,perusing,studying
+pesantran,pesantren
+pest,pestilence,pestis,plague
+pestle,stamp
+peterbald => cat,peterbald
+petition,postulation,request
+petrifaction,petrification
+petticoat,underskirt
+phacelia,scorpionweed
+phaeochromocytoma,pheochromocytoma
+phaeton,tourer
+phalène => dog,phalène
+phanerogam,spermatophyte
+pharmaceutic,pharmaceutical
+pharynx,throat
+phasmatidae,phasmidae
+phasmatodea,phasmida
+phenazopyridine,pyridium
+phenergan,promethazine
+phenicia,phoenicia
+phenolic,phenoplast
+phenothiazine,thiodiphenylamine
+phentolamine,vasomax
+phesgo,pertuzumab,trastuzumab,hyaluronidase-zzxf
+philharmonic,symphony
+philippopolis,plovdiv
+phillidae,phyllidae
+philter,philtre
+philtre,philter
+phlebogram,venogram
+phlegm,sputum
+phoenix => tree
+phonation,vocalisation,vocalism,vocalization,voice
+phone,telephone,cellphone,smartphone
+phoney,phoneys,phony,phonies
+phoronida,phoronidea
+photalgia,photophobia
+photoconduction,photoconductivity
+phragmacone,phragmocone
+phthirius,phthirus
+phylactery,tefillin
+phylloquinone,phytonadione
+phyllostomatidae,phyllostomidae
+phytelephas => tree
+piano,pianoforte
+piaster,piastre
+piazza,place,plaza
+picardie,picardy
+pichkari => tree
+pickerelweed,wampee
+pickup,pick-up
+piddle,piss,urine,water,weewee
+pidlimdi,tera,yamaltu
+piedmont,piemonte
+pieplant,rhubarb
+pifeltro,doravirine
+pigboat,submarine
+piggy,piglet,shoat,shote
+pigpen,pigsty
+pigswill,pigwash,slop,slops,swill
+pilaf,pilaff,pilau,pilaw
+pilaff,pilaf
+pilchard,sardine
+pile,piling,spile,stilt
+pillbox,toque,turban
+pilothouse,wheelhouse
+pilsen,plzen
+pilsener,pilsner
+pimento,pimiento
+pimpernel => flower
+pincer,tweezer
+pinconning => cheese
+pindolol,visken
+pinfish,squirrelfish
+pinion,quill
+pinkie,pinky
+pinna,pinnule
+pinnatiped,pinniped
+pinon,pinyon
+pinophytina,pinopsida
+pinworm,threadworm
+piora => cheese
+pipe,tube,piping
+piperacillin,pipracil
+piperin,piperine
+pipet,pipette
+pipistrel,pipistrelle
+piqray,alpelisib
+pirogi,piroshki,pirozhki
+pisanosaur,pisanosaurus
+pistacia => tree
+piston,plunger
+pitanga => tree
+pitchblende,uraninite
+pitcher,pitcherful
+pithecellobium => tree
+pithecellobium,pithecolobium
+pitomba => tree
+pitprop,sprag
+pitressin,vasopressin
+pity,shame
+pixie-bob => cat,pixie-bob
+pixie,pixy,pyxie
+place,position
+plaid,tartan
+plainchant,plainsong
+plait,pleat
+planaria,planarian
+plant,works
+plash,splash
+plasm,plasma
+plaster,plasterwork
+plasticiser,plasticizer
+platan,sycamore
+plateau,tableland
+platelet,thrombocyte
+platform,program
+platyrrhine,platyrrhinian
+playstation,xbox
+plea,supplication
+plecopteran,stonefly
+pledge,toast
+pleomorphism,polymorphism
+pleopod,swimmeret
+plesiosaur,plesiosaurus
+plessimeter,pleximeter
+pleuronectidae,flounder,bothidae,citharidae
+plexiglas,plexiglass
+plexus,rete
+pliers,plyers
+plonk,plunk
+plough,plow
+ploughshare,plowshare,share
+plug,stopper,stopple
+plumb,plummet
+plumbism,saturnism
+plumeria => tree
+plumeria,plumiera
+pluralisation,pluralization
+pluviometer,udometer
+plyboard,plywood
+pneumoconiosis,pneumonoconiosis
+pneumogastric,vagus
+pocket,pouch
+podhalanski => cheese
+podocarpus => tree
+podsol,podzol
+poeciliid,topminnow
+poesy,poetry,verse
+pohutukawa => tree
+poignance,poignancy
+poilu,purloo
+pointer => dog,pointer
+poison,toxicant
+poitevin => dog,poitevin
+poke,sack
+poker,salamander
+poland,polska
+polarimeter,polariscope
+polaris,polestar
+polarisation,polarization
+polarity,sign
+pole,terminal
+poleax,poleaxe
+polecat,skunk
+polemonium => flower
+polio,poliomyelitis
+polkolbin => cheese
+pollack,pollock
+pollenation,pollination
+pollex,thumb
+polliwog,pollywog,tadpole
+polybotria,polybotrya
+polybutene,polybutylene
+polychaete,polychete
+polychloroprene,neoprene
+polyethylene,polythene
+polymerisation,polymerization
+polyose,polysaccharide
+polyp,polypus
+polypropene,polypropylene
+polytetrafluoroethylene,teflon
+polythene,polyethylene
+polytonalism,polytonality
+polyurethan,polyurethane
+polyvalence,polyvalency
+pomacanthus,angelfish,pterophyllum
+pomade,pomatum
+pomalyst,pomalidomide
+pomello => tree
+pomelo,pummelo,shaddock
+pomeranian => dog,pomeranian
+pommel,saddlebow
+pommelo => tree
+pompey,portsmouth
+ponca,ponka
+pond,pool
+ponvory,ponesimod
+pony => horse
+poodle => dog,poodle
+pool,puddle
+poop,quarter,stern,tail
+poppadum,poppadom
+populace,public,world
+popularisation,popularization
+porc,pork
+porcelaine => dog,porcelaine
+pore,stoma,stomate
+porgy,scup
+pork,gammon
+porridge,oats
+port,cockburns
+portrait,portraiture,portrayal
+portrazza,necitumumab
+poser,sticker,stumper,toughie
+posit,postulate
+positiveness,positivity
+possibility,possibleness
+possumhaw => tree
+postage,stamp
+postdoc,postdoctoral
+postel => cheese
+postfix,suffix
+postulation,predication
+potage,pottage
+poteligeo,mogamulizumab-kpkc
+potence,potency
+potency,potential,potentiality
+potential,voltage
+pothouse,saloon,taphouse
+poultry,chicken,hen
+pounding,throb,throbbing
+pourly => cheese
+powder,pulverisation,pulverization
+powderpuff,puff
+power,superpower
+ppe,ppe
+practise,practice,practice
+praesidium,presidium
+praetorium,pretorium
+prag,prague,praha
+praluent,alirocumab
+prastost => cheese
+pravachol,pravastatin
+prawn,shrimp
+preaching,sermon
+precedence,precedency,priority
+precept,principle
+predisposition,sensitivity
+predominance,predomination,prepotency
+prejudgement,prejudgment
+prelacy,prelature
+prelim,preliminary
+prematureness,prematurity
+preparation,preparedness,readiness
+pressato => cheese
+pressor,vasoconstrictive,vasoconstrictor
+prestige,prestigiousness
+preterit,preterite
+pretomanid,pretomanid
+preussen,prussia
+preventative,preventive,prophylactic
+preview,prevue,trailer
+prevymis,letermovir
+prey,quarry
+prezcobix,darunavir,cobicistat
+prezista,darunavir
+pricker,prickle,spikelet,spine,sticker,thorn
+prickleback,stickleback
+priftin,rifapentine
+primate,ayeaye,baboon,bushbaby,galago,capuchin,chacma,chimpanzee,colobus,douc,douroucouli,colugo,gelada,gibbon,gorilla,grivet,guenon,guereza,indris,indri,langur,lemur,loris,macaco,macaque,mandrill,mangabey,marmoset,monkey,orang-outang,orang-utan,siamang,sifaka,talapoin,tamarin,tana,tarsier,titi,vervet,wanderoo
+primates,apes,chimps,chimpanzees,orangutans,lemurs,baboons,sifaka,gorilla,monkeys,langurs,bonobo
+primrose => flower
+primrose,primula
+princedom,principality
+pristiq,desvenlafaxine
+pritchardia => tree
+privet => flower
+prize,trophy
+proboscidean,proboscidian
+proboscis,trunk
+procardia,nifedipine
+procaryote,prokaryote
+process,summons
+processional,prosodion
+proctocele,rectocele
+proctofoam,hydrocortisone-pramoxine
+prodroma,prodrome
+product,production
+proenzyme,zymogen
+professing,profession
+professionalisation,professionalization
+proffer,proposition,suggestion
+profile,visibility
+profits,winnings
+progestin,progestogen
+program,programme
+prohibition,proscription
+projectile,rocket
+prolia,denosumab
+prolixity,prolixness,windiness,wordiness
+prom,promenade
+promacta,eltrombopag
+promote,promote
+prompt,prompting
+prompting,suggestion
+prongbuck,pronghorn
+prop,property
+propanal,propionaldehyde
+propanamide,proprionamide
+propane,lpg
+propellant,propellent
+propeller,propellor
+propene,propylene
+propjet,turboprop
+proposal,proposition
+proprietary,proprietorship
+prosperity,successfulness
+prostheon,prosthion
+protactinium,protoactinium
+protest,protestation
+prothalamion,prothalamium
+protist,protistan
+protomammal,therapsid
+protozoan,protozoon
+proturan,telsontail
+provel => cheese
+provenge,sipuleucel-t
+province,responsibility
+provision,proviso
+prozac,fluoxetine
+pseudopod,pseudopodium
+pseudotsuga => tree
+pseudowintera,wintera
+psilocin,psilocybin
+psilopsida,psilotatae
+psilosis,sprue
+psittaciforme,kakapo,kea,cockatiel,budgerigar
+psittacosaur,psittacosaurus
+psychokinesis,telekinesis
+psylla,psyllid
+pteridospermae,pteridospermaphyta
+pterocarpus => tree
+pterocarya => tree
+ptomain,ptomaine
+pucker,ruck
+pudelpointer => dog,pudelpointer
+puff,whiff
+pug => dog,pug
+puka => tree
+pukanui => tree
+pulasan,pulassan
+puli => dog,puli
+pull,twist,wrench
+pullback,tieback
+pulmocare,pulmocare
+pumi => dog,pumi
+pummelled,pummelling,pummeled,pummeling
+pummelo => tree
+punch,puncher
+punkey,punkie,punky
+puppy => dog,puppy
+purdah,solitude
+pureblood,purebred,thoroughbred
+pureness,purity
+purification,refinement,refining
+purulence,purulency
+push,thrust
+pusher,zori
+pushpin,thumbtack
+pussley,pussly,verdolagas
+pyaemia,pyemia
+pycnosis,pyknosis
+pylera,metronidazole,tetracycline
+pyorrhea,pyorrhoea
+pyralidae,pyralididae
+pyramide => cheese
+pyrectic,pyrogen
+pyrimethamine,pyrimethamine
+pyrola,wintergreen
+pyroxylin,pyroxyline
+pyrrhotine,pyrrhotite
+pyrukynd,mitapivat
+pyxidium,pyxis
+qelbree,viloxazine
+qiang,qiangic
+qindarka,qintar
+qinlock,ripretinib
+qtern,dapagliflozin,saxagliptin
+quackgrass,witchgrass
+quadrangle,quadrilateral,tetragon
+quadruple,quadruplet,quartet,quartette
+quahaug,quahog
+qualification,reservation
+qualm,queasiness,squeamishness
+quandang,quandong,quantong
+quark => cheese
+quarrels,quarrelled,quarreller,quarrels,quarreled,quarreler
+quartet,quartette
+quayage,wharfage
+queen,tabby
+quesnelia => flower
+quiet,tranquility,tranquillity
+quietus,rest,sleep
+quinidex,quinidine,quinora
+quinquenervia,niaouli
+quittance,repayment
+qulipta,atogepant
+raas => cat,raas
+rabacal => cheese
+rabato,rebato
+rabbet,rebate
+rabbitweed,snakeweed
+raccoon,racoon
+racecourse,racetrack,raceway,track
+rachet,ratch,ratchet
+rachischisis,schistorrhachis
+rachitis,rickets
+raclette => cheese
+racoon,raccoon
+racquet,racket
+radar,radiolocation
+raddle,reddle,ruddle
+radermachera => tree
+radiation,radioactivity
+radio,radiocommunication,wireless,tuner
+radiogram,radiograph,shadowgraph,skiagram,skiagraph
+radiography,skiagraphy
+radiophone,radiotelephone
+radiophoto,radiophotograph
+radiotelegraph,radiotelegraphy
+radiotelephone,radiotelephony
+radius,spoke
+raffia,raphia
+ragamuffin => cat,ragamuffin
+railroad,railway
+railyard,yard
+raincoat,waterproof
+rajapalayam => dog,rajapalayam
+rale,rattle,rattling
+rambotan,rambutan
+ramee,ramie
+ramekin,ramequin
+ranales,ranunculales
+rancour,rancor
+rand,reef,witwatersrand
+range,reach
+rangoon,yangon
+ranitidine,zantac
+rapaflo,silodosin
+rapamune,sirolimus
+rape,colza,oilseed,napus,rapeseed
+raphe,rhaphe
+raphia => tree
+rapier,tuck
+rapport,resonance
+raschera => cheese
+rasht,resht
+rasp,rasping
+rastafari,rastas
+rasuvo,methotrexate
+rata => tree
+ratability,rateability
+ratables,rateables
+ratafee,ratafia
+ratan,rattan
+rateable,rateability,rateably,ratable,ratability,ratably
+rationalisation,rationalization
+rationality,reason,reasonableness
+ratlin,ratline
+rattler,rattlesnake
+raudixin,reserpine,sandril,serpasil
+rauvolfia,rauwolfia
+raveling,ravelling
+ravelled,ravelling,raveled,raveling
+ravigote,ravigotte
+rawness,soreness,tenderness
+rayaldee,calcifediol
+razing,wrecking
+razorback,rorqual
+reabsorption,resorption
+reading,recital,recitation
+reaffirmation,reassertion
+realisation,realization
+realism,reality,realness
+rebirth,reincarnation,renascence
+reblochon => cheese
+reblozyl,luspatercept-aamt
+rebuff,repulse,snub
+rebuke,reprehension,reprimand,reproof,reproval
+rebuttal,rebutter
+recarbrio,relebactam
+recasting,rephrasing,rewording
+reception,response
+recession,recessional
+reciprocality,reciprocity
+reckoning,tally
+recognisance,recognizance
+recommendation,testimonial
+reconnoitre,reconnoitres,reconnoitred,reconnoitring,reconnoiter,reconnoitered,reconnoiters,reconnoitering
+recounting,relation,telling
+recurrence,return
+redberry,snakeberry
+redbreast,robin
+redfish,rosefish
+redialled,redialling,redialed,redialing
+redstart,redtail
+reducer,reductant
+reducing,reduction
+redwood,sequoia
+redwoods => tree
+reenforcement,reinforcement
+reference,source
+refilling,renewal,replacement,replenishment
+reflectance,reflectivity
+reflection,reflexion
+reflexiveness,reflexivity
+refuelled,refuelling,refueled,refueling
+refuge,safety
+refurbishment,renovation,restoration
+refuse,rubbish,garbage
+reggianito => cheese
+register,registry
+regranex,becaplermin
+regularisation,regularization
+reharmonisation,reharmonization
+reign,sovereignty
+reims,rheims
+reinforcement,strengthener
+reissue,reprint,reprinting
+relabelled,relabelling,relabeled,relabeling
+relevance,relevancy
+relinquishing,relinquishment
+relyvrio,taurursodiol
+remake,remaking
+rematch,replay
+remedou => cheese
+remicade,infliximab
+remodelled,remodelling,remodeled,remodeling
+remodulin,treprostinil
+remora,suckerfish
+remould,remold
+rendezvous,tryst
+renflexis,infliximab-abda
+renouncement,renunciation
+renova,tretinoin
+rent,snag,split,tear
+renunciation,repudiation
+repatha,evolocumab
+repeat,repetition
+repellant,repellent
+repercussion,reverberation
+repertoire,repertory
+repetitiousness,repetitiveness
+repletion,satiation,satiety
+replica,replication,reproduction
+reply,response
+report,study
+represser,repressor
+reprieve,respite
+reptile,reptilian
+reputation,repute
+requeson => cheese
+requital,retribution
+reservation,reserve
+reservoir,source
+resilience,resiliency
+resin,rosin
+restasis,cyclosporine
+restharrow => flower
+restorative,tonic
+restoril,temazepam
+resume,sketch,survey
+retardant,retardation,retardent
+retevmo,selpercatinib
+retin-a,tretinoin
+retinal,retinene
+retroflection,retroflexion,retroversion
+retrovir,zidovudine
+revenue,taxation
+revere,revers
+reverse,verso
+revetement,revetment
+review,revue
+revising,rewriting
+revlimid,lenalidomide
+rexulti,brexpiprazole
+reyvow,lasmiditan
+rezurock,belumosudil
+rhabdomyosarcoma,rhabdosarcoma
+rhein,rhine
+rheinland,rhineland
+rhino,rhinoceros
+rhizome,rootstalk,rootstock
+rhizophora => tree
+rhizopod,rhizopodan
+rhodes,rodhos
+rhumba,rumba
+rhus => tree
+rhyme,rime,verse
+riabni,infliximab-axxq,iv
+riband,ribband
+ribavirin,virazole
+ribbon,thread
+ribociclib,letrozole
+ribonuclease,ribonucleinase,rnase
+richelieu => cheese
+riches,wealth
+rickrack,ricrac
+ridaura,auranofin
+ridder => cheese
+ridgel,ridgeling,ridgil,ridgling
+rifadin,rifampin,rimactane
+riffle,ripple,rippling,wavelet
+rigamarole,rigmarole
+rigging,tackle
+right,rightfield
+rigidification,rigidifying,stiffening
+rigotte => cheese
+rigour,rigours,rigourous,rigor,rigors,rigorous
+rijstafel,rijstaffel,rijsttaffel
+riksmaal,riksmal
+rill,rivulet,runnel,streamlet
+ring,ringing,tintinnabulation
+ringhals,rinkhals
+ringworm,roundworm,tinea
+rinvoq,upadacitinib
+riot,rioting
+ripsaw,splitsaw
+rituxan,rituximab
+rivalled,rivalling,rivaled,rivaling
+riverbank,riverside
+rivet,stud
+riveter,rivetter
+road,route
+roads,roadstead
+roadside,wayside
+roadster,runabout
+rocamadour => cheese
+rock,stone
+rocket,skyrocket
+rockfish,striper
+rofecoxib,vioxx
+roller,tumbler
+rollot => cheese
+rolvedon,eflapegrastim-xnst
+roma,rome
+romania,roumania,rumania
+romanian,rumanian
+romano => cheese
+romanoff,romanov
+romansh,rumansh
+romper,rompersuit
+roncal => cheese
+rondeau,rondel,rondo
+rooms,suite
+root,solution
+ropeway,tram,tramway
+rose,rosebush
+roselle,rozelle,sorrel
+rosemallow => tree
+rosemary => flower
+rosewood => tree
+rostrum,snout
+rottenstone,tripoli
+rottweiler => dog,rottweiler
+rotundity,roundness
+roughbush => tree
+roule => cheese
+rowasa,mesalamine
+roystonea => tree
+rozerem,ramelteon
+rozlytrek,entrectinib
+ruanda,rwanda
+rubbish,scrap,trash
+rubens => cheese
+rubraca,rucaparib
+rubric,title
+rucksack,backpack
+rudderpost,rudderstock
+rue => flower
+rugelach,ruggelach,rugulah
+ruin,ruination
+rukobia,fostemsavir
+rule,ruler
+rumour,rumourmonger,rumor,rumormonger
+rundle,rung,spoke
+rundown,summation
+ruralism,rusticism
+rush,spate,surge,upsurge
+rusk,zwieback
+russia,ussr
+rust,rusting
+rustinu => cheese
+rustle,rustling,whisper,whispering
+rutabaga,swede
+rutherfordium,unnilquadium
+ruxience,rituximab-pvvr
+rybelsus,semaglutide
+rybrevant,amivantamab-vmjw
+rydapt,midostaurin
+rytary;,carbidopa,levodopa
+saanenkaese => cheese
+sabal => tree
+sabaton,solleret
+sabayon,zabaglione
+sabre,saber
+sabril,vigabatrin
+saccharin,saccharine
+saccharose,sucrose
+saccule,sacculus
+sachsen,saxe,saxony
+sacristy,vestry
+saddle,saddleback
+saddlery,tack
+sadness,sorrow,sorrowfulness
+safaqis,sfax
+safflower,carthamus
+saffranine,safranin,safranine
+safou => tree
+safyral,drospirenone
+saga => cheese
+sage,salvia
+sago,saksak,rabia,sagu
+saguaro,sahuaro
+sahaptin,shahaptian
+saida,sayda,sidon
+sake,saki
+sakkara,saqqara,saqqarah
+saktism,shaktism
+sal => tree
+salade,sallet
+salal,shallon
+saleable,saleability,salable,salability
+salep,sahlep,sahlab,salepi
+saleroom,salesroom,showroom
+salers => cheese
+salience,saliency,strikingness
+salish,salishan
+saliva,spit,spittle
+salix => tree
+salmonberry,thimbleberry
+salmonidae,salmon
+salonica,salonika,thessalonica,thessaloniki
+saloon,sedan
+salp,salpa
+saltbush => tree
+saltpetre,saltpeter
+saluki => dog,saluki
+salutation,salute
+salwar,shalwar
+samarang,semarang
+samarcand,samarkand
+sambar,sambur
+sambucus => tree
+samiel,simoom,simoon
+samisen,shamisen
+samoyed => dog,samoyed
+samso => cheese
+sanatarium,sanatorium,sanitarium
+sancerre => cheese
+sandarac,sandarach
+sandbox,sandpile,sandpit
+sandbur,sandspur
+sander,smoother
+saneness,sanity
+sangaree,sangria
+sanicle,snakeroot
+sapele => tree
+saphnelo,anifrolumab-fnia
+sapodilla,sapota
+sappanwood => tree
+sapraemia,sapremia
+sapsali => dog,sapsali
+saptrees => tree
+saragossa,zaragoza
+sarape,serape
+sarcenet,sarsenet
+sarclisa,isatuximab-irfc
+sarcocystidean,sarcocystieian,sarcosporidian
+sarcodine,sarcodinian
+sard,sardine,sardius
+saree,sari
+šarplaninac => dog,šarplaninac
+sars-cov,covid,coronavirus
+sassaby,topi
+sassafras => tree
+satinash => tree
+satinet,satinette
+satureia,satureja
+sauerkraut,cabbage,kimchi
+sausage,alheira,andouille,andouillette,androlla,arabiki,azaruja,babic,alkenbrij,banat,belutak,beutelwurst,bierschinken,bierwurst,biroldo,blodpølse,blóðpylsa,bloedworst,blunze,blutwurst,bockwurst,boerewors,bologna,botifarra,botillo,boudin,braadworst,brativurst,bratwurst,braunschweiger,bregenwurst,brühwurst,butifarra,čajna,cervela,cervelat,cervelatwurst,cervellata,češnovka,chaudin,chipolata,chistorra,chorizo,chouriço,chunchullo,ciauscolo,ciavàr,cotechino,csabai,debrecener,diot,drisheen,droëwors,drywors,embutido,extrawurst,falukorv,farinheira,fläskkorv,fleischwurst,frankfurter,frikandel,gelbwurst,goetta,grillpølse,grillworst,gyulai,haggis,isterband,jagdwurst,jausenwurst,kabanos,kaminwurz,käsekrainer,kaszanka,kielbasa,knackwurst,knakworst,knipp,knoblewurst,kochwurst,kohlwurst,krakowska,kulen,kupati,kurobuta,landjäger,leberwurst,lekor,likëngë,linguiça,liverwurst,longaniza,lukanka,makanek,mazzafegati,medisterpølse,merguez,mettwurst,metworst,morcilla,morcón,moronga,morrpølse,mortadella,mustamakkara,myśliwska,nduja,noumboulo,ossenworst,paio,pepperoni,pinkel,pinuneg,plaaswors,pleşcoi,potatiskorv,prasky,prinskorv,qazy,ringriderpølse,rookworst,ryynimakkara,sabodet,salami,salchicha,salchichón,salsichão,salumi,sardel,sardelka,saren,saucisson,saumagen,saveloy,schinkenwurst,schüblig,siskonmakkara,skilandis,snorkers,sobrasada,soppressata,sopressa,stippgrütze,strolghino,sucuk,sujuk,švargl,tako,teewurst,tobă,urutan,verivorst,vossakorv,weckewerk,weisswurst,weselna,wiejska,wollwurst,zampina,zungenwurst,zwiebelwurst
+sauterne,sauternes
+savanna,savannah
+savannah => cat,savannah
+savannah,savannahs,savanna,savannas
+savella,milnacipran
+saviour,saviours,savior,saviors
+savour,savoury,savor,savory
+saxifras => tree
+sayanci,zaar
+scabiosa,scabious
+scaffolding,staging
+scag,skag,smack,thunder
+scallopine,scallopini
+scamorza => cheese
+scandalisation,scandalization
+scantling,stud
+scape,shaft
+scapular,scapulary
+scarab,scarabaeus
+scarabaean,scarabaeid
+scarecrow,scarer,strawman
+scarfpin,tiepin
+scattergun,shotgun
+scattering,sprinkle,sprinkling
+scauper,scorper
+scemblix,asciminib
+scepter,sceptre
+sceptic,sceptical,sceptically,scepticism,skeptic,skeptical,skeptically,skepticism
+schabzieger => cheese
+schaefferia => tree
+schapendoes => dog,schapendoes
+schefflera => tree
+scheme,system
+schemozzle,shemozzle
+schillerstövare => dog,schillerstövare
+schinus => tree
+schipperke => dog,schipperke
+schloss => cheese
+schmear,schmeer,shmear
+schmegegge,shmegegge
+schnapps,schnaps
+scholia,scholium
+school,schoolhouse
+schoolbook,text,textbook
+schrod,scrod
+schtick,schtik,shtick,shtik
+schtickl,schtikl,shtickl,shtikl
+schwa,shwa
+schweiz,suisse,svizzera,switzerland
+sciara,sciarid
+scilla,squill
+scincid,skink
+scintillation,sparkling,twinkle
+scomberesocidae,scombresocidae
+scomberesox,scombresox
+scoop,scoopful
+scooter,scoter
+scope,telescope
+scophthalmidae,turbot
+scorbutus,scurvy
+scorch,singe
+scorpio,scorpion
+scots,scottish
+scrape,scraping
+scree,talus
+screen,sieve
+screening,showing,viewing
+screwbean,tornillo
+scribe,scriber
+scrofula,struma
+scum,trash
+seabird,seafowl
+seaboard,seaside
+seahorse,walrus
+sealant,sealer
+seance,session,sitting
+seascape,waterscape
+seasnail,snailfish
+seaweed,wakame,kombu,nori,dulse,hijiki,dashi,samphire
+sebastopol,sevastopol
+seborrhoea,seborrhea
+secernment,secretion
+secession,sezession
+sechuana,setswana,tswana
+secobarbital,seconal
+secretariat,secretariate
+seeland,sjaelland,zealand
+seesaw,teeter,teeterboard,teetertotter
+segregation,separatism
+seigneury,seigniory,signory
+selection,survival
+selsyn,synchro
+selva => cheese
+selvage,selvedge
+selzentry,maraviroc
+semitropics,subtropics
+sender,transmitter
+sense,signified
+sensipar,cinacalcet
+sensitiser,sensitizer
+septet,septette,sevensome
+septicaemia,septicemia
+sepulcher,sepulchre,sepulture
+sequel,subsequence
+sequenator,sequencer
+sequinned,sequined
+serat => cheese
+serbia,srbija
+serdica,sofia
+serengeti => cat,serengeti
+serfdom,serfhood,vassalage
+sericterium,serictery
+serif,seriph
+serigraph,silkscreen
+seriocomedy,tragicomedy
+serostim,somatropin
+sertraline,zoloft
+serviceberry => tree
+servo,servomechanism,servosystem
+sesamum,sesame
+sesquipedalia,sesquipedalian
+sestet,sextet,sextette
+setline,spiller,trawl,trotline
+settee,settle
+settlement,village
+settling,subsidence,subsiding
+seventeen,xvii
+sevilla,seville
+sewage,sewerage
+sewing,stitchery
+sextet,sextette,sixsome
+shaddick => tree
+shade,shadiness,shadowiness
+shades,sunglasses
+shadow,tincture,trace,vestige
+shagbark,shellbark
+shakeable,shakable
+shallow,shoal
+shandy,shandygaff
+sharia,shariah
+sharpam => cheese
+shedding,sloughing
+sheeprun,sheepwalk
+sheet,tabloid
+sheikdom,sheikhdom
+sheikh,sheikhdom,sheik,sheikdom
+shellflower,snakehead,turtlehead
+shelterbelt,windbreak
+sherbert,sherbet
+sherry,jerez
+shetland,zetland
+shia,shiah
+shift,transformation,transmutation
+shikoku => dog,shikoku
+shillalah,shillelagh
+shimbillo => tree
+shin,shinbone,tibia
+shindig,shindy
+shingles,zoster
+shingrix,adjuvanted
+shipway,slipway,ways
+shipworm,teredinid
+shipwreck,wreck
+shirtwaist,shirtwaister
+shittim,shittimwood
+shivaism,sivaism
+shoe,skid
+shoebill,shoebird
+shoelace,shoestring
+shofar,shophar
+shop,store
+shopfront,storefront
+shore,shoring
+shorea => tree
+shorthand,stenography,tachygraphy
+shorts,trunks
+shoshonean,shoshonian
+shot,snap,snapshot
+shouting,yelling
+shovel,shovelful,spadeful
+shovelled,shovelling,shoveled,shoveling
+showstopper,stopper
+shred,tatter
+shrew,shrewmouse
+shrinkage,shrinking
+shrivelled,shrivelling,shriveled,shriveling
+shudra,sudra
+shumac,sumac,sumach
+shutout,skunk
+siam,thailand
+siamese => cat,siamese
+siamese,thai
+sibine,somrai
+sichuan,szechuan,szechwan
+sicilia,sicily
+siderophilin,transferrin
+sideroxylon => tree
+sidetrack,siding,turnout
+sigh,suspiration
+signalisation,signalization
+signalled,signalling,signaller,signaled,signaled,signaler
+signifor,pasireotide
+siklos,hydroxyurea
+sildenafil,viagra
+siliq,brodalumab
+siliqua,silique
+sillabub,syllabub
+silva,sylva
+silverbell => tree
+silverberry => tree
+silverberry,silverbush
+silverling => tree
+silverside,silversides
+silverweed => flower
+simal => tree
+simponi,golimumab
+simvastatin,zocor
+sinew,tendon
+singapura => cat,singapura
+singhalese,sinhala,sinhalese
+singing,tattle,telling
+single,unity
+singlet,undershirt,vest
+sink,sinkhole
+sinkiang,xinjiang
+sinoper,sinopia,sinopis
+sinuosity,sinuousness
+sion,zion
+siphon,syphon
+siracusa,syracuse
+siraz => cheese
+sirene => cheese
+sirturo,bedaquiline
+sirup,syrup
+sisham,sissoo,sissu
+sisterhood,sistership
+sitsang,thibet,tibet,xizang
+sixpence,tanner
+size,sizing
+skagerak,skagerrak
+skelaxin,metaxalone
+skilful,skilfully,skilfulness,skillful,skillfully,skillfulness
+skim,skimming
+skopje,skoplje,uskub
+skulduggery,skullduggery,slickness,trickery
+skunkbush,squawbush
+skyrizi,risankizumab-rzaa
+skytrofa,lonapegsomatropin-tcgd
+slam,sweep
+slap,smack
+slat,spline
+slate,slating
+slater,woodlouse
+slavic,slavonic
+sled,sledge,sleigh
+sleeplessness,wakefulness
+slide,swoop
+sling,slingback
+sliver,splinter
+sloppiness,slovenliness,unkemptness
+sloughi => dog,sloughi
+slovenia,slovenija
+smalandstövare => dog,smalandstövare
+smallpox,variola
+smart,smarting,smartness
+smelter,smeltery
+smog,smogginess
+smoke,smoking
+smokestack,stack
+smolder,smoulder
+smoulder,smolder
+smuttiness,sootiness
+sneaker,trainer
+sneeze,sneezing,sternutation
+snicker,snigger,snort
+snip,snippet,snipping
+snips,tinsnips
+snivelling,sniveling
+snorkelled,snorkelling,snorkeled,snorkeling
+snow,snowfall
+snowball => flower
+snowberry,waxberry
+snowbird,snowflake
+snowdrop => flower
+snowplough,snowplow
+snowshoe => cat,snowshoe
+soak,soakage,soaking
+soaprock,soapstone,steatite
+soberness,sobriety
+soda,tonic
+softness,unfitness
+soil,territory
+soja,soya,soybean
+sokoke => cat,sokoke
+solace,solacement
+solarium,sunporch,sunroom
+soldiery,troops
+soleidae,sole
+solid,solidness
+soliris,eculizumab
+solmisation,solmization
+solodyn,minocycline
+somali => cat,somali
+somatotrophin,somatotropin
+somavert,pegvisomant
+sombre,sombrely,sombreness,somber,somberly,somberness
+sonata,zaleplon
+songbird,songster
+soochong,souchong
+sophonias,zephaniah
+sophora => tree
+sorbus => tree
+sordidness,squalidness,squalor
+sordino,sourdine
+sorgho,sorgo
+sort,sorting
+sou'easter,southeaster
+sou'wester,southwester
+soudan,sudan
+soumaintrain => cheese
+sound,strait
+sourwood => tree
+sourwood,titi
+sousaphone,tuba
+souslik,suslik
+sousse,susa,susah
+south,southward
+southeast,southeastward
+souther,southerly
+southernwood => flower
+southwest,southwestward
+souvlaki,souvlakia
+sovaldi,sofosbuvir
+soya,soybean
+spaceship,starship
+spall,spawl
+spandrel,spandril
+spanner,wrench
+spatter,spattering,splatter,splattering,splutter,sputter,sputtering
+speaking,speechmaking
+spearhead,spearpoint
+spec,specification
+speciality,specialities,specialty,specialties
+spectre,spectres,specter,specters
+spectrogram,spectrograph
+speculation,venture
+speech,words
+speedwell => flower
+speedwell,veronica
+spenwood => cheese
+sperm,spermatozoan,spermatozoon
+spermatocide,spermicide
+sphaerocarpos,sphaerocarpus
+sphynx => cat,sphynx
+spicule,spiculum
+spider,wanderer
+spiegel,spiegeleisen
+spike,spindle
+spill,spillway,wasteweir
+spindlelegs,spindleshanks
+spindrift,spoondrift
+spiraea,spirea
+spiral,volute
+spiralled,spiralling,spiraled,spiraling
+spire,steeple
+spirilla,spirillum
+spirituality,spiritualty
+spirochaete,spirochete
+spirt,spurt,squirt
+spit,tongue
+spitsbergen,spitzbergen
+splashboard,washboard
+splendour,splendor
+splice,splicing
+splutter,sputter
+spoilage,spoiling
+spondias => tree
+spongefly,spongillafly
+spoon,spoonful
+spork => spork,cutlery
+sporophyl,sporophyll
+spravato,esketamine
+spray,spraying
+sprechgesang,sprechstimme
+springbok,springbuck
+sprycel,dasatinib
+squad,team
+squeeze,wring
+squint,strabismus
+stabiliser,stabilizer
+stable,stalls
+stabyhoun => dog,stabyhoun
+staff,stave
+stage,stagecoach
+stagira,stagirus
+stagnancy,stagnation
+stair,step
+staircase,stairway
+stairs,steps
+stake,stakes,wager
+stalingrad,tsaritsyn,volgograd
+stalinisation,stalinization
+stalk,stem
+stall,stand
+stallion => horse
+stammer,stutter
+stamp,tender
+stand,standstill
+standardisation,standardization
+stapes,stirrup
+staph,staphylococci,staphylococcus
+staplegun,tacker
+starwort => flower
+starwort,stitchwort
+stationary,stationery
+staurikosaur,staurikosaurus
+steamer,steamship
+stearin,stearine
+steed => horse
+steenbok,steinbok
+stegosaur,stegosaurus
+stela,stele
+stelara,ustekinumab
+stencilled,stencilling,stenciled,stenciling
+stenosis,stricture
+step,tone
+stercobilinogen,urobilinogen
+stereo,stereophony
+sternutator,sternutatory
+stillness,windlessness
+stilton => cheese
+sting,stinging
+stivarga,regorafenib
+stockholding,stockholdings
+stockinet,stockinette
+stoep,stoop
+stogie,stogy
+stoop,stoup
+storeroom,stowage
+storm,tempest
+story,tale,taradiddle,tarradiddle
+stove,oven
+strad,stradavarius
+straight,straightaway
+straightjacket,straitjacket
+strain,stress
+strake,wale
+strasbourg,strassburg
+strattera,atomoxetine
+stream,watercourse
+streblus => tree
+streetcar,tram,tramcar,trolley
+strep,streptococci,streptococcus
+strepsiceros,tragelaphus
+stress,tenseness,tension
+stria,striation
+stribild,elvitegravir,cobicistat,emtricitabine
+string,twine
+stringency,tightness
+strobe,stroboscope
+stroke,throw
+stromectol,ivermectin
+stud,studhorse
+stupa,tope
+style,stylus
+stymie,stymy
+styracosaur,styracosaurus
+subdivision,subsection
+subhead,subheading
+subject,theme,topic
+subjection,subjugation
+sublease,sublet
+subordinateness,subsidiarity
+subservience,subservientness
+subshrub,suffrutex
+subsidisation,subsidization
+subsoil,undersoil
+substrate,substratum
+subtotalled,subtotalling,subtotaled,subtotaling
+suburb,suburbia
+subway,underpass
+succory => flower
+succour,succor
+sudatorium,sudatory
+sudatory,sudorific
+sugi => tree
+sulamyd,sulfacetamide
+sulfa,sulfonamide,sulpha
+sulfamethazine,sulfamezathine
+sulfate,sulphate
+sulfide,sulphide
+sulfur => sulphur
+sulfur,sulphur
+sumac => tree
+summarisation,summarization
+sunbeam,sunray
+sunberry,wonderberry
+sunblock,sunscreen
+sunburnt,sunburned
+sunlight,sunshine
+sunshine,temperateness
+superior,superscript
+superiority,transcendence,transcendency
+superslasher,utahraptor
+superstrate,superstratum
+supertax,surtax
+supertitle,surtitle
+suphalak => cat,suphalak
+suplena,suplena
+suppresser,suppressor
+surfactant,wetter
+surffish,surfperch
+surinam,suriname
+surmontil,trimipramine
+surrebuttal,surrebutter
+surrender,yielding
+susceptibility,susceptibleness
+sustol,granisetron;
+susvimo,ranibizumab
+sutura,suture
+sveciaost => cheese
+sverige,sweden
+swab,swob
+swage,upset
+swaledale => cheese
+swamp,swampland
+swampbay => tree
+swanflower,swanneck
+swathe,wrapping
+sweatpant,sweats
+sweats,sweatsuit
+sweetbread,sweetbreads
+sweetener,sweetening
+swimsuit,swimwear
+swine,pig,pork,piglet
+swingletree,whiffletree,whippletree
+swiss => cheese
+swivelled,swivelling,swiveled,swiveling
+swoosh,whoosh
+swot,swat
+syagrus => tree
+sycamore => tree
+sylvant,siltuximab
+sylvine,sylvite
+symbicort,budesonide
+symbolisation,symbolization
+symbyax,olanzapine,fluoxetine
+symdeko,tezacaftor,ivacaftor
+symmetrel,amantadine
+symtuza,darunavir,cobicistat,emtricitabine
+synagis,palivizumab
+synagogue,tabernacle,temple
+syncategorem,syncategoreme
+synchroneity,synchronicity,synchronisation,synchronism,synchronization,synchronizing,synchrony
+synchroniser,synchronizer,synchronoscope,synchroscope
+syncopation,syncope
+syndactylism,syndactyly
+synergism,synergy
+synezesis,synizesis
+synjardy,empagliflozin
+synonymity,synonymousness,synonymy
+syntagm,syntagma
+synthesiser,synthesizer
+synthroid,usp
+syprine,trientine
+syringa => flower
+syringa => tree
+t.b.,tuberculosis
+tabbouleh,tabooli
+tabebuia => tree
+tabi,tabis
+tablespoon,tablespoonful
+tabor,tabour
+taboret,tabouret
+tabrecta,capmatinib
+tach,tachometer
+tacheometer,tachymeter
+tadjik,tadzhik,tadzhikistan,tajik,tajikistan
+taegu,tegu
+tafinlar,dabrafenib
+tagrisso,osimertinib
+taigan => dog,taigan
+tailboard,tailgate
+tailcoat,tails
+taipeh,taipei
+taira,tayra
+takeaway,takeout
+takelma,takilman
+tala => cheese
+talc,talcum
+taleban,taliban
+talicia,amoxicillin,rifabutin
+talipalm => tree
+talipariti => tree
+talk,talking
+tallin,tallinn
+tallis,tallith
+taltz,ixekizumab
+talzenna,talazoparib
+tamal,tamale
+tamandu,tamandua
+tamarao,tamarau
+tamarind,tamarindo
+tamarix => tree
+tambac,tombac,tombak
+tambalacoque => tree
+tamie => cheese
+tammerfors,tampere
+tamp,tamper
+tampion,tompion
+tamponade,tamponage
+tanach,tanakh
+tangelo,ugli
+tangier,tangiers
+tank,tankful
+tapa,tappa
+taper,wick
+tapestry,tapis
+tarabulus,trablous,tripoli
+tares => flower
+targretin,bexarotene
+tarmac,tarmacadam
+tarp,tarpaulin
+tartary,tatary
+tashkent,taskent
+tasigna,nilotinib
+tasmar,talcapone
+tasse,tasset
+tasselled,tasseled
+tatou,tatu
+taupiniere => cheese
+tautness,tenseness,tension,tensity
+tavneos,avacopan
+taxandria => tree
+taxophytina,taxopsida
+taxus => tree
+tazverik,tazemetostat
+tazy => dog,tazy
+tbilisi,tiflis
+tbit,terabit
+teacup,teacupful
+teahouse,tearoom,teashop
+teak,teakwood
+tear,teardrop
+teasel => flower
+teasel,teasle,teazel
+teaser,tormenter,tormentor
+teaspoon,teaspoonful
+teatree => tree
+tebibit,tibit
+tebibyte,terabyte
+tecentriq,atezolizumab
+teepee,tepee,tipi
+teetotaller,teetotallers,teetotaler,teetotalers
+teetotum,whirligig
+teflaro,ceftaroline
+teheran,tehran
+teifi => cheese
+telecasting,television,video
+telecom,telecommunication
+teleconference,teleconferencing
+telegram,wire
+telegraph,telegraphy
+telemea => cheese
+teleost,teleostan
+telephoto,telephotograph
+teleprinter,teletypewriter,telex
+television,telly
+telfer,telpher
+telferage,telpherage
+telomian => dog,telomian
+temporality,temporalty
+tenderiser,tenderizer
+tenderloin,undercut
+tendinitis,tendonitis,tenonitis
+tendosynovitis,tenosynovitis
+tendrac,tenrec
+tenivac,tetanus
+tepezza,teprotumumab-trbw
+tepmetko,tepotinib
+tercel,tercelet,tiercel
+terebinth => tree
+terminalia => tree
+terrapin => reptile
+terry,terrycloth
+tessalon,benzonatate
+tessin,ticino
+testament,will
+testouri => cheese
+tetanilla,tetany
+tetilla => cheese
+tetrachlorethylene,tetrachloroethylene
+tetradium => tree
+tetraiodothyronine,thyroxin,thyroxine
+tetraskele,tetraskelion
+tetrazygia => tree
+tetrix,tetrix
+tevere,tiber
+thalassaemia,thalassemia
+thalomid,thalidomide
+thaw,thawing,warming
+theatre,theater
+theodolite,transit
+thermograph,thermometrograph
+thermogravimeter,thermohydrometer
+thermoregulator,thermostat
+thespesia => tree
+thessalia,thessaly
+thevetia => tree
+thiamine,thiamin
+thickener,thickening
+thickhead,whistler
+thimble,thimbleful
+thiola,tiopromin
+third,tierce
+thirst,thirstiness
+thirteen,xiii
+thraldom,thralldom
+thrasher,thresher
+thread,yarn
+three,trey
+threesome,triad,trinity,trio
+thrinax => tree
+thrip,thripid,thrips
+thrombocytopenia,thrombopenia
+thrombokinase,thromboplastin
+thuja => tree
+thujas => tree
+thyreophora,thyreophoran
+thyrotrophin,thyrotropin
+thyrse,thyrsus
+thysanopter,thysanopteron
+tianjin,tientsin
+tibsovo,ivosidenib
+tibur,tivoli
+tick,ticking
+ticktock,tictac,tocktact
+ticodendron => tree
+tidbit,titbit
+tiglon,tigon
+tikosyn,dofetilide
+till,trough
+timber,wood
+ting,tinkle
+tinselled,tinseled
+tire,tyre
+tirol,tyrol
+tirolean,tyrolean
+titanosaur,titanosaurian
+titbit,tidbit
+tivicay,dolutegravir
+tnkase,tenecteplase
+toadflax => flower
+tobi,tobramycin
+tocainide,tonocard
+toetoe,toitoi
+tokio,tokyo,yeddo,yedo
+tolazamide,tolinase
+tolbooth,tollbooth,tollhouse
+tollbar,tollgate
+toma => cheese
+tommes => cheese
+tone,tonicity,tonus
+tonguefish,cynoglossidae
+tonkinese => cat,tonkinese
+tonnage,tunnage
+tonquin,tonka,coumarin,dipteryx
+tonsil,tonsilla
+toolhouse,toolshed
+toon => tree
+toona => tree
+topee,topi
+toponomy,toponymy
+tore,torus
+torino,turin
+torisel,temsirolimus
+torkuz => dog,torkuz
+torment,torture
+tornado,twister
+tornjak => dog,tornjak
+toroid,torus
+toromiro => tree
+torpidity,torpor
+torque,torsion
+torticollis,wryneck
+tosa => dog,tosa
+toscana,tuscany
+toscanello => cheese
+totalisator,totaliser,totalizator,totalizer
+totaliser,totalizer
+totals,totalled,totalling,totals,totaled,totaling
+touch,touching
+toupe,toupee
+touraco,turaco,turacou,turakoo
+tourmalet => cheese
+tournament,tourney
+towboat,tower,tugboat
+toweling,towelling
+towels,towelled,towelling,towels,toweled,toweling
+towline,towrope
+town,townsfolk,townspeople
+toxaemia,toxaemic,toxemia,toxemic
+toxicodendron => tree
+toybob => cat,toybob
+toyger => cat,toyger
+trace,tracing
+trachea,windpipe
+trachodon,trachodont
+trachycarpus => tree
+tracleer,bosentan
+tradjenta,linagliptin
+tram,tramcar
+tramline,tramway
+trammelling,trammeling
+tramontana,tramontane
+trample,trampling
+transcendence,transcendency
+transferral,transferrable,transferal,transferable
+tranship,transhipment,transship,transshipment
+transistorise,transistorize
+transit,transportation
+transitiveness,transitivity
+transmission,transmittance
+transmitter,vector
+transom,traverse
+transparence,transparency
+transudate,transudation
+transvestism,transvestitism
+trastuzumab,hyaluronidase-oysk
+travelog,travelogue
+travels,travelled,travelling,traveller,travels,traveled,traveler,travelers
+trazimera,trastuzumab-qyyp
+treadmill,treadwheel
+treanda,bendamustine
+trecator,ethionamide
+treenail,trenail,trunnel
+treillage,trellis
+trema => tree
+tremfya,guselkumab
+trent,trento
+trepan,trephine
+trephritidae,trypetidae
+triad,trio,triple,triplet
+trial,tribulation,visitation
+trichiniasis,trichinosis
+trichloroethane,trichloroethylene
+trichopteran,trichopteron
+tricolor,tricolour
+tricolour,tricolor
+tricorn,tricorne
+tricycle,trike,velocipede
+trifle,trivia,triviality
+trigeminal,trigeminus
+trigon,triplicity
+trijardy,empagliflozin,linagliptin,metformin
+trikafta,elexacaftor,tezacaftor,ivacaftor
+trim,trimness
+trintellix,vortioxetine
+trip,tripper
+triskele,triskelion
+trithrinax => tree
+triumeq,abacavir,dolutegravir,lamivudine
+triumph,victory
+trochlear,trochlearis
+tronchon => cheese
+troponomy,troponymy
+truck,lorry,hgv,lkw,camion
+truckle,trundle
+trueness,truth,verity
+truffe => cheese
+trulance,plecanatide
+trulicity,dulaglutide
+truvada,emtricitabine
+truxima,rituximab-abbs
+tryptophan,tryptophane
+tshirt => t-shirt
+tube,tubing
+tuberose => flower
+tufa,tuff
+tuft,tussock
+tughrik,tugrik
+tukysa,tucatinib
+tularaemia,tularemia,yatobyo
+tulestoma,tulostoma
+tuliptree => tree
+tulipwood,whitewood
+tulostomaceae,tulostomataceae
+tumbrel,tumbril
+tumidity,tumidness
+tumour,tumor
+tun => tree
+tuna,tunny
+tuneable,tunable
+tungsten,wolfram
+tunicata,urochorda,urochordata
+tunicate,urochord,urochordate
+tunnelled,tunnelling,tunneled,tunneling
+tupek,tupik
+tupi => cheese
+tuppence,twopence
+turalio,pexidartinib
+turbinal,turbinate
+turcoman,turkmen,turkoman
+turkestan,turkistan
+turki,turkic
+turkmen,turkmenia,turkmenistan,turkomen
+turmeric,tumeric,curcuma
+turnout,widening
+turnsol => flower
+turpentine,turps
+turtle,turtleneck
+turunmaa => cheese
+tussah,tusseh,tusser,tussore,tussur
+twinberry => tree
+twist,wrench
+twitch,twitching,vellication
+tybost,cobicistat
+tygacil,tigecycline
+tykerb,lapatinib
+tymlos,abaloparatide
+tymsboro => cheese
+tyning => cheese
+typewriting,typing
+tyrannosaur,tyrannosaurus
+tyre,tyres,tire,tires
+tyrocidin,tyrocidine
+tzumu => tree
+u308,yellowcake
+ubrelvy,ubrogepant
+ubriaco => cheese
+udenyca,pegfilgrastim-cbqv
+udmurt,votyak
+ugrian,ugric
+uighur,uigur,uygur
+ukraine,ukrayina
+ulama,ulema
+ulcer,ulceration
+ulloa => cheese
+ultimacy,ultimateness
+ultomiris,ravulizumab-cwvz,iv
+umma,ummah
+unai,unau
+uncoloured,uncolored
+underbelly,underbody
+underbrush,undergrowth,underwood
+underclothes,underclothing,underwear
+undercurrent,undertide
+undergarment,unmentionable
+underlay,underlayment
+underline,underscore
+undulation,wave
+unfavourable,unfavourably,unfavorable,unfavorably
+unflavoured,unflavored
+unification,union
+uniross,duracell,energizer,everready,rayovac
+unliveable,unlivable
+unmoveable,unmovable
+unnameable,unnamable
+unploughed,unplowed
+unravelled,unravelling,unraveled,unraveling
+unsavoury,unsavourily,unsavory,unsavorily
+unskilful,unskilfully,unskillful,unskillfully
+unspoilt,unspoiled
+untameable,untamable
+untrammelled,untrammeled
+upheaval,uplift,upthrow,upthrust
+uplizna,inebilizumab-cdon
+uppsala,upsala
+upright,vertical
+uptravi,selexipag
+uraemia,uremia
+urochesia,urochezia
+ursinia => flower
+usbeg,usbek,uzbak,uzbeg,uzbek
+usury,vigorish
+uterus,womb
+utricle,utriculus
+utterance,vocalization
+uzbek,uzbekistan
+vaccina,vaccinia
+vaccine,vaccinum
+vaccum,vacuum
+vacuolation,vacuolisation,vacuolization
+vaishnavism,vaisnavism
+valchlor,mechlorethamine,topical
+valcyte,valganciclovir
+vale,valley
+valediction,valedictory
+valencay => cheese
+valerian => flower
+valetta,valletta
+valour,valor
+valvelet,valvula,valvule
+vancocin,vancomycin
+vane,weathervane
+vapor,vapour
+vaporiser,vaporizer
+varicoloured,varicolored
+varment,varmint
+varubi,rolapitant
+vascularisation,vascularization
+vasodilative,vasodilator
+vasterbottenost => cheese
+vaudois,waldenses
+veal,veau
+vectibix,panitumumab
+vegetable,veggie
+veil,velum
+vein,vena
+velban,vinblastine
+velcade,bortezomib
+veld,veldt
+veletri,epoprostenol
+velour,velours
+veltassa,patiromer
+velvetleaf,velvetweed
+venaco => cheese
+venclexta,venetoclax
+vendomois => cheese
+veneer,veneering
+venetia,veneto
+venezia,venice
+vent,volcano
+ventavis,iloprost
+venula,venule
+veps,vepse,vepsian
+verbena,vervain
+verboseness,verbosity
+vermouth,antica,martini,cinzano,azaline,cocchi,cucielo,bandarra,noilly
+vernicia => tree
+verquvo,vericiguat
+vervain => flower
+verzenio,abemaciclib
+vesicant,vesicatory
+vessel,watercraft
+vetiver,khus
+vfend,voriconazole
+viberzi,eluxadoline
+vibes,vibraharp,vibraphone
+vibrio,vibrion
+vibrissa,whisker
+viburnum => tree
+vicariate,vicarship
+victoza,liraglutide
+vidaza,azacitidine
+videodisc,videodisk
+vignotte => cheese
+vigour,vigourous,vigor,vigorous
+viibryd,vilazodone
+vijoice,alpelisib
+vikhan => dog,vikhan
+villainage,villeinage
+vilna,vilnius,vilno,wilno
+viltepso,viltolarsen
+vimpat,lacosamide
+vinery,vineyard
+vino,wine
+viocin,viomycin
+viokace,pancrelipase
+viraemia,viremia
+virgin,virgo
+viricide,virucide
+viroid,virusoid
+viscometer,viscosimeter
+viscountcy,viscounty
+visor,vizor
+vitaceae,vitidaceae
+vitalisation,vitalization
+vitellus,yolk
+vitex => tree
+vitrakvi,larotrectinib
+viverridae,viverrinae
+vizimpro,dacomitinib
+vizsla => dog,vizsla
+vodka,smirnoff,absolut
+vonjo,pacritinib
+vosevi,sofosbuvir,velpatasvir,voxilaprevir
+votrient,pazopanib
+voxzogo,vosoritide
+vraylar,cariprazine
+vulcanisation,vulcanization
+vulscombe => cheese
+vyndamax,tafamidis
+vyxeos,daunorubicin,cytarabine
+wafture,wave,waving
+waggery,waggishness
+waggon,wagon
+wainscot,wainscoting,wainscotting
+wainscoting,wainscotting
+waist,waistline
+waka => tree
+wakix,pitolisant
+walbiri,warlpiri
+waldmeister,woodruff
+wale,weal,welt,wheal
+walker,zimmer
+wallflower => flower
+walloper,whopper
+wannakai => tree
+warp,warping
+warragal,warrigal
+warsaw,warszawa
+wartweed,wartwort
+wash,washout
+washingtonia => tree
+watch,wristwatch
+waterbird,waterfowl
+watercolor,watercolour
+watercourse,waterway
+waterwitels => tree
+wealth,wealthiness
+weaselling,weaseling
+weatherstrip,weatherstripping
+weaver,weaverbird
+weichkaese => cheese
+weight,weighting
+weimaraner => dog,weimaraner
+welireg,belzutifan
+wellhead,wellspring
+wellingtonia => tree
+west,westward
+westernisation,westernization
+wetterhoun => dog,wetterhoun
+whacker,whopper
+whidah,whydah
+whimper,whine
+whin,whinstone
+whippet => dog,whippet
+whipping,whipstitch,whipstitching
+whirr,whir
+whisky,whiskey
+whistle,whistling
+whiteleg,vannamei
+whitewood => tree
+whizbang,whizzbang
+wickiup,wikiup
+widgeon,wigeon
+widthways,widthwise
+wifi,wlan
+wiggler,wriggler
+wigmore => cheese
+wild,wilderness
+wilful,wilfully,wilfulness,willful,willfully,willfulness
+wiliwili => tree
+willowherb => flower
+winch,windlass
+window,windowpane
+windscreen,windshield
+winterberry => tree
+winterbloom => tree
+wistaria,wisteria
+withe,withy
+woad => flower
+wolfbane,wolfsbane
+woodcreeper,woodhewer
+wool,woolen,woollen
+woollen,woollens,woolen,woolens
+work,workplace
+workbag,workbasket,workbox
+workgear,workwear
+working,workings
+workings,works
+wormwood => flower
+wrap,wrapper,wrapping
+wuerzburg,wurzburg
+xalkori,crizotinib
+xanax,alprazolam
+xarelto,rivaroxaban
+xcopri,cenobamate
+xeljanz,tofacitnib
+xeloda,capecitabine
+xenleta,lefamulin
+xeomin,incobotulinumtoxina
+xeranthemum => flower
+xeroderma,xerodermia
+xeroma,xerophthalmia,xerophthalmus
+xerophile,xerophyte
+xerophyllum => flower
+xgeva,denosumab
+xifaxan,rifaximin
+xolair,omalizumab
+xoloitzcuintle => dog,xoloitzcuintle
+xospata,gilteritinib
+xpovio,selinexor
+xtandi,enzalutamide
+xylene,xylol
+xylosma => tree
+xynotyro => cheese
+xyrem,gammahydroxybutyrate
+xyris => flower
+yarmelke,yarmulka,yarmulke
+yashmac,yashmak
+ybit,yottabit
+yellowroot => flower
+yelp,yelping
+yenisei,yenisey
+yervoy,ipilimumab
+yeshiva,yeshivah
+yibit,yobibit
+yobibyte,yottabyte
+yodelled,yodelling,yodeled,yodeling
+yoghourt,yoghurt,yogurt
+yondelis,trabectedin
+young,youth
+yucatec,yucateco
+yucca => flower
+yucca => tree
+yupelri,revefenacin
+zacharias,zechariah
+zamboorak,zamburak,zamburek,zumbooruck,zumbooruk
+zamorano => cheese
+zanthoxylum => tree
+zapotec,zapotecan
+zarontin,ethosuximide
+zbit,zettabit
+zebibit,zibit
+zebibyte,zettabyte
+zegalogue,dasiglucagon
+zejula,niraparib
+zelapar,selegiline
+zelboraf,vemurafenib
+zelkova => tree
+zenpep,pancrelipase
+zepatier,elbasvir,grazoprevir
+zeposia,ozanimod
+zepzelca,lurbinectedin
+zerbaxa,ceftolozane,tazobactam
+zerdava => dog,zerdava
+zigba => tree
+ziggurat,zikkurat,zikurat
+zinecard,dextrazoxane
+zinplava,bezlotoxumab
+zirabev,bevacizumab
+zirgan,ganciclovir
+zithromax,azithromycin
+zmax,azithromycin
+zokinvy,lonafarnib
+zolinza,vorinostat
+zombi,zombie
+zombia => tree
+zona,zone
+zonegran,zonisamide
+zonula,zonule
+zooflagellate,zoomastigote
+zoryve,rofumilast
+ztalmy,ganaxolone
+zulresso,brexanolone
+zyclara,imiquimod
+zydelig,idelalisib
+zygnemales,zygnematales
+zygomycota,zygomycotina
+zykadia,ceritinib
+zyprexa,olanzapine

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -45,6 +45,10 @@
     PopulateSearchSuggestionsWorker:
       cron: "0 18 * * *"
       description: "Populates search suggestions which are used in the frontend"
+    SpellingFileUploaderWorker:
+      cron: "0 14 * * *"
+      description: "Uploads a new snapshot of the spelling model based on the latest data"
+      enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' %>
     ReportWorker:
       cron: "30 10 * * *" # Needs to run even if the UpdatesSynchronizerWorker failed
       description: "Generates reports and persists them to S3"

--- a/spec/fixtures/spelling_corrector/origin_reference/bar.txt
+++ b/spec/fixtures/spelling_corrector/origin_reference/bar.txt
@@ -1,0 +1,1 @@
+The Origin Reference Document implementing the Agreement establishing a Strategic Partnership and Cooperation Agreement between the United Kingdom of Great Britain and Northern Ireland and Georgia

--- a/spec/fixtures/spelling_corrector/origin_reference/foo.txt
+++ b/spec/fixtures/spelling_corrector/origin_reference/foo.txt
@@ -1,0 +1,1 @@
+Origin Reference Document implementing the Agreement Establishing an Association between the United Kingdom of Great Britain and Northern Ireland and the Republic of Tunisia

--- a/spec/lib/spelling_corrector/loaders/descriptions_spec.rb
+++ b/spec/lib/spelling_corrector/loaders/descriptions_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe SpellingCorrector::Loaders::Descriptions do
+  describe '#load' do
+    subject(:load) { described_class.new.load }
+
+    before do
+      create(:goods_nomenclature, :actual, :with_description, description: 'A current description Flibble fladasd@!@#!@')
+      create(:goods_nomenclature, :expired, :with_description, description: 'A non-current description With Somasda terms in it')
+    end
+
+    let(:expected_terms) do
+      {
+        'current' => 1,
+        'description' => 1,
+        'fladasd' => 1,
+        'flibble' => 1,
+      }
+    end
+
+    it { is_expected.to eq(expected_terms) }
+  end
+end

--- a/spec/lib/spelling_corrector/loaders/initial_spec.rb
+++ b/spec/lib/spelling_corrector/loaders/initial_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe SpellingCorrector::Loaders::Initial do
+  include_context 'with a stubbed spelling corrector bucket'
+
+  describe '#load' do
+    subject(:load) { described_class.new.load }
+
+    let(:expected_terms) do
+      {
+        'aardvark' => 2,
+        'aardvarks' => 1,
+        'aardwolf' => 1,
+        'aare' => 1,
+        'aarhus' => 1,
+        'aaron' => 3,
+        'aarp' => 1,
+        'aas' => 1,
+        'aat' => 1,
+      }
+    end
+
+    it { is_expected.to eq(expected_terms) }
+  end
+end

--- a/spec/lib/spelling_corrector/loaders/intercepts_spec.rb
+++ b/spec/lib/spelling_corrector/loaders/intercepts_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe SpellingCorrector::Loaders::Intercepts do
+  describe '#load' do
+    subject(:load) { described_class.new.load }
+
+    let(:expected_terms) do
+      {
+        'accelerometer' => 1,
+        'accessories' => 13,
+        'acessories' => 1,
+        'accessaries' => 1,
+        'accesrise' => 1,
+      }
+    end
+
+    it { is_expected.to include(expected_terms) }
+
+    context 'with description intercept records' do
+      before do
+        create(:description_intercept, term: 'guided bicycles')
+      end
+
+      it { is_expected.to include('guided' => 1, 'bicycles' => 1) }
+    end
+  end
+end

--- a/spec/lib/spelling_corrector/loaders/labels_spec.rb
+++ b/spec/lib/spelling_corrector/loaders/labels_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe SpellingCorrector::Loaders::Labels do
+  describe '#load' do
+    subject(:load) { described_class.new.load }
+
+    before do
+      create(:goods_nomenclature_label,
+             description: 'Generated label description',
+             known_brands: Sequel.pg_array(['Acme Tools', 'Brand123'], :text),
+             colloquial_terms: Sequel.pg_array(['widget case'], :text),
+             synonyms: Sequel.pg_array(%w[gadget widget], :text))
+      create(:goods_nomenclature_label,
+             description: 'Expired label term',
+             known_brands: Sequel.pg_array(['Expired Brand'], :text),
+             expired: true)
+    end
+
+    let(:expected_terms) do
+      {
+        'acme' => 1,
+        'case' => 1,
+        'description' => 1,
+        'gadget' => 1,
+        'generated' => 1,
+        'label' => 1,
+        'tools' => 1,
+        'widget' => 2,
+      }
+    end
+
+    it { is_expected.to eq(expected_terms) }
+  end
+end

--- a/spec/lib/spelling_corrector/loaders/origin_reference_spec.rb
+++ b/spec/lib/spelling_corrector/loaders/origin_reference_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe SpellingCorrector::Loaders::OriginReference do
+  include_context 'with a stubbed spelling corrector bucket'
+
+  describe '#load' do
+    subject(:load) { described_class.new.load }
+
+    let(:expected_terms) do
+      {
+        'the' => 6,
+        'and' => 5,
+        'agreement' => 3,
+        'ireland' => 2,
+        'northern' => 2,
+        'britain' => 2,
+        'great' => 2,
+        'kingdom' => 2,
+        'united' => 2,
+        'between' => 2,
+        'establishing' => 2,
+        'implementing' => 2,
+        'document' => 2,
+        'reference' => 2,
+        'origin' => 2,
+        'georgia' => 1,
+        'cooperation' => 1,
+        'partnership' => 1,
+        'strategic' => 1,
+        'tunisia' => 1,
+        'republic' => 1,
+        'association' => 1,
+      }
+    end
+
+    it { is_expected.to eq(expected_terms) }
+  end
+end

--- a/spec/lib/spelling_corrector/loaders/references_spec.rb
+++ b/spec/lib/spelling_corrector/loaders/references_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe SpellingCorrector::Loaders::References do
+  describe '#load' do
+    subject(:load) { described_class.new.load }
+
+    before do
+      create(:search_reference, title: 'hello there search, reference (with some stuff in it) That IS capitalized hello')
+    end
+
+    let(:expected_terms) do
+      {
+        'capitalized' => 1,
+        'hello' => 2,
+        'reference' => 1,
+        'search' => 1,
+        'some' => 1,
+        'stuff' => 1,
+        'that' => 1,
+        'there' => 1,
+        'with' => 1,
+      }
+    end
+
+    it { is_expected.to eq(expected_terms) }
+  end
+end

--- a/spec/lib/spelling_corrector/loaders/self_texts_spec.rb
+++ b/spec/lib/spelling_corrector/loaders/self_texts_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe SpellingCorrector::Loaders::SelfTexts do
+  describe '#load' do
+    subject(:load) { described_class.new.load }
+
+    before do
+      create(:goods_nomenclature_self_text, self_text: 'Generated widgets widgetised cases')
+      create(:goods_nomenclature_self_text, self_text: 'Generated expired terms', expired: true)
+      create(:goods_nomenclature_self_text, self_text: 'EU 123 ab cases')
+    end
+
+    let(:expected_terms) do
+      {
+        'cases' => 2,
+        'generated' => 1,
+        'widgetised' => 1,
+        'widgets' => 1,
+      }
+    end
+
+    it { is_expected.to eq(expected_terms) }
+  end
+end

--- a/spec/lib/spelling_corrector/loaders/stop_words_spec.rb
+++ b/spec/lib/spelling_corrector/loaders/stop_words_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe SpellingCorrector::Loaders::StopWords do
+  describe '#load' do
+    subject(:load) { described_class.new.load }
+
+    let(:expected_terms) do
+      {
+        'them' => 1,
+        'themselves' => 1,
+        'then' => 1,
+        'thence' => 1,
+        'there' => 1,
+        "there'll" => 1,
+        "there've" => 1,
+        'thereafter' => 1,
+      }
+    end
+
+    it { is_expected.to include(expected_terms) }
+  end
+end

--- a/spec/lib/spelling_corrector/loaders/synonyms_spec.rb
+++ b/spec/lib/spelling_corrector/loaders/synonyms_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe SpellingCorrector::Loaders::Synonyms do
+  describe '#load' do
+    subject(:load) { described_class.new.load }
+
+    let(:expected_terms) do
+      {
+        'chiliad' => 1,
+        'grand' => 1,
+        'abyssinian' => 2,
+        'cat' => 53,
+      }
+    end
+
+    it { is_expected.to include(expected_terms) }
+  end
+end

--- a/spec/services/spelling_corrector/file_updater_service_spec.rb
+++ b/spec/services/spelling_corrector/file_updater_service_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe SpellingCorrector::FileUpdaterService do
+  describe '#call' do
+    subject(:upload_file) { described_class.new.call }
+
+    context 'when the bucket is setup' do
+      include_context 'with a stubbed spelling corrector bucket'
+
+      before do
+        allow(s3_bucket).to receive(:put_object).and_call_original
+
+        allow(SpellingCorrector::Loaders::Initial).to receive(:new).and_call_original
+        allow(SpellingCorrector::Loaders::Synonyms).to receive(:new).and_call_original
+        allow(SpellingCorrector::Loaders::Descriptions).to receive(:new).and_call_original
+        allow(SpellingCorrector::Loaders::References).to receive(:new).and_call_original
+        allow(SpellingCorrector::Loaders::Intercepts).to receive(:new).and_call_original
+        allow(SpellingCorrector::Loaders::StopWords).to receive(:new).and_call_original
+        allow(SpellingCorrector::Loaders::OriginReference).to receive(:new).and_call_original
+        allow(SpellingCorrector::Loaders::Labels).to receive(:new).and_call_original
+        allow(SpellingCorrector::Loaders::SelfTexts).to receive(:new).and_call_original
+
+        upload_file
+      end
+
+      it 'writes valid content to the correct object' do
+        expect(s3_bucket).to have_received(:put_object) do |args|
+          expect(args[:key]).to eq('spelling-corrector/spelling-model.txt')
+          expect(args[:body]).to be_a(StringIO)
+          expect(args[:body].each_line.first).to eq("tree 387\n")
+        end
+      end
+
+      it { expect(SpellingCorrector::Loaders::Initial).to have_received(:new) }
+      it { expect(SpellingCorrector::Loaders::Synonyms).to have_received(:new) }
+      it { expect(SpellingCorrector::Loaders::Descriptions).to have_received(:new) }
+      it { expect(SpellingCorrector::Loaders::References).to have_received(:new) }
+      it { expect(SpellingCorrector::Loaders::Intercepts).to have_received(:new) }
+      it { expect(SpellingCorrector::Loaders::StopWords).to have_received(:new) }
+      it { expect(SpellingCorrector::Loaders::OriginReference).to have_received(:new) }
+      it { expect(SpellingCorrector::Loaders::Labels).to have_received(:new) }
+      it { expect(SpellingCorrector::Loaders::SelfTexts).to have_received(:new) }
+    end
+
+    context 'when the bucket is not setup' do
+      around do |example|
+        previous = Rails.application.config.spelling_corrector_s3_bucket.dup
+
+        Rails.application.config.spelling_corrector_s3_bucket = nil
+
+        example.call
+
+        Rails.application.config.spelling_corrector_s3_bucket = previous
+      end
+
+      it 'logs a configuration warning message' do
+        allow(Rails.logger).to receive(:warn).and_call_original
+
+        upload_file
+
+        expect(Rails.logger).to have_received(:warn).with('Cannot update. Have you configured your bucket and credentials?')
+      end
+    end
+  end
+end

--- a/spec/services/spelling_corrector/term_handler_service_spec.rb
+++ b/spec/services/spelling_corrector/term_handler_service_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe SpellingCorrector::TermHandlerService do
+  describe '#call' do
+    subject(:result) { described_class.new(term).call }
+
+    context 'when the term includes mixed casing' do
+      let(:term) { 'HeLlo' }
+
+      it { is_expected.to eq('hello') }
+    end
+
+    context 'when the term has any digit chars in it' do
+      let(:term) { '10-HeLlo' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the term is shorter than 3 chars' do
+      let(:term) { 'oF' }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/support/shared_contexts/with_a_stubbed_spelling_corrector_s3_bucket.rb
+++ b/spec/support/shared_contexts/with_a_stubbed_spelling_corrector_s3_bucket.rb
@@ -1,0 +1,43 @@
+RSpec.shared_context 'with a stubbed spelling corrector bucket' do
+  before do
+    s3_bucket.client.stub_responses(:get_object, get_object_handler)
+    s3_bucket.client.stub_responses(:list_objects_v2, list_objects_v2_handler)
+    s3_bucket.client.stub_responses(:put_object)
+  end
+
+  let(:get_object_handler) do
+    lambda do |context|
+      case context.params[:key]
+      when 'spelling-corrector/initial-spelling-model.txt'
+        { body: StringIO.new(file_fixture('spelling_corrector/initial-spelling-model.txt').read) }
+      when 'spelling-corrector/origin-reference/foo.txt'
+        { body: StringIO.new(file_fixture('spelling_corrector/origin_reference/foo.txt').read) }
+      when 'spelling-corrector/origin-reference/bar.txt'
+        { body: StringIO.new(file_fixture('spelling_corrector/origin_reference/bar.txt').read) }
+      when 'config/chief_cds_guidance.json'
+        { body: StringIO.new(file_fixture('chief_cds_guidance.json').read) }
+      end
+    end
+  end
+
+  let(:list_objects_v2_handler) do
+    lambda do |context|
+      case context.params[:prefix]
+      when 'spelling-corrector/origin-reference/'
+        {
+          contents: [
+            { key: 'spelling-corrector/origin-reference/foo.txt' },
+            { key: 'spelling-corrector/origin-reference/bar.txt' },
+          ],
+        }
+      end
+    end
+  end
+
+  let(:s3_bucket) do
+    Rails
+      .application
+      .config
+      .spelling_corrector_s3_bucket
+  end
+end

--- a/spec/workers/spelling_file_uploader_worker_spec.rb
+++ b/spec/workers/spelling_file_uploader_worker_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe SpellingFileUploaderWorker, type: :worker do
+  before do
+    allow(SpellingCorrector::FileUpdaterService).to receive(:new).and_return(file_updater_service)
+
+    silence { described_class.new.perform }
+  end
+
+  let(:file_updater_service) { instance_double(SpellingCorrector::FileUpdaterService, call: 'foo') }
+
+  it { expect(file_updater_service).to have_received(:call) }
+end


### PR DESCRIPTION
### Jira link

[HMRC-2204](https://transformuk.atlassian.net/browse/HMRC-2204)

### What?

- [x] Restore the spelling corrector corpus loaders for descriptions, references, synonyms, stop words, intercepts and origin reference content
- [x] Add corpus loaders for generated self texts and generated labels
- [x] Restore the spelling model file updater service and Sidekiq uploader worker
- [x] Add the spelling corrector S3 bucket initializer using the current ECS credential check pattern
- [x] Schedule the UK spelling model upload worker
- [x] Restore loader, service and worker specs and small test fixtures

### Why?

The spelling correction corpus generation code was removed with the old beta search cleanup. The internal search spelling correction work needs this code back so the dictionary can be regenerated from current tariff content, generated search content and uploaded to the configured spelling bucket.

## Risk:
**Risk level:** 🟢
