### PR TITLE
Route GET requests to Aurora reader instance

### DIFF
--- a/app/middleware/use_reader_for_reads.rb
+++ b/app/middleware/use_reader_for_reads.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Routes GET and HEAD requests to the Aurora reader instance.  All other HTTP
+# methods (POST, PUT, PATCH, DELETE) use the default (writer) connection pool.
+#
+# Sequel's server_block extension (already loaded in application.rb) sets a
+# thread-local so every Sequel::Model.db[...] call within the block is
+# transparently routed to the :read_only server defined in database.yml.
+#
+# Sidekiq workers do not go through Rack middleware and therefore continue
+# using the writer, which is correct — they often read data immediately after
+# writing it.
+class UseReaderForReads
+  READ_METHODS = %w[GET HEAD].freeze
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    if READ_METHODS.include?(env['REQUEST_METHOD'])
+      Sequel::Model.db.with_server(:read_only) { @app.call(env) }
+    else
+      @app.call(env)
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,6 +3,7 @@ require_relative '../lib/core_ext/object'
 require_relative '../app/middleware/handle_goods_nomenclature'
 require_relative '../app/middleware/handle_api_gateway_params'
 require_relative '../app/middleware/clear_cache_control'
+require_relative '../app/middleware/use_reader_for_reads'
 require_relative '../app/lib/trade_tariff_backend'
 
 require 'action_controller/railtie'
@@ -72,6 +73,7 @@ module TradeTariffBackend
 
     config.sequel.allow_missing_migration_files = TradeTariffBackend.allow_missing_migration_files
 
+    config.middleware.use ::UseReaderForReads
     config.middleware.use ::HandleGoodsNomenclature
     config.middleware.use ::HandleApiGatewayParams
     config.middleware.insert_before Rack::ETag, ::ClearCacheControl

--- a/config/database.yml
+++ b/config/database.yml
@@ -25,5 +25,5 @@ production:
   pool: <%= Integer(ENV.fetch('DB_POOL', 6)) %>
   servers:
     read_only:
-      url: <%= ENV.fetch('READER_DATABASE_URL', ENV['DATABASE_URL']) %>
+      conn_str: <%= ENV.fetch('READER_DATABASE_URL', ENV['DATABASE_URL']) %>
       pool: <%= Integer(ENV.fetch('READER_DB_POOL', ENV.fetch('DB_POOL', 6))) %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,3 +23,7 @@ production:
   # setting, so Puma can follow MAX_THREADS and Sidekiq can follow
   # SIDEKIQ_CONCURRENCY without guessing process type here.
   pool: <%= Integer(ENV.fetch('DB_POOL', 6)) %>
+  servers:
+    read_only:
+      url: <%= ENV.fetch('READER_DATABASE_URL', ENV['DATABASE_URL']) %>
+      pool: <%= Integer(ENV.fetch('READER_DB_POOL', ENV.fetch('DB_POOL', 6))) %>

--- a/spec/config/database_yml_spec.rb
+++ b/spec/config/database_yml_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'erb'
+require 'yaml'
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'Database configuration' do
+  subject(:production_config) do
+    YAML.safe_load(
+      ERB.new(File.read('config/database.yml')).result,
+      aliases: true,
+    ).fetch('production')
+  end
+
+  let(:writer_url) { 'postgres://tariff:secret@writer.example.test/tariff' }
+  let(:reader_url) { 'postgres://tariff:secret@reader.example.test/tariff' }
+
+  before do
+    stub_const(
+      'ENV',
+      ENV.to_hash.merge(
+        'DATABASE_URL' => writer_url,
+        'READER_DATABASE_URL' => reader_url,
+      ),
+    )
+  end
+
+  it 'passes the read-only connection string to Sequel as a conn_str' do
+    read_only_config = production_config.fetch('servers').fetch('read_only')
+
+    expect(read_only_config).to include('conn_str' => reader_url)
+    expect(read_only_config).not_to have_key('url')
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/middleware/use_reader_for_reads_spec.rb
+++ b/spec/middleware/use_reader_for_reads_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+RSpec.describe UseReaderForReads do
+  subject(:middleware) { described_class.new(app) }
+
+  let(:app) { ->(env) { [200, env, %w[OK]] } }
+
+  before do
+    allow(Sequel::Model.db).to receive(:with_server).and_yield
+  end
+
+  describe '#call' do
+    context 'when the request method is GET' do
+      let(:env) { Rack::MockRequest.env_for('/uk/api/commodities', method: 'GET') }
+
+      it 'routes through the read_only server' do
+        middleware.call(env)
+        expect(Sequel::Model.db).to have_received(:with_server).with(:read_only)
+      end
+
+      it 'calls the inner app' do
+        status, = middleware.call(env)
+        expect(status).to eq(200)
+      end
+    end
+
+    context 'when the request method is HEAD' do
+      let(:env) { Rack::MockRequest.env_for('/uk/api/commodities', method: 'HEAD') }
+
+      it 'routes through the read_only server' do
+        middleware.call(env)
+        expect(Sequel::Model.db).to have_received(:with_server).with(:read_only)
+      end
+
+      it 'calls the inner app' do
+        status, = middleware.call(env)
+        expect(status).to eq(200)
+      end
+    end
+
+    context 'when the request method is POST' do
+      let(:env) { Rack::MockRequest.env_for('/uk/api/something', method: 'POST') }
+
+      it 'does not route through the read_only server' do
+        middleware.call(env)
+        expect(Sequel::Model.db).not_to have_received(:with_server)
+      end
+
+      it 'calls the inner app' do
+        status, = middleware.call(env)
+        expect(status).to eq(200)
+      end
+    end
+
+    context 'when the request method is PUT' do
+      let(:env) { Rack::MockRequest.env_for('/uk/api/something', method: 'PUT') }
+
+      it 'does not route through the read_only server' do
+        middleware.call(env)
+        expect(Sequel::Model.db).not_to have_received(:with_server)
+      end
+    end
+
+    context 'when the request method is DELETE' do
+      let(:env) { Rack::MockRequest.env_for('/uk/api/something', method: 'DELETE') }
+
+      it 'does not route through the read_only server' do
+        middleware.call(env)
+        expect(Sequel::Model.db).not_to have_received(:with_server)
+      end
+    end
+
+    context 'when the request method is PATCH' do
+      let(:env) { Rack::MockRequest.env_for('/uk/api/something', method: 'PATCH') }
+
+      it 'does not route through the read_only server' do
+        middleware.call(env)
+        expect(Sequel::Model.db).not_to have_received(:with_server)
+      end
+    end
+  end
+end

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -53,12 +53,14 @@ Terraform to deploy the service into AWS.
 | [aws_iam_policy_document.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_lb_target_group.backend_uk_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
 | [aws_lb_target_group.backend_xi_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
+| [aws_secretsmanager_secret.aurora_reader_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.backend_job_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.backend_uk_api_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.backend_uk_worker_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.backend_xi_api_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.backend_xi_worker_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.ecs_tls_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
+| [aws_secretsmanager_secret_version.aurora_reader_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_secretsmanager_secret_version.backend_job_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_secretsmanager_secret_version.backend_uk_api_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_secretsmanager_secret_version.backend_uk_worker_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -67,6 +67,14 @@ data "aws_secretsmanager_secret_version" "backend_job_configuration" {
   secret_id = data.aws_secretsmanager_secret.backend_job_configuration.id
 }
 
+data "aws_secretsmanager_secret" "aurora_reader_connection_string" {
+  name = "aurora-postgres-ro-connection-string"
+}
+
+data "aws_secretsmanager_secret_version" "aurora_reader_connection_string" {
+  secret_id = data.aws_secretsmanager_secret.aurora_reader_connection_string.id
+}
+
 data "aws_secretsmanager_secret" "ecs_tls_certificate" {
   name = "ecs-tls-certificate"
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -102,6 +102,7 @@ data "aws_iam_policy_document" "task" {
     ]
     resources = [
       "arn:aws:secretsmanager:${var.region}:${local.account_id}:secret:aurora-postgres-rw-connection-string-*",
+      "arn:aws:secretsmanager:${var.region}:${local.account_id}:secret:aurora-postgres-ro-connection-string-*",
       "arn:aws:secretsmanager:${var.region}:${local.account_id}:secret:*-postgres-database-url-*",
     ]
   }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -21,6 +21,13 @@ locals {
     }
   ]
 
+  reader_url_env_var = [
+    {
+      name  = "READER_DATABASE_URL"
+      value = data.aws_secretsmanager_secret_version.aurora_reader_connection_string.secret_string
+    }
+  ]
+
 
   worker_uk_secret_value = try(data.aws_secretsmanager_secret_version.backend_uk_worker_configuration.secret_string, "{}")
   worker_uk_secret_map   = jsondecode(local.worker_uk_secret_value)
@@ -39,7 +46,7 @@ locals {
       value = value
     }
   ]
-  backend_uk_service_env_vars = concat(local.backend_uk_secret_env_vars, local.ecs_tls_env_vars)
+  backend_uk_service_env_vars = concat(local.backend_uk_secret_env_vars, local.ecs_tls_env_vars, local.reader_url_env_var)
 
   worker_xi_secret_value = try(data.aws_secretsmanager_secret_version.backend_xi_worker_configuration.secret_string, "{}")
   worker_xi_secret_map   = jsondecode(local.worker_xi_secret_value)
@@ -58,7 +65,7 @@ locals {
       value = value
     }
   ]
-  backend_xi_service_env_vars = concat(local.backend_xi_secret_env_vars, local.ecs_tls_env_vars)
+  backend_xi_service_env_vars = concat(local.backend_xi_secret_env_vars, local.ecs_tls_env_vars, local.reader_url_env_var)
 
   backend_job_secret_value = try(data.aws_secretsmanager_secret_version.backend_job_configuration.secret_string, "{}")
   backend_job_secret_map   = jsondecode(local.backend_job_secret_value)

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -6,7 +6,7 @@ locals {
 
   tls_secret = jsondecode(data.aws_secretsmanager_secret_version.ecs_tls_certificate.secret_string)
 
-  ecs_tls_env_vars = [
+  api_service_env_vars = [
     {
       name  = "SSL_KEY_PEM"
       value = local.tls_secret.private_key
@@ -18,10 +18,7 @@ locals {
     {
       name  = "SSL_PORT"
       value = "8443"
-    }
-  ]
-
-  reader_url_env_var = [
+    },
     {
       name  = "READER_DATABASE_URL"
       value = data.aws_secretsmanager_secret_version.aurora_reader_connection_string.secret_string
@@ -46,7 +43,7 @@ locals {
       value = value
     }
   ]
-  backend_uk_service_env_vars = concat(local.backend_uk_secret_env_vars, local.ecs_tls_env_vars, local.reader_url_env_var)
+  backend_uk_service_env_vars = concat(local.backend_uk_secret_env_vars, local.api_service_env_vars)
 
   worker_xi_secret_value = try(data.aws_secretsmanager_secret_version.backend_xi_worker_configuration.secret_string, "{}")
   worker_xi_secret_map   = jsondecode(local.worker_xi_secret_value)
@@ -65,7 +62,7 @@ locals {
       value = value
     }
   ]
-  backend_xi_service_env_vars = concat(local.backend_xi_secret_env_vars, local.ecs_tls_env_vars, local.reader_url_env_var)
+  backend_xi_service_env_vars = concat(local.backend_xi_secret_env_vars, local.api_service_env_vars)
 
   backend_job_secret_value = try(data.aws_secretsmanager_secret_version.backend_job_configuration.secret_string, "{}")
   backend_job_secret_map   = jsondecode(local.backend_job_secret_value)


### PR DESCRIPTION
## What:
Routes GET and HEAD requests to the Aurora reader instance instead of sending all traffic to the writer.

- New `UseReaderForReads` Rack middleware wraps GET/HEAD in `Sequel::Model.db.with_server(:read_only)` — Sequel's `server_block` extension (already loaded) transparently routes those queries to the reader connection pool
- Adds `servers.read_only` to `config/database.yml` production stanza, pointing at a new `READER_DATABASE_URL` env var (falls back to `DATABASE_URL` so dev/test are unaffected)
- Backend Terraform: fetches `aurora-postgres-ro-connection-string` from Secrets Manager and injects it as `READER_DATABASE_URL` into the UK and XI web task definitions; updates IAM policy to allow access
- Sidekiq worker task definitions are intentionally excluded — they use the writer only, as they read data immediately after writing it

**Depends on https://github.com/trade-tariff/trade-tariff-platform-aws-terraform/pull/591 being applied first (creates the reader secret in Secrets Manager).**

## Why:
All traffic currently hits the Aurora writer even though the cluster has a dedicated reader instance. This is inefficient and increases load on the writer unnecessarily. The app is overwhelmingly read-heavy — GET requests are the vast majority of traffic and do no Sequel writes.

## Ticket:
N/A

## Risk:
**Risk level:** 🟠

**Reason for rating:**
Changes query routing for all GET requests. If the reader falls behind or is unhealthy, Aurora removes it from the reader endpoint automatically, but there is a brief window during failover where reads may get connection errors. The `connection_validator` extension (already configured with a 60s timeout) handles stale connections. The `READER_DATABASE_URL` fallback to `DATABASE_URL` in database.yml means no production impact until the env var is set.