### PR TITLE
BAU: Label deployment PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,6 @@
-# Add "needs-deployment" label to pull requests making database schema changes
+# Add "needs-deployment" label to pull requests that should be deployed
 needs-deployment:
   - changed-files:
-    - any-glob-to-any-file: "db/*"
+    - any-glob-to-any-file:
+      - "db/**"
+      - "Dockerfile"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,3 +4,4 @@ needs-deployment:
     - any-glob-to-any-file:
       - "db/**"
       - "Dockerfile"
+      - "terraform/**"


### PR DESCRIPTION
## What:

- Add root `Dockerfile` changes to the `needs-deployment` label rule.
- Match recursive `db/` changes for the `needs-deployment` label rule.
- Match recursive `terraform/` changes for the `needs-deployment` label rule.

## Why:

PRs that change the deployed image, database files, or app Terraform should request a development deployment automatically.

## Ticket:

BAU

## Risk:

**Risk level:** Green

**Reason for rating:**

CI label configuration only. This changes when a deployment label is applied to PRs, not application runtime behaviour.
