### PR TITLE
HMRC-2198: Label PRs that touch database schema with 'needs-deployment'

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+# Add "needs-deployment" label to pull requests making database schema changes
+needs-deployment:
+  - changed-files:
+    - any-glob-to-any-file: "db/*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: "Label PRs"
+
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/labeler@v6


### PR DESCRIPTION
## What:

This PR adds a 'actions/labeler' workflow that labels any pull request which makes changes to the `db/` directory. This will then trigger the deployment to the development environment, which will then trigger a database migration. We can then test the development environment (or see if database migrations fail) for regressions.

## Why:

Recent database migrations were not automatically run against the development environment, so regressions were deployed to production causing a live issue.

## Ticket:

[HMRC-2198](https://transformuk.atlassian.net/browse/HMRC-2198)

## Risk:
**Risk level:** 🟢

**Reason for rating:**

A simple change that adds a new workflow to label pull requests.