### PR TITLE
BAU: Add PR risk label guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,16 @@ The application is a Rails API using Sequel, PostgreSQL, Redis, Sidekiq, and Ope
 - Use `rg` for code search.
 - Treat tariff data, measures, quotas, duties, certificates, rules of origin, auth, and sync logic as high-risk areas.
 
+## PR Risk Labels
+
+When opening a PR, use `.github/pull_request_template.md` as the canonical risk decision tree. Fill in the Risk section and apply exactly one matching GitHub label:
+
+- `low-risk` for green changes: standard review. Typical examples include dependency bumps with no API changes, copy/content changes, read-only observability, tests-only changes, additive config with safe defaults, covered refactors with no behaviour change, Terraform changes with no resource recreation, and non-destructive S3 lifecycle rules.
+- `medium-risk` for amber changes: socialise with the team before merging. Typical examples include commodity code lookup, measure type, declarable goods, quota, or duty calculation changes; OpenSearch indexing changes; new or modified consumed API endpoints; feature flags affecting live journeys; networking, security group, IAM, CI/CD, deployment ordering, S3 access-control, resource replacement, or deprecation changes.
+- `high-risk` for red changes: requires explicit approval from Thor or Neil before merging. Typical examples include destructive database migrations, changes to how measures, conditions, or footnotes are processed or surfaced, CDS or HMRC upstream sync changes, production AWS changes that cannot be easily rolled back, secrets or credential handling changes, legally significant trader-facing regulatory content changes, and significant architectural shifts.
+
+Do not apply more than one risk label to the same PR. If the risk rating changes during review, remove the old risk label and apply the new one.
+
 ## Key Entry Points
 
 - Routes: `config/routes.rb` and `app/engines/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,15 @@ Before changing code:
 - Run project commands directly by default. If you use Nix/direnv locally, `direnv exec <repo-path> <command>` is also fine.
 - Use `rg` for code search.
 
+Before opening a PR:
+
+- Use `.github/pull_request_template.md` as the canonical risk decision tree.
+- Fill in the Risk section and apply exactly one matching GitHub label: `low-risk` for green, `medium-risk` for amber, or `high-risk` for red.
+- Treat dependency bumps with no API changes, copy/content changes, read-only observability, tests-only changes, additive config with safe defaults, covered refactors with no behaviour change, Terraform changes with no resource recreation, and non-destructive S3 lifecycle rules as typical `low-risk` changes.
+- Treat commodity code lookup, measure type, declarable goods, quota, duty calculation, OpenSearch indexing, consumed API endpoint, live feature flag, networking, security group, IAM, CI/CD, deployment ordering, S3 access-control, resource replacement, and deprecation changes as typical `medium-risk` changes that need a team conversation before merging.
+- Treat destructive database migrations, measure/condition/footnote processing, CDS or HMRC upstream sync, hard-to-rollback production AWS, secrets or credential handling, legally significant regulatory content, and significant architecture changes as typical `high-risk` changes that require explicit approval from Thor or Neil.
+- If the risk rating changes during review, remove the old risk label and apply the new one.
+
 Useful docs:
 
 - `docs/development-and-delivery.md`

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -15,6 +15,15 @@ Before changing code:
 - Read the relevant architecture or domain doc before editing tariff data, search, sync, caching, Green Lanes, rules of origin, exchange rates, or API documentation.
 - Run project commands directly by default. If you use Nix/direnv locally, `direnv exec <repo-path> <command>` is also fine.
 
+Before opening a PR:
+
+- Use `.github/pull_request_template.md` as the canonical risk decision tree.
+- Fill in the Risk section and apply exactly one matching GitHub label: `low-risk` for green, `medium-risk` for amber, or `high-risk` for red.
+- Treat dependency bumps with no API changes, copy/content changes, read-only observability, tests-only changes, additive config with safe defaults, covered refactors with no behaviour change, Terraform changes with no resource recreation, and non-destructive S3 lifecycle rules as typical `low-risk` changes.
+- Treat commodity code lookup, measure type, declarable goods, quota, duty calculation, OpenSearch indexing, consumed API endpoint, live feature flag, networking, security group, IAM, CI/CD, deployment ordering, S3 access-control, resource replacement, and deprecation changes as typical `medium-risk` changes that need a team conversation before merging.
+- Treat destructive database migrations, measure/condition/footnote processing, CDS or HMRC upstream sync, hard-to-rollback production AWS, secrets or credential handling, legally significant regulatory content, and significant architecture changes as typical `high-risk` changes that require explicit approval from Thor or Neil.
+- If the risk rating changes during review, remove the old risk label and apply the new one.
+
 Useful docs:
 
 - `docs/development-and-delivery.md`


### PR DESCRIPTION
## What:

- [x] Add PR risk label guidance to AGENTS.md
- [x] Add matching guidance to CLAUDE.md and GEMINI.md

## Why:

Agent instructions should tell coding tools how to choose and apply the trade-tariff PR risk labels when opening pull requests.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** Documentation-only agent guidance change with no production code or deployment behaviour.