### PR TITLE
Remove User API writer read exception

### DIFF
--- a/app/middleware/use_reader_for_reads.rb
+++ b/app/middleware/use_reader_for_reads.rb
@@ -14,19 +14,12 @@
 class UseReaderForReads
   READ_METHODS = %w[GET HEAD].freeze
 
-  # User API authentication can create PublicUsers::User records on first use,
-  # so these routes need the writer even for GET/HEAD requests.
-  WRITER_READ_PATH_PREFIXES = %w[
-    /uk/user
-    /xi/user
-  ].freeze
-
   def initialize(app)
     @app = app
   end
 
   def call(env)
-    if read_request?(env) && !writer_read_request?(env)
+    if read_request?(env)
       Sequel::Model.db.with_server(:reader) { @app.call(env) }
     else
       @app.call(env)
@@ -37,13 +30,5 @@ private
 
   def read_request?(env)
     READ_METHODS.include?(env['REQUEST_METHOD'])
-  end
-
-  def writer_read_request?(env)
-    path = env['PATH_INFO'].to_s
-
-    WRITER_READ_PATH_PREFIXES.any? do |prefix|
-      path == prefix || path.start_with?("#{prefix}/")
-    end
   end
 end

--- a/spec/middleware/use_reader_for_reads_spec.rb
+++ b/spec/middleware/use_reader_for_reads_spec.rb
@@ -38,24 +38,6 @@ RSpec.describe UseReaderForReads do
       end
     end
 
-    context 'when the GET request is under the user API' do
-      let(:env) { Rack::MockRequest.env_for('/uk/user/commodity_changes', method: 'GET') }
-
-      it 'does not route through the reader server' do
-        middleware.call(env)
-        expect(Sequel::Model.db).not_to have_received(:with_server)
-      end
-    end
-
-    context 'when the HEAD request is under the user API' do
-      let(:env) { Rack::MockRequest.env_for('/uk/user/users', method: 'HEAD') }
-
-      it 'does not route through the reader server' do
-        middleware.call(env)
-        expect(Sequel::Model.db).not_to have_received(:with_server)
-      end
-    end
-
     context 'when the request method is POST' do
       let(:env) { Rack::MockRequest.env_for('/uk/api/something', method: 'POST') }
 


### PR DESCRIPTION
## What:
Restores use of DB reader connection for User API. 

## Why:
An exception had been made because a GET request was writing to the database when a new user was created.
This has been rectified with https://github.com/trade-tariff/trade-tariff-backend/pull/3159.
No GET requests cause writes to the database anymore.

## Ticket:
N/A

## Risk:
**Risk level:** 🟠

**Reason for rating:**
Removes fix for an issue that caused exceptions for new users. The database update that was happening on a GET request has been removed so this should be safe.

