### PR TITLE
Optimise retry sleep specs

### DIFF
--- a/app/lib/embedding_service.rb
+++ b/app/lib/embedding_service.rb
@@ -86,7 +86,7 @@ class EmbeddingService
       if attempts < MAX_RETRIES
         delay = RETRY_DELAY * (2**(attempts - 1))
         SelfTextGenerator::Instrumentation.embedding_api_retry(attempt: attempts, delay:, error: e)
-        sleep delay
+        Kernel.sleep delay
         retry
       else
         raise

--- a/app/lib/openai_client.rb
+++ b/app/lib/openai_client.rb
@@ -84,7 +84,7 @@ class OpenaiClient
       if attempts < MAX_RETRIES
         delay = calculate_retry_delay(attempts, e)
         Rails.logger.warn "OpenaiClient: #{e.class} on attempt #{attempts}, retrying in #{delay}s..."
-        sleep delay
+        Kernel.sleep delay
         retry
       else
         Rails.logger.error "OpenaiClient: #{e.class} after #{attempts} attempts, giving up"

--- a/app/workers/prewarm_commodities_worker.rb
+++ b/app/workers/prewarm_commodities_worker.rb
@@ -96,7 +96,7 @@ class PrewarmCommoditiesWorker
 
       raise "CloudWatch query #{response.status}" if %w[Failed Cancelled Timeout Unknown].include?(response.status)
 
-      sleep QUERY_POLL_INTERVAL_SECONDS
+      Kernel.sleep QUERY_POLL_INTERVAL_SECONDS
     end
 
     raise 'CloudWatch query timed out while polling'


### PR DESCRIPTION
## What:
Changed retry/poll waits from bare `sleep` calls to explicit `Kernel.sleep` calls

## Why:
This lets specs stub `Kernel.sleep` reliably, so retry and polling behaviour is still tested without waiting in real time.

Before/after for the affected spec slice:

```
Before: 56.27s
After:   1.97s
```

That saves about 54 seconds locally for these specs

## Ticket:
N/A

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
This is a low-risk change because production behaviour is preserved: `Kernel.sleep delay` sleeps the same way as bare `sleep delay`