### PR TITLE
AI-334: Mark exact matches as high confidence

### DIFF
--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -241,7 +241,7 @@ module Api
           heading_description: goods_nomenclature.heading&.formatted_description,
           declarable: goods_nomenclature.respond_to?(:declarable?) ? goods_nomenclature.declarable? : false,
           score: nil,
-          confidence: nil,
+          confidence: 'high',
         )
       end
 

--- a/spec/requests/api/internal/search_controller_spec.rb
+++ b/spec/requests/api/internal/search_controller_spec.rb
@@ -95,14 +95,14 @@ RSpec.describe Api::Internal::SearchController, :internal do
                 'score' => nil,
                 'producline_suffix' => '80',
                 'goods_nomenclature_class' => 'Heading',
-                'confidence' => nil,
+                'confidence' => 'high',
               },
             },
           ],
         }
       end
 
-      it 'returns the exact match with null score' do
+      it 'returns the exact match with null score and high confidence' do
         post api_search_path(format: :json), params: { q: 'horse', as_of: Time.zone.today.iso8601 }
 
         expect(response).to have_http_status(:ok)
@@ -140,14 +140,14 @@ RSpec.describe Api::Internal::SearchController, :internal do
                 'score' => nil,
                 'producline_suffix' => '80',
                 'goods_nomenclature_class' => 'Chapter',
-                'confidence' => nil,
+                'confidence' => 'high',
               },
             },
           ],
         }
       end
 
-      it 'returns the exact match with null score' do
+      it 'returns the exact match with null score and high confidence' do
         post api_search_path(format: :json), params: { q: '01', as_of: Time.zone.today.iso8601 }
 
         expect(response).to have_http_status(:ok)


### PR DESCRIPTION
### Jira link

[AI-334](https://transformuk.atlassian.net/browse/AI-334)

### What?

- [x] Mark internal guided-search exact matches as `high` confidence
- [x] Update exact-match request specs for search-reference and padded-code matches

### Why?

Exact matches currently return `confidence: null`, which makes a deterministic exact match look like an unknown-confidence answer to the frontend. Returning `high` makes the backend confidence signal match the certainty of the exact-match path.

### Risk

**Risk level:** 🟠

**Reason for rating:** This is a narrow response-shape change for exact matches only, but it is still consumed by the frontend. Non-exact retrieval results keep their existing confidence behaviour, and request specs cover both exact-match paths changed here.