### PR TITLE
HMRC-2232: My OTT: Commodity Watch List seems to be incorrectly defining an 'expired' code

### DIFF
--- a/app/models/goods_nomenclatures/nested_set.rb
+++ b/app/models/goods_nomenclatures/nested_set.rb
@@ -118,6 +118,27 @@ module GoodsNomenclatures
           end
       end
 
+      many_to_many :historical_children,
+                   left_primary_key: :goods_nomenclature_sid,
+                   left_key: Sequel.qualify(:origin_nodes, :goods_nomenclature_sid),
+                   right_primary_key: :goods_nomenclature_sid,
+                   right_key: :goods_nomenclature_sid,
+                   class_name: '::GoodsNomenclature',
+                   join_table: Sequel.as(:goods_nomenclature_tree_nodes, :child_nodes),
+                   read_only: true do |ds|
+        ds.non_hidden
+          .order(:child_nodes__position)
+          .select_append(:child_nodes__depth, :child_nodes__number_indents)
+          .join(Sequel.as(:goods_nomenclature_tree_nodes, :origin_nodes)) do |origin_table, children_table, _|
+          children = TreeNodeAlias.new(children_table)
+          origin   = TreeNodeAlias.new(origin_table)
+
+          # no with_validity_dates here -> no point-in-time filter
+          (children.depth =~ (origin.depth + 1)) &
+            TreeNode.descendant_node_constraints(origin, children, children)
+        end
+      end
+
       one_to_many :measures,
                   primary_key: :goods_nomenclature_sid,
                   key: :goods_nomenclature_sid,

--- a/app/services/api/user/active_commodities_service.rb
+++ b/app/services/api/user/active_commodities_service.rb
@@ -233,11 +233,13 @@ module Api
       end
 
       def calculate_end_date_from_descendants(commodity)
-        periods = commodity.children
+        periods = TimeMachine.no_time_machine do
+          commodity.historical_children
                            .pluck(:validity_start_date, :validity_end_date)
                            .map { |start_date, end_date| [start_date.to_date, end_date&.to_date] }
                            .uniq
                            .sort_by(&:first)
+        end
 
         return if periods.empty?
 

--- a/app/services/api/user/active_commodities_service.rb
+++ b/app/services/api/user/active_commodities_service.rb
@@ -233,10 +233,22 @@ module Api
       end
 
       def calculate_end_date_from_descendants(commodity)
-        earliest_child_start = commodity.children.minimum(:validity_start_date)
-        return nil if earliest_child_start.blank?
+        periods = commodity.children
+                           .pluck(:validity_start_date, :validity_end_date)
+                           .map { |start_date, end_date| [start_date.to_date, end_date&.to_date] }
+                           .uniq
+                           .sort_by(&:first)
 
-        earliest_child_start.to_date - 1
+        return if periods.empty?
+
+        invalid_dates = periods.each_cons(2).filter_map do |(_, current_end), (next_start, _)|
+          next unless current_end
+          next unless next_start > current_end + 1
+
+          next_start - 1
+        end
+
+        invalid_dates.max || periods.first.first - 1
       end
     end
   end

--- a/spec/services/api/user/active_commodities_service_spec.rb
+++ b/spec/services/api/user/active_commodities_service_spec.rb
@@ -333,7 +333,7 @@ RSpec.describe Api::User::ActiveCommoditiesService do
         commodity.values[:validity_end_date] = nil
 
         # Mock children with earliest start date
-        allow(commodity).to receive(:children).and_return(
+        allow(commodity).to receive(:historical_children).and_return(
           instance_double(Sequel::Dataset, pluck: [
             [Date.new(2023, 6, 1), nil],
           ]),
@@ -348,14 +348,14 @@ RSpec.describe Api::User::ActiveCommoditiesService do
       let(:commodity) { create(:commodity, :expired) }
 
       it 'returns nil when no children exist' do
-        allow(commodity).to receive(:children).and_return(instance_double(Sequel::Dataset, pluck: []))
+        allow(commodity).to receive(:historical_children).and_return(instance_double(Sequel::Dataset, pluck: []))
 
         result = service.send(:calculate_end_date_from_descendants, commodity)
         expect(result).to be_nil
       end
 
       it 'returns one day before earliest start date when descendant periods are continuous' do
-        allow(commodity).to receive(:children).and_return(
+        allow(commodity).to receive(:historical_children).and_return(
           instance_double(Sequel::Dataset, pluck: [
             [Time.zone.parse('2023-01-01T00:00:00Z'), Time.zone.parse('2023-01-31T00:00:00Z')],
             [Time.zone.parse('2023-02-01T00:00:00Z'), Time.zone.parse('2023-02-28T00:00:00Z')],
@@ -367,7 +367,7 @@ RSpec.describe Api::User::ActiveCommoditiesService do
       end
 
       it 'calculates correct end date from gaps between descendant periods' do
-        allow(commodity).to receive(:children).and_return(
+        allow(commodity).to receive(:historical_children).and_return(
           instance_double(Sequel::Dataset, pluck: [
             [Time.zone.parse('2023-01-01T00:00:00Z'), Time.zone.parse('2023-01-31T00:00:00Z')],
             [Time.zone.parse('2023-02-10T00:00:00Z'), Time.zone.parse('2023-03-01T00:00:00Z')],
@@ -379,7 +379,7 @@ RSpec.describe Api::User::ActiveCommoditiesService do
       end
 
       it 'returns the latest invalid date when multiple gaps exist' do
-        allow(commodity).to receive(:children).and_return(
+        allow(commodity).to receive(:historical_children).and_return(
           instance_double(Sequel::Dataset, pluck: [
             [Time.zone.parse('2023-03-01T00:00:00Z'), Time.zone.parse('2023-03-31T00:00:00Z')],
             [Time.zone.parse('2023-04-05T00:00:00Z'), Time.zone.parse('2023-04-30T00:00:00Z')],

--- a/spec/services/api/user/active_commodities_service_spec.rb
+++ b/spec/services/api/user/active_commodities_service_spec.rb
@@ -334,7 +334,9 @@ RSpec.describe Api::User::ActiveCommoditiesService do
 
         # Mock children with earliest start date
         allow(commodity).to receive(:children).and_return(
-          instance_double(Sequel::Dataset, minimum: Date.new(2023, 6, 1)),
+          instance_double(Sequel::Dataset, pluck: [
+            [Date.new(2023, 6, 1), nil],
+          ]),
         )
 
         result = service.send(:apply_validity_end_date, commodity)
@@ -346,19 +348,49 @@ RSpec.describe Api::User::ActiveCommoditiesService do
       let(:commodity) { create(:commodity, :expired) }
 
       it 'returns nil when no children exist' do
-        allow(commodity).to receive(:children).and_return(instance_double(Sequel::Dataset, minimum: nil))
+        allow(commodity).to receive(:children).and_return(instance_double(Sequel::Dataset, pluck: []))
 
         result = service.send(:calculate_end_date_from_descendants, commodity)
         expect(result).to be_nil
       end
 
-      it 'calculates correct end date from earliest child start date' do
+      it 'returns one day before earliest start date when descendant periods are continuous' do
         allow(commodity).to receive(:children).and_return(
-          instance_double(Sequel::Dataset, minimum: Date.new(2023, 6, 1)),
+          instance_double(Sequel::Dataset, pluck: [
+            [Time.zone.parse('2023-01-01T00:00:00Z'), Time.zone.parse('2023-01-31T00:00:00Z')],
+            [Time.zone.parse('2023-02-01T00:00:00Z'), Time.zone.parse('2023-02-28T00:00:00Z')],
+          ]),
         )
 
         result = service.send(:calculate_end_date_from_descendants, commodity)
-        expect(result).to eq(Date.new(2023, 5, 31))
+        expect(result).to eq(Date.new(2022, 12, 31))
+      end
+
+      it 'calculates correct end date from gaps between descendant periods' do
+        allow(commodity).to receive(:children).and_return(
+          instance_double(Sequel::Dataset, pluck: [
+            [Time.zone.parse('2023-01-01T00:00:00Z'), Time.zone.parse('2023-01-31T00:00:00Z')],
+            [Time.zone.parse('2023-02-10T00:00:00Z'), Time.zone.parse('2023-03-01T00:00:00Z')],
+          ]),
+        )
+
+        result = service.send(:calculate_end_date_from_descendants, commodity)
+        expect(result).to eq(Date.new(2023, 2, 9))
+      end
+
+      it 'returns the latest invalid date when multiple gaps exist' do
+        allow(commodity).to receive(:children).and_return(
+          instance_double(Sequel::Dataset, pluck: [
+            [Time.zone.parse('2023-03-01T00:00:00Z'), Time.zone.parse('2023-03-31T00:00:00Z')],
+            [Time.zone.parse('2023-04-05T00:00:00Z'), Time.zone.parse('2023-04-30T00:00:00Z')],
+            [Time.zone.parse('2023-01-01T00:00:00Z'), Time.zone.parse('2023-01-31T00:00:00Z')],
+            [Time.zone.parse('2023-02-10T00:00:00Z'), Time.zone.parse('2023-03-01T00:00:00Z')],
+          ]),
+        )
+
+        result = service.send(:calculate_end_date_from_descendants, commodity)
+        # Gaps produce invalid dates of 2023-02-09 and 2023-04-04; we return the latest.
+        expect(result).to eq(Date.new(2023, 4, 4))
       end
     end
 


### PR DESCRIPTION
## What:
Fix commodity expiry date to align CCWL with the OTT

## Why:
Currently CCWL returns the date 1 day before the start date of the active child as the expiry date of the commodity. This ignores children that were valid before that period. Where as OTT returns the date 1 day before the earliest child record.

## Ticket:
[<!-- Link to the relevant Jira/ticket, or 'N/A' if not applicable -->](https://transformuk.atlassian.net/browse/HMRC-2232)

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
Fixing an existing bug

───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.

───────────────────────────────────────────────────

🟢 GREEN – things that are typically low risk:
───────────────────────────────────────────────────
- Dependency bumps with no API changes (e.g. minor/patch gems, npm packages)
- Copy or content changes in GOV.UK-style UI components
- Adding or updating CloudWatch alarms or dashboards (read-only observability)
- New tests or improved test coverage with no production code changes
- Config/env var additions that are purely additive and have safe defaults
- Refactors with full test coverage and no behaviour change
- Terraform formatting or variable renaming with no resource recreation
- S3 lifecycle rule additions (non-destructive, time-delayed effect)

🟠 AMBER – things that need a team conversation first:
───────────────────────────────────────────────────
- Changes to commodity code lookups, measure type logic, or duty calculation
- Modifications to the search indexing pipeline (OpenSearch mappings, synonyms, stop words)
- Changes to declarable goods or quota logic
- New or modified API endpoints that other services (backend, frontend, admin) consume
- Adding or changing feature flags that affect live user journeys
- Infrastructure changes that alter networking, security groups, or IAM permissions in non-production first
- Terraform changes that will cause a resource replacement (check plan output carefully)
- Changes to CI/CD pipeline steps or deployment order dependencies
- S3 bucket policy or access control changes
- Removing or deprecating an endpoint or field that may still be consumed

🔴 RED – requires explicit approval from Thor or Neil:
───────────────────────────────────────────────────
- Dangerous database migrations, especially destructive ones (dropping columns/tables, removing indexes)
- Modifications to how measures, conditions, or footnotes are processed or surfaced
- Changes to the synchronisation mechanism from CDS or HMRC upstream data feeds
- Any change to production AWS infrastructure that cannot be easily rolled back (e.g. RDS parameter groups, KMS key policy, removal of resources)
- Secrets rotation or changes to how credentials are stored, scoped, or accessed
- Changes that affect trader-facing regulatory content or legally significant data (e.g. trade remedies, licensing, prohibitions)
- Significant architectural shifts (e.g. new service boundaries, queue/event topology changes)
