### PR TITLE
BAU: Update agent instructions for request specs and Data classes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,7 +15,11 @@ Guidance:
 
 - Keep suggestions narrowly scoped to the requested change.
 - Prefer existing service, query, presenter, and serializer patterns.
+- Write controller coverage as request specs under `spec/requests/`. Do not add new files under `spec/controllers/`; when touching legacy controller specs, migrate the coverage into request specs and remove the controller spec.
+- Request specs must use concrete paths or route helpers, not controller-style action symbols such as `get :show`.
 - For public V2 endpoint changes, include swagger spec changes under `spec/swagger/api/v2/`.
+- Treat swagger specs as API documentation coverage, not a replacement for request specs.
 - Do not suggest manual edits to generated `swagger/v2/swagger.json`.
+- Use Ruby data classes such as `Data.define` for simple value objects. Do not introduce `Struct`.
 - Treat tariff measures, quota logic, duty calculation, upstream sync, auth, and production operations as high-risk.
 - Verify Code Wiki or other generated documentation against source files before relying on it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,9 @@ The application is a Rails API using Sequel, PostgreSQL, Redis, Sidekiq, and Ope
 
 - Keep scope tight and prefer simple changes.
 - Verify generated or AI-suggested claims against source code and tests.
+- Write controller coverage as request specs under `spec/requests/`. Do not add new files under `spec/controllers/`; when touching legacy controller specs, migrate the coverage into request specs and remove the controller spec.
+- Request specs must use concrete paths or route helpers, not controller-style action symbols such as `get :show`.
+- Use Ruby data classes such as `Data.define` for simple value objects. Do not introduce `Struct`.
 - For public V2 API changes, update swagger specs under `spec/swagger/api/v2/`.
 - Do not manually edit generated `swagger/v2/swagger.json` for endpoint changes.
 - Run project commands directly by default. If you use Nix/direnv locally, `direnv exec <repo-path> <command>` is also fine.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@ Before changing code:
 
 - Identify the route, controller, service/query/model, serializer, and tests involved.
 - Verify generated explanations against source files.
+- Write controller coverage as request specs under `spec/requests/`. Do not add new files under `spec/controllers/`; when touching legacy controller specs, migrate the coverage into request specs and remove the controller spec.
+- Request specs must use concrete paths or route helpers, not controller-style action symbols such as `get :show`.
+- Treat swagger specs under `spec/swagger/api/v2/` as API documentation coverage, not a replacement for request specs.
+- Use Ruby data classes such as `Data.define` for simple value objects. Do not introduce `Struct`.
 - Read the relevant architecture or domain doc before editing tariff data, search, sync, caching, Green Lanes, rules of origin, exchange rates, or API documentation.
 - Run project commands directly by default. If you use Nix/direnv locally, `direnv exec <repo-path> <command>` is also fine.
 - Use `rg` for code search.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,6 +8,10 @@ Before changing code:
 
 - Identify the route, controller, service/query/model, serializer, and tests involved.
 - Verify generated explanations against source files.
+- Write controller coverage as request specs under `spec/requests/`. Do not add new files under `spec/controllers/`; when touching legacy controller specs, migrate the coverage into request specs and remove the controller spec.
+- Request specs must use concrete paths or route helpers, not controller-style action symbols such as `get :show`.
+- Treat swagger specs under `spec/swagger/api/v2/` as API documentation coverage, not a replacement for request specs.
+- Use Ruby data classes such as `Data.define` for simple value objects. Do not introduce `Struct`.
 - Read the relevant architecture or domain doc before editing tariff data, search, sync, caching, Green Lanes, rules of origin, exchange rates, or API documentation.
 - Run project commands directly by default. If you use Nix/direnv locally, `direnv exec <repo-path> <command>` is also fine.
 


### PR DESCRIPTION
### What?

- [x] Add guidance to prefer request specs under `spec/requests/` (and remove legacy controller specs)
- [x] Require concrete paths or route helpers in request specs (not `get :show` style)
- [x] Standardise on `Data.define` for value objects instead of `Struct`

Files:
- `AGENTS.md`
- `CLAUDE.md`
- `GEMINI.md`
- `.github/copilot-instructions.md`

### Why?

These rules codify the outcomes of the recent controller-specs-to-request-specs migration and the Struct → Data.define refactor. They prevent future agents from creating new controller specs or using mutable `Struct` for simple data carriers.

Extracted from #3158 so the migration PR can remain strictly test-only.

### Risk

**Risk level:** 🟢 Green

**Reason for rating:** Documentation-only change to agent instruction files. No code, test, or runtime behaviour impact.

### Have you?

- [x] Rebased on latest main from dedicated worktree
- [x] Aligned with the Risk section requirements in the PR template