### PR TITLE
Revert "Fix commodity cache fragmentation from meursing additional code"

### DIFF
--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -217,33 +217,7 @@ class CachedCommodityService
     TradeTariffRequest.meursing_additional_code_id
   end
 
-  # Only fragment the cache by meursing code when the commodity actually has
-  # meursing measures (types 672, 673, 674 — agricultural duty add-ons).
-  # Most commodities (e.g. vehicles, electronics) never have these, so
-  # including the code in the key would create N identical cache entries —
-  # one per distinct meursing code seen in requests — for no benefit.
-  def effective_meursing_code
-    return nil if meursing_additional_code_id.blank?
-
-    commodity_has_meursing_measures? ? meursing_additional_code_id : nil
-  end
-
-  # Cached per commodity+date so we pay at most one DB query per commodity
-  # per day. The result is stable within a trading day; the 24-hour TTL
-  # matches the commodity response TTL for today's date.
-  def commodity_has_meursing_measures?
-    Rails.cache.fetch(
-      "commodity-has-meursing-#{@commodity_sid}-#{actual_date}",
-      expires_in: ttl,
-    ) do
-      Measure.actual
-             .where(goods_nomenclature_sid: @commodity_sid)
-             .where(measure_type_id: MeasureType::MEURSING_MEASURES)
-             .any?
-    end
-  end
-
   def cache_key
-    "_commodity-v#{CACHE_VERSION}-#{@commodity_sid}-#{actual_date}-#{effective_meursing_code}"
+    "_commodity-v#{CACHE_VERSION}-#{@commodity_sid}-#{actual_date}-#{meursing_additional_code_id}"
   end
 end

--- a/spec/services/cached_commodity_service_spec.rb
+++ b/spec/services/cached_commodity_service_spec.rb
@@ -145,33 +145,10 @@ RSpec.describe CachedCommodityService do
       context 'with meursing_additional_code_id' do
         include_context 'with meursing additional code id', 'foo'
 
-        context 'when the commodity has no meursing measures' do
-          it 'uses the canonical cache key (no meursing code) to prevent fragmentation' do
-            service.call
-            expected_key = "_commodity-v#{CachedCommodityService::CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-"
-            expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 24.hours)
-          end
-        end
-
-        context 'when the commodity has meursing measures' do
-          before do
-            create(:measure_type, measure_type_id: '672', trade_movement_code: 0)
-            create(
-              :measure,
-              :with_base_regulation,
-              measure_type_id: '672',
-              goods_nomenclature: commodity,
-              goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
-              goods_nomenclature_sid: commodity.goods_nomenclature_sid,
-              for_geo_area: erga_omnes_area,
-            ).tap(&:reload)
-          end
-
-          it 'includes the meursing code in the cache key' do
-            service.call
-            expected_key = "_commodity-v#{CachedCommodityService::CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-foo"
-            expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 24.hours)
-          end
+        it 'includes meursing code in cache key' do
+          service.call
+          expected_key = "_commodity-v#{CachedCommodityService::CACHE_VERSION}-#{commodity.goods_nomenclature_sid}-#{actual_date}-foo"
+          expect(Rails.cache).to have_received(:fetch).with(expected_key, expires_in: 24.hours)
         end
       end
 


### PR DESCRIPTION
`CachedCommodityService` decides whether to include meursing_additional_code_id in the cache key via effective_meursing_code, but that decision is based on commodity_has_meursing_measures?, which checks only measures directly on @commodity_sid.

```
def effective_meursing_code
  return nil if meursing_additional_code_id.blank?

  commodity_has_meursing_measures? ? meursing_additional_code_id : nil
end

def commodity_has_meursing_measures?
  Rails.cache.fetch(
    "commodity-has-meursing-#{@commodity_sid}-#{actual_date}",
    expires_in: ttl,
  ) do
    Measure.actual
           .where(goods_nomenclature_sid: @commodity_sid)
           .where(measure_type_id: MeasureType::MEURSING_MEASURES)
           .any?
  end
end
```

But the commodity response is built from commodity.applicable_measures, and applicable_measures includes ancestor measures + own measures.

So the cache key can be without meursing code even when applicable ancestor measures require Meursing resolution.

During rendering, measure duty values are resolved through `ComponentResolver`, and that calls `MeursingMeasureFinderService `with `TradeTariffRequest.meursing_additional_code_id`, and serialized in commodity output

```
def resolves_meursing?
  measure.meursing? &&
    meursing_additional_code_id.present? &&
    meursing_measures.present?
end
```

If a commodity has no own Meursing measures but has ancestor Meursing measures, commodity_has_meursing_measures? returns false, so cache key omits meursing_additional_code_id.
Then a request with one meursing code can populate cache, and subsequent requests with different meursing codes reuse that cached payload, even though resolved_duty_expression should vary because `MeursingMeasureFinderService` depends on the request’s `meursing_additional_code_id`.

So the cache key currently under-represents the inputs that affect serialized duty output. To represent both ancestor meursing measures and meursing measures fetched for reduction_indicator and request additional_code_id, we need wider cache key filtering in commodity_has_meursing_measures?