### PR TITLE
OTTIMP-633 Enable unsubscribing without authentication

### DIFF
--- a/app/controllers/api/user/subscriptions_controller.rb
+++ b/app/controllers/api/user/subscriptions_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module User
     class SubscriptionsController < UserController
-      skip_before_action :authenticate!, only: %i[destroy]
+      skip_before_action :authenticate!, only: %i[show destroy]
       before_action :find_subscription
 
       def show

--- a/spec/requests/api/user/subscriptions_controller_spec.rb
+++ b/spec/requests/api/user/subscriptions_controller_spec.rb
@@ -85,6 +85,30 @@ RSpec.describe Api::User::SubscriptionsController do
         expect(response.body).to eq(serialized_subscription.to_json)
       end
     end
+
+    context 'when no authentication header is provided' do
+      let(:request_header_overrides) { {} }
+      let(:subscription) do
+        create(:user_subscription,
+               subscription_type_id: Subscriptions::Type.stop_press.id,
+               user: user)
+      end
+
+      before do
+        allow(PublicUsers::Subscription).to receive(:find).with(uuid: valid_id).and_return(subscription)
+        get "/uk/user/subscriptions/#{valid_id}", headers: request_headers
+      end
+
+      it 'returns a successful response' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns the subscription payload' do
+        serialized_subscription =
+          Api::User::SubscriptionSerializer.new(subscription, include: [:subscription_type]).serializable_hash
+        expect(response.body).to eq(serialized_subscription.to_json)
+      end
+    end
   end
 
   describe '#destroy' do


### PR DESCRIPTION
## What:
An unsubscribe link should work without a user needing to be logged in. 
The authentication for retrieving a subscription has been removed to allow this.

## Why:
This makes it easier to unsubscribe

## Ticket:
https://transformuk.atlassian.net/browse/OTTIMP-633

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Allows anyone to unsubscribe another user if they have the correct link, but this is the expected behaviour.