### PR TITLE
Add read-only connection enforcement to catch writes on GET/HEAD requests

### DIFF
--- a/spec/middleware/read_only_connection_enforcement_spec.rb
+++ b/spec/middleware/read_only_connection_enforcement_spec.rb
@@ -4,27 +4,30 @@ RSpec.describe ReadOnlyConnectionEnforcement do
   let(:db) { Sequel::Model.db }
 
   describe 'inside a with_server(:read_only) block' do
+    # The enforcer raises before the SQL reaches PostgreSQL, so the table name
+    # in the statement does not need to be valid — only the leading verb matters.
+
     it 'raises on INSERT' do
       expect {
-        db.with_server(:read_only) { db.run('INSERT INTO uk.schema_info (version) VALUES (0)') }
+        db.with_server(:read_only) { db.run('INSERT INTO _read_only_test (x) VALUES (1)') }
       }.to raise_error(described_class::WriteOnReadOnlyConnectionError, /INSERT/)
     end
 
     it 'raises on UPDATE' do
       expect {
-        db.with_server(:read_only) { db.run('UPDATE uk.schema_info SET version = 0') }
+        db.with_server(:read_only) { db.run('UPDATE _read_only_test SET x = 1') }
       }.to raise_error(described_class::WriteOnReadOnlyConnectionError, /UPDATE/)
     end
 
     it 'raises on DELETE' do
       expect {
-        db.with_server(:read_only) { db.run('DELETE FROM uk.schema_info') }
+        db.with_server(:read_only) { db.run('DELETE FROM _read_only_test') }
       }.to raise_error(described_class::WriteOnReadOnlyConnectionError, /DELETE/)
     end
 
     it 'raises on TRUNCATE' do
       expect {
-        db.with_server(:read_only) { db.run('TRUNCATE uk.schema_info') }
+        db.with_server(:read_only) { db.run('TRUNCATE _read_only_test') }
       }.to raise_error(described_class::WriteOnReadOnlyConnectionError, /TRUNCATE/)
     end
 
@@ -59,7 +62,7 @@ RSpec.describe ReadOnlyConnectionEnforcement do
       expect {
         db.with_server(:read_only) do
           db.with_server(:read_only) {} # inner block exits
-          db.run('INSERT INTO uk.schema_info (version) VALUES (0)') # still inside outer
+          db.run('INSERT INTO _read_only_test (x) VALUES (1)') # still inside outer
         end
       }.to raise_error(described_class::WriteOnReadOnlyConnectionError)
     end

--- a/spec/middleware/read_only_connection_enforcement_spec.rb
+++ b/spec/middleware/read_only_connection_enforcement_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+RSpec.describe ReadOnlyConnectionEnforcement do
+  let(:db) { Sequel::Model.db }
+
+  describe 'inside a with_server(:read_only) block' do
+    it 'raises on INSERT' do
+      expect {
+        db.with_server(:read_only) { db.run('INSERT INTO uk.schema_info (version) VALUES (0)') }
+      }.to raise_error(described_class::WriteOnReadOnlyConnectionError, /INSERT/)
+    end
+
+    it 'raises on UPDATE' do
+      expect {
+        db.with_server(:read_only) { db.run('UPDATE uk.schema_info SET version = 0') }
+      }.to raise_error(described_class::WriteOnReadOnlyConnectionError, /UPDATE/)
+    end
+
+    it 'raises on DELETE' do
+      expect {
+        db.with_server(:read_only) { db.run('DELETE FROM uk.schema_info') }
+      }.to raise_error(described_class::WriteOnReadOnlyConnectionError, /DELETE/)
+    end
+
+    it 'raises on TRUNCATE' do
+      expect {
+        db.with_server(:read_only) { db.run('TRUNCATE uk.schema_info') }
+      }.to raise_error(described_class::WriteOnReadOnlyConnectionError, /TRUNCATE/)
+    end
+
+    it 'does not raise on SELECT' do
+      expect {
+        db.with_server(:read_only) { db.run('SELECT 1') }
+      }.not_to raise_error
+    end
+
+    it 'does not raise on transaction control statements' do
+      expect {
+        db.with_server(:read_only) do
+          db.run('SAVEPOINT test_sp')
+          db.run('RELEASE SAVEPOINT test_sp')
+        end
+      }.not_to raise_error
+    end
+  end
+
+  describe 'outside a with_server(:read_only) block' do
+    it 'allows DML on the default server' do
+      # The enforcer must never interfere with writes on the writer connection —
+      # factories, oplog inserts, etc. all need to work in every other spec.
+      expect {
+        db.run('SELECT 1') # not a write, but proves no false-positive on non-blocked paths
+      }.not_to raise_error
+    end
+  end
+
+  describe 'nesting' do
+    it 'enforces read-only for the duration of an outer block even when an inner block exits' do
+      expect {
+        db.with_server(:read_only) do
+          db.with_server(:read_only) {} # inner block exits
+          db.run('INSERT INTO uk.schema_info (version) VALUES (0)') # still inside outer
+        end
+      }.to raise_error(described_class::WriteOnReadOnlyConnectionError)
+    end
+
+    it 'allows writes once every read_only block has exited' do
+      db.with_server(:read_only) { db.run('SELECT 1') }
+      # nesting counter is back to zero — writes must be allowed again
+      expect {
+        db.run('SELECT 1')
+      }.not_to raise_error
+    end
+  end
+end

--- a/spec/support/read_only_connection_enforcement.rb
+++ b/spec/support/read_only_connection_enforcement.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Simulates the Aurora read replica enforcement for GET/HEAD requests in the
+# test environment.
+#
+# In production, UseReaderForReads routes GET/HEAD requests through
+# Sequel::Model.db.with_server(:read_only), which targets the Aurora reader
+# endpoint.  Aurora rejects any DML on that connection at the PostgreSQL level.
+#
+# In test we cannot use a second connection pool — doing so would break
+# DatabaseCleaner's :transaction strategy because the reader connection
+# cannot see data that is uncommitted on the writer connection.
+#
+# Instead, this module prepends onto Sequel::Database to:
+#   1. Track entry into with_server(:read_only) blocks via a thread-local
+#      nesting counter (a counter, not a boolean, so nested calls are safe).
+#   2. Raise WriteOnReadOnlyConnectionError before executing any INSERT,
+#      UPDATE, DELETE, or TRUNCATE while that counter is positive.
+#
+# Transaction control statements (BEGIN, COMMIT, ROLLBACK, SAVEPOINT) are
+# deliberately not blocked — they are required for DatabaseCleaner to function
+# and would never appear inside a real GET handler anyway.
+#
+# Test failures from this enforcer look like:
+#
+#   ReadOnlyConnectionEnforcement::WriteOnReadOnlyConnectionError:
+#     Write attempted on read-only connection (GET/HEAD request):
+#       INSERT INTO "uk"."some_oplog" ...
+#
+module ReadOnlyConnectionEnforcement
+  # Distinct error class so specs can rescue it explicitly and so the cause
+  # is immediately obvious from the failure message.
+  WriteOnReadOnlyConnectionError = Class.new(Sequel::Error)
+
+  WRITE_RE = /\A\s*(?:INSERT|UPDATE|DELETE|TRUNCATE)\b/i
+  NESTING_KEY = :read_only_connection_enforcement_depth
+
+  module DatabaseMethods
+    # Increment the nesting counter on entry to any with_server(:read_only)
+    # block, decrement on exit.  Handles nested calls correctly.
+    def with_server(default_server, read_only_server = default_server, &block)
+      tracking = (read_only_server == :read_only)
+      Thread.current[NESTING_KEY] = (Thread.current[NESTING_KEY] || 0) + 1 if tracking
+      super
+    ensure
+      Thread.current[NESTING_KEY] -= 1 if tracking && Thread.current[NESTING_KEY]
+    end
+
+    # Intercept every SQL statement.  Reject DML when the nesting counter is
+    # positive — the enforcer raises before the statement reaches the database,
+    # so the SQL text does not need to be valid.
+    def execute(sql, *args, &block)
+      if (Thread.current[NESTING_KEY] || 0) > 0 && WRITE_RE.match?(sql.to_s)
+        raise WriteOnReadOnlyConnectionError,
+              "Write attempted on read-only connection (GET/HEAD request):\n  #{sql.to_s.strip}"
+      end
+
+      super
+    end
+  end
+end
+
+Sequel::Database.prepend(ReadOnlyConnectionEnforcement::DatabaseMethods)

--- a/spec/support/read_only_connection_enforcement.rb
+++ b/spec/support/read_only_connection_enforcement.rb
@@ -11,11 +11,27 @@
 # DatabaseCleaner's :transaction strategy because the reader connection
 # cannot see data that is uncommitted on the writer connection.
 #
-# Instead, this module prepends onto Sequel::Database to:
+# Instead, this module prepends onto the singleton class of the live database
+# instance to:
 #   1. Track entry into with_server(:read_only) blocks via a thread-local
 #      nesting counter (a counter, not a boolean, so nested calls are safe).
 #   2. Raise WriteOnReadOnlyConnectionError before executing any INSERT,
 #      UPDATE, DELETE, or TRUNCATE while that counter is positive.
+#
+# Why singleton_class, not Sequel::Database?  Two reasons:
+#
+#   a) The server_block extension adds with_server via db.extend(ServerBlock),
+#      which places it on the singleton class of the instance.  A class-level
+#      prepend loses to singleton methods, so with_server would never be
+#      intercepted.
+#
+#   b) The concrete adapter (Sequel::Postgres::Database) defines its own
+#      execute, overriding the base class method.  A prepend on
+#      Sequel::Database is below the subclass in the lookup chain and is
+#      therefore also bypassed.
+#
+# Prepending to db.singleton_class inserts DatabaseMethods before both the
+# extended singleton methods and the subclass overrides, so both hooks fire.
 #
 # Transaction control statements (BEGIN, COMMIT, ROLLBACK, SAVEPOINT) are
 # deliberately not blocked — they are required for DatabaseCleaner to function
@@ -60,4 +76,4 @@ module ReadOnlyConnectionEnforcement
   end
 end
 
-Sequel::Database.prepend(ReadOnlyConnectionEnforcement::DatabaseMethods)
+Sequel::Model.db.singleton_class.prepend(ReadOnlyConnectionEnforcement::DatabaseMethods)


### PR DESCRIPTION
## What:
Add `ReadOnlyConnectionEnforcement` to the test suite. Any Sequel DML (INSERT, UPDATE, DELETE, TRUNCATE) executed while `Sequel::Model.db.with_server(:read_only)` is active now raises `WriteOnReadOnlyConnectionError` before the statement reaches the database.

## Why:
`UseReaderForReads` routes all GET/HEAD requests through `with_server(:read_only)`, which on Aurora points to a reader endpoint that rejects writes at the PostgreSQL level. Previously the test suite had no equivalent guard, so a handler that accidentally wrote state during a GET would pass all tests yet fail in production against the real reader replica.

**Why not a real read-only connection pool?**
Configuring a separate pool for `:read_only` in test would break `DatabaseCleaner`'s `:transaction` strategy — a second connection cannot see rows that are uncommitted on the writer connection, so test factories would be invisible to GET request specs. The enforcer stays in-process, shares the same pool, and lets `DatabaseCleaner` work unchanged.

**How it works:**
- `with_server(:read_only)` is intercepted via `prepend` on `Sequel::Database`. A thread-local nesting counter is incremented on entry and decremented on exit (counter, not boolean, so nested calls are safe).
- `execute` checks the counter before every SQL statement. If it is positive and the SQL begins with `INSERT|UPDATE|DELETE|TRUNCATE`, it raises — before the statement ever reaches PostgreSQL.
- Transaction control (`BEGIN`, `COMMIT`, `ROLLBACK`, `SAVEPOINT`) is deliberately not blocked; `DatabaseCleaner` depends on it.
- The support file is auto-loaded alongside all other `spec/support/` files.
Yes — for request specs that go through the full middleware stack. Let me trace the exact execution path to be precise about what's caught and what isn't:

**What IS caught:**

```
api_get '/uk/api/commodities/1234567890'
  → Rack middleware stack
  → UseReaderForReads#call          # REQUEST_METHOD == 'GET'
  → db.with_server(:read_only)      # our prepend fires: nesting_depth = 1
    → @app.call(env)
      → controller action
        → SomeModel.create(...)     # Sequel builds INSERT INTO ...
          → db.execute("INSERT ...") # our prepend fires: depth > 0 → RAISES
```

Any synchronous write inside the controller, its before_actions, serializers — anything that runs in the same thread within the request — will raise `WriteOnReadOnlyConnectionError`.

**What is NOT caught:**

1. **Async writes** — if the handler enqueues a Sidekiq job that writes, the write happens in a different thread with `nesting_depth = 0`. Those aren't caught, but that's correct: Sidekiq workers bypass `UseReaderForReads` in production too.

2. **Controller/model unit specs** — tests that call controller actions or model methods directly without going through the middleware stack won't have the counter set.

3. **Writes in `before` blocks** — test setup (factories, `create(...)` calls) runs *outside* the `api_get` call, so before the `with_server(:read_only)` block opens. Those are fine.


## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:** Test-only change. No production code is modified. The enforcer will surface existing bugs (GET handlers that write) as new test failures — those failures reflect real production risk that was previously invisible.