### PR TITLE
BAU: Remove secret-pulled value for read only connection

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -53,14 +53,12 @@ Terraform to deploy the service into AWS.
 | [aws_iam_policy_document.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_lb_target_group.backend_uk_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
 | [aws_lb_target_group.backend_xi_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
-| [aws_secretsmanager_secret.aurora_reader_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.backend_job_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.backend_uk_api_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.backend_uk_worker_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.backend_xi_api_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.backend_xi_worker_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.ecs_tls_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
-| [aws_secretsmanager_secret_version.aurora_reader_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_secretsmanager_secret_version.backend_job_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_secretsmanager_secret_version.backend_uk_api_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_secretsmanager_secret_version.backend_uk_worker_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -67,14 +67,6 @@ data "aws_secretsmanager_secret_version" "backend_job_configuration" {
   secret_id = data.aws_secretsmanager_secret.backend_job_configuration.id
 }
 
-data "aws_secretsmanager_secret" "aurora_reader_connection_string" {
-  name = "aurora-postgres-ro-connection-string"
-}
-
-data "aws_secretsmanager_secret_version" "aurora_reader_connection_string" {
-  secret_id = data.aws_secretsmanager_secret.aurora_reader_connection_string.id
-}
-
 data "aws_secretsmanager_secret" "ecs_tls_certificate" {
   name = "ecs-tls-certificate"
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -93,19 +93,6 @@ data "aws_iam_policy_document" "task" {
       "arn:aws:s3:::trade-tariff-database-backups-${local.account_id}/*",
     ]
   }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "secretsmanager:GetSecretValue",
-      "secretsmanager:DescribeSecret",
-    ]
-    resources = [
-      "arn:aws:secretsmanager:${var.region}:${local.account_id}:secret:aurora-postgres-rw-connection-string-*",
-      "arn:aws:secretsmanager:${var.region}:${local.account_id}:secret:aurora-postgres-ro-connection-string-*",
-      "arn:aws:secretsmanager:${var.region}:${local.account_id}:secret:*-postgres-database-url-*",
-    ]
-  }
 }
 
 resource "aws_iam_policy" "task" {

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -19,10 +19,6 @@ locals {
       name  = "SSL_PORT"
       value = "8443"
     },
-    {
-      name  = "READER_DATABASE_URL"
-      value = data.aws_secretsmanager_secret_version.aurora_reader_connection_string.secret_string
-    }
   ]
 
 


### PR DESCRIPTION
## What:
<!-- A brief description of what this PR does -->

- Remove borked secret reference being passed in as configuration

## Why:
<!-- The reasoning or context behind this change -->

- The secrets are different (lower cased) from the actual configured value in each environment. We can unpick that separately and set manually for now

## Ticket:
<!-- Link to the relevant Jira/ticket, or 'N/A' if not applicable -->

## Risk:
**Risk level:** 🟠 <!-- delete as appropriate -->

**Reason for rating:**
<!-- One or two sentences explaining your assessment, especially for Amber or Red -->

This requires a manual change to a core part of the system across all environments but won't actually break anything since we fallback to the writer connection
───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.