### PR TITLE
HMRC-2217: Generate canonical OpenAPI document

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add swagger/v2/swagger.json
-          git diff --staged --quiet || git commit -m "Generate swagger/v2/swagger.json [skip ci]" && git push
+          if ! git diff --staged --quiet; then
+            git commit -m "Generate swagger/v2/swagger.json [skip ci]"
+            git push
+          fi
 
       - name: Publish Test Report
         uses: ctrf-io/github-test-reporter@v1

--- a/lib/tasks/swagger.rake
+++ b/lib/tasks/swagger.rake
@@ -1,7 +1,7 @@
 require 'json'
 
 namespace :swagger do
-  swagger_spec_pattern = 'spec/swagger/**/*_spec.rb'
+  swagger_spec_pattern = 'spec/swagger/api/**/*_spec.rb'
   swagger_json_path = File.expand_path('../../swagger/v2/swagger.json', __dir__)
 
   # Paths that have specs (useful for contract testing) but must not appear in
@@ -20,7 +20,7 @@ namespace :swagger do
     /api/news/items/{id}
     /api/news/years
     /api/preference_codes/{id}
-    /api/sections/{id}/chapters
+    /api/sections/{position}/chapters
     /api/subheadings/{subheading_id}/validity_periods
   ].freeze
 

--- a/spec/swagger/api/v2/chapters_spec.rb
+++ b/spec/swagger/api/v2/chapters_spec.rb
@@ -46,11 +46,11 @@ RSpec.describe 'Chapters', swagger_doc: 'v2/swagger.json', type: :request do
     end
   end
 
-  path '/api/chapters/{id}' do
+  path '/api/chapters/{chapter_id}' do
     parameter name: :Accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
-    parameter name: :id, in: :path, required: true,
+    parameter name: :chapter_id, in: :path, required: true,
               schema: { type: :string, pattern: '^\d{1,2}$' },
               description: 'Chapter short code (1–2 digits, e.g. "01")'
 
@@ -150,24 +150,24 @@ RSpec.describe 'Chapters', swagger_doc: 'v2/swagger.json', type: :request do
                }
 
         let(:chapter) { create(:chapter, :with_section, :with_description) }
-        let(:id) { chapter.goods_nomenclature_item_id.first(2) }
+        let(:chapter_id) { chapter.goods_nomenclature_item_id.first(2) }
 
         run_test!
       end
 
       response '404', 'chapter not found' do
-        let(:id) { '99' }
+        let(:chapter_id) { '99' }
 
         run_test!
       end
     end
   end
 
-  path '/api/chapters/{id}/changes' do
+  path '/api/chapters/{chapter_id}/changes' do
     parameter name: :Accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
-    parameter name: :id, in: :path, required: true,
+    parameter name: :chapter_id, in: :path, required: true,
               schema: { type: :string, pattern: '^\d{1,2}$' },
               description: 'Chapter short code (1–2 digits, e.g. "01")'
 
@@ -218,7 +218,7 @@ RSpec.describe 'Chapters', swagger_doc: 'v2/swagger.json', type: :request do
                }
 
         let(:chapter) { create(:chapter, :with_description) }
-        let(:id) { chapter.goods_nomenclature_item_id.first(2) }
+        let(:chapter_id) { chapter.goods_nomenclature_item_id.first(2) }
 
         run_test!
       end

--- a/spec/swagger/api/v2/exchange_rates_spec.rb
+++ b/spec/swagger/api/v2/exchange_rates_spec.rb
@@ -3,13 +3,16 @@ require 'swagger_helper'
 RSpec.describe 'Exchange Rates', swagger_doc: 'v2/swagger.json', type: :request do
   let(:Accept) { 'application/vnd.hmrc.2.0+json' }
 
-  path '/api/exchange_rates/{id}' do
+  path '/api/exchange_rates/{year}-{month}' do
     parameter name: :Accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
-    parameter name: :id, in: :path, required: true,
-              schema: { type: :string, pattern: '^\d{4}-\d{1,2}$' },
-              description: 'Year and month in "YYYY-M" format (e.g. "2024-3")'
+    parameter name: :year, in: :path, required: true,
+              schema: { type: :integer },
+              description: 'Four-digit year to retrieve rates for'
+    parameter name: :month, in: :path, required: true,
+              schema: { type: :integer },
+              description: 'Month to retrieve rates for'
     parameter name: 'filter[type]', in: :query, required: true,
               schema: { type: :string, enum: %w[monthly spot average] },
               description: 'Rate type to retrieve'
@@ -65,14 +68,16 @@ RSpec.describe 'Exchange Rates', swagger_doc: 'v2/swagger.json', type: :request 
             .and_return(build(:exchange_rates_collection, month: 3, year: 2024))
         end
 
-        let(:id) { '2024-3' }
+        let(:year) { 2024 }
+        let(:month) { 3 }
         let(:'filter[type]') { 'monthly' }
 
         run_test!
       end
 
       response '404', 'invalid year/month format' do
-        let(:id) { 'invalid' }
+        let(:year) { 'invalid' }
+        let(:month) { 3 }
         let(:'filter[type]') { 'monthly' }
 
         run_test!

--- a/spec/swagger/api/v2/headings_spec.rb
+++ b/spec/swagger/api/v2/headings_spec.rb
@@ -3,11 +3,11 @@ require 'swagger_helper'
 RSpec.describe 'Headings', swagger_doc: 'v2/swagger.json', type: :request do
   let(:Accept) { 'application/vnd.hmrc.2.0+json' }
 
-  path '/api/headings/{id}' do
+  path '/api/headings/{heading_id}' do
     parameter name: :Accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
-    parameter name: :id, in: :path, required: true,
+    parameter name: :heading_id, in: :path, required: true,
               schema: { type: :string, pattern: '^\d{4}$' },
               description: 'Heading code (exactly 4 digits, e.g. "0101")'
 
@@ -123,24 +123,24 @@ RSpec.describe 'Headings', swagger_doc: 'v2/swagger.json', type: :request do
                }
 
         let(:heading) { create(:heading, :with_chapter, :with_description) }
-        let(:id) { heading.goods_nomenclature_item_id.first(4) }
+        let(:heading_id) { heading.goods_nomenclature_item_id.first(4) }
 
         run_test!
       end
 
       response '404', 'heading not found' do
-        let(:id) { '9999' }
+        let(:heading_id) { '9999' }
 
         run_test!
       end
     end
   end
 
-  path '/api/headings/{id}/commodities' do
+  path '/api/headings/{heading_id}/commodities' do
     parameter name: :Accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
-    parameter name: :id, in: :path, required: true,
+    parameter name: :heading_id, in: :path, required: true,
               schema: { type: :string, pattern: '^\d{4}$' },
               description: 'Heading code (exactly 4 digits, e.g. "0101")'
 
@@ -166,18 +166,18 @@ RSpec.describe 'Headings', swagger_doc: 'v2/swagger.json', type: :request do
                }
 
         let(:heading) { create(:heading, :with_chapter, :with_description) }
-        let(:id) { heading.goods_nomenclature_item_id.first(4) }
+        let(:heading_id) { heading.goods_nomenclature_item_id.first(4) }
 
         run_test!
       end
     end
   end
 
-  path '/api/headings/{id}/changes' do
+  path '/api/headings/{heading_id}/changes' do
     parameter name: :Accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
-    parameter name: :id, in: :path, required: true,
+    parameter name: :heading_id, in: :path, required: true,
               schema: { type: :string, pattern: '^\d{4}$' },
               description: 'Heading code (exactly 4 digits, e.g. "0101")'
 
@@ -228,7 +228,7 @@ RSpec.describe 'Headings', swagger_doc: 'v2/swagger.json', type: :request do
                }
 
         let(:heading) { create(:heading, :with_description) }
-        let(:id) { heading.goods_nomenclature_item_id.first(4) }
+        let(:heading_id) { heading.goods_nomenclature_item_id.first(4) }
 
         run_test!
       end

--- a/spec/swagger/api/v2/measures_spec.rb
+++ b/spec/swagger/api/v2/measures_spec.rb
@@ -3,11 +3,11 @@ require 'swagger_helper'
 RSpec.describe 'Measures', swagger_doc: 'v2/swagger.json', type: :request do
   let(:Accept) { 'application/vnd.hmrc.2.0+json' }
 
-  path '/api/measures/{id}' do
+  path '/api/measures/{measure_sid}' do
     parameter name: :Accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
-    parameter name: :id, in: :path, required: true,
+    parameter name: :measure_sid, in: :path, required: true,
               schema: { type: :integer },
               description: 'Measure SID (may be negative for national measures)'
 
@@ -102,13 +102,13 @@ RSpec.describe 'Measures', swagger_doc: 'v2/swagger.json', type: :request do
                }
 
         let(:measure) { create(:measure) }
-        let(:id) { measure.measure_sid }
+        let(:measure_sid) { measure.measure_sid }
 
         run_test!
       end
 
       response '404', 'measure not found' do
-        let(:id) { 99_999_999 }
+        let(:measure_sid) { 99_999_999 }
 
         run_test!
       end

--- a/spec/swagger/api/v2/sections_spec.rb
+++ b/spec/swagger/api/v2/sections_spec.rb
@@ -51,11 +51,11 @@ RSpec.describe 'Sections', swagger_doc: 'v2/swagger.json', type: :request do
     end
   end
 
-  path '/api/sections/{id}' do
+  path '/api/sections/{position}' do
     parameter name: :Accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
-    parameter name: :id, in: :path, required: true,
+    parameter name: :position, in: :path, required: true,
               schema: { type: :integer },
               description: 'Section position number'
 
@@ -138,25 +138,25 @@ RSpec.describe 'Sections', swagger_doc: 'v2/swagger.json', type: :request do
                }
 
         let(:section) { create(:section, :with_chapter) }
-        let(:id) { section.position }
+        let(:position) { section.position }
 
         run_test!
       end
 
       response '400', 'invalid section id — id must be an integer' do
         # The controller returns head :bad_request (empty body) for non-integer ids.
-        let(:id) { 'invalid' }
+        let(:position) { 'invalid' }
 
         run_test!
       end
     end
   end
 
-  path '/api/sections/{id}/chapters' do
+  path '/api/sections/{position}/chapters' do
     parameter name: :Accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
-    parameter name: :id, in: :path, required: true,
+    parameter name: :position, in: :path, required: true,
               schema: { type: :integer },
               description: 'Section position number'
 
@@ -197,7 +197,7 @@ RSpec.describe 'Sections', swagger_doc: 'v2/swagger.json', type: :request do
                }
 
         let(:section) { create(:section, :with_chapter) }
-        let(:id) { section.position }
+        let(:position) { section.position }
 
         run_test!
       end

--- a/spec/swagger/canonical_artifact_spec.rb
+++ b/spec/swagger/canonical_artifact_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+require 'json'
+
+RSpec.describe 'canonical V2 OpenAPI artifact' do
+  subject(:openapi) { JSON.parse(File.read('swagger/v2/swagger.json')) }
+
+  # This validates the committed artifact during the normal RSpec phase.
+  # CI regenerates and self-heals this file later via swagger:generate.
+
+  def path_parameter_names(path)
+    openapi.fetch('paths').fetch(path).fetch('parameters', [])
+      .select { |parameter| parameter.fetch('in') == 'path' }
+      .map { |parameter| parameter.fetch('name') }
+  end
+
+  it 'orders paths deterministically' do
+    paths = openapi.fetch('paths').keys
+
+    expect(paths).to eq(paths.sort)
+  end
+
+  it 'excludes internal-only endpoints' do
+    expect(openapi.fetch('paths')).not_to include(
+      '/api/chemicals/{id}',
+      '/api/news/items/{id}',
+      '/api/sections/{id}/chapters',
+      '/api/sections/{position}/chapters',
+    )
+  end
+
+  it 'uses docs-ready path names' do
+    expect(openapi.fetch('paths')).to include(
+      '/api/sections/{position}',
+      '/api/chapters/{chapter_id}',
+      '/api/headings/{heading_id}',
+      '/api/measures/{measure_sid}',
+      '/api/exchange_rates/{year}-{month}',
+      '/api/exchange_rates/period_lists/{year}',
+    )
+  end
+
+  it 'uses docs-ready parameter names', :aggregate_failures do
+    expect(path_parameter_names('/api/sections/{position}')).to eq(%w[position])
+    expect(path_parameter_names('/api/chapters/{chapter_id}')).to eq(%w[chapter_id])
+    expect(path_parameter_names('/api/headings/{heading_id}')).to eq(%w[heading_id])
+    expect(path_parameter_names('/api/measures/{measure_sid}')).to eq(%w[measure_sid])
+    expect(path_parameter_names('/api/exchange_rates/{year}-{month}')).to eq(%w[year month])
+  end
+
+  it 'defines reusable docs metadata' do
+    components = openapi.fetch('components')
+
+    expect(components.fetch('parameters')).to include('accept_header')
+    expect(components.fetch('schemas')).to include('error_response')
+  end
+
+  it 'documents response example coverage' do
+    expect(openapi.fetch('info').fetch('x-response-examples')).to include('not yet complete')
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -27,6 +27,7 @@ RSpec.configure do |config|
           name: 'MIT',
           url: 'https://opensource.org/licenses/MIT',
         },
+        'x-response-examples': 'Response example coverage is not yet complete in this generated artifact. Endpoint schemas are available; examples will be added incrementally as the backend contract tests are expanded.',
       },
       servers: [
         {

--- a/swagger/v2/swagger.json
+++ b/swagger/v2/swagger.json
@@ -11,7 +11,8 @@
     "license": {
       "name": "MIT",
       "url": "https://opensource.org/licenses/MIT"
-    }
+    },
+    "x-response-examples": "Response example coverage is not yet complete in this generated artifact. Endpoint schemas are available; examples will be added incrementally as the backend contract tests are expanded."
   },
   "servers": [
     {
@@ -799,7 +800,7 @@
         }
       }
     },
-    "/api/chapters/{id}": {
+    "/api/chapters/{chapter_id}": {
       "parameters": [
         {
           "name": "Accept",
@@ -814,7 +815,7 @@
           "description": "API version negotiation header"
         },
         {
-          "name": "id",
+          "name": "chapter_id",
           "in": "path",
           "required": true,
           "schema": {
@@ -1004,7 +1005,7 @@
         }
       }
     },
-    "/api/chapters/{id}/changes": {
+    "/api/chapters/{chapter_id}/changes": {
       "parameters": [
         {
           "name": "Accept",
@@ -1019,7 +1020,7 @@
           "description": "API version negotiation header"
         },
         {
-          "name": "id",
+          "name": "chapter_id",
           "in": "path",
           "required": true,
           "schema": {
@@ -2119,7 +2120,7 @@
         }
       }
     },
-    "/api/exchange_rates/{id}": {
+    "/api/exchange_rates/{year}-{month}": {
       "parameters": [
         {
           "name": "Accept",
@@ -2134,14 +2135,22 @@
           "description": "API version negotiation header"
         },
         {
-          "name": "id",
+          "name": "year",
           "in": "path",
           "required": true,
           "schema": {
-            "type": "string",
-            "pattern": "^\\d{4}-\\d{1,2}$"
+            "type": "integer"
           },
-          "description": "Year and month in \"YYYY-M\" format (e.g. \"2024-3\")"
+          "description": "Four-digit year to retrieve rates for"
+        },
+        {
+          "name": "month",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          },
+          "description": "Month to retrieve rates for"
         },
         {
           "name": "filter[type]",
@@ -3263,7 +3272,7 @@
         }
       }
     },
-    "/api/headings/{id}": {
+    "/api/headings/{heading_id}": {
       "parameters": [
         {
           "name": "Accept",
@@ -3278,7 +3287,7 @@
           "description": "API version negotiation header"
         },
         {
-          "name": "id",
+          "name": "heading_id",
           "in": "path",
           "required": true,
           "schema": {
@@ -3497,7 +3506,7 @@
         }
       }
     },
-    "/api/headings/{id}/changes": {
+    "/api/headings/{heading_id}/changes": {
       "parameters": [
         {
           "name": "Accept",
@@ -3512,7 +3521,7 @@
           "description": "API version negotiation header"
         },
         {
-          "name": "id",
+          "name": "heading_id",
           "in": "path",
           "required": true,
           "schema": {
@@ -3607,7 +3616,7 @@
         }
       }
     },
-    "/api/headings/{id}/commodities": {
+    "/api/headings/{heading_id}/commodities": {
       "parameters": [
         {
           "name": "Accept",
@@ -3622,7 +3631,7 @@
           "description": "API version negotiation header"
         },
         {
-          "name": "id",
+          "name": "heading_id",
           "in": "path",
           "required": true,
           "schema": {
@@ -4153,7 +4162,7 @@
         }
       }
     },
-    "/api/measures/{id}": {
+    "/api/measures/{measure_sid}": {
       "parameters": [
         {
           "name": "Accept",
@@ -4168,7 +4177,7 @@
           "description": "API version negotiation header"
         },
         {
-          "name": "id",
+          "name": "measure_sid",
           "in": "path",
           "required": true,
           "schema": {
@@ -5426,7 +5435,7 @@
         }
       }
     },
-    "/api/sections/{id}": {
+    "/api/sections/{position}": {
       "parameters": [
         {
           "name": "Accept",
@@ -5441,7 +5450,7 @@
           "description": "API version negotiation header"
         },
         {
-          "name": "id",
+          "name": "position",
           "in": "path",
           "required": true,
           "schema": {


### PR DESCRIPTION
### Jira link

[HMRC-2217](https://transformuk.atlassian.net/browse/HMRC-2217)

```mermaid
flowchart LR
    A[Backend rswag specs] --> B[Generate docs-ready swagger/v2/swagger.json]
    B --> C[CI commits generated artifact when it changes]
    C -. HMRC-2218 .-> D[API docs repo fetches committed artifact from backend main]
    D -. later .-> E[Replace current generated reference HTML]
```

### What?

- [x] Rename docs-facing OpenAPI placeholders to match the API docs contract.
- [x] Regenerate `swagger/v2/swagger.json` as the canonical public V2 artifact.
- [x] Add committed artifact checks for deterministic ordering, excluded internal paths, docs-ready names, reusable metadata, and documented response-example coverage gaps.
- [x] Narrow `swagger:generate` to rswag endpoint specs under `spec/swagger/api/**/*_spec.rb`.
- [x] Keep CI self-healing by committing generated Swagger output back to the branch when it changes.

### Why?

The docs repo needs a stable backend-owned OpenAPI source of truth. This keeps the generated artifact aligned with the docs-facing path and parameter names, preserves the existing self-healing CI behaviour, and leaves HMRC-2218 to consume the committed backend artifact during the API docs build.

### Risk

**Risk level:** 🟢

**Reason for rating:**
Swagger generation, committed documentation output, and CI checks only. There is no application runtime change; the main risk is CI committing regenerated docs or exposing gaps in the generated OpenAPI contract.
