### PR TITLE
BAU: Add description intercept delete endpoint

### DIFF
--- a/app/controllers/api/admin/description_intercepts_controller.rb
+++ b/app/controllers/api/admin/description_intercepts_controller.rb
@@ -31,6 +31,12 @@ module Api
         end
       end
 
+      def destroy
+        description_intercept.destroy
+
+        head :no_content
+      end
+
       def bulk_import
         result = DescriptionIntercepts::TemplateImporter.new(csv_content: bulk_import_params[:csv]).call
 

--- a/app/engines/admin_api.rb
+++ b/app/engines/admin_api.rb
@@ -94,7 +94,7 @@ AdminApi.routes.draw do
 
         resources :live_issues, only: %i[index show create update destroy]
         resources :admin_configurations, only: %i[index show update]
-        resources :description_intercepts, only: %i[index show create update] do
+        resources :description_intercepts, only: %i[index show create update destroy] do
           collection do
             post :bulk_import
           end

--- a/spec/requests/api/admin/description_intercepts_controller_spec.rb
+++ b/spec/requests/api/admin/description_intercepts_controller_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Api::Admin::DescriptionInterceptsController, :admin, type: :request do
+  describe 'DELETE #destroy' do
+    let!(:intercept) { create(:description_intercept, term: 'footwear') }
+
+    it 'deletes the description intercept' do
+      expect {
+        authenticated_delete api_admin_description_intercept_path(intercept.id, format: :json)
+      }.to change(DescriptionIntercept, :count).by(-1)
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it 'returns 404 when not found' do
+      authenticated_delete api_admin_description_intercept_path(999_999, format: :json)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
## What:
- [x] Add admin API support for deleting description intercepts
- [x] Add request coverage for successful deletion and missing records

## Why:
Admins need to be able to remove description intercepts that are no longer required.

## Ticket:
BAU

## Risk:
**Risk level:** 🟠

**Reason for rating:**
Adds a destructive admin API action. The scope is limited to authenticated admin description intercept management and is covered by request specs.