### PR TITLE
Fix RefreshAppendix5aGuidanceWorker job death from SES v2 single-address bug

### DIFF
--- a/app/lib/trade_tariff_backend/config.rb
+++ b/app/lib/trade_tariff_backend/config.rb
@@ -179,7 +179,7 @@ module TradeTariffBackend
     end
 
     def cupid_team_to_emails
-      ENV['CUPID_TEAM_TO_EMAILS']
+      ENV['CUPID_TEAM_TO_EMAILS']&.split(',')&.map(&:strip) || []
     end
 
     def myott_report_email

--- a/config/initializers/ses_v2_to_addresses_coercion.rb
+++ b/config/initializers/ses_v2_to_addresses_coercion.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# The aws-actionmailer-ses gem's SESV2::Mailer#to_addresses passes
+# message.to directly to the AWS SES v2 API, which requires an Array.
+# The mail gem normalises a single recipient address to a plain String,
+# so any mailer with exactly one To: address raises:
+#
+#   ArgumentError: expected params[:destination][:to_addresses] to be
+#   an Array, got class String instead
+#
+# Wrapping the return value in Array() coerces both cases safely:
+#   Array("a@b.com")          # => ["a@b.com"]
+#   Array(["a@b.com","c@d"]) # => ["a@b.com", "c@d"]
+#   Array(nil)                # => []
+Aws::ActionMailer::SESV2::Mailer.prepend(
+  Module.new do
+    private
+
+    def to_addresses(message)
+      Array(super)
+    end
+  end,
+)

--- a/spec/config/initializers/ses_v2_to_addresses_coercion_spec.rb
+++ b/spec/config/initializers/ses_v2_to_addresses_coercion_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'ses_v2_to_addresses_coercion initializer' do # rubocop:disable R
   # which requires an Array. This spec verifies that the prepended module
   # always coerces the return value to an Array.
   describe 'Aws::ActionMailer::SESV2::Mailer#to_addresses' do
-    subject(:mailer) { Aws::ActionMailer::SESV2::Mailer.new }
+    subject(:mailer) { Aws::ActionMailer::SESV2::Mailer.new(stub_responses: true) }
 
     def build_message(to:)
       mail_double = instance_double(Mail::Message, to:)

--- a/spec/config/initializers/ses_v2_to_addresses_coercion_spec.rb
+++ b/spec/config/initializers/ses_v2_to_addresses_coercion_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ses_v2_to_addresses_coercion initializer' do # rubocop:disable RSpec/DescribeClass
+  # The mail gem normalises a single-recipient To: header to a plain String.
+  # The SES v2 delivery method passes message.to directly to the AWS SDK,
+  # which requires an Array. This spec verifies that the prepended module
+  # always coerces the return value to an Array.
+  describe 'Aws::ActionMailer::SESV2::Mailer#to_addresses' do
+    subject(:mailer) { Aws::ActionMailer::SESV2::Mailer.new }
+
+    def build_message(to:)
+      mail_double = instance_double(Mail::Message, to:)
+      allow(mail_double).to receive(:instance_variable_get).with(:@smtp_envelope_to).and_return(nil)
+      mail_double
+    end
+
+    context 'when message.to is a String (single recipient, mail gem normalisation)' do
+      it 'returns an Array' do
+        message = build_message(to: 'single@example.com')
+        result = mailer.send(:to_addresses, message)
+        expect(result).to eq(['single@example.com'])
+      end
+    end
+
+    context 'when message.to is already an Array (multiple recipients)' do
+      it 'returns the Array unchanged' do
+        message = build_message(to: ['a@example.com', 'b@example.com'])
+        result = mailer.send(:to_addresses, message)
+        expect(result).to eq(['a@example.com', 'b@example.com'])
+      end
+    end
+
+    context 'when message.to is nil' do
+      it 'returns an empty Array' do
+        message = build_message(to: nil)
+        result = mailer.send(:to_addresses, message)
+        expect(result).to eq([])
+      end
+    end
+  end
+end

--- a/spec/lib/trade_tariff_backend/config_spec.rb
+++ b/spec/lib/trade_tariff_backend/config_spec.rb
@@ -407,5 +407,27 @@ RSpec.describe TradeTariffBackend::Config do
         expect(config.green_lanes_notify_measure_updates).to be true
       end
     end
+
+    describe '.cupid_team_to_emails' do
+      it 'returns an empty array when the env var is not set' do
+        ENV.delete('CUPID_TEAM_TO_EMAILS')
+        expect(config.cupid_team_to_emails).to eq([])
+      end
+
+      it 'returns a single-element array for one address' do
+        ENV['CUPID_TEAM_TO_EMAILS'] = 'cupid@example.com'
+        expect(config.cupid_team_to_emails).to eq(['cupid@example.com'])
+      end
+
+      it 'splits a comma-separated list into an array' do
+        ENV['CUPID_TEAM_TO_EMAILS'] = 'a@example.com,b@example.com'
+        expect(config.cupid_team_to_emails).to eq(['a@example.com', 'b@example.com'])
+      end
+
+      it 'strips whitespace around addresses' do
+        ENV['CUPID_TEAM_TO_EMAILS'] = 'a@example.com, b@example.com'
+        expect(config.cupid_team_to_emails).to eq(['a@example.com', 'b@example.com'])
+      end
+    end
   end
 end


### PR DESCRIPTION
## What:
Two targeted fixes for the `ArgumentError` that kills `RefreshAppendix5aGuidanceWorker` when Appendix 5a changes are detected:

1. **Prepend a fix onto `Aws::ActionMailer::SESV2::Mailer`** — wraps the return of `to_addresses` in `Array()` so the AWS SDK always receives an Array, regardless of how many recipients the `mail` gem produces.
2. **Fix `TradeTariffBackend.cupid_team_to_emails`** — splits the env var on commas so multi-address configuration works and the method always returns an Array.

## Why:
The `mail` gem normalises a single-recipient `To:` header to a plain `String` (not an `Array`). The `aws-actionmailer-ses` gem's `SESV2::Mailer#to_addresses` passes `message.to` directly to the AWS SDK, which validates:

```
ArgumentError: expected params[:destination][:to_addresses] to be an Array,
got class String instead
```

`CUPID_TEAM_TO_EMAILS` contains one address. Every time Appendix 5a changes are detected and the mailer fires, the worker exhausts retries and dies.

Fix (1) is the primary defence — it handles the String/Array/nil ambiguity at the delivery layer. Fix (2) is belt-and-braces: correctly splitting a comma-separated env var is the right behaviour regardless, and makes multi-recipient configuration actually work.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:** Narrowly scoped to the Appendix 5a notification mailer. The prepend only overrides one private method on the SES v2 delivery class; all other mailers are unaffected. No data or schema changes.