### PR TITLE
Add INCLUDE (oid) to FTS oplog natural-key indexes for index-only scans

### DIFF
--- a/db/migrate/20260506120000_add_oid_covering_column_to_fts_oplog_indexes.rb
+++ b/db/migrate/20260506120000_add_oid_covering_column_to_fts_oplog_indexes.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Add INCLUDE (oid) to the natural-key indexes on full_temporary_stop_regulations_oplog
+# and fts_regulation_actions_oplog so that the correlated MAX(oid) subquery inside
+# each view's WHERE clause can be satisfied with an index-only scan.
+#
+# Both oplog views deduplicate historical rows with a correlated subquery of the form:
+#
+#   WHERE oid IN (
+#     SELECT MAX(t2.oid) FROM <table>_oplog t2
+#     WHERE t2.<natural_key_cols> = t1.<natural_key_cols>
+#   )
+#
+# The natural-key indexes cover the WHERE predicate, but without oid in the index
+# PostgreSQL must heap-fetch each matching row to read oid before computing MAX.
+# On production oplog tables that accumulate one row per CDS sync (years of history),
+# this correlated subquery accounts for ~600ms per commodity request.
+#
+# With INCLUDE (oid), the aggregate is computed directly from the index leaf pages —
+# no heap access — reducing the correlated subquery to a sub-millisecond index-only scan.
+
+Sequel.migration do
+  up do
+    run <<-SQL
+      DROP INDEX IF EXISTS full_temp_stop_reg_pk;
+      CREATE INDEX full_temp_stop_reg_pk
+        ON full_temporary_stop_regulations_oplog
+        USING btree (full_temporary_stop_regulation_id, full_temporary_stop_regulation_role)
+        INCLUDE (oid);
+
+      DROP INDEX IF EXISTS fts_reg_act_pk;
+      CREATE INDEX fts_reg_act_pk
+        ON fts_regulation_actions_oplog
+        USING btree (fts_regulation_id, fts_regulation_role, stopped_regulation_id, stopped_regulation_role)
+        INCLUDE (oid);
+    SQL
+  end
+
+  down do
+    run <<-SQL
+      DROP INDEX IF EXISTS full_temp_stop_reg_pk;
+      CREATE INDEX full_temp_stop_reg_pk
+        ON full_temporary_stop_regulations_oplog
+        USING btree (full_temporary_stop_regulation_id, full_temporary_stop_regulation_role);
+
+      DROP INDEX IF EXISTS fts_reg_act_pk;
+      CREATE INDEX fts_reg_act_pk
+        ON fts_regulation_actions_oplog
+        USING btree (fts_regulation_id, fts_regulation_role, stopped_regulation_id, stopped_regulation_role);
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -11378,7 +11378,7 @@ CREATE INDEX fto_footypopl_otepeslog_operation_date ON uk.footnote_types_oplog U
 -- Name: fts_reg_act_pk; Type: INDEX; Schema: uk; Owner: -
 --
 
-CREATE INDEX fts_reg_act_pk ON uk.fts_regulation_actions_oplog USING btree (fts_regulation_id, fts_regulation_role, stopped_regulation_id, stopped_regulation_role);
+CREATE INDEX fts_reg_act_pk ON uk.fts_regulation_actions_oplog USING btree (fts_regulation_id, fts_regulation_role, stopped_regulation_id, stopped_regulation_role) INCLUDE (oid);
 
 
 --
@@ -11434,7 +11434,7 @@ CREATE INDEX full_temp_explicit_abrogation_regulation ON uk.full_temporary_stop_
 -- Name: full_temp_stop_reg_pk; Type: INDEX; Schema: uk; Owner: -
 --
 
-CREATE INDEX full_temp_stop_reg_pk ON uk.full_temporary_stop_regulations_oplog USING btree (full_temporary_stop_regulation_id, full_temporary_stop_regulation_role);
+CREATE INDEX full_temp_stop_reg_pk ON uk.full_temporary_stop_regulations_oplog USING btree (full_temporary_stop_regulation_id, full_temporary_stop_regulation_role) INCLUDE (oid);
 
 
 --


### PR DESCRIPTION
## What:

Adds `INCLUDE (oid)` to two existing natural-key indexes on the FTS oplog tables:

- `full_temp_stop_reg_pk` on `full_temporary_stop_regulations_oplog (full_temporary_stop_regulation_id, full_temporary_stop_regulation_role)`
- `fts_reg_act_pk` on `fts_regulation_actions_oplog (fts_regulation_id, fts_regulation_role, stopped_regulation_id, stopped_regulation_role)`

## Why:

Both non-materialized oplog views deduplicate historical rows with a correlated subquery:

```sql
WHERE oid IN (
  SELECT MAX(t2.oid) FROM <table>_oplog t2
  WHERE t2.<natural_key_cols> = t1.<natural_key_cols>
)
```

The natural-key indexes already covered the `WHERE` predicate, but because `oid` was not in the index, PostgreSQL had to heap-fetch every matching historical row to read `oid` before computing `MAX`. On production oplog tables that accumulate one row per CDS sync over years of history, this made the correlated subquery account for ~600ms on every commodity request hitting a measure with full temporary stop regulations.

`INCLUDE (oid)` makes the aggregate index-only: `MAX(oid)` is computed directly from the index leaf pages with no heap access. The query drops to sub-millisecond.

## Ticket:

N/A — performance fix

## Risk:

🟠 Medium — this drops and recreates two existing indexes. The migration takes a brief exclusive lock on each oplog table while the old index is dropped and the new one built. Both tables are small in row count (tens of rows live, though the oplog accumulates history); index builds should be fast. Deploying outside peak hours is advisable.

The indexes being replaced serve the same lookup predicate — the only change is the addition of `oid` as a covering column. No queries will regress; any query that used the old index can use the new one identically, and queries involving `MAX(oid)` over the natural key will improve significantly.