### PR TITLE
BAU: Extend stale pull request threshold

### DIFF
--- a/.github/workflows/close-stale-pull-requests.yml
+++ b/.github/workflows/close-stale-pull-requests.yml
@@ -8,7 +8,7 @@ on:
       stale_days:
         description: Days without pull request activity before closure
         required: false
-        default: '14'
+        default: '30'
       keep_label:
         description: Label exempting a pull request from closure
         required: false
@@ -30,6 +30,6 @@ jobs:
   close-stale:
     uses: trade-tariff/trade-tariff-tools/.github/workflows/close-stale-pull-requests-reusable.yml@main
     with:
-      stale_days: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.stale_days != '' && fromJSON(github.event.inputs.stale_days) || 14 }}
+      stale_days: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.stale_days != '' && fromJSON(github.event.inputs.stale_days) || 30 }}
       keep_label: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.keep_label != '' && github.event.inputs.keep_label || 'keep' }}
       dry_run: ${{ github.event_name != 'schedule' && (github.event.inputs.dry_run != 'false') }}


### PR DESCRIPTION
## What changed

- Updated the stale pull request workflow default from 14 days to 30 days.
- Updated both the manual dispatch default and the scheduled fallback value passed to the reusable `trade-tariff-tools` workflow.

## Why

Pull requests should remain open by default for 30 days before being considered stale.

## Verification

- Pre-commit hooks during commit: YAML check and GitHub Actions workflow lint passed.
- `ruby -ryaml -e '...'` parsed `.github/workflows/close-stale-pull-requests.yml` and asserted both stale defaults are `30`.