### PR TITLE
BAU: Keep user API read requests on writer

### DIFF
--- a/app/middleware/use_reader_for_reads.rb
+++ b/app/middleware/use_reader_for_reads.rb
@@ -14,15 +14,36 @@
 class UseReaderForReads
   READ_METHODS = %w[GET HEAD].freeze
 
+  # User API authentication can create PublicUsers::User records on first use,
+  # so these routes need the writer even for GET/HEAD requests.
+  WRITER_READ_PATH_PREFIXES = %w[
+    /uk/user
+    /xi/user
+  ].freeze
+
   def initialize(app)
     @app = app
   end
 
   def call(env)
-    if READ_METHODS.include?(env['REQUEST_METHOD'])
+    if read_request?(env) && !writer_read_request?(env)
       Sequel::Model.db.with_server(:reader) { @app.call(env) }
     else
       @app.call(env)
+    end
+  end
+
+private
+
+  def read_request?(env)
+    READ_METHODS.include?(env['REQUEST_METHOD'])
+  end
+
+  def writer_read_request?(env)
+    path = env['PATH_INFO'].to_s
+
+    WRITER_READ_PATH_PREFIXES.any? do |prefix|
+      path == prefix || path.start_with?("#{prefix}/")
     end
   end
 end

--- a/spec/middleware/use_reader_for_reads_spec.rb
+++ b/spec/middleware/use_reader_for_reads_spec.rb
@@ -38,6 +38,24 @@ RSpec.describe UseReaderForReads do
       end
     end
 
+    context 'when the GET request is under the user API' do
+      let(:env) { Rack::MockRequest.env_for('/uk/user/commodity_changes', method: 'GET') }
+
+      it 'does not route through the reader server' do
+        middleware.call(env)
+        expect(Sequel::Model.db).not_to have_received(:with_server)
+      end
+    end
+
+    context 'when the HEAD request is under the user API' do
+      let(:env) { Rack::MockRequest.env_for('/uk/user/users', method: 'HEAD') }
+
+      it 'does not route through the reader server' do
+        middleware.call(env)
+        expect(Sequel::Model.db).not_to have_received(:with_server)
+      end
+    end
+
     context 'when the request method is POST' do
       let(:env) { Rack::MockRequest.env_for('/uk/api/something', method: 'POST') }
 


### PR DESCRIPTION
### Jira link

[HMRC-2230](https://transformuk.atlassian.net/browse/HMRC-2230)

### What?

- [x] Keep GET/HEAD requests under `/uk/user` on the default writer connection
- [x] Add the same guard for `/xi/user` if that mount point is introduced later
- [x] Cover the middleware behaviour for user API GET and HEAD requests

### Why?

`PublicUserAuthenticatable#authenticate!` calls `Api::User::UserService.find_or_create` for authenticated user API requests. That means a user API GET can still perform an insert when a public user is first seen. Wrapping those requests in `with_server(:reader)` can route that insert to the Aurora reader and fail with the same read-only recovery error.

The broader reader pool still applies to ordinary GET/HEAD API requests, but mounted user API requests now stay on the writer because authentication is not read-only.

### Risk

**Risk level:** Orange

**Reason for rating:**
This changes production request routing. The blast radius is constrained to the mounted user API, and the failure mode is conservative: user API GET/HEAD requests use the writer rather than the reader.