### PR TITLE
AI-863: Match guided search suggestions case-insensitively

### DIFF
--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -234,7 +234,7 @@ module Api
       def find_by_suggestion(query)
         ::SearchSuggestion
           .declarable
-          .by_value(singular_and_plural(query))
+          .by_value(singular_and_plural(query.downcase))
           .where(type: allowed_suggestion_types)
           .eager(:goods_nomenclature)
           .first

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -71,6 +71,18 @@ RSpec.describe Api::Internal::SearchService do
         expect(result[:data][0][:attributes][:score]).to be_nil
         expect(TradeTariffBackend.search_client).not_to have_received(:search)
       end
+
+      it 'matches text suggestions case-insensitively' do
+        allow(TradeTariffBackend.search_client).to receive(:search).and_return({ 'hits' => { 'hits' => [] } })
+
+        result = described_class.new(q: 'Horse').call
+
+        expect(result[:data].length).to eq(1)
+        expect(result[:data][0][:type]).to eq(:heading)
+        expect(result[:data][0][:attributes][:goods_nomenclature_item_id]).to eq('0101000000')
+        expect(result[:data][0][:attributes][:score]).to be_nil
+        expect(TradeTariffBackend.search_client).not_to have_received(:search)
+      end
     end
 
     context 'when exact match via singular/plural expansion' do


### PR DESCRIPTION
## What changed

Downcases the guided-search exact suggestion query before matching stored suggestions, and adds service coverage for a capitalized query matching a lowercase stored suggestion.

## Why

AI-863 reports different guided search behaviour for `Disposable camera` and `disposable camera`. Stored text suggestions are already normalized lower-case, but the exact lookup used the raw query, so capitalized queries could miss an existing exact suggestion and fall through into the refine-question flow.

## Risk

Low. This keeps `SearchSuggestion.by_value` as an exact lookup and only normalizes guided-search input before calling it, matching how stored text suggestions are populated.