### PR TITLE
OTTIMP-610 Remove revised enquiry form alias

### DIFF
--- a/app/engines/v2_api.rb
+++ b/app/engines/v2_api.rb
@@ -134,7 +134,6 @@ V2Api.routes.draw do
 
       namespace :enquiry_form do
         resources :submissions, only: %i[create]
-        resources :revised_submissions, only: %i[create], controller: :submissions
       end
 
       get '/changes(/:as_of)', to: 'changes#index', as: :changes, constraints: { as_of: /\d{4}-\d{1,2}-\d{1,2}/ }

--- a/spec/requests/api/v2/enquiry_form/submissions_controller_spec.rb
+++ b/spec/requests/api/v2/enquiry_form/submissions_controller_spec.rb
@@ -83,46 +83,6 @@ RSpec.describe Api::V2::EnquiryForm::SubmissionsController, :v2 do
       )
     end
 
-    context 'with a classification enquiry from the revised alias endpoint' do
-      let(:classification_params) do
-        params.merge(
-          enquiry_category: 'classification',
-          enquiry_description: nil,
-          goods_product: 'Baked beans',
-          goods_made_of: 'Beans and tomato sauce',
-          goods_used_for: 'Food',
-          goods_function: 'Ready to eat',
-          goods_processed: 'Cooked and mixed',
-          goods_packaged: 'Tinned',
-          has_commodity_code: 'yes',
-          commodity_code: '2005590000',
-        ).compact
-      end
-
-      it 'caches the structured classification answers for the worker' do
-        post api_enquiry_form_revised_submissions_path,
-             params: { data: { attributes: classification_params } },
-             headers: headers,
-             as: :json
-
-        cached = Sidekiq.redis { |conn| conn.get("enquiry_form_#{reference_number}") }
-
-        expect(JSON.parse(cached, symbolize_names: true)).to include(
-          enquiry_category: 'classification',
-          goods_product: 'Baked beans',
-          goods_made_of: 'Beans and tomato sauce',
-          goods_used_for: 'Food',
-          goods_function: 'Ready to eat',
-          goods_processed: 'Cooked and mixed',
-          goods_packaged: 'Tinned',
-          has_commodity_code: 'yes',
-          commodity_code: '2005590000',
-          reference_number: reference_number,
-          created_at: frozen_time.strftime('%Y-%m-%d %H:%M'),
-        )
-      end
-    end
-
     context 'with revised enquiry payload combinations on the original endpoint' do
       let(:large_text) do
         [


### PR DESCRIPTION
### Jira link

[OTTIMP-610](https://transformuk.atlassian.net/browse/OTTIMP-610)

### What?

I have added/removed/altered:

- [x] Removed the temporary `revised_submissions` enquiry form API route alias
- [x] Kept the canonical `enquiry_form/submissions` endpoint and revised payload support
- [x] Added request coverage that the retired alias is no longer routable

### Why?

I am doing this because:

- the frontend now posts the revised enquiry form payload to the canonical submissions endpoint
- the temporary alias was only needed during the frontend/backend rollout window
- removing it reduces duplicate API surface area after the rollout has completed

### Have you? (optional)

- [ ] Added documentation for new apis
- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks (optional)

- Low risk cleanup after the frontend has moved back to the canonical endpoint
- Removes the temporary `revised_submissions` alias, so this should deploy after the frontend endpoint cleanup has reached production
- No destructive or migratory actions

### Verification

- `PGHOST=127.0.0.1 PGPORT=15432 REDIS_URL=redis://127.0.0.1:16379 ELASTICSEARCH_URL=http://127.0.0.1:9200 bundle exec rspec spec/requests/api/v2/enquiry_form/submissions_controller_spec.rb`
- `PGHOST=127.0.0.1 PGPORT=15432 REDIS_URL=redis://127.0.0.1:16379 ELASTICSEARCH_URL=http://127.0.0.1:9200 bundle exec rails routes | rg enquiry_form`
- `bundle exec rubocop app/engines/v2_api.rb spec/requests/api/v2/enquiry_form/submissions_controller_spec.rb`