### PR TITLE
AI-517: Add per-note approval fields to customs tariff note tables

### DIFF
--- a/app/lib/customs_tariff_importer/importer.rb
+++ b/app/lib/customs_tariff_importer/importer.rb
@@ -49,15 +49,33 @@ module CustomsTariffImporter
         )
 
         extracted.chapters.each do |chapter_id, content|
-          CustomsTariffChapterNote.create(customs_tariff_update_version: update.version, chapter_id:, content:)
+          CustomsTariffChapterNote.create(
+            customs_tariff_update_version: update.version,
+            chapter_id:,
+            content:,
+            validity_start_date: update.validity_start_date,
+            status: CustomsTariffChapterNote::PENDING,
+          )
         end
 
         extracted.sections.each do |section_id, content|
-          CustomsTariffSectionNote.create(customs_tariff_update_version: update.version, section_id:, content:)
+          CustomsTariffSectionNote.create(
+            customs_tariff_update_version: update.version,
+            section_id:,
+            content:,
+            validity_start_date: update.validity_start_date,
+            status: CustomsTariffSectionNote::PENDING,
+          )
         end
 
         extracted.general_rules.each do |rule_label, content|
-          CustomsTariffGeneralRule.create(customs_tariff_update_version: update.version, rule_label:, content:)
+          CustomsTariffGeneralRule.create(
+            customs_tariff_update_version: update.version,
+            rule_label:,
+            content:,
+            validity_start_date: update.validity_start_date,
+            status: CustomsTariffGeneralRule::PENDING,
+          )
         end
       end
 

--- a/app/models/customs_tariff_chapter_note.rb
+++ b/app/models/customs_tariff_chapter_note.rb
@@ -1,3 +1,21 @@
 class CustomsTariffChapterNote < Sequel::Model
+  PENDING  = 'pending'.freeze
+  APPROVED = 'approved'.freeze
+  REJECTED = 'rejected'.freeze
+
   many_to_one :customs_tariff_update, key: :customs_tariff_update_version
+
+  dataset_module do
+    def pending
+      where(status: PENDING)
+    end
+
+    def approved
+      where(status: APPROVED)
+    end
+
+    def rejected
+      where(status: REJECTED)
+    end
+  end
 end

--- a/app/models/customs_tariff_general_rule.rb
+++ b/app/models/customs_tariff_general_rule.rb
@@ -1,3 +1,21 @@
 class CustomsTariffGeneralRule < Sequel::Model
+  PENDING  = 'pending'.freeze
+  APPROVED = 'approved'.freeze
+  REJECTED = 'rejected'.freeze
+
   many_to_one :customs_tariff_update, key: :customs_tariff_update_version
+
+  dataset_module do
+    def pending
+      where(status: PENDING)
+    end
+
+    def approved
+      where(status: APPROVED)
+    end
+
+    def rejected
+      where(status: REJECTED)
+    end
+  end
 end

--- a/app/models/customs_tariff_section_note.rb
+++ b/app/models/customs_tariff_section_note.rb
@@ -1,3 +1,21 @@
 class CustomsTariffSectionNote < Sequel::Model
+  PENDING  = 'pending'.freeze
+  APPROVED = 'approved'.freeze
+  REJECTED = 'rejected'.freeze
+
   many_to_one :customs_tariff_update, key: :customs_tariff_update_version
+
+  dataset_module do
+    def pending
+      where(status: PENDING)
+    end
+
+    def approved
+      where(status: APPROVED)
+    end
+
+    def rejected
+      where(status: REJECTED)
+    end
+  end
 end

--- a/app/models/customs_tariff_update.rb
+++ b/app/models/customs_tariff_update.rb
@@ -23,6 +23,10 @@ class CustomsTariffUpdate < Sequel::Model
       where(status: APPROVED)
     end
 
+    def rejected
+      where(status: REJECTED)
+    end
+
     def failed
       where(status: FAILED)
     end

--- a/db/data_migrations/20260506130000_backfill_customs_tariff_note_approval_fields.rb
+++ b/db/data_migrations/20260506130000_backfill_customs_tariff_note_approval_fields.rb
@@ -1,0 +1,23 @@
+# Idempotent: only updates rows where validity_start_date IS NULL.
+# Records already populated (by this migration or the updated importer) are untouched.
+Sequel.migration do
+  up do
+    %i[customs_tariff_section_notes customs_tariff_chapter_notes customs_tariff_general_rules].each do |table|
+      run <<~SQL
+        UPDATE #{table}
+        SET validity_start_date = customs_tariff_updates.validity_start_date,
+            status = CASE customs_tariff_updates.status
+                       WHEN 'failed' THEN 'pending'
+                       ELSE customs_tariff_updates.status
+                     END
+        FROM customs_tariff_updates
+        WHERE #{table}.customs_tariff_update_version = customs_tariff_updates.version
+          AND #{table}.validity_start_date IS NULL
+      SQL
+    end
+  end
+
+  down do
+    # Not reversible — restoring nulls would discard legitimately set dates.
+  end
+end

--- a/db/migrate/20260506120000_add_approval_fields_to_customs_tariff_notes.rb
+++ b/db/migrate/20260506120000_add_approval_fields_to_customs_tariff_notes.rb
@@ -1,0 +1,21 @@
+Sequel.migration do
+  up do
+    %i[customs_tariff_section_notes customs_tariff_chapter_notes customs_tariff_general_rules].each do |table|
+      alter_table(table) do
+        add_column :status, String, null: false, default: 'pending'
+        add_column :validity_start_date, Date
+        add_column :validity_end_date, Date
+      end
+    end
+  end
+
+  down do
+    %i[customs_tariff_section_notes customs_tariff_chapter_notes customs_tariff_general_rules].each do |table|
+      alter_table(table) do
+        drop_column :status
+        drop_column :validity_start_date
+        drop_column :validity_end_date
+      end
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1804,7 +1804,10 @@ CREATE TABLE uk.customs_tariff_chapter_notes (
     id integer NOT NULL,
     customs_tariff_update_version text NOT NULL,
     chapter_id character varying(2) NOT NULL,
-    content text NOT NULL
+    content text NOT NULL,
+    status text DEFAULT 'pending'::text NOT NULL,
+    validity_start_date date,
+    validity_end_date date
 );
 
 
@@ -1830,7 +1833,10 @@ CREATE TABLE uk.customs_tariff_general_rules (
     id integer NOT NULL,
     customs_tariff_update_version text NOT NULL,
     rule_label character varying(10) NOT NULL,
-    content text NOT NULL
+    content text NOT NULL,
+    status text DEFAULT 'pending'::text NOT NULL,
+    validity_start_date date,
+    validity_end_date date
 );
 
 
@@ -1856,7 +1862,10 @@ CREATE TABLE uk.customs_tariff_section_notes (
     id integer NOT NULL,
     customs_tariff_update_version text NOT NULL,
     section_id integer NOT NULL,
-    content text NOT NULL
+    content text NOT NULL,
+    status text DEFAULT 'pending'::text NOT NULL,
+    validity_start_date date,
+    validity_end_date date
 );
 
 
@@ -14262,3 +14271,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20260414113629_create_cust
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260424120000_materialise_hot_path_footnote_and_measure_views.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260429120000_add_aliases_to_description_intercepts.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260429151751_fixes_schema_reference_in_views.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20260506120000_add_approval_fields_to_customs_tariff_notes.rb');

--- a/spec/factories/customs_tariff_update_factory.rb
+++ b/spec/factories/customs_tariff_update_factory.rb
@@ -26,9 +26,19 @@ FactoryBot.define do
     association :customs_tariff_update
     sequence(:chapter_id) { |n| sprintf('%02d', n % 99 + 1) }
     content { 'This chapter covers all live animals.' }
+    status { CustomsTariffChapterNote::PENDING }
 
     after(:build) do |note|
       note.customs_tariff_update_version = note.customs_tariff_update.version
+    end
+
+    trait :approved do
+      status { CustomsTariffChapterNote::APPROVED }
+      validity_start_date { Time.zone.today }
+    end
+
+    trait :rejected do
+      status { CustomsTariffChapterNote::REJECTED }
     end
   end
 
@@ -36,9 +46,19 @@ FactoryBot.define do
     association :customs_tariff_update
     sequence(:section_id) { |n| (n % 21) + 1 }
     content { 'Any reference in this section to a particular genus or species of an animal includes a reference to the young of that genus or species.' }
+    status { CustomsTariffSectionNote::PENDING }
 
     after(:build) do |note|
       note.customs_tariff_update_version = note.customs_tariff_update.version
+    end
+
+    trait :approved do
+      status { CustomsTariffSectionNote::APPROVED }
+      validity_start_date { Time.zone.today }
+    end
+
+    trait :rejected do
+      status { CustomsTariffSectionNote::REJECTED }
     end
   end
 
@@ -46,9 +66,19 @@ FactoryBot.define do
     association :customs_tariff_update
     sequence(:rule_label, &:to_s)
     content { 'Classification shall be determined according to the terms of the headings.' }
+    status { CustomsTariffGeneralRule::PENDING }
 
     after(:build) do |rule|
       rule.customs_tariff_update_version = rule.customs_tariff_update.version
+    end
+
+    trait :approved do
+      status { CustomsTariffGeneralRule::APPROVED }
+      validity_start_date { Time.zone.today }
+    end
+
+    trait :rejected do
+      status { CustomsTariffGeneralRule::REJECTED }
     end
   end
 end

--- a/spec/lib/customs_tariff_importer/importer_spec.rb
+++ b/spec/lib/customs_tariff_importer/importer_spec.rb
@@ -93,6 +93,27 @@ RSpec.describe CustomsTariffImporter::Importer do
         expect(CustomsTariffGeneralRule.where(customs_tariff_update_version: '1.30').count).to eq(2)
       end
 
+      it 'creates chapter notes with the update validity_start_date and pending status' do
+        results
+        note = CustomsTariffChapterNote.where(customs_tariff_update_version: '1.30').first
+        expect(note.validity_start_date).to eq(entry_into_force_on)
+        expect(note.status).to eq(CustomsTariffChapterNote::PENDING)
+      end
+
+      it 'creates section notes with the update validity_start_date and pending status' do
+        results
+        note = CustomsTariffSectionNote.where(customs_tariff_update_version: '1.30').first
+        expect(note.validity_start_date).to eq(entry_into_force_on)
+        expect(note.status).to eq(CustomsTariffSectionNote::PENDING)
+      end
+
+      it 'creates general rules with the update validity_start_date and pending status' do
+        results
+        rule = CustomsTariffGeneralRule.where(customs_tariff_update_version: '1.30').first
+        expect(rule.validity_start_date).to eq(entry_into_force_on)
+        expect(rule.status).to eq(CustomsTariffGeneralRule::PENDING)
+      end
+
       it 'emits a document_imported instrumentation event' do
         results
         expect(CustomsTariffImporter::Instrumentation).to have_received(:document_imported).with(

--- a/spec/models/customs_tariff_chapter_note_spec.rb
+++ b/spec/models/customs_tariff_chapter_note_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe CustomsTariffChapterNote do
+  describe 'status default' do
+    it 'defaults to pending' do
+      note = create(:customs_tariff_chapter_note)
+      expect(note.status).to eq(CustomsTariffChapterNote::PENDING)
+    end
+  end
+
+  describe 'dataset scopes' do
+    let!(:pending_note)  { create(:customs_tariff_chapter_note) }
+    let!(:approved_note) { create(:customs_tariff_chapter_note, :approved) }
+    let!(:rejected_note) { create(:customs_tariff_chapter_note, :rejected) }
+
+    describe '.pending' do
+      it 'returns only pending records' do
+        expect(described_class.pending.all).to contain_exactly(pending_note)
+      end
+    end
+
+    describe '.approved' do
+      it 'returns only approved records' do
+        expect(described_class.approved.all).to contain_exactly(approved_note)
+      end
+    end
+
+    describe '.rejected' do
+      it 'returns only rejected records' do
+        expect(described_class.rejected.all).to contain_exactly(rejected_note)
+      end
+    end
+  end
+end

--- a/spec/models/customs_tariff_general_rule_spec.rb
+++ b/spec/models/customs_tariff_general_rule_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe CustomsTariffGeneralRule do
+  describe 'status default' do
+    it 'defaults to pending' do
+      rule = create(:customs_tariff_general_rule)
+      expect(rule.status).to eq(CustomsTariffGeneralRule::PENDING)
+    end
+  end
+
+  describe 'dataset scopes' do
+    let!(:pending_rule)  { create(:customs_tariff_general_rule) }
+    let!(:approved_rule) { create(:customs_tariff_general_rule, :approved) }
+    let!(:rejected_rule) { create(:customs_tariff_general_rule, :rejected) }
+
+    describe '.pending' do
+      it 'returns only pending records' do
+        expect(described_class.pending.all).to contain_exactly(pending_rule)
+      end
+    end
+
+    describe '.approved' do
+      it 'returns only approved records' do
+        expect(described_class.approved.all).to contain_exactly(approved_rule)
+      end
+    end
+
+    describe '.rejected' do
+      it 'returns only rejected records' do
+        expect(described_class.rejected.all).to contain_exactly(rejected_rule)
+      end
+    end
+  end
+end

--- a/spec/models/customs_tariff_section_note_spec.rb
+++ b/spec/models/customs_tariff_section_note_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe CustomsTariffSectionNote do
+  describe 'status default' do
+    it 'defaults to pending' do
+      note = create(:customs_tariff_section_note)
+      expect(note.status).to eq(CustomsTariffSectionNote::PENDING)
+    end
+  end
+
+  describe 'dataset scopes' do
+    let!(:pending_note)  { create(:customs_tariff_section_note) }
+    let!(:approved_note) { create(:customs_tariff_section_note, :approved) }
+    let!(:rejected_note) { create(:customs_tariff_section_note, :rejected) }
+
+    describe '.pending' do
+      it 'returns only pending records' do
+        expect(described_class.pending.all).to contain_exactly(pending_note)
+      end
+    end
+
+    describe '.approved' do
+      it 'returns only approved records' do
+        expect(described_class.approved.all).to contain_exactly(approved_note)
+      end
+    end
+
+    describe '.rejected' do
+      it 'returns only rejected records' do
+        expect(described_class.rejected.all).to contain_exactly(rejected_note)
+      end
+    end
+  end
+end

--- a/spec/models/customs_tariff_update_spec.rb
+++ b/spec/models/customs_tariff_update_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe CustomsTariffUpdate do
   describe 'dataset scopes' do
-    let!(:pending) { create(:customs_tariff_update, status: CustomsTariffUpdate::PENDING) }
+    let!(:pending)  { create(:customs_tariff_update, status: CustomsTariffUpdate::PENDING) }
     let!(:approved) { create(:customs_tariff_update, :approved) }
+    let!(:rejected) { create(:customs_tariff_update, :rejected) }
     let!(:failed)   { create(:customs_tariff_update, :failed) }
 
     describe '.pending' do
@@ -13,6 +14,12 @@ RSpec.describe CustomsTariffUpdate do
     describe '.approved' do
       it 'returns only approved records' do
         expect(described_class.approved.all).to contain_exactly(approved)
+      end
+    end
+
+    describe '.rejected' do
+      it 'returns only rejected records' do
+        expect(described_class.rejected.all).to contain_exactly(rejected)
       end
     end
 


### PR DESCRIPTION
## Jira Ticket:
[AI-517](https://transformuk.atlassian.net/browse/AI-517)

## What:
Adds three new columns — `status`, `validity_start_date`, and `validity_end_date` — to the `customs_tariff_section_notes`, `customs_tariff_chapter_notes`, and `customs_tariff_general_rules` tables. Each note now has its own approval state, separate from the parent `CustomsTariffUpdate`.

Also includes a small fix: `CustomsTariffUpdate` had a `REJECTED` constant defined but no matching `.rejected` dataset scope — that gap is now closed.

## Why:
The team has agreed that individual notes need their own approval process, not just the whole document batch. This PR lays the groundwork — the new fields let us later build an admin UI to approve or reject notes one by one. The importer now sets `validity_start_date` on each note at creation time (copying from the parent update), and an idempotent data migration backfills existing records.

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Purely additive changes — new nullable columns with safe defaults, no existing queries or API responses are affected. The data migration is idempotent and only touches rows where `validity_start_date` is null.
