### PR TITLE
Replace measure_components index with a covering composite index

### DIFF
--- a/db/migrate/20260429140000_add_covering_index_to_measure_components.rb
+++ b/db/migrate/20260429140000_add_covering_index_to_measure_components.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Replaces the single-column measure_sid index on the measure_components
+# materialized view with a composite covering index.
+#
+# The hot query is:
+#
+#   SELECT * FROM measure_components
+#   WHERE measure_sid IN (...)
+#   ORDER BY duty_expression_id
+#
+# With the old index (measure_sid only), PostgreSQL does an Index Scan to
+# locate rows by measure_sid and then fetches each matched row from the heap.
+# With 64 measure_sid values and ~80 result rows scattered across many heap
+# pages, this causes ~80 random page reads — explaining the high index-scan
+# cost (450 cost units for 80 rows) seen in EXPLAIN output.
+#
+# The new index is:
+#
+#   (measure_sid, duty_expression_id)
+#   INCLUDE (duty_amount, monetary_unit_code, measurement_unit_code,
+#            measurement_unit_qualifier_code, filename)
+#
+# The INCLUDE columns are all remaining columns that Sequel selects (the oplog
+# plugin strips oid, operation, operation_date). With all selected columns
+# present in the index, PostgreSQL can use an Index Only Scan — it never
+# touches the heap at all. Materialized views are always fully all-visible
+# after a REFRESH, so index-only scans work unconditionally.
+#
+# The old single-column measure_sid index is dropped; the new composite index
+# subsumes it (measure_sid is the leading key column) so no query regresses.
+
+Sequel.migration do
+  up do
+    run <<~SQL
+      CREATE INDEX IF NOT EXISTS measure_components_covering_index
+        ON measure_components (measure_sid, duty_expression_id)
+        INCLUDE (duty_amount, monetary_unit_code, measurement_unit_code,
+                 measurement_unit_qualifier_code, filename);
+
+      DROP INDEX IF EXISTS measure_components_measure_sid_index;
+    SQL
+  end
+
+  down do
+    run <<~SQL
+      DROP INDEX IF EXISTS measure_components_covering_index;
+
+      CREATE INDEX IF NOT EXISTS measure_components_measure_sid_index
+        ON measure_components (measure_sid);
+    SQL
+  end
+end


### PR DESCRIPTION
## What:
Replaces the single-column `measure_sid` index on the `measure_components` materialized view with a composite covering index on `(measure_sid, duty_expression_id) INCLUDE (duty_amount, monetary_unit_code, measurement_unit_code, measurement_unit_qualifier_code, filename)`.

## Why:
The eager-load query for measure components is:

```sql
SELECT * FROM measure_components
WHERE measure_sid IN (up to 64 values)
ORDER BY duty_expression_id
```

The old single-column index on `measure_sid` caused PostgreSQL to do an **Index Scan** — finding rows via the index then fetching each from the heap. With 64 `measure_sid` values and ~80 result rows scattered across many heap pages, this meant ~80 random page reads. EXPLAIN shows `cost=450` for 80 rows; the `ORDER BY` sort costs only ~2.5 of that, so the heap fetches are the problem.

The new covering index carries all columns Sequel selects (the oplog plugin strips `oid`, `operation`, `operation_date`). PostgreSQL can use an **Index Only Scan** — the heap is never touched. Materialized views are always fully all-visible after `REFRESH MATERIALIZED VIEW`, so index-only scans are always available here without any extra `VACUUM` requirements.

The old single-column `measure_sid` index is dropped — the new composite index subsumes it as its leading key column, so no query regresses.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:** Pure index change on a materialized view. No schema or data changes. The old index is subsumed by the new one (leading column is still `measure_sid`), so all existing query patterns remain covered. Worst case on deploy is a brief index build during migration; the MV remains readable throughout.