### PR TITLE
AI-822: Add product description from URL

### DIFF
--- a/app/controllers/api/internal/product_descriptions_controller.rb
+++ b/app/controllers/api/internal/product_descriptions_controller.rb
@@ -1,0 +1,34 @@
+module Api
+  module Internal
+    class ProductDescriptionsController < InternalController
+      def create
+        result = ProductDescriptionFromUrlService.call(product_description_params[:url].to_s)
+
+        if result.success?
+          render json: ProductDescriptionSerializer.new(result).serializable_hash
+        else
+          render json: error_payload(result), status: :unprocessable_content
+        end
+      end
+
+      private
+
+      def product_description_params
+        params.permit(:url)
+      end
+
+      def error_payload(result)
+        {
+          errors: [
+            {
+              status: '422',
+              title: result.error_title,
+              detail: result.error_detail,
+              source: { pointer: '/data/attributes/url' },
+            },
+          ],
+        }
+      end
+    end
+  end
+end

--- a/app/engines/internal_api.rb
+++ b/app/engines/internal_api.rb
@@ -7,6 +7,7 @@ InternalApi.routes.draw do
       post 'search' => 'search#search'
       get 'search' => 'search#search'
       get 'search_suggestions' => 'search#suggestions'
+      post 'product_description' => 'product_descriptions#create'
     end
   end
 end

--- a/app/lib/openai_client.rb
+++ b/app/lib/openai_client.rb
@@ -45,7 +45,7 @@ class OpenaiClient
       user: TradeTariffBackend.openai_user,
       response_format: { type: 'json_object' },
     }
-    body[:reasoning_effort] = reasoning_effort if reasoning_effort.present?
+    body[:reasoning_effort] = reasoning_effort if supported_reasoning_effort?(model, reasoning_effort)
     body = body.to_json
 
     with_retry do
@@ -101,6 +101,15 @@ class OpenaiClient
     else
       [base_delay, MAX_RETRY_DELAY].min
     end
+  end
+
+  def supported_reasoning_effort?(model, reasoning_effort)
+    return false if reasoning_effort.blank?
+
+    model_config = MODEL_CONFIGS[model]
+    return true if model_config.blank?
+
+    model_config[:reasoning_levels].include?(reasoning_effort)
   end
 
   class << self

--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -9,6 +9,10 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
       selected: 'gpt-4.1-mini-2025-04-14',
       sub_values: { 'reasoning_effort' => 'low' },
     },
+    'product_description_model' => {
+      selected: 'gpt-4.1-mini-2025-04-14',
+      sub_values: {},
+    },
     'label_model' => {
       selected: 'gpt-5.4',
       sub_values: { 'reasoning_effort' => 'high' },
@@ -98,6 +102,7 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
     },
     'expand_search_enabled' => false,
     'expand_model' => NESTED_OPTION_DEFAULTS['expand_model'][:selected],
+    'product_description_model' => NESTED_OPTION_DEFAULTS['product_description_model'][:selected],
     'interactive_search_enabled' => true,
     'interactive_search_excluded_chapters' => %w[98 99].freeze,
     'interactive_search_max_questions' => 7,
@@ -128,6 +133,10 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
     'other_self_text_batch_size' => 5,
     'non_other_self_text_model' => NESTED_OPTION_DEFAULTS['non_other_self_text_model'][:selected],
     'non_other_self_text_batch_size' => 15,
+    'product_description_max_redirects' => 3,
+    'product_description_open_timeout_seconds' => 3,
+    'product_description_read_timeout_seconds' => 5,
+    'product_description_max_response_bytes' => 256.kilobytes,
   }.freeze
 
   plugin :auto_validations, not_null: :presence

--- a/app/serializers/api/internal/product_description_serializer.rb
+++ b/app/serializers/api/internal/product_description_serializer.rb
@@ -1,0 +1,12 @@
+module Api
+  module Internal
+    class ProductDescriptionSerializer
+      include JSONAPI::Serializer
+
+      set_type :product_description
+      set_id :source_url
+
+      attributes :description, :source_url, :confidence, :metadata
+    end
+  end
+end

--- a/app/services/api/internal/product_description/extracted_content.rb
+++ b/app/services/api/internal/product_description/extracted_content.rb
@@ -1,0 +1,38 @@
+module Api
+  module Internal
+    module ProductDescription
+      class ExtractedContent < Data.define(
+        :title,
+        :meta_description,
+        :open_graph_title,
+        :open_graph_description,
+        :h1,
+        :product_data,
+        :body_text,
+      )
+        def sufficient?
+          product_data.present? ||
+            [
+              title,
+              meta_description,
+              open_graph_title,
+              open_graph_description,
+              h1,
+            ].any?(&:present?)
+        end
+
+        def to_prompt_payload
+          {
+            title:,
+            meta_description:,
+            open_graph_title:,
+            open_graph_description:,
+            h1:,
+            product_data:,
+            body_text:,
+          }.compact_blank
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/internal/product_description/fetched_page.rb
+++ b/app/services/api/internal/product_description/fetched_page.rb
@@ -1,0 +1,7 @@
+module Api
+  module Internal
+    module ProductDescription
+      FetchedPage = Data.define(:final_url, :content_type, :body)
+    end
+  end
+end

--- a/app/services/api/internal/product_description/instrumentation.rb
+++ b/app/services/api/internal/product_description/instrumentation.rb
@@ -1,0 +1,17 @@
+module Api
+  module Internal
+    module ProductDescription
+      module Instrumentation
+        module_function
+
+        def description_failed(error)
+          ActiveSupport::Notifications.instrument(
+            'description_failed.product_description',
+            error_class: error.class.name,
+            error_message: error.message,
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/internal/product_description/product_description_generator.rb
+++ b/app/services/api/internal/product_description/product_description_generator.rb
@@ -1,0 +1,92 @@
+module Api
+  module Internal
+    module ProductDescription
+      class ProductDescriptionGenerator
+        VALID_CONFIDENCE = %w[low medium high].freeze
+
+        def self.call(extracted_content, source_url:)
+          new(extracted_content, source_url:).call
+        end
+
+        def initialize(extracted_content, source_url:)
+          @extracted_content = extracted_content
+          @source_url = source_url
+        end
+
+        def call
+          response = AiResponseSanitizer.call(
+            OpenaiClient.call(messages, model: configured_model, reasoning_effort: configured_reasoning_effort),
+          )
+          return malformed_response('Generated response was not valid') unless response.is_a?(Hash)
+
+          description = response['description'].to_s.strip
+          return malformed_response('Generated description was blank') if description.blank?
+
+          Result.success(
+            description:,
+            source_url: @source_url,
+            confidence: normalize_confidence(response['confidence']),
+            metadata: normalize_metadata(response['metadata']),
+          )
+        end
+
+        private
+
+        def messages
+          [
+            {
+              role: 'system',
+              content: system_prompt,
+            },
+            {
+              role: 'user',
+              content: JSON.generate(@extracted_content.to_prompt_payload),
+            },
+          ]
+        end
+
+        def system_prompt
+          <<~PROMPT.squish
+            Convert extracted product page information into JSON for commodity search.
+            Return only JSON with description, confidence, and metadata.
+            The description must state what the product is, what it is made from,
+            and essential attributes such as use, form, dimensions, or packaging
+            only when the extracted content supports them. Do not infer unsupported claims.
+            Confidence must be one of low, medium, or high.
+          PROMPT
+        end
+
+        def normalize_confidence(value)
+          confidence = value.to_s.downcase
+          VALID_CONFIDENCE.include?(confidence) ? confidence : 'medium'
+        end
+
+        def normalize_metadata(value)
+          return {} unless value.is_a?(Hash)
+
+          value.each_with_object({}) do |(key, metadata_value), result|
+            next if metadata_value.blank?
+
+            result[key.to_s] = metadata_value.to_s.strip
+          end
+        end
+
+        def malformed_response(detail)
+          Result.failure('Malformed product description', detail)
+        end
+
+        def model_config
+          @model_config ||= AdminConfiguration.nested_options_value('product_description_model')
+        end
+
+        def configured_model
+          model_config[:selected]
+        end
+
+        def configured_reasoning_effort
+          model_config[:sub_values]['reasoning_effort']
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/internal/product_description/product_page_extractor.rb
+++ b/app/services/api/internal/product_description/product_page_extractor.rb
@@ -1,0 +1,97 @@
+module Api
+  module Internal
+    module ProductDescription
+      class ProductPageExtractor
+        BODY_TEXT_LIMIT = 2_000
+
+        def self.call(html)
+          new(html).call
+        end
+
+        def initialize(html)
+          @html = html.to_s
+        end
+
+        def call
+          doc = Nokogiri::HTML5.parse(@html)
+          doc.css('script:not([type="application/ld+json"]), style, noscript').remove
+
+          ExtractedContent.new(
+            title: text_at(doc, 'title'),
+            meta_description: meta_content(doc, 'meta[name="description"]'),
+            open_graph_title: meta_content(doc, 'meta[property="og:title"]'),
+            open_graph_description: meta_content(doc, 'meta[property="og:description"]'),
+            h1: text_at(doc, 'h1'),
+            product_data: product_data(doc),
+            body_text: body_text(doc),
+          )
+        end
+
+        private
+
+        def text_at(doc, selector)
+          normalize_text(doc.at_css(selector)&.text)
+        end
+
+        def meta_content(doc, selector)
+          normalize_text(doc.at_css(selector)&.attr('content'))
+        end
+
+        def body_text(doc)
+          normalize_text(doc.at_css('body')&.text || doc.text).to_s.first(BODY_TEXT_LIMIT)
+        end
+
+        def product_data(doc)
+          doc.css('script[type="application/ld+json"]').each_with_object({}) do |script, data|
+            product_nodes(JSON.parse(script.text)).each do |node|
+              data.merge!(extract_product_fields(node))
+            end
+          rescue JSON::ParserError
+            next
+          end
+        end
+
+        def product_nodes(value)
+          case value
+          when Array
+            value.flat_map { |item| product_nodes(item) }
+          when Hash
+            graph_nodes = product_nodes(value['@graph'])
+            current_node = product_type?(value['@type']) ? [value] : []
+            current_node + graph_nodes
+          else
+            []
+          end
+        end
+
+        def product_type?(type)
+          Array(type).map(&:to_s).include?('Product')
+        end
+
+        def extract_product_fields(node)
+          {
+            'name' => normalize_text(node['name']),
+            'brand' => normalize_brand(node['brand']),
+            'material' => normalize_text(Array(node['material']).join(', ')),
+            'description' => normalize_text(node['description']),
+          }.compact_blank
+        end
+
+        def normalize_brand(brand)
+          case brand
+          when Hash
+            normalize_text(brand['name'])
+          when Array
+            normalize_text(brand.map { |entry| entry.is_a?(Hash) ? entry['name'] : entry }.compact.join(', '))
+          else
+            normalize_text(brand)
+          end
+        end
+
+        def normalize_text(value)
+          value.to_s.gsub(/\s+/, ' ').strip.presence
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/internal/product_description/result.rb
+++ b/app/services/api/internal/product_description/result.rb
@@ -1,0 +1,21 @@
+module Api
+  module Internal
+    module ProductDescription
+      class Result < Data.define(:success, :description, :source_url, :confidence, :metadata, :error_title, :error_detail)
+        def success?
+          success
+        end
+
+        class << self
+          def success(description:, source_url:, confidence:, metadata:)
+            new(true, description, source_url, confidence, metadata, nil, nil)
+          end
+
+          def failure(title, detail)
+            new(false, nil, nil, nil, {}, title, detail)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/internal/product_description/safe_url_fetcher.rb
+++ b/app/services/api/internal/product_description/safe_url_fetcher.rb
@@ -1,0 +1,172 @@
+require 'ipaddr'
+require 'uri'
+
+module Api
+  module Internal
+    module ProductDescription
+      class SafeUrlFetcher
+        class FetchError < StandardError
+          attr_reader :title, :reason
+
+          def initialize(title, detail, reason: nil)
+            @title = title
+            @reason = reason
+            super(detail)
+          end
+
+          def http_status?
+            reason == :http_status
+          end
+        end
+
+        ALLOWED_CONTENT_TYPES = [
+          'text/html',
+          'application/xhtml+xml',
+          'text/plain',
+        ].freeze
+        UNSAFE_IP_RANGES = [
+          '0.0.0.0/8',
+          '10.0.0.0/8',
+          '100.64.0.0/10',
+          '127.0.0.0/8',
+          '169.254.0.0/16',
+          '172.16.0.0/12',
+          '192.0.0.0/24',
+          '192.0.2.0/24',
+          '192.168.0.0/16',
+          '198.18.0.0/15',
+          '198.51.100.0/24',
+          '203.0.113.0/24',
+          '224.0.0.0/4',
+          '240.0.0.0/4',
+          '255.255.255.255/32',
+          '::/128',
+          '::1/128',
+          'fc00::/7',
+          'fe80::/10',
+          'ff00::/8',
+          '2001:db8::/32',
+        ].map { |range| IPAddr.new(range) }.freeze
+
+        def self.call(url)
+          new(url).call
+        end
+
+        def initialize(url)
+          @url = url.to_s
+        end
+
+        def call
+          fetch(parse_and_validate_url(@url), redirect_count: 0)
+        end
+
+        private
+
+        def fetch(uri, redirect_count:)
+          validate_resolved_addresses!(uri.host)
+
+          streamed_body = +''
+          response = connection.get(uri.to_s) do |request|
+            request.options.on_data = proc do |chunk, _received_bytes, _env|
+              append_body_chunk(streamed_body, chunk)
+            end
+          end
+
+          if redirect?(response)
+            raise FetchError.new('Too many redirects', 'Too many redirects') if redirect_count >= max_redirects
+
+            location = response.headers['location'] || response.headers['Location']
+            raise FetchError.new('Invalid URL', 'Redirect response did not include a location') if location.blank?
+
+            return fetch(parse_and_validate_url(URI.join(uri.to_s, location).to_s), redirect_count: redirect_count + 1)
+          end
+
+          raise FetchError.new('Fetch failed', "URL returned HTTP #{response.status}", reason: :http_status) unless response.success?
+
+          content_type = response.headers['content-type'] || response.headers['Content-Type'] || ''
+          raise FetchError.new('Unsupported content type', 'Unsupported content type') unless allowed_content_type?(content_type)
+
+          FetchedPage.new(final_url: uri.to_s, content_type:, body: response_body(response, streamed_body))
+        rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
+          raise FetchError.new('Fetch failed', e.message)
+        end
+
+        def append_body_chunk(body, chunk)
+          return if body.bytesize >= max_response_bytes
+
+          body << chunk.byteslice(0, max_response_bytes - body.bytesize).to_s
+        end
+
+        def response_body(response, streamed_body)
+          body = streamed_body.presence || response.body.to_s
+          return body unless body.bytesize > max_response_bytes
+
+          body.byteslice(0, max_response_bytes).to_s
+        end
+
+        def parse_and_validate_url(raw_url)
+          raise FetchError.new('Invalid URL', 'Url is required') if raw_url.blank?
+
+          uri = URI.parse(raw_url)
+          raise FetchError.new('Invalid URL', 'Only https URLs are supported') unless uri.is_a?(URI::HTTPS)
+          raise FetchError.new('Invalid URL', 'URL host is required') if uri.host.blank?
+          raise FetchError.new('Invalid URL', 'URL credentials are not supported') if uri.user.present? || uri.password.present?
+
+          uri
+        rescue URI::InvalidURIError
+          raise FetchError.new('Invalid URL', 'URL is invalid')
+        end
+
+        def validate_resolved_addresses!(host)
+          addresses = Addrinfo.getaddrinfo(host, nil)
+          raise FetchError.new('Unsafe URL', 'URL resolves to an unsafe address') if addresses.empty?
+
+          addresses.each do |address|
+            ip = IPAddr.new(address.ip_address)
+            raise FetchError.new('Unsafe URL', 'URL resolves to an unsafe address') if unsafe_ip?(ip)
+          end
+        rescue SocketError
+          raise FetchError.new('Fetch failed', 'URL host could not be resolved')
+        end
+
+        def unsafe_ip?(ip)
+          UNSAFE_IP_RANGES.any? { |range| range.include?(ip) }
+        end
+
+        def redirect?(response)
+          response.status.between?(300, 399)
+        end
+
+        def allowed_content_type?(content_type)
+          media_type = content_type.to_s.split(';').first.to_s.strip.downcase
+          ALLOWED_CONTENT_TYPES.include?(media_type)
+        end
+
+        def max_response_bytes
+          AdminConfiguration.integer_value('product_description_max_response_bytes')
+        end
+
+        def max_redirects
+          AdminConfiguration.integer_value('product_description_max_redirects')
+        end
+
+        def open_timeout
+          AdminConfiguration.integer_value('product_description_open_timeout_seconds')
+        end
+
+        def read_timeout
+          AdminConfiguration.integer_value('product_description_read_timeout_seconds')
+        end
+
+        def connection
+          Faraday.new do |faraday|
+            faraday.adapter Faraday.default_adapter
+            faraday.headers['User-Agent'] = TradeTariffBackend.user_agent
+            faraday.options.open_timeout = open_timeout
+            faraday.options.timeout = read_timeout
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/internal/product_description/url_content_extractor.rb
+++ b/app/services/api/internal/product_description/url_content_extractor.rb
@@ -1,0 +1,97 @@
+require 'cgi'
+require 'uri'
+
+module Api
+  module Internal
+    module ProductDescription
+      class UrlContentExtractor
+        TOKEN_SEPARATORS = /[^a-z0-9]+/
+        IGNORED_HOST_TOKENS = %w[www co com org net uk].freeze
+        IGNORED_PATH_TOKENS = %w[p product products shop groceries dp gp en gb uk html htm pd clp].freeze
+        UUID_PATTERN = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/
+        LONG_HEX_PATTERN = /\A[0-9a-f]{16,}\z/
+        TOKEN_LIKE_PATTERN = /\A(?=.*[a-z])(?=.*\d)[a-z0-9_-]{20,}\z/
+
+        def self.call(url)
+          new(url).call
+        end
+
+        def initialize(url)
+          @url = url.to_s
+        end
+
+        def call
+          product_words = path_words
+          words = product_words.present? ? (host_words + product_words).uniq.join(' ') : nil
+
+          ExtractedContent.new(
+            title: words.presence,
+            meta_description: nil,
+            open_graph_title: nil,
+            open_graph_description: nil,
+            h1: nil,
+            product_data: words.present? ? { 'source' => 'url' } : {},
+            body_text: words.present? ? "URL path suggests: #{words}" : nil,
+          )
+        end
+
+        private
+
+        def uri
+          @uri ||= URI.parse(@url)
+        rescue URI::InvalidURIError
+          nil
+        end
+
+        def host_words
+          tokenize(uri&.host).reject { |word| IGNORED_HOST_TOKENS.include?(word) }
+        end
+
+        def path_words
+          path_segments = uri&.path.to_s.split('/')
+
+          words = path_segments.flat_map do |segment|
+            next [] if risky_segment?(segment)
+
+            tokenize(CGI.unescape(segment))
+          end
+
+          words.reject { |word| ignored_path_word?(word) || risky_word?(word) }
+        end
+
+        def tokenize(value)
+          value.to_s
+            .downcase
+            .split(TOKEN_SEPARATORS)
+            .filter_map { |word| normalize_word(word) }
+        end
+
+        def normalize_word(word)
+          word = word.to_s.strip
+          return if word.length < 2 && word != 't'
+          return if risky_word?(word)
+
+          word
+        end
+
+        def ignored_path_word?(word)
+          IGNORED_PATH_TOKENS.include?(word) || word.match?(/\A\d+\z/) || word.match?(/\Aclp\d+\z/)
+        end
+
+        def risky_segment?(segment)
+          decoded_segment = CGI.unescape(segment.to_s)
+
+          decoded_segment.include?('@') ||
+            decoded_segment.include?('=') ||
+            decoded_segment.match?(UUID_PATTERN)
+        end
+
+        def risky_word?(word)
+          word.match?(UUID_PATTERN) ||
+            word.match?(LONG_HEX_PATTERN) ||
+            word.match?(TOKEN_LIKE_PATTERN)
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/internal/product_description_from_url_service.rb
+++ b/app/services/api/internal/product_description_from_url_service.rb
@@ -1,0 +1,66 @@
+module Api
+  module Internal
+    class ProductDescriptionFromUrlService
+      def self.call(url)
+        new(url).call
+      end
+
+      def initialize(url)
+        @url = url
+      end
+
+      def call
+        page = ProductDescription::SafeUrlFetcher.call(@url)
+        extracted_content = ProductDescription::ProductPageExtractor.call(page.body)
+
+        unless extracted_content.sufficient?
+          return ProductDescription::Result.failure(
+            'Insufficient product information',
+            'Could not identify enough product information from the URL',
+          )
+        end
+
+        ProductDescription::ProductDescriptionGenerator.call(extracted_content, source_url: page.final_url)
+      rescue ProductDescription::SafeUrlFetcher::FetchError => e
+        if e.http_status?
+          begin
+            return generate_from_url_content
+          rescue StandardError => fallback_error
+            return controlled_failure(fallback_error)
+          end
+        end
+
+        ProductDescription::Result.failure(e.title, e.message)
+      rescue StandardError => e
+        controlled_failure(e)
+      end
+
+      private
+
+      def controlled_failure(error)
+        ProductDescription::Instrumentation.description_failed(error)
+
+        ProductDescription::Result.failure(
+          'Product description failed',
+          'Could not generate a product description from the URL',
+        )
+      end
+
+      def generate_from_url_content
+        extracted_content = ProductDescription::UrlContentExtractor.call(@url)
+
+        unless extracted_content.sufficient?
+          return ProductDescription::Result.failure(
+            'Insufficient product information',
+            'Could not identify enough product information from the URL',
+          )
+        end
+
+        result = ProductDescription::ProductDescriptionGenerator.call(extracted_content, source_url: @url)
+        return result unless result.success?
+
+        result.with(confidence: 'low', metadata: result.metadata.merge('source' => 'url'))
+      end
+    end
+  end
+end

--- a/spec/lib/openai_client_spec.rb
+++ b/spec/lib/openai_client_spec.rb
@@ -66,6 +66,13 @@ RSpec.describe OpenaiClient do
         expect(WebMock).to(have_requested(:post, "#{api_base_url}/chat/completions")
           .with { |req| !JSON.parse(req.body).key?('reasoning_effort') })
       end
+
+      it 'omits reasoning_effort from the request body when the model does not support it' do
+        client.call(context, model: 'gpt-4.1-mini-2025-04-14', reasoning_effort: 'low')
+
+        expect(WebMock).to(have_requested(:post, "#{api_base_url}/chat/completions")
+          .with { |req| !JSON.parse(req.body).key?('reasoning_effort') })
+      end
     end
 
     context 'when given an array of messages' do

--- a/spec/models/admin_configuration_spec.rb
+++ b/spec/models/admin_configuration_spec.rb
@@ -580,6 +580,18 @@ RSpec.describe AdminConfiguration do
         result = described_class.nested_options_value('expand_model')
         expect(result).to eq({ selected: 'gpt-4.1-mini-2025-04-14', sub_values: { 'reasoning_effort' => 'low' } })
       end
+
+      it 'returns the default product description model without reasoning_effort' do
+        result = described_class.nested_options_value('product_description_model')
+        expect(result).to eq({ selected: 'gpt-4.1-mini-2025-04-14', sub_values: {} })
+      end
+
+      it 'returns default product description fetch controls' do
+        expect(described_class.integer_value('product_description_max_redirects')).to eq(3)
+        expect(described_class.integer_value('product_description_open_timeout_seconds')).to eq(3)
+        expect(described_class.integer_value('product_description_read_timeout_seconds')).to eq(5)
+        expect(described_class.integer_value('product_description_max_response_bytes')).to eq(256.kilobytes)
+      end
     end
 
     context 'when config record exists' do

--- a/spec/requests/api/internal/product_descriptions_controller_spec.rb
+++ b/spec/requests/api/internal/product_descriptions_controller_spec.rb
@@ -1,0 +1,134 @@
+RSpec.describe Api::Internal::ProductDescriptionsController, :internal do
+  describe 'POST /product_description' do
+    it 'returns a generated product description' do
+      allow(Api::Internal::ProductDescriptionFromUrlService).to receive(:call)
+        .with('https://example.com/product')
+        .and_return(
+          Api::Internal::ProductDescription::Result.success(
+            description: "Lightweight men's cotton T-shirt with short sleeves and a crew neck",
+            source_url: 'https://example.com/product',
+            confidence: 'high',
+            metadata: { title: "Men's cotton T-shirt", brand: 'Example' },
+          ),
+        )
+
+      post api_product_description_path(format: :json), params: { url: 'https://example.com/product' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        'data' => {
+          'id' => 'https://example.com/product',
+          'type' => 'product_description',
+          'attributes' => {
+            'description' => "Lightweight men's cotton T-shirt with short sleeves and a crew neck",
+            'source_url' => 'https://example.com/product',
+            'confidence' => 'high',
+            'metadata' => { 'title' => "Men's cotton T-shirt", 'brand' => 'Example' },
+          },
+        },
+      )
+    end
+
+    it 'returns 422 when the service rejects the URL' do
+      allow(Api::Internal::ProductDescriptionFromUrlService).to receive(:call)
+        .with('')
+        .and_return(Api::Internal::ProductDescription::Result.failure('Invalid URL', 'Url is required'))
+
+      post api_product_description_path(format: :json), params: { url: '' }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.parsed_body).to eq(
+        'errors' => [
+          {
+            'status' => '422',
+            'title' => 'Invalid URL',
+            'detail' => 'Url is required',
+            'source' => { 'pointer' => '/data/attributes/url' },
+          },
+        ],
+      )
+    end
+
+    it 'fetches a product page and returns a generated description' do
+      allow(Addrinfo).to receive(:getaddrinfo)
+        .with('example.com', nil)
+        .and_return([instance_double(Addrinfo, ip_address: '93.184.216.34')])
+      stub_request(:get, 'https://example.com/product')
+        .to_return(
+          status: 200,
+          headers: { 'Content-Type' => 'text/html' },
+          body: <<~HTML,
+            <html>
+              <head>
+                <title>Men's cotton T-shirt</title>
+                <meta name="description" content="A soft short-sleeved T-shirt made from cotton.">
+              </head>
+              <body>
+                <h1>Men's cotton T-shirt</h1>
+                <p>This product has short sleeves, a crew neck and a regular fit.</p>
+              </body>
+            </html>
+          HTML
+        )
+      allow(OpenaiClient).to receive(:call).and_return(
+        {
+          'description' => "Lightweight men's cotton T-shirt with short sleeves and a crew neck",
+          'confidence' => 'high',
+          'metadata' => { 'title' => "Men's cotton T-shirt", 'brand' => 'Example' },
+        },
+      )
+
+      post api_product_description_path(format: :json), params: { url: 'https://example.com/product' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        'data' => {
+          'id' => 'https://example.com/product',
+          'type' => 'product_description',
+          'attributes' => {
+            'description' => "Lightweight men's cotton T-shirt with short sleeves and a crew neck",
+            'source_url' => 'https://example.com/product',
+            'confidence' => 'high',
+            'metadata' => { 'title' => "Men's cotton T-shirt", 'brand' => 'Example' },
+          },
+        },
+      )
+    end
+
+    it 'falls back to sanitized URL content when the product page returns an HTTP status error' do
+      url = 'https://example.com/products/cotton-shirt/550e8400-e29b-41d4-a716-446655440000?token=secret-token#private'
+      request_url = 'https://example.com/products/cotton-shirt/550e8400-e29b-41d4-a716-446655440000?token=secret-token'
+
+      allow(Addrinfo).to receive(:getaddrinfo)
+        .with('example.com', nil)
+        .and_return([instance_double(Addrinfo, ip_address: '93.184.216.34')])
+      stub_request(:get, request_url)
+        .to_return(status: 404, headers: { 'Content-Type' => 'text/html' }, body: 'Not found')
+      allow(OpenaiClient).to receive(:call).and_return(
+        {
+          'description' => 'Cotton shirt',
+          'confidence' => 'low',
+          'metadata' => { 'source' => 'url' },
+        },
+      )
+
+      post api_product_description_path(format: :json), params: { url: }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.dig('data', 'attributes')).to include(
+        'description' => 'Cotton shirt',
+        'source_url' => url,
+        'confidence' => 'low',
+        'metadata' => { 'source' => 'url' },
+      )
+      expect(OpenaiClient).to have_received(:call) do |messages|
+        payload = messages.last.fetch(:content)
+
+        expect(payload).to include('example cotton shirt')
+        expect(payload).not_to include('secret-token')
+        expect(payload).not_to include('550e8400')
+        expect(payload).not_to include('private')
+      end
+    end
+  end
+end

--- a/spec/serializers/api/internal/product_description_serializer_spec.rb
+++ b/spec/serializers/api/internal/product_description_serializer_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe Api::Internal::ProductDescriptionSerializer do
+  subject(:serialized) { described_class.new(result).serializable_hash.as_json }
+
+  let(:result) do
+    Api::Internal::ProductDescription::Result.success(
+      description: 'Cotton T-shirt',
+      source_url: 'https://example.com/product',
+      confidence: 'high',
+      metadata: { 'title' => 'Cotton T-shirt' },
+    )
+  end
+
+  it 'serializes a product description result' do
+    expect(serialized).to eq(
+      'data' => {
+        'id' => 'https://example.com/product',
+        'type' => 'product_description',
+        'attributes' => {
+          'description' => 'Cotton T-shirt',
+          'source_url' => 'https://example.com/product',
+          'confidence' => 'high',
+          'metadata' => { 'title' => 'Cotton T-shirt' },
+        },
+      },
+    )
+  end
+end

--- a/spec/services/api/internal/product_description/product_description_generator_spec.rb
+++ b/spec/services/api/internal/product_description/product_description_generator_spec.rb
@@ -1,0 +1,116 @@
+RSpec.describe Api::Internal::ProductDescription::ProductDescriptionGenerator do
+  describe '.call' do
+    let(:extracted_content) do
+      Api::Internal::ProductDescription::ExtractedContent.new(
+        title: "Men's cotton T-shirt",
+        meta_description: 'A soft short-sleeved T-shirt made from cotton.',
+        open_graph_title: nil,
+        open_graph_description: nil,
+        h1: "Men's cotton T-shirt",
+        product_data: { 'brand' => 'Example', 'material' => '100% cotton' },
+        body_text: 'This product has short sleeves, a crew neck and a regular fit.',
+      )
+    end
+
+    it 'returns a generated product description' do
+      allow(OpenaiClient).to receive(:call).and_return(
+        {
+          'description' => "Lightweight men's cotton T-shirt with short sleeves and a crew neck",
+          'confidence' => 'high',
+          'metadata' => { 'title' => "Men's cotton T-shirt", 'brand' => 'Example' },
+        },
+      )
+
+      result = described_class.call(extracted_content, source_url: 'https://example.com/product')
+
+      expect(result).to be_success
+      expect(result).to have_attributes(
+        description: "Lightweight men's cotton T-shirt with short sleeves and a crew neck",
+        source_url: 'https://example.com/product',
+        confidence: 'high',
+        metadata: { 'title' => "Men's cotton T-shirt", 'brand' => 'Example' },
+      )
+      expect(OpenaiClient).to have_received(:call) do |messages|
+        expect(messages).to be_an(Array)
+        expect(messages.last[:content]).to include("Men's cotton T-shirt")
+        expect(messages.last[:content]).not_to include('<html')
+      end
+    end
+
+    it 'uses the admin-configured product description model' do
+      allow(AdminConfiguration).to receive(:nested_options_value)
+        .with('product_description_model')
+        .and_return({ selected: 'gpt-4.1-mini-2025-04-14', sub_values: {} })
+      allow(OpenaiClient).to receive(:call).and_return(
+        {
+          'description' => 'Cotton T-shirt',
+          'confidence' => 'high',
+          'metadata' => {},
+        },
+      )
+
+      described_class.call(extracted_content, source_url: 'https://example.com/product')
+
+      expect(OpenaiClient).to have_received(:call).with(
+        an_instance_of(Array),
+        model: 'gpt-4.1-mini-2025-04-14',
+        reasoning_effort: nil,
+      )
+    end
+
+    it 'sanitizes AI output' do
+      allow(OpenaiClient).to receive(:call).and_return(
+        {
+          'description' => "Cotton T-shirt\u0000",
+          'confidence' => 'medium',
+          'metadata' => { 'title' => "Men's cotton T-shirt\u0000" },
+        },
+      )
+
+      result = described_class.call(extracted_content, source_url: 'https://example.com/product')
+
+      expect(result.description).to eq('Cotton T-shirt')
+      expect(result.metadata).to eq('title' => "Men's cotton T-shirt")
+    end
+
+    it 'normalizes unknown confidence to medium' do
+      allow(OpenaiClient).to receive(:call).and_return(
+        {
+          'description' => 'Cotton T-shirt',
+          'confidence' => 'certain',
+          'metadata' => {},
+        },
+      )
+
+      result = described_class.call(extracted_content, source_url: 'https://example.com/product')
+
+      expect(result.confidence).to eq('medium')
+    end
+
+    it 'rejects blank descriptions' do
+      allow(OpenaiClient).to receive(:call).and_return(
+        {
+          'description' => '',
+          'confidence' => 'low',
+          'metadata' => {},
+        },
+      )
+
+      result = described_class.call(extracted_content, source_url: 'https://example.com/product')
+
+      expect(result).not_to be_success
+      expect(result.error_title).to eq('Malformed product description')
+      expect(result.error_detail).to eq('Generated description was blank')
+    end
+
+    it 'rejects malformed responses' do
+      allow(OpenaiClient).to receive(:call).and_return('not json')
+
+      result = described_class.call(extracted_content, source_url: 'https://example.com/product')
+
+      expect(result).not_to be_success
+      expect(result.error_title).to eq('Malformed product description')
+      expect(result.error_detail).to eq('Generated response was not valid')
+    end
+  end
+end

--- a/spec/services/api/internal/product_description/product_page_extractor_spec.rb
+++ b/spec/services/api/internal/product_description/product_page_extractor_spec.rb
@@ -1,0 +1,74 @@
+RSpec.describe Api::Internal::ProductDescription::ProductPageExtractor do
+  describe '.call' do
+    it 'extracts product signals from html metadata and JSON-LD' do
+      html = <<~HTML
+        <html>
+          <head>
+            <title>Cotton T-shirt | Example</title>
+            <meta name="description" content="A soft short-sleeved T-shirt made from cotton.">
+            <meta property="og:title" content="Men's cotton T-shirt">
+            <meta property="og:description" content="Crew neck cotton top for casual wear.">
+            <script type="application/ld+json">
+              {
+                "@context": "https://schema.org",
+                "@type": "Product",
+                "name": "Cotton T-shirt",
+                "brand": { "name": "Example" },
+                "material": "100% cotton",
+                "description": "A lightweight knitted T-shirt."
+              }
+            </script>
+          </head>
+          <body>
+            <h1>Men's cotton T-shirt</h1>
+            <p>This product has short sleeves, a crew neck and a regular fit.</p>
+            <script>window.secret = "ignore me"</script>
+          </body>
+        </html>
+      HTML
+
+      result = described_class.call(html)
+
+      expect(result).to have_attributes(
+        title: 'Cotton T-shirt | Example',
+        meta_description: 'A soft short-sleeved T-shirt made from cotton.',
+        open_graph_title: "Men's cotton T-shirt",
+        open_graph_description: 'Crew neck cotton top for casual wear.',
+        h1: "Men's cotton T-shirt",
+      )
+      expect(result.product_data).to include(
+        'name' => 'Cotton T-shirt',
+        'brand' => 'Example',
+        'material' => '100% cotton',
+        'description' => 'A lightweight knitted T-shirt.',
+      )
+      expect(result.body_text).to include('short sleeves')
+      expect(result.body_text).not_to include('ignore me')
+      expect(result).to be_sufficient
+    end
+
+    it 'extracts Product entries from JSON-LD graphs' do
+      html = <<~HTML
+        <script type="application/ld+json">
+          {
+            "@graph": [
+              { "@type": "BreadcrumbList", "name": "Breadcrumbs" },
+              { "@type": ["Thing", "Product"], "name": "Leather belt", "brand": "Example" }
+            ]
+          }
+        </script>
+      HTML
+
+      result = described_class.call(html)
+
+      expect(result.product_data).to include('name' => 'Leather belt', 'brand' => 'Example')
+      expect(result).to be_sufficient
+    end
+
+    it 'marks pages with no product signals as insufficient' do
+      result = described_class.call('<html><body><nav>Home</nav></body></html>')
+
+      expect(result).not_to be_sufficient
+    end
+  end
+end

--- a/spec/services/api/internal/product_description/safe_url_fetcher_spec.rb
+++ b/spec/services/api/internal/product_description/safe_url_fetcher_spec.rb
@@ -1,0 +1,135 @@
+RSpec.describe Api::Internal::ProductDescription::SafeUrlFetcher do
+  subject(:fetcher) { described_class.new(url) }
+
+  let(:url) { 'https://example.com/product' }
+  let(:public_addrinfo) { instance_double(Addrinfo, ip_address: '93.184.216.34') }
+
+  before do
+    allow(Addrinfo).to receive(:getaddrinfo).and_return([public_addrinfo])
+  end
+
+  it 'fetches a public https html page' do
+    stub_request(:get, 'https://example.com/product')
+      .to_return(status: 200, headers: { 'Content-Type' => 'text/html; charset=utf-8' }, body: '<html>Product</html>')
+
+    result = fetcher.call
+
+    expect(result).to have_attributes(
+      final_url: 'https://example.com/product',
+      content_type: 'text/html; charset=utf-8',
+      body: '<html>Product</html>',
+    )
+  end
+
+  it 'rejects blank URLs' do
+    expect {
+      described_class.new('').call
+    }.to raise_error(described_class::FetchError, 'Url is required')
+  end
+
+  it 'rejects non-https URLs' do
+    expect {
+      described_class.new('http://example.com/product').call
+    }.to raise_error(described_class::FetchError, 'Only https URLs are supported')
+  end
+
+  it 'rejects URLs with credentials' do
+    expect {
+      described_class.new('https://user:password@example.com/product').call
+    }.to raise_error(described_class::FetchError, 'URL credentials are not supported')
+  end
+
+  it 'rejects unsafe resolved IPs' do
+    allow(Addrinfo).to receive(:getaddrinfo).and_return([instance_double(Addrinfo, ip_address: '127.0.0.1')])
+
+    expect {
+      fetcher.call
+    }.to raise_error(described_class::FetchError, 'URL resolves to an unsafe address')
+  end
+
+  it 'revalidates redirect targets' do
+    allow(Addrinfo).to receive(:getaddrinfo)
+      .with('example.com', nil)
+      .and_return([public_addrinfo])
+    allow(Addrinfo).to receive(:getaddrinfo)
+      .with('internal.example', nil)
+      .and_return([instance_double(Addrinfo, ip_address: '10.0.0.1')])
+
+    stub_request(:get, 'https://example.com/product')
+      .to_return(status: 302, headers: { 'Location' => 'https://internal.example/admin' })
+
+    expect {
+      fetcher.call
+    }.to raise_error(described_class::FetchError, 'URL resolves to an unsafe address')
+  end
+
+  it 'rejects too many redirects' do
+    allow(AdminConfiguration).to receive(:integer_value).and_call_original
+    allow(AdminConfiguration).to receive(:integer_value)
+      .with('product_description_max_redirects')
+      .and_return(1)
+
+    stub_request(:get, 'https://example.com/product')
+      .to_return(status: 302, headers: { 'Location' => 'https://example.com/product-2' })
+    stub_request(:get, 'https://example.com/product-2')
+      .to_return(status: 302, headers: { 'Location' => 'https://example.com/product-3' })
+
+    expect {
+      fetcher.call
+    }.to raise_error(described_class::FetchError, 'Too many redirects')
+  end
+
+  it 'uses admin configured open and read timeouts' do
+    allow(AdminConfiguration).to receive(:integer_value).and_call_original
+    allow(AdminConfiguration).to receive(:integer_value)
+      .with('product_description_open_timeout_seconds')
+      .and_return(7)
+    allow(AdminConfiguration).to receive(:integer_value)
+      .with('product_description_read_timeout_seconds')
+      .and_return(11)
+
+    stub_request(:get, 'https://example.com/product')
+      .to_return(status: 200, headers: { 'Content-Type' => 'text/html' }, body: '<html>Product</html>')
+
+    fetcher.call
+
+    expect(a_request(:get, 'https://example.com/product')).to have_been_made
+    expect(AdminConfiguration).to have_received(:integer_value).with('product_description_open_timeout_seconds')
+    expect(AdminConfiguration).to have_received(:integer_value).with('product_description_read_timeout_seconds')
+  end
+
+  it 'rejects unsupported content types' do
+    stub_request(:get, 'https://example.com/product')
+      .to_return(status: 200, headers: { 'Content-Type' => 'application/pdf' }, body: '%PDF')
+
+    expect {
+      fetcher.call
+    }.to raise_error(described_class::FetchError, 'Unsupported content type')
+  end
+
+  it 'keeps only response content up to the byte limit' do
+    allow(AdminConfiguration).to receive(:integer_value).and_call_original
+    allow(AdminConfiguration).to receive(:integer_value)
+      .with('product_description_max_response_bytes')
+      .and_return(12)
+
+    stub_request(:get, 'https://example.com/product')
+      .to_return(
+        status: 200,
+        headers: { 'Content-Type' => 'text/html' },
+        body: 'a' * 13,
+      )
+
+    result = fetcher.call
+
+    expect(result.body).to eq('a' * 12)
+  end
+
+  it 'rejects unsafe IPv6 resolved IPs' do
+    allow(Addrinfo).to receive(:getaddrinfo).and_return([instance_double(Addrinfo, ip_address: '::1')])
+
+    expect {
+      fetcher.call
+    }.to raise_error(described_class::FetchError, 'URL resolves to an unsafe address')
+  end
+end

--- a/spec/services/api/internal/product_description/url_content_extractor_spec.rb
+++ b/spec/services/api/internal/product_description/url_content_extractor_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe Api::Internal::ProductDescription::UrlContentExtractor do
+  describe '.call' do
+    it 'extracts product-like words from the URL host and path' do
+      result = described_class.call('https://www.marksandspencer.com/pure-cotton-garment-dyed-t-shirt/p/clp60770886')
+
+      expect(result).to be_sufficient
+      expect(result.title).to eq('marksandspencer pure cotton garment dyed t shirt')
+      expect(result.body_text).to eq('URL path suggests: marksandspencer pure cotton garment dyed t shirt')
+      expect(result.product_data).to eq('source' => 'url')
+    end
+
+    it 'does not include credentials, query strings, fragments, ids, or token-like path segments' do
+      result = described_class.call(
+        'https://user:secret@example.com/products/cotton-shirt/550e8400-e29b-41d4-a716-446655440000/abc123def456ghi789jkl012mno345?token=secret-token&email=buyer@example.com#private',
+      )
+      payload = result.to_prompt_payload.to_json
+
+      expect(payload).to include('example cotton shirt')
+      expect(payload).not_to include('user')
+      expect(payload).not_to include('secret')
+      expect(payload).not_to include('token')
+      expect(payload).not_to include('buyer')
+      expect(payload).not_to include('550e8400')
+      expect(payload).not_to include('abc123def456')
+      expect(payload).not_to include('private')
+    end
+
+    it 'keeps hyphenated product slugs that include product ids' do
+      result = described_class.call('https://www.boots.com/remington-hydraluxe-hairdryer-10282703')
+
+      expect(result.title).to eq('boots remington hydraluxe hairdryer')
+    end
+
+    it 'does not treat host and route words as sufficient product information' do
+      result = described_class.call('https://www.tesco.com/shop/en-GB/products/326236899')
+
+      expect(result).not_to be_sufficient
+      expect(result.title).to be_nil
+      expect(result.body_text).to be_nil
+      expect(result.product_data).to eq({})
+    end
+  end
+end

--- a/spec/services/api/internal/product_description_from_url_service_spec.rb
+++ b/spec/services/api/internal/product_description_from_url_service_spec.rb
@@ -1,0 +1,147 @@
+RSpec.describe Api::Internal::ProductDescriptionFromUrlService do
+  describe '.call' do
+    let(:url) { 'https://example.com/product' }
+    let(:page) do
+      Api::Internal::ProductDescription::FetchedPage.new(
+        final_url: 'https://example.com/canonical-product',
+        content_type: 'text/html',
+        body: '<html><h1>Cotton T-shirt</h1></html>',
+      )
+    end
+    let(:extracted_content) do
+      Api::Internal::ProductDescription::ExtractedContent.new(
+        title: 'Cotton T-shirt',
+        meta_description: nil,
+        open_graph_title: nil,
+        open_graph_description: nil,
+        h1: 'Cotton T-shirt',
+        product_data: {},
+        body_text: 'Short-sleeved cotton T-shirt',
+      )
+    end
+    let(:generated_result) do
+      Api::Internal::ProductDescription::Result.success(
+        description: 'Short-sleeved cotton T-shirt',
+        source_url: 'https://example.com/canonical-product',
+        confidence: 'high',
+        metadata: { 'title' => 'Cotton T-shirt' },
+      )
+    end
+
+    it 'fetches, extracts and generates a product description' do
+      allow(Api::Internal::ProductDescription::SafeUrlFetcher).to receive(:call).with(url).and_return(page)
+      allow(Api::Internal::ProductDescription::ProductPageExtractor).to receive(:call).with(page.body).and_return(extracted_content)
+      allow(Api::Internal::ProductDescription::ProductDescriptionGenerator).to receive(:call)
+        .with(extracted_content, source_url: page.final_url)
+        .and_return(generated_result)
+
+      result = described_class.call(url)
+
+      expect(result).to eq(generated_result)
+    end
+
+    it 'returns fetcher failures as controlled result failures' do
+      allow(Api::Internal::ProductDescription::SafeUrlFetcher).to receive(:call)
+        .and_raise(Api::Internal::ProductDescription::SafeUrlFetcher::FetchError.new('Unsafe URL', 'URL resolves to an unsafe address'))
+
+      result = described_class.call(url)
+
+      expect(result).not_to be_success
+      expect(result.error_title).to eq('Unsafe URL')
+      expect(result.error_detail).to eq('URL resolves to an unsafe address')
+    end
+
+    it 'generates a product description from URL content when fetching returns an HTTP status error' do
+      url_content = extracted_content.with(
+        title: 'pure cotton garment dyed t shirt',
+        h1: nil,
+        body_text: 'URL path suggests: pure cotton garment dyed t shirt',
+      )
+      fetch_error = Api::Internal::ProductDescription::SafeUrlFetcher::FetchError.new(
+        'Fetch failed',
+        'URL returned HTTP 404',
+        reason: :http_status,
+      )
+
+      allow(Api::Internal::ProductDescription::SafeUrlFetcher).to receive(:call)
+        .with(url)
+        .and_raise(fetch_error)
+      allow(Api::Internal::ProductDescription::UrlContentExtractor).to receive(:call)
+        .with(url)
+        .and_return(url_content)
+      allow(Api::Internal::ProductDescription::ProductDescriptionGenerator).to receive(:call)
+        .with(url_content, source_url: url)
+        .and_return(generated_result.with(source_url: url, confidence: 'high'))
+
+      result = described_class.call(url)
+
+      expect(result).to be_success
+      expect(result.source_url).to eq(url)
+      expect(result.confidence).to eq('low')
+    end
+
+    it 'returns a controlled failure when URL content fallback generation fails' do
+      url_content = extracted_content.with(
+        title: 'pure cotton garment dyed t shirt',
+        h1: nil,
+        body_text: 'URL path suggests: pure cotton garment dyed t shirt',
+      )
+      fetch_error = Api::Internal::ProductDescription::SafeUrlFetcher::FetchError.new(
+        'Fetch failed',
+        'URL returned HTTP 404',
+        reason: :http_status,
+      )
+
+      allow(Api::Internal::ProductDescription::SafeUrlFetcher).to receive(:call)
+        .with(url)
+        .and_raise(fetch_error)
+      allow(Api::Internal::ProductDescription::UrlContentExtractor).to receive(:call)
+        .with(url)
+        .and_return(url_content)
+      allow(Api::Internal::ProductDescription::ProductDescriptionGenerator).to receive(:call)
+        .with(url_content, source_url: url)
+        .and_raise(OpenaiClient::ApiError.new(status: 400, body: { 'error' => 'bad request' }))
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+
+      result = described_class.call(url)
+
+      expect(result).not_to be_success
+      expect(result.error_title).to eq('Product description failed')
+      expect(result.error_detail).to eq('Could not generate a product description from the URL')
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'description_failed.product_description',
+        error_class: 'OpenaiClient::ApiError',
+        error_message: /OpenAI API error/,
+      )
+    end
+
+    it 'returns a controlled failure when extracted content is insufficient' do
+      insufficient_content = extracted_content.with(title: nil, h1: nil, body_text: 'Home')
+
+      allow(Api::Internal::ProductDescription::SafeUrlFetcher).to receive(:call).with(url).and_return(page)
+      allow(Api::Internal::ProductDescription::ProductPageExtractor).to receive(:call).with(page.body).and_return(insufficient_content)
+
+      result = described_class.call(url)
+
+      expect(result).not_to be_success
+      expect(result.error_title).to eq('Insufficient product information')
+      expect(result.error_detail).to eq('Could not identify enough product information from the URL')
+    end
+
+    it 'logs unexpected exceptions and returns a generic failure' do
+      allow(Api::Internal::ProductDescription::SafeUrlFetcher).to receive(:call).and_raise(StandardError, 'boom')
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+
+      result = described_class.call(url)
+
+      expect(result).not_to be_success
+      expect(result.error_title).to eq('Product description failed')
+      expect(result.error_detail).to eq('Could not generate a product description from the URL')
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'description_failed.product_description',
+        error_class: 'StandardError',
+        error_message: 'boom',
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[AI-822](https://transformuk.atlassian.net/browse/AI-822)

```mermaid
%%{init: {"theme":"base", "themeVariables": {"fontFamily":"Inter, ui-sans-serif, system-ui", "primaryColor":"#eef2ff", "primaryBorderColor":"#4f46e5", "primaryTextColor":"#111827", "lineColor":"#64748b", "tertiaryColor":"#f8fafc"}} }%%
flowchart TD
    URL[Product URL]

    subgraph SAFETY [Safe extraction]
        FETCH[Validate and fetch URL]
        PAGE[Bounded page prefix]
        FALLBACK[Sanitized URL product words]
    end

    subgraph AI [AI description]
        EXTRACT[Extract product signals]
        MODEL[Configured low-cost model]
        SERIALIZER[Internal API serializer]
    end

    URL --> FETCH
    FETCH -->|2xx HTML/text| PAGE
    FETCH -->|HTTP status error| FALLBACK
    PAGE --> EXTRACT
    FALLBACK --> MODEL
    EXTRACT --> MODEL
    MODEL --> SERIALIZER

    classDef source fill:#ecfeff,stroke:#0891b2,stroke-width:2px,color:#164e63
    classDef safety fill:#fef3c7,stroke:#d97706,stroke-width:2px,color:#78350f
    classDef ai fill:#eef2ff,stroke:#4f46e5,stroke-width:2px,color:#312e81
    classDef output fill:#dcfce7,stroke:#16a34a,stroke-width:2px,color:#14532d

    class URL source
    class FETCH,PAGE,FALLBACK,EXTRACT safety
    class MODEL ai
    class SERIALIZER output
```

### What?

- [x] Add `POST /internal/product_description` for generating a commodity-search-ready product description from a product URL.
- [x] Add HTTPS-only URL validation, credential rejection, DNS/IP safety checks, redirect revalidation, content-type checks, bounded response retention, redirect limits, and fetch timeouts.
- [x] Add admin configuration for the AI model, response byte cap, redirect limit, and fetch timeouts.
- [x] Default product description generation to `gpt-4.1-mini-2025-04-14` for cost/speed, and avoid sending unsupported `reasoning_effort` values to OpenAI.
- [x] Extract bounded page signals with Nokogiri and send only the extracted product context to `OpenaiClient`.
- [x] Fall back to sanitized URL-derived product words when a safe fetch reaches the host but returns an HTTP status error.
- [x] Prevent risky URL components from reaching the model by excluding credentials, query strings, fragments, numeric IDs, UUIDs, long hex strings, and token-like path words from the fallback payload.
- [x] Avoid generic URL fallback descriptions when the URL only contains host/route words and a product id, for example blocked Tesco numeric product URLs.
- [x] Emit `description_failed.product_description` notifications for unexpected generation failures instead of direct logger calls.
- [x] Serialize successful responses through `Api::Internal::ProductDescriptionSerializer`.
- [x] Add request, service, serializer, URL extraction, OpenAI client, and admin configuration specs for the new behaviour.

### Why?

Guided commodity search needs a safe way to turn product links into concise, semantically useful product descriptions. This adds the backend capability behind the internal API while keeping network access constrained, model selection configurable, and response shape consistent with the rest of the internal controllers.

Retail URLs often contain useful product words even when the page is unavailable, blocked, expired, or returns a status error. The fallback keeps that useful signal without sending raw URLs or sensitive URL components to the model. When a site blocks the server-side fetch and the URL only contains generic route words plus a numeric id, the API now returns an insufficient-information error rather than manufacturing a weak description.

### Validation

- [x] `direnv exec . bundle exec rspec spec/requests/api/internal spec/services/api/internal spec/serializers/api/internal spec/models/admin_configuration_spec.rb spec/lib/openai_client_spec.rb` - 230 examples, 0 failures.
- [x] `direnv exec . bundle exec rubocop app/lib/openai_client.rb app/controllers/api/internal/product_descriptions_controller.rb app/models/admin_configuration.rb app/serializers/api/internal/product_description_serializer.rb app/services/api/internal/product_description app/services/api/internal/product_description_from_url_service.rb spec/lib/openai_client_spec.rb spec/requests/api/internal/product_descriptions_controller_spec.rb spec/serializers/api/internal/product_description_serializer_spec.rb spec/services/api/internal/product_description spec/services/api/internal/product_description_from_url_service_spec.rb spec/models/admin_configuration_spec.rb` - 22 files inspected, no offenses detected.
- [x] Live batch CSV generated at `tmp/product_description_batch/product_descriptions_20260519_131403_strict_url_fallback.csv`: 117 rows, 82 successes, 18 controlled API errors, 17 non-URL inputs recorded by the batch script.

### Risk

**Risk level:** 🟠

**Reason for rating:** This adds a new internal API endpoint and server-side URL fetching, so it falls under the API-change and external-networking risk area. The implementation keeps the endpoint internal, validates and revalidates URLs before each fetch, blocks private/link-local/reserved IP ranges, caps retained response content, limits redirects and timeouts through admin configuration, and covers the flow with request and service specs.
