### PR TITLE
Add index on geographical_area_memberships by group_sid and validity dates

### DIFF
--- a/db/migrate/20260529120000_add_geographical_area_memberships_group_sid_index.rb
+++ b/db/migrate/20260529120000_add_geographical_area_memberships_group_sid_index.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    add_index :geographical_area_memberships,
+              %i[geographical_area_group_sid validity_start_date validity_end_date],
+              name: :geo_area_memberships_group_sid_validity_index
+  end
+
+  down do
+    drop_index :geographical_area_memberships,
+               %i[geographical_area_group_sid validity_start_date validity_end_date],
+               name: :geo_area_memberships_group_sid_validity_index
+  end
+end


### PR DESCRIPTION
## What:
Add a composite index on `geographical_area_memberships(geographical_area_group_sid, validity_start_date, validity_end_date)`.

## Why:
The `contained_geographical_areas` eager load on `GeographicalArea` generates a query that filters `geographical_area_memberships` by `geographical_area_group_sid IN (...)` plus a validity date window. The existing composite index leads with `geographical_area_sid`, which is absent from the WHERE clause, so PostgreSQL falls back to a sequential scan of the materialized view.

The new index leads with `geographical_area_group_sid`, allowing the planner to seek directly to the relevant group SIDs and evaluate both date columns from the index without a heap fetch.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:** Additive index on a materialized view — no schema destructuring, no behaviour change. Safe to deploy at any time.