### PR TITLE
Revert: Remove init containers from worker-uk and worker-xi

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
         args: ["--severity=warning"]
 
   - repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.95.2
+    rev: v3.93.6
     hooks:
       - id: trufflehog
 
@@ -43,6 +43,6 @@ repos:
 
 
   - repo: https://github.com/rhysd/actionlint.git
-    rev: v1.7.12
+    rev: v1.7.11
     hooks:
       - id: actionlint-docker

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -7,7 +7,6 @@ provider "registry.terraform.io/hashicorp/aws" {
   hashes = [
     "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
     "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
-    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
     "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
     "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
@@ -31,7 +30,6 @@ provider "registry.terraform.io/hashicorp/random" {
   hashes = [
     "h1:BYpqK2+ZHqNF9sauVugKJSeFWMCx11I/z/1lMplwUC0=",
     "h1:SqwYP3u2T4rNxWvcrUc693VLY1V7DJPusZR9nn5NqSo=",
-    "h1:a6J4v7/4LbNCr8boUAJ7+xyVILRECYlRHicm543y+uU=",
     "zh:0e71891d8f25564e8d0b61654ed2ca52101862b9a2a07d736395193ae07b134b",
     "zh:1c56852d094161997df5fd8a6cbca7c6c979b3f8c3c00fbcc374a59305d117b1",
     "zh:20698fb8a2eaa7e23c4f8e3d22250368862f578cf618be0281d5b61496cbef13",

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -2,6 +2,7 @@ locals {
   has_autoscaler = var.environment == "development" ? false : true
   account_id     = data.aws_caller_identity.current.account_id
   worker_command = ["/bin/sh", "-c", "export DB_POOL=$${DB_POOL:-$${SIDEKIQ_CONCURRENCY:-10}} && bundle exec sidekiq -C ./config/sidekiq.yml"]
+  init_command   = ["/bin/sh", "-c", "bundle exec rails db:migrate && bundle exec rails data:migrate"]
   job_command    = ["/bin/sh", "-c", "bin/null-service"]
 
   tls_secret = jsondecode(data.aws_secretsmanager_secret_version.ecs_tls_certificate.secret_string)

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -28,6 +28,9 @@ module "worker_uk" {
   container_entrypoint = [""]
   container_command    = local.worker_command
 
+  init_container_entrypoint = [""]
+  init_container_command    = local.init_command
+
   service_environment_config = local.worker_uk_secret_env_vars
 
   has_autoscaler = local.has_autoscaler

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -28,6 +28,9 @@ module "worker_xi" {
   container_entrypoint = [""]
   container_command    = local.worker_command
 
+  init_container_entrypoint = [""]
+  init_container_command    = local.init_command
+
   service_environment_config = local.worker_xi_secret_env_vars
 
   has_autoscaler = local.has_autoscaler


### PR DESCRIPTION
## What:
This reverts the changes from PR #3070 (\"BAU: Remove init containers\"), which removed the init containers from the `worker-uk` and `worker-xi` ECS task definitions.

## Why:
After the merge of #3070 landed on `main`, the staging deploy started failing. Both `worker-uk` and `worker-xi` got stuck in a `PENDING` state for the full 15-minute ECS stabilisation window and never became healthy — causing the Terraform apply to time out and the deploy to fail.

The init containers that were removed were responsible for running database migrations (`rails db:migrate` and `rails data:migrate`) before the worker process started. Removing them triggered ECS to roll out a new task definition revision for both services at the same time, and the new tasks couldn't start successfully.

Reverting this gets staging (and production) back to a known-good state. Once we've confirmed deploys are stable again, we can look at re-landing the init container removal more carefully — making sure any health check or startup dependencies are handled cleanly first.

## Ticket:
N/A

## Risk:
**Risk level:** 🟠

**Reason for rating:**
This touches ECS task definitions for both worker services and will trigger a rolling redeploy on staging and production. It's a revert to a previously working state, so the risk is low in practice, but it's worth a quick team check before merging given it affects live workers.