### PR TITLE
Fix static_cache boot crash: declare set_primary_key before plugin :static_cache

### DIFF
--- a/app/models/duty_expression.rb
+++ b/app/models/duty_expression.rb
@@ -10,11 +10,11 @@ class DutyExpression < Sequel::Model
     '29' => '673', # + reduced additional duty on flour
   }.freeze
 
+  set_primary_key [:duty_expression_id]
+
   plugin :time_machine
   plugin :oplog, primary_key: :duty_expression_id
   plugin :static_cache, frozen: false unless Rails.env.test?
-
-  set_primary_key [:duty_expression_id]
 
   one_to_one :duty_expression_description
 

--- a/app/models/duty_expression_description.rb
+++ b/app/models/duty_expression_description.rb
@@ -1,8 +1,8 @@
 class DutyExpressionDescription < Sequel::Model
+  set_primary_key [:duty_expression_id]
+
   plugin :oplog, primary_key: :duty_expression_id
   plugin :static_cache, frozen: false unless Rails.env.test?
-
-  set_primary_key [:duty_expression_id]
 
   def abbreviation
     {

--- a/app/models/measure_action.rb
+++ b/app/models/measure_action.rb
@@ -1,9 +1,9 @@
 class MeasureAction < Sequel::Model
+  set_primary_key [:action_code]
+
   plugin :time_machine
   plugin :oplog, primary_key: :action_code
   plugin :static_cache, frozen: false unless Rails.env.test?
-
-  set_primary_key [:action_code]
 
   many_to_one :measure_action_description, key: :action_code,
                                            primary_key: :action_code

--- a/app/models/measure_action_description.rb
+++ b/app/models/measure_action_description.rb
@@ -1,6 +1,6 @@
 class MeasureActionDescription < Sequel::Model
+  set_primary_key [:action_code]
+
   plugin :oplog, primary_key: :action_code
   plugin :static_cache, frozen: false unless Rails.env.test?
-
-  set_primary_key [:action_code]
 end

--- a/app/models/measure_condition_code.rb
+++ b/app/models/measure_condition_code.rb
@@ -16,11 +16,11 @@ class MeasureConditionCode < Sequel::Model
     "X": '>',
   }.freeze
 
+  set_primary_key [:condition_code]
+
   plugin :time_machine
   plugin :oplog, primary_key: :condition_code
   plugin :static_cache, frozen: false unless Rails.env.test?
-
-  set_primary_key [:condition_code]
 
   one_to_one :measure_condition_code_description, key: :condition_code,
                                                   primary_key: :condition_code

--- a/app/models/measure_condition_code_description.rb
+++ b/app/models/measure_condition_code_description.rb
@@ -1,6 +1,6 @@
 class MeasureConditionCodeDescription < Sequel::Model
+  set_primary_key [:condition_code]
+
   plugin :oplog, primary_key: :condition_code
   plugin :static_cache, frozen: false unless Rails.env.test?
-
-  set_primary_key [:condition_code]
 end

--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -55,11 +55,11 @@ class MeasureType < Sequel::Model
     2 => 'both',
   }.freeze
 
+  set_primary_key [:measure_type_id]
+
   plugin :time_machine
   plugin :oplog, primary_key: :measure_type_id
   plugin :static_cache, frozen: false unless Rails.env.test?
-
-  set_primary_key [:measure_type_id]
 
   one_to_one :measure_type_description, key: :measure_type_id,
                                         foreign_key: :measure_type_id

--- a/app/models/measure_type_series_description.rb
+++ b/app/models/measure_type_series_description.rb
@@ -1,6 +1,6 @@
 class MeasureTypeSeriesDescription < Sequel::Model
+  set_primary_key [:measure_type_series_id]
+
   plugin :oplog, primary_key: :measure_type_series_id
   plugin :static_cache, frozen: false unless Rails.env.test?
-
-  set_primary_key [:measure_type_series_id]
 end

--- a/app/models/measurement_unit.rb
+++ b/app/models/measurement_unit.rb
@@ -2,11 +2,11 @@ class MeasurementUnit < Sequel::Model
   STANDARD_MEASUREMENT_UNIT_CODE_LENGTH = 3
   MEASUREMENT_UNIT_OVERLAY_FILE = 'db/measurement_units.json'.freeze
 
+  set_primary_key [:measurement_unit_code]
+
   plugin :oplog, primary_key: :measurement_unit_code
   plugin :time_machine
   plugin :static_cache, frozen: false unless Rails.env.test?
-
-  set_primary_key [:measurement_unit_code]
 
   one_to_one :measurement_unit_description, primary_key: :measurement_unit_code,
                                             key: :measurement_unit_code

--- a/app/models/measurement_unit_description.rb
+++ b/app/models/measurement_unit_description.rb
@@ -1,6 +1,6 @@
 class MeasurementUnitDescription < Sequel::Model
+  set_primary_key [:measurement_unit_code]
+
   plugin :oplog, primary_key: :measurement_unit_code
   plugin :static_cache, frozen: false unless Rails.env.test?
-
-  set_primary_key [:measurement_unit_code]
 end

--- a/app/models/measurement_unit_qualifier.rb
+++ b/app/models/measurement_unit_qualifier.rb
@@ -1,9 +1,9 @@
 class MeasurementUnitQualifier < Sequel::Model
+  set_primary_key [:measurement_unit_qualifier_code]
+
   plugin :time_machine
   plugin :oplog, primary_key: :measurement_unit_qualifier_code
   plugin :static_cache, frozen: false unless Rails.env.test?
-
-  set_primary_key [:measurement_unit_qualifier_code]
 
   one_to_one :measurement_unit_qualifier_description, key: :measurement_unit_qualifier_code,
                                                       primary_key: :measurement_unit_qualifier_code

--- a/app/models/measurement_unit_qualifier_description.rb
+++ b/app/models/measurement_unit_qualifier_description.rb
@@ -1,10 +1,10 @@
 class MeasurementUnitQualifierDescription < Sequel::Model
   include Formatter
 
+  set_primary_key [:measurement_unit_qualifier_code]
+
   plugin :oplog, primary_key: :measurement_unit_qualifier_code
   plugin :static_cache, frozen: false unless Rails.env.test?
-
-  set_primary_key [:measurement_unit_qualifier_code]
 
   custom_format :formatted_measurement_unit_qualifier, with: DescriptionFormatter,
                                                        using: :description

--- a/app/models/monetary_unit.rb
+++ b/app/models/monetary_unit.rb
@@ -1,9 +1,9 @@
 class MonetaryUnit < Sequel::Model
+  set_primary_key [:monetary_unit_code]
+
   plugin :time_machine
   plugin :oplog, primary_key: :monetary_unit_code
   plugin :static_cache, frozen: false unless Rails.env.test?
-
-  set_primary_key [:monetary_unit_code]
 
   one_to_one :monetary_unit_description, key: :monetary_unit_code,
                                          primary_key: :monetary_unit_code


### PR DESCRIPTION
## What:
Move `set_primary_key` to be the first statement in 13 view-backed reference models so it runs before `plugin :static_cache` fires `load_cache`.

## Why:
All 13 affected models are backed by PostgreSQL VIEWs. Views have no `PRIMARY KEY` constraint, so Sequel's schema introspection (which runs during class definition, before the class body executes) calls `no_primary_key` — setting `Model.primary_key = nil`. The class bodies previously called `plugin :static_cache` before `set_primary_key`, meaning `load_cache` fired while `primary_key` was still nil. `load_cache` calls `o.pk` on every row, and `Model#pk` raises when `primary_key` is nil:

```
No primary key is associated with this model (Sequel::Error)
```

This is a production regression introduced by #3115. The fix is to call `set_primary_key` first so it overrides the nil before any plugin runs.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:** Pure ordering change within class bodies — no logic, no schema, no API changes. The correct primary key was always intended to be set; this just ensures it is set before `static_cache` reads it.