### PR TITLE
BAU: Clean test output

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -23,7 +23,7 @@ SET row_security = off;
 -- Name: public; Type: SCHEMA; Schema: -; Owner: -
 --
 
-CREATE SCHEMA IF NOT EXISTS public;
+CREATE SCHEMA public;
 
 
 --
@@ -10804,6 +10804,13 @@ CREATE INDEX certificate_descriptions_description_trgm_idx ON uk.certificate_des
 
 
 --
+-- Name: chapter_note_experimentals_chapter_id_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE UNIQUE INDEX chapter_note_experimentals_chapter_id_index ON uk.chapter_note_experimentals USING btree (chapter_id);
+
+
+--
 -- Name: chapter_notes_chapter_id_index; Type: INDEX; Schema: uk; Owner: -
 --
 
@@ -14267,6 +14274,11 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20260421120000_add_commodi
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260421120001_add_oid_covering_indexes_to_goods_nomenclature_description_oplogs.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260422143000_add_lifecycle_flags_to_generated_classification_content.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260423120000_add_regulation_and_fts_performance_indexes.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20260424120000_materialise_hot_path_footnote_and_measure_views.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20260414113626_create_customs_tariff_updates.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20260414113627_create_customs_tariff_chapter_notes.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20260414113628_create_customs_tariff_section_notes.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20260414113629_create_customs_tariff_general_rules.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260424120000_materialise_hot_path_footnote_and_measure_views.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260429120000_add_aliases_to_description_intercepts.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260506170000_add_unique_index_to_description_intercepts_term.rb');

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -23,7 +23,7 @@ SET row_security = off;
 -- Name: public; Type: SCHEMA; Schema: -; Owner: -
 --
 
-CREATE SCHEMA public;
+CREATE SCHEMA IF NOT EXISTS public;
 
 
 --
@@ -10804,13 +10804,6 @@ CREATE INDEX certificate_descriptions_description_trgm_idx ON uk.certificate_des
 
 
 --
--- Name: chapter_note_experimentals_chapter_id_index; Type: INDEX; Schema: uk; Owner: -
---
-
-CREATE UNIQUE INDEX chapter_note_experimentals_chapter_id_index ON uk.chapter_note_experimentals USING btree (chapter_id);
-
-
---
 -- Name: chapter_notes_chapter_id_index; Type: INDEX; Schema: uk; Owner: -
 --
 
@@ -14274,11 +14267,6 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20260421120000_add_commodi
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260421120001_add_oid_covering_indexes_to_goods_nomenclature_description_oplogs.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260422143000_add_lifecycle_flags_to_generated_classification_content.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260423120000_add_regulation_and_fts_performance_indexes.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20260424120000_materialise_hot_path_footnote_and_measure_views.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20260414113626_create_customs_tariff_updates.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20260414113627_create_customs_tariff_chapter_notes.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20260414113628_create_customs_tariff_section_notes.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20260414113629_create_customs_tariff_general_rules.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260424120000_materialise_hot_path_footnote_and_measure_views.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260429120000_add_aliases_to_description_intercepts.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260506170000_add_unique_index_to_description_intercepts_term.rb');

--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,99 @@
             -c maintenance_work_mem=8GB
         '';
 
+        opensearch-start = pkgs.writeShellScriptBin "opensearch-start" ''
+          set -euo pipefail
+
+          runtime_dir="$PWD/.nix/opensearch"
+          home="$runtime_dir/home"
+          config="$runtime_dir/config"
+          data="$runtime_dir/data"
+          logs="$runtime_dir/logs"
+          store_marker="$runtime_dir/store-path"
+
+          mkdir -p "$runtime_dir" "$config" "$data" "$logs"
+
+          if [ ! -f "$store_marker" ] || [ "$(cat "$store_marker")" != "${pkgs.opensearch}" ]; then
+            rm -rf "$home"
+            mkdir -p "$home/bin"
+
+            ln -sfn "${pkgs.opensearch}/agent" "$home/agent"
+            ln -sfn "${pkgs.opensearch}/lib" "$home/lib"
+            ln -sfn "${pkgs.opensearch}/modules" "$home/modules"
+            ln -sfn "${pkgs.opensearch}/plugins" "$home/plugins"
+
+            ${pkgs.gnused}/bin/sed "s|${pkgs.opensearch}|$home|g" \
+              "${pkgs.opensearch}/bin/.opensearch-wrapped" > "$home/bin/.opensearch-wrapped"
+            ${pkgs.gnused}/bin/sed "s|${pkgs.opensearch}|$home|g" \
+              "${pkgs.opensearch}/bin/opensearch-keystore" > "$home/bin/opensearch-keystore"
+
+            cp "${pkgs.opensearch}/bin/opensearch-env" "$home/bin/opensearch-env"
+            cp "${pkgs.opensearch}/bin/opensearch-env-from-file" "$home/bin/opensearch-env-from-file"
+            chmod +x "$home/bin/.opensearch-wrapped" "$home/bin/opensearch-keystore" \
+              "$home/bin/opensearch-env" "$home/bin/opensearch-env-from-file"
+
+            cat > "$home/bin/opensearch-cli" <<'OPENSEARCH_CLI'
+#!/usr/bin/env bash
+set -e -o pipefail
+
+source "$(dirname "$0")"/opensearch-env
+
+if [ -z "$OPENSEARCH_TMPDIR" ]; then
+  OPENSEARCH_TMPDIR="$("$JAVA" "$XSHARE" -cp "$OPENSEARCH_CLASSPATH" org.opensearch.tools.launchers.TempDirectory)"
+fi
+
+if [ -n "''${OPENSEARCH_ADDITIONAL_CLASSPATH_DIRECTORIES:-}" ]; then
+  for directory in $OPENSEARCH_ADDITIONAL_CLASSPATH_DIRECTORIES; do
+    OPENSEARCH_CLASSPATH="$OPENSEARCH_CLASSPATH:$OPENSEARCH_HOME/$directory/*"
+  done
+fi
+
+exec "$JAVA" "$XSHARE" \
+  -Dopensearch.path.home="$OPENSEARCH_HOME" \
+  -Dopensearch.path.conf="$OPENSEARCH_PATH_CONF" \
+  -Dopensearch.distribution.type="$OPENSEARCH_DISTRIBUTION_TYPE" \
+  -Dopensearch.bundled_jdk="$OPENSEARCH_BUNDLED_JDK" \
+  -cp "$OPENSEARCH_CLASSPATH" \
+  "$OPENSEARCH_MAIN_CLASS" \
+  "$@"
+OPENSEARCH_CLI
+            chmod +x "$home/bin/opensearch-cli"
+
+            echo "${pkgs.opensearch}" > "$store_marker"
+          fi
+
+          ${pkgs.gnused}/bin/sed "s|logs/gc.log|$logs/gc.log|g" \
+            "${pkgs.opensearch}/config/jvm.options" > "$config/jvm.options"
+          rm -f "$config/opensearch.yml" "$config/log4j2.properties"
+          cp "${pkgs.opensearch}/config/opensearch.yml" "$config/opensearch.yml"
+          cp "${pkgs.opensearch}/config/log4j2.properties" "$config/log4j2.properties"
+
+          exec env \
+            JAVA_HOME="${pkgs.jdk21_headless.home}" \
+            OPENSEARCH_PATH_CONF="$config" \
+            OPENSEARCH_JAVA_OPTS="''${OPENSEARCH_JAVA_OPTS:--Xms512m -Xmx512m}" \
+            "$home/bin/.opensearch-wrapped" \
+            -E discovery.type=single-node \
+            -E plugins.security.disabled=true \
+            -E path.data="$data" \
+            -E path.logs="$logs" \
+            -E http.port="''${OPENSEARCH_PORT:-9200}" \
+            -E network.host="''${OPENSEARCH_HOST:-127.0.0.1}" \
+            "$@"
+        '';
+
+        redis-start = pkgs.writeShellScriptBin "redis-start" ''
+          set -euo pipefail
+
+          mkdir -p "$PWD/.nix/redis"
+
+          exec ${pkgs.redis}/bin/redis-server \
+            --dir "$PWD/.nix/redis" \
+            --port "''${REDIS_PORT:-6379}" \
+            --save "" \
+            --appendonly no
+        '';
+
         lint = pkgs.writeShellScriptBin "lint" ''
           changed_files=$(git diff --name-only --diff-filter=ACM --merge-base main)
 
@@ -102,10 +195,14 @@
             init
             lint
             pkgs.python3
+            pkgs.opensearch
+            pkgs.redis
             pkgs.socat
             pkgs.zlib
+            opensearch-start
             postgresql
             postgresql-start
+            redis-start
             ruby
             update-providers
           ];

--- a/spec/lib/tasks/paper_trail_rake_spec.rb
+++ b/spec/lib/tasks/paper_trail_rake_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe 'paper_trail:reset_initial_versions' do
   end
 
   it 'aborts unless CONFIRM=true' do
-    expect { Rake::Task['paper_trail:reset_initial_versions'].invoke }.to raise_error(SystemExit)
+    expect { suppress_output { Rake::Task['paper_trail:reset_initial_versions'].invoke } }.to raise_error(SystemExit)
   end
 
   it 'does not eager load classes without confirmation' do
     allow(Rails.application).to receive(:eager_load!).and_return(true)
 
-    expect { Rake::Task['paper_trail:reset_initial_versions'].invoke }.to raise_error(SystemExit)
+    expect { suppress_output { Rake::Task['paper_trail:reset_initial_versions'].invoke } }.to raise_error(SystemExit)
 
     expect(Rails.application).not_to have_received(:eager_load!)
   end

--- a/spec/lib/tasks/tariff_sync_tooling_rake_spec.rb
+++ b/spec/lib/tasks/tariff_sync_tooling_rake_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe 'tariff:sync:failure_detail' do
 
   context 'without FILENAME set' do
     it 'aborts with an instruction' do
-      expect { Rake::Task['tariff:sync:failure_detail'].invoke }
+      expect { suppress_output { Rake::Task['tariff:sync:failure_detail'].invoke } }
         .to raise_error(SystemExit)
     end
   end
@@ -146,7 +146,7 @@ RSpec.describe 'tariff:sync:failure_detail' do
     before { ENV['FILENAME'] = 'nonexistent.gzip' }
 
     it 'aborts' do
-      expect { Rake::Task['tariff:sync:failure_detail'].invoke }
+      expect { suppress_output { Rake::Task['tariff:sync:failure_detail'].invoke } }
         .to raise_error(SystemExit)
     end
   end
@@ -248,7 +248,7 @@ RSpec.describe 'tariff:sync:inspect_file' do
 
   context 'without FILENAME set' do
     it 'aborts with an instruction' do
-      expect { Rake::Task['tariff:sync:inspect_file'].invoke }
+      expect { suppress_output { Rake::Task['tariff:sync:inspect_file'].invoke } }
         .to raise_error(SystemExit)
     end
   end
@@ -257,7 +257,7 @@ RSpec.describe 'tariff:sync:inspect_file' do
     before { ENV['FILENAME'] = 'nonexistent.gzip' }
 
     it 'aborts' do
-      expect { Rake::Task['tariff:sync:inspect_file'].invoke }
+      expect { suppress_output { Rake::Task['tariff:sync:inspect_file'].invoke } }
         .to raise_error(SystemExit)
     end
   end
@@ -271,7 +271,7 @@ RSpec.describe 'tariff:sync:inspect_file' do
     end
 
     it 'aborts' do
-      expect { Rake::Task['tariff:sync:inspect_file'].invoke }
+      expect { suppress_output { Rake::Task['tariff:sync:inspect_file'].invoke } }
         .to raise_error(SystemExit)
     end
   end
@@ -408,7 +408,7 @@ RSpec.describe 'tariff:sync:force_apply' do
 
   context 'without FILENAME set' do
     it 'aborts' do
-      expect { Rake::Task['tariff:sync:force_apply'].invoke }
+      expect { suppress_output { Rake::Task['tariff:sync:force_apply'].invoke } }
         .to raise_error(SystemExit)
     end
   end
@@ -419,7 +419,7 @@ RSpec.describe 'tariff:sync:force_apply' do
     before { ENV['FILENAME'] = update.filename }
 
     it 'exits without applying' do
-      expect { Rake::Task['tariff:sync:force_apply'].invoke }
+      expect { suppress_output { Rake::Task['tariff:sync:force_apply'].invoke } }
         .to raise_error(SystemExit)
     end
 
@@ -446,7 +446,7 @@ RSpec.describe 'tariff:sync:force_apply' do
     end
 
     it 'aborts with a state error' do
-      expect { Rake::Task['tariff:sync:force_apply'].invoke }
+      expect { suppress_output { Rake::Task['tariff:sync:force_apply'].invoke } }
         .to raise_error(SystemExit)
     end
   end

--- a/spec/support/output_helpers.rb
+++ b/spec/support/output_helpers.rb
@@ -1,11 +1,14 @@
-# Helper for suppressing stdout during tests (e.g., rake task output)
+# Helper for suppressing stdout/stderr during tests (e.g., rake task output)
 module OutputHelpers
   def suppress_output
     original_stdout = $stdout
+    original_stderr = $stderr
     $stdout = StringIO.new
+    $stderr = StringIO.new
     yield
   ensure
     $stdout = original_stdout
+    $stderr = original_stderr
   end
 end
 

--- a/spec/workers/prewarm_commodities_worker_spec.rb
+++ b/spec/workers/prewarm_commodities_worker_spec.rb
@@ -112,7 +112,13 @@ RSpec.describe PrewarmCommoditiesWorker do
       it 'logs and continues with preconfigured ids' do
         allow(ENV).to receive(:fetch).with('PREWARM_COMMODITY_IDS', '').and_return(preconfigured_id)
 
-        worker.perform
+        original_logger = Sidekiq.default_configuration.logger
+        Sidekiq.default_configuration.logger = Logger.new(StringIO.new)
+        begin
+          worker.perform
+        ensure
+          Sidekiq.default_configuration.logger = original_logger
+        end
 
         expect(CachedCommodityService).to have_received(:new).with(preconfigured_commodity, Date.current)
       end


### PR DESCRIPTION
### Jira link

[BAU](https://transformuk.atlassian.net/browse/BAU)

### What?

- [x] Suppress intentional stderr/stdout from rake task abort-path specs
- [x] Suppress the intentional Sidekiq error log in the CloudWatch failure worker spec
- [x] Clean stale duplicate/missing entries from `db/structure.sql` so structure loading is quiet
- [x] Add Nix dev shell helpers for Redis and OpenSearch local test dependencies

### Why?

The full suite was passing, but its output included expected warnings/errors from tests and schema-load noise. This keeps the signal focused on real failures and makes the non-Docker local test path easier to run.
