### PR TITLE
[HMRC-2194] Add formatting to start and end date

### DIFF
--- a/app/lib/reporting/differences.rb
+++ b/app/lib/reporting/differences.rb
@@ -73,6 +73,7 @@ module Reporting
 
     attr_reader :workbook,
                 :regular_style,
+                :date_style,
                 :bold_style,
                 :centered_style,
                 :print_style,
@@ -97,6 +98,14 @@ module Reporting
         font_name: 'Calibri',
         font_size: 11,
         text_wrap: true,
+      )
+
+      @date_style = workbook.add_format(
+        align: { h: :left, v: :top },
+        font_name: 'Calibri',
+        font_size: 11,
+        text_wrap: true,
+        num_format: 'd mmmm yyyy',
       )
 
       @centered_style = workbook.add_format(

--- a/app/lib/reporting/differences/loaders/seasonal.rb
+++ b/app/lib/reporting/differences/loaders/seasonal.rb
@@ -27,8 +27,8 @@ module Reporting
             measure.goods_nomenclature_item_id,
             measure.geographical_area_id,
             measure.measure_type_id,
-            measure.validity_start_date.to_fs(:govuk),
-            measure.validity_end_date.to_fs(:govuk),
+            measure.validity_start_date,
+            measure.validity_end_date,
             measure.failed_duty_status,
           ]
         end

--- a/app/lib/reporting/differences/loaders/seasonal.rb
+++ b/app/lib/reporting/differences/loaders/seasonal.rb
@@ -27,8 +27,8 @@ module Reporting
             measure.goods_nomenclature_item_id,
             measure.geographical_area_id,
             measure.measure_type_id,
-            measure.validity_start_date,
-            measure.validity_end_date,
+            measure.validity_start_date.to_fs(:govuk),
+            measure.validity_end_date.to_fs(:govuk),
             measure.failed_duty_status,
           ]
         end

--- a/app/lib/reporting/differences/renderers/seasonal.rb
+++ b/app/lib/reporting/differences/renderers/seasonal.rb
@@ -4,6 +4,7 @@ module Reporting
       class Seasonal
         delegate :workbook,
                  :regular_style,
+                 :date_style,
                  :bold_style,
                  to: :report
 
@@ -54,7 +55,15 @@ module Reporting
           worksheet.freeze_panes(5, 0)
 
           (rows || []).compact.each do |row|
-            worksheet.append_row(row, regular_style)
+            worksheet.append_row(row, [
+              regular_style,
+              regular_style,
+              regular_style,
+              date_style,
+              date_style,
+              regular_style,
+              regular_style,
+            ])
           end
 
           COLUMN_WIDTHS.each_with_index do |width, index|


### PR DESCRIPTION
## What:
Adds formatting to validity start and end date

## Why:

The Start date and End date columns on the Seasonal duties tab come through as raw 5-digit integers like 46157 and 46326 instead of dates. They're valid Excel date serials, but no date number_format was applied, so Excel just shows the General number. Every other tab in the workbook side-steps this by pre-formatting dates to strings server-side before writing them out (Omitted duties uses '01/01', Measure quot def coverage uses '1 Jan 21 - 18 Jan 25', etc.). The Seasonal loader is the only one that hands raw Ruby Date objects straight to FastExcel.

The fix is in app/lib/reporting/differences/loaders/seasonal.rb#build_row_for - pre-format the two dates the same way the other loaders do:

## Ticket:
[HMRC-2194](https://transformuk.atlassian.net/browse/HMRC-2194)

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Adds formatting to reporting


