### PR TITLE
Parse CUPID_TEAM_TO_EMAILS as JSON hash from Secrets Manager

### DIFF
--- a/app/lib/trade_tariff_backend/config.rb
+++ b/app/lib/trade_tariff_backend/config.rb
@@ -179,7 +179,10 @@ module TradeTariffBackend
     end
 
     def cupid_team_to_emails
-      ENV['CUPID_TEAM_TO_EMAILS']&.split(',')&.map(&:strip) || []
+      raw = ENV['CUPID_TEAM_TO_EMAILS']
+      return [] if raw.blank?
+
+      parse_email_list(raw)
     end
 
     def myott_report_email
@@ -268,6 +271,17 @@ module TradeTariffBackend
     # Goods nomenclature
     def goods_nomenclature_label_page_size
       ENV.fetch('GOODS_NOMENCLATURE_LABEL_PAGE_SIZE', '10').to_i
+    end
+
+    private
+
+    # Parse a comma-separated email list, or a JSON hash whose values are
+    # email addresses (the format used when the secret is injected directly
+    # from an AWS Secrets Manager JSON object).
+    def parse_email_list(raw)
+      JSON.parse(raw).values.map(&:strip).reject(&:empty?)
+    rescue JSON::ParserError
+      raw.split(',').map(&:strip).reject(&:empty?)
     end
   end
 end

--- a/spec/lib/trade_tariff_backend/config_spec.rb
+++ b/spec/lib/trade_tariff_backend/config_spec.rb
@@ -428,6 +428,11 @@ RSpec.describe TradeTariffBackend::Config do
         ENV['CUPID_TEAM_TO_EMAILS'] = 'a@example.com, b@example.com'
         expect(config.cupid_team_to_emails).to eq(['a@example.com', 'b@example.com'])
       end
+
+      it 'extracts addresses from a JSON hash (AWS Secrets Manager format)' do
+        ENV['CUPID_TEAM_TO_EMAILS'] = '{"backend-cupid-team-to-emails":"cupid@example.com"}'
+        expect(config.cupid_team_to_emails).to eq(['cupid@example.com'])
+      end
     end
   end
 end


### PR DESCRIPTION
## What:
`cupid_team_to_emails` now handles a JSON-hash env var value in addition to a plain comma-separated string.

## Why:
The `CUPID_TEAM_TO_EMAILS` secret is stored in AWS Secrets Manager as a JSON object. When the raw JSON is injected directly as the env var value (rather than extracting an individual key), the value looks like:

```
{"backend-cupid-team-to-emails":"cupid@example.com"}
```

Passing that string to SES causes `Aws::SESV2::Errors::BadRequestException - Local address contains illegal character` because `{` is illegal in an email local part.

Before PR #3103 the job died earlier with an array/string type error that masked this. After #3103 fixed the array wrapping the job reaches SES and hits this address validation failure instead.

The fix: attempt `JSON.parse` first and take the hash values as the address list. If the value isn't JSON, fall back to the existing comma-split behaviour. Both paths strip whitespace and reject empty strings.

## Ticket:
N/A

## Risk:
🟢 Low. Additive — existing plain-string format continues to work. Change is isolated to one private helper method with tests for both code paths.