### PR TITLE
AI-696: Validate tariff update filenames

### DIFF
--- a/app/lib/tariff_synchronizer/tariff_downloader.rb
+++ b/app/lib/tariff_synchronizer/tariff_downloader.rb
@@ -2,8 +2,13 @@ module TariffSynchronizer
   # Download pending updates for TARIC and CDS data
   class TariffDownloader
     TariffDownloaderZipError = Class.new(StandardError)
+    InvalidFilenameError = Class.new(StandardError)
 
     ZIP_SIGNATURE = "\x50\x4B\x03\x04".freeze
+    VALID_FILENAME_PATTERNS = {
+      'TariffSynchronizer::CdsUpdate' => /\Atariff_dailyExtract_v1_\d{8}T\d+\.gzip\z/,
+      'TariffSynchronizer::TaricUpdate' => /\A\d{4}-\d{2}-\d{2}_TGB\d+\.xml\z/,
+    }.freeze
 
     delegate :instrument, :subscribe, to: ActiveSupport::Notifications
 
@@ -114,7 +119,7 @@ module TariffSynchronizer
     end
 
     def file_path
-      File.join(TariffSynchronizer.root_path, update_type.to_s, filename)
+      File.join(TariffSynchronizer.root_path, update_type.to_s, validated_filename)
     end
 
     def persist_exception_for_review(exception)
@@ -132,6 +137,14 @@ module TariffSynchronizer
 
     def zip_file?(content)
       content.to_s.start_with?(ZIP_SIGNATURE)
+    end
+
+    def validated_filename
+      pattern = VALID_FILENAME_PATTERNS.fetch(update_klass.name)
+
+      return filename if pattern.match?(filename.to_s)
+
+      raise InvalidFilenameError, "Unexpected #{update_klass.name} filename: #{filename}"
     end
 
     delegate :update_type, to: :update_klass

--- a/spec/unit/tariff_synchronizer/tariff_downloader_spec.rb
+++ b/spec/unit/tariff_synchronizer/tariff_downloader_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe TariffSynchronizer::TariffDownloader do
   describe '#perform' do
     subject(:perform) { described_class.new(filename, url, date, update_klass).perform }
 
-    let(:filename) { 'tariff_dailyExtract_v1_20201004T235959.gzip' }
+    let(:filename) { 'tariff_dailyExtract_v1_20991231T235959.gzip' }
     let(:url) { 'https://example.com/download-the-file' }
     let(:date) { Date.current }
     let(:update_klass) { TariffSynchronizer::CdsUpdate }

--- a/spec/unit/tariff_synchronizer/tariff_downloader_spec.rb
+++ b/spec/unit/tariff_synchronizer/tariff_downloader_spec.rb
@@ -20,6 +20,21 @@ RSpec.describe TariffSynchronizer::TariffDownloader do
       it { expect { perform }.to change { update_klass.where(state: TariffSynchronizer::BaseUpdate::FAILED_STATE).count }.by(1) }
     end
 
+    context 'when the filename contains path traversal characters' do
+      let(:filename) { '../foo.xml.gzip' }
+
+      before do
+        allow(TariffSynchronizer::FileService).to receive(:file_exists?)
+      end
+
+      it 'rejects the update before checking the filesystem' do
+        expect { perform }
+          .to change { update_klass.where(state: TariffSynchronizer::BaseUpdate::FAILED_STATE).count }.by(1)
+
+        expect(TariffSynchronizer::FileService).not_to have_received(:file_exists?)
+      end
+    end
+
     context 'when the file is already downloaded' do
       before do
         allow(TariffSynchronizer::FileService).to receive(:file_exists?).with('tmp/data/cds/foo.xml.gzip').and_return(true)

--- a/spec/unit/tariff_synchronizer/tariff_downloader_spec.rb
+++ b/spec/unit/tariff_synchronizer/tariff_downloader_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe TariffSynchronizer::TariffDownloader do
   describe '#perform' do
     subject(:perform) { described_class.new(filename, url, date, update_klass).perform }
 
-    let(:filename) { 'foo.xml.gzip' }
+    let(:filename) { 'tariff_dailyExtract_v1_20201004T235959.gzip' }
     let(:url) { 'https://example.com/download-the-file' }
     let(:date) { Date.current }
     let(:update_klass) { TariffSynchronizer::CdsUpdate }
@@ -37,8 +37,8 @@ RSpec.describe TariffSynchronizer::TariffDownloader do
 
     context 'when the file is already downloaded' do
       before do
-        allow(TariffSynchronizer::FileService).to receive(:file_exists?).with('tmp/data/cds/foo.xml.gzip').and_return(true)
-        allow(TariffSynchronizer::FileService).to receive(:file_size).with('tmp/data/cds/foo.xml.gzip').and_return(1)
+        allow(TariffSynchronizer::FileService).to receive(:file_exists?).with("tmp/data/cds/#{filename}").and_return(true)
+        allow(TariffSynchronizer::FileService).to receive(:file_size).with("tmp/data/cds/#{filename}").and_return(1)
         allow(TariffSynchronizer::TariffUpdatesRequester).to receive(:perform).with(url)
       end
 
@@ -98,7 +98,7 @@ RSpec.describe TariffSynchronizer::TariffDownloader do
 
       context 'when the download response is successful' do
         before do
-          allow(TariffSynchronizer::FileService).to receive(:write_file).with("tmp/data/#{update_klass.update_type}/foo.xml.gzip", be_a(String))
+          allow(TariffSynchronizer::FileService).to receive(:write_file).with("tmp/data/#{update_klass.update_type}/#{filename}", be_a(String))
         end
 
         context 'when the response body is a valid ZIP file' do
@@ -112,7 +112,7 @@ RSpec.describe TariffSynchronizer::TariffDownloader do
 
           it 'writes using the FileService' do
             perform
-            expect(TariffSynchronizer::FileService).to have_received(:write_file).with('tmp/data/cds/foo.xml.gzip', be_a(String))
+            expect(TariffSynchronizer::FileService).to have_received(:write_file).with("tmp/data/cds/#{filename}", be_a(String))
           end
 
           it 'records a state transition to pending' do
@@ -127,6 +127,7 @@ RSpec.describe TariffSynchronizer::TariffDownloader do
         end
 
         context 'when the response body is not a ZIP file and the update type is Taric' do
+          let(:filename) { '2020-10-04_TGB20278.xml' }
           let(:response) { build(:response, :success, content: 'not_a_zip_file') }
           let(:update_klass) { TariffSynchronizer::TaricUpdate }
 
@@ -138,7 +139,7 @@ RSpec.describe TariffSynchronizer::TariffDownloader do
 
           it 'writes using the FileService' do
             perform
-            expect(TariffSynchronizer::FileService).to have_received(:write_file).with('tmp/data/taric/foo.xml.gzip', 'not_a_zip_file')
+            expect(TariffSynchronizer::FileService).to have_received(:write_file).with("tmp/data/taric/#{filename}", 'not_a_zip_file')
           end
         end
 


### PR DESCRIPTION
## What:

- [x] Add an explicit filename whitelist for CDS and TARIC tariff update downloads
- [x] Reject path-like or unexpected filenames before deriving a storage path
- [x] Add regression coverage for traversal-style filenames
- [x] Update downloader specs to use real CDS/TARIC filename shapes

## Why:

GitHub CodeQL alert #16 flags external tariff update data flowing into file path operations.

The downloader now accepts only the known CDS/TARIC filename formats before calling `FileService`, preventing unexpected local or S3 paths from being read or written. Unexpected filenames fail closed and are recorded as failed updates for operator review.

Security alert: https://github.com/trade-tariff/trade-tariff-backend/security/code-scanning/16

## Ticket:

[AI-696](https://transformuk.atlassian.net/browse/AI-696)

## Risk:

**Risk level:** 🔴

**Reason for rating:**
This touches the tariff update synchronisation path from upstream CDS/TARIC feeds. The code footprint is small, but an upstream filename format change would now fail closed instead of downloading the file, so this should get explicit approval from Thor or Neil before merging.