### PR TITLE
BAU: Cache expanded internal search query

### DIFF
--- a/app/controllers/api/internal/search_controller.rb
+++ b/app/controllers/api/internal/search_controller.rb
@@ -18,7 +18,7 @@ module Api
       private
 
       def search_params
-        params.permit(:q, :as_of, :request_id, answers: %i[question answer options])
+        params.permit(:q, :as_of, :request_id, :expanded_query, answers: %i[question answer options])
       end
     end
   end

--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -5,7 +5,7 @@ module Api
 
       RetrievalResult = Data.define(:goods_nomenclatures, :max_score, :expanded_query, :results_type)
 
-      attr_reader :q, :as_of, :answers, :request_id, :description_intercept
+      attr_reader :q, :as_of, :answers, :request_id, :description_intercept, :expanded_query
 
       def initialize(params = {})
         sanitiser_result = InputSanitiser.new(params[:q]).call
@@ -20,6 +20,7 @@ module Api
         @as_of = parse_date(params[:as_of])
         @answers = normalize_answers(params[:answers])
         @request_id = params[:request_id] || SecureRandom.uuid
+        @expanded_query = params[:expanded_query].to_s.strip.presence
       end
 
       def call
@@ -142,6 +143,8 @@ module Api
       end
 
       def normalised_query
+        return InternalSearchQueryNormaliserService::Result.new(query: q, expanded_query: expanded_query) if expanded_query.present?
+
         @normalised_query ||= InternalSearchQueryNormaliserService.call(query: q, request_id: request_id)
       end
 

--- a/spec/requests/api/internal/search_controller_spec.rb
+++ b/spec/requests/api/internal/search_controller_spec.rb
@@ -367,13 +367,17 @@ RSpec.describe Api::Internal::SearchController, :internal do
       end
 
       it 'accepts answers parameter and responds successfully' do
+        allow(ExpandSearchQueryService).to receive(:call)
+
         post api_search_path(format: :json), params: {
           q: 'handbag',
+          expanded_query: 'leather handbag travel bag',
           request_id: 'test-123',
           answers: [{ question: 'Material?', answer: 'Leather' }],
         }
 
         expect(response).to have_http_status(:ok)
+        expect(ExpandSearchQueryService).not_to have_received(:call)
         expect(InteractiveSearchService).to have_received(:call)
       end
     end

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -1089,5 +1089,66 @@ RSpec.describe Api::Internal::SearchService do
         expect(result[:meta][:interactive_search]).to include(expanded_query: 'portable data processing machine')
       end
     end
+
+    context 'when expanded_query is supplied by the client' do
+      let(:opensearch_response) do
+        {
+          'hits' => {
+            'hits' => [
+              {
+                '_score' => 10.0,
+                '_source' => {
+                  'goods_nomenclature_sid' => 1,
+                  'goods_nomenclature_item_id' => '8471300000',
+                  'producline_suffix' => '80',
+                  'goods_nomenclature_class' => 'Commodity',
+                  'description' => 'portable data processing machine',
+                  'formatted_description' => 'Portable data processing machine',
+                  'declarable' => true,
+                },
+              },
+            ],
+          },
+        }
+      end
+
+      let(:interactive_result) do
+        InteractiveSearchService::Result.new(
+          type: :questions,
+          data: [{ question: 'What type of laptop?', options: %w[Personal Business] }],
+          attempt: 2,
+          model: 'gpt-5.2',
+          result_limit: 5,
+        )
+      end
+
+      before do
+        allow(AdminConfiguration).to receive(:enabled?).and_call_original
+        allow(AdminConfiguration).to receive(:enabled?).with('expand_search_enabled').and_return(true)
+        allow(ExpandSearchQueryService).to receive(:call)
+        allow(Search::GoodsNomenclatureQuery).to receive(:new).and_call_original
+        allow(TradeTariffBackend.search_client).to receive(:search).and_return(opensearch_response)
+        allow(InteractiveSearchService).to receive(:call).and_return(interactive_result)
+      end
+
+      it 'reuses the supplied expanded query without expanding again' do
+        result = described_class.new(
+          q: 'laptop',
+          expanded_query: 'portable data processing machine',
+          answers: [{ question: 'What type of laptop?', answer: 'Personal' }],
+        ).call
+
+        expect(ExpandSearchQueryService).not_to have_received(:call)
+        expect(Search::GoodsNomenclatureQuery).to have_received(:new).with(
+          'laptop',
+          anything,
+          hash_including(expanded_query: 'portable data processing machine'),
+        )
+        expect(InteractiveSearchService).to have_received(:call).with(
+          hash_including(expanded_query: 'portable data processing machine'),
+        )
+        expect(result[:meta][:interactive_search]).to include(expanded_query: 'portable data processing machine')
+      end
+    end
   end
 end


### PR DESCRIPTION
## What:

- [x] Permit `expanded_query` on the internal search endpoint.
- [x] Reuse a supplied expanded query instead of calling `ExpandSearchQueryService` again.
- [x] Keep returning the expanded query in interactive search meta when it differs from the original query.
- [x] Add service and request specs for the follow-up request path.

## Why:

Query expansion can call the configured AI expansion service. Interactive search repeats the backend request for each answered question, so reusing the expanded query avoids expanding the same original search term on every iteration.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** This affects the internal guided search flow, which is not enabled in production yet. The change is additive: existing clients can omit `expanded_query` and keep the current expansion behaviour.