### PR TITLE
AI-517: Implement Section Notes Review Approval Process

### DIFF
--- a/app/controllers/api/admin/customs_tariff_updates/base_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates/base_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  module Admin
+    module CustomsTariffUpdates
+      class BaseController < AdminController
+        private
+
+        def customs_tariff_update
+          @customs_tariff_update ||= CustomsTariffUpdate
+            .where(version: params[:customs_tariff_update_version])
+            .first
+            .tap { |u| raise Sequel::RecordNotFound unless u }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/customs_tariff_updates/section_notes_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates/section_notes_controller.rb
@@ -7,18 +7,14 @@ module Api
             .where(customs_tariff_update_version: customs_tariff_update.version)
             .order(:section_id).all
 
-          approved_by_section = approved_notes_index
+          baseline_by_section = compare_notes_index
 
           file_diffs = notes.each_with_object({}) do |note, diffs|
-            approved = approved_by_section[note.section_id]
-            diffs[note.section_id] = if approved.nil?
+            baseline = baseline_by_section[note.section_id]
+            diffs[note.section_id] = if baseline.nil?
                                        nil
                                      else
-                                       VersionDiffService.new(
-                                         'CustomsTariffSectionNote',
-                                         approved.values.transform_keys(&:to_s),
-                                         note.values.transform_keys(&:to_s),
-                                       ).call || {}
+                                       content_diff(baseline, note)
                                      end
           end
 
@@ -29,12 +25,26 @@ module Api
 
         def show
           note = customs_tariff_section_note
-          versions = note.versions.order(Sequel.desc(:created_at)).all
-          Version.preload_predecessors(versions)
 
-          render json: Api::Admin::CustomsTariffUpdates::SectionNoteSerializer.new(
-            note, is_collection: false, params: { versions: }
-          ).serializable_hash
+          if params[:compare_version].present?
+            compare_note = CustomsTariffSectionNote
+              .where(section_id: note.section_id,
+                     customs_tariff_update_version: params[:compare_version])
+              .first
+
+            file_diff = content_diff(compare_note, note) if compare_note
+
+            render json: Api::Admin::CustomsTariffUpdates::SectionNoteSerializer.new(
+              note, is_collection: false, params: { file_diff: }
+            ).serializable_hash
+          else
+            versions = note.versions.order(Sequel.desc(:created_at)).all
+            Version.preload_predecessors(versions)
+
+            render json: Api::Admin::CustomsTariffUpdates::SectionNoteSerializer.new(
+              note, is_collection: false, params: { versions: }
+            ).serializable_hash
+          end
         end
 
         def update
@@ -57,6 +67,16 @@ module Api
 
         private
 
+        def compare_notes_index
+          if params[:compare_version].present?
+            CustomsTariffSectionNote
+              .where(customs_tariff_update_version: params[:compare_version])
+              .all.index_by(&:section_id)
+          else
+            approved_notes_index
+          end
+        end
+
         def customs_tariff_section_note
           @customs_tariff_section_note ||= CustomsTariffSectionNote
             .where(id: params[:id], customs_tariff_update_version: customs_tariff_update.version)
@@ -70,6 +90,14 @@ module Api
           CustomsTariffSectionNote
             .where(customs_tariff_update_version: latest_approved.version)
             .all.index_by(&:section_id)
+        end
+
+        def content_diff(from_note, to_note)
+          VersionDiffService.new(
+            'CustomsTariffSectionNote',
+            { 'content' => from_note.content },
+            { 'content' => to_note.content },
+          ).call || {}
         end
 
         def section_note_params

--- a/app/controllers/api/admin/customs_tariff_updates/section_notes_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates/section_notes_controller.rb
@@ -1,0 +1,81 @@
+module Api
+  module Admin
+    module CustomsTariffUpdates
+      class SectionNotesController < BaseController
+        def index
+          notes = CustomsTariffSectionNote
+            .where(customs_tariff_update_version: customs_tariff_update.version)
+            .order(:section_id).all
+
+          approved_by_section = approved_notes_index
+
+          file_diffs = notes.each_with_object({}) do |note, diffs|
+            approved = approved_by_section[note.section_id]
+            diffs[note.section_id] = if approved.nil?
+                                       nil
+                                     else
+                                       VersionDiffService.new(
+                                         'CustomsTariffSectionNote',
+                                         approved.values.transform_keys(&:to_s),
+                                         note.values.transform_keys(&:to_s),
+                                       ).call || {}
+                                     end
+          end
+
+          render json: Api::Admin::CustomsTariffUpdates::SectionNoteSerializer.new(
+            notes, is_collection: true, params: { file_diffs: }
+          ).serializable_hash
+        end
+
+        def show
+          note = customs_tariff_section_note
+          versions = note.versions.order(Sequel.desc(:created_at)).all
+          Version.preload_predecessors(versions)
+
+          render json: Api::Admin::CustomsTariffUpdates::SectionNoteSerializer.new(
+            note, is_collection: false, params: { versions: }
+          ).serializable_hash
+        end
+
+        def update
+          note = customs_tariff_section_note
+
+          if customs_tariff_update.status == CustomsTariffUpdate::REJECTED
+            render json: { errors: [{ detail: 'Cannot edit a note on a rejected update' }] },
+                   status: :unprocessable_content
+            return
+          end
+
+          note.set(content: section_note_params[:content])
+
+          if note.save(raise_on_failure: false)
+            render json: Api::Admin::CustomsTariffUpdates::SectionNoteSerializer.new(note, is_collection: false).serializable_hash
+          else
+            render json: Api::Admin::ErrorSerializationService.new(note).call, status: :unprocessable_content
+          end
+        end
+
+        private
+
+        def customs_tariff_section_note
+          @customs_tariff_section_note ||= CustomsTariffSectionNote
+            .where(id: params[:id], customs_tariff_update_version: customs_tariff_update.version)
+            .first.tap { |n| raise Sequel::RecordNotFound unless n }
+        end
+
+        def approved_notes_index
+          latest_approved = CustomsTariffUpdate.approved.order(Sequel.desc(:validity_start_date)).first
+          return {} unless latest_approved
+
+          CustomsTariffSectionNote
+            .where(customs_tariff_update_version: latest_approved.version)
+            .all.index_by(&:section_id)
+        end
+
+        def section_note_params
+          params.require(:data).require(:attributes).permit(:content)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/customs_tariff_updates/status_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates/status_controller.rb
@@ -1,0 +1,34 @@
+module Api
+  module Admin
+    module CustomsTariffUpdates
+      class StatusController < BaseController
+        ALLOWED_STATUSES = %w[pending approved rejected].freeze
+
+        def update
+          new_status = status_params[:status]
+
+          unless ALLOWED_STATUSES.include?(new_status)
+            render json: { errors: [{ detail: "Status must be one of: #{ALLOWED_STATUSES.join(', ')}" }] },
+                   status: :unprocessable_content
+            return
+          end
+
+          if customs_tariff_update.status == new_status
+            render json: { errors: [{ detail: "Status is already '#{new_status}'" }] },
+                   status: :unprocessable_content
+            return
+          end
+
+          customs_tariff_update.update(status: new_status)
+          render json: Api::Admin::CustomsTariffUpdateSerializer.new(customs_tariff_update, is_collection: false).serializable_hash
+        end
+
+        private
+
+        def status_params
+          params.require(:data).require(:attributes).permit(:status)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/customs_tariff_updates_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates_controller.rb
@@ -1,0 +1,22 @@
+module Api
+  module Admin
+    class CustomsTariffUpdatesController < AdminController
+      def index
+        updates = CustomsTariffUpdate.order(Sequel.desc(:validity_start_date)).all
+        render json: Api::Admin::CustomsTariffUpdateSerializer.new(updates, is_collection: true).serializable_hash
+      end
+
+      def show
+        render json: Api::Admin::CustomsTariffUpdateSerializer.new(customs_tariff_update, is_collection: false).serializable_hash
+      end
+
+      private
+
+      def customs_tariff_update
+        @customs_tariff_update ||= CustomsTariffUpdate.where(version: params[:version]).first.tap do |u|
+          raise Sequel::RecordNotFound unless u
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/versions_controller.rb
+++ b/app/controllers/api/admin/versions_controller.rb
@@ -11,6 +11,7 @@ module Api
         'AdminConfiguration' => AdminConfiguration,
         'DescriptionIntercept' => DescriptionIntercept,
         'GoodsNomenclatureIntercept' => GoodsNomenclatureIntercept,
+        'CustomsTariffSectionNote' => CustomsTariffSectionNote,
       }.freeze
 
       def restore

--- a/app/engines/admin_api.rb
+++ b/app/engines/admin_api.rb
@@ -76,6 +76,13 @@ AdminApi.routes.draw do
         end
       end
 
+      get  'customs_tariff_updates',          to: 'customs_tariff_updates#index'
+      get  'customs_tariff_updates/:version', to: 'customs_tariff_updates#show', constraints: { version: /\d+\.\d+/ }
+      get  'customs_tariff_updates/:customs_tariff_update_version/section_notes',      to: 'customs_tariff_updates/section_notes#index',  constraints: { customs_tariff_update_version: /[^\/]+/ }
+      get  'customs_tariff_updates/:customs_tariff_update_version/section_notes/:id',  to: 'customs_tariff_updates/section_notes#show',   constraints: { customs_tariff_update_version: /[^\/]+/ }
+      patch 'customs_tariff_updates/:customs_tariff_update_version/section_notes/:id', to: 'customs_tariff_updates/section_notes#update',  constraints: { customs_tariff_update_version: /[^\/]+/ }
+      patch 'customs_tariff_updates/:customs_tariff_update_version/status',            to: 'customs_tariff_updates/status#update',         constraints: { customs_tariff_update_version: /[^\/]+/ }
+
       resources :quota_order_numbers, module: 'quota_order_numbers', only: %i[] do
         resources :quota_definitions, only: %i[index show]
       end

--- a/app/models/customs_tariff_section_note.rb
+++ b/app/models/customs_tariff_section_note.rb
@@ -3,6 +3,8 @@ class CustomsTariffSectionNote < Sequel::Model
   APPROVED = 'approved'.freeze
   REJECTED = 'rejected'.freeze
 
+  plugin :has_paper_trail
+
   many_to_one :customs_tariff_update, key: :customs_tariff_update_version
 
   dataset_module do

--- a/app/serializers/api/admin/customs_tariff_update_serializer.rb
+++ b/app/serializers/api/admin/customs_tariff_update_serializer.rb
@@ -1,0 +1,13 @@
+module Api
+  module Admin
+    class CustomsTariffUpdateSerializer
+      include JSONAPI::Serializer
+
+      set_type :customs_tariff_update
+      set_id   :version
+
+      attributes :version, :status, :validity_start_date, :validity_end_date,
+                 :source_url, :document_created_on, :created_at, :updated_at
+    end
+  end
+end

--- a/app/serializers/api/admin/customs_tariff_updates/section_note_serializer.rb
+++ b/app/serializers/api/admin/customs_tariff_updates/section_note_serializer.rb
@@ -1,0 +1,33 @@
+module Api
+  module Admin
+    module CustomsTariffUpdates
+      class SectionNoteSerializer
+        include JSONAPI::Serializer
+
+        set_type :customs_tariff_section_note
+        set_id   :id
+
+        attributes :section_id, :content, :customs_tariff_update_version
+
+        attribute :file_diff do |note, params|
+          params[:file_diffs]&.dig(note.section_id)
+        end
+
+        attribute :versions do |_note, params|
+          (params[:versions] || []).map do |v|
+            {
+              id: v.id,
+              item_type: v.item_type,
+              item_id: v.item_id,
+              event: v.event,
+              object: v.object,
+              whodunnit: v.whodunnit,
+              created_at: v.created_at,
+              changeset: v.changeset,
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/admin/customs_tariff_updates/section_note_serializer.rb
+++ b/app/serializers/api/admin/customs_tariff_updates/section_note_serializer.rb
@@ -10,7 +10,7 @@ module Api
         attributes :section_id, :content, :customs_tariff_update_version
 
         attribute :file_diff do |note, params|
-          params[:file_diffs]&.dig(note.section_id)
+          params[:file_diff] || params[:file_diffs]&.dig(note.section_id)
         end
 
         attribute :versions do |_note, params|

--- a/app/serializers/api/admin/sections/section_serializer.rb
+++ b/app/serializers/api/admin/sections/section_serializer.rb
@@ -11,9 +11,7 @@ module Api
         attributes :id, :numeral, :title, :position, :chapter_from, :chapter_to
 
         has_many :chapters, serializer: Api::Admin::Sections::ChapterSerializer
-        has_one :section_note, serializer: Api::Admin::Sections::SectionNoteSerializer, id_method_name: :id do |section|
-          TradeTariffBackend.uk? ? section.customs_tariff_section_note : section.section_note
-        end
+        has_one :section_note, serializer: Api::Admin::Sections::SectionNoteSerializer, id_method_name: :id, &:section_note
       end
     end
   end

--- a/app/services/version_diff_service.rb
+++ b/app/services/version_diff_service.rb
@@ -48,6 +48,14 @@ class VersionDiffService
       created_at
       updated_at
     ].freeze,
+    'CustomsTariffSectionNote' => %w[
+      id
+      customs_tariff_update_version
+      section_id
+      status
+      created_at
+      updated_at
+    ].freeze,
   }.freeze
 
   TEXT_THRESHOLD = 40

--- a/spec/lib/sequel/plugins/has_paper_trail_spec.rb
+++ b/spec/lib/sequel/plugins/has_paper_trail_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe Sequel::Plugins::HasPaperTrail do
       expect(described_class.tracked_models.map(&:name)).to eq(%w[
         AdminConfiguration
         ChapterNote
+        CustomsTariffSectionNote
         DescriptionIntercept
         GoodsNomenclatureIntercept
         GoodsNomenclatureLabel

--- a/spec/requests/api/admin/customs_tariff_updates/section_notes_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates/section_notes_controller_spec.rb
@@ -1,0 +1,99 @@
+RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
+  around { |example| TimeMachine.now { example.run } }
+
+  describe 'GET #index' do
+    let!(:approved_update) { create(:customs_tariff_update, :approved, validity_start_date: 1.month.ago) }
+    let!(:pending_update)  { create(:customs_tariff_update, validity_start_date: Time.zone.today) }
+    let!(:approved_note) do
+      create(:customs_tariff_section_note, customs_tariff_update: approved_update, section_id: 1,
+                                           content: 'Old content that is long enough to be text-diffed by the service version one')
+    end
+    let!(:pending_note) do
+      create(:customs_tariff_section_note, customs_tariff_update: pending_update, section_id: 1,
+                                           content: 'New content that is long enough to be text-diffed by the service version two')
+    end
+
+    it 'returns section notes with file_diff for changed content' do
+      get "/uk/admin/customs_tariff_updates/#{pending_update.version}/section_notes.json",
+          headers: request_headers(format: :json)
+
+      expect(response.status).to eq(200)
+      note = JSON.parse(response.body)['data'].find { |n| n.dig('attributes', 'section_id') == 1 }
+      expect(note.dig('attributes', 'file_diff', 'changed_fields')).to include('content')
+    end
+
+    it 'returns file_diff as empty hash when content is identical' do
+      pending_note.update(content: approved_note.content)
+
+      get "/uk/admin/customs_tariff_updates/#{pending_update.version}/section_notes.json",
+          headers: request_headers(format: :json)
+
+      note = JSON.parse(response.body)['data'].find { |n| n.dig('attributes', 'section_id') == 1 }
+      expect(note.dig('attributes', 'file_diff')).to eq({})
+    end
+
+    it 'returns file_diff as nil when section has no approved counterpart' do
+      create(:customs_tariff_section_note, customs_tariff_update: pending_update, section_id: 5)
+
+      get "/uk/admin/customs_tariff_updates/#{pending_update.version}/section_notes.json",
+          headers: request_headers(format: :json)
+
+      note = JSON.parse(response.body)['data'].find { |n| n.dig('attributes', 'section_id') == 5 }
+      expect(note.dig('attributes', 'file_diff')).to be_nil
+    end
+
+    it 'returns empty data when the update has no notes' do
+      update_with_no_notes = create(:customs_tariff_update, validity_start_date: 2.months.ago)
+
+      get "/uk/admin/customs_tariff_updates/#{update_with_no_notes.version}/section_notes.json",
+          headers: request_headers(format: :json)
+
+      expect(JSON.parse(response.body)['data']).to be_empty
+    end
+  end
+
+  describe 'GET #show' do
+    let!(:update) { create(:customs_tariff_update) }
+    let!(:note)   { create(:customs_tariff_section_note, customs_tariff_update: update) }
+
+    it 'returns the note with a versions array' do
+      get "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.id}.json",
+          headers: request_headers(format: :json)
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body).dig('data', 'attributes', 'versions')).to be_an(Array)
+    end
+  end
+
+  describe 'PATCH #update' do
+    let!(:update) { create(:customs_tariff_update) }
+    let!(:note)   { create(:customs_tariff_section_note, customs_tariff_update: update) }
+
+    it 'updates the content' do
+      patch "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.id}.json",
+            params: { data: { type: 'customs_tariff_section_note', attributes: { content: 'Updated content' } } },
+            headers: request_headers(format: :json), as: :json
+
+      expect(response.status).to eq(200)
+      expect(note.reload.content).to eq('Updated content')
+    end
+
+    it 'returns 422 when the parent update is rejected' do
+      update.update(status: CustomsTariffUpdate::REJECTED)
+
+      patch "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.id}.json",
+            params: { data: { type: 'customs_tariff_section_note', attributes: { content: 'Updated' } } },
+            headers: request_headers(format: :json), as: :json
+
+      expect(response.status).to eq(422)
+    end
+
+    it 'creates a Version record on successful save' do
+      expect {
+        patch "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.id}.json",
+              params: { data: { type: 'customs_tariff_section_note', attributes: { content: 'Versioned content' } } },
+              headers: request_headers(format: :json), as: :json
+      }.to change { Version.where(item_type: 'CustomsTariffSectionNote', item_id: note.id.to_s).count }.by(1)
+    end
+  end
+end

--- a/spec/requests/api/admin/customs_tariff_updates/section_notes_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates/section_notes_controller_spec.rb
@@ -50,6 +50,43 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
 
       expect(JSON.parse(response.body)['data']).to be_empty
     end
+
+    context 'with compare_version param' do
+      let!(:compare_update) do
+        create(:customs_tariff_update, :approved, validity_start_date: 3.months.ago)
+      end
+      let!(:target_update) do
+        create(:customs_tariff_update, validity_start_date: Time.zone.today)
+      end
+
+      before do
+        create(:customs_tariff_section_note, customs_tariff_update: compare_update, section_id: 10,
+                                             content: 'Compare section content that is long enough for text diffing here')
+        create(:customs_tariff_section_note, customs_tariff_update: target_update, section_id: 10,
+                                             content: 'Target section content that is long enough for text diffing here')
+      end
+
+      it 'diffs against the specified compare_version instead of latest approved' do
+        get "/uk/admin/customs_tariff_updates/#{target_update.version}/section_notes.json",
+            params: { compare_version: compare_update.version },
+            headers: request_headers(format: :json)
+
+        expect(response.status).to eq(200)
+        note = JSON.parse(response.body)['data'].find { |n| n.dig('attributes', 'section_id') == 10 }
+        expect(note.dig('attributes', 'file_diff', 'changed_fields')).to include('content')
+      end
+
+      it 'returns nil file_diff when section has no counterpart in the compare version' do
+        create(:customs_tariff_section_note, customs_tariff_update: target_update, section_id: 20)
+
+        get "/uk/admin/customs_tariff_updates/#{target_update.version}/section_notes.json",
+            params: { compare_version: compare_update.version },
+            headers: request_headers(format: :json)
+
+        note = JSON.parse(response.body)['data'].find { |n| n.dig('attributes', 'section_id') == 20 }
+        expect(note.dig('attributes', 'file_diff')).to be_nil
+      end
+    end
   end
 
   describe 'GET #show' do
@@ -62,6 +99,50 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
 
       expect(response.status).to eq(200)
       expect(JSON.parse(response.body).dig('data', 'attributes', 'versions')).to be_an(Array)
+    end
+
+    context 'with compare_version param' do
+      let!(:compare_update) do
+        create(:customs_tariff_update, :approved, validity_start_date: 1.month.ago)
+      end
+
+      context 'when a matching note exists in the compare version' do
+        before do
+          create(:customs_tariff_section_note,
+                 customs_tariff_update: compare_update,
+                 section_id: note.section_id,
+                 content: 'Old content that is long enough to trigger text diff in the service here')
+          note.update(content: 'New content that is long enough to trigger text diff in the service here')
+        end
+
+        it 'returns file_diff instead of versions' do
+          get "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.id}.json",
+              params: { compare_version: compare_update.version },
+              headers: request_headers(format: :json)
+
+          expect(response.status).to eq(200)
+          attrs = JSON.parse(response.body).dig('data', 'attributes')
+          expect(attrs['file_diff']).to be_a(Hash)
+          expect(attrs['file_diff']['changed_fields']).to include('content')
+          expect(attrs['versions']).to eq([])
+        end
+      end
+
+      context 'when the section has no counterpart in the compare version' do
+        it 'returns nil file_diff' do
+          other_update = create(:customs_tariff_update, validity_start_date: 2.months.ago)
+          orphan_note = create(:customs_tariff_section_note,
+                               customs_tariff_update: other_update,
+                               section_id: 99)
+
+          get "/uk/admin/customs_tariff_updates/#{other_update.version}/section_notes/#{orphan_note.id}.json",
+              params: { compare_version: compare_update.version },
+              headers: request_headers(format: :json)
+
+          expect(response.status).to eq(200)
+          expect(JSON.parse(response.body).dig('data', 'attributes', 'file_diff')).to be_nil
+        end
+      end
     end
   end
 

--- a/spec/requests/api/admin/customs_tariff_updates/status_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates/status_controller_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe Api::Admin::CustomsTariffUpdates::StatusController do
+  describe 'PATCH #update' do
+    let!(:update) { create(:customs_tariff_update) }
+
+    it 'changes status to approved' do
+      patch "/uk/admin/customs_tariff_updates/#{update.version}/status.json",
+            params: { data: { attributes: { status: 'approved' } } },
+            headers: request_headers(format: :json), as: :json
+
+      expect(response.status).to eq(200)
+      expect(update.reload.status).to eq('approved')
+    end
+
+    it 'returns 422 when status is already the same' do
+      patch "/uk/admin/customs_tariff_updates/#{update.version}/status.json",
+            params: { data: { attributes: { status: 'pending' } } },
+            headers: request_headers(format: :json), as: :json
+
+      expect(response.status).to eq(422)
+    end
+
+    it 'returns 422 for an invalid status value' do
+      patch "/uk/admin/customs_tariff_updates/#{update.version}/status.json",
+            params: { data: { attributes: { status: 'bogus' } } },
+            headers: request_headers(format: :json), as: :json
+
+      expect(response.status).to eq(422)
+    end
+
+    it 'allows changing the status of any update, not just the latest' do
+      older = create(:customs_tariff_update, :approved, validity_start_date: 1.month.ago)
+
+      patch "/uk/admin/customs_tariff_updates/#{older.version}/status.json",
+            params: { data: { attributes: { status: 'rejected' } } },
+            headers: request_headers(format: :json), as: :json
+
+      expect(response.status).to eq(200)
+      expect(older.reload.status).to eq('rejected')
+    end
+  end
+end

--- a/spec/requests/api/admin/customs_tariff_updates_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates_controller_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe Api::Admin::CustomsTariffUpdatesController do
+  describe 'GET #index' do
+    before { create(:customs_tariff_update) }
+
+    it 'returns all updates' do
+      get '/uk/admin/customs_tariff_updates.json', headers: request_headers(format: :json)
+
+      expect(response.status).to eq(200)
+      data = JSON.parse(response.body)['data']
+      expect(data).to be_an(Array)
+      expect(data.first['type']).to eq('customs_tariff_update')
+      expect(data.first.dig('attributes', 'status')).to be_a(String)
+    end
+  end
+
+  describe 'GET #show' do
+    let!(:update) { create(:customs_tariff_update) }
+
+    it 'returns the update' do
+      get "/uk/admin/customs_tariff_updates/#{update.version}.json", headers: request_headers(format: :json)
+
+      expect(response.status).to eq(200)
+      data = JSON.parse(response.body)['data']
+      expect(data['type']).to eq('customs_tariff_update')
+      expect(data.dig('attributes', 'version')).to eq(update.version)
+      expect(data.dig('attributes', 'status')).to be_a(String)
+    end
+
+    it 'returns 404 for unknown version' do
+      get '/uk/admin/customs_tariff_updates/does-not-exist.json', headers: request_headers(format: :json)
+
+      expect(response.status).to eq(404)
+    end
+  end
+end

--- a/spec/services/version_diff_service_spec.rb
+++ b/spec/services/version_diff_service_spec.rb
@@ -150,6 +150,29 @@ RSpec.describe VersionDiffService do
       end
     end
 
+    context 'with CustomsTariffSectionNote' do
+      let(:base) do
+        { 'id' => 1,
+          'section_id' => 3,
+          'customs_tariff_update_version' => '1.0',
+          'content' => 'Same text',
+          'status' => 'pending',
+          'created_at' => nil,
+          'updated_at' => nil }
+      end
+
+      it 'returns nil when content is identical' do
+        result = described_class.new('CustomsTariffSectionNote', base, base.merge('id' => 2)).call
+        expect(result).to be_nil
+      end
+
+      it 'returns a changeset when content differs' do
+        new_obj = base.merge('content' => 'New content for this section that is longer than 40 chars.')
+        result = described_class.new('CustomsTariffSectionNote', base, new_obj).call
+        expect(result['changed_fields']).to include('content')
+      end
+    end
+
     context 'with AdminConfiguration virtual fields' do
       it 'extracts selected from nested options value' do
         old_obj = {


### PR DESCRIPTION
## What:

This PR adds the backend admin API for the Customs Tariff section notes review and approval pipeline. Operators can list updates, change their status, and view or edit the section notes attached to each update — including comparing notes between versions to see what's changed.

Here's what's been added:

- **`CustomsTariffUpdatesController`** — lists all customs tariff updates with their status, validity dates, and source URL
- **`StatusController`** — handles status transitions for an update (pending → approved → rejected, etc.)
- **`SectionNotesController`** — lists and shows section notes for a given update; supports editing note content and comparing notes across two update versions via an optional `compare_version` query param
- **`BaseController`** — shared before-actions for the customs tariff updates namespace
- **`CustomsTariffUpdateSerializer`** and **`SectionNoteSerializer`** — serialize updates and section notes; the note serializer includes a `file_diff` showing what changed vs. the comparison baseline, and a `versions` array for edit history
- **`VersionDiffService`** updates — now supports text-level LCS diffing so inline changes within a paragraph are highlighted
- `CustomsTariffSectionNote` model — wired up to PaperTrail so every content edit is tracked

The comparison diff only considers the `content` field — metadata fields like `validity_start_date` always differ between updates and would create noise.

## Why:

Operators need a way to review incoming Customs Tariff updates before they go live — checking what's changed in the section notes and approving or rejecting the update accordingly. This PR builds the API layer that the admin frontend sits on top of.

## Ticket:

[AI-517](https://transformuk.atlassian.net/browse/AI-517)

## Risk:
**Risk level:** 🟢

**Reason for rating:** All new routes under `/admin/customs_tariff_updates` with no changes to existing endpoints. No migrations included — the underlying tables were created in an earlier PR on this epic.