### PR TITLE
OTTIMP-610 Support revised enquiry form submissions

### DIFF
--- a/app/controllers/api/v2/enquiry_form/revised_submissions_controller.rb
+++ b/app/controllers/api/v2/enquiry_form/revised_submissions_controller.rb
@@ -1,0 +1,27 @@
+module Api
+  module V2
+    class EnquiryForm::RevisedSubmissionsController < EnquiryForm::SubmissionsController
+      private
+
+      def enquiry_form_params
+        params.require(:data).require(:attributes).permit(
+          :name,
+          :company_name,
+          :job_title,
+          :email,
+          :enquiry_category,
+          :other_category,
+          :enquiry_description,
+          :goods_product,
+          :goods_made_of,
+          :goods_used_for,
+          :goods_function,
+          :goods_processed,
+          :goods_packaged,
+          :has_commodity_code,
+          :commodity_code,
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/enquiry_form/submissions_controller.rb
+++ b/app/controllers/api/v2/enquiry_form/submissions_controller.rb
@@ -34,16 +34,7 @@ module Api
           :job_title,
           :email,
           :enquiry_category,
-          :other_category,
           :enquiry_description,
-          :goods_product,
-          :goods_made_of,
-          :goods_used_for,
-          :goods_function,
-          :goods_processed,
-          :goods_packaged,
-          :has_commodity_code,
-          :commodity_code,
         )
       end
 

--- a/app/controllers/api/v2/enquiry_form/submissions_controller.rb
+++ b/app/controllers/api/v2/enquiry_form/submissions_controller.rb
@@ -34,7 +34,16 @@ module Api
           :job_title,
           :email,
           :enquiry_category,
+          :other_category,
           :enquiry_description,
+          :goods_product,
+          :goods_made_of,
+          :goods_used_for,
+          :goods_function,
+          :goods_processed,
+          :goods_packaged,
+          :has_commodity_code,
+          :commodity_code,
         )
       end
 

--- a/app/engines/v2_api.rb
+++ b/app/engines/v2_api.rb
@@ -134,6 +134,7 @@ V2Api.routes.draw do
 
       namespace :enquiry_form do
         resources :submissions, only: %i[create]
+        resources :revised_submissions, only: %i[create]
       end
 
       get '/changes(/:as_of)', to: 'changes#index', as: :changes, constraints: { as_of: /\d{4}-\d{1,2}-\d{1,2}/ }

--- a/app/services/enquiry_form/csv_generator_service.rb
+++ b/app/services/enquiry_form/csv_generator_service.rb
@@ -4,31 +4,15 @@ class EnquiryForm::CsvGeneratorService
   end
 
   def generate
-    headers = [
-      'Reference',
-      'Submission date',
-      'Full name',
-      'Company name',
-      'Job title',
-      'Email address',
-      'What do you need help with?',
-      'How can we help?',
-    ]
-
-    keys = %i[
-      reference_number
-      created_at
-      name
-      company_name
-      job_title
-      email
-      enquiry_category
-      enquiry_description
-    ]
-
     CSV.generate do |csv|
-      csv << headers
-      csv << keys.map { |key| @enquiry_form_data[key] }
+      csv << formatter.csv_headers
+      csv << formatter.csv_row
     end
+  end
+
+  private
+
+  def formatter
+    @formatter ||= EnquiryForm::SubmissionFormatter.new(@enquiry_form_data)
   end
 end

--- a/app/services/enquiry_form/submission_formatter.rb
+++ b/app/services/enquiry_form/submission_formatter.rb
@@ -1,0 +1,127 @@
+class EnquiryForm::SubmissionFormatter
+  CATEGORY_TAGS = {
+    'classification' => 'classification',
+    'import_duties_and_quota' => 'import_duties',
+    'import_duties_and_quotas' => 'import_duties',
+    'valuation' => 'customs_valuation',
+    'origin' => 'origin',
+    'stop_press_and_commodity_code_watch_lists' => 'stop_press_subscriptions',
+    'developer_portal' => 'api_dev_portal_support',
+    'other' => 'other',
+  }.freeze
+
+  CATEGORY_LABELS = {
+    'classification' => 'Classification',
+    'import_duties_and_quota' => 'Import duties and quotas',
+    'import_duties_and_quotas' => 'Import duties and quotas',
+    'valuation' => 'Valuation',
+    'origin' => 'Origin',
+    'stop_press_and_commodity_code_watch_lists' => 'Stop Press and commodity code watch lists',
+    'developer_portal' => 'API support and Developer Portal',
+    'other' => 'Other',
+  }.freeze
+
+  COMMON_HEADERS = [
+    'Reference',
+    'Submission date',
+    'Full name',
+    'Company name',
+    'Job title',
+    'Email address',
+    'What do you need help with?',
+  ].freeze
+
+  COMMON_KEYS = %i[
+    reference_number
+    created_at
+    name
+    company_name
+    job_title
+    email
+  ].freeze
+
+  CLASSIFICATION_FIELDS = [
+    [:goods_product, 'What is the product?'],
+    [:goods_made_of, 'What is it made of?'],
+    [:goods_used_for, 'What is it used for?'],
+    [:goods_function, 'How does it work or function?'],
+    [:goods_processed, 'Has it been processed, prepared or treated in any way?'],
+    [:goods_packaged, 'How is it presented or packaged?'],
+    [:has_commodity_code, 'Do you already have a possible commodity code?'],
+    [:commodity_code, 'Possible commodity code'],
+  ].freeze
+
+  def initialize(enquiry_form_data)
+    @enquiry_form_data = enquiry_form_data.to_h.symbolize_keys
+  end
+
+  def notify_category
+    CATEGORY_TAGS.fetch(enquiry_form_data[:enquiry_category].to_s, 'other')
+  end
+
+  def enquiry_description
+    (enquiry_form_data[:enquiry_description].presence || classification_description).to_s
+  end
+
+  def csv_headers
+    if classification?
+      COMMON_HEADERS + CLASSIFICATION_FIELDS.map(&:second)
+    else
+      COMMON_HEADERS + ['How can we help?']
+    end
+  end
+
+  def csv_row
+    common_values = COMMON_KEYS.map { |key| enquiry_form_data[key] } + [display_category]
+
+    if classification?
+      common_values + CLASSIFICATION_FIELDS.map { |key, _label| display_value(key, enquiry_form_data[key]) }
+    else
+      common_values + [enquiry_form_data[:enquiry_description]]
+    end
+  end
+
+  private
+
+  attr_reader :enquiry_form_data
+
+  def classification?
+    enquiry_form_data[:enquiry_category].to_s == 'classification'
+  end
+
+  def display_category
+    category = CATEGORY_LABELS.fetch(enquiry_form_data[:enquiry_category].to_s, enquiry_form_data[:enquiry_category])
+
+    if enquiry_form_data[:enquiry_category].to_s == 'other' && enquiry_form_data[:other_category].present?
+      "#{category} - #{enquiry_form_data[:other_category]}"
+    else
+      category
+    end
+  end
+
+  def classification_description
+    return unless classification?
+
+    answers = CLASSIFICATION_FIELDS.filter_map do |key, label|
+      value = display_value(key, enquiry_form_data[key])
+      next if value.blank?
+
+      "#{label}\n#{value}"
+    end
+
+    answers.join("\n\n").presence
+  end
+
+  def display_value(key, value)
+    return if value.blank?
+
+    if key == :has_commodity_code
+      {
+        'yes' => 'Yes',
+        'no' => 'No',
+      }.fetch(value.to_s, value)
+    else
+      value
+    end
+  end
+end

--- a/app/services/enquiry_form/submission_formatter.rb
+++ b/app/services/enquiry_form/submission_formatter.rb
@@ -1,22 +1,34 @@
 class EnquiryForm::SubmissionFormatter
   CATEGORY_TAGS = {
     'classification' => 'classification',
+    'api_dev_portal_support' => 'api_dev_portal_support',
+    'customs_valuation' => 'customs_valuation',
+    'import_duties' => 'import_duties',
     'import_duties_and_quota' => 'import_duties',
     'import_duties_and_quotas' => 'import_duties',
     'valuation' => 'customs_valuation',
+    'quotas' => 'import_duties',
     'origin' => 'origin',
+    'stop_press_subscription' => 'stop_press_subscriptions',
     'stop_press_and_commodity_code_watch_lists' => 'stop_press_subscriptions',
+    'tariff_watch_lists' => 'stop_press_subscriptions',
     'developer_portal' => 'api_dev_portal_support',
     'other' => 'other',
   }.freeze
 
   CATEGORY_LABELS = {
     'classification' => 'Classification',
+    'api_dev_portal_support' => 'API & Dev Portal Support',
+    'customs_valuation' => 'Customs Valuation',
+    'import_duties' => 'Import duties',
     'import_duties_and_quota' => 'Import duties and quotas',
     'import_duties_and_quotas' => 'Import duties and quotas',
     'valuation' => 'Valuation',
+    'quotas' => 'Quotas',
     'origin' => 'Origin',
+    'stop_press_subscription' => 'Stop Press Subscription',
     'stop_press_and_commodity_code_watch_lists' => 'Stop Press and commodity code watch lists',
+    'tariff_watch_lists' => 'Tariff Watch Lists',
     'developer_portal' => 'API support and Developer Portal',
     'other' => 'Other',
   }.freeze
@@ -64,7 +76,7 @@ class EnquiryForm::SubmissionFormatter
   end
 
   def csv_headers
-    if classification?
+    if structured_classification?
       COMMON_HEADERS + CLASSIFICATION_FIELDS.map(&:second)
     else
       COMMON_HEADERS + ['How can we help?']
@@ -74,7 +86,7 @@ class EnquiryForm::SubmissionFormatter
   def csv_row
     common_values = COMMON_KEYS.map { |key| enquiry_form_data[key] } + [display_category]
 
-    if classification?
+    if structured_classification?
       common_values + CLASSIFICATION_FIELDS.map { |key, _label| display_value(key, enquiry_form_data[key]) }
     else
       common_values + [enquiry_form_data[:enquiry_description]]
@@ -87,6 +99,10 @@ class EnquiryForm::SubmissionFormatter
 
   def classification?
     enquiry_form_data[:enquiry_category].to_s == 'classification'
+  end
+
+  def structured_classification?
+    classification? && CLASSIFICATION_FIELDS.any? { |key, _label| enquiry_form_data[key].present? }
   end
 
   def display_category

--- a/app/services/enquiry_form/submission_formatter.rb
+++ b/app/services/enquiry_form/submission_formatter.rb
@@ -14,6 +14,15 @@ class EnquiryForm::SubmissionFormatter
     'tariff_watch_lists' => 'stop_press_subscriptions',
     'developer_portal' => 'api_dev_portal_support',
     'other' => 'other',
+    'Classification' => 'classification',
+    'Import duties' => 'import_duties',
+    'Import Duties and Quota' => 'import_duties',
+    'Customs valuation' => 'customs_valuation',
+    'Origin' => 'origin',
+    'Quotas' => 'import_duties',
+    'Developer portal' => 'api_dev_portal_support',
+    'Stop Press and commodity code watch lists' => 'stop_press_subscriptions',
+    'Other' => 'other',
   }.freeze
 
   CATEGORY_LABELS = {
@@ -31,7 +40,18 @@ class EnquiryForm::SubmissionFormatter
     'tariff_watch_lists' => 'Tariff Watch Lists',
     'developer_portal' => 'API support and Developer Portal',
     'other' => 'Other',
+    'Classification' => 'Classification',
+    'Import duties' => 'Import duties',
+    'Import Duties and Quota' => 'Import duties and quotas',
+    'Customs valuation' => 'Customs Valuation',
+    'Origin' => 'Origin',
+    'Quotas' => 'Quotas',
+    'Developer portal' => 'API support and Developer Portal',
+    'Stop Press and commodity code watch lists' => 'Stop Press and commodity code watch lists',
+    'Other' => 'Other',
   }.freeze
+
+  DANGEROUS_CSV_PREFIX = /\A[=+\-@\t\r\n]/
 
   COMMON_HEADERS = [
     'Reference',
@@ -86,11 +106,14 @@ class EnquiryForm::SubmissionFormatter
   def csv_row
     common_values = COMMON_KEYS.map { |key| enquiry_form_data[key] } + [display_category]
 
-    if structured_classification?
-      common_values + CLASSIFICATION_FIELDS.map { |key, _label| display_value(key, enquiry_form_data[key]) }
-    else
-      common_values + [enquiry_form_data[:enquiry_description]]
-    end
+    values =
+      if structured_classification?
+        common_values + CLASSIFICATION_FIELDS.map { |key, _label| display_value(key, enquiry_form_data[key]) }
+      else
+        common_values + [enquiry_form_data[:enquiry_description]]
+      end
+
+    values.map { |value| csv_value(value) }
   end
 
   private
@@ -139,5 +162,11 @@ class EnquiryForm::SubmissionFormatter
     else
       value
     end
+  end
+
+  def csv_value(value)
+    return value unless value.is_a?(String) && value.match?(DANGEROUS_CSV_PREFIX)
+
+    "'#{value}"
   end
 end

--- a/app/workers/enquiry_form/send_submission_email_worker.rb
+++ b/app/workers/enquiry_form/send_submission_email_worker.rb
@@ -21,14 +21,15 @@ class EnquiryForm::SendSubmissionEmailWorker
     created_at = Time.zone.parse(form_data[:created_at]).in_time_zone('London').strftime('%Y-%m-%d %H:%M')
     csv_data = ::EnquiryForm::CsvGeneratorService.new(form_data).generate
     csv_file = Notifications.prepare_upload(StringIO.new(csv_data), filename: "enquiry_form_#{form_data[:reference_number]}.csv")
+    formatter = EnquiryForm::SubmissionFormatter.new(form_data)
 
     personalisation = {
       name: form_data[:name],
       company_name: form_data[:company_name],
       job_title: form_data[:job_title],
       email: form_data[:email],
-      enquiry_category: form_data[:enquiry_category],
-      enquiry_description: form_data[:enquiry_description],
+      enquiry_category: formatter.notify_category,
+      enquiry_description: formatter.enquiry_description,
       reference_number: form_data[:reference_number],
       created_at: created_at,
       csv_file: csv_file,

--- a/lib/tasks/swagger.rake
+++ b/lib/tasks/swagger.rake
@@ -61,6 +61,7 @@ namespace :swagger do
       green_lanes/faq_feedback_controller.rb
       green_lanes/goods_nomenclatures_controller.rb
       green_lanes/themes_controller.rb
+      enquiry_form/revised_submissions_controller.rb
       enquiry_form/submissions_controller.rb
       errors_controller.rb
       notifications_controller.rb

--- a/spec/requests/api/v2/enquiry_form/submissions_controller_spec.rb
+++ b/spec/requests/api/v2/enquiry_form/submissions_controller_spec.rb
@@ -60,6 +60,29 @@ RSpec.describe Api::V2::EnquiryForm::SubmissionsController, :v2 do
       expect(::EnquiryForm::SendSubmissionEmailWorker).to have_received(:perform_async).with(reference_number)
     end
 
+    it 'keeps the legacy endpoint scoped to the legacy enquiry payload' do
+      legacy_payload = params.merge(
+        goods_product: 'Baked beans',
+        goods_made_of: 'Beans and tomato sauce',
+        has_commodity_code: 'yes',
+        commodity_code: '2005590000',
+      )
+
+      post api_enquiry_form_submissions_path,
+           params: { data: { attributes: legacy_payload } },
+           headers: headers,
+           as: :json
+
+      cached = Sidekiq.redis { |conn| conn.get("enquiry_form_#{reference_number}") }
+
+      expect(JSON.parse(cached, symbolize_names: true)).to eq(
+        params.merge(
+          reference_number: reference_number,
+          created_at: frozen_time.strftime('%Y-%m-%d %H:%M'),
+        ),
+      )
+    end
+
     context 'with a classification enquiry from the revised frontend form' do
       let(:classification_params) do
         params.merge(
@@ -77,7 +100,7 @@ RSpec.describe Api::V2::EnquiryForm::SubmissionsController, :v2 do
       end
 
       it 'caches the structured classification answers for the worker' do
-        post api_enquiry_form_submissions_path,
+        post api_enquiry_form_revised_submissions_path,
              params: { data: { attributes: classification_params } },
              headers: headers,
              as: :json
@@ -172,7 +195,7 @@ RSpec.describe Api::V2::EnquiryForm::SubmissionsController, :v2 do
           )
           frontend_payload[:other_category] = large_text if category == 'other'
 
-          post api_enquiry_form_submissions_path,
+          post api_enquiry_form_revised_submissions_path,
                params: { data: { attributes: frontend_payload } },
                headers: headers,
                as: :json
@@ -210,7 +233,7 @@ RSpec.describe Api::V2::EnquiryForm::SubmissionsController, :v2 do
             goods_made_of: large_text,
           ).merge(optional_answers).merge(commodity_code_answer)
 
-          post api_enquiry_form_submissions_path,
+          post api_enquiry_form_revised_submissions_path,
                params: { data: { attributes: frontend_payload } },
                headers: headers,
                as: :json

--- a/spec/requests/api/v2/enquiry_form/submissions_controller_spec.rb
+++ b/spec/requests/api/v2/enquiry_form/submissions_controller_spec.rb
@@ -60,6 +60,46 @@ RSpec.describe Api::V2::EnquiryForm::SubmissionsController, :v2 do
       expect(::EnquiryForm::SendSubmissionEmailWorker).to have_received(:perform_async).with(reference_number)
     end
 
+    context 'with a classification enquiry from the revised frontend form' do
+      let(:classification_params) do
+        params.merge(
+          enquiry_category: 'classification',
+          enquiry_description: nil,
+          goods_product: 'Baked beans',
+          goods_made_of: 'Beans and tomato sauce',
+          goods_used_for: 'Food',
+          goods_function: 'Ready to eat',
+          goods_processed: 'Cooked and mixed',
+          goods_packaged: 'Tinned',
+          has_commodity_code: 'yes',
+          commodity_code: '2005590000',
+        ).compact
+      end
+
+      it 'caches the structured classification answers for the worker' do
+        post api_enquiry_form_submissions_path,
+             params: { data: { attributes: classification_params } },
+             headers: headers,
+             as: :json
+
+        cached = Sidekiq.redis { |conn| conn.get("enquiry_form_#{reference_number}") }
+
+        expect(JSON.parse(cached, symbolize_names: true)).to include(
+          enquiry_category: 'classification',
+          goods_product: 'Baked beans',
+          goods_made_of: 'Beans and tomato sauce',
+          goods_used_for: 'Food',
+          goods_function: 'Ready to eat',
+          goods_processed: 'Cooked and mixed',
+          goods_packaged: 'Tinned',
+          has_commodity_code: 'yes',
+          commodity_code: '2005590000',
+          reference_number: reference_number,
+          created_at: frozen_time.strftime('%Y-%m-%d %H:%M'),
+        )
+      end
+    end
+
     context 'when required params are missing' do
       it 'returns a 422 Unprocessable Content with errors' do
         post api_enquiry_form_submissions_path,

--- a/spec/requests/api/v2/enquiry_form/submissions_controller_spec.rb
+++ b/spec/requests/api/v2/enquiry_form/submissions_controller_spec.rb
@@ -100,6 +100,135 @@ RSpec.describe Api::V2::EnquiryForm::SubmissionsController, :v2 do
       end
     end
 
+    context 'with revised frontend enquiry payload combinations' do
+      let(:large_text) do
+        [
+          'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+          'It has survived not only five centuries, but also the leap into electronic typesetting.',
+          'Various versions have evolved over the years, sometimes by accident, sometimes on purpose.',
+        ].join("\n\n").then { |text| (text * 30).first(5_000) }
+      end
+
+      let(:contact_variants) do
+        optional_values = {
+          name: 'Jane Doe',
+          company_name: 'Jane Ltd.',
+          job_title: 'Product Manager',
+        }
+
+        power_set(optional_values.keys).map do |keys|
+          optional_values.keys.index_with { |key| keys.include?(key) ? optional_values[key] : '' }
+        end
+      end
+
+      let(:generic_categories) do
+        %w[
+          import_duties_and_quota
+          origin
+          valuation
+          developer_portal
+          stop_press_and_commodity_code_watch_lists
+          other
+        ]
+      end
+
+      let(:classification_optional_variants) do
+        optional_values = {
+          goods_used_for: large_text,
+          goods_function: large_text,
+          goods_processed: large_text,
+          goods_packaged: large_text,
+        }
+
+        power_set(optional_values.keys).map do |keys|
+          optional_values.keys.index_with { |key| keys.include?(key) ? optional_values[key] : '' }
+        end
+      end
+
+      let(:commodity_code_variants) do
+        [
+          { has_commodity_code: 'no', commodity_code: '' },
+          { has_commodity_code: 'yes', commodity_code: '2005590000' },
+        ]
+      end
+
+      it 'accepts and caches every generic category and optional contact combination with large text' do
+        expect(large_text.bytesize).to be > 4.kilobytes
+
+        test_cases = generic_categories.product(contact_variants, [large_text])
+        created_references = []
+
+        test_cases.each_with_index do |(category, contact_details, query), index|
+          reference = "GEN#{index.to_s.rjust(5, '0')}"
+          created_references << reference
+          allow(CreateReferenceNumberService).to receive(:new).and_return(
+            instance_double(CreateReferenceNumberService, call: reference),
+          )
+
+          frontend_payload = contact_details.merge(
+            email: 'matrix@example.com',
+            enquiry_category: category,
+            enquiry_description: query,
+          )
+          frontend_payload[:other_category] = large_text if category == 'other'
+
+          post api_enquiry_form_submissions_path,
+               params: { data: { attributes: frontend_payload } },
+               headers: headers,
+               as: :json
+
+          cached = Sidekiq.redis { |conn| conn.get("enquiry_form_#{reference}") }
+
+          aggregate_failures("generic category #{category} contact variant #{index}") do
+            expect(response).to have_http_status(:created)
+            expect(JSON.parse(cached, symbolize_names: true)).to include(frontend_payload)
+          end
+        end
+      ensure
+        Array(created_references).each do |reference|
+          Sidekiq.redis { |conn| conn.del("enquiry_form_#{reference}") }
+        end
+      end
+
+      it 'accepts and caches every classification optional answer, commodity code and contact combination' do
+        expect(large_text.bytesize).to be > 4.kilobytes
+
+        test_cases = classification_optional_variants.product(commodity_code_variants, contact_variants)
+        created_references = []
+
+        test_cases.each_with_index do |(optional_answers, commodity_code_answer, contact_details), index|
+          reference = "CLS#{index.to_s.rjust(5, '0')}"
+          created_references << reference
+          allow(CreateReferenceNumberService).to receive(:new).and_return(
+            instance_double(CreateReferenceNumberService, call: reference),
+          )
+
+          frontend_payload = contact_details.merge(
+            email: 'matrix@example.com',
+            enquiry_category: 'classification',
+            goods_product: large_text,
+            goods_made_of: large_text,
+          ).merge(optional_answers).merge(commodity_code_answer)
+
+          post api_enquiry_form_submissions_path,
+               params: { data: { attributes: frontend_payload } },
+               headers: headers,
+               as: :json
+
+          cached = Sidekiq.redis { |conn| conn.get("enquiry_form_#{reference}") }
+
+          aggregate_failures("classification variant #{index}") do
+            expect(response).to have_http_status(:created)
+            expect(JSON.parse(cached, symbolize_names: true)).to include(frontend_payload)
+          end
+        end
+      ensure
+        Array(created_references).each do |reference|
+          Sidekiq.redis { |conn| conn.del("enquiry_form_#{reference}") }
+        end
+      end
+    end
+
     context 'when required params are missing' do
       it 'returns a 422 Unprocessable Content with errors' do
         post api_enquiry_form_submissions_path,
@@ -109,6 +238,12 @@ RSpec.describe Api::V2::EnquiryForm::SubmissionsController, :v2 do
 
         expect(response).to have_http_status(:unprocessable_content)
       end
+    end
+  end
+
+  def power_set(values)
+    values.each_with_object([[]]) do |value, combinations|
+      combinations.concat(combinations.map { |combination| combination + [value] })
     end
   end
 end

--- a/spec/services/enquiry_form/csv_generator_service_spec.rb
+++ b/spec/services/enquiry_form/csv_generator_service_spec.rb
@@ -96,4 +96,39 @@ RSpec.describe EnquiryForm::CsvGeneratorService do
       ])
     end
   end
+
+  context 'with a legacy classification enquiry' do
+    let(:enquiry_data) do
+      super().merge(
+        enquiry_category: 'classification',
+        enquiry_description: 'Legacy free text classification question.',
+      )
+    end
+
+    it 'keeps the legacy free-text CSV format' do
+      csv = CSV.parse(csv_content)
+
+      expect(csv.first).to eq([
+        'Reference',
+        'Submission date',
+        'Full name',
+        'Company name',
+        'Job title',
+        'Email address',
+        'What do you need help with?',
+        'How can we help?',
+      ])
+
+      expect(csv.second).to eq([
+        'ABC123',
+        '2025-07-21 10:00:00 UTC',
+        'Jane Doe',
+        'Jane Ltd.',
+        'Product Manager',
+        'jane@example.com',
+        'Classification',
+        'Legacy free text classification question.',
+      ])
+    end
+  end
 end

--- a/spec/services/enquiry_form/csv_generator_service_spec.rb
+++ b/spec/services/enquiry_form/csv_generator_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe EnquiryForm::CsvGeneratorService do
       company_name: 'Jane Ltd.',
       job_title: 'Product Manager',
       email: 'jane@example.com',
-      enquiry_category: 'Quotas',
+      enquiry_category: 'import_duties_and_quota',
       enquiry_description: 'Need help with quotas.',
     }
   end
@@ -35,8 +35,65 @@ RSpec.describe EnquiryForm::CsvGeneratorService do
       'Jane Ltd.',
       'Product Manager',
       'jane@example.com',
-      'Quotas',
+      'Import duties and quotas',
       'Need help with quotas.',
     ])
+  end
+
+  context 'with a classification enquiry' do
+    let(:enquiry_data) do
+      super().merge(
+        enquiry_category: 'classification',
+        enquiry_description: nil,
+        goods_product: 'Baked beans',
+        goods_made_of: 'Beans and tomato sauce',
+        goods_used_for: 'Food',
+        goods_function: 'Ready to eat',
+        goods_processed: 'Cooked and mixed',
+        goods_packaged: 'Tinned',
+        has_commodity_code: 'yes',
+        commodity_code: '2005590000',
+      )
+    end
+
+    it 'generates a CSV with structured classification answers' do
+      csv = CSV.parse(csv_content)
+
+      expect(csv.first).to eq([
+        'Reference',
+        'Submission date',
+        'Full name',
+        'Company name',
+        'Job title',
+        'Email address',
+        'What do you need help with?',
+        'What is the product?',
+        'What is it made of?',
+        'What is it used for?',
+        'How does it work or function?',
+        'Has it been processed, prepared or treated in any way?',
+        'How is it presented or packaged?',
+        'Do you already have a possible commodity code?',
+        'Possible commodity code',
+      ])
+
+      expect(csv.second).to eq([
+        'ABC123',
+        '2025-07-21 10:00:00 UTC',
+        'Jane Doe',
+        'Jane Ltd.',
+        'Product Manager',
+        'jane@example.com',
+        'Classification',
+        'Baked beans',
+        'Beans and tomato sauce',
+        'Food',
+        'Ready to eat',
+        'Cooked and mixed',
+        'Tinned',
+        'Yes',
+        '2005590000',
+      ])
+    end
   end
 end

--- a/spec/services/enquiry_form/csv_generator_service_spec.rb
+++ b/spec/services/enquiry_form/csv_generator_service_spec.rb
@@ -131,4 +131,44 @@ RSpec.describe EnquiryForm::CsvGeneratorService do
       ])
     end
   end
+
+  context 'with spreadsheet formula-like user input' do
+    let(:enquiry_data) do
+      super().merge(
+        name: '=Jane Doe',
+        company_name: '+Jane Ltd.',
+        job_title: '-Product Manager',
+        email: '@jane.example',
+        enquiry_category: 'other',
+        other_category: '=Other topic',
+        enquiry_description: '=Need help with quotas.',
+      )
+    end
+
+    it 'escapes user-controlled CSV cells without changing headers' do
+      csv = CSV.parse(csv_content)
+
+      expect(csv.first).to eq([
+        'Reference',
+        'Submission date',
+        'Full name',
+        'Company name',
+        'Job title',
+        'Email address',
+        'What do you need help with?',
+        'How can we help?',
+      ])
+
+      expect(csv.second).to eq([
+        'ABC123',
+        '2025-07-21 10:00:00 UTC',
+        "'=Jane Doe",
+        "'+Jane Ltd.",
+        "'-Product Manager",
+        "'@jane.example",
+        'Other - =Other topic',
+        "'=Need help with quotas.",
+      ])
+    end
+  end
 end

--- a/spec/services/enquiry_form/submission_formatter_spec.rb
+++ b/spec/services/enquiry_form/submission_formatter_spec.rb
@@ -16,7 +16,15 @@ RSpec.describe EnquiryForm::SubmissionFormatter do
         'tariff_watch_lists' => 'stop_press_subscriptions',
         'developer_portal' => 'api_dev_portal_support',
         'other' => 'other',
-        'Classification' => 'other',
+        'Classification' => 'classification',
+        'Import duties' => 'import_duties',
+        'Import Duties and Quota' => 'import_duties',
+        'Customs valuation' => 'customs_valuation',
+        'Origin' => 'origin',
+        'Quotas' => 'import_duties',
+        'Developer portal' => 'api_dev_portal_support',
+        'Stop Press and commodity code watch lists' => 'stop_press_subscriptions',
+        'Other' => 'other',
         'unexpected' => 'other',
       }.each do |enquiry_category, notify_category|
         formatter = described_class.new(enquiry_category: enquiry_category)

--- a/spec/services/enquiry_form/submission_formatter_spec.rb
+++ b/spec/services/enquiry_form/submission_formatter_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe EnquiryForm::SubmissionFormatter do
+  describe '#notify_category' do
+    it 'returns the Notify subject category tag' do
+      {
+        'classification' => 'classification',
+        'import_duties_and_quota' => 'import_duties',
+        'import_duties_and_quotas' => 'import_duties',
+        'valuation' => 'customs_valuation',
+        'origin' => 'origin',
+        'stop_press_and_commodity_code_watch_lists' => 'stop_press_subscriptions',
+        'developer_portal' => 'api_dev_portal_support',
+        'other' => 'other',
+        'Classification' => 'other',
+        'unexpected' => 'other',
+      }.each do |enquiry_category, notify_category|
+        formatter = described_class.new(enquiry_category: enquiry_category)
+
+        expect(formatter.notify_category).to eq(notify_category)
+      end
+    end
+  end
+
+  describe '#enquiry_description' do
+    it 'returns an empty string when no enquiry details are present' do
+      formatter = described_class.new(enquiry_category: 'classification')
+
+      expect(formatter.enquiry_description).to eq('')
+    end
+  end
+end

--- a/spec/services/enquiry_form/submission_formatter_spec.rb
+++ b/spec/services/enquiry_form/submission_formatter_spec.rb
@@ -3,11 +3,17 @@ RSpec.describe EnquiryForm::SubmissionFormatter do
     it 'returns the Notify subject category tag' do
       {
         'classification' => 'classification',
+        'api_dev_portal_support' => 'api_dev_portal_support',
+        'customs_valuation' => 'customs_valuation',
+        'import_duties' => 'import_duties',
         'import_duties_and_quota' => 'import_duties',
         'import_duties_and_quotas' => 'import_duties',
         'valuation' => 'customs_valuation',
+        'quotas' => 'import_duties',
         'origin' => 'origin',
+        'stop_press_subscription' => 'stop_press_subscriptions',
         'stop_press_and_commodity_code_watch_lists' => 'stop_press_subscriptions',
+        'tariff_watch_lists' => 'stop_press_subscriptions',
         'developer_portal' => 'api_dev_portal_support',
         'other' => 'other',
         'Classification' => 'other',

--- a/spec/workers/enquiry_form/send_submission_email_worker_spec.rb
+++ b/spec/workers/enquiry_form/send_submission_email_worker_spec.rb
@@ -117,6 +117,22 @@ RSpec.describe EnquiryForm::SendSubmissionEmailWorker, type: :worker do
       end
     end
 
+    context 'with a legacy display-value enquiry category' do
+      let(:form_data) { super().merge(enquiry_category: 'Quotas') }
+
+      it 'keeps the Notify routing tag backwards compatible' do
+        worker.perform(reference)
+
+        expect(notifier_client).to have_received(:send_email).with(
+          'support@example.com',
+          NOTIFY_CONFIGURATION.dig(:templates, :enquiry_form, :submission),
+          hash_including(enquiry_category: 'import_duties'),
+          nil,
+          'ABC12345',
+        )
+      end
+    end
+
     context 'with revised frontend enquiry payload combinations' do
       let(:large_text) do
         [

--- a/spec/workers/enquiry_form/send_submission_email_worker_spec.rb
+++ b/spec/workers/enquiry_form/send_submission_email_worker_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe EnquiryForm::SendSubmissionEmailWorker, type: :worker do
       company_name: 'Doe & Co Inc.',
       job_title: 'CEO',
       email: 'john@example.com',
-      enquiry_category: 'Quotas',
+      enquiry_category: 'import_duties_and_quota',
       enquiry_description: 'I have a question about quotas',
       reference_number: reference,
       created_at: '2025-08-15 10:00',
@@ -45,7 +45,7 @@ RSpec.describe EnquiryForm::SendSubmissionEmailWorker, type: :worker do
             retention_period: nil,
           },
           email: 'john@example.com',
-          enquiry_category: 'Quotas',
+          enquiry_category: 'import_duties',
           enquiry_description: 'I have a question about quotas',
           job_title: 'CEO',
           name: 'John Doe',
@@ -61,7 +61,60 @@ RSpec.describe EnquiryForm::SendSubmissionEmailWorker, type: :worker do
 
       worker.perform(reference)
 
-      expect(StringIO).to have_received(:new).with("Reference,Submission date,Full name,Company name,Job title,Email address,What do you need help with?,How can we help?\nABC12345,2025-08-15 10:00,John Doe,Doe & Co Inc.,CEO,john@example.com,Quotas,I have a question about quotas\n").twice
+      expect(StringIO).to have_received(:new).with("Reference,Submission date,Full name,Company name,Job title,Email address,What do you need help with?,How can we help?\nABC12345,2025-08-15 10:00,John Doe,Doe & Co Inc.,CEO,john@example.com,Import duties and quotas,I have a question about quotas\n").twice
+    end
+
+    context 'with a classification enquiry' do
+      let(:form_data) do
+        {
+          name: 'John Doe',
+          company_name: 'Doe & Co Inc.',
+          job_title: 'CEO',
+          email: 'john@example.com',
+          enquiry_category: 'classification',
+          goods_product: 'Baked beans',
+          goods_made_of: 'Beans and tomato sauce',
+          goods_used_for: 'Food',
+          goods_function: 'Ready to eat',
+          goods_processed: 'Cooked and mixed',
+          goods_packaged: 'Tinned',
+          has_commodity_code: 'yes',
+          commodity_code: '2005590000',
+          reference_number: reference,
+          created_at: '2025-08-15 10:00',
+        }
+      end
+
+      it 'sends the structured answers as the enquiry description personalisation' do
+        worker.perform(reference)
+
+        expect(notifier_client).to have_received(:send_email).with(
+          'support@example.com',
+          NOTIFY_CONFIGURATION.dig(:templates, :enquiry_form, :submission),
+          hash_including(
+            enquiry_category: 'classification',
+            enquiry_description: "What is the product?\nBaked beans\n\nWhat is it made of?\nBeans and tomato sauce\n\nWhat is it used for?\nFood\n\nHow does it work or function?\nReady to eat\n\nHas it been processed, prepared or treated in any way?\nCooked and mixed\n\nHow is it presented or packaged?\nTinned\n\nDo you already have a possible commodity code?\nYes\n\nPossible commodity code\n2005590000",
+          ),
+          nil,
+          'ABC12345',
+        )
+      end
+    end
+
+    context 'with an unexpected enquiry category' do
+      let(:form_data) { super().merge(enquiry_category: 'unknown_category') }
+
+      it 'defaults the Notify category tag to other' do
+        worker.perform(reference)
+
+        expect(notifier_client).to have_received(:send_email).with(
+          'support@example.com',
+          NOTIFY_CONFIGURATION.dig(:templates, :enquiry_form, :submission),
+          hash_including(enquiry_category: 'other'),
+          nil,
+          'ABC12345',
+        )
+      end
     end
 
     context 'when the cache key has expired or is missing' do

--- a/spec/workers/enquiry_form/send_submission_email_worker_spec.rb
+++ b/spec/workers/enquiry_form/send_submission_email_worker_spec.rb
@@ -117,6 +117,138 @@ RSpec.describe EnquiryForm::SendSubmissionEmailWorker, type: :worker do
       end
     end
 
+    context 'with revised frontend enquiry payload combinations' do
+      let(:large_text) do
+        [
+          'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+          'It has survived not only five centuries, but also the leap into electronic typesetting.',
+          'Various versions have evolved over the years, sometimes by accident, sometimes on purpose.',
+        ].join("\n\n").then { |text| (text * 30).first(5_000) }
+      end
+
+      let(:contact_variants) do
+        optional_values = {
+          name: 'Jane Doe',
+          company_name: 'Jane Ltd.',
+          job_title: 'Product Manager',
+        }
+
+        power_set(optional_values.keys).map do |keys|
+          optional_values.keys.index_with { |key| keys.include?(key) ? optional_values[key] : '' }
+        end
+      end
+
+      let(:category_tags) do
+        {
+          'import_duties_and_quota' => 'import_duties',
+          'origin' => 'origin',
+          'valuation' => 'customs_valuation',
+          'developer_portal' => 'api_dev_portal_support',
+          'stop_press_and_commodity_code_watch_lists' => 'stop_press_subscriptions',
+          'other' => 'other',
+        }
+      end
+
+      let(:classification_optional_variants) do
+        optional_values = {
+          goods_used_for: large_text,
+          goods_function: large_text,
+          goods_processed: large_text,
+          goods_packaged: large_text,
+        }
+
+        power_set(optional_values.keys).map do |keys|
+          optional_values.keys.index_with { |key| keys.include?(key) ? optional_values[key] : '' }
+        end
+      end
+
+      let(:commodity_code_variants) do
+        [
+          { has_commodity_code: 'no', commodity_code: '' },
+          { has_commodity_code: 'yes', commodity_code: '2005590000' },
+        ]
+      end
+
+      before do
+        allow(Notifications).to receive(:prepare_upload).and_return(
+          {
+            confirm_email_before_download: nil,
+            file: 'csv-upload',
+            filename: 'enquiry_form.csv',
+            retention_period: nil,
+          },
+        )
+      end
+
+      it 'sends every generic category and optional contact combination to Notify' do
+        expect(large_text.bytesize).to be > 4.kilobytes
+
+        category_tags.to_a.product(contact_variants).each_with_index do |((category, notify_category), contact_details), index|
+          reference = "GEN#{index.to_s.rjust(5, '0')}"
+          payload = contact_details.merge(
+            email: 'matrix@example.com',
+            enquiry_category: category,
+            enquiry_description: large_text,
+            reference_number: reference,
+            created_at: '2025-08-15 10:00',
+          )
+          payload[:other_category] = large_text if category == 'other'
+
+          Sidekiq.redis { |conn| conn.set(described_class.cache_key(reference), payload.to_json, ex: 3600) }
+
+          aggregate_failures("generic category #{category} contact variant #{index}") do
+            expect { worker.perform(reference) }.not_to raise_error
+            expect(notifier_client).to have_received(:send_email).with(
+              'support@example.com',
+              NOTIFY_CONFIGURATION.dig(:templates, :enquiry_form, :submission),
+              hash_including(
+                enquiry_category: notify_category,
+                enquiry_description: large_text,
+              ),
+              nil,
+              reference,
+            )
+          end
+        ensure
+          Sidekiq.redis { |conn| conn.del(described_class.cache_key(reference)) } if reference
+        end
+      end
+
+      it 'sends every classification optional answer, commodity code and contact combination to Notify' do
+        expect(large_text.bytesize).to be > 4.kilobytes
+
+        classification_optional_variants.product(commodity_code_variants, contact_variants).each_with_index do |(optional_answers, commodity_code_answer, contact_details), index|
+          reference = "CLS#{index.to_s.rjust(5, '0')}"
+          payload = contact_details.merge(
+            email: 'matrix@example.com',
+            enquiry_category: 'classification',
+            goods_product: large_text,
+            goods_made_of: large_text,
+            reference_number: reference,
+            created_at: '2025-08-15 10:00',
+          ).merge(optional_answers).merge(commodity_code_answer)
+
+          Sidekiq.redis { |conn| conn.set(described_class.cache_key(reference), payload.to_json, ex: 3600) }
+
+          aggregate_failures("classification variant #{index}") do
+            expect { worker.perform(reference) }.not_to raise_error
+            expect(notifier_client).to have_received(:send_email).with(
+              'support@example.com',
+              NOTIFY_CONFIGURATION.dig(:templates, :enquiry_form, :submission),
+              hash_including(
+                enquiry_category: 'classification',
+                enquiry_description: include('What is the product?', large_text, 'What is it made of?'),
+              ),
+              nil,
+              reference,
+            )
+          end
+        ensure
+          Sidekiq.redis { |conn| conn.del(described_class.cache_key(reference)) } if reference
+        end
+      end
+    end
+
     context 'when the cache key has expired or is missing' do
       before do
         Sidekiq.redis { |conn| conn.del(described_class.cache_key(reference)) }
@@ -129,6 +261,12 @@ RSpec.describe EnquiryForm::SendSubmissionEmailWorker, type: :worker do
         expect(Rails.logger).to have_received(:error).with("EnquiryForm::SendSubmissionEmailWorker: No data found in cache for reference #{reference}")
         expect(notifier_client).not_to have_received(:send_email)
       end
+    end
+  end
+
+  def power_set(values)
+    values.each_with_object([[]]) do |value, combinations|
+      combinations.concat(combinations.map { |combination| combination + [value] })
     end
   end
 end


### PR DESCRIPTION
## What:
- Accept the revised enquiry form payload sent by the frontend, including structured classification fields and optional “Other” category text.
- Add the revised enquiry form submission endpoint while keeping the legacy submission endpoint working for deploy safety.
- Format enquiry submissions for GOV.UK Notify so the subject category tag uses the agreed HMRC routing values.
- Keep category mapping backwards-compatible for legacy display-value payloads, including `Quotas` -> `import_duties`.
- Build a classification enquiry description from structured answers so Notify still receives `enquiry_description`.
- Output structured classification answers in the generated CSV attachment while preserving the generic CSV shape for other categories.
- Escape CSV cells that begin with spreadsheet formula characters (`=`, `+`, `-`, `@`, tab, newline) without changing the Notify personalisation text.
- Add focused request, worker, CSV generator, and formatter coverage.

## Why:
The revised frontend enquiry form sends classification answers as structured fields rather than only the old generic `enquiry_description`. The backend needs to support that new shape without breaking the existing endpoint while frontend and backend deploys are coordinated.

HMRC also rely on the subject-line category tag for email routing, so the backend maps both revised category ids and legacy display values to the agreed tags, defaulting safely to `other` for unexpected values.

## Ticket:
https://transformuk.atlassian.net/browse/OTTIMP-610

## Risk:
**Risk level:** 🟠

**Reason for rating:**
This changes the backend email/CSV formatting path for enquiry submissions and adds a revised endpoint consumed by the frontend PR. The change is backwards-compatible with the legacy endpoint and has focused request, worker, formatter, CSV, and local frontend-to-backend E2E coverage.

## Verification:
- `PGHOST=localhost PGPORT=15432 REDIS_URL=redis://localhost:16379 ELASTICSEARCH_URL=http://localhost:9200 bundle exec rspec spec/services/enquiry_form/submission_formatter_spec.rb spec/services/enquiry_form/csv_generator_service_spec.rb spec/workers/enquiry_form/send_submission_email_worker_spec.rb spec/requests/api/v2/enquiry_form/submissions_controller_spec.rb`
  - 21 examples, 0 failures
- `bundle exec rubocop app/services/enquiry_form/submission_formatter.rb spec/services/enquiry_form/submission_formatter_spec.rb spec/services/enquiry_form/csv_generator_service_spec.rb spec/workers/enquiry_form/send_submission_email_worker_spec.rb`
  - 4 files inspected, no offenses detected
- Local backend API POST to `/uk/api/enquiry_form/revised_submissions` returned `201 Created`.
- Local E2E: ran frontend branch `OTTIMP-517-enquiry-form-v4` on `http://127.0.0.1:3015` against this backend branch on `http://127.0.0.1:3002`.
- Local E2E completed classification with 5,000 characters and formula-like leading text through confirmation (`L8P75RNS`).
- Local E2E completed generic valuation with long text through confirmation (`FJYR9AK3`).
- Checked backend cached submission payloads and generated CSV rows for both references; category values were correct and formula-like CSV cell values were escaped.
- Local legacy-frontend compatibility E2E: ran detached `trade-tariff-frontend` `origin/main` on `http://127.0.0.1:3016` against this backend branch on `http://127.0.0.1:3002`; completed the old start-page form with `Quotas` through `/uk/api/enquiry_form/submissions` to legacy confirmation (`C7MEP9QX`), then verified backend cached payload `category=quotas`, `notify_category=import_duties`, and CSV category `Quotas`.