### PR TITLE
BAU: Set tariff DB connection limit to 790

### DIFF
--- a/db/data_migrations/20260518121405_update_tariff_connection_limit.rb
+++ b/db/data_migrations/20260518121405_update_tariff_connection_limit.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  up do
+    run "ALTER ROLE tariff CONNECTION LIMIT 790;"
+  end
+
+  down do
+     # Intentionally left blank — connection limit should not be removed
+  end
+end


### PR DESCRIPTION
## What:
Updates the `tariff` Postgres role connection limit from 450 → 790, and removes the down rollback to -1 since this limit should be permanent.

## Why:
The previous limit of 450 was undercalculated. Based on current ECS capacity: (24 threads × 16 tasks) × 2 services + (2 workers × 10 threads) + 1 job process = 789. Also fixes the down block, which would have silently removed the cap on rollback.

## Ticket:
'N/A'

## Risk:
Risk level: 🟢

**Reason for rating:**
 Operational Postgres role config change only — no schema, data, or application code affected. Raises the cap rather than lowering it, so no risk of rejecting legitimate connections. Easily corrected with a follow-up migration if the calculation is wrong.