### PR TITLE
Add gem-update-bot workflow

### DIFF
--- a/.github/workflows/gem-update-bot.yml
+++ b/.github/workflows/gem-update-bot.yml
@@ -21,9 +21,9 @@ jobs:
           ruby-version: '4.0.3'
           bundler-cache: true
 
-      - name: Update non-development gems
+      - name: Update gems
         run: |
-          bundle update --jobs=4 --retry=3 --group default --group test --group production || true
+          bundle update --jobs=4 --retry=3
 
       - name: Create PR
         run: |
@@ -41,4 +41,4 @@ jobs:
           git commit -m "Update Gemfile.lock"
           git push -u origin "$BRANCH"
           
-          gh pr create --title "Update Gemfile.lock"             --body "**Risk level:** 🟢 Green — Dependency bumps with no API changes (minor/patch gems)"             --label "dependencies"             --reviewer "trade-tariff/team-leads"
+          gh pr create             --title "Update Gemfile.lock"             --body "**Risk level:** 🟢 Green — Dependency bumps with no API changes (minor/patch gems)"             --label "dependencies"             --reviewer "trade-tariff/team-leads"


### PR DESCRIPTION
## What:
Adds a GitHub Actions workflow that runs weekly gem updates and can be triggered manually.

## Why:
Automated gem updates ensure dependencies stay current without manual effort, producing reviewable PRs rather than auto-merged Dependabot updates.

## Ticket:
N/A — maintenance automation

## Risk:
**Risk level:** 🟢 Green
**Reason for rating:** Adds an internal CI workflow; PRs it creates require normal team review before merging.
