### PR TITLE
Preload tariff change measures to avoid N+1 queries

### DIFF
--- a/app/models/tariff_change.rb
+++ b/app/models/tariff_change.rb
@@ -6,16 +6,45 @@ class TariffChange < Sequel::Model
 
   def measure
     return nil unless type == 'Measure'
+    return @measure if instance_variable_defined?(:@measure)
 
-    @measure ||= Measure.operation_klass
-                        .where(measure_sid: object_sid)
-                        .order(:oid)
-                        .last
-                        &.record_from_oplog
+    @measure = Measure.operation_klass
+                      .where(measure_sid: object_sid)
+                      .order(:oid)
+                      .last
+                      &.record_from_oplog
   end
 
   def self.delete_for(operation_date:)
     TariffChange.where(operation_date: operation_date).delete
+  end
+
+  def self.preload_measures(tariff_changes)
+    measure_sids = tariff_changes
+      .filter_map { |tc| tc.object_sid if tc.type == 'Measure' }
+      .uniq
+
+    return if measure_sids.empty?
+
+    oid_by_sid = Measure.operation_klass
+      .select(:measure_sid, Sequel.function(:max, :oid).as(:max_oid))
+      .where(measure_sid: measure_sids)
+      .group(:measure_sid)
+      .all
+      .to_h { |row| [row.values[:measure_sid], row.values[:max_oid]] }
+
+    measures = Measure
+      .from(:measures_oplog)
+      .where(oid: oid_by_sid.values)
+      .eager(:measure_type)
+      .all
+      .index_by { |m| m.values[:oid] }
+
+    tariff_changes.each do |tc|
+      next unless tc.type == 'Measure'
+
+      tc.instance_variable_set(:@measure, measures[oid_by_sid[tc.object_sid]])
+    end
   end
 
   dataset_module do

--- a/app/services/tariff_changes_service/transform_records.rb
+++ b/app/services/tariff_changes_service/transform_records.rb
@@ -35,14 +35,7 @@ class TariffChangesService
 
       tariff_changes = query.all
 
-      # Eagerly load measures for Measure type records
-      measure_sids = tariff_changes.select { |tc| tc.type == 'Measure' }.map(&:object_sid).uniq
-      if measure_sids.any?
-        measures = Measure.where(measure_sid: measure_sids).eager(:measure_type).all.index_by(&:measure_sid)
-        tariff_changes.each do |tc|
-          tc.instance_variable_set(:@measure, measures[tc.object_sid]) if tc.type == 'Measure'
-        end
-      end
+      TariffChange.preload_measures(tariff_changes)
 
       # Batch load geographical areas
       geo_area_ids = tariff_changes.map { |tc| tc.metadata&.dig('measure', 'geographical_area_id') }.compact.uniq

--- a/spec/models/tariff_change_spec.rb
+++ b/spec/models/tariff_change_spec.rb
@@ -48,6 +48,45 @@ RSpec.describe TariffChange do
     end
   end
 
+  describe '.preload_measures' do
+    let(:measure) { create(:measure) }
+    let(:tariff_change) { create(:tariff_change, type: 'Measure', object_sid: measure.measure_sid) }
+
+    it 'batch-loads measures to avoid N+1 queries' do
+      described_class.preload_measures([tariff_change])
+
+      allow(Measure).to receive(:operation_klass)
+      tariff_change.measure
+
+      expect(Measure).not_to have_received(:operation_klass)
+    end
+
+    it 'makes the correct measure available via #measure' do
+      described_class.preload_measures([tariff_change])
+
+      expect(tariff_change.measure.measure_sid).to eq(measure.measure_sid)
+    end
+
+    context 'when the measure_sid has no oplog entry' do
+      let(:tariff_change) { create(:tariff_change, type: 'Measure', object_sid: 999_999_999) }
+
+      it 'returns nil from #measure without raising' do
+        described_class.preload_measures([tariff_change])
+
+        expect(tariff_change.measure).to be_nil
+      end
+
+      it 'does not query again after preloading the missing measure' do
+        described_class.preload_measures([tariff_change])
+
+        allow(Measure).to receive(:operation_klass)
+        tariff_change.measure
+
+        expect(Measure).not_to have_received(:operation_klass)
+      end
+    end
+  end
+
   describe '.delete_for' do
     let(:operation_date) { Date.new(2025, 1, 15) }
 


### PR DESCRIPTION
## What:
Adds `TariffChange.preload_measures` to batch-load measures for measure-type tariff changes.
`TransformRecords` now calls this once after loading tariff changes, so later calls to `TariffChange#measure` use the preloaded measure instead of querying per record.
Also updates `#measure` memoization so a preloaded missing measure is cached as nil and does not fall back to another DB lookup.
Before/after query check:

Scenario | Records | Queries
-- | -- | --
Before: no preload | 20 | 40
After: preload | 20 | 3
After: subsequent #measure calls | 20 | 0

## Why:
`TariffChange#measure` previously queried `Measure.operation_klass` lazily for each measure-type tariff change.
When a collection of tariff changes is transformed or exported, this created an N+1 pattern. Batch-loading the latest measure oplog rows removes those repeated lookups while preserving the existing "latest oplog row" behaviour.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
- Lazy `#measure` behaviour is preserved when no preload has happened
- Preload uses the same latest-oplog-row semantics as the old method
- Missing measures are handled safely and cached as `nil`
- The change only affects the tariff-change transform/report path
