### PR TITLE
Cache the latest updates endpoint

### DIFF
--- a/app/controllers/api/v2/updates_controller.rb
+++ b/app/controllers/api/v2/updates_controller.rb
@@ -2,7 +2,10 @@ module Api
   module V2
     class UpdatesController < ApiController
       def latest
-        @updates = TariffSynchronizer::BaseUpdate.latest_applied_of_both_kinds.all
+        last_applied_at = TariffSynchronizer::BaseUpdate.applied.max(:applied_at).to_i
+        @updates = Rails.cache.fetch("api/v2/updates/latest/#{TradeTariffBackend.service}/#{last_applied_at}", expires_in: 1.hour) do
+          TariffSynchronizer::BaseUpdate.latest_applied_of_both_kinds.all
+        end
 
         render json: Api::V2::TariffUpdateSerializer.new(@updates).serializable_hash
       end

--- a/spec/requests/api/v2/updates_controller_spec.rb
+++ b/spec/requests/api/v2/updates_controller_spec.rb
@@ -36,5 +36,19 @@ RSpec.describe Api::V2::UpdatesController do
         ).to eq []
       end
     end
+
+    context 'when the result is cached' do
+      it 'only queries the database once across multiple requests' do
+        create :taric_update, :applied
+
+        allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+        allow(TariffSynchronizer::BaseUpdate).to receive(:latest_applied_of_both_kinds).and_call_original
+
+        get '/uk/api/updates/latest.json', headers: request_headers(format: :json)
+        get '/uk/api/updates/latest.json', headers: request_headers(format: :json)
+
+        expect(TariffSynchronizer::BaseUpdate).to have_received(:latest_applied_of_both_kinds).once
+      end
+    end
   end
 end


### PR DESCRIPTION
## What:
Cache the `/uk/api/updates/latest` endpoint response in `Rails.cache`, keyed by service.

## Why:
The Aurora read replica has no statistics for `uk.tariff_updates` (replicas can't run `ANALYZE`), so the query planner occasionally produces a bad plan causing ~800ms response times. The data changes at most once per day after a sync, making it a good candidate for caching. No explicit invalidation wiring is needed — `ClearCacheWorker` already calls `Rails.cache.clear` after every sync.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Purely additive caching with a safe invalidation path already in place. No behaviour change for callers — the response is identical, just served from cache after the first request.