### PR TITLE
BAU: Fix Sequel reader routing defaults

### DIFF
--- a/app/middleware/use_reader_for_reads.rb
+++ b/app/middleware/use_reader_for_reads.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
-# Routes GET and HEAD requests to the Aurora reader instance.  All other HTTP
-# methods (POST, PUT, PATCH, DELETE) use the default (writer) connection pool.
+# Routes GET and HEAD requests to the Aurora reader instance. All other HTTP
+# methods (POST, PUT, PATCH, DELETE) use Sequel's default writer connection.
 #
 # Sequel's server_block extension (already loaded in application.rb) sets a
 # thread-local so every Sequel::Model.db[...] call within the block is
-# transparently routed to the :read_only server defined in database.yml.
+# transparently routed to the :reader server defined in database.yml.
 #
-# Sidekiq workers do not go through Rack middleware and therefore continue
-# using the writer, which is correct — they often read data immediately after
-# writing it.
+# The server is deliberately named :reader instead of :read_only. Sequel treats
+# :read_only as a reserved default for all SELECT queries in sharded mode. By not
+# defining a :read_only server, Sidekiq and non-GET web requests fall back to the
+# writer unless this middleware explicitly selects the reader.
 class UseReaderForReads
   READ_METHODS = %w[GET HEAD].freeze
 
@@ -19,7 +20,7 @@ class UseReaderForReads
 
   def call(env)
     if READ_METHODS.include?(env['REQUEST_METHOD'])
-      Sequel::Model.db.with_server(:read_only) { @app.call(env) }
+      Sequel::Model.db.with_server(:reader) { @app.call(env) }
     else
       @app.call(env)
     end

--- a/config/database.yml
+++ b/config/database.yml
@@ -24,6 +24,6 @@ production:
   # SIDEKIQ_CONCURRENCY without guessing process type here.
   pool: <%= Integer(ENV.fetch('DB_POOL', 6)) %>
   servers:
-    read_only:
+    reader:
       conn_str: <%= ENV.fetch('READER_DATABASE_URL', ENV['DATABASE_URL']) %>
       pool: <%= Integer(ENV.fetch('READER_DB_POOL', ENV.fetch('DB_POOL', 6))) %>

--- a/spec/config/database_yml_spec.rb
+++ b/spec/config/database_yml_spec.rb
@@ -25,11 +25,54 @@ RSpec.describe 'Database configuration' do
     )
   end
 
-  it 'passes the read-only connection string to Sequel as a conn_str' do
-    read_only_config = production_config.fetch('servers').fetch('read_only')
+  it 'passes the reader connection string to Sequel as a conn_str' do
+    reader_config = production_config.fetch('servers').fetch('reader')
 
-    expect(read_only_config).to include('conn_str' => reader_url)
-    expect(read_only_config).not_to have_key('url')
+    expect(reader_config).to include('conn_str' => reader_url)
+    expect(reader_config).not_to have_key('url')
+  end
+
+  it 'does not configure a read_only server that Sequel would use by default for selects' do
+    expect(production_config.fetch('servers')).not_to have_key('read_only')
+  end
+
+  it 'uses the writer for plain model reads unless reader routing is explicit' do
+    db = Sequel.connect(
+      Sequel::Model.db.opts.slice(
+        :adapter,
+        :host,
+        :port,
+        :database,
+        :user,
+        :password,
+        :search_path,
+      ).compact.merge(
+        connect_sqls: ["SET application_name = 'writer'"],
+        servers: {
+          reader: {
+            connect_sqls: ["SET application_name = 'reader'"],
+          },
+        },
+      ),
+    )
+    db.extension :server_block
+
+    expect(application_name_for(db)).to eq('writer')
+
+    db.with_server(:reader) do
+      expect(application_name_for(db)).to eq('reader')
+    end
+  ensure
+    if db
+      db.disconnect
+      Sequel::DATABASES.delete(db)
+    end
+  end
+
+  def application_name_for(db)
+    db.fetch("SELECT current_setting('application_name') AS application_name")
+      .first
+      .fetch(:application_name)
   end
 end
 # rubocop:enable RSpec/DescribeClass

--- a/spec/middleware/use_reader_for_reads_spec.rb
+++ b/spec/middleware/use_reader_for_reads_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe UseReaderForReads do
     context 'when the request method is GET' do
       let(:env) { Rack::MockRequest.env_for('/uk/api/commodities', method: 'GET') }
 
-      it 'routes through the read_only server' do
+      it 'routes through the reader server' do
         middleware.call(env)
-        expect(Sequel::Model.db).to have_received(:with_server).with(:read_only)
+        expect(Sequel::Model.db).to have_received(:with_server).with(:reader)
       end
 
       it 'calls the inner app' do
@@ -27,9 +27,9 @@ RSpec.describe UseReaderForReads do
     context 'when the request method is HEAD' do
       let(:env) { Rack::MockRequest.env_for('/uk/api/commodities', method: 'HEAD') }
 
-      it 'routes through the read_only server' do
+      it 'routes through the reader server' do
         middleware.call(env)
-        expect(Sequel::Model.db).to have_received(:with_server).with(:read_only)
+        expect(Sequel::Model.db).to have_received(:with_server).with(:reader)
       end
 
       it 'calls the inner app' do


### PR DESCRIPTION
### Jira link

BAU

```mermaid
flowchart LR
    A[Plain Sequel SELECT] --> B[Writer / default]
    C[GET or HEAD request] --> D[UseReaderForReads]
    D --> E[Reader server]
```

### What?

- [x] Rename the production replica server from `read_only` to `reader`
- [x] Route GET and HEAD requests explicitly through `:reader`
- [x] Add config coverage proving plain model reads use the writer unless reader routing is explicit
- [x] Keep CDS staging coverage in the focused validation set

### Why?

Sequel treats a server named `:read_only` as the default target for SELECT queries in sharded mode. That meant plain reads in Sidekiq and non-GET request flows could hit the Aurora reader without going through our Rack middleware.

That broke CDS staging because the importer creates UNLOGGED staging tables on the writer, then Sequel's column metadata SELECT was routed to the reader. Aurora rejects access to unlogged relations during recovery on the reader.

Renaming the replica server to `:reader` removes Sequel's implicit SELECT routing. Plain model reads now use the writer/default connection. GET and HEAD requests still opt into the reader explicitly via `UseReaderForReads`.

### Risk

**Risk level:** 🟠

**Reason for rating:**
This changes production database routing defaults. It fixes correctness for workers and write-path requests by keeping plain reads on the writer, while preserving explicit reader routing for GET and HEAD requests. Main operational risk is extra read load on the writer for non-GET web requests and Sidekiq jobs.