### PR TITLE
Update CODEOWNERS to include GitHub Copilot

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @trade-tariff/trade-tariff-core
+*  @trade-tariff/trade-tariff-core @github-copilot


### PR DESCRIPTION
## What:

Adds `@github-copilot` as a reviewer in CODEOWNERS so Copilot is automatically requested on every PR.

## Why:

Trialling Copilot code review as an input to the review process. With Copilot Business (current plan), reviews have to be manually requested per-PR — adding it to CODEOWNERS makes the request automatic without needing an Enterprise upgrade. The existing `copilot-instructions.md` already provides repo context to guide its feedback.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** CODEOWNERS change only. Adds an automated reviewer alongside the existing team; does not remove any human reviewer or change any branch protection rule.