### PR TITLE
BAU: Exclude specs from PR line count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
             db/
             data/
             docs/
+            spec/
             terraform/versions.tf
             *.md
             *.lock


### PR DESCRIPTION
## What:

- [x] Exclude `spec/` from the PR line-count guard.
- [x] Keep the line-count threshold focused on production code and other non-test changes.

## Why:

The line-count guard is intended to highlight large production changes for review. Specs can legitimately add a lot of lines when we improve coverage, and counting them discourages the right behaviour.

## Ticket:

N/A

## Risk:

**Risk level:** 🟠

**Reason for rating:** This changes a CI quality gate, so it should be visible to the team. It does not change application runtime behaviour and is limited to excluding test files from the line-count calculation.

## Verification:

- `git diff --check`
- Commit hooks passed, including YAML check and GitHub Actions workflow lint.