### PR TITLE
HMRC-2262: Add backend search request correlation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::API
+  MAX_LOGGED_REQUEST_ID_LENGTH = 100
+
   include ActionController::Helpers
   include ::ActionController::MimeResponds
   # SequelRails incorrectly includes this into ActionController::Base but our
@@ -20,7 +22,7 @@ class ApplicationController < ActionController::API
 
   def append_info_to_payload(payload)
     super
-    payload[:request_id] = TradeTariffRequest.request_id
+    payload[:request_id] = logged_request_id
     payload[:user_agent] = request.headers['HTTP_X_ORIGINAL_USER_AGENT'].presence || request.env['HTTP_USER_AGENT']
     payload[:client_id] = request.headers['HTTP_X_CLIENT_ID']
   end
@@ -67,5 +69,9 @@ class ApplicationController < ActionController::API
 
   def set_trade_tariff_request_id
     TradeTariffRequest.request_id = params[:request_id].presence || request.request_id
+  end
+
+  def logged_request_id
+    (TradeTariffRequest.request_id.presence || request.request_id).to_s.first(MAX_LOGGED_REQUEST_ID_LENGTH)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,7 @@ class ApplicationController < ActionController::API
 
   def append_info_to_payload(payload)
     super
+    payload[:request_id] = TradeTariffRequest.request_id
     payload[:user_agent] = request.headers['HTTP_X_ORIGINAL_USER_AGENT'].presence || request.env['HTTP_USER_AGENT']
     payload[:client_id] = request.headers['HTTP_X_CLIENT_ID']
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,6 +49,7 @@ Rails.application.configure do
   config.lograge.formatter = Lograge::Formatters::Logstash.new
   config.lograge.custom_options = lambda do |event|
     {
+      request_id: event.payload[:request_id],
       auth_type: event.payload[:auth_type],
       client_id: event.payload[:client_id],
       params: event.payload[:params].except('controller', 'action', 'format', 'utf8'),

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -70,18 +70,37 @@ RSpec.describe ApplicationController, type: :request do
     end
 
     context 'with request logging payload' do
-      it 'adds the current request_id to the action controller payload' do
+      def process_action_payload_for(params:)
         events = []
         subscriber = ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*args|
           events << ActiveSupport::Notifications::Event.new(*args)
         end
 
-        api_get('/uk/api/healthcheck', params: { request_id: 'search-request-id' })
+        api_get('/uk/api/healthcheck', params:)
 
-        payload = events.last.payload
-        expect(payload[:request_id]).to eq('search-request-id')
+        events.last.payload
       ensure
         ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      end
+
+      it 'adds the current request_id to the action controller payload' do
+        payload = process_action_payload_for(params: { request_id: 'search-request-id' })
+
+        expect(payload[:request_id]).to eq('search-request-id')
+      end
+
+      it 'bounds request_id values added to the action controller payload' do
+        long_request_id = 'a' * 101
+        payload = process_action_payload_for(params: { request_id: long_request_id })
+
+        expect(payload[:request_id]).to eq('a' * ApplicationController::MAX_LOGGED_REQUEST_ID_LENGTH)
+      end
+
+      it 'falls back to the Rails request id when the search request_id is blank' do
+        payload = process_action_payload_for(params: { request_id: '' })
+
+        expect(payload[:request_id]).to be_present
+        expect(payload[:request_id].length).to be <= ApplicationController::MAX_LOGGED_REQUEST_ID_LENGTH
       end
     end
   end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -68,5 +68,21 @@ RSpec.describe ApplicationController, type: :request do
         it { expect(TimeMachine).to have_received(:at).with(Date.new(2024, 1, 1)) }
       end
     end
+
+    context 'with request logging payload' do
+      it 'adds the current request_id to the action controller payload' do
+        events = []
+        subscriber = ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*args|
+          events << ActiveSupport::Notifications::Event.new(*args)
+        end
+
+        api_get('/uk/api/healthcheck', params: { request_id: 'search-request-id' })
+
+        payload = events.last.payload
+        expect(payload[:request_id]).to eq('search-request-id')
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      end
+    end
   end
 end


### PR DESCRIPTION
### Jira link

[HMRC-2262](https://transformuk.atlassian.net/browse/HMRC-2262)

### What?

- [x] Add the current TradeTariffRequest request id to backend controller logging payloads
- [x] Include that request id in production Lograge custom options
- [x] Cover the payload behaviour through a request spec and process_action notification

### Why?

Operators need to jump from a frontend /search failure to matching backend request and search instrumentation logs. This makes the backend request log expose the same request id used by V2 search instrumentation.

### Risk

**Risk level:** Low

**Reason for rating:** Observability-only change. API responses and search behaviour are unchanged.