### PR TITLE
Fix 3 missing eager loads on commodities#show

### DIFF
--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -141,8 +141,8 @@ class CachedCommodityService
         .where(goods_nomenclatures__goods_nomenclature_sid: @commodity_sid)
         .eager(
           goods_nomenclature_descriptions: {},
-          heading: :footnotes,
-          chapter: [:chapter_note, { sections: :section_note }],
+          heading: %i[footnotes goods_nomenclature_descriptions],
+          chapter: [:chapter_note, :goods_nomenclature_descriptions, :guides, { sections: :section_note }],
           ancestors: :goods_nomenclature_descriptions,
           full_chemicals: {},
         )


### PR DESCRIPTION
## What:

Adds `goods_nomenclature_descriptions` to the heading and chapter eager loads, and adds `guides` to the chapter eager load in `CachedCommodityService#commodity`.

## Why:

Three associations were missing from the phase-1 eager load graph, causing a lazy SQL query for each on every cache miss:

**`heading.goods_nomenclature_descriptions`** — `HeadingSerializer` renders `description`, `formatted_description`, and `description_plain`. All three delegate through `goods_nomenclature_description` to `goods_nomenclature_descriptions.first`. Without this in the eager graph, Sequel fires a separate query to load the heading's descriptions.

**`chapter.goods_nomenclature_descriptions`** — Same issue: `ChapterSerializer` renders `description` and `formatted_description`, both backed by `goods_nomenclature_descriptions`.

**`chapter.guides`** — `ChapterSerializer` has `has_many :guides` and `chapter.guides` is listed in `DEFAULT_INCLUDES`, so JSONAPI calls `chapter.guides` for every response. Without eager loading, this fires a separate query per request.

Before:
```ruby
heading: :footnotes,
chapter: [:chapter_note, { sections: :section_note }],
```

After:
```ruby
heading: %i[footnotes goods_nomenclature_descriptions],
chapter: [:chapter_note, :goods_nomenclature_descriptions, :guides, { sections: :section_note }],
```

Sequel batch-loads all three in the same phase-1 pass — 3 fewer queries on every cache miss.

## Ticket:

N/A

## Risk:

🟢 Low — additive-only change to the eager load graph. No logic changes. The associations being added are all `many_to_many` or `many_to_one` associations already defined on the models and already accessed by the serializers; we are simply preloading them instead of lazy-loading.