### PR TITLE
Expand VIEWS_TO_PREWARM to cover all commodity-critical materialized views

### DIFF
--- a/app/helpers/materialize_view_helper.rb
+++ b/app/helpers/materialize_view_helper.rb
@@ -1,9 +1,20 @@
 module MaterializeViewHelper
-  # Tables the commodity query plan always seq-scans via Hash Left Join.
-  # Loading them into shared_buffers here means they are warm before
-  # PrewarmCommoditiesWorker fires HTTP requests that hit them concurrently.
+  # Materialized views that the commodity query plan seq-scans via Hash Left Join.
+  # Calling `.count` on each model forces PostgreSQL to read every page into
+  # shared_buffers so the data is warm before PrewarmCommoditiesWorker fires
+  # concurrent HTTP requests that would otherwise all pay the cold-read cost.
   VIEWS_TO_PREWARM = %w[
+    AdditionalCode
+    AdditionalCodeDescription
     BaseRegulation
+    Footnote
+    FootnoteDescription
+    GeographicalArea
+    GeographicalAreaDescription
+    GeographicalAreaMembership
+    Measure
+    MeasureComponent
+    MeasureCondition
     ModificationRegulation
   ].freeze
 


### PR DESCRIPTION
## What:

Expand `VIEWS_TO_PREWARM` in `MaterializeViewHelper` from 2 entries to 12, adding the ten materialized views that the commodity query plan seq-scans: `Measure`, `MeasureComponent`, `MeasureCondition`, `GeographicalArea`, `GeographicalAreaDescription`, `GeographicalAreaMembership`, `Footnote`, `FootnoteDescription`, `AdditionalCode`, `AdditionalCodeDescription`.

## Why:

After the daily materialized view refresh, `PrewarmCommoditiesWorker` fires a concurrent wave of HTTP requests that all need these views. If a view's pages aren't in PostgreSQL's `shared_buffers`, every one of those parallel requests pays the disk read cost simultaneously — the worst possible cache miss pattern.

Calling `.count` on each model forces a seq-scan that loads every page of the view into shared_buffers. The two models added in PR #3086 (BaseRegulation, ModificationRegulation) are the smallest of the views; the ten added here are larger and sit on the critical path of every commodity response. Prewarming them converts concurrent cold reads into a single sequential warm pass run before the first request arrives.

## Ticket:

N/A — performance improvement

## Risk:

🟢 Low — the change adds ten more `.count` calls to an already-existing post-refresh warmup step. The calls run in the same Sidekiq worker that already refreshes the materialized views, adding a few seconds of DB time that is negligible compared with the refresh itself. No application logic is changed; no new queries are introduced to the request path.