### PR TITLE
AI-815: Expand internal search queries before retrieval

### DIFF
--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -94,7 +94,7 @@ module Api
 
       def vector_short_list
         goods_nomenclatures = VectorRetrievalService.call(
-          query: q,
+          query: normalised_query.expanded_query,
           limit: opensearch_result_limit,
           filter_prefixes: filter_prefixes,
         )
@@ -102,14 +102,15 @@ module Api
         RetrievalResult.new(
           goods_nomenclatures: goods_nomenclatures,
           max_score: goods_nomenclatures.map(&:score).compact.max,
-          expanded_query: nil,
+          expanded_query: normalised_query.expanded_query,
           results_type: 'vector',
         )
       end
 
       def opensearch_short_list
         result = OpensearchRetrievalService.call(
-          query: q, as_of: as_of, request_id: request_id, limit: opensearch_result_limit,
+          query: q, expanded_query: normalised_query.expanded_query,
+          as_of: as_of, request_id: request_id, limit: opensearch_result_limit,
           filter_prefixes: filter_prefixes
         )
 
@@ -123,7 +124,8 @@ module Api
 
       def hybrid_short_list
         result = HybridRetrievalService.call(
-          query: q, as_of: as_of, request_id: request_id, limit: opensearch_result_limit,
+          query: q, expanded_query: normalised_query.expanded_query,
+          as_of: as_of, request_id: request_id, limit: opensearch_result_limit,
           filter_prefixes: filter_prefixes
         )
 
@@ -137,6 +139,10 @@ module Api
 
       def opensearch_result_limit
         AdminConfiguration.integer_value('opensearch_result_limit')
+      end
+
+      def normalised_query
+        @normalised_query ||= InternalSearchQueryNormaliserService.call(query: q, request_id: request_id)
       end
 
       def allowed_suggestion_types

--- a/app/services/hybrid_retrieval_service.rb
+++ b/app/services/hybrid_retrieval_service.rb
@@ -1,12 +1,13 @@
 class HybridRetrievalService
   Result = Data.define(:results, :expanded_query)
 
-  def self.call(query:, as_of:, request_id: nil, limit: 30, filter_prefixes: [])
-    new(query:, as_of:, request_id:, limit:, filter_prefixes:).call
+  def self.call(query:, as_of:, expanded_query: nil, request_id: nil, limit: 30, filter_prefixes: [])
+    new(query:, as_of:, expanded_query:, request_id:, limit:, filter_prefixes:).call
   end
 
-  def initialize(query:, as_of:, request_id: nil, limit: 30, filter_prefixes: [])
+  def initialize(query:, as_of:, expanded_query: nil, request_id: nil, limit: 30, filter_prefixes: [])
     @query = query
+    @expanded_query = expanded_query.presence || query
     @as_of = as_of
     @request_id = request_id
     @limit = limit
@@ -18,11 +19,10 @@ class HybridRetrievalService
 
     opensearch_items = opensearch_result&.results || []
     vector_items = vector_results || []
-    expanded_query = opensearch_result&.expanded_query
 
     merged = rrf_merge(opensearch_items, vector_items)
 
-    Result.new(results: merged, expanded_query: expanded_query)
+    Result.new(results: merged, expanded_query: @expanded_query)
   end
 
   private
@@ -67,13 +67,19 @@ class HybridRetrievalService
   end
 
   def opensearch_args
-    args = { query: @query, as_of: @as_of, request_id: @request_id, limit: @limit }
+    args = {
+      query: @query,
+      expanded_query: @expanded_query,
+      as_of: @as_of,
+      request_id: @request_id,
+      limit: @limit,
+    }
     args[:filter_prefixes] = @filter_prefixes if @filter_prefixes.present?
     args
   end
 
   def vector_args
-    args = { query: @query, limit: @limit }
+    args = { query: @expanded_query, limit: @limit }
     args[:filter_prefixes] = @filter_prefixes if @filter_prefixes.present?
     args
   end

--- a/app/services/internal_search_query_normaliser_service.rb
+++ b/app/services/internal_search_query_normaliser_service.rb
@@ -1,0 +1,31 @@
+class InternalSearchQueryNormaliserService
+  Result = Data.define(:query, :expanded_query)
+
+  def self.call(query:, request_id: nil)
+    new(query:, request_id:).call
+  end
+
+  def initialize(query:, request_id: nil)
+    @query = query.to_s
+    @request_id = request_id
+  end
+
+  def call
+    Result.new(query: query, expanded_query: expanded_query)
+  end
+
+  private
+
+  attr_reader :query, :request_id
+
+  def expanded_query
+    return query unless AdminConfiguration.enabled?('expand_search_enabled')
+
+    result = Search::Instrumentation.query_expanded(
+      request_id: request_id,
+      original_query: query,
+    ) { ExpandSearchQueryService.call(query) }
+
+    result.expanded_query
+  end
+end

--- a/app/services/opensearch_retrieval_service.rb
+++ b/app/services/opensearch_retrieval_service.rb
@@ -1,22 +1,22 @@
 class OpensearchRetrievalService
   Result = Data.define(:results, :expanded_query)
 
-  def self.call(query:, as_of:, request_id: nil, limit: 30, filter_prefixes: [])
-    new(query:, as_of:, request_id:, limit:, filter_prefixes:).call
+  def self.call(query:, as_of:, expanded_query: nil, request_id: nil, limit: 30, filter_prefixes: [])
+    new(query:, as_of:, expanded_query:, request_id:, limit:, filter_prefixes:).call
   end
 
-  def initialize(query:, as_of:, request_id: nil, limit: 30, filter_prefixes: [])
+  def initialize(query:, as_of:, expanded_query: nil, request_id: nil, limit: 30, filter_prefixes: [])
     @query = query
     @as_of = as_of
+    @expanded_query = expanded_query.presence || query
     @request_id = request_id
     @limit = limit
     @filter_prefixes = Array(filter_prefixes).compact_blank
   end
 
   def call
-    expanded = expand_query(@query)
-    hits = run_search(expanded)
-    Result.new(results: hits.map { |h| build_result_from_hit(h) }, expanded_query: expanded)
+    hits = run_search(@expanded_query)
+    Result.new(results: hits.map { |h| build_result_from_hit(h) }, expanded_query: @expanded_query)
   end
 
   private
@@ -38,21 +38,6 @@ class OpensearchRetrievalService
     end
 
     results.dig('hits', 'hits') || []
-  end
-
-  def expand_query(query)
-    return query unless expand_search_enabled?
-
-    result = ::Search::Instrumentation.query_expanded(
-      request_id: @request_id,
-      original_query: query,
-    ) { ExpandSearchQueryService.call(query) }
-
-    result.expanded_query
-  end
-
-  def expand_search_enabled?
-    AdminConfiguration.enabled?('expand_search_enabled')
   end
 
   def pos_search_enabled?

--- a/lib/tasks/admin_configurations.rake
+++ b/lib/tasks/admin_configurations.rake
@@ -333,9 +333,11 @@ module AdminConfigurationSeeder
     <<~MARKDOWN.strip
       You are an expert in trade tariff classification and search queries.
 
-      Your task is to rephrase and expand a given search query to improve its effectiveness when searching an OpenSearch index for trade commodities. The goal is to generate a query that is more likely to match relevant documents, especially considering that the original query might not use the exact terminology found in the tariff data.
+      Your task is to rephrase and expand a given search query so it matches trade commodities more effectively.
+      The goal is to generate a query likely to match relevant tariff data, especially when the original query does not
+      use official terminology found in commodity descriptions and supporting classification text.
 
-      Provide only the rephrased and expanded search query as plain text, without any additional formatting or explanation.
+      Provide only the rephrased and expanded search query as plain text, without extra formatting or explanation.
 
       **Original search query:** %{search_query}
 
@@ -454,12 +456,14 @@ namespace :admin_configurations do
       {
         name: 'retrieval_method',
         config_type: 'options',
-        description: 'Search retrieval method: opensearch uses traditional text search with query expansion, vector uses pgvector cosine similarity and skips query expansion, hybrid runs both and fuses with RRF',
+        description: 'Search retrieval method: opensearch uses traditional text search, ' \
+          'vector uses pgvector cosine similarity, and hybrid runs both and fuses with RRF. ' \
+          'Query expansion runs before the selected retrieval method.',
         value: { 'selected' => AdminConfiguration.default_for('retrieval_method'),
                  'options' => [
-                   { 'key' => 'opensearch', 'label' => 'OpenSearch (text search + query expansion)' },
+                   { 'key' => 'opensearch', 'label' => 'OpenSearch (text search)' },
                    { 'key' => 'vector', 'label' => 'pgvector (cosine similarity)' },
-                   { 'key' => 'hybrid', 'label' => 'Hybrid (opensearch + vector with RRF fusion)' },
+                   { 'key' => 'hybrid', 'label' => 'Hybrid (text + vector with RRF fusion)' },
                  ] },
       },
       {
@@ -651,7 +655,7 @@ namespace :admin_configurations do
     if retrieval
       options = retrieval.value['options'] || []
       unless options.any? { |o| o['key'] == 'hybrid' }
-        options << { 'key' => 'hybrid', 'label' => 'Hybrid (opensearch + vector with RRF fusion)' }
+        options << { 'key' => 'hybrid', 'label' => 'Hybrid (text + vector with RRF fusion)' }
         retrieval.update(value: Sequel.pg_jsonb_wrap(retrieval.value.to_hash.merge('options' => options)))
         puts '  patched: retrieval_method (added hybrid option)'
         created += 1

--- a/spec/lib/tasks/admin_configurations_rake_spec.rb
+++ b/spec/lib/tasks/admin_configurations_rake_spec.rb
@@ -125,6 +125,7 @@ RSpec.describe 'admin_configurations:seed' do
     expect(expand_query.config_type).to eq('markdown')
     expect(expand_query.value).to include('## Output format')
     expect(expand_query.value).to include('## Example')
+    expect(expand_query.value).not_to include('OpenSearch')
 
     other_self_text_context = AdminConfiguration.where(name: 'other_self_text_context').first
     expect(other_self_text_context.config_type).to eq('markdown')

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -901,20 +901,27 @@ RSpec.describe Api::Internal::SearchService do
       before do
         allow(AdminConfiguration).to receive(:option_value).and_call_original
         allow(AdminConfiguration).to receive(:option_value).with('retrieval_method').and_return('vector')
+        allow(AdminConfiguration).to receive(:enabled?).and_call_original
+        allow(AdminConfiguration).to receive(:enabled?).with('expand_search_enabled').and_return(true)
+        allow(ExpandSearchQueryService).to receive(:call)
+          .and_return(ExpandSearchQueryService::Result.new(
+                        expanded_query: 'pure-bred breeding horses',
+                        reason: 'horses is broader than tariff terminology',
+                      ))
         allow(VectorRetrievalService).to receive(:call).and_return(vector_results)
       end
 
-      it 'skips query expansion' do
+      it 'expands the query before vector retrieval' do
         described_class.new(q: 'horses').call
 
-        expect(ExpandSearchQueryService).not_to have_received(:call)
+        expect(ExpandSearchQueryService).to have_received(:call).with('horses')
       end
 
-      it 'calls VectorRetrievalService with query' do
+      it 'calls VectorRetrievalService with the expanded query' do
         described_class.new(q: 'horses').call
 
         expect(VectorRetrievalService).to have_received(:call).with(
-          hash_including(query: 'horses'),
+          hash_including(query: 'pure-bred breeding horses'),
         )
       end
 
@@ -982,14 +989,21 @@ RSpec.describe Api::Internal::SearchService do
       before do
         allow(AdminConfiguration).to receive(:option_value).and_call_original
         allow(AdminConfiguration).to receive(:option_value).with('retrieval_method').and_return('hybrid')
+        allow(AdminConfiguration).to receive(:enabled?).and_call_original
+        allow(AdminConfiguration).to receive(:enabled?).with('expand_search_enabled').and_return(true)
+        allow(ExpandSearchQueryService).to receive(:call)
+          .and_return(ExpandSearchQueryService::Result.new(
+                        expanded_query: 'pure-bred breeding horses',
+                        reason: 'horses is broader than tariff terminology',
+                      ))
         allow(HybridRetrievalService).to receive(:call).and_return(hybrid_result)
       end
 
-      it 'calls HybridRetrievalService' do
+      it 'calls HybridRetrievalService with the original and expanded query' do
         described_class.new(q: 'horses').call
 
         expect(HybridRetrievalService).to have_received(:call).with(
-          hash_including(query: 'horses'),
+          hash_including(query: 'horses', expanded_query: 'pure-bred breeding horses'),
         )
       end
 

--- a/spec/services/hybrid_retrieval_service_spec.rb
+++ b/spec/services/hybrid_retrieval_service_spec.rb
@@ -34,10 +34,12 @@ RSpec.describe HybridRetrievalService do
     ]
   end
 
+  let(:expanded_query) { 'expanded horses' }
+
   let(:opensearch_result) do
     OpensearchRetrievalService::Result.new(
       results: opensearch_results,
-      expanded_query: 'expanded horses',
+      expanded_query: expanded_query,
     )
   end
 
@@ -54,25 +56,26 @@ RSpec.describe HybridRetrievalService do
       as_of = Time.zone.today
       allow(TimeMachine).to receive(:at).with(as_of).and_yield
 
-      described_class.call(query: 'horses', as_of: as_of)
+      described_class.call(query: 'horses', expanded_query: expanded_query, as_of: as_of)
 
       expect(TimeMachine).to have_received(:at).with(as_of).at_least(:twice)
       expect(OpensearchRetrievalService).to have_received(:call).with(
-        query: 'horses', as_of: as_of, request_id: nil, limit: 30,
+        query: 'horses', expanded_query: expanded_query, as_of: as_of, request_id: nil, limit: 30,
       )
-      expect(VectorRetrievalService).to have_received(:call).with(query: 'horses', limit: 30)
+      expect(VectorRetrievalService).to have_received(:call).with(query: expanded_query, limit: 30)
     end
 
     it 'passes filter prefixes to both retrieval legs' do
       as_of = Time.zone.today
 
-      described_class.call(query: 'horses', as_of: as_of, filter_prefixes: %w[0101])
+      described_class.call(query: 'horses', expanded_query: expanded_query, as_of: as_of, filter_prefixes: %w[0101])
 
       expect(OpensearchRetrievalService).to have_received(:call).with(
-        query: 'horses', as_of: as_of, request_id: nil, limit: 30, filter_prefixes: %w[0101],
+        query: 'horses', expanded_query: expanded_query,
+        as_of: as_of, request_id: nil, limit: 30, filter_prefixes: %w[0101]
       )
       expect(VectorRetrievalService).to have_received(:call).with(
-        query: 'horses', limit: 30, filter_prefixes: %w[0101],
+        query: expanded_query, limit: 30, filter_prefixes: %w[0101],
       )
     end
 
@@ -101,9 +104,9 @@ RSpec.describe HybridRetrievalService do
     end
 
     it 'returns expanded_query from the opensearch leg' do
-      result = described_class.call(query: 'horses', as_of: Time.zone.today)
+      result = described_class.call(query: 'horses', expanded_query: expanded_query, as_of: Time.zone.today)
 
-      expect(result.expanded_query).to eq('expanded horses')
+      expect(result.expanded_query).to eq(expanded_query)
     end
 
     it 'reads rrf_k from AdminConfiguration' do
@@ -159,10 +162,10 @@ RSpec.describe HybridRetrievalService do
         expect(sids).to eq([1, 2, 3])
       end
 
-      it 'still returns expanded_query from opensearch' do
-        result = described_class.call(query: 'horses', as_of: Time.zone.today)
+      it 'still returns the expanded_query passed by internal search' do
+        result = described_class.call(query: 'horses', expanded_query: expanded_query, as_of: Time.zone.today)
 
-        expect(result.expanded_query).to eq('expanded horses')
+        expect(result.expanded_query).to eq(expanded_query)
       end
 
       it 'emits error status for vector leg' do

--- a/spec/services/opensearch_retrieval_service_spec.rb
+++ b/spec/services/opensearch_retrieval_service_spec.rb
@@ -1,9 +1,6 @@
 RSpec.describe OpensearchRetrievalService do
   before do
-    allow(ExpandSearchQueryService).to receive(:call).and_wrap_original do |_method, query|
-      ExpandSearchQueryService::Result.new(expanded_query: query, reason: nil)
-    end
-    allow(Search::Instrumentation).to receive(:query_expanded).and_yield
+    allow(ExpandSearchQueryService).to receive(:call)
   end
 
   describe '#call' do
@@ -37,26 +34,19 @@ RSpec.describe OpensearchRetrievalService do
     end
 
     it 'returns a Result with results and expanded_query' do
-      result = described_class.call(query: 'animals', as_of: Time.zone.today)
+      result = described_class.call(query: 'animals', expanded_query: 'live animals', as_of: Time.zone.today)
 
       expect(result).to be_a(described_class::Result)
       expect(result.results.length).to eq(1)
       expect(result.results.first.goods_nomenclature_item_id).to eq('0100000000')
       expect(result.results.first.score).to eq(12.5)
-      expect(result.expanded_query).to eq('animals')
+      expect(result.expanded_query).to eq('live animals')
     end
 
-    context 'when expand_search_enabled is false' do
-      before do
-        allow(AdminConfiguration).to receive(:enabled?).and_call_original
-        allow(AdminConfiguration).to receive(:enabled?).with('expand_search_enabled').and_return(false)
-      end
+    it 'does not expand queries itself' do
+      described_class.call(query: 'animals', as_of: Time.zone.today)
 
-      it 'does not call ExpandSearchQueryService' do
-        described_class.call(query: 'animals', as_of: Time.zone.today)
-
-        expect(ExpandSearchQueryService).not_to have_received(:call)
-      end
+      expect(ExpandSearchQueryService).not_to have_received(:call)
     end
 
     context 'when opensearch returns empty hits' do


### PR DESCRIPTION
### Jira link

[AI-815](https://transformuk.atlassian.net/browse/AI-815)

```mermaid
flowchart TD
    INPUT[User query]

    subgraph NORMALISE [Normalise query]
        EXPAND[Expand tariff terms]
    end

    subgraph RETRIEVE [Retrieve candidates]
        METHOD{Retrieval method}
        TEXT[Text search]
        VECTOR[Vector search]
        HYBRID[Hybrid fusion]
    end

    OUTPUT[Shortlist]

    INPUT --> EXPAND
    EXPAND --> METHOD
    METHOD -->|OpenSearch| TEXT
    METHOD -->|Vector| VECTOR
    METHOD -->|Hybrid| HYBRID
    TEXT --> OUTPUT
    VECTOR --> OUTPUT
    HYBRID --> OUTPUT

    classDef box stroke:#6366f1,stroke-width:2px
    class INPUT,NORMALISE,EXPAND,RETRIEVE,METHOD,TEXT,VECTOR,HYBRID,OUTPUT box
```

### What?

- [x] Move LLM query expansion into internal search query normalisation before retrieval selection.
- [x] Pass the expanded query into OpenSearch, vector, and hybrid retrieval.
- [x] Remove OpenSearch-owned expansion so hybrid and vector use the same expanded tariff-language query.
- [x] Refresh the default expansion prompt and retrieval-method copy so it is retrieval-method neutral.

### Why?

Query expansion is intended to translate user language into tariff language before searching. Keeping it inside the OpenSearch retrieval path meant vector search embedded the original user query and hybrid only expanded the OpenSearch leg.

### Risk

**Risk level:** 🟠

**Reason for rating:** This changes internal search retrieval behaviour and query expansion now feeds all retrieval methods. The change is feature-flagged through the existing `expand_search_enabled` configuration and covered by focused service specs, but it affects search result selection enough to warrant team visibility before merging.