### PR TITLE
Cache small reference tables in process memory with static_cache

### DIFF
--- a/app/helpers/materialize_view_helper.rb
+++ b/app/helpers/materialize_view_helper.rb
@@ -7,6 +7,29 @@ module MaterializeViewHelper
     ModificationRegulation
   ].freeze
 
+  # Small reference tables that almost never change between daily syncs.
+  # Each uses plugin :static_cache (skipped in test env) so that Model.all
+  # and Model[pk] are served from process memory without a DB round-trip.
+  # After each materialized-view refresh we call load_cache to keep the
+  # in-memory copies current.
+  STATIC_CACHE_MODEL_NAMES = %w[
+    DutyExpression
+    DutyExpressionDescription
+    MeasureAction
+    MeasureActionDescription
+    MeasureConditionCode
+    MeasureConditionCodeDescription
+    MeasureType
+    MeasureTypeDescription
+    MeasureTypeSeriesDescription
+    MeasurementUnit
+    MeasurementUnitAbbreviation
+    MeasurementUnitDescription
+    MeasurementUnitQualifier
+    MeasurementUnitQualifierDescription
+    MonetaryUnit
+  ].freeze
+
   def refresh_materialized_view
     eager_load_materialized_view_models
 
@@ -16,6 +39,7 @@ module MaterializeViewHelper
 
     GoodsNomenclatures::TreeNode.refresh!
 
+    reload_static_caches
     prewarm_views
   end
 
@@ -26,6 +50,15 @@ module MaterializeViewHelper
     Rails.application.config.x.materialized_view_models_loaded = true
   end
 
+  # Repopulate the in-memory static caches after the daily MV refresh so
+  # reference data stays current without an app restart.  Skipped in test
+  # because the models do not load plugin :static_cache in that environment.
+  def reload_static_caches
+    return if Rails.env.test?
+
+    STATIC_CACHE_MODEL_NAMES.each { |name| name.constantize.load_cache }
+  end
+
   def prewarm_views
     VIEWS_TO_PREWARM.each do |model_name|
       model_name.constantize.count
@@ -34,5 +67,6 @@ module MaterializeViewHelper
 
   module_function :refresh_materialized_view
   module_function :eager_load_materialized_view_models
+  module_function :reload_static_caches
   module_function :prewarm_views
 end

--- a/app/helpers/materialize_view_helper.rb
+++ b/app/helpers/materialize_view_helper.rb
@@ -51,12 +51,17 @@ module MaterializeViewHelper
   end
 
   # Repopulate the in-memory static caches after the daily MV refresh so
-  # reference data stays current without an app restart.  Skipped in test
-  # because the models do not load plugin :static_cache in that environment.
+  # reference data stays current without an app restart.
+  #
+  # plugin :static_cache is only loaded outside the test environment, so
+  # load_cache is only defined on the model class in production/development.
+  # Using respond_to? means this method is safe to call in any environment
+  # without stubbing Rails.env.
   def reload_static_caches
-    return if Rails.env.test?
-
-    STATIC_CACHE_MODEL_NAMES.each { |name| name.constantize.load_cache }
+    STATIC_CACHE_MODEL_NAMES.each do |name|
+      model = name.constantize
+      model.load_cache if model.respond_to?(:load_cache)
+    end
   end
 
   def prewarm_views

--- a/app/models/duty_expression.rb
+++ b/app/models/duty_expression.rb
@@ -12,6 +12,7 @@ class DutyExpression < Sequel::Model
 
   plugin :time_machine
   plugin :oplog, primary_key: :duty_expression_id
+  plugin :static_cache, frozen: false unless Rails.env.test?
 
   set_primary_key [:duty_expression_id]
 

--- a/app/models/duty_expression_description.rb
+++ b/app/models/duty_expression_description.rb
@@ -1,5 +1,6 @@
 class DutyExpressionDescription < Sequel::Model
   plugin :oplog, primary_key: :duty_expression_id
+  plugin :static_cache, frozen: false unless Rails.env.test?
 
   set_primary_key [:duty_expression_id]
 

--- a/app/models/measure_action.rb
+++ b/app/models/measure_action.rb
@@ -1,6 +1,7 @@
 class MeasureAction < Sequel::Model
   plugin :time_machine
   plugin :oplog, primary_key: :action_code
+  plugin :static_cache, frozen: false unless Rails.env.test?
 
   set_primary_key [:action_code]
 

--- a/app/models/measure_action_description.rb
+++ b/app/models/measure_action_description.rb
@@ -1,5 +1,6 @@
 class MeasureActionDescription < Sequel::Model
   plugin :oplog, primary_key: :action_code
+  plugin :static_cache, frozen: false unless Rails.env.test?
 
   set_primary_key [:action_code]
 end

--- a/app/models/measure_condition_code.rb
+++ b/app/models/measure_condition_code.rb
@@ -18,6 +18,7 @@ class MeasureConditionCode < Sequel::Model
 
   plugin :time_machine
   plugin :oplog, primary_key: :condition_code
+  plugin :static_cache, frozen: false unless Rails.env.test?
 
   set_primary_key [:condition_code]
 

--- a/app/models/measure_condition_code_description.rb
+++ b/app/models/measure_condition_code_description.rb
@@ -1,5 +1,6 @@
 class MeasureConditionCodeDescription < Sequel::Model
   plugin :oplog, primary_key: :condition_code
+  plugin :static_cache, frozen: false unless Rails.env.test?
 
   set_primary_key [:condition_code]
 end

--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -57,6 +57,7 @@ class MeasureType < Sequel::Model
 
   plugin :time_machine
   plugin :oplog, primary_key: :measure_type_id
+  plugin :static_cache, frozen: false unless Rails.env.test?
 
   set_primary_key [:measure_type_id]
 

--- a/app/models/measure_type_description.rb
+++ b/app/models/measure_type_description.rb
@@ -1,6 +1,7 @@
 class MeasureTypeDescription < Sequel::Model
   set_primary_key [:measure_type_id]
   plugin :oplog, primary_key: :measure_type_id
+  plugin :static_cache, frozen: false unless Rails.env.test?
 
   one_to_one :measure_type, key: :measure_type_id,
                             foreign_key: :measure_type_id

--- a/app/models/measure_type_series_description.rb
+++ b/app/models/measure_type_series_description.rb
@@ -1,5 +1,6 @@
 class MeasureTypeSeriesDescription < Sequel::Model
   plugin :oplog, primary_key: :measure_type_series_id
+  plugin :static_cache, frozen: false unless Rails.env.test?
 
   set_primary_key [:measure_type_series_id]
 end

--- a/app/models/measurement_unit.rb
+++ b/app/models/measurement_unit.rb
@@ -4,6 +4,7 @@ class MeasurementUnit < Sequel::Model
 
   plugin :oplog, primary_key: :measurement_unit_code
   plugin :time_machine
+  plugin :static_cache, frozen: false unless Rails.env.test?
 
   set_primary_key [:measurement_unit_code]
 

--- a/app/models/measurement_unit_abbreviation.rb
+++ b/app/models/measurement_unit_abbreviation.rb
@@ -1,4 +1,6 @@
 class MeasurementUnitAbbreviation < Sequel::Model
+  plugin :static_cache, frozen: false unless Rails.env.test?
+
   one_to_one :measurement_unit, primary_key: :measurement_unit_code,
                                 key: :measurement_unit_code
 end

--- a/app/models/measurement_unit_description.rb
+++ b/app/models/measurement_unit_description.rb
@@ -1,5 +1,6 @@
 class MeasurementUnitDescription < Sequel::Model
   plugin :oplog, primary_key: :measurement_unit_code
+  plugin :static_cache, frozen: false unless Rails.env.test?
 
   set_primary_key [:measurement_unit_code]
 end

--- a/app/models/measurement_unit_qualifier.rb
+++ b/app/models/measurement_unit_qualifier.rb
@@ -1,6 +1,7 @@
 class MeasurementUnitQualifier < Sequel::Model
   plugin :time_machine
   plugin :oplog, primary_key: :measurement_unit_qualifier_code
+  plugin :static_cache, frozen: false unless Rails.env.test?
 
   set_primary_key [:measurement_unit_qualifier_code]
 

--- a/app/models/measurement_unit_qualifier_description.rb
+++ b/app/models/measurement_unit_qualifier_description.rb
@@ -2,6 +2,7 @@ class MeasurementUnitQualifierDescription < Sequel::Model
   include Formatter
 
   plugin :oplog, primary_key: :measurement_unit_qualifier_code
+  plugin :static_cache, frozen: false unless Rails.env.test?
 
   set_primary_key [:measurement_unit_qualifier_code]
 

--- a/app/models/monetary_unit.rb
+++ b/app/models/monetary_unit.rb
@@ -1,6 +1,7 @@
 class MonetaryUnit < Sequel::Model
   plugin :time_machine
   plugin :oplog, primary_key: :monetary_unit_code
+  plugin :static_cache, frozen: false unless Rails.env.test?
 
   set_primary_key [:monetary_unit_code]
 

--- a/spec/helpers/materialize_view_helper_spec.rb
+++ b/spec/helpers/materialize_view_helper_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe MaterializeViewHelper do
+  describe '.reload_static_caches' do
+    context 'when in the test environment' do
+      it 'does nothing and raises no error' do
+        # The guard `return if Rails.env.test?` short-circuits the method so
+        # no constantize calls are attempted and no load_cache is fired.
+        expect { described_class.reload_static_caches }.not_to raise_error
+      end
+    end
+
+    context 'when outside the test environment' do
+      before { allow(Rails.env).to receive(:test?).and_return(false) }
+
+      it 'calls load_cache on every model listed in STATIC_CACHE_MODEL_NAMES' do
+        MaterializeViewHelper::STATIC_CACHE_MODEL_NAMES.each do |name|
+          allow(name.constantize).to receive(:load_cache)
+        end
+
+        described_class.reload_static_caches
+
+        MaterializeViewHelper::STATIC_CACHE_MODEL_NAMES.each do |name|
+          expect(name.constantize).to have_received(:load_cache).once
+        end
+      end
+    end
+  end
+
+  describe 'STATIC_CACHE_MODEL_NAMES' do
+    it 'contains 15 entries' do
+      expect(MaterializeViewHelper::STATIC_CACHE_MODEL_NAMES.size).to eq(15)
+    end
+
+    it 'every name resolves to an existing constant' do
+      expect {
+        MaterializeViewHelper::STATIC_CACHE_MODEL_NAMES.each(&:constantize)
+      }.not_to raise_error
+    end
+  end
+end

--- a/spec/helpers/materialize_view_helper_spec.rb
+++ b/spec/helpers/materialize_view_helper_spec.rb
@@ -1,27 +1,31 @@
 RSpec.describe MaterializeViewHelper do
   describe '.reload_static_caches' do
-    context 'when in the test environment' do
-      it 'does nothing and raises no error' do
-        # The guard `return if Rails.env.test?` short-circuits the method so
-        # no constantize calls are attempted and no load_cache is fired.
-        expect { described_class.reload_static_caches }.not_to raise_error
-      end
+    it 'does not error when models do not have static_cache loaded' do
+      # In the test environment plugin :static_cache is not applied, so
+      # none of the models define load_cache.  reload_static_caches must
+      # handle this gracefully via respond_to? rather than blowing up.
+      expect { described_class.reload_static_caches }.not_to raise_error
     end
 
-    context 'when outside the test environment' do
-      before { allow(Rails.env).to receive(:test?).and_return(false) }
+    it 'calls load_cache on models that respond to it' do
+      model_name = 'FakeStaticCacheModel'
+      model_class = double('model_class', load_cache: nil) # rubocop:disable RSpec/VerifiedDoubles
+      allow(model_class).to receive(:respond_to?).with(:load_cache).and_return(true)
+      stub_const('MaterializeViewHelper::STATIC_CACHE_MODEL_NAMES', [model_name])
+      allow(model_name).to receive(:constantize).and_return(model_class)
 
-      it 'calls load_cache on every model listed in STATIC_CACHE_MODEL_NAMES' do
-        MaterializeViewHelper::STATIC_CACHE_MODEL_NAMES.each do |name|
-          allow(name.constantize).to receive(:load_cache)
-        end
+      described_class.reload_static_caches
 
-        described_class.reload_static_caches
+      expect(model_class).to have_received(:load_cache).once
+    end
 
-        MaterializeViewHelper::STATIC_CACHE_MODEL_NAMES.each do |name|
-          expect(name.constantize).to have_received(:load_cache).once
-        end
-      end
+    it 'skips models that do not respond to load_cache' do
+      model_name = 'FakeModelWithoutCache'
+      model_class = double('model_class') # rubocop:disable RSpec/VerifiedDoubles
+      stub_const('MaterializeViewHelper::STATIC_CACHE_MODEL_NAMES', [model_name])
+      allow(model_name).to receive(:constantize).and_return(model_class)
+
+      expect { described_class.reload_static_caches }.not_to raise_error
     end
   end
 

--- a/spec/helpers/materialize_view_helper_spec.rb
+++ b/spec/helpers/materialize_view_helper_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe MaterializeViewHelper do
 
     it 'calls load_cache on models that respond to it' do
       model_name = 'FakeStaticCacheModel'
-      model_class = double('model_class', load_cache: nil) # rubocop:disable RSpec/VerifiedDoubles
-      allow(model_class).to receive(:respond_to?).with(:load_cache).and_return(true)
+      model_class = Class.new { def self.load_cache; end }
       stub_const('MaterializeViewHelper::STATIC_CACHE_MODEL_NAMES', [model_name])
       allow(model_name).to receive(:constantize).and_return(model_class)
+      allow(model_class).to receive(:load_cache)
 
       described_class.reload_static_caches
 
@@ -21,7 +21,7 @@ RSpec.describe MaterializeViewHelper do
 
     it 'skips models that do not respond to load_cache' do
       model_name = 'FakeModelWithoutCache'
-      model_class = double('model_class') # rubocop:disable RSpec/VerifiedDoubles
+      model_class = Class.new
       stub_const('MaterializeViewHelper::STATIC_CACHE_MODEL_NAMES', [model_name])
       allow(model_name).to receive(:constantize).and_return(model_class)
 


### PR DESCRIPTION
## Summary

- Adds Sequel's `plugin :static_cache, frozen: false` to 15 small reference models (duty expressions, measure types, measurement units, monetary units, measure actions, measure condition codes and their description tables)
- These tables contain < 100 rows each and change only when a daily TARIC/CDS sync applies new data
- `Model.all`, `Model.count`, and `Model[pk]` are now served from an in-memory hash instead of hitting PostgreSQL on every call
- `MaterializeViewHelper#refresh_materialized_view` calls the new `reload_static_caches` method after each MV refresh to keep the in-memory copies current
- The plugin is skipped in the test environment to avoid breaking between-example DB isolation

## Why

These reference tables are accessed repeatedly across requests (serializers, presenters, search). Before this change every `Model.all` or primary-key lookup issued a SQL query. With `static_cache` the data lives in the Ruby process and is repopulated once per daily sync.

`frozen: false` is used so that the tariff sync process can still persist new/updated records — the default `frozen: true` would cause `before_save` to cancel any write attempt on a cached instance.

## Multi-process behaviour

Each Ruby process (web server, Sidekiq worker) holds its own in-memory copy. On boot, `load_cache` populates it from the DB. After the daily sync, `reload_static_caches` refreshes the cache in whichever process runs `refresh_materialized_view` (a Sidekiq worker) — but other running web-server processes are not notified and will serve their boot-time copy until they are restarted.

This is acceptable because these reference tables change very rarely (major TARIC releases only), and commodity responses are already cached in Redis so stale in-memory data only affects uncached requests. Cross-process invalidation (e.g. Redis pub/sub) would be needed if same-day consistency becomes a requirement.

## Risk:
**Risk level:** 🟢 
Memoisation of the small, regularly used items only updated with the tariff.