### PR TITLE
Added simplecov coverage report setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,7 @@ group :test do
   gem 'rspec-rails'
   gem 'rspec-rebound'
   gem 'rswag-specs'
+  gem 'simplecov'
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,7 @@ GEM
       sequel
     date (3.5.1)
     diff-lcs (1.6.2)
+    docile (1.4.1)
     dotenv (3.2.0)
     dotenv-rails (3.2.0)
       dotenv (= 3.2.0)
@@ -467,6 +468,12 @@ GEM
     sidekiq-scheduler (6.0.2)
       rufus-scheduler (~> 3.2)
       sidekiq (>= 7.3, < 9)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
     sin_lru_redux (2.5.2)
     slack-notifier (2.4.0)
     stringio (3.2.0)
@@ -557,6 +564,7 @@ DEPENDENCIES
   sequel-rails
   sidekiq
   sidekiq-scheduler
+  simplecov
   slack-notifier
   webmock
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,10 @@
 ENV['RAILS_ENV'] ||= 'test'
 
+require 'simplecov'
 require 'spec_helper'
+
+SimpleCov.start 'rails'
+SimpleCov.formatters = SimpleCov::Formatter::HTMLFormatter
 
 require 'webmock/rspec'
 WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
## What:
Added the SimpleCov HTML coverage report setup for `tariff-backend`

## Why:
Helps developers quickly inspect which parts of the backend codebase are covered by specs, spot untested areas, and make more informed decisions when adding or changing tests.

## Ticket:
[HMRC-2290](https://transformuk.atlassian.net/browse/HMRC-2290)

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
Only affects the test environment.