### PR TITLE
Halve commodity measure query count by collapsing dual eager-load passes

### DIFF
--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -120,24 +120,57 @@ class CachedCommodityService
   end
 
   def commodity
-    @commodity ||= Commodity
-      .actual
-      .with_leaf_column
-      .where(goods_nomenclatures__goods_nomenclature_sid: @commodity_sid)
-      .eager(
-        goods_nomenclature_descriptions: {},
-        heading: :footnotes,
-        chapter: [:chapter_note, { sections: :section_note }],
-        ancestors: { measures: MEASURES_EAGER_LOAD_GRAPH,
-                     goods_nomenclature_descriptions: {} },
-        measures: MEASURES_EAGER_LOAD_GRAPH,
-        full_chemicals: {},
-      )
-      .take
+    @commodity ||= begin
+      # Phase 1: load the commodity and its ancestors for their own attributes.
+      # Measures are deliberately excluded here and loaded in a separate
+      # batched pass below so that MEASURES_EAGER_LOAD_GRAPH is applied once
+      # across all applicable goods_nomenclature_sids instead of twice
+      # (once for own measures, once for ancestor measures).
+      result = Commodity
+        .actual
+        .with_leaf_column
+        .where(goods_nomenclatures__goods_nomenclature_sid: @commodity_sid)
+        .eager(
+          goods_nomenclature_descriptions: {},
+          heading: :footnotes,
+          chapter: [:chapter_note, { sections: :section_note }],
+          ancestors: :goods_nomenclature_descriptions,
+          full_chemicals: {},
+        )
+        .take
+
+      load_applicable_measures(result)
+      result
+    end
   end
 
   def measures
     commodity.applicable_measures
+  end
+
+  # Fetches all measures for the commodity and every ancestor in one batched
+  # Sequel query, then distributes them back into each object's :measures
+  # association slot. This halves the number of queries compared with loading
+  # own measures and ancestor measures with separate eager-load passes.
+  def load_applicable_measures(commodity)
+    all_sids = [commodity.goods_nomenclature_sid] +
+      commodity.ancestors.map(&:goods_nomenclature_sid)
+
+    all_measures = Measure
+      .actual
+      .dedupe_similar
+      .with_regulation_dates_query
+      .without_excluded_types
+      .where(goods_nomenclature_sid: all_sids)
+      .eager(MEASURES_EAGER_LOAD_GRAPH)
+      .all
+
+    measures_by_sid = all_measures.group_by(&:goods_nomenclature_sid)
+
+    commodity.associations[:measures] = measures_by_sid.fetch(commodity.goods_nomenclature_sid, [])
+    commodity.ancestors.each do |ancestor|
+      ancestor.associations[:measures] = measures_by_sid.fetch(ancestor.goods_nomenclature_sid, [])
+    end
   end
 
   def geographical_area_id

--- a/spec/services/cached_commodity_service_spec.rb
+++ b/spec/services/cached_commodity_service_spec.rb
@@ -98,6 +98,27 @@ RSpec.describe CachedCommodityService do
 
         expect(loaded_commodity.associations).to include(full_chemicals: be_present)
       end
+
+      it 'pre-populates :measures on the commodity and each ancestor (single-pass load)' do
+        loaded_commodity = nil
+
+        allow(Api::V2::Commodities::CommodityPresenter).to receive(:new).and_wrap_original do |original, commodity, measures|
+          loaded_commodity = commodity
+          original.call(commodity, measures)
+        end
+
+        described_class.new(commodity.reload, actual_date).call
+
+        # Own measures slot must be set (even if empty) so applicable_measures
+        # does not fire a lazy DB query.
+        expect(loaded_commodity.associations).to have_key(:measures)
+
+        # Every ancestor must also have its measures slot pre-populated.
+        loaded_commodity.ancestors.each do |ancestor|
+          expect(ancestor.associations).to have_key(:measures),
+                                           "ancestor #{ancestor.goods_nomenclature_sid} had no :measures association set"
+        end
+      end
     end
 
     describe 'cache key' do


### PR DESCRIPTION
## What:
`CachedCommodityService` now loads all applicable measures — commodity's own and every ancestor's — in a single batched Sequel query instead of applying `MEASURES_EAGER_LOAD_GRAPH` twice.

## Why:
`MEASURES_EAGER_LOAD_GRAPH` contains ~60 associations. Sequel issues one batched SQL query per association, so the previous implementation fired:

- ~60 queries for the commodity's own measures (`measures: MEASURES_EAGER_LOAD_GRAPH`)
- ~60 more queries for the ancestors' measures (`ancestors: { measures: MEASURES_EAGER_LOAD_GRAPH }`)

The root cause is that `GoodsNomenclature#measures` is a FK-scoped one_to_many (not position-based), so `applicable_measures` has to combine `ancestors.flat_map(&:measures) + measures` in Ruby. Both sets were eager-loaded separately, each triggering the full graph.

The fix is a two-phase load:

**Phase 1** — load the commodity and ancestors for their own data (descriptions, footnotes, chapter, section). No measures.

**Phase 2** — collect all `goods_nomenclature_sid` values (self + ancestors) and fetch every applicable measure in a single query with `MEASURES_EAGER_LOAD_GRAPH` applied once. The records are then distributed back into each object's `:measures` association slot so that `applicable_measures` works as before without any further queries.

Net reduction: **~60 queries per commodity response** (≈ 50% of the previous measure-related query count).

## Ticket:
N/A

## Risk:
🟠 Medium. The output of the serializer is unchanged — the existing spec suite compares against a `reference_response` helper that still uses the old double-graph load. A new spec asserts that `:measures` is pre-populated on the commodity and all ancestors, confirming the single-pass load is wired up correctly.