### PR TITLE
AI-840: Update intercept template copy

### DIFF
--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -48,21 +48,29 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
     - online listings
     - product information documents included in the packaging
 
+    ## What if I need more help?
+
+    Guidance on classifying products can be found in [help on using the tariff (opens in new tab)](https://www.gov.uk/guidance/classification-of-goods/) where you can find information about:
+
+    - structure of commodity codes
+    - the information you need to classify a product
+    - detailed guidance on hard to classify products
+
     ## Next steps
 
     Go back and add more details so we can find the relevant commodity code with the highest accuracy.
   MARKDOWN
 
   ESCALATION_DESCRIPTION_INTERCEPT_MESSAGE = <<~MARKDOWN.strip.freeze
-    You should contact HMRC for help classifying this product.
+    The product you're searching for is difficult to classify.
 
     ## Next steps
 
-    Contact HMRC and quote reference {{request_id}}
+    You should contact HMRC for help classifying this product.
 
-    *Webchat*: [Ask HMRC online]({{webchat_url}})
+    **Webchat:** [Ask HMRC online]({{webchat_url}})
 
-    *Email*: [{{enquiries_email}}](mailto:{{enquiries_email}})
+    **Email:** [{{enquiries_email}}](mailto:{{enquiries_email}})
   MARKDOWN
 
   DEFAULTS = {

--- a/spec/lib/tasks/admin_configurations_rake_spec.rb
+++ b/spec/lib/tasks/admin_configurations_rake_spec.rb
@@ -63,18 +63,20 @@ RSpec.describe 'admin_configurations:seed' do
     expect(config.value['generic']['attributes']).to include(
       'excluded' => true,
       'message_header' => "We can't suggest a tariff code yet",
-      'message' => include('This information might be found on:'),
+      'message' => include('## What if I need more help?'),
       'guidance_level' => 'info',
       'guidance_location' => 'interstitial',
       'sources' => %w[guided_search fpo_search],
     )
+    expect(config.value['generic']['attributes']['message']).to include('Guidance on classifying products can be found in [help on using the tariff (opens in new tab)]')
     expect(config.value['escalation']['label']).to eq('Escalation guidance')
     expect(config.value['escalation']['attributes']).to include(
       'excluded' => true,
       'escalate_to_webchat' => true,
       'message_header' => 'Contact HMRC for help',
     )
-    expect(config.value['escalation']['attributes']['message']).to include('{{request_id}}')
+    expect(config.value['escalation']['attributes']['message']).to include("The product you're searching for is difficult to classify.")
+    expect(config.value['escalation']['attributes']['message']).not_to include('{{request_id}}')
     expect(config.value['escalation']['attributes']['message']).to include('{{webchat_url}}')
     expect(config.value['escalation']['attributes']['message']).to include('{{enquiries_email}}')
   end

--- a/spec/models/admin_configuration_spec.rb
+++ b/spec/models/admin_configuration_spec.rb
@@ -400,6 +400,29 @@ RSpec.describe AdminConfiguration do
       expect(described_class.default_for('input_sanitiser_max_length')).to eq(1000)
     end
 
+    it 'returns the current description intercept template copy' do
+      templates = described_class.default_for('description_intercept_templates')
+
+      expect(templates['generic']['attributes']['message']).to include(
+        '## What if I need more help?',
+        'Guidance on classifying products can be found in [help on using the tariff (opens in new tab)]',
+        '- structure of commodity codes',
+        '- the information you need to classify a product',
+        '- detailed guidance on hard to classify products',
+      )
+      expect(templates['escalation']['attributes']['message']).to eq(<<~MARKDOWN.strip)
+        The product you're searching for is difficult to classify.
+
+        ## Next steps
+
+        You should contact HMRC for help classifying this product.
+
+        **Webchat:** [Ask HMRC online]({{webchat_url}})
+
+        **Email:** [{{enquiries_email}}](mailto:{{enquiries_email}})
+      MARKDOWN
+    end
+
     it 'returns explicit nested model defaults' do
       expect(described_class.default_for('search_model')).to eq('gpt-5.4')
     end


### PR DESCRIPTION
## What

Updates the default description intercept templates used for guided and FPO search interstitials:

- adds the generic guidance "What if I need more help?" section and link to classification guidance
- changes the escalation guidance to match the HMRC contact copy
- removes the request ID instruction from the escalation copy
- adds coverage for the default template copy and seeded admin configuration registry

## Why

The no-code-suggested templates need to match the updated content for AI-840.

## Risk

Low. This changes seeded/default template copy only; existing stored admin configuration values will only change when seeded/imported from these defaults.