### PR TITLE
OTTIMP-634 Handle measure end date being removed

### DIFF
--- a/app/models/tariff_change.rb
+++ b/app/models/tariff_change.rb
@@ -1,4 +1,6 @@
 class TariffChange < Sequel::Model
+  END_DATE_REMOVED_DISPLAY = 'end date removed'.freeze
+
   plugin :auto_validations, not_null: :presence
   plugin :timestamps, update_on_create: true
 
@@ -117,6 +119,12 @@ class TariffChange < Sequel::Model
     measure_metadata['quota_order_number']
   end
 
+  def measure_end_date_removed?
+    type == 'Measure' &&
+      action == TariffChangesService::BaseChanges::ENDING &&
+      validity_end_date.nil?
+  end
+
   def description
     case action
     when TariffChangesService::BaseChanges::CREATION
@@ -133,6 +141,8 @@ class TariffChange < Sequel::Model
   # When this change becomes effective to the public.
   # e.g. for ENDING measures, it is no longer visible the day after its end date
   def date_of_effect_visible
+    return if measure_end_date_removed?
+
     action == TariffChangesService::BaseChanges::ENDING ? date_of_effect + 1.day : date_of_effect
   end
 end

--- a/app/models/tariff_changes/grouped_measure_commodity_change.rb
+++ b/app/models/tariff_changes/grouped_measure_commodity_change.rb
@@ -63,7 +63,7 @@ module TariffChanges
         changes.sort_by(&:date_of_effect).map do |change|
           {
             measure_sid: change.object_sid,
-            date_of_effect: change.date_of_effect,
+            date_of_effect: change.measure_end_date_removed? ? TariffChange::END_DATE_REMOVED_DISPLAY : change.date_of_effect,
             date_of_effect_visible: change.date_of_effect_visible,
             change_type: change.description,
             additional_code: change.additional_code,

--- a/app/services/tariff_changes_service/presenter.rb
+++ b/app/services/tariff_changes_service/presenter.rb
@@ -72,11 +72,14 @@ class TariffChangesService
     end
 
     def date_of_effect
+      return TariffChange::END_DATE_REMOVED_DISPLAY if measure_end_date_removed?
+
       super.strftime('%d/%m/%Y')
     end
 
     def ott_url
-      url = "https://www.trade-tariff.service.gov.uk/commodities/#{goods_nomenclature_item_id}?day=#{date_of_effect_visible.day}&month=#{date_of_effect_visible.month}&year=#{date_of_effect_visible.year}&#{UTM_TAGS}"
+      query = measure_end_date_removed? ? UTM_TAGS : "#{ott_date_query}&#{UTM_TAGS}"
+      url = "#{commodity_base_url}?#{query}"
       url += '#export' if trade_movement_code == 1
       url += '#import' if trade_movement_code.in?([0, 2])
 
@@ -84,10 +87,23 @@ class TariffChangesService
     end
 
     def api_url
-      "https://www.trade-tariff.service.gov.uk/uk/api/commodities/#{goods_nomenclature_item_id}?as_of=#{date_of_effect_visible.strftime('%Y-%m-%d')}&#{UTM_TAGS}"
+      query = measure_end_date_removed? ? UTM_TAGS : "as_of=#{date_of_effect_visible.strftime('%Y-%m-%d')}&#{UTM_TAGS}"
+      "#{commodity_api_base_url}?#{query}"
     end
 
     private
+
+    def commodity_base_url
+      "https://www.trade-tariff.service.gov.uk/commodities/#{goods_nomenclature_item_id}"
+    end
+
+    def commodity_api_base_url
+      "https://www.trade-tariff.service.gov.uk/uk/api/commodities/#{goods_nomenclature_item_id}"
+    end
+
+    def ott_date_query
+      "day=#{date_of_effect_visible.day}&month=#{date_of_effect_visible.month}&year=#{date_of_effect_visible.year}"
+    end
 
     def format_excluded_areas
       return '' if excluded_geographical_area_ids.empty?

--- a/spec/models/tariff_change_spec.rb
+++ b/spec/models/tariff_change_spec.rb
@@ -469,7 +469,7 @@ RSpec.describe TariffChange do
   end
 
   describe '#description' do
-    let(:tariff_change) { described_class.new(type: 'Commodity', action: action) }
+    let(:tariff_change) { described_class.new(type: 'Commodity', action: action, validity_end_date: Date.parse('2024-08-15')) }
 
     context 'when action is CREATION' do
       let(:action) { TariffChangesService::BaseChanges::CREATION }
@@ -484,6 +484,22 @@ RSpec.describe TariffChange do
 
       it 'returns end description' do
         expect(tariff_change.description).to eq('Commodity will end')
+      end
+
+      context 'when validity_end_date is nil' do
+        let(:tariff_change) do
+          described_class.new(
+            type: 'Commodity',
+            action: action,
+            operation_date: Date.parse('2024-08-14'),
+            date_of_effect: Date.parse('2024-08-15'),
+            validity_end_date: nil,
+          )
+        end
+
+        it 'returns end description' do
+          expect(tariff_change.description).to eq('Commodity will end')
+        end
       end
     end
 
@@ -506,7 +522,8 @@ RSpec.describe TariffChange do
 
   describe '#date_of_effect_visible' do
     let(:date_of_effect) { Date.parse('2024-08-15') }
-    let(:tariff_change) { create(:tariff_change, date_of_effect:, action:) }
+    let(:tariff_change) { create(:tariff_change, date_of_effect:, action:, validity_end_date:) }
+    let(:validity_end_date) { Date.parse('2024-08-15') }
 
     context 'when action is ENDING' do
       let(:action) { TariffChangesService::BaseChanges::ENDING }
@@ -519,10 +536,30 @@ RSpec.describe TariffChange do
         result = tariff_change.date_of_effect_visible
         expect(result).to eq(Date.parse('2024-08-16'))
       end
+
+      context 'when measure and validity_end_date is nil' do
+        let(:validity_end_date) { nil }
+        let(:date_of_effect) { Date.parse('2024-08-16') }
+        let(:tariff_change) do
+          create(
+            :tariff_change,
+            type: 'Measure',
+            action: action,
+            operation_date: Date.parse('2024-08-15'),
+            date_of_effect: date_of_effect,
+            validity_end_date: validity_end_date,
+          )
+        end
+
+        it 'returns nil' do
+          expect(tariff_change.date_of_effect_visible).to be_nil
+        end
+      end
     end
 
     context 'when action is CREATION' do
       let(:action) { TariffChangesService::BaseChanges::CREATION }
+      let(:validity_end_date) { nil }
 
       it 'returns the same date_of_effect' do
         expect(tariff_change.date_of_effect_visible).to eq(date_of_effect)
@@ -536,6 +573,7 @@ RSpec.describe TariffChange do
 
     context 'when action is UPDATE' do
       let(:action) { TariffChangesService::BaseChanges::UPDATE }
+      let(:validity_end_date) { nil }
 
       it 'returns the same date_of_effect' do
         expect(tariff_change.date_of_effect_visible).to eq(date_of_effect)
@@ -544,9 +582,75 @@ RSpec.describe TariffChange do
 
     context 'when action is DELETION' do
       let(:action) { TariffChangesService::BaseChanges::DELETION }
+      let(:validity_end_date) { nil }
 
       it 'returns the same date_of_effect' do
         expect(tariff_change.date_of_effect_visible).to eq(date_of_effect)
+      end
+    end
+  end
+
+  describe '#measure_end_date_removed?' do
+    context 'when Commodity and action is ending and validity_end_date is nil' do
+      let(:tariff_change) do
+        described_class.new(
+          type: 'Commodity',
+          action: TariffChangesService::BaseChanges::ENDING,
+          operation_date: Date.parse('2024-08-14'),
+          date_of_effect: Date.parse('2024-08-15'),
+          validity_end_date: nil,
+        )
+      end
+
+      it 'returns false' do
+        expect(tariff_change.measure_end_date_removed?).to be(false)
+      end
+    end
+
+    context 'when measure and action is ending and validity_end_date is nil' do
+      let(:tariff_change) do
+        described_class.new(
+          type: 'Measure',
+          action: TariffChangesService::BaseChanges::ENDING,
+          operation_date: Date.parse('2024-08-14'),
+          date_of_effect: Date.parse('2024-08-15'),
+          validity_end_date: nil,
+        )
+      end
+
+      it 'returns true' do
+        expect(tariff_change.measure_end_date_removed?).to be(true)
+      end
+    end
+
+    context 'when measure and action is ending and validity_end_date is present' do
+      let(:tariff_change) do
+        described_class.new(
+          type: 'Measure',
+          action: TariffChangesService::BaseChanges::ENDING,
+          operation_date: Date.parse('2024-08-14'),
+          date_of_effect: Date.parse('2024-08-15'),
+          validity_end_date: Date.parse('2024-08-15'),
+        )
+      end
+
+      it 'returns false' do
+        expect(tariff_change.measure_end_date_removed?).to be(false)
+      end
+    end
+
+    context 'when action is not ending' do
+      let(:tariff_change) do
+        described_class.new(
+          action: TariffChangesService::BaseChanges::UPDATE,
+          operation_date: Date.parse('2024-08-14'),
+          date_of_effect: Date.parse('2024-08-15'),
+          validity_end_date: nil,
+        )
+      end
+
+      it 'returns false' do
+        expect(tariff_change.measure_end_date_removed?).to be(false)
       end
     end
   end

--- a/spec/models/tariff_changes/grouped_measure_commodity_change_spec.rb
+++ b/spec/models/tariff_changes/grouped_measure_commodity_change_spec.rb
@@ -389,6 +389,44 @@ RSpec.describe TariffChanges::GroupedMeasureCommodityChange do
 
           expect(date_of_effects).to eq([Date.parse('2023-01-10'), Date.parse('2023-01-20')])
         end
+
+        it 'returns end date removed for undated ending changes' do
+          removed_measure = create(:measure,
+                                   measure_sid: 102,
+                                   measure_type_id: import_measure_type.measure_type_id,
+                                   geographical_area_id: 'GB',
+                                   geographical_area_sid: geographical_area.geographical_area_sid)
+
+          create(:measure_excluded_geographical_area,
+                 measure_sid: removed_measure.measure_sid,
+                 excluded_geographical_area: 'FR')
+          create(:measure_excluded_geographical_area,
+                 measure_sid: removed_measure.measure_sid,
+                 excluded_geographical_area: 'DE')
+
+          create(:tariff_change,
+                 type: 'Measure',
+                 action: 'ending',
+                 validity_end_date: nil,
+                 object_sid: removed_measure.measure_sid,
+                 operation_date: date,
+                 date_of_effect: date + 1.day,
+                 goods_nomenclature_item_id: '1234567890',
+                 metadata: {
+                   'measure' => {
+                     'measure_type_id' => removed_measure.measure_type_id,
+                     'trade_movement_code' => import_measure_type.trade_movement_code,
+                     'geographical_area_id' => removed_measure.geographical_area_id,
+                     'excluded_geographical_area_ids' => %w[DE FR],
+                   },
+                 })
+
+          result = grouped_commodity_change.measure_changes(date)
+          removed_change = result.fetch(import_measure_type.description).find { |change| change[:measure_sid] == removed_measure.measure_sid }
+
+          expect(removed_change[:date_of_effect]).to eq('end date removed')
+          expect(removed_change[:date_of_effect_visible]).to be_nil
+        end
       end
 
       context 'for export measures' do

--- a/spec/services/tariff_changes_service/presenter_spec.rb
+++ b/spec/services/tariff_changes_service/presenter_spec.rb
@@ -530,6 +530,23 @@ RSpec.describe TariffChangesService::Presenter do
       result = presenter.date_of_effect
       expect(result).to eq('15/08/2024')
     end
+
+    context 'when measure end date has been removed' do
+      let(:tariff_change) do
+        create(:tariff_change,
+               action: 'ending',
+               type: 'Measure',
+               operation_date: Date.parse('2024-08-14'),
+               validity_end_date: nil,
+               goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
+               goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
+               date_of_effect: Date.parse('2024-08-15'))
+      end
+
+      it 'returns end date removed' do
+        expect(presenter.date_of_effect).to eq('end date removed')
+      end
+    end
   end
 
   describe '#ott_url' do
@@ -596,6 +613,24 @@ RSpec.describe TariffChangesService::Presenter do
         expect(result).to eq(expected_url)
       end
     end
+
+    context 'when end date has been removed' do
+      let(:tariff_change) do
+        create(:tariff_change,
+               type: 'Measure',
+               action: 'ending',
+               operation_date: Date.parse('2024-08-14'),
+               validity_end_date: nil,
+               goods_nomenclature_item_id: '0202000000',
+               goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
+               date_of_effect: Date.parse('2024-08-15'),
+               metadata: { 'measure' => { 'trade_movement_code' => 0 } })
+      end
+
+      it 'builds the OTT URL without date parameters' do
+        expect(presenter.ott_url).to eq('https://www.trade-tariff.service.gov.uk/commodities/0202000000?utm_source=offline&utm_medium=excel&utm_campaign=change_data#import')
+      end
+    end
   end
 
   describe '#api_url' do
@@ -610,6 +645,23 @@ RSpec.describe TariffChangesService::Presenter do
       result = presenter.api_url
       expected_url = 'https://www.trade-tariff.service.gov.uk/uk/api/commodities/0202000000?as_of=2024-08-15&utm_source=offline&utm_medium=excel&utm_campaign=change_data'
       expect(result).to eq(expected_url)
+    end
+
+    context 'when end date has been removed' do
+      let(:tariff_change) do
+        create(:tariff_change,
+               type: 'Measure',
+               action: 'ending',
+               operation_date: Date.parse('2024-08-14'),
+               validity_end_date: nil,
+               goods_nomenclature_item_id: '0202000000',
+               goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
+               date_of_effect: Date.parse('2024-08-15'))
+      end
+
+      it 'builds the API URL without as_of' do
+        expect(presenter.api_url).to eq('https://www.trade-tariff.service.gov.uk/uk/api/commodities/0202000000?utm_source=offline&utm_medium=excel&utm_campaign=change_data')
+      end
     end
   end
 end

--- a/spec/services/tariff_changes_service/transform_records_spec.rb
+++ b/spec/services/tariff_changes_service/transform_records_spec.rb
@@ -177,6 +177,7 @@ RSpec.describe TariffChangesService::TransformRecords do
                operation_date: operation_date,
                type: 'Commodity',
                action: 'ending',
+               validity_end_date: operation_date,
                goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
                goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id)
       end
@@ -305,6 +306,7 @@ RSpec.describe TariffChangesService::TransformRecords do
                operation_date: operation_date,
                type: 'Measure',
                action: 'ending',
+               validity_end_date: operation_date,
                object_sid: measure.measure_sid,
                goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
                goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
@@ -326,6 +328,46 @@ RSpec.describe TariffChangesService::TransformRecords do
 
         expect(record[:type_of_change]).to eq('Measure End Date Updated')
         expect(record[:change_detail]).to eq('Measure will end')
+      end
+    end
+
+    context 'when measure end date is removed' do
+      let(:measure_type) { create(:measure_type, trade_movement_code: 0) }
+      let(:measure) { create(:measure, measure_type: measure_type) }
+      let(:goods_nomenclature) { create(:goods_nomenclature, goods_nomenclature_sid: measure.goods_nomenclature_sid) }
+
+      before do
+        goods_nomenclature
+        create(:goods_nomenclature_description, goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid)
+        create(:tariff_change,
+               operation_date: operation_date,
+               date_of_effect: operation_date + 1.day,
+               validity_end_date: nil,
+               type: 'Measure',
+               action: 'ending',
+               object_sid: measure.measure_sid,
+               goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
+               goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
+               metadata: {
+                 'measure' => {
+                   'measure_type_id' => measure.measure_type_id,
+                   'trade_movement_code' => measure_type.trade_movement_code,
+                   'geographical_area_id' => measure.geographical_area_id,
+                   'excluded_geographical_area_ids' => [],
+                   'additional_code' => '',
+                   'quota_order_number' => nil,
+                 },
+               })
+      end
+
+      it 'uses end date removed messaging and undated links' do
+        record = service.call.first
+
+        expect(record[:type_of_change]).to eq('Measure End Date Updated')
+        expect(record[:date_of_effect]).to eq('end date removed')
+        expect(record[:change_detail]).to eq('Measure will end')
+        expect(record[:ott_url]).to eq("https://www.trade-tariff.service.gov.uk/commodities/#{goods_nomenclature.goods_nomenclature_item_id}?#{TariffChangesService::Presenter::UTM_TAGS}#import")
+        expect(record[:api_url]).to eq("https://www.trade-tariff.service.gov.uk/uk/api/commodities/#{goods_nomenclature.goods_nomenclature_item_id}?#{TariffChangesService::Presenter::UTM_TAGS}")
       end
     end
 
@@ -545,7 +587,7 @@ RSpec.describe TariffChangesService::TransformRecords do
       end
 
       context 'when action is ending' do
-        let(:tariff_change) { build(:tariff_change, type: 'Commodity', action: 'ending') }
+        let(:tariff_change) { build(:tariff_change, type: 'Commodity', action: 'ending', validity_end_date: Date.parse('2024-08-15')) }
 
         it 'returns ending message' do
           result = service.send(:describe_commodity_change, presented_change)
@@ -631,7 +673,7 @@ RSpec.describe TariffChangesService::TransformRecords do
       end
 
       context 'when action is ending' do
-        let(:tariff_change) { build(:tariff_change, type: 'Measure', action: 'ending') }
+        let(:tariff_change) { build(:tariff_change, type: 'Measure', action: 'ending', validity_end_date: Date.parse('2024-08-15')) }
 
         it 'returns ending message' do
           result = service.send(:describe_measure_change, presented_change)


### PR DESCRIPTION
## What:
Currently changes to measures where the end date is being removed are not handled well. The data_of_effect value will now be a string instead of a date to show that the end data has been removed.

## Why:
We will retain the same action for end date changing but the new text will make the details of the change clearer to users

## Ticket:
https://transformuk.atlassian.net/browse/OTTIMP-634

## Risk:
**Risk level:** 🟢

**Reason for rating:**
This change requires a front end change to handle the change of format of some date fields.
https://github.com/trade-tariff/trade-tariff-frontend/pull/3061
It is a fairly narrow change and has been tested in dev.
