### PR TITLE
HMRC-2191: Data Loader Timestamp Report (UK)

### DIFF
--- a/app/lib/reporting/admin_report_registry.rb
+++ b/app/lib/reporting/admin_report_registry.rb
@@ -129,6 +129,15 @@ module Reporting
             dependencies: [],
             email_generator: nil,
           ),
+          ReportDefinition.new(
+            id: 'cds_update',
+            name: 'CDS Update report',
+            description: 'Spreadsheet containing relevant dates/timestamps for the download and ingest of CDS tariff files into OTT.',
+            generator: -> { Reporting::CdsUpdates },
+            services: %w[uk],
+            dependencies: [],
+            email_generator: nil,
+            )
         ]
       end
     end

--- a/app/lib/reporting/admin_report_registry.rb
+++ b/app/lib/reporting/admin_report_registry.rb
@@ -137,7 +137,7 @@ module Reporting
             services: %w[uk],
             dependencies: [],
             email_generator: nil,
-            )
+          ),
         ]
       end
     end

--- a/app/lib/reporting/cds_updates.rb
+++ b/app/lib/reporting/cds_updates.rb
@@ -63,17 +63,15 @@ module Reporting
             Rails.env.production? ? workbook.read_string : nil
           end
 
-          log_report_metric('output_bytes', workbook_data.bytesize) if workbook_data
+          if workbook_data
+            log_report_metric('output_bytes', workbook_data.bytesize)
 
-          if Rails.env.development?
-            return
-          end
-
-          instrument_report_step('upload', rows_written:, output_bytes: workbook_data.bytesize) do
-            object.put(
-              body: workbook_data,
-              content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-            )
+            instrument_report_step('upload', rows_written:, output_bytes: workbook_data.bytesize) do
+              object.put(
+                body: workbook_data,
+                content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+              )
+            end
           end
         end
       end

--- a/app/lib/reporting/cds_updates.rb
+++ b/app/lib/reporting/cds_updates.rb
@@ -2,7 +2,7 @@ module Reporting
   class CdsUpdates
     include Reporting::Reportable
 
-    HEADER_ROW = ["Date of the file", "Downloaded Time", "Updated Time", "Status"].freeze
+    HEADER_ROW = ['Date of the file', 'Downloaded Time', 'Updated Time', 'Status'].freeze
     COLUMN_WIDTHS = [30, 50, 50, 20].freeze
 
     class << self

--- a/app/lib/reporting/cds_updates.rb
+++ b/app/lib/reporting/cds_updates.rb
@@ -1,0 +1,129 @@
+module Reporting
+  class CdsUpdates
+    include Reporting::Reportable
+
+    HEADER_ROW = ["Date of the file", "Downloaded Time", "Updated Time", "Status"].freeze
+    COLUMN_WIDTHS = [30, 50, 50, 20].freeze
+
+    class << self
+      def generate
+        with_report_logging do
+          workbook = instrument_report_step('open_workbook') do
+            if Rails.env.development?
+              FileUtils.rm(filename) if File.exist?(filename)
+
+              FastExcel.open(
+                filename,
+                constant_memory: true,
+              )
+            else
+              FastExcel.open(
+                constant_memory: true,
+              )
+            end
+          end
+
+          bold_format = instrument_report_step('add_format') do
+            workbook.add_format(bold: true)
+          end
+
+          worksheet = instrument_report_step('setup_worksheet') do
+            sheet = workbook.add_worksheet(Time.zone.today.iso8601)
+
+            COLUMN_WIDTHS.each_with_index do |width, index|
+              sheet.set_column_width(index, width)
+            end
+
+            sheet.append_row(HEADER_ROW, bold_format)
+            sheet.freeze_panes(1, 0)
+            sheet
+          end
+
+          rows = instrument_report_step('load_rows') do
+            cds_updates
+          end
+
+          rows_written = instrument_report_step('append_rows') do
+            count = 0
+
+            rows.each do |update|
+              build_rows_for(update).each do |row|
+                worksheet.append_row(row)
+                count += 1
+              end
+            end
+
+            count
+          end
+
+          log_report_metric('rows_written', rows_written)
+
+          workbook_data = instrument_report_step('close_workbook', rows_written:) do
+            workbook.close
+            Rails.env.production? ? workbook.read_string : nil
+          end
+
+          log_report_metric('output_bytes', workbook_data.bytesize) if workbook_data
+
+          if Rails.env.development?
+            return
+          end
+
+          instrument_report_step('upload', rows_written:, output_bytes: workbook_data.bytesize) do
+            object.put(
+              body: workbook_data,
+              content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            )
+          end
+        end
+      end
+
+      private
+
+      def cds_updates
+        previous_month = Time.zone.today.last_month
+        start_of_previous_month = previous_month.beginning_of_month
+        start_of_current_month = previous_month.next_month.beginning_of_month
+
+        TariffSynchronizer::CdsUpdate
+          .exclude(filename: nil)
+          .where(Sequel[:created_at] >= start_of_previous_month)
+          .where(Sequel[:created_at] < start_of_current_month)
+          .eager(state_changes: ->(association_dataset) { association_dataset.order(:created_at) })
+          .reverse_order(:created_at)
+          .all
+      end
+
+      def build_rows_for(update)
+        state_changes = update.state_changes
+        return [default_row_for(update)] if state_changes.empty?
+
+        state_changes.map do |change|
+          [
+            update.issue_date&.iso8601,
+            update.created_at&.iso8601,
+            change.created_at&.iso8601,
+            change.to_state,
+          ]
+        end
+      end
+
+      def default_row_for(update)
+        [
+          update.issue_date&.iso8601,
+          update.created_at&.iso8601,
+          update.updated_at&.iso8601,
+          update.state,
+        ]
+      end
+
+      def object_key
+        "#{service}/reporting/#{year}/#{month}/#{day}/cds_updates_#{service}_#{now.strftime('%Y_%m_%d')}.xlsx"
+      end
+
+      def filename
+        File.basename(object_key)
+      end
+    end
+  end
+end

--- a/app/lib/tariff_synchronizer/base_update.rb
+++ b/app/lib/tariff_synchronizer/base_update.rb
@@ -2,8 +2,7 @@ module TariffSynchronizer
   class BaseUpdate < Sequel::Model(:tariff_updates)
     DOWNLOAD_FROM = 20.days
 
-    # Used for TARIC updates only.
-    one_to_many :presence_errors, class: TariffUpdatePresenceError, key: :tariff_update_filename
+    one_to_many :presence_errors, class: TariffUpdatePresenceError, key: :tariff_update_filename # Used for TARIC updates only.
     one_to_many :state_changes, class: TariffUpdateStateChange, key: :tariff_update_filename, primary_key: :filename
     def presence_error_ids
       presence_errors.pluck(:id)

--- a/app/lib/tariff_synchronizer/base_update.rb
+++ b/app/lib/tariff_synchronizer/base_update.rb
@@ -4,6 +4,7 @@ module TariffSynchronizer
 
     # Used for TARIC updates only.
     one_to_many :presence_errors, class: TariffUpdatePresenceError, key: :tariff_update_filename
+    one_to_many :state_changes, class: TariffUpdateStateChange, key: :tariff_update_filename, primary_key: :filename
     def presence_error_ids
       presence_errors.pluck(:id)
     end

--- a/app/lib/tariff_synchronizer/tariff_downloader.rb
+++ b/app/lib/tariff_synchronizer/tariff_downloader.rb
@@ -82,9 +82,25 @@ module TariffSynchronizer
     end
 
     def update_or_create(filename, state, filesize = nil)
-      update_klass
-        .find_or_create(filename:, update_type: update_klass.name, issue_date:)
-        .update(state:, filesize:)
+      update = update_klass
+               .find_or_create(filename:, update_type: update_klass.name, issue_date:)
+
+      transition_update_state(update, state)
+      update.update(filesize:)
+      update
+    end
+
+    def transition_update_state(update, state)
+      return if update.state == state
+
+      case state
+      when BaseUpdate::PENDING_STATE
+        update.mark_as_pending
+      when BaseUpdate::FAILED_STATE
+        update.mark_as_failed
+      else
+        update.update(state:)
+      end
     end
 
     def write_update_file(response_body)

--- a/app/workers/report_worker.rb
+++ b/app/workers/report_worker.rb
@@ -38,7 +38,7 @@ class ReportWorker
   def generate_report?(report)
     return true unless report == Reporting::CdsUpdates
 
-    second_monday_of_month?
+    TradeTariffBackend.uk? && second_monday_of_month?
   end
 
   def generate_differences?

--- a/app/workers/report_worker.rb
+++ b/app/workers/report_worker.rb
@@ -11,6 +11,7 @@ class ReportWorker
     Reporting::Prohibitions,
     Reporting::GeographicalAreaGroups,
     Reporting::CategoryAssessments,
+    Reporting::CdsUpdates,
   ].freeze
 
   def perform(trigger_differences_report = true)
@@ -19,6 +20,8 @@ class ReportWorker
     failures = []
 
     REPORTS.each do |report|
+      next unless generate_report?(report)
+
       report.generate
     rescue StandardError => e
       failures << { report: report.name, error: e }
@@ -32,6 +35,12 @@ class ReportWorker
 
   private
 
+  def generate_report?(report)
+    return true unless report == Reporting::CdsUpdates
+
+    second_monday_of_month?
+  end
+
   def generate_differences?
     TradeTariffBackend.uk? && monday?
   end
@@ -44,5 +53,11 @@ class ReportWorker
 
   def monday?
     Time.zone.now.monday?
+  end
+
+  def second_monday_of_month?
+    now = Time.zone.now
+
+    now.monday? && now.day.between?(8, 14)
   end
 end

--- a/spec/lib/reporting/cds_updates_spec.rb
+++ b/spec/lib/reporting/cds_updates_spec.rb
@@ -1,0 +1,169 @@
+RSpec.describe Reporting::CdsUpdates do
+  describe '.cds_updates' do
+    around do |example|
+      travel_to Time.zone.parse('2026-02-15 12:00:00') do
+        example.run
+      end
+    end
+
+    it 'returns only records created in the previous month' do
+      january_record = create(
+        :cds_update,
+        filename: 'tariff_dailyExtract_v1_20260115T000001.gzip',
+        created_at: Time.zone.parse('2026-01-15 10:00:00'),
+      )
+      create(
+        :cds_update,
+        filename: 'tariff_dailyExtract_v1_20251215T000001.gzip',
+        created_at: Time.zone.parse('2025-12-15 10:00:00'),
+      )
+      create(
+        :cds_update,
+        filename: 'tariff_dailyExtract_v1_20260201T000001.gzip',
+        created_at: Time.zone.parse('2026-02-01 10:00:00'),
+      )
+
+      expect(described_class.send(:cds_updates)).to eq([january_record])
+    end
+
+    it 'includes records on previous month boundaries only' do
+      january_start = create(
+        :cds_update,
+        filename: 'tariff_dailyExtract_v1_20260101T000001.gzip',
+        created_at: Time.zone.parse('2026-01-01 00:00:00'),
+      )
+      january_end = create(
+        :cds_update,
+        filename: 'tariff_dailyExtract_v1_20260131T235959.gzip',
+        created_at: Time.zone.parse('2026-01-31 23:59:59'),
+      )
+      create(
+        :cds_update,
+        filename: 'tariff_dailyExtract_v1_20251231T235959.gzip',
+        created_at: Time.zone.parse('2025-12-31 23:59:59'),
+      )
+      create(
+        :cds_update,
+        filename: 'tariff_dailyExtract_v1_20260201T000000.gzip',
+        created_at: Time.zone.parse('2026-02-01 00:00:00'),
+      )
+
+      expect(described_class.send(:cds_updates)).to contain_exactly(january_start, january_end)
+    end
+
+    it 'eager-loads state changes' do
+      update = create(
+        :cds_update,
+        filename: 'tariff_dailyExtract_v1_20260115T000001.gzip',
+        created_at: Time.zone.parse('2026-01-15 10:00:00'),
+      )
+      TariffSynchronizer::TariffUpdateStateChange.create(
+        tariff_update_filename: update.filename,
+        from_state: nil,
+        to_state: 'P',
+        created_at: Time.zone.parse('2026-01-15 10:00:00'),
+      )
+
+      result = described_class.send(:cds_updates)
+
+      expect(result.first.associations).to have_key(:state_changes)
+      expect(result.first.state_changes.map(&:to_state)).to eq(%w[P])
+    end
+  end
+
+  describe '.generate' do
+    include_context 'with a stubbed reporting bucket'
+
+    before do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
+
+      create(
+        :cds_update,
+        filename: 'tariff_dailyExtract_v1_20260102T000001.gzip',
+        issue_date: '2026-01-02',
+        created_at: Time.zone.parse('2026-01-02 10:00:00'),
+        applied_at: Time.zone.parse('2026-01-02 12:00:00'),
+        state: 'A',
+      )
+      create(
+        :cds_update,
+        filename: 'tariff_dailyExtract_v1_20260101T000001.gzip',
+        issue_date: '2026-01-01',
+        created_at: Time.zone.parse('2026-01-01 10:00:00'),
+        applied_at: nil,
+        state: 'P',
+      )
+    end
+
+    it 'writes an XLSX file to the reporting bucket' do
+      described_class.generate
+
+      expect(s3_bucket.client.api_requests).to include(
+        hash_including(
+          operation_name: :put_object,
+          params: hash_including(
+            bucket: s3_bucket.name,
+            key: /^.*\/cds_updates_.*\.xlsx$/,
+            body: instance_of(String),
+            content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          ),
+        ),
+      )
+    end
+  end
+
+  describe '.build_rows_for' do
+    it 'returns one row per state transition for the cds update' do
+      update = create(
+        :cds_update,
+        filename: 'tariff_dailyExtract_v1_20260120T000001.gzip',
+        issue_date: '2026-01-20',
+        created_at: Time.zone.parse('2026-01-20 08:00:00'),
+        applied_at: Time.zone.parse('2026-01-20 08:10:00'),
+        state: 'A',
+      )
+      [
+        TariffSynchronizer::TariffUpdateStateChange.create(
+          tariff_update_filename: update.filename,
+          from_state: nil,
+          to_state: 'P',
+          created_at: Time.zone.parse('2026-01-20 08:00:00'),
+        ),
+        TariffSynchronizer::TariffUpdateStateChange.create(
+          tariff_update_filename: update.filename,
+          from_state: 'P',
+          to_state: 'A',
+          created_at: Time.zone.parse('2026-01-20 08:10:00'),
+        ),
+      ]
+
+      rows = described_class.send(:build_rows_for, update)
+
+      expect(rows).to eq(
+        [
+          %w[2026-01-20 2026-01-20T08:00:00Z 2026-01-20T08:00:00Z P],
+          %w[2026-01-20 2026-01-20T08:00:00Z 2026-01-20T08:10:00Z A],
+        ],
+      )
+    end
+
+    it 'returns a default row when there are no state transitions' do
+      update = create(
+        :cds_update,
+        filename: 'tariff_dailyExtract_v1_20260122T000001.gzip',
+        issue_date: '2026-01-22',
+        created_at: Time.zone.parse('2026-01-22 09:00:00'),
+        updated_at: Time.zone.parse('2026-01-22 09:05:00'),
+        state: 'P',
+      )
+
+      rows = described_class.send(:build_rows_for, update)
+
+      expect(rows).to eq(
+        [
+          %w[2026-01-22 2026-01-22T09:00:00Z 2026-01-22T09:05:00Z P],
+        ],
+      )
+    end
+  end
+end

--- a/spec/unit/tariff_synchronizer/tariff_downloader_spec.rb
+++ b/spec/unit/tariff_synchronizer/tariff_downloader_spec.rb
@@ -99,6 +99,16 @@ RSpec.describe TariffSynchronizer::TariffDownloader do
             perform
             expect(TariffSynchronizer::FileService).to have_received(:write_file).with('tmp/data/cds/foo.xml.gzip', be_a(String))
           end
+
+          it 'records a state transition to pending' do
+            expect { perform }
+              .to change {
+                TariffSynchronizer::TariffUpdateStateChange.where(
+                  tariff_update_filename: filename,
+                  to_state: TariffSynchronizer::BaseUpdate::PENDING_STATE,
+                ).count
+              }.by(1)
+          end
         end
 
         context 'when the response body is not a ZIP file and the update type is Taric' do
@@ -136,6 +146,22 @@ RSpec.describe TariffSynchronizer::TariffDownloader do
           it 'does not write using the FileService' do
             perform
             expect(TariffSynchronizer::FileService).not_to have_received(:write_file)
+          end
+
+          it 'records pending then failed state transitions' do
+            perform
+
+            transitions = TariffSynchronizer::TariffUpdateStateChange
+                            .where(tariff_update_filename: filename)
+                            .order(:created_at)
+                            .all
+
+            expect(transitions.map { |transition| [transition.from_state, transition.to_state] }).to eq(
+              [
+                [nil, TariffSynchronizer::BaseUpdate::PENDING_STATE],
+                [TariffSynchronizer::BaseUpdate::PENDING_STATE, TariffSynchronizer::BaseUpdate::FAILED_STATE],
+              ],
+            )
           end
         end
       end

--- a/spec/workers/report_worker_spec.rb
+++ b/spec/workers/report_worker_spec.rb
@@ -12,12 +12,13 @@ RSpec.describe ReportWorker, type: :worker do
       allow(Reporting::GeographicalAreaGroups).to receive(:generate)
       allow(Reporting::Prohibitions).to receive(:generate)
       allow(Reporting::CategoryAssessments).to receive(:generate).and_call_original
+      allow(Reporting::CdsUpdates).to receive(:generate)
       allow(DifferencesReportWorker).to receive(:perform_in).and_call_original
       allow(TradeTariffBackend).to receive(:service).and_return(service)
       travel_to Date.parse(date).beginning_of_day
     end
 
-    shared_examples 'all reports are generated' do
+    shared_examples 'core reports are generated' do
       it { expect(Reporting::Commodities).to have_received(:generate) }
       it { expect(Reporting::Basic).to have_received(:generate) }
       it { expect(Reporting::SupplementaryUnits).to have_received(:generate) }
@@ -27,20 +28,40 @@ RSpec.describe ReportWorker, type: :worker do
       it { expect(Reporting::CategoryAssessments).to have_received(:generate) }
     end
 
+    shared_examples 'cds updates report is generated' do
+      it { expect(Reporting::CdsUpdates).to have_received(:generate) }
+    end
+
+    shared_examples 'cds updates report is skipped' do
+      it { expect(Reporting::CdsUpdates).not_to have_received(:generate) }
+    end
+
     context 'with default behaviour' do
       before { worker.perform }
 
       context 'when on the xi service' do
         let(:service) { 'xi' }
 
-        it_behaves_like 'all reports are generated'
+        it_behaves_like 'core reports are generated'
+        it_behaves_like 'cds updates report is skipped'
         it { expect(DifferencesReportWorker).not_to have_received(:perform_in) }
       end
 
-      context 'when on the uk service and the day is a monday' do
+      context 'when on the uk service and the day is the second monday of the month' do
         let(:service) { 'uk' }
+        let(:date) { '2023-10-09' }
 
-        it_behaves_like 'all reports are generated'
+        it_behaves_like 'core reports are generated'
+        it_behaves_like 'cds updates report is generated'
+        it { expect(DifferencesReportWorker).to have_received(:perform_in) }
+      end
+
+      context 'when on the uk service and the day is a monday but not the second monday' do
+        let(:service) { 'uk' }
+        let(:date) { '2023-10-30' }
+
+        it_behaves_like 'core reports are generated'
+        it_behaves_like 'cds updates report is skipped'
         it { expect(DifferencesReportWorker).to have_received(:perform_in) }
       end
 
@@ -48,7 +69,8 @@ RSpec.describe ReportWorker, type: :worker do
         let(:service) { 'uk' }
         let(:date) { '2023-10-31' }
 
-        it_behaves_like 'all reports are generated'
+        it_behaves_like 'core reports are generated'
+        it_behaves_like 'cds updates report is skipped'
         it { expect(DifferencesReportWorker).not_to have_received(:perform_in) }
       end
     end
@@ -58,7 +80,8 @@ RSpec.describe ReportWorker, type: :worker do
 
       let(:service) { 'uk' }
 
-      it_behaves_like 'all reports are generated'
+      it_behaves_like 'core reports are generated'
+      it_behaves_like 'cds updates report is skipped'
       it { expect(DifferencesReportWorker).not_to have_received(:perform_in) }
     end
 


### PR DESCRIPTION
## What:
Create a report containing relevant dates/timestamps for the download and ingest of CDS tariff files into OTT.  Report also includes the full TariffUpdateStateChange history per CDS update. Runs every 2nd Monday of a given month.

## Why:
For internal use to investigate CDS update status.

## Ticket:
[HMRC-2191](https://transformuk.atlassian.net/browse/HMRC-2191)

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
Independent sidekiq job that doesn't interfere with any other process
───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.

───────────────────────────────────────────────────

🟢 GREEN – things that are typically low risk:
───────────────────────────────────────────────────
- Dependency bumps with no API changes (e.g. minor/patch gems, npm packages)
- Copy or content changes in GOV.UK-style UI components
- Adding or updating CloudWatch alarms or dashboards (read-only observability)
- New tests or improved test coverage with no production code changes
- Config/env var additions that are purely additive and have safe defaults
- Refactors with full test coverage and no behaviour change
- Terraform formatting or variable renaming with no resource recreation
- S3 lifecycle rule additions (non-destructive, time-delayed effect)

🟠 AMBER – things that need a team conversation first:
───────────────────────────────────────────────────
- Changes to commodity code lookups, measure type logic, or duty calculation
- Modifications to the search indexing pipeline (OpenSearch mappings, synonyms, stop words)
- Changes to declarable goods or quota logic
- New or modified API endpoints that other services (backend, frontend, admin) consume
- Adding or changing feature flags that affect live user journeys
- Infrastructure changes that alter networking, security groups, or IAM permissions in non-production first
- Terraform changes that will cause a resource replacement (check plan output carefully)
- Changes to CI/CD pipeline steps or deployment order dependencies
- S3 bucket policy or access control changes
- Removing or deprecating an endpoint or field that may still be consumed

🔴 RED – requires explicit approval from Thor or Neil:
───────────────────────────────────────────────────
- Dangerous database migrations, especially destructive ones (dropping columns/tables, removing indexes)
- Modifications to how measures, conditions, or footnotes are processed or surfaced
- Changes to the synchronisation mechanism from CDS or HMRC upstream data feeds
- Any change to production AWS infrastructure that cannot be easily rolled back (e.g. RDS parameter groups, KMS key policy, removal of resources)
- Secrets rotation or changes to how credentials are stored, scoped, or accessed
- Changes that affect trader-facing regulatory content or legally significant data (e.g. trade remedies, licensing, prohibitions)
- Significant architectural shifts (e.g. new service boundaries, queue/event topology changes)
