### PR TITLE
BAU: Opt database apps into full deploy migrations

### DIFF
--- a/.github/workflows/deploy-to-development-full.yml
+++ b/.github/workflows/deploy-to-development-full.yml
@@ -26,6 +26,7 @@ jobs:
         [
           {
             "name": "tariff-backend",
+            "migrate": true,
             "service-names": ["backend-uk", "backend-xi", "worker-uk", "worker-xi"]
           },
           {
@@ -36,6 +37,7 @@ jobs:
           {
             "name": "tariff-admin",
             "repo": "trade-tariff/trade-tariff-admin",
+            "migrate": true,
             "service-names": ["admin"]
           },
           {


### PR DESCRIPTION
## What

Opt database-backed apps into full deploy migrations under the new `deploy-multi-ecs` convention.

## Why

The reusable workflow now treats migrations as an explicit per-app opt-in, so callers need to mark only apps that can run the Rails migration action.