### PR TITLE
AI-517: Fix section XI notes extraction and add reimport rake task

### DIFF
--- a/app/lib/customs_tariff_importer/notes_extractor.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor.rb
@@ -145,7 +145,6 @@ module CustomsTariffImporter
         @current_section = m[1].upcase
         @note_lines = []
       elsif (m = text.match(CHAPTER_PATTERN))
-        finalize_section_note
         @current_chapter = sprintf('%02d', m[1].to_i)
         @note_lines = []
         @state = :in_chapter
@@ -163,13 +162,19 @@ module CustomsTariffImporter
         @current_chapter = sprintf('%02d', m[1].to_i)
         @note_lines = []
         @state = :in_chapter
+      elsif text.match?(COMMODITY_CODE_PATTERN)
+        finalize_section_note
+        @state = :skipping
       elsif text.present? || (@note_lines.any? && @note_lines.last.present?)
         @note_lines << text
       end
     end
 
     def handle_in_chapter(text)
-      if text.match?(CHAPTER_NOTES_PATTERN)
+      if text.match?(SECTION_NOTES_PATTERN)
+        @note_lines = []
+        @state = :collecting_section
+      elsif text.match?(CHAPTER_NOTES_PATTERN)
         @note_lines = []
         @state = :collecting_chapter
       elsif (m = text.match(CHAPTER_PATTERN))

--- a/app/lib/customs_tariff_importer/reimporter.rb
+++ b/app/lib/customs_tariff_importer/reimporter.rb
@@ -1,0 +1,53 @@
+module CustomsTariffImporter
+  # this class is responsible for re-importing customs tariff notes from stored S3 documents into the database as part of rake task "importer:customs_tariff:reimport"
+  class Reimporter
+    def call
+      CustomsTariffUpdate.exclude(status: CustomsTariffUpdate::FAILED).each do |update|
+        reimport(update)
+      end
+    end
+
+    private
+
+    def reimport(update)
+      content = TariffSynchronizer::FileService.get(update.s3_path).read
+      extracted = NotesExtractor.new(update.version, content).call
+
+      CustomsTariffUpdate.db.transaction do
+        CustomsTariffSectionNote.where(customs_tariff_update_version: update.version).delete
+        CustomsTariffChapterNote.where(customs_tariff_update_version: update.version).delete
+        CustomsTariffGeneralRule.where(customs_tariff_update_version: update.version).delete
+
+        extracted.sections.each do |section_id, note_content|
+          CustomsTariffSectionNote.create(
+            customs_tariff_update_version: update.version,
+            section_id:,
+            content: note_content,
+            validity_start_date: update.validity_start_date,
+            status: CustomsTariffSectionNote::PENDING,
+          )
+        end
+
+        extracted.chapters.each do |chapter_id, note_content|
+          CustomsTariffChapterNote.create(
+            customs_tariff_update_version: update.version,
+            chapter_id:,
+            content: note_content,
+            validity_start_date: update.validity_start_date,
+            status: CustomsTariffChapterNote::PENDING,
+          )
+        end
+
+        extracted.general_rules.each do |rule_label, note_content|
+          CustomsTariffGeneralRule.create(
+            customs_tariff_update_version: update.version,
+            rule_label:,
+            content: note_content,
+            validity_start_date: update.validity_start_date,
+            status: CustomsTariffGeneralRule::PENDING,
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/tariff_importer.rake
+++ b/lib/tasks/tariff_importer.rake
@@ -28,4 +28,12 @@ namespace :importer do
       end
     end
   end
+
+  namespace :customs_tariff do
+    desc 'Wipe and re-populate customs tariff notes from stored S3 documents'
+    task reimport: %i[environment] do
+      CustomsTariffImporter::Reimporter.new.call
+      puts 'Customs tariff notes re-imported successfully.'
+    end
+  end
 end

--- a/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
+++ b/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
@@ -102,6 +102,31 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
         result = parse(['SECTION I', 'CHAPTER 1'])
         expect(result.sections).to be_empty
       end
+
+      context 'when a chapter header appears before the section notes heading' do
+        it 'still captures the section notes' do
+          result = parse([
+            'SECTION XI',
+            'CHAPTER 50',
+            'Section notes',
+            'This section does not cover bristles.',
+            'CHAPTER 51',
+          ])
+          expect(result.sections[11]).to eq('This section does not cover bristles.')
+        end
+
+        it 'stops collecting section notes when a commodity code is encountered' do
+          result = parse([
+            'SECTION XI',
+            'CHAPTER 50',
+            'Section notes',
+            'Note content.',
+            '5001000000',
+            'Silkworm cocoons suitable for reeling',
+          ])
+          expect(result.sections[11]).to eq('Note content.')
+        end
+      end
     end
 
     describe 'chapter notes' do

--- a/spec/lib/customs_tariff_importer/reimporter_spec.rb
+++ b/spec/lib/customs_tariff_importer/reimporter_spec.rb
@@ -1,0 +1,131 @@
+require 'zip'
+
+RSpec.describe CustomsTariffImporter::Reimporter do
+  subject(:reimporter) { described_class.new }
+
+  def build_docx(*paragraph_texts)
+    ns = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main'
+    paras = paragraph_texts.map { |t|
+      "<w:p><w:r><w:t>#{CGI.escapeHTML(t)}</w:t></w:r></w:p>"
+    }.join
+    xml = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <w:document xmlns:w="#{ns}"><w:body>#{paras}</w:body></w:document>
+    XML
+    buffer = StringIO.new.tap(&:binmode)
+    Zip::OutputStream.write_buffer(buffer) do |z|
+      z.put_next_entry('word/document.xml')
+      z.write(xml)
+    end
+    StringIO.new(buffer.string)
+  end
+
+  let(:update) do
+    create(:customs_tariff_update,
+           version: '1.31',
+           status: CustomsTariffUpdate::APPROVED,
+           validity_start_date: Date.new(2026, 4, 1),
+           s3_path: 'data/customs_tariff_documents/UKGT_1.31.docx')
+  end
+
+  let(:docx_io) do
+    build_docx(
+      'SECTION I', 'Section Notes', 'Live animals note.', 'CHAPTER 1',
+      'Chapter Notes', 'All live animals are classified here.', 'CHAPTER 2'
+    )
+  end
+
+  before do
+    update
+    allow(TariffSynchronizer::FileService).to receive(:get)
+      .with(update.s3_path)
+      .and_return(docx_io)
+  end
+
+  describe '#call' do
+    context 'when note records already exist for the update' do
+      before do
+        create(:customs_tariff_section_note, customs_tariff_update: update, section_id: 1, content: 'Old section note.')
+        create(:customs_tariff_chapter_note, customs_tariff_update: update, chapter_id: '01', content: 'Old chapter note.')
+      end
+
+      it 'replaces existing notes with freshly extracted content' do
+        reimporter.call
+
+        section_note = CustomsTariffSectionNote.where(
+          customs_tariff_update_version: update.version, section_id: 1,
+        ).first
+
+        chapter_note = CustomsTariffChapterNote.where(
+          customs_tariff_update_version: update.version, chapter_id: '01',
+        ).first
+
+        expect(section_note.content).to eq('Live animals note.')
+        expect(chapter_note.content).to eq('All live animals are classified here.')
+      end
+
+      it 'sets newly created notes to pending status' do
+        reimporter.call
+
+        statuses = CustomsTariffSectionNote
+          .where(customs_tariff_update_version: update.version)
+          .select_map(:status)
+
+        expect(statuses).to all(eq(CustomsTariffSectionNote::PENDING))
+      end
+    end
+
+    context 'when no note records exist yet' do
+      it 'inserts extracted notes' do
+        expect { reimporter.call }
+          .to change { CustomsTariffSectionNote.where(customs_tariff_update_version: update.version).count }.by(1)
+          .and change { CustomsTariffChapterNote.where(customs_tariff_update_version: update.version).count }.by(1)
+      end
+    end
+
+    context 'when there are no updates' do
+      before { update.destroy }
+
+      it 'does nothing' do
+        allow(TariffSynchronizer::FileService).to receive(:get)
+        expect { reimporter.call }.not_to raise_error
+        expect(TariffSynchronizer::FileService).not_to have_received(:get)
+      end
+    end
+
+    context 'when there are multiple updates' do
+      let(:update2) do
+        create(:customs_tariff_update,
+               version: '1.30',
+               status: CustomsTariffUpdate::PENDING,
+               validity_start_date: Date.new(2026, 3, 1),
+               s3_path: 'data/customs_tariff_documents/UKGT_1.30.docx')
+      end
+      let(:docx_io2) { build_docx('SECTION II', 'Section Notes', 'Vegetable products are classified here.', 'CHAPTER 6') }
+
+      before do
+        update2
+        allow(TariffSynchronizer::FileService).to receive(:get)
+          .with(update2.s3_path)
+          .and_return(docx_io2)
+      end
+
+      it 'reimports notes for every non-failed update' do
+        reimporter.call
+
+        expect(CustomsTariffSectionNote.where(customs_tariff_update_version: '1.31').count).to eq(1)
+        expect(CustomsTariffSectionNote.where(customs_tariff_update_version: '1.30').count).to eq(1)
+      end
+    end
+
+    context 'when an update has FAILED status' do
+      before { update.update(status: CustomsTariffUpdate::FAILED) }
+
+      it 'skips failed updates' do
+        allow(TariffSynchronizer::FileService).to receive(:get)
+        reimporter.call
+        expect(TariffSynchronizer::FileService).not_to have_received(:get)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[AI-517](https://transformuk.atlassian.net/browse/AI-517)

### What?

The notes extractor was silently dropping all of Section XI (Textiles) when parsing the UK Global Tariff document, so the database had no section notes for it. This PR fixes the parser and adds a rake task to re-populate the note tables from documents already stored in S3.

Here's what's changed:

- **`CustomsTariffImporter::NotesExtractor`** — three targeted fixes to the state machine. Section XI is unique in the source document: its `CHAPTER 50` heading appears *before* the `Section notes` heading, which caused the parser to switch states too early and discard the notes entirely. The fixes preserve the current section context across that transition, recognise a deferred `Section notes` heading while in chapter state, and stop collecting section notes once a 10-digit commodity code is encountered (so chapter classification data isn't absorbed into the notes).
- **`CustomsTariffImporter::Reimporter`** — new service that wipes the three note tables (`customs_tariff_section_notes`, `customs_tariff_chapter_notes`, `customs_tariff_general_rules`) for each existing update and re-populates them from the `.docx` file already stored in S3. It leaves `customs_tariff_updates` untouched.
- **`lib/tasks/tariff_importer.rake`** — new task `importer:customs_tariff:reimport` that calls the Reimporter service, allowing production to be fixed without needing direct AWS/database access.

### Why?

The UKGT document has a formatting quirk unique to Section XI: every other section places the chapter heading *after* the `Section notes` heading, but Section XI reverses this order. The parser wasn't built to handle that case, so all of Section XI's notes were silently dropped.

Because the importer has already run in production and its deduplication guard would block a clean re-run against the same document, the rake task reads from the existing S3-stored document and does a targeted wipe-and-repopulate of the note tables only.

Run after deployment to fix production:
```bash
bundle exec rake importer:customs_tariff:reimport
```

### Have you?

- [ ] Added documentation for new APIs
- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks

- None — the customs tariff note tables are not yet publicly exposed. The rake task must be run manually after deployment to backfill Section XI.