### PR TITLE
BAU: Validate historical date params

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,10 +34,10 @@ class ApplicationController < ActionController::API
       return default
     end
 
-    date = Date.parse(as_of_param)
+    date = Date.iso8601(as_of_param)
 
-    # Ensure the date is within a 20-year range
-    if date > 20.years.from_now
+    # Ensure the date is within a supported range
+    if date < Date.new(1, 1, 1) || date > 20.years.from_now
       default
     else
       date

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe ApplicationController, type: :request do
         it { expect(TimeMachine).to have_received(:at).with(Time.zone.today) }
       end
 
+      context 'when as_of has year zero' do
+        subject(:api_response) do
+          make_request
+          response
+        end
+
+        let(:make_request) { api_get('/uk/api/healthcheck', params: { as_of: '0000-05-24' }) }
+
+        it { expect(TimeMachine).to have_received(:at).with(Time.zone.today) }
+      end
+
       context 'when as_of is in range' do
         subject(:api_response) do
           make_request


### PR DESCRIPTION
### Jira link

BAU

### What?

- [x] Add request coverage for `as_of` dates with year zero.
- [x] Parse `as_of` values with strict ISO date parsing.
- [x] Reject dates below year 1 before configuring `TimeMachine`.

### Why?

Production logs showed `PG::DatetimeFieldOverflow` for requests such as `as_of=0000-05-24`. PostgreSQL cannot handle year-zero timestamps, so malformed dates should fall back to today before query construction.

### Risk

**Risk level:** 🟢

**Reason for rating:** Defensive validation for invalid historical date input. Valid ISO dates in the supported range continue to use the requested date.