### PR TITLE
AI-633: Add answer-driven retrieval refresh to guided search

### DIFF
--- a/app/controllers/api/v2/search_controller.rb
+++ b/app/controllers/api/v2/search_controller.rb
@@ -7,7 +7,7 @@ module Api
       no_caching
 
       def search
-        request_id = params[:request_id] || SecureRandom.uuid
+        request_id = TradeTariffRequest.request_id.presence || SecureRandom.uuid
 
         results = ::Search::Instrumentation.search(request_id:, query: params[:q], search_type: 'classic') do
           res = SearchService.new(Api::V2::SearchSerializationService.new, params).to_json

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::API
 
   respond_to :json
 
+  before_action :set_trade_tariff_request_id
   before_action :maintenance_mode_if_active
   around_action :configure_time_machine
   after_action  :check_query_count, if: -> { TradeTariffBackend.check_query_count? }
@@ -61,5 +62,9 @@ class ApplicationController < ActionController::API
 
   def maintenance_mode_if_active
     MaintenanceMode.check! params[:maintenance_bypass]
+  end
+
+  def set_trade_tariff_request_id
+    TradeTariffRequest.request_id = params[:request_id].presence || request.request_id
   end
 end

--- a/app/lib/search/instrumentation.rb
+++ b/app/lib/search/instrumentation.rb
@@ -7,7 +7,7 @@ module Search
     ERROR_MESSAGE_MAX_LENGTH = 500
 
     def instrument(event_name, payload = {}, &block)
-      ActiveSupport::Notifications.instrument("#{event_name}.search", payload, &block)
+      ActiveSupport::Notifications.instrument("#{event_name}.search", with_request_id(payload), &block)
     end
 
     def search_started(request_id:, query:, search_type:)
@@ -44,6 +44,16 @@ module Search
       )
 
       result
+    end
+
+    def query_refined(request_id:, original_query:, refined_query:, answer_count:)
+      result = yield
+      instrument('query_refined', request_id:, original_query:, refined_query:, answer_count:)
+      result
+    end
+
+    def query_expansion_decided(request_id:, query:, expand:, reason:, result_count:, max_score:)
+      instrument('query_expansion_decided', request_id:, query:, expand:, reason:, result_count:, max_score:)
     end
 
     def api_call(request_id:, model:, attempt_number:)
@@ -196,6 +206,12 @@ module Search
         error_message: message.first(ERROR_MESSAGE_MAX_LENGTH),
         error_message_truncated: message.length > ERROR_MESSAGE_MAX_LENGTH,
       }
+    end
+
+    def with_request_id(payload)
+      return payload unless payload.key?(:request_id)
+
+      payload.merge(request_id: payload[:request_id].presence || TradeTariffRequest.request_id.presence || SecureRandom.uuid)
     end
   end
 end

--- a/app/lib/search/logger.rb
+++ b/app/lib/search/logger.rb
@@ -22,6 +22,28 @@ module Search
       )
     end
 
+    def query_refined(event)
+      info log_entry(
+        event: 'query_refined',
+        request_id: event.payload[:request_id],
+        original_query: event.payload[:original_query],
+        refined_query: event.payload[:refined_query],
+        answer_count: event.payload[:answer_count],
+      )
+    end
+
+    def query_expansion_decided(event)
+      info log_entry(
+        event: 'query_expansion_decided',
+        request_id: event.payload[:request_id],
+        query: event.payload[:query],
+        expand: event.payload[:expand],
+        reason: event.payload[:reason],
+        result_count: event.payload[:result_count],
+        max_score: event.payload[:max_score],
+      )
+    end
+
     def api_call_completed(event)
       data = {
         event: 'api_call_completed',

--- a/app/lib/trade_tariff_request.rb
+++ b/app/lib/trade_tariff_request.rb
@@ -1,5 +1,6 @@
 class TradeTariffRequest < ActiveSupport::CurrentAttributes
   attribute :whodunnit,
+            :request_id,
             :green_lanes,
             :time_machine_now,
             # Controls how TimeMachine filters associated records in queries.

--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -7,7 +7,7 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
   NESTED_OPTION_DEFAULTS = {
     'expand_model' => {
       selected: 'gpt-4.1-mini-2025-04-14',
-      sub_values: { 'reasoning_effort' => 'low' },
+      sub_values: {},
     },
     'label_model' => {
       selected: 'gpt-5.4',
@@ -105,10 +105,14 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
       },
     },
     'expand_search_enabled' => false,
+    'expand_search_min_results' => 5,
+    'expand_search_min_score' => 5,
+    'expand_search_when_needed_enabled' => false,
     'expand_model' => NESTED_OPTION_DEFAULTS['expand_model'][:selected],
     'interactive_search_enabled' => true,
     'interactive_search_excluded_chapters' => %w[98 99].freeze,
     'interactive_search_max_questions' => 7,
+    'refine_search_with_answers_enabled' => false,
     'label_model' => NESTED_OPTION_DEFAULTS['label_model'][:selected],
     'label_page_size' => -> { TradeTariffBackend.goods_nomenclature_label_page_size },
     'opensearch_result_limit' => 50,
@@ -220,9 +224,11 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
     default_value = default_for(name)
 
     if config.nil?
+      selected = nested_default&.fetch(:selected, default_value) || default_value
+
       return {
-        selected: nested_default&.fetch(:selected, default_value) || default_value,
-        sub_values: nested_default&.fetch(:sub_values, {}) || {},
+        selected: selected,
+        sub_values: supported_nested_sub_values(selected, nested_default&.fetch(:sub_values, {}) || {}),
       }
     end
 
@@ -233,10 +239,26 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
            else {}
            end
 
+    selected = hash['selected'].presence || default_value
+
     {
-      selected: hash['selected'].presence || default_value,
-      sub_values: hash['sub_values'].is_a?(Hash) ? hash['sub_values'] : {},
+      selected: selected,
+      sub_values: supported_nested_sub_values(selected, hash['sub_values'].is_a?(Hash) ? hash['sub_values'] : {}),
     }
+  end
+
+  def self.supported_nested_sub_values(selected, sub_values)
+    return {} unless sub_values.is_a?(Hash)
+
+    model_config = OpenaiClient::MODEL_CONFIGS[selected.to_s]
+    return sub_values if model_config.nil?
+
+    allowed = {}
+    if model_config[:reasoning_levels].present? && model_config[:reasoning_levels].include?(sub_values['reasoning_effort'])
+      allowed['reasoning_effort'] = sub_values['reasoning_effort']
+    end
+
+    allowed
   end
 
   def self.description_intercept_templates_value

--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -19,7 +19,8 @@ module Api
 
         @as_of = parse_date(params[:as_of])
         @answers = normalize_answers(params[:answers])
-        @request_id = params[:request_id] || SecureRandom.uuid
+        @request_id = params[:request_id].presence || TradeTariffRequest.request_id.presence || SecureRandom.uuid
+        TradeTariffRequest.request_id ||= @request_id
         @expanded_query = params[:expanded_query].to_s.strip.presence
       end
 
@@ -82,10 +83,35 @@ module Api
       end
 
       def retrieve_short_list
+        if conditional_expansion_enabled?
+          return retrieve_short_list_with_conditional_expansion
+        end
+
+        retrieve_short_list_with_expanded_query(normalised_query.expanded_query)
+      end
+
+      def retrieve_short_list_with_conditional_expansion
+        unexpanded_query = retrieval_query
+        preliminary_retrieval = retrieve_short_list_with_expanded_query(unexpanded_query)
+        decision = SearchExpansionDecisionService.call(
+          query: unexpanded_query,
+          results: preliminary_retrieval.goods_nomenclatures,
+          request_id: request_id,
+        )
+
+        return preliminary_retrieval unless decision.expand?
+
+        expanded = expand_query(unexpanded_query)
+        return preliminary_retrieval if expanded == unexpanded_query
+
+        retrieve_short_list_with_expanded_query(expanded)
+      end
+
+      def retrieve_short_list_with_expanded_query(search_expanded_query)
         case retrieval_method
-        when 'vector' then vector_short_list
-        when 'hybrid' then hybrid_short_list
-        else opensearch_short_list
+        when 'vector' then vector_short_list(search_expanded_query)
+        when 'hybrid' then hybrid_short_list(search_expanded_query)
+        else opensearch_short_list(search_expanded_query)
         end
       end
 
@@ -93,9 +119,9 @@ module Api
         AdminConfiguration.option_value('retrieval_method')
       end
 
-      def vector_short_list
+      def vector_short_list(search_expanded_query)
         goods_nomenclatures = VectorRetrievalService.call(
-          query: normalised_query.expanded_query,
+          query: search_expanded_query,
           limit: opensearch_result_limit,
           filter_prefixes: filter_prefixes,
         )
@@ -103,14 +129,14 @@ module Api
         RetrievalResult.new(
           goods_nomenclatures: goods_nomenclatures,
           max_score: goods_nomenclatures.map(&:score).compact.max,
-          expanded_query: normalised_query.expanded_query,
+          expanded_query: search_expanded_query,
           results_type: 'vector',
         )
       end
 
-      def opensearch_short_list
+      def opensearch_short_list(search_expanded_query)
         result = OpensearchRetrievalService.call(
-          query: q, expanded_query: normalised_query.expanded_query,
+          query: q, expanded_query: search_expanded_query,
           as_of: as_of, request_id: request_id, limit: opensearch_result_limit,
           filter_prefixes: filter_prefixes
         )
@@ -123,9 +149,9 @@ module Api
         )
       end
 
-      def hybrid_short_list
+      def hybrid_short_list(search_expanded_query)
         result = HybridRetrievalService.call(
-          query: q, expanded_query: normalised_query.expanded_query,
+          query: q, expanded_query: search_expanded_query,
           as_of: as_of, request_id: request_id, limit: opensearch_result_limit,
           filter_prefixes: filter_prefixes
         )
@@ -142,10 +168,51 @@ module Api
         AdminConfiguration.integer_value('opensearch_result_limit')
       end
 
-      def normalised_query
-        return InternalSearchQueryNormaliserService::Result.new(query: q, expanded_query: expanded_query) if expanded_query.present?
+      def conditional_expansion_enabled?
+        expanded_query.blank? &&
+          AdminConfiguration.enabled?('expand_search_enabled') &&
+          AdminConfiguration.enabled?('expand_search_when_needed_enabled')
+      end
 
-        @normalised_query ||= InternalSearchQueryNormaliserService.call(query: q, request_id: request_id)
+      def normalised_query
+        if expanded_query.present?
+          return InternalSearchQueryNormaliserService::Result.new(query: q, expanded_query: refine_query(expanded_query))
+        end
+
+        @normalised_query ||= InternalSearchQueryNormaliserService.call(query: retrieval_query, request_id: request_id)
+      end
+
+      def expand_query(query)
+        result = ::Search::Instrumentation.query_expanded(
+          request_id: request_id,
+          original_query: query,
+        ) { ExpandSearchQueryService.call(query) }
+
+        result.expanded_query
+      end
+
+      def retrieval_query
+        @retrieval_query ||= refine_query(q)
+      end
+
+      def refine_query(base_query)
+        values = answered_values.reject { |value| base_query.downcase.include?(value.downcase) }
+        refined_query = [base_query, values.join(' ')].compact_blank.join(' ').squish
+
+        return base_query if refined_query == base_query
+
+        ::Search::Instrumentation.query_refined(
+          request_id: request_id,
+          original_query: base_query,
+          refined_query: refined_query,
+          answer_count: values.size,
+        ) { refined_query }
+      end
+
+      def answered_values
+        return [] unless AdminConfiguration.enabled?('refine_search_with_answers_enabled')
+
+        @answered_values ||= answers.filter_map { |answer| answer[:answer].presence }.uniq
       end
 
       def allowed_suggestion_types

--- a/app/services/interactive_search_service.rb
+++ b/app/services/interactive_search_service.rb
@@ -2,6 +2,15 @@ class InteractiveSearchService
   Result = Data.define(:type, :data, :attempt, :model, :result_limit)
 
   CONFIDENCE_ORDER = %w[strong good possible].freeze
+  UNCERTAINTY_OPTION_PATTERNS = [
+    /\Ai\s+don'?t\s+know\z/i,
+    /\Adon'?t\s+know\z/i,
+    /\Anot\s+sure\z/i,
+    /\Aunknown\z/i,
+    /\Aunsure\z/i,
+    /\Acannot\s+determine\z/i,
+    %r{\An/?a\z}i,
+  ].freeze
   FINAL_ANSWER_INSTRUCTION = <<~INSTRUCTION.freeze
 
     IMPORTANT: You have asked the maximum number of questions allowed. Based on the search input, OpenSearch results, and the answers provided so far, you MUST now provide your best answer. Do not ask any more questions. Rank the opensearch results by confidence using the information you have.
@@ -278,11 +287,17 @@ class InteractiveSearchService
       case q
       when Hash
         text = q['question']
-        options = q['options'].is_a?(Array) ? q['options'].map(&:to_s) : %w[Yes No]
-        { question: text, options: options } if text.present?
+        options = q['options'].is_a?(Array) ? concrete_options(q['options']) : %w[Yes No]
+        { question: text, options: options } if text.present? && options.any?
       when String
         { question: q, options: %w[Yes No] }
       end
+    end
+  end
+
+  def concrete_options(options)
+    options.map(&:to_s).reject do |option|
+      UNCERTAINTY_OPTION_PATTERNS.any? { |pattern| pattern.match?(option.strip) }
     end
   end
 

--- a/app/services/search_expansion_decision_service.rb
+++ b/app/services/search_expansion_decision_service.rb
@@ -1,0 +1,88 @@
+class SearchExpansionDecisionService
+  NOISE_TAGS = Search::GoodsNomenclatureQuery::NOISE_TAGS
+  NON_WORD_TOKEN_PATTERN = /\b[A-Z]{2,6}\b/
+
+  Result = Data.define(:expand, :reason, :result_count, :max_score) do
+    def expand?
+      expand
+    end
+  end
+
+  def self.call(query:, results: nil, request_id: nil)
+    new(query:, results:, request_id:).call
+  end
+
+  def initialize(query:, results: nil, request_id: nil)
+    @query = query.to_s
+    @results = Array(results)
+    @request_id = request_id
+  end
+
+  def call
+    decision = expansion_decision
+
+    Search::Instrumentation.query_expansion_decided(
+      request_id: request_id,
+      query: query,
+      expand: decision.expand?,
+      reason: decision.reason,
+      result_count: decision.result_count,
+      max_score: decision.max_score,
+    )
+
+    decision
+  end
+
+  private
+
+  attr_reader :query, :results, :request_id
+
+  def expansion_decision
+    return result(false, 'disabled') unless AdminConfiguration.enabled?('expand_search_enabled')
+    return result(true, 'always_enabled') unless AdminConfiguration.enabled?('expand_search_when_needed_enabled')
+    return result(true, 'non_word_token') if non_word_token?
+    return result(true, 'no_significant_word_parts') if no_significant_word_parts?
+    return result(true, 'low_result_count') if low_result_count?
+    return result(true, 'low_max_score') if low_max_score?
+
+    result(false, 'sufficient_results')
+  end
+
+  def non_word_token?
+    query.scan(NON_WORD_TOKEN_PATTERN).any?
+  end
+
+  def no_significant_word_parts?
+    tagged_words = tag_words
+    return false if tagged_words.empty?
+
+    tagged_words.none? { |_word, tag| tag.present? && !NOISE_TAGS.include?(tag) }
+  end
+
+  def tag_words
+    Search::GoodsNomenclatureQuery.tagger.get_readable(query).split.filter_map do |token|
+      word, tag = token.split('/')
+      next if word.blank? || word.match?(/\A\W+\z/)
+
+      [word, tag&.downcase]
+    end
+  end
+
+  def low_result_count?
+    results.size < AdminConfiguration.integer_value('expand_search_min_results')
+  end
+
+  def low_max_score?
+    return false if max_score.nil?
+
+    max_score < AdminConfiguration.integer_value('expand_search_min_score')
+  end
+
+  def max_score
+    @max_score ||= results.filter_map { |result| result.score&.to_f }.max
+  end
+
+  def result(expand, reason)
+    Result.new(expand:, reason:, result_count: results.size, max_score:)
+  end
+end

--- a/lib/tasks/admin_configurations.rake
+++ b/lib/tasks/admin_configurations.rake
@@ -103,13 +103,19 @@ module AdminConfigurationSeeder
 
           {
             "questions": [
-              { "question": "What is the material of the clothing?", "options": ["Cotton", "Wool", "Synthetic"] }
+              { "question": "What is the material of the clothing?", "options": ["Cotton", "Wool", "Synthetic", "Other"] }
             ]
           }
 
       Prefer questions and options that will help you narrow down the commodity code the most and avoid repeating the same question.
 
       Ask the single next question that will narrow down the commodity code the most.
+
+      Question options must be concrete, user-selectable product attributes or categories.
+
+      Do not include uncertainty options such as "I don't know", "Don't know", "Not sure", "Unknown", "Unsure", "Cannot determine", "N/A", or similar. The user should never be offered an option whose meaning is that they do not know the answer.
+
+      You may include "Other" where it represents a real catch-all category outside the named options. "Other" must mean "something else" and should allow follow-up narrowing later; it must not mean "I don't know".
 
       ### Error
 
@@ -122,6 +128,8 @@ module AdminConfigurationSeeder
       - Always respond in JSON as per the three examples above and never try and code anything up.
       - Always structure questions so they have multiple meaningful options, not just yes/no.
       - Avoid hallucinating codes and only provide codes that you are certain of based on the information provided.
+      - Never include "I don't know", "Don't know", "Not sure", "Unknown", "Unsure", or equivalent uncertainty wording in question options.
+      - If the distinction cannot be expressed as concrete options, ask a better question or provide the best available ranked answers.
 
       ## Context sections
 
@@ -409,6 +417,24 @@ namespace :admin_configurations do
         value: AdminConfiguration.default_for('expand_search_enabled'),
       },
       {
+        name: 'expand_search_when_needed_enabled',
+        config_type: 'boolean',
+        description: 'Requires expand_search_enabled. Only expand search queries when simple heuristics suggest expansion is useful: acronym-like terms, no useful word parts from POS tagging, low result count, or low top score from weak retrieval results',
+        value: AdminConfiguration.default_for('expand_search_when_needed_enabled'),
+      },
+      {
+        name: 'expand_search_min_results',
+        config_type: 'integer',
+        description: 'Minimum number of retrieval results required before conditional query expansion is skipped',
+        value: AdminConfiguration.default_for('expand_search_min_results').to_s,
+      },
+      {
+        name: 'expand_search_min_score',
+        config_type: 'integer',
+        description: 'Minimum top retrieval score required before conditional query expansion is skipped',
+        value: AdminConfiguration.default_for('expand_search_min_score').to_s,
+      },
+      {
         name: 'expand_model',
         config_type: 'nested_options',
         description: 'AI model used for search query expansion',
@@ -440,6 +466,12 @@ namespace :admin_configurations do
         config_type: 'integer',
         description: 'Maximum number of clarifying questions to ask before forcing a best-guess answer from the AI',
         value: AdminConfiguration.default_for('interactive_search_max_questions').to_s,
+      },
+      {
+        name: 'refine_search_with_answers_enabled',
+        config_type: 'boolean',
+        description: 'Append answered interactive search question values to the retrieval query so each iteration targets the shortlist more closely',
+        value: AdminConfiguration.default_for('refine_search_with_answers_enabled'),
       },
       {
         name: 'input_sanitiser_enabled',

--- a/spec/lib/search/instrumentation_spec.rb
+++ b/spec/lib/search/instrumentation_spec.rb
@@ -12,6 +12,20 @@ RSpec.describe Search::Instrumentation do
         search_type: 'interactive',
       )
     end
+
+    it 'uses the TradeTariffRequest request_id when the payload request_id is blank' do
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+      TradeTariffRequest.request_id = 'current-request-id'
+
+      described_class.search_started(request_id: nil, query: 'horses', search_type: 'interactive')
+
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'search_started.search',
+        request_id: 'current-request-id',
+        query: 'horses',
+        search_type: 'interactive',
+      )
+    end
   end
 
   describe '.search' do
@@ -109,6 +123,53 @@ RSpec.describe Search::Instrumentation do
       expect(ActiveSupport::Notifications).to have_received(:instrument).with(
         'query_expanded.search',
         hash_including(duration_ms: a_kind_of(Float)),
+      )
+    end
+  end
+
+  describe '.query_refined' do
+    it 'instruments the query_refined event' do
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+
+      result = described_class.query_refined(
+        request_id: 'req-1',
+        original_query: 'handbag',
+        refined_query: 'handbag Leather',
+        answer_count: 1,
+      ) { 'handbag Leather' }
+
+      expect(result).to eq('handbag Leather')
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'query_refined.search',
+        request_id: 'req-1',
+        original_query: 'handbag',
+        refined_query: 'handbag Leather',
+        answer_count: 1,
+      )
+    end
+  end
+
+  describe '.query_expansion_decided' do
+    it 'instruments the query_expansion_decided event' do
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+
+      described_class.query_expansion_decided(
+        request_id: 'req-1',
+        query: 'CBD oil',
+        expand: true,
+        reason: 'non_word_token',
+        result_count: 3,
+        max_score: 4.5,
+      )
+
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'query_expansion_decided.search',
+        request_id: 'req-1',
+        query: 'CBD oil',
+        expand: true,
+        reason: 'non_word_token',
+        result_count: 3,
+        max_score: 4.5,
       )
     end
   end

--- a/spec/lib/search/logger_spec.rb
+++ b/spec/lib/search/logger_spec.rb
@@ -77,6 +77,64 @@ RSpec.describe Search::Logger do
     end
   end
 
+  describe '#query_refined' do
+    let(:payload) do
+      {
+        request_id: 'req-1',
+        original_query: 'handbag',
+        refined_query: 'handbag Leather',
+        answer_count: 1,
+      }
+    end
+
+    it_behaves_like 'a search log entry', :query_refined, 'query_refined',
+                    { request_id: 'req-1',
+                      original_query: 'handbag',
+                      refined_query: 'handbag Leather',
+                      answer_count: 1 }
+
+    it 'logs correct fields' do
+      logger_instance.query_refined(build_event('query_refined', payload))
+      json = parsed_log_output
+      expect(json['event']).to eq('query_refined')
+      expect(json['original_query']).to eq('handbag')
+      expect(json['refined_query']).to eq('handbag Leather')
+      expect(json['answer_count']).to eq(1)
+    end
+  end
+
+  describe '#query_expansion_decided' do
+    let(:payload) do
+      {
+        request_id: 'req-1',
+        query: 'CBD oil',
+        expand: true,
+        reason: 'non_word_token',
+        result_count: 3,
+        max_score: 4.5,
+      }
+    end
+
+    it_behaves_like 'a search log entry', :query_expansion_decided, 'query_expansion_decided',
+                    { request_id: 'req-1',
+                      query: 'CBD oil',
+                      expand: true,
+                      reason: 'non_word_token',
+                      result_count: 3,
+                      max_score: 4.5 }
+
+    it 'logs correct fields' do
+      logger_instance.query_expansion_decided(build_event('query_expansion_decided', payload))
+      json = parsed_log_output
+      expect(json['event']).to eq('query_expansion_decided')
+      expect(json['query']).to eq('CBD oil')
+      expect(json['expand']).to be(true)
+      expect(json['reason']).to eq('non_word_token')
+      expect(json['result_count']).to eq(3)
+      expect(json['max_score']).to eq(4.5)
+    end
+  end
+
   describe '#api_call_completed' do
     let(:payload) do
       { request_id: 'req-1', model: 'gpt-4', duration_ms: 2500.0, response_type: 'answers', attempt_number: 1 }

--- a/spec/lib/tasks/admin_configurations_rake_spec.rb
+++ b/spec/lib/tasks/admin_configurations_rake_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe 'admin_configurations:seed' do
     Rake::Task['admin_configurations:seed'].reenable
   end
 
-  it 'creates all 37 admin configurations', :aggregate_failures do
-    expect { seed }.to change(AdminConfiguration, :count).by(37)
+  it 'creates all 41 admin configurations', :aggregate_failures do
+    expect { seed }.to change(AdminConfiguration, :count).by(41)
 
     names = AdminConfiguration.order(:name).select_map(:name)
     expect(names).to eq(%w[
@@ -17,6 +17,9 @@ RSpec.describe 'admin_configurations:seed' do
       expand_model
       expand_query_context
       expand_search_enabled
+      expand_search_min_results
+      expand_search_min_score
+      expand_search_when_needed_enabled
       input_sanitiser_enabled
       input_sanitiser_max_length
       interactive_search_enabled
@@ -35,6 +38,7 @@ RSpec.describe 'admin_configurations:seed' do
       pos_noun_boost
       pos_qualifier_boost
       pos_search_enabled
+      refine_search_with_answers_enabled
       retrieval_method
       rrf_k
       search_context
@@ -121,6 +125,8 @@ RSpec.describe 'admin_configurations:seed' do
     expect(search_context.value).to include('## Response format')
     expect(search_context.value).to include('### Confident answer')
     expect(search_context.value).to include('Ask exactly one question per turn')
+    expect(search_context.value).to include('Do not include uncertainty options')
+    expect(search_context.value).to include('"Other" must mean "something else"')
     expect(search_context.value).not_to include('Try and ask at least a few questions each time')
 
     expand_query = AdminConfiguration.where(name: 'expand_query_context').first
@@ -139,6 +145,34 @@ RSpec.describe 'admin_configurations:seed' do
     expect(non_other_self_text_context.config_type).to eq('markdown')
     expect(non_other_self_text_context.value).to include('## Output format')
     expect(non_other_self_text_context.value).to include('## Style rules')
+  end
+
+  it 'seeds answer-based query refinement as disabled by default', :aggregate_failures do
+    seed
+
+    config = AdminConfiguration.where(name: 'refine_search_with_answers_enabled').first
+    expect(config.config_type).to eq('boolean')
+    expect(config.value).to be false
+  end
+
+  it 'seeds conditional expansion controls', :aggregate_failures do
+    seed
+
+    enabled = AdminConfiguration.where(name: 'expand_search_when_needed_enabled').first
+    expect(enabled.config_type).to eq('boolean')
+    expect(enabled.description).to include('Requires expand_search_enabled')
+    expect(enabled.description).to include('acronym-like terms')
+    expect(enabled.description).to include('no useful word parts')
+    expect(enabled.description).to include('weak retrieval results')
+    expect(enabled.value).to be false
+
+    min_results = AdminConfiguration.where(name: 'expand_search_min_results').first
+    expect(min_results.config_type).to eq('integer')
+    expect(min_results.value).to eq(AdminConfiguration.default_for('expand_search_min_results'))
+
+    min_score = AdminConfiguration.where(name: 'expand_search_min_score').first
+    expect(min_score.config_type).to eq('integer')
+    expect(min_score.value).to eq(AdminConfiguration.default_for('expand_search_min_score'))
   end
 
   it 'seeds other_self_text_batch_size as an integer config defaulting to 5', :aggregate_failures do
@@ -323,7 +357,7 @@ RSpec.describe 'admin_configurations:seed' do
   it 'patches existing configurations when their type changes' do
     create(:admin_configuration, name: 'description_intercept_templates', config_type: 'string', value: 'legacy')
 
-    expect { seed }.to change(AdminConfiguration, :count).by(36)
+    expect { seed }.to change(AdminConfiguration, :count).by(40)
     expect(AdminConfiguration.where(name: 'description_intercept_templates').first.config_type).to eq('object_template')
   end
 end

--- a/spec/models/admin_configuration_spec.rb
+++ b/spec/models/admin_configuration_spec.rb
@@ -601,9 +601,9 @@ RSpec.describe AdminConfiguration do
         expect(result).to eq({ selected: 'gpt-5.4', sub_values: { 'reasoning_effort' => 'medium' } })
       end
 
-      it 'returns the default expand model with reasoning_effort' do
+      it 'returns the default expand model without unsupported sub_values' do
         result = described_class.nested_options_value('expand_model')
-        expect(result).to eq({ selected: 'gpt-4.1-mini-2025-04-14', sub_values: { 'reasoning_effort' => 'low' } })
+        expect(result).to eq({ selected: 'gpt-4.1-mini-2025-04-14', sub_values: {} })
       end
     end
 
@@ -623,7 +623,28 @@ RSpec.describe AdminConfiguration do
 
       it 'returns the selected value and sub_values' do
         result = described_class.nested_options_value('search_model')
-        expect(result).to eq({ selected: 'gpt-4.1-mini-2025-04-14', sub_values: { 'reasoning_effort' => 'high' } })
+        expect(result).to eq({ selected: 'gpt-4.1-mini-2025-04-14', sub_values: {} })
+      end
+    end
+
+    context 'when config has stale sub_values for the selected model' do
+      before do
+        create(:admin_configuration, :nested_options,
+               name: 'expand_model',
+               area: 'classification',
+               value: {
+                 'selected' => 'gpt-4.1-mini-2025-04-14',
+                 'sub_values' => { 'reasoning_effort' => 'low' },
+                 'options' => [
+                   { 'key' => 'gpt-4.1-mini-2025-04-14', 'label' => 'GPT-4.1 Mini', 'sub_options' => {} },
+                   { 'key' => 'gpt-5.2', 'label' => 'GPT-5.2', 'sub_options' => { 'reasoning_effort' => %w[none low medium high] } },
+                 ],
+               })
+      end
+
+      it 'drops unsupported sub_values' do
+        result = described_class.nested_options_value('expand_model')
+        expect(result).to eq({ selected: 'gpt-4.1-mini-2025-04-14', sub_values: {} })
       end
     end
 

--- a/spec/requests/api/v2/search_controller_search_spec.rb
+++ b/spec/requests/api/v2/search_controller_search_spec.rb
@@ -15,6 +15,18 @@ RSpec.describe Api::V2::SearchController do
   end
 
   describe 'POST /search' do
+    it 'sets the search request id from the request params' do
+      allow(Search::Instrumentation).to receive(:search).and_call_original
+
+      post '/uk/api/search', params: { q: 'horse', request_id: 'param-request-id' }, headers: request_headers, as: :json
+
+      expect(Search::Instrumentation).to have_received(:search).with(
+        request_id: 'param-request-id',
+        query: 'horse',
+        search_type: 'classic',
+      )
+    end
+
     context 'when an exact match' do
       before do
         goods_nomenclature = create :chapter, goods_nomenclature_item_id: '0100000000'

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Api::Internal::SearchService do
     allow(InteractiveSearchService).to receive(:call).and_return(nil)
     allow(Search::Instrumentation).to receive(:search) { |**_kwargs, &block| block.call&.first }
     allow(Search::Instrumentation).to receive(:query_expanded).and_yield
+    allow(Search::Instrumentation).to receive(:query_refined).and_call_original
     allow(Search::Instrumentation).to receive(:description_intercept_checked)
   end
 
@@ -668,6 +669,7 @@ RSpec.describe Api::Internal::SearchService do
       before do
         allow(AdminConfiguration).to receive(:enabled?).and_call_original
         allow(AdminConfiguration).to receive(:enabled?).with('expand_search_enabled').and_return(true)
+        allow(AdminConfiguration).to receive(:enabled?).with('expand_search_when_needed_enabled').and_return(false)
         allow(TradeTariffBackend.search_client).to receive(:search).and_return(opensearch_response)
       end
 
@@ -675,6 +677,118 @@ RSpec.describe Api::Internal::SearchService do
         described_class.new(q: 'laptop').call
 
         expect(ExpandSearchQueryService).to have_received(:call).with('laptop')
+      end
+
+      it 'appends answer text before expanding the query' do
+        answers = [{ question: 'What material?', answer: 'Leather' }]
+        allow(AdminConfiguration).to receive(:enabled?).with('refine_search_with_answers_enabled').and_return(true)
+
+        described_class.new(q: 'handbag', answers: answers).call
+
+        expect(ExpandSearchQueryService).to have_received(:call).with('handbag Leather')
+      end
+    end
+
+    context 'when conditional expansion is enabled' do
+      let(:weak_opensearch_response) { { 'hits' => { 'hits' => [] } } }
+      let(:expanded_opensearch_response) do
+        {
+          'hits' => {
+            'hits' => [
+              {
+                '_score' => 12.5,
+                '_source' => {
+                  'goods_nomenclature_sid' => 1,
+                  'goods_nomenclature_item_id' => '3304990000',
+                  'producline_suffix' => '80',
+                  'goods_nomenclature_class' => 'Commodity',
+                  'description' => 'beauty preparations',
+                  'formatted_description' => 'Beauty preparations',
+                  'declarable' => true,
+                },
+              },
+            ],
+          },
+        }
+      end
+
+      before do
+        allow(AdminConfiguration).to receive(:enabled?).and_call_original
+        allow(AdminConfiguration).to receive(:enabled?).with('expand_search_enabled').and_return(true)
+        allow(AdminConfiguration).to receive(:enabled?).with('expand_search_when_needed_enabled').and_return(true)
+        allow(AdminConfiguration).to receive(:integer_value).and_call_original
+        allow(AdminConfiguration).to receive(:integer_value).with('expand_search_min_results').and_return(5)
+        allow(AdminConfiguration).to receive(:integer_value).with('expand_search_min_score').and_return(5)
+        allow(ExpandSearchQueryService).to receive(:call)
+          .and_return(ExpandSearchQueryService::Result.new(
+                        expanded_query: 'cannabidiol oil',
+                        reason: 'CBD is an acronym',
+                      ))
+        allow(TradeTariffBackend.search_client).to receive(:search)
+          .and_return(weak_opensearch_response, expanded_opensearch_response)
+      end
+
+      it 'runs expansion after the initial result set is judged weak' do
+        result = described_class.new(q: 'CBD oil').call
+
+        expect(ExpandSearchQueryService).to have_received(:call).with('CBD oil')
+        expect(TradeTariffBackend.search_client).to have_received(:search).twice
+        expect(result[:data].first[:attributes][:goods_nomenclature_item_id]).to eq('3304990000')
+      end
+    end
+
+    context 'when answer-based query refinement is enabled' do
+      let(:opensearch_response) { { 'hits' => { 'hits' => [] } } }
+
+      before do
+        allow(AdminConfiguration).to receive(:enabled?).and_call_original
+        allow(AdminConfiguration).to receive(:enabled?).with('expand_search_enabled').and_return(false)
+        allow(AdminConfiguration).to receive(:enabled?).with('refine_search_with_answers_enabled').and_return(true)
+        allow(TradeTariffBackend.search_client).to receive(:search).and_return(opensearch_response)
+        allow(Search::GoodsNomenclatureQuery).to receive(:new).and_call_original
+      end
+
+      it 'uses answered questions to target retrieval even when AI expansion is disabled' do
+        described_class.new(q: 'handbag', answers: [{ question: 'What material?', answer: 'Leather' }]).call
+
+        expect(Search::GoodsNomenclatureQuery).to have_received(:new).with(
+          'handbag',
+          anything,
+          hash_including(expanded_query: 'handbag Leather'),
+        )
+      end
+
+      it 'instruments the query refinement' do
+        described_class.new(q: 'handbag', answers: [{ question: 'What material?', answer: 'Leather' }]).call
+
+        expect(Search::Instrumentation).to have_received(:query_refined).with(
+          request_id: anything,
+          original_query: 'handbag',
+          refined_query: 'handbag Leather',
+          answer_count: 1,
+        )
+      end
+    end
+
+    context 'when answer-based query refinement is disabled' do
+      let(:opensearch_response) { { 'hits' => { 'hits' => [] } } }
+
+      before do
+        allow(AdminConfiguration).to receive(:enabled?).and_call_original
+        allow(AdminConfiguration).to receive(:enabled?).with('expand_search_enabled').and_return(false)
+        allow(AdminConfiguration).to receive(:enabled?).with('refine_search_with_answers_enabled').and_return(false)
+        allow(TradeTariffBackend.search_client).to receive(:search).and_return(opensearch_response)
+        allow(Search::GoodsNomenclatureQuery).to receive(:new).and_call_original
+      end
+
+      it 'keeps retrieval on the original query' do
+        described_class.new(q: 'handbag', answers: [{ question: 'What material?', answer: 'Leather' }]).call
+
+        expect(Search::GoodsNomenclatureQuery).to have_received(:new).with(
+          'handbag',
+          anything,
+          hash_including(expanded_query: 'handbag'),
+        )
       end
     end
 
@@ -1125,13 +1239,14 @@ RSpec.describe Api::Internal::SearchService do
       before do
         allow(AdminConfiguration).to receive(:enabled?).and_call_original
         allow(AdminConfiguration).to receive(:enabled?).with('expand_search_enabled').and_return(true)
+        allow(AdminConfiguration).to receive(:enabled?).with('refine_search_with_answers_enabled').and_return(true)
         allow(ExpandSearchQueryService).to receive(:call)
         allow(Search::GoodsNomenclatureQuery).to receive(:new).and_call_original
         allow(TradeTariffBackend.search_client).to receive(:search).and_return(opensearch_response)
         allow(InteractiveSearchService).to receive(:call).and_return(interactive_result)
       end
 
-      it 'reuses the supplied expanded query without expanding again' do
+      it 'reuses the supplied expanded query without expanding again and appends answered questions' do
         result = described_class.new(
           q: 'laptop',
           expanded_query: 'portable data processing machine',
@@ -1142,12 +1257,26 @@ RSpec.describe Api::Internal::SearchService do
         expect(Search::GoodsNomenclatureQuery).to have_received(:new).with(
           'laptop',
           anything,
-          hash_including(expanded_query: 'portable data processing machine'),
+          hash_including(expanded_query: 'portable data processing machine Personal'),
         )
         expect(InteractiveSearchService).to have_received(:call).with(
-          hash_including(expanded_query: 'portable data processing machine'),
+          hash_including(expanded_query: 'portable data processing machine Personal'),
         )
-        expect(result[:meta][:interactive_search]).to include(expanded_query: 'portable data processing machine')
+        expect(result[:meta][:interactive_search]).to include(expanded_query: 'portable data processing machine Personal')
+      end
+
+      it 'does not append answer text that is already present in the supplied expanded query' do
+        described_class.new(
+          q: 'laptop',
+          expanded_query: 'portable data processing machine Personal',
+          answers: [{ question: 'What type of laptop?', answer: 'Personal' }],
+        ).call
+
+        expect(Search::GoodsNomenclatureQuery).to have_received(:new).with(
+          'laptop',
+          anything,
+          hash_including(expanded_query: 'portable data processing machine Personal'),
+        )
       end
     end
   end

--- a/spec/services/expand_search_query_service_spec.rb
+++ b/spec/services/expand_search_query_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ExpandSearchQueryService do
         expect(OpenaiClient).to have_received(:call).with(
           a_string_including('laptop'),
           model: 'gpt-4.1-mini-2025-04-14',
-          reasoning_effort: 'low',
+          reasoning_effort: nil,
         )
       end
     end
@@ -134,6 +134,7 @@ RSpec.describe ExpandSearchQueryService do
 
       before do
         allow(OpenaiClient).to receive(:call).and_raise(Faraday::TimeoutError)
+        TradeTariffRequest.request_id = 'req-1'
       end
 
       it 'falls back to the original query' do
@@ -200,7 +201,7 @@ RSpec.describe ExpandSearchQueryService do
         expect(OpenaiClient).to have_received(:call).with(
           'Custom prompt for: laptop',
           model: 'gpt-4.1-mini-2025-04-14',
-          reasoning_effort: 'low',
+          reasoning_effort: nil,
         )
       end
     end

--- a/spec/services/interactive_search_service_spec.rb
+++ b/spec/services/interactive_search_service_spec.rb
@@ -337,6 +337,20 @@ RSpec.describe InteractiveSearchService do
         expect(result.attempt).to eq(2)
       end
     end
+
+    context 'when AI returns uncertainty options' do
+      let(:ai_response) do
+        %q({"questions": [{"question": "What is the material?", "options": ["Leather", "I don't know", "Unknown", "Other"]}]})
+      end
+
+      before do
+        allow(OpenaiClient).to receive(:call).and_return(ai_response)
+      end
+
+      it 'removes uncertainty options but keeps Other as a catch-all option' do
+        expect(result.data.first[:options]).to eq(%w[Leather Other])
+      end
+    end
   end
 
   describe 'question extraction' do

--- a/spec/services/search_expansion_decision_service_spec.rb
+++ b/spec/services/search_expansion_decision_service_spec.rb
@@ -1,0 +1,125 @@
+RSpec.describe SearchExpansionDecisionService do
+  subject(:decision) { described_class.call(query: query, results: results, request_id: 'req-1') }
+
+  let(:query) { 'laptop' }
+  let(:results) do
+    [
+      build_result(score: 12.5),
+      build_result(score: 8.0),
+      build_result(score: 7.0),
+      build_result(score: 6.0),
+      build_result(score: 5.5),
+    ]
+  end
+
+  before do
+    allow(AdminConfiguration).to receive(:enabled?).and_call_original
+    allow(AdminConfiguration).to receive(:integer_value).and_call_original
+    allow(Search::Instrumentation).to receive(:query_expansion_decided).and_call_original
+  end
+
+  context 'when expansion is disabled' do
+    before do
+      allow(AdminConfiguration).to receive(:enabled?).with('expand_search_enabled').and_return(false)
+    end
+
+    it 'does not expand' do
+      expect(decision.expand?).to be(false)
+      expect(decision.reason).to eq('disabled')
+    end
+  end
+
+  context 'when conditional expansion is disabled' do
+    before do
+      allow(AdminConfiguration).to receive(:enabled?).with('expand_search_enabled').and_return(true)
+      allow(AdminConfiguration).to receive(:enabled?).with('expand_search_when_needed_enabled').and_return(false)
+    end
+
+    it 'preserves the existing always-expand behaviour' do
+      expect(decision.expand?).to be(true)
+      expect(decision.reason).to eq('always_enabled')
+    end
+  end
+
+  context 'when conditional expansion is enabled' do
+    before do
+      allow(AdminConfiguration).to receive(:enabled?).with('expand_search_enabled').and_return(true)
+      allow(AdminConfiguration).to receive(:enabled?).with('expand_search_when_needed_enabled').and_return(true)
+      allow(AdminConfiguration).to receive(:integer_value).with('expand_search_min_results').and_return(5)
+      allow(AdminConfiguration).to receive(:integer_value).with('expand_search_min_score').and_return(5)
+    end
+
+    it 'expands acronym-like query tokens' do
+      result = described_class.call(query: 'CBD oil', results: results, request_id: 'req-1')
+
+      expect(result.expand?).to be(true)
+      expect(result.reason).to eq('non_word_token')
+    end
+
+    it 'expands when result count is below the configured threshold' do
+      result = described_class.call(query: 'laptop', results: [build_result(score: 12.5)], request_id: 'req-1')
+
+      expect(result.expand?).to be(true)
+      expect(result.reason).to eq('low_result_count')
+    end
+
+    it 'expands when the maximum score is below the configured threshold' do
+      result = described_class.call(
+        query: 'laptop',
+        results: [build_result(score: 2.5), build_result(score: 1.2), build_result(score: nil), build_result(score: 0.5), build_result(score: 0.4)],
+        request_id: 'req-1',
+      )
+
+      expect(result.expand?).to be(true)
+      expect(result.reason).to eq('low_max_score')
+    end
+
+    it 'expands when the tagger finds no useful word parts' do
+      result = described_class.call(
+        query: 'of the',
+        results: results,
+        request_id: 'req-1',
+      )
+
+      expect(result.expand?).to be(true)
+      expect(result.reason).to eq('no_significant_word_parts')
+    end
+
+    it 'does not expand when query and results look strong enough' do
+      expect(decision.expand?).to be(false)
+      expect(decision.reason).to eq('sufficient_results')
+    end
+
+    it 'instruments the expansion decision' do
+      decision
+
+      expect(Search::Instrumentation).to have_received(:query_expansion_decided).with(
+        request_id: 'req-1',
+        query: 'laptop',
+        expand: false,
+        reason: 'sufficient_results',
+        result_count: 5,
+        max_score: 12.5,
+      )
+    end
+  end
+
+  def build_result(score:)
+    GoodsNomenclatureResult.new(
+      id: 1,
+      goods_nomenclature_item_id: '0101210000',
+      goods_nomenclature_sid: 1,
+      producline_suffix: '80',
+      goods_nomenclature_class: 'Commodity',
+      description: 'pure-bred breeding horses',
+      formatted_description: 'Pure-bred breeding horses',
+      self_text: nil,
+      classification_description: nil,
+      full_description: nil,
+      heading_description: nil,
+      declarable: true,
+      score: score,
+      confidence: nil,
+    )
+  end
+end


### PR DESCRIPTION
### Jira link

[AI-633](https://transformuk.atlassian.net/browse/AI-633)

Parent epic: [AI-630](https://transformuk.atlassian.net/browse/AI-630)

Related tickets: [AI-634](https://transformuk.atlassian.net/browse/AI-634), [AI-635](https://transformuk.atlassian.net/browse/AI-635), [AI-845](https://transformuk.atlassian.net/browse/AI-845)

```mermaid
flowchart TD
    INPUT[Search input]

    subgraph QUERY_STAGE [Query preparation]
        ANSWERS[Append answers]
        CONDITIONAL{Conditional expansion?}
    end

    subgraph DECISION_STAGE [Expansion decision]
        BASELINE[Baseline retrieval]
        USEFUL{Expansion useful?}
        EXPAND[Expand query]
        KEEP[Keep query]
    end

    subgraph RESULT_STAGE [Search iteration]
        SHORTLIST[Retrieve shortlist]
        PROMPT[Ask or answer]
    end

    INPUT --> ANSWERS
    ANSWERS --> CONDITIONAL
    CONDITIONAL -->|No| SHORTLIST
    CONDITIONAL -->|Yes| BASELINE
    BASELINE --> USEFUL
    USEFUL -->|Yes| EXPAND
    USEFUL -->|No| KEEP
    EXPAND --> SHORTLIST
    KEEP --> SHORTLIST
    SHORTLIST --> PROMPT

    classDef box stroke:#6366f1,stroke-width:2px
    class INPUT,QUERY_STAGE,ANSWERS,CONDITIONAL,DECISION_STAGE,BASELINE,USEFUL,EXPAND,KEEP,RESULT_STAGE,SHORTLIST,PROMPT box
```

### What?

- [x] Set `TradeTariffRequest.request_id` in `ApplicationController` from `params[:request_id]` or Rails request id.
- [x] Add configurable answer-based query refinement for interactive search.
- [x] Add `SearchExpansionDecisionService` so conditional expansion heuristics live in one place and can grow over time.
- [x] Seed `expand_search_when_needed_enabled`, `expand_search_min_results`, and `expand_search_min_score`.
- [x] Drop unsupported nested model sub-values so `reasoning_effort` is only sent to models that support it.
- [x] Document that conditional expansion requires `expand_search_enabled`.
- [x] Instrument expansion decisions with `query_expansion_decided.search`, including whether expansion ran and why.
- [x] Have search instrumentation fill missing event request ids from `TradeTariffRequest`.
- [x] Instrument answer-refined queries with `query_refined.search`.
- [x] Update the default interactive search prompt to ban uncertainty options while allowing `Other` as a real catch-all.
- [x] Filter uncertainty options from AI question responses before they reach users.

### Why?

Answered follow-up questions currently help the LLM but not the retrieval query. Later turns can still retrieve a broad shortlist, leaving the LLM to do more narrowing work. When enabled, answer-based refinement appends selected answers to the retrieval query before normalisation, expansion, and retrieval, so BM25/vector retrieval receives a more targeted query on each iteration. The config defaults to `false` until the team has tested it.

Query expansion was also all-or-nothing. `expand_search_enabled` remains the master switch, but `expand_search_when_needed_enabled` adds a second gate. With conditional expansion enabled, the service first retrieves without LLM expansion and only expands when heuristics suggest it is useful: acronym-like terms such as `CBD`, no useful POS word parts, too few results, or a low top score. This avoids paying for expansion when the initial retrieval already looks good enough.

Search instrumentation expected every search event to carry a request id, but lower-level expansion failures could log without one. Setting the active request id once in `ApplicationController` lets instrumentation fill missing ids at the logging boundary instead of threading ids through every lower-level service.

### Ticket

AI-633

### Risk

**Risk level:** 🟠

**Reason for rating:** This changes search retrieval behaviour and adds feature flags that can affect the live interactive search journey. The behaviour-changing configs default to `false`, so deployment keeps current behaviour until the team explicitly enables and tests them.