### PR TITLE
Batch tariff change goods nomenclature lookups

### DIFF
--- a/app/services/tariff_changes_service.rb
+++ b/app/services/tariff_changes_service.rb
@@ -93,23 +93,42 @@ class TariffChangesService
       add_change_record(change, change[:goods_nomenclature_item_id], change[:goods_nomenclature_sid])
     end
 
+    declarables_by_sid = measure_declarables_by_sid
+
     @changes[:measures].each do |change|
-      gn = GoodsNomenclature.where(goods_nomenclature_sid: change[:goods_nomenclature_sid]).first
-
-      declarables = if gn.nil?
-                      []
-                    elsif gn&.declarable?
-                      [gn]
-                    else
-                      gn.descendants.select(&:declarable?)
-                    end
-
-      declarables.each do |declarable|
+      declarables_by_sid.fetch(change[:goods_nomenclature_sid], []).each do |declarable|
         next if matching_commodity_change?(declarable.goods_nomenclature_sid, change[:action])
 
         add_change_record(change, declarable.goods_nomenclature_item_id, declarable.goods_nomenclature_sid)
       end
     end
+  end
+
+  def measure_declarables_by_sid
+    @measure_declarables_by_sid ||= begin
+      goods_nomenclature_sids = @changes[:measures].filter_map { |change| change[:goods_nomenclature_sid] }.uniq
+
+      if goods_nomenclature_sids.empty?
+        {}
+      else
+        goods_nomenclatures = GoodsNomenclature
+          .where(goods_nomenclature_sid: goods_nomenclature_sids)
+          .eager(:descendants)
+          .all
+          .index_by(&:goods_nomenclature_sid)
+
+        goods_nomenclature_sids.index_with do |goods_nomenclature_sid|
+          declarables_for(goods_nomenclatures[goods_nomenclature_sid])
+        end
+      end
+    end
+  end
+
+  def declarables_for(goods_nomenclature)
+    return [] if goods_nomenclature.nil?
+    return [goods_nomenclature] if goods_nomenclature.declarable?
+
+    goods_nomenclature.descendants.select(&:declarable?)
   end
 
   def matching_commodity_change?(goods_nomenclature_sid, action)

--- a/spec/services/tariff_changes_service_spec.rb
+++ b/spec/services/tariff_changes_service_spec.rb
@@ -534,6 +534,53 @@ RSpec.describe TariffChangesService do
         end
       end
 
+      context 'with multiple measure changes' do
+        let!(:first_goods_nomenclature) { create(:commodity, :declarable, goods_nomenclature_sid: 67_890) }
+        let!(:second_goods_nomenclature) { create(:commodity, :declarable, goods_nomenclature_sid: 67_891) }
+
+        before do
+          service.instance_variable_set(:@changes, {
+            commodities: [],
+            commodity_descriptions: [],
+            measures: [
+              {
+                type: 'Measure',
+                object_sid: 54_321,
+                goods_nomenclature_sid: first_goods_nomenclature.goods_nomenclature_sid,
+              },
+              {
+                type: 'Measure',
+                object_sid: 54_322,
+                goods_nomenclature_sid: first_goods_nomenclature.goods_nomenclature_sid,
+              },
+              {
+                type: 'Measure',
+                object_sid: 54_323,
+                goods_nomenclature_sid: second_goods_nomenclature.goods_nomenclature_sid,
+              },
+            ],
+          })
+        end
+
+        it 'loads goods nomenclatures once for the measure batch' do
+          allow(service).to receive(:matching_commodity_change?).and_return(false)
+          allow(GoodsNomenclature).to receive(:where).and_call_original
+
+          service.generate_commodity_change_records
+
+          expect(GoodsNomenclature).to have_received(:where).with(goods_nomenclature_sid: [
+            first_goods_nomenclature.goods_nomenclature_sid,
+            second_goods_nomenclature.goods_nomenclature_sid,
+          ]).once
+          measure_records = service.tariff_change_records.select { |record| record[:type] == 'Measure' }
+          expect(measure_records.map { |record| record[:goods_nomenclature_sid] }).to contain_exactly(
+            first_goods_nomenclature.goods_nomenclature_sid,
+            first_goods_nomenclature.goods_nomenclature_sid,
+            second_goods_nomenclature.goods_nomenclature_sid,
+          )
+        end
+      end
+
       context 'when goods nomenclature is not declarable but has declarable descendants' do
         let(:non_declarable_parent) { create(:heading, goods_nomenclature_sid: 67_890) }
         let(:declarable_child) { create(:commodity, :declarable, parent: non_declarable_parent) }


### PR DESCRIPTION
## What:
Batch goods nomenclature lookups during tariff-change generation for measure changes.

Previously, `TariffChangesService` looked up the goods nomenclature inside the measure-change loop:

`GoodsNomenclature.where(goods_nomenclature_sid: change[:goods_nomenclature_sid]).first`

That caused repeated DB queries for every measure change, and repeated descendant lookups when the goods nomenclature was not declarable.

The change now collects all unique `goods_nomenclature_sid` values from measure changes, loads the matching goods nomenclatures once with eager-loaded descendants, builds a `sid => declarable goods nomenclatures` map, and then expands each measure change from that in-memory map.

Before/after comparison from local development data for `2023-10-02`:

Case | Expanded records | Queries | Elapsed
-- | -- | -- | --
Before | 121 | 524 | 430.18 ms
After | 121 | 19 | 21.68 ms

Impact:
- `505` fewer queries
- `96.4%` query reduction
- `95.0%` faster for the measured expansion step
- Same generated output count: `121` records before and after

## Why:
This removes a pure N+1 query pattern in tariff-change generation.

Measure changes can contain repeated goods nomenclature SIDs, and each non-declarable goods nomenclature can require descendant expansion. Doing this inside the loop scales poorly for batch dates with many measure changes.

Using `.eager(:descendants)` keeps the existing model behaviour intact because it uses the current `descendants` association, including hidden filtering, validity-date handling, tree ordering, and recursive child/parent population used by `declarable?`.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢 (Low to medium)

**Reason for rating:**
The change is intentionally defensive: it preserves the original direct goods nomenclature lookup semantics by still using:

`GoodsNomenclature.where(goods_nomenclature_sid: ...)`

It only changes when the DB work happens: once per batch instead of once per measure change.

**Main risks:**

- A subtle difference in descendant eager-loading behaviour compared with lazy loading.
- Increased memory usage for dates with very large numbers of unique measure-change goods nomenclature SIDs.
- Any hidden dependency on lazy-loading side effects, though the existing nested-set specs cover eager descendant behaviour.

**Mitigations:**

- Existing behaviour paths are covered: missing goods nomenclature, declarable goods nomenclature, non-declarable parent with declarable descendants, and matching commodity-change skip.
- Added regression coverage confirming multiple measure changes use a single batch lookup.
- Verified before/after generated record count matched on development data.
