### PR TITLE
[HMRC-2038] Externalise hardcoded tariff sync pipeline variables

### DIFF
--- a/app/lib/tariff_synchronizer.rb
+++ b/app/lib/tariff_synchronizer.rb
@@ -8,15 +8,15 @@ module TariffSynchronizer
 
   # Number of seconds to sleep between sync retries
   cattr_accessor :request_throttle
-  self.request_throttle = 60
+  self.request_throttle = TradeTariffBackend.request_throttle
 
   # Times to retry downloading update before giving up
   cattr_accessor :retry_count
-  self.retry_count = 20
+  self.retry_count = TradeTariffBackend.tariff_sync_retry_count
 
   # Times to retry downloading update in case of serious problems (host resolution, ssl handshake, partial file) before giving up
   cattr_accessor :exception_retry_count
-  self.exception_retry_count = 10
+  self.exception_retry_count = TradeTariffBackend.exception_retry_count
 
   def apply_updates(update_type)
     applied_updates = []

--- a/app/lib/tariff_synchronizer/cds_update.rb
+++ b/app/lib/tariff_synchronizer/cds_update.rb
@@ -1,6 +1,5 @@
 module TariffSynchronizer
   class CdsUpdate < BaseUpdate
-    EMPTY_FILE_SIZE_THRESHOLD = 500
     REGEX_CDS_SEQUENCE = /^tariff_dailyExtract_v1_(?<year>\d{4})(?<month>\d{2})(?<day>\d{2})T\d+\.gzip$/
 
     class << self
@@ -72,7 +71,7 @@ module TariffSynchronizer
     private
 
     def check_oplog_inserts
-      return if filesize <= EMPTY_FILE_SIZE_THRESHOLD
+      return if filesize <= TradeTariffBackend.empty_file_size_threshold
       return if @oplog_inserts[:total_count].positive?
 
       alert_potential_failed_import

--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -76,5 +76,29 @@ module TradeTariffBackend
     def data_migration_path
       Rails.root.join('db/data_migrations')
     end
+
+    def tariff_sync_retry_count
+      ENV.fetch('TARIFF_SYNC_RETRY_COUNT', 20).to_i
+    end
+
+    def exception_retry_count
+      ENV.fetch('EXCEPTION_RETRY_COUNT', 10).to_i
+    end
+
+    def request_throttle
+      ENV.fetch('REQUEST_THROTTLE', 60).to_i
+    end
+
+    def cut_off_time
+      ENV.fetch('CUT_OFF_TIME', '10:00')
+    end
+
+    def try_again_in
+      ENV.fetch('TRY_AGAIN_IN', 20).minutes
+    end
+
+    def empty_file_size_threshold
+      ENV.fetch('EMPTY_FILE_SIZE_THRESHOLD', 500).to_i
+    end
   end
 end

--- a/app/workers/cds_updates_synchronizer_worker.rb
+++ b/app/workers/cds_updates_synchronizer_worker.rb
@@ -1,10 +1,6 @@
 class CdsUpdatesSynchronizerWorker
   include Sidekiq::Worker
 
-  TRY_AGAIN_IN = 20.minutes
-  CUT_OFF_TIME = '10:00'.freeze
-  DOWNLOAD_MAX_RETRIES = TariffSynchronizer.retry_count
-
   sidekiq_options queue: :sync, retry: false
 
   def perform(check_for_todays_file = true, reapply_data_migrations = false, download_retry_count = 0)
@@ -57,7 +53,7 @@ private
 
   def cut_off_date_time
     @cut_off_date_time ||= begin
-      hour, minute = CUT_OFF_TIME.split(':', 2).map(&:to_i)
+      hour, minute = TradeTariffBackend.cut_off_time.split(':', 2).map(&:to_i)
 
       Time.zone.now.beginning_of_day + hour.hours + minute.minutes
     end
@@ -85,8 +81,8 @@ private
 
   def attempt_reschedule!
     if still_time_to_reschedule?
-      self.class.perform_in(TRY_AGAIN_IN, true)
-      TariffSynchronizer::Instrumentation.download_delayed(retry_at: TRY_AGAIN_IN.from_now.iso8601)
+      self.class.perform_in(TradeTariffBackend.try_again_in, true)
+      TariffSynchronizer::Instrumentation.download_delayed(retry_at: TradeTariffBackend.try_again_in.from_now.iso8601)
       true
     else
       false
@@ -96,7 +92,7 @@ private
   def attempt_reschedule_download!(download_retry_count, check_for_todays_file, reapply_data_migrations)
     delay = TariffSynchronizer.request_throttle.seconds
 
-    if download_retry_count < DOWNLOAD_MAX_RETRIES
+    if download_retry_count < TariffSynchronizer.retry_count
       self.class.perform_in(delay, check_for_todays_file, reapply_data_migrations, download_retry_count + 1)
       TariffSynchronizer::Instrumentation.download_delayed(retry_at: delay.from_now.iso8601)
     else

--- a/app/workers/taric_updates_synchronizer_worker.rb
+++ b/app/workers/taric_updates_synchronizer_worker.rb
@@ -1,8 +1,6 @@
 class TaricUpdatesSynchronizerWorker
   include Sidekiq::Worker
 
-  DOWNLOAD_MAX_RETRIES = TariffSynchronizer.retry_count
-
   sidekiq_options queue: :sync, retry: false
 
   def perform(reapply_data_migrations = false, download_retry_count = 0)
@@ -65,7 +63,7 @@ private
   def attempt_reschedule_download!(download_retry_count, reapply_data_migrations)
     delay = TariffSynchronizer.request_throttle.seconds
 
-    if download_retry_count < DOWNLOAD_MAX_RETRIES
+    if download_retry_count < TariffSynchronizer.retry_count
       self.class.perform_in(delay, reapply_data_migrations, download_retry_count + 1)
       TariffSynchronizer::Instrumentation.download_delayed(retry_at: delay.from_now.iso8601)
     else

--- a/docs/architecture/data-import-and-sync.md
+++ b/docs/architecture/data-import-and-sync.md
@@ -16,6 +16,17 @@ Tariff data is primarily imported from upstream CDS and TARIC update files. UK m
 
 Successful sync paths usually have follow-on work: cache invalidation, search/cache index rebuilding, reports, and generated classification content refresh. Check worker code and `config/sidekiq.yml` before changing sync behaviour, because UK and XI schedules differ.
 
+## Sync Configuration
+
+The sync pipeline reads these environment variables, with defaults preserved when unset:
+
+- `TARIFF_SYNC_RETRY_COUNT`: download retry budget, default `20`.
+- `EXCEPTION_RETRY_COUNT`: retry budget for exceptional download failures, default `10`.
+- `REQUEST_THROTTLE`: seconds before retrying retriable downloads, default `60`.
+- `CUT_OFF_TIME`: latest time to keep waiting for today's CDS file, default `10:00`.
+- `TRY_AGAIN_IN`: minutes before retrying when today's CDS file has not arrived, default `20`.
+- `EMPTY_FILE_SIZE_THRESHOLD`: bytes below which an empty CDS update is treated as expected, default `500`.
+
 ## CDS and TARIC Modes
 
 `app/lib/cds_synchronizer.rb` extends `TariffSynchronizer` for UK CDS updates. It requires `HMRC_API_HOST`, `HMRC_CLIENT_ID`, and `HMRC_CLIENT_SECRET` before download.

--- a/spec/workers/cds_updates_synchronizer_worker_spec.rb
+++ b/spec/workers/cds_updates_synchronizer_worker_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe CdsUpdatesSynchronizerWorker, type: :worker do
       allow(DataMigrator).to receive_messages(migrations_dir:, migrate_up!: true)
 
       allow(GoodsNomenclatures::TreeNode).to receive(:refresh!).and_call_original
-      stub_const 'CdsUpdatesSynchronizerWorker::CUT_OFF_TIME',
-                 cut_off_time.strftime('%H:%M')
+      allow(TradeTariffBackend).to receive(:cut_off_time).and_return(cut_off_time.strftime('%H:%M'))
+      allow(TradeTariffBackend).to receive(:try_again_in).and_call_original
 
       allow(SlackNotifierService).to receive(:call)
     end
@@ -62,7 +62,7 @@ RSpec.describe CdsUpdatesSynchronizerWorker, type: :worker do
         it 'creates a later job to re-attempt download and processing' do
           expect(described_class.jobs.first).to \
             include 'at' => be_within(2)
-                            .of(described_class::TRY_AGAIN_IN.from_now.to_f),
+                            .of(TradeTariffBackend.try_again_in.from_now.to_f),
                     'args' => [true],
                     'retry' => false
         end
@@ -197,6 +197,8 @@ RSpec.describe CdsUpdatesSynchronizerWorker, type: :worker do
       context 'when retry budget remains' do
         subject(:perform) { described_class.new.perform(true, false, 0) }
 
+        before { allow(TariffSynchronizer).to receive(:retry_count).and_return(1) }
+
         it 'reschedules the job with an incremented retry count' do
           perform
 
@@ -206,7 +208,9 @@ RSpec.describe CdsUpdatesSynchronizerWorker, type: :worker do
       end
 
       context 'when retry budget is exhausted' do
-        subject(:perform) { described_class.new.perform(true, false, described_class::DOWNLOAD_MAX_RETRIES) }
+        subject(:perform) { described_class.new.perform(true, false, 1) }
+
+        before { allow(TariffSynchronizer).to receive(:retry_count).and_return(1) }
 
         it 'does not reschedule the job' do
           perform

--- a/spec/workers/cds_updates_synchronizer_worker_spec.rb
+++ b/spec/workers/cds_updates_synchronizer_worker_spec.rb
@@ -21,8 +21,6 @@ RSpec.describe CdsUpdatesSynchronizerWorker, type: :worker do
       allow(CdsSynchronizer).to receive(:download)
       allow(CdsSynchronizer).to receive(:apply).and_return(changes_applied)
 
-      allow(TradeTariffBackend).to receive(:service).and_return(service)
-
       allow(ActiveSupport::Notifications).to receive(:instrument).and_call_original
       allow(ActiveSupport::Notifications).to receive(:instrument).with(
         TradeTariffBackend::TariffUpdateEventListener::TARIFF_UPDATES_APPLIED,
@@ -33,7 +31,7 @@ RSpec.describe CdsUpdatesSynchronizerWorker, type: :worker do
       allow(DataMigrator).to receive_messages(migrations_dir:, migrate_up!: true)
 
       allow(GoodsNomenclatures::TreeNode).to receive(:refresh!).and_call_original
-      allow(TradeTariffBackend).to receive(:cut_off_time).and_return(cut_off_time.strftime('%H:%M'))
+      allow(TradeTariffBackend).to receive_messages(service: service, cut_off_time: cut_off_time.strftime('%H:%M'))
       allow(TradeTariffBackend).to receive(:try_again_in).and_call_original
 
       allow(SlackNotifierService).to receive(:call)

--- a/spec/workers/taric_updates_synchronizer_worker_spec.rb
+++ b/spec/workers/taric_updates_synchronizer_worker_spec.rb
@@ -92,6 +92,8 @@ RSpec.describe TaricUpdatesSynchronizerWorker, type: :worker do
       end
 
       context 'when retry budget remains' do
+        before { allow(TariffSynchronizer).to receive(:retry_count).and_return(1) }
+
         it 'reschedules the job with an incremented retry count' do
           described_class.new.perform(false, 0)
 
@@ -101,8 +103,10 @@ RSpec.describe TaricUpdatesSynchronizerWorker, type: :worker do
       end
 
       context 'when retry budget is exhausted' do
+        before { allow(TariffSynchronizer).to receive(:retry_count).and_return(1) }
+
         it 'does not reschedule the job' do
-          described_class.new.perform(false, described_class::DOWNLOAD_MAX_RETRIES)
+          described_class.new.perform(false, 1)
 
           expect(described_class.jobs).to be_empty
         end


### PR DESCRIPTION
## What:

The sync pipeline has ~10 hardcoded values (retry count=20, throttle=60s, cutoff=10:00, health threshold=4 days, etc.) that can only be changed by deploying new code. Operators should be able to tune these in response to upstream API behaviour changes.

The following parameters are now configurable with environment variables, but set sensible defaults if not present:

- `TARIFF_SYNC_RETRY_COUNT`: download retry budget, default `20`.
- `EXCEPTION_RETRY_COUNT`: retry budget for exceptional download failures, default `10`.
- `REQUEST_THROTTLE`: seconds before retrying retriable downloads, default `60`.
- `CUT_OFF_TIME`: latest time to keep waiting for today's CDS file, default `10:00`.
- `TRY_AGAIN_IN`: minutes before retrying when today's CDS file has not arrived, default `20`.
- `EMPTY_FILE_SIZE_THRESHOLD`: bytes below which an empty CDS update is treated as expected, default `500`.

## Why:
We should be able to tune these parameters in response to upstream API behaviour changes.

## Ticket:
[HMRC-2038](https://transformuk.atlassian.net/browse/HMRC-2038)

## Risk:
🟢 / 🟠

**Reason for rating:**
Refactors existing code, but affects the tariff sync pipeline, so a second set of eyes would be worth it here