### PR TITLE
HMRC-2263: Expose backend search failure details

### DIFF
--- a/app/services/search_service/fuzzy_search.rb
+++ b/app/services/search_service/fuzzy_search.rb
@@ -15,7 +15,7 @@ class SearchService
         error_message: e.message,
         search_type: 'classic',
       )
-      # rescue from malformed queries, return empty resultset in that case
+      # OpenSearch transport failures should not prevent the blank-result fallback.
       @results = BLANK_RESULT
       self
     end

--- a/app/services/search_service/fuzzy_search.rb
+++ b/app/services/search_service/fuzzy_search.rb
@@ -8,7 +8,13 @@ class SearchService
       end
 
       self
-    rescue OpenSearch::Transport::Transport::Error
+    rescue OpenSearch::Transport::Transport::Error => e
+      Search::Instrumentation.search_failed(
+        request_id: TradeTariffRequest.request_id,
+        error_type: e.class.name,
+        error_message: e.message,
+        search_type: 'classic',
+      )
       # rescue from malformed queries, return empty resultset in that case
       @results = BLANK_RESULT
       self

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,9 +48,14 @@ Rails.application.configure do
   config.lograge.enabled = true
   config.lograge.formatter = Lograge::Formatters::Logstash.new
   config.lograge.custom_options = lambda do |event|
+    exception = event.payload[:exception_object]
+    exception_class, exception_message = event.payload[:exception]
+
     {
       auth_type: event.payload[:auth_type],
       client_id: event.payload[:client_id],
+      exception_class: exception&.class&.name || exception_class,
+      exception_message: exception&.message || exception_message,
       params: event.payload[:params].except('controller', 'action', 'format', 'utf8'),
       user_agent: event.payload[:user_agent],
     }.compact

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,18 +47,30 @@ Rails.application.configure do
   config.logger = ActiveSupport::Logger.new($stdout)
   config.lograge.enabled = true
   config.lograge.formatter = Lograge::Formatters::Logstash.new
+  lograge_exception_message_max_length = 500
+  truncate_lograge_exception_message = lambda do |exception_message|
+    next {} if exception_message.blank?
+
+    message = exception_message.to_s
+
+    {
+      exception_message: message.first(lograge_exception_message_max_length),
+      exception_message_truncated: message.length > lograge_exception_message_max_length,
+    }
+  end
+
   config.lograge.custom_options = lambda do |event|
     exception = event.payload[:exception_object]
     exception_class, exception_message = event.payload[:exception]
+    raw_exception_message = exception&.message || exception_message
 
     {
       auth_type: event.payload[:auth_type],
       client_id: event.payload[:client_id],
       exception_class: exception&.class&.name || exception_class,
-      exception_message: exception&.message || exception_message,
       params: event.payload[:params].except('controller', 'action', 'format', 'utf8'),
       user_agent: event.payload[:user_agent],
-    }.compact
+    }.merge(truncate_lograge_exception_message.call(raw_exception_message)).compact
   end
 
   config.lograge.ignore_actions = [

--- a/spec/services/search_service/fuzzy_search_spec.rb
+++ b/spec/services/search_service/fuzzy_search_spec.rb
@@ -135,9 +135,13 @@ RSpec.describe SearchService::FuzzySearch do
     end
 
     context 'when OpenSearch raises an error' do
+      let(:error) { OpenSearch::Transport::Transport::Error.new('OpenSearch timeout') }
+
       before do
+        TradeTariffRequest.request_id = 'request-123'
+        allow(Search::Instrumentation).to receive(:search_failed)
         allow(TradeTariffBackend.search_client).to receive(:msearch)
-          .and_raise(OpenSearch::Transport::Transport::Error)
+          .and_raise(error)
       end
 
       it 'returns BLANK_RESULT without raising' do
@@ -145,6 +149,17 @@ RSpec.describe SearchService::FuzzySearch do
 
         expect(results[:type]).to eq('fuzzy_match')
         expect(results).to include(SearchService::BaseSearch::BLANK_RESULT)
+      end
+
+      it 'emits a search_failed event' do
+        fuzzy_search.serializable_hash
+
+        expect(Search::Instrumentation).to have_received(:search_failed).with(
+          request_id: 'request-123',
+          error_type: 'OpenSearch::Transport::Transport::Error',
+          error_message: 'OpenSearch timeout',
+          search_type: 'classic',
+        )
       end
     end
   end

--- a/spec/services/search_service/fuzzy_search_spec.rb
+++ b/spec/services/search_service/fuzzy_search_spec.rb
@@ -137,8 +137,16 @@ RSpec.describe SearchService::FuzzySearch do
     context 'when OpenSearch raises an error' do
       let(:error) { OpenSearch::Transport::Transport::Error.new('OpenSearch timeout') }
 
-      before do
+      around do |example|
+        previous_request_id = TradeTariffRequest.request_id
         TradeTariffRequest.request_id = 'request-123'
+
+        example.run
+      ensure
+        TradeTariffRequest.request_id = previous_request_id
+      end
+
+      before do
         allow(Search::Instrumentation).to receive(:search_failed)
         allow(TradeTariffBackend.search_client).to receive(:msearch)
           .and_raise(error)


### PR DESCRIPTION
### Jira link

[HMRC-2263](https://transformuk.atlassian.net/browse/HMRC-2263)

### What?

- [x] Emit a search_failed instrumentation event when classic fuzzy search catches an OpenSearch transport error
- [x] Keep the existing blank fuzzy result fallback behaviour
- [x] Include exception class and message in backend production Lograge custom options for unhandled request failures

### Why?

OpenSearch transport failures during classic search were indistinguishable from normal empty fuzzy results in search-specific logs. This keeps the user-facing fallback but leaves structured backend evidence for operators.

### Risk

**Risk level:** Low

**Reason for rating:** Observability-only change. Existing OpenSearch transport failure fallback is preserved.