### PR TITLE
AI-334: Increase guided search input limit

### DIFF
--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -119,7 +119,7 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
     'suggest_known_brands' => false,
     'suggest_synonyms' => false,
     'input_sanitiser_enabled' => true,
-    'input_sanitiser_max_length' => 500,
+    'input_sanitiser_max_length' => 1000,
     'retrieval_method' => 'hybrid',
     'rrf_k' => 60,
     'vector_ef_search' => 100,

--- a/app/services/api/internal/input_sanitiser.rb
+++ b/app/services/api/internal/input_sanitiser.rb
@@ -1,7 +1,7 @@
 module Api
   module Internal
     class InputSanitiser
-      MAX_QUERY_LENGTH = 500
+      MAX_QUERY_LENGTH = 1000
       NON_PRINTABLE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F\u200B\u200C\u200D\uFEFF]/
 
       def initialize(query)

--- a/spec/models/admin_configuration_spec.rb
+++ b/spec/models/admin_configuration_spec.rb
@@ -397,6 +397,7 @@ RSpec.describe AdminConfiguration do
   describe '.default_for' do
     it 'returns static values directly' do
       expect(described_class.default_for('opensearch_result_limit')).to eq(50)
+      expect(described_class.default_for('input_sanitiser_max_length')).to eq(1000)
     end
 
     it 'returns explicit nested model defaults' do
@@ -444,6 +445,7 @@ RSpec.describe AdminConfiguration do
     context 'when config record is missing' do
       it 'returns the default value' do
         expect(described_class.integer_value('opensearch_result_limit')).to eq(50)
+        expect(described_class.integer_value('input_sanitiser_max_length')).to eq(1000)
         expect(described_class.integer_value('pos_noun_boost')).to eq(10)
         expect(described_class.integer_value('search_result_limit')).to eq(0)
       end

--- a/spec/requests/api/internal/search_controller_spec.rb
+++ b/spec/requests/api/internal/search_controller_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe Api::Internal::SearchController, :internal do
 
     context 'when query exceeds max length' do
       it 'returns 422 with JSON:API errors' do
-        post api_search_path(format: :json), params: { q: 'a' * 501 }
+        post api_search_path(format: :json), params: { q: 'a' * 1001 }
 
         expect(response).to have_http_status(:unprocessable_content)
         body = response.parsed_body

--- a/spec/services/api/internal/input_sanitiser_spec.rb
+++ b/spec/services/api/internal/input_sanitiser_spec.rb
@@ -67,13 +67,21 @@ RSpec.describe Api::Internal::InputSanitiser do
       end
     end
 
+    context 'when input is exactly the max length' do
+      let(:query) { 'a' * 1000 }
+
+      it 'returns the cleaned query' do
+        expect(result).to eq(query: query)
+      end
+    end
+
     context 'when input exceeds max length' do
-      let(:query) { 'a' * 501 }
+      let(:query) { 'a' * 1001 }
 
       it 'returns an error' do
         expect(result[:errors]).to be_present
         expect(result[:errors].first[:status]).to eq('422')
-        expect(result[:errors].first[:detail]).to eq('Query exceeds maximum length of 500 characters')
+        expect(result[:errors].first[:detail]).to eq('Query exceeds maximum length of 1000 characters')
       end
     end
 
@@ -90,16 +98,16 @@ RSpec.describe Api::Internal::InputSanitiser do
       end
     end
 
-    context 'when max length is configured above 500' do
-      let(:query) { 'a' * 501 }
+    context 'when max length is configured above 1000' do
+      let(:query) { 'a' * 1001 }
 
       before do
-        create(:admin_configuration, :integer, name: 'input_sanitiser_max_length', value: 600)
+        create(:admin_configuration, :integer, name: 'input_sanitiser_max_length', value: 1100)
       end
 
-      it 'caps validation at 500 characters' do
+      it 'caps validation at 1000 characters' do
         expect(result[:errors]).to be_present
-        expect(result[:errors].first[:detail]).to eq('Query exceeds maximum length of 500 characters')
+        expect(result[:errors].first[:detail]).to eq('Query exceeds maximum length of 1000 characters')
       end
     end
 

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -616,7 +616,7 @@ RSpec.describe Api::Internal::SearchService do
       it 'returns errors hash without searching' do
         allow(TradeTariffBackend.search_client).to receive(:search)
 
-        result = described_class.new(q: 'a' * 501).call
+        result = described_class.new(q: 'a' * 1001).call
 
         expect(result[:errors]).to be_present
         expect(result[:errors].first[:status]).to eq('422')


### PR DESCRIPTION
### Jira link

[AI-334](https://transformuk.atlassian.net/browse/AI-334)

### What?

- [x] Increase the internal guided search query limit from 500 to 1000 characters
- [x] Update the `input_sanitiser_max_length` admin configuration default to 1000
- [x] Update service, request, and admin configuration specs for the 1000/1001 boundary

### Why?

Guided search needs to accept longer user search inputs. The backend sanitiser enforces the server-side limit for the internal search endpoint, so it needs to match the frontend validation limit.

### Risk

**Risk level:** 🟠

**Reason for rating:** This changes validation behaviour on an internal search API consumed by the frontend. The change is additive because it accepts longer queries than before, and it is covered by focused service and request specs.