### PR TITLE
HMRC-2209: Update ECS configs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
         args: ["--severity=warning"]
 
   - repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.95.2
+    rev: v3.95.3
     hooks:
       - id: trufflehog
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -20,17 +20,17 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 | ---- | ------ | ------- |
-| <a name="module_backend-job"></a> [backend-job](#module\_backend-job) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.21.0 |
-| <a name="module_backend_uk"></a> [backend\_uk](#module\_backend\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.21.0 |
-| <a name="module_backend_xi"></a> [backend\_xi](#module\_backend\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.21.0 |
+| <a name="module_backend-job"></a> [backend-job](#module\_backend-job) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.0.1 |
+| <a name="module_backend_uk"></a> [backend\_uk](#module\_backend\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.0.1 |
+| <a name="module_backend_xi"></a> [backend\_xi](#module\_backend\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.0.1 |
 | <a name="module_label_generator_dashboard"></a> [label\_generator\_dashboard](#module\_label\_generator\_dashboard) | ./modules/label_generator_dashboard | n/a |
 | <a name="module_search_dashboard"></a> [search\_dashboard](#module\_search\_dashboard) | ./modules/search_dashboard | n/a |
 | <a name="module_search_operations_dashboard"></a> [search\_operations\_dashboard](#module\_search\_operations\_dashboard) | ./modules/search_operations_dashboard | n/a |
 | <a name="module_search_quality_dashboard"></a> [search\_quality\_dashboard](#module\_search\_quality\_dashboard) | ./modules/search_quality_dashboard | n/a |
 | <a name="module_self_text_generator_dashboard"></a> [self\_text\_generator\_dashboard](#module\_self\_text\_generator\_dashboard) | ./modules/self_text_generator_dashboard | n/a |
 | <a name="module_tariff_sync_dashboard"></a> [tariff\_sync\_dashboard](#module\_tariff\_sync\_dashboard) | ./modules/tariff_sync_dashboard | n/a |
-| <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.21.0 |
-| <a name="module_worker_xi"></a> [worker\_xi](#module\_worker\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.21.0 |
+| <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.0.1 |
+| <a name="module_worker_xi"></a> [worker\_xi](#module\_worker\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.0.1 |
 
 ## Resources
 
@@ -77,12 +77,14 @@ Terraform to deploy the service into AWS.
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
 | <a name="input_database_backup_secret_name"></a> [database\_backup\_secret\_name](#input\_database\_backup\_secret\_name) | Secrets Manager secret name containing the database URL for backups. | `string` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
-| <a name="input_enable_service_count_alarm"></a> [enable\_service\_count\_alarm](#input\_enable\_service\_count\_alarm) | Whether to enable an alarm that triggers when the service count is below the desired count. | `bool` | `true` | no |
+| <a name="input_enable_alarms"></a> [enable\_alarms](#input\_enable\_alarms) | Whether to enable CloudWatch alarms for the service. | `bool` | `true` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Largest number of tasks the service can scale-out to. | `number` | `5` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory to allocate in MB. Powers of 2 only. | `number` | n/a | yes |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | Smallest number of tasks the service can scale-in to. | `number` | `1` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region to use. | `string` | n/a | yes |
+| <a name="input_scale_in_cooldown"></a> [scale\_in\_cooldown](#input\_scale\_in\_cooldown) | Prevents aggressive scale-in by enforcing a waiting period after tasks are removed. | `number` | `300` | no |
+| <a name="input_scale_out_cooldown"></a> [scale\_out\_cooldown](#input\_scale\_out\_cooldown) | Minimum time to wait after a scale-out before allowing another scale-out, giving new tasks time to start contributing capacity. | `number` | `60` | no |
 | <a name="input_service_count"></a> [service\_count](#input\_service\_count) | Number of services to use. | `number` | `2` | no |
 
 ## Outputs

--- a/terraform/backend_job.tf
+++ b/terraform/backend_job.tf
@@ -24,9 +24,9 @@ module "backend-job" {
 
   enable_ecs_exec = true
 
-  has_autoscaler = false
-  max_capacity   = 1
-  min_capacity   = 0
+  has_autoscaler     = false
+  max_capacity       = 1
+  min_capacity       = 0
   scale_in_cooldown  = var.scale_in_cooldown
   scale_out_cooldown = var.scale_out_cooldown
 

--- a/terraform/backend_job.tf
+++ b/terraform/backend_job.tf
@@ -1,5 +1,5 @@
 module "backend-job" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.21.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.0.1"
 
   region = var.region
 
@@ -27,6 +27,8 @@ module "backend-job" {
   has_autoscaler = false
   max_capacity   = 1
   min_capacity   = 0
+  scale_in_cooldown  = var.scale_in_cooldown
+  scale_out_cooldown = var.scale_out_cooldown
 
   sns_topic_arns = [data.aws_sns_topic.slack_topic.arn]
 }

--- a/terraform/backend_uk.tf
+++ b/terraform/backend_uk.tf
@@ -1,5 +1,5 @@
 module "backend_uk" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.21.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.0.1"
 
   region = var.region
 
@@ -34,8 +34,22 @@ module "backend_uk" {
   has_autoscaler = local.has_autoscaler
   min_capacity   = var.min_capacity
   max_capacity   = var.max_capacity
+  scale_in_cooldown  = var.scale_in_cooldown
+  scale_out_cooldown = var.scale_out_cooldown
 
-  enable_service_count_alarm = var.enable_service_count_alarm
+  autoscaling_metrics = {
+    cpu = {
+      metric_type  = "ECSServiceAverageCPUUtilization"
+      target_value = 45
+    }
+    memory = {
+      metric_type  = "ECSServiceAverageMemoryUtilization"
+      target_value = 70
+    }
+  }
+
+  enable_alarms       = var.enable_alarms
+  cpu_alarm_threshold = 85 # Temporarily set higher to avoid alarm noise during load testing, will be adjusted based on observed metrics after testing is complete.
 
   sns_topic_arns = [data.aws_sns_topic.slack_topic.arn]
 }

--- a/terraform/backend_uk.tf
+++ b/terraform/backend_uk.tf
@@ -31,9 +31,9 @@ module "backend_uk" {
 
   enable_ecs_exec = true
 
-  has_autoscaler = local.has_autoscaler
-  min_capacity   = var.min_capacity
-  max_capacity   = var.max_capacity
+  has_autoscaler     = local.has_autoscaler
+  min_capacity       = var.min_capacity
+  max_capacity       = var.max_capacity
   scale_in_cooldown  = var.scale_in_cooldown
   scale_out_cooldown = var.scale_out_cooldown
 

--- a/terraform/backend_xi.tf
+++ b/terraform/backend_xi.tf
@@ -31,9 +31,9 @@ module "backend_xi" {
 
   enable_ecs_exec = true
 
-  has_autoscaler = local.has_autoscaler
-  min_capacity   = var.min_capacity
-  max_capacity   = var.max_capacity
+  has_autoscaler     = local.has_autoscaler
+  min_capacity       = var.min_capacity
+  max_capacity       = var.max_capacity
   scale_in_cooldown  = var.scale_in_cooldown
   scale_out_cooldown = var.scale_out_cooldown
 

--- a/terraform/backend_xi.tf
+++ b/terraform/backend_xi.tf
@@ -1,5 +1,5 @@
 module "backend_xi" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.21.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.0.1"
 
   region = var.region
 
@@ -34,8 +34,22 @@ module "backend_xi" {
   has_autoscaler = local.has_autoscaler
   min_capacity   = var.min_capacity
   max_capacity   = var.max_capacity
+  scale_in_cooldown  = var.scale_in_cooldown
+  scale_out_cooldown = var.scale_out_cooldown
 
-  enable_service_count_alarm = var.enable_service_count_alarm
+  autoscaling_metrics = {
+    cpu = {
+      metric_type  = "ECSServiceAverageCPUUtilization"
+      target_value = 30
+    }
+    memory = {
+      metric_type  = "ECSServiceAverageMemoryUtilization"
+      target_value = 70
+    }
+  }
+
+  enable_alarms       = var.enable_alarms
+  cpu_alarm_threshold = 85 # Temporarily set higher to avoid alarm noise during load testing, will be adjusted based on observed metrics after testing is complete.
 
   sns_topic_arns = [data.aws_sns_topic.slack_topic.arn]
 }

--- a/terraform/config_development.tfvars
+++ b/terraform/config_development.tfvars
@@ -5,4 +5,4 @@ memory                      = 2048
 min_capacity                = 1
 max_capacity                = 1
 database_backup_secret_name = "aurora-postgres-rw-connection-string"
-enable_alarms = false
+enable_alarms               = false

--- a/terraform/config_development.tfvars
+++ b/terraform/config_development.tfvars
@@ -5,4 +5,4 @@ memory                      = 2048
 min_capacity                = 1
 max_capacity                = 1
 database_backup_secret_name = "aurora-postgres-rw-connection-string"
-enable_service_count_alarm  = false
+enable_alarms = false

--- a/terraform/config_production.tfvars
+++ b/terraform/config_production.tfvars
@@ -6,3 +6,8 @@ service_count               = 4
 min_capacity                = 2
 max_capacity                = 16
 database_backup_secret_name = "production-postgres-database-url"
+
+# Temporarily pinned autoscaling cooldown values in Production to preserve existing behaviour while testing changes in dev and staging
+# Can also remove those variables (in variables.tf) if we decide to keep the default cooldown values
+scale_in_cooldown  = 0
+scale_out_cooldown = 0

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -46,8 +46,20 @@ variable "database_backup_secret_name" {
   type        = string
 }
 
-variable "enable_service_count_alarm" {
-  description = "Whether to enable an alarm that triggers when the service count is below the desired count."
+variable "enable_alarms" {
+  description = "Whether to enable CloudWatch alarms for the service."
   type        = bool
   default     = true
+}
+# Can remove that variable after deploying to P
+variable "scale_in_cooldown" {
+  description = "Prevents aggressive scale-in by enforcing a waiting period after tasks are removed."
+  type        = number
+  default     = 300
+}
+
+variable "scale_out_cooldown" {
+  description = "Minimum time to wait after a scale-out before allowing another scale-out, giving new tasks time to start contributing capacity."
+  type        = number
+  default     = 60
 }

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -1,5 +1,5 @@
 module "worker_uk" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.21.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.0.1"
 
   service_name = "worker-uk"
   region       = var.region
@@ -32,8 +32,10 @@ module "worker_uk" {
   has_autoscaler = local.has_autoscaler
   min_capacity   = 1
   max_capacity   = var.max_capacity
+  scale_in_cooldown  = var.scale_in_cooldown
+  scale_out_cooldown = var.scale_out_cooldown
 
-  enable_service_count_alarm = var.enable_service_count_alarm
+  enable_alarms = var.enable_alarms
 
   sns_topic_arns = [data.aws_sns_topic.slack_topic.arn]
 }

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -29,9 +29,9 @@ module "worker_uk" {
 
   service_environment_config = local.worker_uk_secret_env_vars
 
-  has_autoscaler = local.has_autoscaler
-  min_capacity   = 1
-  max_capacity   = var.max_capacity
+  has_autoscaler     = local.has_autoscaler
+  min_capacity       = 1
+  max_capacity       = var.max_capacity
   scale_in_cooldown  = var.scale_in_cooldown
   scale_out_cooldown = var.scale_out_cooldown
 

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -29,9 +29,9 @@ module "worker_xi" {
 
   service_environment_config = local.worker_xi_secret_env_vars
 
-  has_autoscaler = local.has_autoscaler
-  min_capacity   = 1
-  max_capacity   = var.max_capacity
+  has_autoscaler     = local.has_autoscaler
+  min_capacity       = 1
+  max_capacity       = var.max_capacity
   scale_in_cooldown  = var.scale_in_cooldown
   scale_out_cooldown = var.scale_out_cooldown
 

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -1,5 +1,5 @@
 module "worker_xi" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.21.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.0.1"
 
   service_name = "worker-xi"
   region       = var.region
@@ -32,8 +32,10 @@ module "worker_xi" {
   has_autoscaler = local.has_autoscaler
   min_capacity   = 1
   max_capacity   = var.max_capacity
+  scale_in_cooldown  = var.scale_in_cooldown
+  scale_out_cooldown = var.scale_out_cooldown
 
-  enable_service_count_alarm = var.enable_service_count_alarm
+  enable_alarms = var.enable_alarms
 
   sns_topic_arns = [data.aws_sns_topic.slack_topic.arn]
 }


### PR DESCRIPTION
## What:
Updated the backend service to align with recent ECS service module changes (v2.0.1 and v3.0.1), including:

- Adding explicit scale_in_cooldown and scale_out_cooldown configuration. 
- Applying non‑zero autoscaling cooldowns in staging only for validation
- Updating target tracking autoscaling thresholds
- Enabling newly introduced ECS CloudWatch alarms

## Why:
To keep the backend service consistent with the latest ECS module standards, improve autoscaling stability and observability, and safely adopt new module features. Autoscaling cooldowns are enabled in staging first to monitor behaviour and tune settings before rolling them out to production. Production autoscaling remains pinned to the existing behaviour (scale_in_cooldown = 0, scale_out_cooldown = 0).

## Ticket:
[HMRC-2209](https://transformuk.atlassian.net/browse/HMRC-2209)

## Risk:
Risk level: 🟠 Amber

**Reason for rating:**
This PR introduces ECS autoscaling and alarm configuration changes. While production behaviour is explicitly preserved and cooldowns are enabled only in staging for observation, the changes affect infrastructure behaviour and require team awareness and careful plan review.

───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.

───────────────────────────────────────────────────

🟢 GREEN – things that are typically low risk:
───────────────────────────────────────────────────
- Dependency bumps with no API changes (e.g. minor/patch gems, npm packages)
- Copy or content changes in GOV.UK-style UI components
- Adding or updating CloudWatch alarms or dashboards (read-only observability)
- New tests or improved test coverage with no production code changes
- Config/env var additions that are purely additive and have safe defaults
- Refactors with full test coverage and no behaviour change
- Terraform formatting or variable renaming with no resource recreation
- S3 lifecycle rule additions (non-destructive, time-delayed effect)

🟠 AMBER – things that need a team conversation first:
───────────────────────────────────────────────────
- Changes to commodity code lookups, measure type logic, or duty calculation
- Modifications to the search indexing pipeline (OpenSearch mappings, synonyms, stop words)
- Changes to declarable goods or quota logic
- New or modified API endpoints that other services (backend, frontend, admin) consume
- Adding or changing feature flags that affect live user journeys
- Infrastructure changes that alter networking, security groups, or IAM permissions in non-production first
- Terraform changes that will cause a resource replacement (check plan output carefully)
- Changes to CI/CD pipeline steps or deployment order dependencies
- S3 bucket policy or access control changes
- Removing or deprecating an endpoint or field that may still be consumed

🔴 RED – requires explicit approval from Thor or Neil:
───────────────────────────────────────────────────
- Dangerous database migrations, especially destructive ones (dropping columns/tables, removing indexes)
- Modifications to how measures, conditions, or footnotes are processed or surfaced
- Changes to the synchronisation mechanism from CDS or HMRC upstream data feeds
- Any change to production AWS infrastructure that cannot be easily rolled back (e.g. RDS parameter groups, KMS key policy, removal of resources)
- Secrets rotation or changes to how credentials are stored, scoped, or accessed
- Changes that affect trader-facing regulatory content or legally significant data (e.g. trade remedies, licensing, prohibitions)
- Significant architectural shifts (e.g. new service boundaries, queue/event topology changes)
