### PR TITLE
[HMRC-2134] - Add retries to redis rb client

### DIFF
--- a/app/lib/trade_tariff_backend/config.rb
+++ b/app/lib/trade_tariff_backend/config.rb
@@ -87,7 +87,7 @@ module TradeTariffBackend
 
     def sidekiq_redis_config
       db = Rails.env.test? ? 1 : 0
-      { url: ENV.fetch('SIDEKIQ_REDIS_URL', ENV['REDIS_URL']), db:, id: nil, timeout: 5 }
+      { url: ENV.fetch('SIDEKIQ_REDIS_URL', ENV['REDIS_URL']), db:, id: nil, timeout: 5, reconnect_attempts: [0.1, 0.5, 1.0] }
     end
 
     def frontend_redis_url


### PR DESCRIPTION
## What:
- Adds spaced reconnect attempts to redis.

## Why:
Worker logs show repeated Redis latency warnings, heartbeat failures and connection timeouts across both UK and XI.

After investigation, this seems to be large jobs causing the sidekiq heartbeat to be dropped. 
Adding retry behaviour is a low risk attempt at easing this and nice behaviour to have.

## Ticket:
[HMRC-2134](https://transformuk.atlassian.net/browse/HMRC-2134)

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
- Config change with safe defaults