### PR TITLE
Parallelise tariff-backend RSpec test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,11 @@ env:
   AWS_REGION: eu-west-2
   BUNDLE_JOBS: "3"
   BUNDLE_RETRY: "3"
-  DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/tariff_test"
   ECR_URL: 382373577178.dkr.ecr.eu-west-2.amazonaws.com/tariff-backend-production
   ENVIRONMENT: development
   IAM_ROLE_ARN: arn:aws:iam::844815912454:role/GithubActions-ECS-Deployments-Role
+  PARALLEL_TEST_PROCESSORS: "5"
+  PGHOST: localhost
   RAILS_ENV: test
 
 permissions:
@@ -80,8 +81,7 @@ jobs:
       postgres:
         image: pgvector/pgvector:pg18
         env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_DB: tariff_test
         ports:
           - 5432:5432
@@ -105,9 +105,16 @@ jobs:
         with:
           bundler-cache: true
 
-      - run: bundle exec rails db:structure:load --trace
+      - name: Prepare test databases
+        run: bundle exec rails db:test:prepare_parallel
 
-      - run: bundle exec rspec --format progress --format Ctrf::RSpecFormatter --out ./ctrf/ctrf.json
+      - name: Run tests
+        run: |
+          mkdir -p ctrf
+          bundle exec parallel_test spec \
+            -n "$PARALLEL_TEST_PROCESSORS" \
+            --type rspec \
+            --exec-args "sh -c 'PARALLEL_RSPEC_CHILD=true bundle exec rspec \"\$@\" --format progress --format Ctrf::RSpecFormatter --out ./ctrf/ctrf\${TEST_ENV_NUMBER:-1}.json' sh"
 
       - name: Check all public V2 controllers have swagger specs
         run: bundle exec rake swagger:check_coverage

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --color
+--require ./spec/parallel_rspec
 --require rails_helper
 --tag ~flaky

--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ group :test do
   gem 'database_cleaner-sequel'
   gem 'forgery'
   gem 'json_expressions'
+  gem 'parallel_tests'
   gem 'rspec-ctrf'
   gem 'rspec-json_expectations'
   gem 'rspec_junit_formatter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,6 +270,8 @@ GEM
       faraday (>= 1.0, < 3)
       multi_json (>= 1.0)
     parallel (1.28.0)
+    parallel_tests (5.7.0)
+      parallel
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
@@ -528,6 +530,7 @@ DEPENDENCIES
   nokogiri
   notifications-ruby-client
   opensearch-ruby
+  parallel_tests
   pg
   pry-rails
   puma

--- a/app/lib/trade_tariff_backend/clients.rb
+++ b/app/lib/trade_tariff_backend/clients.rb
@@ -6,7 +6,7 @@ module TradeTariffBackend
 
     def frontend_redis
       @frontend_redis ||= begin
-        db = Rails.env.test? ? 1 : 0
+        db = Rails.env.test? ? test_redis_db : 0
         Redis.new(url: frontend_redis_url, db:)
       end
     end

--- a/app/lib/trade_tariff_backend/config.rb
+++ b/app/lib/trade_tariff_backend/config.rb
@@ -81,17 +81,21 @@ module TradeTariffBackend
 
     # Redis connection config (no connections created here)
     def redis_config
-      db = Rails.env.test? ? 1 : 0
+      db = Rails.env.test? ? test_redis_db : 0
       { url: ENV['REDIS_URL'], db:, id: nil }
     end
 
     def sidekiq_redis_config
-      db = Rails.env.test? ? 1 : 0
+      db = Rails.env.test? ? test_redis_db : 0
       { url: ENV.fetch('SIDEKIQ_REDIS_URL', ENV['REDIS_URL']), db:, id: nil, timeout: 5, reconnect_attempts: [0.1, 0.5, 1.0] }
     end
 
     def frontend_redis_url
       ENV.fetch('FRONTEND_REDIS_URL', 'redis://host.docker.internal:6379')
+    end
+
+    def test_redis_db
+      ENV.fetch('TEST_ENV_NUMBER', '').to_i + 1
     end
 
     # OpenSearch

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,8 +13,9 @@ development:
 test:
   <<: *default
   user: <%= ENV.fetch("DB_USER", "postgres") %>
+  password: <%= ENV["DB_PASSWORD"] %>
   host: <%= ENV.fetch('PGHOST', "localhost") %>
-  database: tariff_test
+  database: <%= "tariff_test#{ENV['TEST_ENV_NUMBER']}" %>
 
 production:
   <<: *default

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -59,7 +59,8 @@ Rails.application.configure do
   config.after_initialize do
     require_relative '../../app/lib/trade_tariff_backend'
 
-    TradeTariffBackend::SearchClient.server_namespace = 'tariff-test' # default is just tariff
+    search_index_namespace = ['tariff-test', ENV['TEST_ENV_NUMBER']].compact_blank.join('-')
+    TradeTariffBackend::SearchClient.server_namespace = search_index_namespace # default is just tariff
 
     # We need search index to be refreshed after each operation
     # in order to assert record presence in the index (in integration specs)

--- a/lib/tasks/test_database.rake
+++ b/lib/tasks/test_database.rake
@@ -1,9 +1,55 @@
+require 'open3'
+
 namespace :db do
   namespace :test do
     desc 'Populate empty materialized views after loading the test structure'
     task populate_empty_materialized_views: :environment do
-      Rails.application.eager_load!
-      MaterializeViewHelper.refresh_materialized_view
+      db = begin
+        Sequel::Model.db
+      rescue Sequel::Error
+        Sequel.connect(Rails.application.config.database_configuration.fetch(Rails.env).symbolize_keys)
+      end
+
+      db.fetch(<<~SQL).each do |row|
+        SELECT quote_ident(schemaname) || '.' || quote_ident(matviewname) AS view_name
+        FROM pg_matviews
+      SQL
+        db.run("REFRESH MATERIALIZED VIEW #{row[:view_name]}")
+      end
+    end
+
+    desc 'Prepare parallel test databases'
+    task prepare_parallel: :environment do
+      workers = Integer(ENV.fetch('PARALLEL_TEST_PROCESSORS', 5))
+
+      raise 'PARALLEL_TEST_PROCESSORS must be at least 1' if workers < 1
+
+      puts 'Preparing test databases...'
+
+      1.upto(workers) do |worker|
+        test_env_number = worker == 1 ? '' : worker.to_s
+        database_name = "tariff_test#{test_env_number}"
+        env = {
+          'RAILS_ENV' => 'test',
+          'TEST_ENV_NUMBER' => test_env_number,
+        }
+        command = %w[bundle exec rails db:drop db:create db:structure:load]
+
+        stdout, stderr, status = Open3.capture3(env, *command)
+
+        if ENV['PARALLEL_TEST_PREPARE_VERBOSE'] == 'true'
+          puts stdout
+          warn stderr
+        end
+
+        unless status.success?
+          puts stdout
+          warn stderr
+          abort "Failed to prepare #{database_name}"
+        end
+
+        puts "Prepared #{database_name}"
+      end
     end
   end
 end

--- a/spec/indexes/search/search_suggestions_index_spec.rb
+++ b/spec/indexes/search/search_suggestions_index_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Search::SearchSuggestionsIndex do
   subject(:instance) { described_class.new 'testnamespace' }
 
   it { is_expected.to have_attributes type: 'search_suggestion' }
-  it { is_expected.to have_attributes name: 'tariff-test-search_suggestions-uk' }
+  it { is_expected.to have_attributes name: "#{TradeTariffBackend::SearchClient.server_namespace}-search_suggestions-uk" }
   it { is_expected.to have_attributes name_without_namespace: 'SearchSuggestionsIndex' }
   it { is_expected.to have_attributes model_class: SearchSuggestion }
   it { is_expected.to have_attributes serializer: Search::SearchSuggestionsSerializer }

--- a/spec/lib/trade_tariff_backend/search_client_spec.rb
+++ b/spec/lib/trade_tariff_backend/search_client_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe TradeTariffBackend::SearchClient do
   describe '.server_namespace' do
     subject { described_class.server_namespace }
 
-    it { is_expected.to eql 'tariff-test' }
+    it { is_expected.to eql ['tariff-test', ENV['TEST_ENV_NUMBER']].compact_blank.join('-') }
 
     context 'when overridden' do
       before do

--- a/spec/parallel_rspec.rb
+++ b/spec/parallel_rspec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'English'
+
+if ENV['PARALLEL_RSPEC_CHILD'] != 'true' && !ENV.key?('TEST_ENV_NUMBER')
+  if ARGV.any?
+    ENV['PARALLEL_RSPEC_CHILD'] = 'true'
+  else
+    workers = Integer(ENV.fetch('PARALLEL_TEST_PROCESSORS', 5))
+
+    unless ENV['SKIP_PARALLEL_TEST_PREPARE'] == 'true'
+      system({ 'PARALLEL_TEST_PROCESSORS' => workers.to_s }, 'bundle', 'exec', 'rails', 'db:test:prepare_parallel')
+      exit($CHILD_STATUS.exitstatus || 1) unless $CHILD_STATUS.success?
+    end
+
+    exec(
+      { 'PARALLEL_RSPEC_CHILD' => 'true' },
+      'bundle',
+      'exec',
+      'parallel_test',
+      '-n',
+      workers.to_s,
+      '--type',
+      'rspec',
+      '--serialize-stdout',
+      'spec',
+    )
+  end
+end

--- a/spec/queries/search/fuzzy/goods_nomenclature_query_spec.rb
+++ b/spec/queries/search/fuzzy/goods_nomenclature_query_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Search::Fuzzy::GoodsNomenclatureQuery do
 
     let(:pattern) do
       {
-        index: 'tariff-test-commodities-uk',
+        index: index.name,
         search: {
           query: {
             bool: {

--- a/spec/queries/search/fuzzy/reference_query_spec.rb
+++ b/spec/queries/search/fuzzy/reference_query_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Search::Fuzzy::ReferenceQuery do
 
     let(:pattern) do
       {
-        index: 'tariff-test-search_references-uk',
+        index: index.name,
         search: {
           query: {
             bool: {

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,9 +42,10 @@ RSpec.configure do |config|
   end
 
   config.before(:all) do
-    FileUtils.rm_rf('tmp/data/cds')
-    FileUtils.mkpath('tmp/data/cds')
-    FileUtils.cp_r('spec/fixtures/cds_samples/.', 'tmp/data/cds')
+    cds_data_path = File.join(TariffSynchronizer.root_path, 'cds')
+    FileUtils.rm_rf(cds_data_path)
+    FileUtils.mkpath(cds_data_path)
+    FileUtils.cp_r('spec/fixtures/cds_samples/.', cds_data_path)
   end
 
   config.before(:suite) do

--- a/spec/support/adjust_tariff_synchronizer.rb
+++ b/spec/support/adjust_tariff_synchronizer.rb
@@ -1,4 +1,4 @@
 TariffSynchronizer.request_throttle = 0
 TariffSynchronizer.retry_count = 1
 TariffSynchronizer.exception_retry_count = 1
-TariffSynchronizer.root_path = 'tmp/data'
+TariffSynchronizer.root_path = "tmp/data#{ENV['TEST_ENV_NUMBER']}"

--- a/spec/unit/tariff_synchronizer/tariff_downloader_spec.rb
+++ b/spec/unit/tariff_synchronizer/tariff_downloader_spec.rb
@@ -21,9 +21,11 @@ RSpec.describe TariffSynchronizer::TariffDownloader do
     end
 
     context 'when the file is already downloaded' do
+      let(:file_path) { File.join(TariffSynchronizer.root_path, 'cds', filename) }
+
       before do
-        allow(TariffSynchronizer::FileService).to receive(:file_exists?).with('tmp/data/cds/foo.xml.gzip').and_return(true)
-        allow(TariffSynchronizer::FileService).to receive(:file_size).with('tmp/data/cds/foo.xml.gzip').and_return(1)
+        allow(TariffSynchronizer::FileService).to receive(:file_exists?).with(file_path).and_return(true)
+        allow(TariffSynchronizer::FileService).to receive(:file_size).with(file_path).and_return(1)
         allow(TariffSynchronizer::TariffUpdatesRequester).to receive(:perform).with(url)
       end
 
@@ -82,8 +84,10 @@ RSpec.describe TariffSynchronizer::TariffDownloader do
       end
 
       context 'when the download response is successful' do
+        let(:file_path) { File.join(TariffSynchronizer.root_path, update_klass.update_type.to_s, filename) }
+
         before do
-          allow(TariffSynchronizer::FileService).to receive(:write_file).with("tmp/data/#{update_klass.update_type}/foo.xml.gzip", be_a(String))
+          allow(TariffSynchronizer::FileService).to receive(:write_file).with(file_path, be_a(String))
         end
 
         context 'when the response body is a valid ZIP file' do
@@ -97,7 +101,7 @@ RSpec.describe TariffSynchronizer::TariffDownloader do
 
           it 'writes using the FileService' do
             perform
-            expect(TariffSynchronizer::FileService).to have_received(:write_file).with('tmp/data/cds/foo.xml.gzip', be_a(String))
+            expect(TariffSynchronizer::FileService).to have_received(:write_file).with(file_path, be_a(String))
           end
 
           it 'records a state transition to pending' do
@@ -123,7 +127,7 @@ RSpec.describe TariffSynchronizer::TariffDownloader do
 
           it 'writes using the FileService' do
             perform
-            expect(TariffSynchronizer::FileService).to have_received(:write_file).with('tmp/data/taric/foo.xml.gzip', 'not_a_zip_file')
+            expect(TariffSynchronizer::FileService).to have_received(:write_file).with(file_path, 'not_a_zip_file')
           end
         end
 

--- a/spec/unit/trade_tariff_backend_spec.rb
+++ b/spec/unit/trade_tariff_backend_spec.rb
@@ -41,6 +41,24 @@ RSpec.describe TradeTariffBackend do
         expect(described_class.sidekiq_redis_config[:url]).to eq('redis://default-host:6379')
       end
     end
+
+    context 'when TEST_ENV_NUMBER is set' do
+      before { stub_const('ENV', ENV.to_hash.merge('TEST_ENV_NUMBER' => '2')) }
+
+      it 'uses a worker-specific Redis database' do
+        expect(described_class.sidekiq_redis_config[:db]).to eq(3)
+      end
+    end
+  end
+
+  describe '.redis_config' do
+    context 'when TEST_ENV_NUMBER is set' do
+      before { stub_const('ENV', ENV.to_hash.merge('TEST_ENV_NUMBER' => '2')) }
+
+      it 'uses a worker-specific Redis database' do
+        expect(described_class.redis_config[:db]).to eq(3)
+      end
+    end
   end
 
   describe '.currency' do


### PR DESCRIPTION
## What:
Parallelise the RSpec test suite by default using `parallel_tests`

A plain `bundle exec rspec` now prepares worker-specific test databases and runs the suite with 5 workers. The change also isolates worker-specific DBs, Redis DBs, OpenSearch namespaces, and tariff synchronizer temp paths so parallel workers do not share mutable state.

## Why:
The full suite was taking >3 minutes in a single process. Running it across workers gives a much faster feedback loop while keeping the default command simple for developers and CI.

Single file runs still work normally, for example:

`bundle exec rspec spec/unit/trade_tariff_backend_spec.rb`

These do not trigger the parallel setup

## Ticket:
[HMRC-2289](https://transformuk.atlassian.net/browse/HMRC-2289)

## Risk:
**Risk level:** 🟠 (Low to Medium) 

**Reason for rating:**
This touches test infrastructure rather than production behaviour, but it changes the default way the suite runs in CI and locally. The main risks are around shared test resources, especially PostgreSQL, Redis, OpenSearch, and temp files.

The risk is mitigated by worker-specific isolation and verification.