### PR TITLE
AI-558: Update generic intercept template copy

### DIFF
--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -42,7 +42,7 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
 
     ## Where can I find this information?
 
-    The information might be found on:
+    This information might be found on:
 
     - invoice or other billing documents
     - online listings

--- a/spec/lib/tasks/admin_configurations_rake_spec.rb
+++ b/spec/lib/tasks/admin_configurations_rake_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe 'admin_configurations:seed' do
     expect(config.value['generic']['attributes']).to include(
       'excluded' => true,
       'message_header' => "We can't suggest a tariff code yet",
+      'message' => include('This information might be found on:'),
       'guidance_level' => 'info',
       'guidance_location' => 'interstitial',
       'sources' => %w[guided_search fpo_search],


### PR DESCRIPTION
### Jira link

[AI-558](https://transformuk.atlassian.net/browse/AI-558)

### What?

- [x] Update the generic description intercept template wording to match the interstitial content.
- [x] Add seed coverage for the updated generic message copy.

### Why?

The generic intercept template is the seed used when a search term is too broad to suggest a tariff code. The seeded copy had one line that did not match the approved page content: "The information might be found on:" instead of "This information might be found on:".

### Risk

**Risk level:** Low

**Reason for rating:**
Seed copy only. Existing configured admin values are not migrated by this change, and runtime behaviour is unchanged apart from the default template text used when the seed/default is applied.