### PR TITLE
Remove reference to issue_count in differences report email

### DIFF
--- a/app/views/reports_mailer/differences/_worksheet.html.erb
+++ b/app/views/reports_mailer/differences/_worksheet.html.erb
@@ -4,8 +4,4 @@
         <span style='font-size:14px;color:#000'><%= worksheet.worksheet_name %></span><br>
         <span style='font-size:12px;color:#666'><%= worksheet.subtext %></span>
     </td>
-    <td
-        style="text-align:right;width:15%;border-bottom:1px solid #ccc;font-size:14px;vertical-align:top;padding-bottom:0.5em;padding-top:0.5em;font-family:Calibri,Arial,sans-serif;line-height:1.3em;">
-        <%= worksheet.issue_count %>
-    </td>
 </tr>


### PR DESCRIPTION
## What:
Removes issue_count from email template for the differences report.

## Why:
The value was always empty because it was [previously removed](https://github.com/trade-tariff/trade-tariff-backend/pull/1969).

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Removes unused value
