### PR TITLE
OTTIMP-629 Use Data objects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,6 @@ gem 'logstash-event'
 gem 'newrelic_rpm'
 gem 'nokogiri'
 gem 'notifications-ruby-client'
-gem 'ostruct'
 gem 'slack-notifier'
 
 # API related

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,7 +269,6 @@ GEM
     opensearch-ruby (3.4.0)
       faraday (>= 1.0, < 3)
       multi_json (>= 1.0)
-    ostruct (0.6.3)
     parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -529,7 +528,6 @@ DEPENDENCIES
   nokogiri
   notifications-ruby-client
   opensearch-ruby
-  ostruct
   pg
   pry-rails
   puma

--- a/app/controllers/api/admin/goods_nomenclature_labels/stats_controller.rb
+++ b/app/controllers/api/admin/goods_nomenclature_labels/stats_controller.rb
@@ -4,9 +4,8 @@ module Api
       class StatsController < AdminController
         def show
           stats = StatsService.new.call
-          stats_object = OpenStruct.new(stats)
 
-          render json: StatsSerializer.new(stats_object).serializable_hash
+          render json: StatsSerializer.new(stats).serializable_hash
         end
       end
     end

--- a/app/controllers/api/v2/enquiry_form/submissions_controller.rb
+++ b/app/controllers/api/v2/enquiry_form/submissions_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V2
     class EnquiryForm::SubmissionsController < ApiController
       CACHE_DURATION = 1.hour
+      SubmissionResult = Data.define(:reference_number)
 
       def create
         store_enquiry_form_data
@@ -9,7 +10,7 @@ module Api
         ::EnquiryForm::SendSubmissionEmailWorker.perform_async(reference_number)
 
         begin
-          render json: serialize(OpenStruct.new(reference_number: reference_number)), status: :created
+          render json: serialize(SubmissionResult.new(reference_number:)), status: :created
         rescue ActionController::ParameterMissing => e
           render json: { errors: [e.message] }, status: :unprocessable_content
         end

--- a/app/lib/reporting/differences.rb
+++ b/app/lib/reporting/differences.rb
@@ -3,6 +3,9 @@ module Reporting
   # relies on source date about supplementary units and commodities to compare
   # the UK and XI data.
   class Differences
+    Worksheet = Data.define(:worksheet, :worksheet_name, :subtext)
+    Section = Data.define(:section, :worksheets)
+
     MEASURE_EAGER = [
       {
         measure_components: [
@@ -278,14 +281,14 @@ module Reporting
     def sections
       Reporting::Differences::Renderers::Overview::OVERVIEW_SECTION_CONFIG.keys.map do |section|
         worksheets = Reporting::Differences::Renderers::Overview::OVERVIEW_SECTION_CONFIG.dig(section, :worksheets).map do |worksheet, config|
-          OpenStruct.new(
+          Worksheet.new(
             worksheet:,
             worksheet_name: config[:worksheet_name],
             subtext: config[:description].sub('as_of', as_of.to_date.to_fs(:govuk)),
           )
         end
 
-        OpenStruct.new(
+        Section.new(
           section:,
           worksheets:,
         )

--- a/app/models/additional_code.rb
+++ b/app/models/additional_code.rb
@@ -8,6 +8,7 @@ class AdditionalCode < Sequel::Model
   PREFERENCE_TYPE_IDS = %w[2].freeze
   REMEDY_TYPE_IDS = %w[8 A B C].freeze
   EXCISE_TYPE_IDS = %w[X].freeze
+  NullCode = Data.define(:code, :description)
 
   plugin :time_machine
   plugin :oplog, primary_key: :additional_code_sid, materialized: true
@@ -69,7 +70,7 @@ class AdditionalCode < Sequel::Model
 
   class << self
     def null_code
-      OpenStruct.new(code: 'none', description: 'No additional code')
+      NullCode.new(code: 'none', description: 'No additional code')
     end
 
     def heading_for(type)

--- a/app/services/api/admin/goods_nomenclature_labels/stats_service.rb
+++ b/app/services/api/admin/goods_nomenclature_labels/stats_service.rb
@@ -2,8 +2,19 @@ module Api
   module Admin
     module GoodsNomenclatureLabels
       class StatsService
+        Result = Data.define(
+          :total_goods_nomenclatures,
+          :descriptions_count,
+          :known_brands_count,
+          :colloquial_terms_count,
+          :synonyms_count,
+          :ai_created_only,
+          :human_edited,
+          :coverage_by_chapter,
+        )
+
         def call
-          {
+          Result.new(
             total_goods_nomenclatures: total_goods_nomenclatures,
             descriptions_count: descriptions_count,
             known_brands_count: jsonb_array_sum('known_brands'),
@@ -12,7 +23,7 @@ module Api
             ai_created_only: ai_created_only,
             human_edited: human_edited,
             coverage_by_chapter: coverage_by_chapter,
-          }
+          )
         end
 
         private

--- a/app/services/reporting/backfill_differences_reports.rb
+++ b/app/services/reporting/backfill_differences_reports.rb
@@ -52,6 +52,8 @@ module Reporting
     private
 
     ReportSource = Data.define(:date, :key)
+    Worksheet = Data.define(:worksheet, :worksheet_name, :subtext)
+    Section = Data.define(:section, :worksheets)
 
     class WorkbookWrapper
       def initialize(data)
@@ -74,14 +76,14 @@ module Reporting
       def sections
         Reporting::Differences::Renderers::Overview::OVERVIEW_SECTION_CONFIG.keys.map do |section|
           worksheets = Reporting::Differences::Renderers::Overview::OVERVIEW_SECTION_CONFIG.dig(section, :worksheets).map do |worksheet, config|
-            OpenStruct.new(
+            Worksheet.new(
               worksheet:,
               worksheet_name: config[:worksheet_name],
               subtext: config[:description].sub('as_of', as_of.to_date.to_fs(:govuk)),
             )
           end
 
-          OpenStruct.new(section:, worksheets:)
+          Section.new(section:, worksheets:)
         end
       end
 

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,4 @@
 # Load the Rails application.
-require 'ostruct'
 require_relative 'application'
 
 # Initialize the Rails application.

--- a/lib/tasks/tariff_importer.rake
+++ b/lib/tasks/tariff_importer.rake
@@ -1,4 +1,6 @@
 # Import TARIC or CDS file manually. Usually for initial seed files.
+DummyUpdate = Data.define(:file_path, :issue_date)
+
 namespace :importer do
   namespace :taric do
     desc 'Import TARIC file'
@@ -6,7 +8,7 @@ namespace :importer do
       if ENV['TARGET'] && TariffSynchronizer::FileService.file_exists?(ENV['TARGET'])
         Sequel::Model.subclasses.each(&:unrestrict_primary_key)
         Sequel::Model.plugin :skip_create_refresh
-        dummy_update = OpenStruct.new(file_path: ENV['TARGET'], issue_date: nil)
+        dummy_update = DummyUpdate.new(file_path: ENV['TARGET'], issue_date: nil)
         TaricImporter.new(dummy_update).import(validate: false)
       else
         puts 'Please provide TARGET environment variable pointing to Tariff file to import'
@@ -20,7 +22,7 @@ namespace :importer do
       if ENV['TARGET'] && TariffSynchronizer::FileService.file_exists?(ENV['TARGET'])
         Sequel::Model.subclasses.each(&:unrestrict_primary_key)
         Sequel::Model.plugin :skip_create_refresh
-        dummy_update = OpenStruct.new(file_path: ENV['TARGET'], issue_date: nil)
+        dummy_update = DummyUpdate.new(file_path: ENV['TARGET'], issue_date: nil)
 
         CdsImporter.new(dummy_update).import
       else

--- a/spec/cds_importer/xml_parser/reader_spec.rb
+++ b/spec/cds_importer/xml_parser/reader_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CdsImporter::XmlParser::Reader do
 
       let(:xml_io) { StringIO.new }
       let(:stack) { [{ __content__: '' }] }
-      let(:handler) { OpenStruct.new { def process_xml_node(_key, _attributes); end } }
+      let(:handler) { Class.new { def process_xml_node(_key, _attributes); end }.new }
 
       before do
         reader.instance_variable_set('@in_target', in_target)

--- a/spec/requests/api/admin/goods_nomenclature_labels/stats_controller_spec.rb
+++ b/spec/requests/api/admin/goods_nomenclature_labels/stats_controller_spec.rb
@@ -26,18 +26,23 @@ RSpec.describe Api::Admin::GoodsNomenclatureLabels::StatsController do
       expect(response.body).to match_json_expression(pattern)
     end
 
-    context 'when there are labels' do
-      let(:commodity) { create :commodity }
+    context 'when service returns non-zero stats' do
+      let(:stats_result) do
+        Api::Admin::GoodsNomenclatureLabels::StatsService::Result.new(
+          total_goods_nomenclatures: 1,
+          descriptions_count: 1,
+          known_brands_count: 2,
+          colloquial_terms_count: 0,
+          synonyms_count: 1,
+          ai_created_only: 1,
+          human_edited: 0,
+          coverage_by_chapter: [],
+        )
+      end
 
       before do
-        create :goods_nomenclature_label,
-               goods_nomenclature: commodity,
-               labels: {
-                 'description' => 'Test description',
-                 'known_brands' => %w[BrandA BrandB],
-                 'colloquial_terms' => [],
-                 'synonyms' => %w[syn1],
-               }
+        service = instance_double(Api::Admin::GoodsNomenclatureLabels::StatsService, call: stats_result)
+        allow(Api::Admin::GoodsNomenclatureLabels::StatsService).to receive(:new).and_return(service)
       end
 
       it 'returns correct counts' do

--- a/spec/serializers/api/internal/goods_nomenclature_search_serializer_spec.rb
+++ b/spec/serializers/api/internal/goods_nomenclature_search_serializer_spec.rb
@@ -1,29 +1,49 @@
 RSpec.describe Api::Internal::GoodsNomenclatureSearchSerializer do
+  let(:serializer_for_record_class) { Data.define(:goods_nomenclature_class) }
+  let(:search_record_class) do
+    Data.define(
+      :id,
+      :goods_nomenclature_sid,
+      :goods_nomenclature_item_id,
+      :producline_suffix,
+      :goods_nomenclature_class,
+      :description,
+      :formatted_description,
+      :self_text,
+      :classification_description,
+      :full_description,
+      :heading_description,
+      :confidence,
+      :declarable,
+      :score,
+    )
+  end
+
   it_behaves_like 'a serialized goods nomenclature search result', 'goods_nomenclature'
 
   describe '.serializer_for' do
     it 'returns ChapterSearchSerializer for Chapter class' do
-      record = OpenStruct.new(goods_nomenclature_class: 'Chapter')
+      record = serializer_for_record_class.new(goods_nomenclature_class: 'Chapter')
       expect(described_class.serializer_for(record)).to eq(Api::Internal::ChapterSearchSerializer)
     end
 
     it 'returns HeadingSearchSerializer for Heading class' do
-      record = OpenStruct.new(goods_nomenclature_class: 'Heading')
+      record = serializer_for_record_class.new(goods_nomenclature_class: 'Heading')
       expect(described_class.serializer_for(record)).to eq(Api::Internal::HeadingSearchSerializer)
     end
 
     it 'returns SubheadingSearchSerializer for Subheading class' do
-      record = OpenStruct.new(goods_nomenclature_class: 'Subheading')
+      record = serializer_for_record_class.new(goods_nomenclature_class: 'Subheading')
       expect(described_class.serializer_for(record)).to eq(Api::Internal::SubheadingSearchSerializer)
     end
 
     it 'returns CommoditySearchSerializer for Commodity class' do
-      record = OpenStruct.new(goods_nomenclature_class: 'Commodity')
+      record = serializer_for_record_class.new(goods_nomenclature_class: 'Commodity')
       expect(described_class.serializer_for(record)).to eq(Api::Internal::CommoditySearchSerializer)
     end
 
     it 'returns self when goods_nomenclature_class is nil' do
-      record = OpenStruct.new(goods_nomenclature_class: nil)
+      record = serializer_for_record_class.new(goods_nomenclature_class: nil)
       expect(described_class.serializer_for(record)).to eq(described_class)
     end
   end
@@ -35,16 +55,18 @@ RSpec.describe Api::Internal::GoodsNomenclatureSearchSerializer do
     end
 
     it 'serializes each record with the correct type-specific serializer' do
-      chapter = OpenStruct.new(
+      chapter = search_record_class.new(
         id: 1, goods_nomenclature_sid: 1, goods_nomenclature_item_id: '0100000000',
         producline_suffix: '80', goods_nomenclature_class: 'Chapter',
         description: 'animals', formatted_description: 'Animals',
+        self_text: nil, classification_description: nil, full_description: nil, heading_description: nil, confidence: nil,
         declarable: false, score: 10.0
       )
-      heading = OpenStruct.new(
+      heading = search_record_class.new(
         id: 2, goods_nomenclature_sid: 2, goods_nomenclature_item_id: '0101000000',
         producline_suffix: '80', goods_nomenclature_class: 'Heading',
         description: 'horses', formatted_description: 'Horses',
+        self_text: nil, classification_description: nil, full_description: nil, heading_description: nil, confidence: nil,
         declarable: true, score: 8.5
       )
 

--- a/spec/serializers/api/shared/csv_serializer_spec.rb
+++ b/spec/serializers/api/shared/csv_serializer_spec.rb
@@ -1,17 +1,17 @@
 RSpec.describe Api::Shared::CsvSerializer do
   subject(:serialized) { serializer.new([data]).serialized_csv }
 
+  let(:csv_row_class) { Data.define(:name, :age, :date_of_birth, :is_admin, :bio, :created_at) }
   let :data do
-    OpenStruct.new.tap do |data|
-      data.name = 'A String'
-      data.age = 1
-      data.date_of_birth = Date.parse('2000-01-01')
-      data.is_admin = true
-      data.bio = nil
-      data.created_at = Time.zone.parse('2010-01-01 23:59:59.999999')
-    end
+    csv_row_class.new(
+      name: 'A String',
+      age: 1,
+      date_of_birth: Date.parse('2000-01-01'),
+      is_admin: true,
+      bio: nil,
+      created_at: Time.zone.parse('2010-01-01 23:59:59.999999'),
+    )
   end
-
   let :serializer do
     Class.new do
       include Api::Shared::CsvSerializer

--- a/spec/services/api/admin/goods_nomenclature_labels/stats_service_spec.rb
+++ b/spec/services/api/admin/goods_nomenclature_labels/stats_service_spec.rb
@@ -1,20 +1,24 @@
 RSpec.describe Api::Admin::GoodsNomenclatureLabels::StatsService do
   subject(:service) { described_class.new }
 
+  let(:result_class) { described_class::Result }
+
   describe '#call' do
     let(:result) { service.call }
 
     context 'when there are no labels' do
       it 'returns zero counts' do
         expect(result).to eq(
-          total_goods_nomenclatures: 0,
-          descriptions_count: 0,
-          known_brands_count: 0,
-          colloquial_terms_count: 0,
-          synonyms_count: 0,
-          ai_created_only: 0,
-          human_edited: 0,
-          coverage_by_chapter: [],
+          result_class.new(
+            total_goods_nomenclatures: 0,
+            descriptions_count: 0,
+            known_brands_count: 0,
+            colloquial_terms_count: 0,
+            synonyms_count: 0,
+            ai_created_only: 0,
+            human_edited: 0,
+            coverage_by_chapter: [],
+          ),
         )
       end
     end
@@ -54,23 +58,23 @@ RSpec.describe Api::Admin::GoodsNomenclatureLabels::StatsService do
       end
 
       it 'counts total goods nomenclatures with labels' do
-        expect(result[:total_goods_nomenclatures]).to eq(3)
+        expect(result.total_goods_nomenclatures).to eq(3)
       end
 
       it 'counts records with a description' do
-        expect(result[:descriptions_count]).to eq(2)
+        expect(result.descriptions_count).to eq(2)
       end
 
       it 'sums individual known brands across all records' do
-        expect(result[:known_brands_count]).to eq(3)
+        expect(result.known_brands_count).to eq(3)
       end
 
       it 'sums individual colloquial terms across all records' do
-        expect(result[:colloquial_terms_count]).to eq(1)
+        expect(result.colloquial_terms_count).to eq(1)
       end
 
       it 'sums individual synonyms across all records' do
-        expect(result[:synonyms_count]).to eq(2)
+        expect(result.synonyms_count).to eq(2)
       end
     end
 
@@ -90,11 +94,11 @@ RSpec.describe Api::Admin::GoodsNomenclatureLabels::StatsService do
       end
 
       it 'counts AI-created labels' do
-        expect(result[:ai_created_only]).to eq(1)
+        expect(result.ai_created_only).to eq(1)
       end
 
       it 'counts human-edited labels' do
-        expect(result[:human_edited]).to eq(1)
+        expect(result.human_edited).to eq(1)
       end
     end
 
@@ -113,16 +117,16 @@ RSpec.describe Api::Admin::GoodsNomenclatureLabels::StatsService do
       end
 
       it 'does not count null description' do
-        expect(result[:descriptions_count]).to eq(0)
+        expect(result.descriptions_count).to eq(0)
       end
 
       it 'returns zero for null arrays' do
-        expect(result[:known_brands_count]).to eq(0)
+        expect(result.known_brands_count).to eq(0)
       end
 
       it 'returns zero for empty arrays' do
-        expect(result[:colloquial_terms_count]).to eq(0)
-        expect(result[:synonyms_count]).to eq(0)
+        expect(result.colloquial_terms_count).to eq(0)
+        expect(result.synonyms_count).to eq(0)
       end
     end
   end

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -1,4 +1,23 @@
 RSpec.describe Api::Internal::SearchService do
+  let(:retrieval_result_class) do
+    Data.define(
+      :id,
+      :goods_nomenclature_item_id,
+      :goods_nomenclature_sid,
+      :producline_suffix,
+      :goods_nomenclature_class,
+      :description,
+      :formatted_description,
+      :self_text,
+      :classification_description,
+      :full_description,
+      :heading_description,
+      :declarable,
+      :score,
+      :confidence,
+    )
+  end
+
   before do
     allow(AdminConfiguration).to receive(:option_value).and_call_original
     allow(AdminConfiguration).to receive(:option_value).with('retrieval_method').and_return('opensearch')
@@ -993,7 +1012,7 @@ RSpec.describe Api::Internal::SearchService do
     context 'when retrieval_method is vector' do
       let(:vector_results) do
         [
-          OpenStruct.new(
+          retrieval_result_class.new(
             id: 1,
             goods_nomenclature_item_id: '0101210000',
             goods_nomenclature_sid: 1,
@@ -1074,7 +1093,7 @@ RSpec.describe Api::Internal::SearchService do
     context 'when retrieval_method is hybrid' do
       let(:hybrid_results) do
         [
-          OpenStruct.new(
+          retrieval_result_class.new(
             id: 1,
             goods_nomenclature_item_id: '0101210000',
             goods_nomenclature_sid: 1,

--- a/spec/services/interactive_search_service_spec.rb
+++ b/spec/services/interactive_search_service_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe InteractiveSearchService do
   subject(:result) { described_class.call(**params) }
 
+  let(:search_result_class) { Data.define(:goods_nomenclature_item_id, :description, :full_description, :score) }
   let(:params) do
     {
       query: query,
@@ -10,12 +11,10 @@ RSpec.describe InteractiveSearchService do
       request_id: request_id,
     }
   end
-
   let(:query) { 'leather handbag' }
   let(:expanded_query) { 'leather handbag travel bag accessory' }
   let(:request_id) { 'test-request-123' }
   let(:answers) { [] }
-
   let(:opensearch_results) do
     [
       build_result('4202210000', 'Handbags with outer surface of leather', 10.5),
@@ -23,7 +22,6 @@ RSpec.describe InteractiveSearchService do
       build_result('4202290000', 'Other handbags', 6.1),
     ]
   end
-
   let(:default_search_context) do
     <<~CONTEXT
       You are a UK trade tariff classification assistant.
@@ -46,7 +44,7 @@ RSpec.describe InteractiveSearchService do
   end
 
   def build_result(code, description, score, full_description: nil)
-    OpenStruct.new(
+    search_result_class.new(
       goods_nomenclature_item_id: code,
       description: description,
       full_description: full_description,

--- a/spec/support/shared_examples/a_serialized_goods_nomenclature_search_result.rb
+++ b/spec/support/shared_examples/a_serialized_goods_nomenclature_search_result.rb
@@ -1,8 +1,27 @@
 RSpec.shared_examples_for 'a serialized goods nomenclature search result' do |type|
   subject(:serializer) { described_class.new(serializable) }
 
+  let(:serializable_goods_nomenclature_class) do
+    Data.define(
+      :id,
+      :goods_nomenclature_item_id,
+      :goods_nomenclature_sid,
+      :producline_suffix,
+      :goods_nomenclature_class,
+      :description,
+      :formatted_description,
+      :self_text,
+      :classification_description,
+      :full_description,
+      :heading_description,
+      :confidence,
+      :declarable,
+      :score,
+    )
+  end
+
   let(:serializable) do
-    OpenStruct.new(
+    serializable_goods_nomenclature_class.new(
       id: 12_345,
       goods_nomenclature_item_id: '0100000000',
       goods_nomenclature_sid: 12_345,
@@ -12,6 +31,9 @@ RSpec.shared_examples_for 'a serialized goods nomenclature search result' do |ty
       formatted_description: 'Live animals',
       self_text: nil,
       classification_description: nil,
+      full_description: nil,
+      heading_description: nil,
+      confidence: nil,
       declarable: false,
       score: 12.5,
     )

--- a/spec/taric_importer/xml_parser/reader_spec.rb
+++ b/spec/taric_importer/xml_parser/reader_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe TaricImporter::XmlParser::Reader do
 
       let(:xml_io) { StringIO.new }
       let(:stack) { [{ __content__: '' }] }
-      let(:handler) { OpenStruct.new { def process_xml_node(_attributes); end } }
+      let(:handler) { Class.new { def process_xml_node(_attributes); end }.new }
 
       before do
         reader.instance_variable_set('@in_target', in_target)


### PR DESCRIPTION
## What:
Replaces usage of OpenStruct with [Data](https://docs.ruby-lang.org/en/3.2/Data.html)
- ostruct dependency has been removed, and instances of OpenStruct converted to use Data.define
- 2 instances of using OpenStruct to define a class in specs have been converted to use Class.new
- Admin::GoodsNomenclatureLabels::StatsService.call now returns a data object which can be passed straight to the serializer

## Why:
Data objects are immutable and more performant that OpenStructs. 

## Ticket:
https://transformuk.atlassian.net/browse/OTTIMP-629

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Like for like change with improved performance
