### PR TITLE
Fix test when running on Monday

### DIFF
--- a/spec/workers/differences_report_check_worker_spec.rb
+++ b/spec/workers/differences_report_check_worker_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe DifferencesReportCheckWorker, type: :worker do
       let(:uk) { true }
 
       it 'is happy if the differences report has run this week' do
-        DifferencesLog.create(date: Time.zone.yesterday, key: 'foo', value: 'foo')
+        DifferencesLog.create(date: Date.current.beginning_of_week, key: 'foo', value: 'foo')
         worker.perform
         expect(SlackNotifierService).not_to have_received(:call)
       end


### PR DESCRIPTION
## What:
Update test so that the created log is from the current week. 
Using yesterday was causing the test to fail on a Monday because Sunday is in the previous week.

## Why:
Makes test work on all days of the week

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Fixes a test
