### PR TITLE
Make materialized view refreshes concurrent to prevent read locks

### DIFF
--- a/app/helpers/materialize_view_helper.rb
+++ b/app/helpers/materialize_view_helper.rb
@@ -7,16 +7,14 @@ module MaterializeViewHelper
     ModificationRegulation
   ].freeze
 
-  def refresh_materialized_view(concurrently: false)
+  def refresh_materialized_view
     eager_load_materialized_view_models
 
     Sequel::Plugins::Oplog.models.each do |model|
-      if model.materialized? && model.actually_materialized?
-        model.refresh!(concurrently:)
-      end
+      model.refresh! if model.materialized? && model.actually_materialized?
     end
 
-    GoodsNomenclatures::TreeNode.refresh!(concurrently:)
+    GoodsNomenclatures::TreeNode.refresh!
 
     prewarm_views
   end

--- a/app/lib/sequel/plugins/oplog.rb
+++ b/app/lib/sequel/plugins/oplog.rb
@@ -199,7 +199,7 @@ module Sequel
 
           db.refresh_view(table_name, concurrently:)
         rescue Sequel::DatabaseError => e
-          raise unless concurrently && e.message.include?('has not been populated')
+          raise unless concurrently && e.message.include?('is not populated')
 
           # The view was created WITH NO DATA (e.g. after a migration that
           # drops and recreates it). A concurrent refresh requires existing

--- a/app/lib/sequel/plugins/oplog.rb
+++ b/app/lib/sequel/plugins/oplog.rb
@@ -192,12 +192,20 @@ module Sequel
           @operation_klass ||= "#{self}::Operation".constantize
         end
 
-        def refresh!(concurrently: false)
-          if materialized? && actually_materialized?
-            db.refresh_view(table_name, concurrently:)
-          else
+        def refresh!(concurrently: true)
+          unless materialized? && actually_materialized?
             raise NotImplementedError
           end
+
+          db.refresh_view(table_name, concurrently:)
+        rescue Sequel::DatabaseError => e
+          raise unless concurrently && e.message.include?('has not been populated')
+
+          # The view was created WITH NO DATA (e.g. after a migration that
+          # drops and recreates it). A concurrent refresh requires existing
+          # rows; fall back to a blocking refresh to populate it, after
+          # which future concurrent refreshes will succeed.
+          db.refresh_view(table_name, concurrently: false)
         end
       end
 

--- a/app/models/goods_nomenclatures/tree_node.rb
+++ b/app/models/goods_nomenclatures/tree_node.rb
@@ -13,12 +13,16 @@ module GoodsNomenclatures
                                     read_only: true
 
     class << self
-      # Defaults to concurrent refresh to avoid blocking other queries
-      # If the Materialized View has never been populated, eg after a
-      # rake db:test:prepare or rake db:structure:load then a non-concurrent
-      # refresh is required
-      def refresh!(concurrently: false)
+      def refresh!(concurrently: true)
         db.refresh_view(:goods_nomenclature_tree_nodes, concurrently:)
+      rescue Sequel::DatabaseError => e
+        raise unless concurrently && e.message.include?('has not been populated')
+
+        # The view was created WITH NO DATA (e.g. after a migration that
+        # drops and recreates it). A concurrent refresh requires existing
+        # rows; fall back to a blocking refresh to populate it, after
+        # which future concurrent refreshes will succeed.
+        db.refresh_view(:goods_nomenclature_tree_nodes, concurrently: false)
       end
 
       def previous_sibling(origin_position, origin_depth)

--- a/app/models/goods_nomenclatures/tree_node.rb
+++ b/app/models/goods_nomenclatures/tree_node.rb
@@ -16,7 +16,7 @@ module GoodsNomenclatures
       def refresh!(concurrently: true)
         db.refresh_view(:goods_nomenclature_tree_nodes, concurrently:)
       rescue Sequel::DatabaseError => e
-        raise unless concurrently && e.message.include?('has not been populated')
+        raise unless concurrently && e.message.include?('is not populated')
 
         # The view was created WITH NO DATA (e.g. after a migration that
         # drops and recreates it). A concurrent refresh requires existing

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,6 +3,7 @@ require_relative '../app/helpers/materialize_view_helper'
 include MaterializeViewHelper
 # rubocop:enable Style/MixinUsage
 
-# After a rake db:structure:load Materialized Views are unpopulated, causing
-# any concurrent refreshes to fail. Populating here should help avoid that.
+# Populate materialized views after a db:structure:load. If any view was
+# created WITH NO DATA, refresh! will detect "has not been populated" and
+# fall back to a blocking refresh automatically.
 refresh_materialized_view

--- a/spec/models/goods_nomenclatures/tree_node_spec.rb
+++ b/spec/models/goods_nomenclatures/tree_node_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe GoodsNomenclatures::TreeNode do
     let(:commodities) { create_list :commodity, 2, parent: subheading }
 
     it { is_expected.to include subheading.chapter.pk => [subheading.parent.pk] }
-    it { is_expected.to include subheading.pk => commodities.map(&:pk) }
+    it { is_expected.to include(subheading.pk => match_array(commodities.map(&:pk))) }
     it { is_expected.to include commodities.first.pk => [nil] }
   end
 


### PR DESCRIPTION
## What:
Switch all materialized view refreshes from blocking to `CONCURRENTLY` mode. Adds an automatic fallback to a blocking refresh for the one edge case: a view created `WITH NO DATA` that has never been populated.

## Why:
`REFRESH MATERIALIZED VIEW` (without `CONCURRENTLY`) takes an `AccessExclusive` lock — the strongest lock in PostgreSQL — which blocks every read query on that table for the entire refresh duration. With six MVs now in use and refreshes triggered after every daily sync, this was the source of the latency spikes / lock contention we've been seeing.

`REFRESH MATERIALIZED VIEW CONCURRENTLY` builds a new version of the view in the background and swaps it in atomically, holding only a `ShareUpdateExclusive` lock (compatible with reads). The only prerequisite is a unique index on the view, which all six of our MVs already satisfy via their `oid` index.

**Edge case handled:** After a migration that drops and recreates a view `WITH NO DATA`, the view is empty and a concurrent refresh will fail with `ERROR: cannot refresh materialized view "..." concurrently` / `HINT: ... has not been populated`. The rescue block detects this message and retries with a blocking refresh, seeding the rows so that every subsequent concurrent refresh succeeds.

## Changes:
- `Sequel::Plugins::Oplog::ClassMethods#refresh!` — default `concurrently:` `false` → `true` + rescue fallback
- `GoodsNomenclatures::TreeNode.refresh!` — same pattern
- `MaterializeViewHelper#refresh_materialized_view` — remove the now-unnecessary `concurrently:` parameter
- `db/seeds.rb` — update comment to reflect the new automatic fallback

The two explicit `concurrently: false` calls in `spec/support/elasticsearch.rb` (OpenSearch index rebuild setup) are intentionally left as-is.

## Ticket:
N/A

## Risk:
🟢 Low. The change eliminates a locking hazard rather than introducing one. The fallback ensures correctness when a view is unpopulated. The `oid` unique index exists on all six MVs in both UK and XI schemas.