### PR TITLE
AI-663: Add description intercept template import

### DIFF
--- a/app/controllers/api/admin/description_intercepts_controller.rb
+++ b/app/controllers/api/admin/description_intercepts_controller.rb
@@ -31,6 +31,16 @@ module Api
         end
       end
 
+      def bulk_import
+        result = DescriptionIntercepts::TemplateImporter.new(csv_content: bulk_import_params[:csv]).call
+
+        if result.success?
+          render json: serialize_bulk_import(result), status: :created
+        else
+          render json: { errors: result.summary_errors + result.row_errors }, status: :unprocessable_content
+        end
+      end
+
       def versions
         versions = description_intercept.versions.all
         Version.preload_predecessors(versions)
@@ -100,6 +110,7 @@ module Api
         permitted = attrs.permit(
           :term,
           :message,
+          :message_header,
           :excluded,
           :guidance_level,
           :guidance_location,
@@ -112,6 +123,7 @@ module Api
         {}.tap do |result|
           result[:term] = permitted[:term] if permitted.key?(:term)
           result[:message] = permitted[:message] if permitted.key?(:message)
+          result[:message_header] = permitted[:message_header] if permitted.key?(:message_header)
           result[:excluded] = permitted[:excluded] if permitted.key?(:excluded)
           result[:guidance_level] = permitted[:guidance_level] if permitted.key?(:guidance_level)
           result[:guidance_location] = permitted[:guidance_location] if permitted.key?(:guidance_location)
@@ -120,6 +132,23 @@ module Api
           result[:sources] = Sequel.pg_array(Array(permitted[:sources]).compact_blank, :text) if permitted.key?(:sources)
           result[:filter_prefixes] = Sequel.pg_array(Array(permitted[:filter_prefixes]).compact_blank, :text) if permitted.key?(:filter_prefixes)
         end
+      end
+
+      def bulk_import_params
+        params.require(:data).require(:attributes).permit(:csv)
+      end
+
+      def serialize_bulk_import(result)
+        {
+          data: {
+            type: 'description_intercept_bulk_import',
+            attributes: {
+              created: result.created_count,
+              updated: result.updated_count,
+              total: result.total_count,
+            },
+          },
+        }
       end
     end
   end

--- a/app/engines/admin_api.rb
+++ b/app/engines/admin_api.rb
@@ -95,6 +95,10 @@ AdminApi.routes.draw do
         resources :live_issues, only: %i[index show create update destroy]
         resources :admin_configurations, only: %i[index show update]
         resources :description_intercepts, only: %i[index show create update] do
+          collection do
+            post :bulk_import
+          end
+
           member do
             get :versions
           end

--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -27,7 +27,75 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
     },
   }.freeze
 
+  GENERIC_DESCRIPTION_INTERCEPT_MESSAGE = <<~MARKDOWN.strip.freeze
+    To find the relevant commodity code, we need more information about the product.
+
+    ## What information is needed?
+
+    The kind of details about the product you should include are:
+
+    - the type of product
+    - what the product is used for
+    - the materials used to make it
+    - how it's produced
+    - how it's packaged
+
+    ## Where can I find this information?
+
+    The information might be found on:
+
+    - invoice or other billing documents
+    - online listings
+    - product information documents included in the packaging
+
+    ## Next steps
+
+    Go back and add more details so we can find the relevant commodity code with the highest accuracy.
+  MARKDOWN
+
+  ESCALATION_DESCRIPTION_INTERCEPT_MESSAGE = <<~MARKDOWN.strip.freeze
+    You should contact HMRC for help classifying this product.
+
+    ## Next steps
+
+    Contact HMRC and quote reference {{request_id}}
+
+    *Webchat*: [Ask HMRC online]({{webchat_url}})
+
+    *Email*: [{{enquiries_email}}](mailto:{{enquiries_email}})
+  MARKDOWN
+
   DEFAULTS = {
+    'description_intercept_templates' => {
+      'generic' => {
+        'label' => 'Generic guidance',
+        'description' => 'Use when more detail is needed before a commodity code can be suggested.',
+        'attributes' => {
+          'escalate_to_webchat' => false,
+          'excluded' => true,
+          'filter_prefixes' => [],
+          'guidance_level' => 'info',
+          'guidance_location' => 'interstitial',
+          'message_header' => "We can't suggest a tariff code yet",
+          'message' => GENERIC_DESCRIPTION_INTERCEPT_MESSAGE,
+          'sources' => %w[guided_search fpo_search],
+        },
+      },
+      'escalation' => {
+        'label' => 'Escalation guidance',
+        'description' => 'Use when HMRC support is needed to classify the product.',
+        'attributes' => {
+          'escalate_to_webchat' => true,
+          'excluded' => true,
+          'filter_prefixes' => [],
+          'guidance_level' => 'info',
+          'guidance_location' => 'interstitial',
+          'message_header' => 'Contact HMRC for help',
+          'message' => ESCALATION_DESCRIPTION_INTERCEPT_MESSAGE,
+          'sources' => %w[guided_search fpo_search],
+        },
+      },
+    },
     'expand_search_enabled' => false,
     'expand_model' => NESTED_OPTION_DEFAULTS['expand_model'][:selected],
     'interactive_search_enabled' => true,
@@ -163,6 +231,17 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
     }
   end
 
+  def self.description_intercept_templates_value
+    config = classification.by_name('description_intercept_templates')
+    val = config&.value || default_for('description_intercept_templates')
+
+    case val
+    when Hash then val
+    when Sequel::Postgres::JSONBHash then val.to_hash
+    else default_for('description_intercept_templates')
+    end
+  end
+
   def self.schema_type_class(column)
     return nil if column == :value
 
@@ -175,7 +254,7 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
     validates_presence :config_type
     validates_presence :area
     validates_presence :description
-    validates_includes %w[string markdown boolean options multi_options integer nested_options], :config_type
+    validates_includes %w[string markdown boolean options multi_options integer nested_options object_template], :config_type
     validate_unique_name if new?
     validate_value_for_type
   end

--- a/app/models/admin_configuration/value_normalizer.rb
+++ b/app/models/admin_configuration/value_normalizer.rb
@@ -19,6 +19,8 @@ class AdminConfiguration
                   val.to_i
                 when 'options', 'nested_options', 'multi_options'
                   coerce_json_object(val)
+                when 'object_template'
+                  coerce_template_object(val)
                 else # string, markdown
                   val.to_s
                 end
@@ -35,6 +37,17 @@ class AdminConfiguration
       end
     rescue JSON::ParserError
       { 'selected' => default_selected_value, 'options' => [] }
+    end
+
+    def coerce_template_object(val)
+      case val
+      when Hash then val
+      when Sequel::Postgres::JSONBHash then val.to_hash
+      when String then JSON.parse(val)
+      else val
+      end
+    rescue JSON::ParserError
+      val
     end
 
     def default_selected_value

--- a/app/models/admin_configuration/value_validator.rb
+++ b/app/models/admin_configuration/value_validator.rb
@@ -21,6 +21,8 @@ class AdminConfiguration
         validate_multi_options_value
       when 'nested_options'
         validate_nested_options_value
+      when 'object_template'
+        validate_object_template_value
       when 'string', 'markdown'
         validate_text_value
       end
@@ -107,6 +109,43 @@ class AdminConfiguration
 
       option_keys = options.filter_map { |option| option['key'] if option.is_a?(Hash) }
       errors.add(:value, t('value.invalid_options')) unless (selected - option_keys).empty?
+    end
+
+    def validate_object_template_value
+      templates = hash_value
+      return errors.add(:value, 'must be a map of object templates') unless templates.is_a?(Hash) && templates.present?
+
+      templates.each do |key, template|
+        unless key.to_s.match?(/\A[a-z][a-z0-9_]*\z/)
+          errors.add(:value, 'template keys must be lowercase snake case')
+          next
+        end
+
+        validate_object_template(key, template)
+      end
+    end
+
+    def validate_object_template(key, template)
+      unless template.is_a?(Hash) && template.keys.sort == %w[attributes description label]
+        errors.add(:value, "#{key} must include label, description and attributes")
+        return
+      end
+
+      errors.add(:value, "#{key} label is required") if template['label'].blank?
+      errors.add(:value, "#{key} description is required") if template['description'].blank?
+
+      attrs = template['attributes']
+      unless attrs.is_a?(Hash)
+        errors.add(:value, "#{key} attributes must be a map")
+      end
+    end
+
+    def hash_value
+      val = self[:value]
+      case val
+      when Hash then val
+      when Sequel::Postgres::JSONBHash then val.to_hash
+      end
     end
   end
 end

--- a/app/models/description_intercept.rb
+++ b/app/models/description_intercept.rb
@@ -94,6 +94,7 @@ class DescriptionIntercept < Sequel::Model
       filtering: filtering?,
       filter_prefixes: filter_prefixes_array,
       message: message,
+      message_header: message_header,
       guidance_level: guidance_level,
       guidance_location: guidance_location,
       escalate_to_webchat: escalate_to_webchat,
@@ -110,10 +111,13 @@ class DescriptionIntercept < Sequel::Model
 
     validate_filter_prefixes
     validate_aliases
+    validate_unique_search_terms
     validate_guidance_dependencies
+    validates_unique :term
   end
 
   def before_validation
+    self.term = self.class.normalize_alias(term) if term.present?
     self.aliases = Sequel.pg_array(Array(aliases).map { |value| self.class.normalize_alias(value) }.uniq, :text)
 
     super
@@ -131,14 +135,53 @@ class DescriptionIntercept < Sequel::Model
   end
 
   def validate_aliases
-    aliases = Array(self.aliases)
-    return if aliases.empty?
+    raw_aliases = Array(aliases)
+    aliases = raw_aliases.compact_blank
 
-    errors.add(:aliases, 'cannot contain blank aliases') if aliases.any?(&:blank?)
+    errors.add(:aliases, 'cannot contain blank aliases') if raw_aliases.any?(&:blank?)
+    errors.add(:aliases, 'cannot duplicate the search term') if term.present? && aliases.include?(term)
+  end
+
+  def validate_unique_search_terms
+    term_conflicts = []
+    alias_conflicts = []
+
+    search_terms.each do |search_term|
+      conflict = search_term_conflict(search_term)
+      next if conflict.blank?
+
+      search_term == term ? term_conflicts << search_term : alias_conflicts << search_term
+    end
+
+    term_conflicts.each { |search_term| errors.add(:term, "is already used by another description intercept (#{search_term})") }
+    add_alias_conflict_error(alias_conflicts)
   end
 
   def validate_guidance_dependencies
     errors.add(:guidance_level, 'requires message') if guidance_level.present? && message.blank?
     errors.add(:guidance_location, 'requires message') if guidance_location.present? && message.blank?
+  end
+
+  def search_terms
+    ([term] + aliases_array).compact_blank
+  end
+
+  def search_term_conflict(search_term)
+    query = Sequel.expr(term: search_term) | Sequel.lit('aliases @> ARRAY[?]::text[]', search_term)
+    dataset = self.class.where(query)
+    dataset = dataset.exclude(id:) if id.present?
+    dataset.first
+  end
+
+  def add_alias_conflict_error(alias_conflicts)
+    return if alias_conflicts.empty?
+
+    message = if alias_conflicts.one?
+                "include a value already used by another description intercept (#{alias_conflicts.first})"
+              else
+                "include values already used by another description intercept (#{alias_conflicts.join(', ')})"
+              end
+
+    errors.add(:aliases, message)
   end
 end

--- a/app/serializers/api/admin/description_intercept_serializer.rb
+++ b/app/serializers/api/admin/description_intercept_serializer.rb
@@ -9,6 +9,7 @@ module Api
                  :aliases,
                  :sources,
                  :message,
+                 :message_header,
                  :excluded,
                  :created_at,
                  :guidance_level,

--- a/app/serializers/api/v2/description_intercept_serializer.rb
+++ b/app/serializers/api/v2/description_intercept_serializer.rb
@@ -10,6 +10,7 @@ module Api
                  :aliases,
                  :sources,
                  :message,
+                 :message_header,
                  :excluded,
                  :created_at,
                  :updated_at,

--- a/app/services/description_intercepts/template_importer.rb
+++ b/app/services/description_intercepts/template_importer.rb
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+module DescriptionIntercepts
+  class TemplateImporter
+    Result = Data.define(:created_count, :updated_count, :summary_errors, :row_errors) do
+      def success?
+        summary_errors.empty? && row_errors.empty?
+      end
+
+      def total_count
+        created_count + updated_count
+      end
+    end
+
+    REQUIRED_HEADERS = %w[term template].freeze
+    OPTIONAL_HEADERS = %w[aliases].freeze
+    ALLOWED_HEADERS = (REQUIRED_HEADERS + OPTIONAL_HEADERS).freeze
+    TEMPLATE_ATTRIBUTES = %w[
+      sources
+      message_header
+      message
+      excluded
+      guidance_level
+      guidance_location
+      escalate_to_webchat
+      filter_prefixes
+    ].freeze
+
+    def initialize(csv_content:)
+      @csv_content = csv_content.to_s
+      @summary_errors = []
+      @row_errors = []
+    end
+
+    def call
+      rows = parse_rows
+      return failure_result if errors?
+
+      candidates = build_candidates(rows)
+      return failure_result if errors?
+
+      persist(candidates)
+    rescue CSV::MalformedCSVError => e
+      @summary_errors << error(detail: "CSV could not be parsed: #{e.message}")
+      failure_result
+    end
+
+    private
+
+    def parse_rows
+      csv = CSV.parse(@csv_content, headers: true, skip_blanks: true)
+      validate_headers(csv.headers)
+      return [] if errors?
+
+      csv.each_with_index.filter_map do |row, index|
+        next if row.to_h.values.all?(&:blank?)
+
+        {
+          line_number: index + 2,
+          term: DescriptionIntercept.normalize_alias(row['term']),
+          aliases: parse_aliases(row['aliases']),
+          template: row['template'].to_s.squish,
+        }
+      end
+    end
+
+    def validate_headers(headers)
+      normalized_headers = Array(headers).compact.map(&:strip)
+      @aliases_header_present = normalized_headers.include?('aliases')
+
+      unless (REQUIRED_HEADERS - normalized_headers).empty? && (normalized_headers - ALLOWED_HEADERS).empty?
+        @summary_errors << error(detail: 'CSV must contain term and template columns, and may include an aliases column')
+      end
+    end
+
+    def build_candidates(rows)
+      validate_duplicate_search_values(rows)
+      validate_required_cells(rows)
+      validate_templates(rows)
+      return [] if errors?
+
+      rows.map do |row|
+        existing = DescriptionIntercept.first(term: row[:term])
+        attrs = template_attributes(row[:template]).merge(term: row[:term])
+        if @aliases_header_present
+          attrs[:aliases] = row[:aliases]
+        elsif existing
+          attrs[:aliases] = existing.aliases
+        end
+        intercept = existing || DescriptionIntercept.new
+        coerced_attrs = coerce_attributes(attrs)
+        intercept.set(coerced_attrs)
+
+        unless intercept.valid?
+          intercept.errors.each do |attribute, messages|
+            messages.each do |message|
+              @row_errors << error(
+                detail: "#{row[:term]} #{attribute} #{message}",
+                pointer: "/data/attributes/csv/#{row[:line_number]}/#{attribute}",
+              )
+            end
+          end
+        end
+
+        { existing:, attrs: coerced_attrs }
+      end
+    end
+
+    def validate_duplicate_search_values(rows)
+      duplicate_values = rows.flat_map { |row| [row[:term], *row[:aliases]] }.compact_blank.tally.select { |_value, count| count > 1 }.keys
+      duplicate_values.each do |value|
+        @summary_errors << error(
+          detail: "#{value} appears more than once across terms and aliases",
+          meta: { code: 'duplicate_search_value', value: value },
+        )
+      end
+    end
+
+    def parse_aliases(value)
+      value.to_s.split(',').map { |aliaz| DescriptionIntercept.normalize_alias(aliaz) }.compact_blank.uniq
+    end
+
+    def validate_required_cells(rows)
+      rows.each do |row|
+        @row_errors << error(detail: 'term is required', pointer: "/data/attributes/csv/#{row[:line_number]}/term") if row[:term].blank?
+        @row_errors << error(detail: 'template is required', pointer: "/data/attributes/csv/#{row[:line_number]}/template") if row[:template].blank?
+      end
+    end
+
+    def validate_templates(rows)
+      invalid_templates = rows.map { |row| row[:template] }.compact_blank.reject { |template| templates.key?(template) }.uniq
+      return if invalid_templates.empty?
+
+      @summary_errors << error(
+        detail: invalid_template_summary(invalid_templates),
+        meta: { code: 'invalid_templates', values: invalid_templates },
+      )
+    end
+
+    def invalid_template_summary(invalid_templates)
+      return "#{invalid_templates.first} is not a valid template" if invalid_templates.one?
+
+      "#{to_sentence(invalid_templates)} are not valid templates"
+    end
+
+    def persist(candidates)
+      created = 0
+      updated = 0
+
+      Sequel::Model.db.transaction do
+        candidates.each do |candidate|
+          intercept = candidate[:existing] || DescriptionIntercept.new
+          intercept.set(candidate[:attrs])
+          unless intercept.save(raise_on_failure: false)
+            intercept.errors.each do |attribute, messages|
+              messages.each { |message| @summary_errors << error(detail: "#{attribute} #{message}") }
+            end
+            raise Sequel::Rollback
+          end
+
+          candidate[:existing] ? updated += 1 : created += 1
+        end
+      end
+
+      return failure_result if errors?
+
+      Result.new(created_count: created, updated_count: updated, summary_errors: [], row_errors: [])
+    end
+
+    def template_attributes(template)
+      templates.fetch(template).fetch('attributes').slice(*TEMPLATE_ATTRIBUTES).symbolize_keys
+    end
+
+    def templates
+      @templates ||= AdminConfiguration.description_intercept_templates_value
+    end
+
+    def coerce_attributes(attrs)
+      attrs.merge(
+        sources: Sequel.pg_array(Array(attrs[:sources]).compact_blank, :text),
+        filter_prefixes: Sequel.pg_array(Array(attrs[:filter_prefixes]).compact_blank, :text),
+        aliases: Sequel.pg_array(Array(attrs[:aliases]).compact_blank, :text),
+      )
+    end
+
+    def failure_result
+      Result.new(created_count: 0, updated_count: 0, summary_errors: @summary_errors, row_errors: @row_errors)
+    end
+
+    def errors?
+      @summary_errors.any? || @row_errors.any?
+    end
+
+    def error(detail:, pointer: nil, meta: nil)
+      {}.tap do |payload|
+        payload[:detail] = detail
+        payload[:source] = { pointer: } if pointer
+        payload[:meta] = meta if meta
+      end
+    end
+
+    def to_sentence(values)
+      case values.length
+      when 0 then ''
+      when 1 then values.first
+      when 2 then values.join(' and ')
+      else "#{values[0...-1].join(', ')} and #{values.last}"
+      end
+    end
+  end
+end

--- a/db/migrate/20260506170000_add_unique_index_to_description_intercepts_term.rb
+++ b/db/migrate/20260506170000_add_unique_index_to_description_intercepts_term.rb
@@ -1,0 +1,28 @@
+Sequel.migration do
+  up do
+    duplicates = fetch(<<~SQL).map(:normalised_term)
+      SELECT lower(trim(term)) AS normalised_term
+      FROM description_intercepts
+      GROUP BY lower(trim(term))
+      HAVING count(*) > 1
+    SQL
+
+    if duplicates.any?
+      raise Sequel::Error, "Cannot add unique description intercept term index while duplicates exist: #{duplicates.join(', ')}"
+    end
+
+    run 'UPDATE description_intercepts SET term = lower(trim(term))'
+    run 'DROP INDEX IF EXISTS description_intercepts_term_index'
+
+    alter_table :description_intercepts do
+      add_unique_constraint :term, name: :description_intercepts_term_unique
+    end
+  end
+
+  down do
+    alter_table :description_intercepts do
+      drop_constraint :description_intercepts_term_unique
+      add_index :term
+    end
+  end
+end

--- a/db/migrate/20260507110000_add_message_header_and_alias_constraints_to_description_intercepts.rb
+++ b/db/migrate/20260507110000_add_message_header_and_alias_constraints_to_description_intercepts.rb
@@ -1,0 +1,15 @@
+Sequel.migration do
+  up do
+    alter_table :description_intercepts do
+      add_column :message_header, String, text: true
+      add_constraint :description_intercepts_term_not_alias, Sequel.lit('NOT (term = ANY(COALESCE(aliases, ARRAY[]::text[])))')
+    end
+  end
+
+  down do
+    alter_table :description_intercepts do
+      drop_constraint :description_intercepts_term_not_alias
+      drop_column :message_header
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1927,7 +1927,8 @@ CREATE TABLE uk.description_intercepts (
     guidance_location text,
     escalate_to_webchat boolean DEFAULT false NOT NULL,
     filter_prefixes text[],
-    aliases text[] DEFAULT '{}'::text[] NOT NULL
+    aliases text[] DEFAULT '{}'::text[] NOT NULL,
+    message_header text
 );
 
 
@@ -9167,6 +9168,22 @@ ALTER TABLE ONLY uk.description_intercepts
 
 
 --
+-- Name: description_intercepts description_intercepts_term_not_alias; Type: CHECK CONSTRAINT; Schema: uk; Owner: -
+--
+
+ALTER TABLE ONLY uk.description_intercepts
+    ADD CONSTRAINT description_intercepts_term_not_alias CHECK ((NOT (term = ANY (COALESCE(aliases, ARRAY[]::text[])))));
+
+
+--
+-- Name: description_intercepts description_intercepts_term_unique; Type: CONSTRAINT; Schema: uk; Owner: -
+--
+
+ALTER TABLE ONLY uk.description_intercepts
+    ADD CONSTRAINT description_intercepts_term_unique UNIQUE (term);
+
+
+--
 -- Name: differences_logs differences_logs_pkey; Type: CONSTRAINT; Schema: uk; Owner: -
 --
 
@@ -10927,12 +10944,6 @@ CREATE INDEX deo_dutexpopl_utyonslog_operation_date ON uk.duty_expressions_oplog
 
 CREATE INDEX description_intercepts_excluded_index ON uk.description_intercepts USING btree (excluded);
 
-
---
--- Name: description_intercepts_term_index; Type: INDEX; Schema: uk; Owner: -
---
-
-CREATE INDEX description_intercepts_term_index ON uk.description_intercepts USING btree (term);
 
 
 --
@@ -14270,5 +14281,7 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20260414113628_create_cust
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260414113629_create_customs_tariff_general_rules.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260424120000_materialise_hot_path_footnote_and_measure_views.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260429120000_add_aliases_to_description_intercepts.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20260506170000_add_unique_index_to_description_intercepts_term.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20260507110000_add_message_header_and_alias_constraints_to_description_intercepts.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260429151751_fixes_schema_reference_in_views.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260506120000_add_approval_fields_to_customs_tariff_notes.rb');

--- a/lib/tasks/admin_configurations.rake
+++ b/lib/tasks/admin_configurations.rake
@@ -395,6 +395,12 @@ namespace :admin_configurations do
 
     configs = [
       {
+        name: 'description_intercept_templates',
+        config_type: 'object_template',
+        description: 'Named templates used by the description intercept bulk import. CSV uploads provide term and template only.',
+        value: AdminConfiguration.default_for('description_intercept_templates'),
+      },
+      {
         name: 'expand_search_enabled',
         config_type: 'boolean',
         description: 'Expand search queries using AI to translate everyday language into tariff terminology before searching',
@@ -623,8 +629,15 @@ namespace :admin_configurations do
     created = 0
 
     configs.each do |attrs|
-      if AdminConfiguration.where(name: attrs[:name]).any?
-        puts "  skip: #{attrs[:name]} (already exists)"
+      config = AdminConfiguration.where(name: attrs[:name]).first
+      if config
+        if config.config_type != attrs[:config_type]
+          config.update(config_type: attrs[:config_type], value: attrs[:value])
+          puts "  patched: #{attrs[:name]} (config type)"
+          created += 1
+        else
+          puts "  skip: #{attrs[:name]} (already exists)"
+        end
         next
       end
 

--- a/spec/controllers/api/admin/description_intercepts_controller_spec.rb
+++ b/spec/controllers/api/admin/description_intercepts_controller_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Api::Admin::DescriptionInterceptsController do
         sources: Sequel.pg_array(%w[guided_search], :text),
         guidance_level: 'warning',
         guidance_location: 'results',
+        message_header: 'Check the term',
         escalate_to_webchat: true,
         filter_prefixes: Sequel.pg_array(%w[6403 6404], :text),
       )
@@ -114,6 +115,7 @@ RSpec.describe Api::Admin::DescriptionInterceptsController do
         aliases: Sequel.pg_array(%w[trainers shoes], :text),
         guidance_level: 'warning',
         guidance_location: 'results',
+        message_header: 'Check the term',
         escalate_to_webchat: true,
         filter_prefixes: Sequel.pg_array(%w[6403 6404], :text),
       )
@@ -132,6 +134,7 @@ RSpec.describe Api::Admin::DescriptionInterceptsController do
             aliases: %w[trainers shoes],
             sources: %w[guided_search],
             message: 'Please be more specific.',
+            message_header: 'Check the term',
             excluded: false,
             created_at: wildcard_matcher,
             guidance_level: 'warning',
@@ -183,6 +186,7 @@ RSpec.describe Api::Admin::DescriptionInterceptsController do
               term: 'bicycles',
               aliases: %w[cycle bike],
               message: 'Read the bicycle guidance.',
+              message_header: 'Bicycle guidance',
               guidance_level: 'info',
               guidance_location: 'results',
               escalate_to_webchat: true,
@@ -200,6 +204,7 @@ RSpec.describe Api::Admin::DescriptionInterceptsController do
       expect(intercept.term).to eq('bicycles')
       expect(intercept.aliases).to eq(%w[cycle bike])
       expect(intercept.message).to eq('Read the bicycle guidance.')
+      expect(intercept.message_header).to eq('Bicycle guidance')
       expect(intercept.guidance_level).to eq('info')
       expect(intercept.guidance_location).to eq('results')
       expect(intercept.escalate_to_webchat).to be true
@@ -240,6 +245,7 @@ RSpec.describe Api::Admin::DescriptionInterceptsController do
           type: 'description_intercept',
           attributes: {
             message: 'Read the footwear guidance.',
+            message_header: 'Footwear guidance',
             guidance_level: 'warning',
             guidance_location: 'results',
             escalate_to_webchat: true,
@@ -254,6 +260,7 @@ RSpec.describe Api::Admin::DescriptionInterceptsController do
 
       intercept.reload
       expect(intercept.message).to eq('Read the footwear guidance.')
+      expect(intercept.message_header).to eq('Footwear guidance')
       expect(intercept.guidance_level).to eq('warning')
       expect(intercept.guidance_location).to eq('results')
       expect(intercept.escalate_to_webchat).to be true
@@ -265,7 +272,7 @@ RSpec.describe Api::Admin::DescriptionInterceptsController do
     it 'clears array fields when blank values are submitted' do
       intercept.update(
         filter_prefixes: Sequel.pg_array(%w[6403 6404], :text),
-        aliases: Sequel.pg_array(%w[trainers shoes], :text),
+        aliases: Sequel.pg_array(%w[trainers], :text),
         sources: Sequel.pg_array(%w[guided_search fpo_search], :text),
       )
 
@@ -304,6 +311,64 @@ RSpec.describe Api::Admin::DescriptionInterceptsController do
       expect(response).to have_http_status(:unprocessable_content)
       json = JSON.parse(response.body)
       expect(json['errors'].first.dig('source', 'pointer')).to eq('/data/attributes/filter_prefixes')
+    end
+  end
+
+  describe '#bulk_import' do
+    let(:template_value) do
+      {
+        'vague' => {
+          'label' => 'Vague term',
+          'description' => 'Use when the term is too broad to classify safely.',
+          'attributes' => {
+            'escalate_to_webchat' => false,
+            'excluded' => true,
+            'filter_prefixes' => [],
+            'guidance_level' => 'info',
+            'guidance_location' => 'interstitial',
+            'message_header' => 'Placeholder guidance heading',
+            'message' => 'This is too vague. Please be better at classification',
+            'sources' => %w[guided_search fpo_search],
+          },
+        },
+      }
+    end
+
+    before do
+      create(:admin_configuration, name: 'description_intercept_templates', config_type: 'object_template', value: template_value)
+    end
+
+    it 'imports valid CSV content' do
+      expect {
+        post :bulk_import, params: {
+          data: {
+            type: 'description_intercept_bulk_import',
+            attributes: { csv: "term,template\ngift,vague\n" },
+          },
+        }, format: :json
+      }.to change(DescriptionIntercept, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      json = JSON.parse(response.body)
+      expect(json.dig('data', 'attributes')).to include('created' => 1, 'updated' => 0, 'total' => 1)
+    end
+
+    it 'returns grouped validation errors without importing' do
+      expect {
+        post :bulk_import, params: {
+          data: {
+            type: 'description_intercept_bulk_import',
+            attributes: { csv: "term,template\ngift,foo\npresent,baz\n" },
+          },
+        }, format: :json
+      }.not_to change(DescriptionIntercept, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      json = JSON.parse(response.body)
+      expect(json['errors'].first).to include(
+        'detail' => 'foo and baz are not valid templates',
+        'meta' => { 'code' => 'invalid_templates', 'values' => %w[foo baz] },
+      )
     end
   end
 

--- a/spec/lib/tasks/admin_configurations_rake_spec.rb
+++ b/spec/lib/tasks/admin_configurations_rake_spec.rb
@@ -8,11 +8,12 @@ RSpec.describe 'admin_configurations:seed' do
     Rake::Task['admin_configurations:seed'].reenable
   end
 
-  it 'creates all 36 admin configurations', :aggregate_failures do
-    expect { seed }.to change(AdminConfiguration, :count).by(36)
+  it 'creates all 37 admin configurations', :aggregate_failures do
+    expect { seed }.to change(AdminConfiguration, :count).by(37)
 
     names = AdminConfiguration.order(:name).select_map(:name)
     expect(names).to eq(%w[
+      description_intercept_templates
       expand_model
       expand_query_context
       expand_search_enabled
@@ -50,6 +51,31 @@ RSpec.describe 'admin_configurations:seed' do
       vector_ef_search
       vector_score_threshold
     ])
+  end
+
+  it 'seeds the initial description intercept template registry', :aggregate_failures do
+    seed
+
+    config = AdminConfiguration.where(name: 'description_intercept_templates').first
+    expect(config.config_type).to eq('object_template')
+    expect(config.value.keys).to contain_exactly('generic', 'escalation')
+    expect(config.value['generic']['label']).to eq('Generic guidance')
+    expect(config.value['generic']['attributes']).to include(
+      'excluded' => true,
+      'message_header' => "We can't suggest a tariff code yet",
+      'guidance_level' => 'info',
+      'guidance_location' => 'interstitial',
+      'sources' => %w[guided_search fpo_search],
+    )
+    expect(config.value['escalation']['label']).to eq('Escalation guidance')
+    expect(config.value['escalation']['attributes']).to include(
+      'excluded' => true,
+      'escalate_to_webchat' => true,
+      'message_header' => 'Contact HMRC for help',
+    )
+    expect(config.value['escalation']['attributes']['message']).to include('{{request_id}}')
+    expect(config.value['escalation']['attributes']['message']).to include('{{webchat_url}}')
+    expect(config.value['escalation']['attributes']['message']).to include('{{enquiries_email}}')
   end
 
   it 'seeds nested_options configs with sorted model options', :aggregate_failures do
@@ -288,6 +314,13 @@ RSpec.describe 'admin_configurations:seed' do
 
     expect { suppress_output { Rake::Task['admin_configurations:seed'].invoke } }
       .not_to change(AdminConfiguration, :count)
+  end
+
+  it 'patches existing configurations when their type changes' do
+    create(:admin_configuration, name: 'description_intercept_templates', config_type: 'string', value: 'legacy')
+
+    expect { seed }.to change(AdminConfiguration, :count).by(36)
+    expect(AdminConfiguration.where(name: 'description_intercept_templates').first.config_type).to eq('object_template')
   end
 end
 # rubocop:enable RSpec/DescribeClass

--- a/spec/models/admin_configuration_spec.rb
+++ b/spec/models/admin_configuration_spec.rb
@@ -677,4 +677,71 @@ RSpec.describe AdminConfiguration do
       end
     end
   end
+
+  describe 'object templates' do
+    let(:template_value) do
+      {
+        'vague' => {
+          'label' => 'Vague term',
+          'description' => 'Use when the term is too broad to classify safely.',
+          'attributes' => {
+            'escalate_to_webchat' => false,
+            'excluded' => true,
+            'filter_prefixes' => [],
+            'guidance_level' => 'info',
+            'guidance_location' => 'interstitial',
+            'message_header' => 'Placeholder guidance heading',
+            'message' => 'This is too vague. Please be better at classification',
+            'sources' => %w[guided_search fpo_search],
+          },
+        },
+      }
+    end
+
+    it 'accepts valid template registries' do
+      config = build(:admin_configuration, name: 'description_intercept_templates', config_type: 'object_template', value: template_value)
+
+      expect(config).to be_valid
+    end
+
+    it 'rejects values that are not template maps' do
+      config = build(:admin_configuration, name: 'description_intercept_templates', config_type: 'object_template', value: 'not json')
+
+      expect(config).not_to be_valid
+      expect(config.errors[:value]).to include('must be a map of object templates')
+    end
+
+    it 'rejects template keys that are not lowercase snake case' do
+      config = build(:admin_configuration, name: 'description_intercept_templates', config_type: 'object_template', value: template_value.merge('Bad Key' => template_value['vague']))
+
+      expect(config).not_to be_valid
+      expect(config.errors[:value]).to include('template keys must be lowercase snake case')
+    end
+
+    it 'rejects templates without admin guidance' do
+      invalid = template_value.deep_dup
+      invalid['vague'].delete('label')
+      config = build(:admin_configuration, name: 'description_intercept_templates', config_type: 'object_template', value: invalid)
+
+      expect(config).not_to be_valid
+      expect(config.errors[:value]).to include('vague must include label, description and attributes')
+    end
+
+    it 'rejects templates without attribute maps' do
+      invalid = template_value.deep_dup
+      invalid['vague']['attributes'] = []
+      config = build(:admin_configuration, name: 'description_intercept_templates', config_type: 'object_template', value: invalid)
+
+      expect(config).not_to be_valid
+      expect(config.errors[:value]).to include('vague attributes must be a map')
+    end
+
+    describe '.description_intercept_templates_value' do
+      it 'returns the configured template map' do
+        create(:admin_configuration, name: 'description_intercept_templates', config_type: 'object_template', value: template_value)
+
+        expect(described_class.description_intercept_templates_value).to eq(template_value)
+      end
+    end
+  end
 end

--- a/spec/models/description_intercept_spec.rb
+++ b/spec/models/description_intercept_spec.rb
@@ -149,6 +149,78 @@ RSpec.describe DescriptionIntercept do
         expect(intercept.errors[:aliases]).to include('cannot contain blank aliases')
       end
     end
+
+    context 'when more than one alias is set' do
+      let(:attrs) do
+        {
+          aliases: Sequel.pg_array(%w[present gifts], :text),
+        }
+      end
+
+      it 'is valid' do
+        expect(intercept).to be_valid
+      end
+    end
+
+    context 'when an alias duplicates the term' do
+      let(:attrs) do
+        {
+          term: 'gift',
+          aliases: Sequel.pg_array(%w[gift], :text),
+        }
+      end
+
+      it 'is invalid' do
+        expect(intercept).not_to be_valid
+        expect(intercept.errors[:aliases]).to include('cannot duplicate the search term')
+      end
+    end
+
+    context 'when an alias is already used as another term' do
+      let(:attrs) do
+        {
+          term: 'gift',
+          aliases: Sequel.pg_array(%w[present], :text),
+        }
+      end
+
+      before { create(:description_intercept, term: 'present') }
+
+      it 'is invalid' do
+        expect(intercept).not_to be_valid
+        expect(intercept.errors[:aliases]).to include('include a value already used by another description intercept (present)')
+      end
+    end
+
+    context 'when multiple aliases are already used by other intercepts' do
+      let(:attrs) do
+        {
+          term: 'horses',
+          aliases: Sequel.pg_array(%w[present gift], :text),
+        }
+      end
+
+      before do
+        create(:description_intercept, term: 'present')
+        create(:description_intercept, term: 'gift')
+      end
+
+      it 'accumulates the duplicate alias values into one error' do
+        expect(intercept).not_to be_valid
+        expect(intercept.errors[:aliases]).to contain_exactly('include values already used by another description intercept (present, gift)')
+      end
+    end
+
+    context 'when a term is already used as another alias' do
+      let(:attrs) { { term: 'present' } }
+
+      before { create(:description_intercept, term: 'gift', aliases: Sequel.pg_array(%w[present], :text)) }
+
+      it 'is invalid' do
+        expect(intercept).not_to be_valid
+        expect(intercept.errors[:term]).to include('is already used by another description intercept (present)')
+      end
+    end
   end
 
   describe '.for_search' do
@@ -190,7 +262,7 @@ RSpec.describe DescriptionIntercept do
       create(
         :description_intercept,
         term: 'sofa',
-        aliases: Sequel.pg_array(%w[settee], :text),
+        aliases: Sequel.pg_array(%w[settee couch], :text),
         sources: Sequel.pg_array(%w[fpo_search], :text),
       )
 
@@ -207,6 +279,22 @@ RSpec.describe DescriptionIntercept do
       }.to change { Version.where(item_type: 'DescriptionIntercept', item_id: intercept.id.to_s).count }.by(1)
 
       expect(Version.where(item_type: 'DescriptionIntercept', item_id: intercept.id.to_s).count).to eq(2)
+    end
+  end
+
+  describe 'term normalisation' do
+    it 'normalises terms before validation' do
+      intercept = create(:description_intercept, term: ' Gift  ')
+
+      expect(intercept.reload.term).to eq('gift')
+    end
+
+    it 'rejects duplicate terms after normalisation' do
+      create(:description_intercept, term: 'gift')
+      intercept = build(:description_intercept, term: ' Gift ')
+
+      expect(intercept).not_to be_valid
+      expect(intercept.errors[:term]).to include('is already taken')
     end
   end
 end

--- a/spec/requests/api/internal/search_controller_spec.rb
+++ b/spec/requests/api/internal/search_controller_spec.rb
@@ -189,6 +189,7 @@ RSpec.describe Api::Internal::SearchController, :internal do
               'filtering' => false,
               'filter_prefixes' => [],
               'message' => 'Gift is too vague.',
+              'message_header' => nil,
               'guidance_level' => 'warning',
               'guidance_location' => 'interstitial',
               'escalate_to_webchat' => true,

--- a/spec/requests/api/v2/description_intercepts_controller_spec.rb
+++ b/spec/requests/api/v2/description_intercepts_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Api::V2::DescriptionInterceptsController, :v2 do
       create(
         :description_intercept,
         term: 'alpha',
-        aliases: Sequel.pg_array(%w[aleph first], :text),
+        aliases: Sequel.pg_array(%w[aleph], :text),
         sources: Sequel.pg_array(%w[guided_search], :text),
         message: 'Alpha guidance',
         excluded: true,
@@ -53,6 +53,7 @@ RSpec.describe Api::V2::DescriptionInterceptsController, :v2 do
         aliases
         sources
         message
+        message_header
         excluded
         created_at
         updated_at

--- a/spec/services/description_intercepts/template_importer_spec.rb
+++ b/spec/services/description_intercepts/template_importer_spec.rb
@@ -1,0 +1,139 @@
+RSpec.describe DescriptionIntercepts::TemplateImporter do
+  let(:templates) do
+    {
+      'vague' => {
+        'label' => 'Vague term',
+        'description' => 'Use when the term is too broad to classify safely.',
+        'attributes' => {
+          'escalate_to_webchat' => false,
+          'excluded' => true,
+          'filter_prefixes' => [],
+          'guidance_level' => 'info',
+          'guidance_location' => 'interstitial',
+          'message_header' => 'Placeholder guidance heading',
+          'message' => 'This is too vague. Please be better at classification',
+          'sources' => %w[guided_search fpo_search],
+        },
+      },
+      'escalate' => {
+        'label' => 'Escalate',
+        'description' => 'Escalate to webchat.',
+        'attributes' => {
+          'escalate_to_webchat' => true,
+          'excluded' => false,
+          'filter_prefixes' => [],
+          'guidance_level' => nil,
+          'guidance_location' => nil,
+          'message_header' => nil,
+          'message' => nil,
+          'sources' => %w[guided_search],
+        },
+      },
+    }
+  end
+
+  before do
+    create(:admin_configuration, name: 'description_intercept_templates', config_type: 'object_template', value: templates)
+  end
+
+  describe '#call' do
+    it 'creates intercepts from template rows' do
+      result = described_class.new(csv_content: "term,template\nGift,vague\n").call
+
+      expect(result).to be_success
+      expect(result.created_count).to eq(1)
+      intercept = DescriptionIntercept.first(term: 'gift')
+      expect(intercept).to have_attributes(
+        excluded: true,
+        guidance_level: 'info',
+        guidance_location: 'interstitial',
+        message_header: 'Placeholder guidance heading',
+        message: 'This is too vague. Please be better at classification',
+      )
+      expect(intercept.sources).to eq(%w[guided_search fpo_search])
+    end
+
+    it 'creates intercepts with aliases from template rows' do
+      result = described_class.new(csv_content: "term,aliases,template\nGift,\"Present,Gifts\",vague\n").call
+
+      expect(result).to be_success
+      intercept = DescriptionIntercept.first(term: 'gift')
+      expect(intercept.aliases).to eq(%w[present gifts])
+    end
+
+    it 'updates existing intercepts by normalised term and preserves aliases' do
+      existing = create(:description_intercept, term: 'gift', aliases: Sequel.pg_array(%w[present], :text), excluded: false)
+
+      result = described_class.new(csv_content: "term,template\n Gift ,vague\n").call
+
+      expect(result).to be_success
+      expect(result.updated_count).to eq(1)
+      existing.reload
+      expect(existing.excluded).to be(true)
+      expect(existing.aliases).to eq(%w[present])
+    end
+
+    it 'clears the existing aliases when the aliases column is present and blank' do
+      existing = create(:description_intercept, term: 'gift', aliases: Sequel.pg_array(%w[present], :text), excluded: false)
+
+      result = described_class.new(csv_content: "term,aliases,template\n Gift, ,vague\n").call
+
+      expect(result).to be_success
+      expect(existing.reload.aliases).to eq([])
+    end
+
+    it 'rejects duplicate search values across terms and aliases before writing' do
+      result = described_class.new(csv_content: "term,aliases,template\ngift,present,vague\n Present ,something,vague\n").call
+
+      expect(result).not_to be_success
+      expect(result.summary_errors.first[:detail]).to eq('present appears more than once across terms and aliases')
+      expect(DescriptionIntercept.count).to eq(0)
+    end
+
+    it 'rejects an alias already used by another intercept' do
+      create(:description_intercept, term: 'hamper', aliases: Sequel.pg_array(%w[present], :text))
+
+      result = described_class.new(csv_content: "term,aliases,template\ngift,present,vague\n").call
+
+      expect(result).not_to be_success
+      expect(result.row_errors.first[:detail]).to eq('gift aliases include a value already used by another description intercept (present)')
+      expect(DescriptionIntercept.first(term: 'gift')).to be_nil
+    end
+
+    it 'deduplicates invalid template errors' do
+      result = described_class.new(csv_content: "term,template\na,foo\nb,baz\nc,foo\nd,bar\n").call
+
+      expect(result).not_to be_success
+      expect(result.summary_errors).to include(
+        detail: 'foo, baz and bar are not valid templates',
+        meta: { code: 'invalid_templates', values: %w[foo baz bar] },
+      )
+      expect(result.row_errors).to be_empty
+    end
+
+    it 'uses a singular invalid template message' do
+      result = described_class.new(csv_content: "term,template\na,foo\n").call
+
+      expect(result).not_to be_success
+      expect(result.summary_errors).to include(
+        detail: 'foo is not a valid template',
+        meta: { code: 'invalid_templates', values: %w[foo] },
+      )
+      expect(result.row_errors).to be_empty
+    end
+
+    it 'rejects unknown headers before writing' do
+      result = described_class.new(csv_content: "term,template,notes\ngift,vague,nope\n").call
+
+      expect(result).not_to be_success
+      expect(result.summary_errors.first[:detail]).to eq('CSV must contain term and template columns, and may include an aliases column')
+    end
+
+    it 'rolls back all writes when any row is invalid' do
+      result = described_class.new(csv_content: "term,template\ngift,vague\nshoe,missing\n").call
+
+      expect(result).not_to be_success
+      expect(DescriptionIntercept.count).to eq(0)
+    end
+  end
+end

--- a/spec/swagger/api/v2/description_intercepts_spec.rb
+++ b/spec/swagger/api/v2/description_intercepts_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe 'Description Intercepts', swagger_doc: 'v2/swagger.json', type: :
                            aliases: { type: :array, items: { type: :string }, nullable: true },
                            sources: { type: :array, items: { type: :string }, nullable: true },
                            message: { type: :string, nullable: true },
+                           message_header: { type: :string, nullable: true },
                            excluded: { type: :boolean, nullable: true },
                            created_at: { type: :string, format: :'date-time', nullable: true },
                            updated_at: { type: :string, format: :'date-time', nullable: true },

--- a/swagger/v2/swagger.json
+++ b/swagger/v2/swagger.json
@@ -1951,6 +1951,10 @@
                                 "type": "string",
                                 "nullable": true
                               },
+                              "message_header": {
+                                "type": "string",
+                                "nullable": true
+                              },
                               "excluded": {
                                 "type": "boolean",
                                 "nullable": true


### PR DESCRIPTION
### Jira link

[AI-663](https://transformuk.atlassian.net/browse/AI-663)

### What?

- [x] Adds seeded `description_intercept_templates` admin configuration with the initial `vague` template.
- [x] Adds validation and normalisation for the template registry configuration.
- [x] Adds CSV bulk import endpoint for description intercepts using `term,template` rows.
- [x] Upserts by normalised term in a transaction, with grouped validation errors and no partial writes.
- [x] Adds a unique term constraint for description intercepts.

### Why?

So admins can bulk load description intercepts by supplying only a term and a named template, while keeping the template behaviour centrally configurable.