### PR TITLE
Fix for New Relic deployment marker failing

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -10,6 +10,10 @@ on:
       - labeled
       - unlabeled
 
+concurrency:
+  group: deploy-development
+  cancel-in-progress: true
+
 permissions:
   contents: read
   id-token: write
@@ -39,3 +43,46 @@ jobs:
         with:
           service-names: backend-uk backend-xi worker-uk worker-xi
           environment: development
+
+  newrelic:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'needs-deployment')
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - uses: actions/checkout@v6
+      - id: docker-tag
+        run: echo "DOCKER_TAG=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - name: New Relic deployment marker for backend UK
+        uses: newrelic/deployment-marker-action@v2.6.2
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          region: "EU"
+          guid: ${{ secrets.NEW_RELIC_BACKEND_UK_GUID }}
+          version: ${{ steps.docker-tag.outputs.DOCKER_TAG }}
+          user: "${{ github.actor }}"
+      - name: New Relic deployment marker for backend XI
+        uses: newrelic/deployment-marker-action@v2.6.2
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          region: "EU"
+          guid: ${{ secrets.NEW_RELIC_BACKEND_XI_GUID }}
+          version: ${{ steps.docker-tag.outputs.DOCKER_TAG }}
+          user: "${{ github.actor }}"
+      - name: New Relic deployment marker for worker UK
+        uses: newrelic/deployment-marker-action@v2.6.2
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          region: "EU"
+          guid: ${{ secrets.NEW_RELIC_WORKER_UK_GUID }}
+          version: ${{ steps.docker-tag.outputs.DOCKER_TAG }}
+          user: "${{ github.actor }}"
+      - name: New Relic deployment marker for worker XI
+        uses: newrelic/deployment-marker-action@v2.6.2
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          region: "EU"
+          guid: ${{ secrets.NEW_RELIC_WORKER_XI_GUID }}
+          version: ${{ steps.docker-tag.outputs.DOCKER_TAG }}
+          user: "${{ github.actor }}"

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: deploy-production
+  cancel-in-progress: true
+
 permissions:
   contents: read
   id-token: write
@@ -26,3 +30,43 @@ jobs:
       basic-password: ${{ secrets.BASIC_PASSWORD }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
       ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
+
+  newrelic:
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - uses: actions/checkout@v6
+      - id: docker-tag
+        run: echo "DOCKER_TAG=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - name: New Relic deployment marker for backend UK
+        uses: newrelic/deployment-marker-action@v2.6.2
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          region: "EU"
+          guid: ${{ secrets.NEW_RELIC_BACKEND_UK_GUID }}
+          version: ${{ steps.docker-tag.outputs.DOCKER_TAG }}
+          user: "${{ github.actor }}"
+      - name: New Relic deployment marker for backend XI
+        uses: newrelic/deployment-marker-action@v2.6.2
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          region: "EU"
+          guid: ${{ secrets.NEW_RELIC_BACKEND_XI_GUID }}
+          version: ${{ steps.docker-tag.outputs.DOCKER_TAG }}
+          user: "${{ github.actor }}"
+      - name: New Relic deployment marker for worker UK
+        uses: newrelic/deployment-marker-action@v2.6.2
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          region: "EU"
+          guid: ${{ secrets.NEW_RELIC_WORKER_UK_GUID }}
+          version: ${{ steps.docker-tag.outputs.DOCKER_TAG }}
+          user: "${{ github.actor }}"
+      - name: New Relic deployment marker for worker XI
+        uses: newrelic/deployment-marker-action@v2.6.2
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          region: "EU"
+          guid: ${{ secrets.NEW_RELIC_WORKER_XI_GUID }}
+          version: ${{ steps.docker-tag.outputs.DOCKER_TAG }}
+          user: "${{ github.actor }}"

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: true
+
 permissions:
   contents: read
   id-token: write
@@ -21,3 +25,43 @@ jobs:
       basic-password: ${{ secrets.BASIC_PASSWORD }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
       ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
+
+  newrelic:
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - uses: actions/checkout@v6
+      - id: docker-tag
+        run: echo "DOCKER_TAG=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - name: New Relic deployment marker for backend UK
+        uses: newrelic/deployment-marker-action@v2.6.2
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          region: "EU"
+          guid: ${{ secrets.NEW_RELIC_BACKEND_UK_GUID }}
+          version: ${{ steps.docker-tag.outputs.DOCKER_TAG }}
+          user: "${{ github.actor }}"
+      - name: New Relic deployment marker for backend XI
+        uses: newrelic/deployment-marker-action@v2.6.2
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          region: "EU"
+          guid: ${{ secrets.NEW_RELIC_BACKEND_XI_GUID }}
+          version: ${{ steps.docker-tag.outputs.DOCKER_TAG }}
+          user: "${{ github.actor }}"
+      - name: New Relic deployment marker for worker UK
+        uses: newrelic/deployment-marker-action@v2.6.2
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          region: "EU"
+          guid: ${{ secrets.NEW_RELIC_WORKER_UK_GUID }}
+          version: ${{ steps.docker-tag.outputs.DOCKER_TAG }}
+          user: "${{ github.actor }}"
+      - name: New Relic deployment marker for worker XI
+        uses: newrelic/deployment-marker-action@v2.6.2
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          region: "EU"
+          guid: ${{ secrets.NEW_RELIC_WORKER_XI_GUID }}
+          version: ${{ steps.docker-tag.outputs.DOCKER_TAG }}
+          user: "${{ github.actor }}"


### PR DESCRIPTION
## What:
Add New Relic deployment markers for all backend runtime entities: backend UK, backend XI, worker UK, and worker XI. 

## Why:
When backend is deployed a marker should be added in New Relic as part of the deployment process. 

This job has started failing with the error - `Valid entityGuids are required to create a deployment marker`.

## Ticket:
[HMRC-1289](https://transformuk.atlassian.net/browse/HMRC-1289)

## Risk:
🟢 

**Reason for rating:**
The change is limited to GitHub Actions deployment workflows. The main risk is missing or incorrect GitHub secrets for one of the four New Relic GUIDs, which would fail the marker step after deployment. Application runtime behaviour is unaffected.