### PR TITLE
[HMRC-2041] Enable store_oplog_inserts for taric import

### DIFF
--- a/app/lib/taric_importer.rb
+++ b/app/lib/taric_importer.rb
@@ -82,7 +82,7 @@ class TaricImporter
       if count.positive?
         duration = oplog_event.duration
         operation = oplog_event.payload[:operation]
-        entity_class = oplog_event.payload[:entity_class]
+        entity_class = oplog_event.payload[:entity_class].to_s
 
         oplog_inserts[:operations][operation][entity_class] ||= {}
         oplog_inserts[:operations][operation][entity_class][:count] ||= 0

--- a/app/lib/tariff_synchronizer/taric_update.rb
+++ b/app/lib/tariff_synchronizer/taric_update.rb
@@ -89,8 +89,8 @@ module TariffSynchronizer
         @oplog_inserts = TaricImporter.new(self).import
       end
 
-      mark_as_applied
       store_oplog_inserts
+      mark_as_applied
 
       duration_ms = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at) * 1000
       Instrumentation.file_import_completed(filename:, duration_ms:)
@@ -162,8 +162,6 @@ module TariffSynchronizer
 
     def store_oplog_inserts
       self.inserts = @oplog_inserts.to_json
-
-      save
     end
   end
 end

--- a/app/lib/tariff_synchronizer/taric_update.rb
+++ b/app/lib/tariff_synchronizer/taric_update.rb
@@ -161,7 +161,7 @@ module TariffSynchronizer
     end
 
     def store_oplog_inserts
-      # self.inserts = @oplog_inserts.to_json
+      self.inserts = @oplog_inserts.to_json
 
       save
     end

--- a/spec/unit/taric_importer_spec.rb
+++ b/spec/unit/taric_importer_spec.rb
@@ -101,6 +101,14 @@ RSpec.describe TaricImporter do
         expect(Rails.logger).to have_received(:info)
         expect(Rails.logger).to have_received(:info).with('Successfully imported Taric file: 2013-08-02_TGB13214.xml')
       end
+
+      it 'stores string entity keys in the oplog inserts payload' do
+        oplog_inserts = described_class.new(taric_update).import
+
+        expect(oplog_inserts[:operations][:create]).to include('ExplicitAbrogationRegulation')
+        expect(oplog_inserts[:operations][:create]).not_to include(ExplicitAbrogationRegulation)
+        expect { oplog_inserts.to_json }.not_to raise_error
+      end
     end
 
     context 'on an unexpected update operation type'

--- a/spec/unit/tariff_synchronizer/taric_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/taric_update_spec.rb
@@ -36,10 +36,16 @@ RSpec.describe TariffSynchronizer::TaricUpdate do
   describe '#import!' do
     let(:taric_update) { create :taric_update }
     let(:taric_importer) { instance_double(TaricImporter) }
+    let(:inserted_oplog_records) do
+      {
+        total_count: 1,
+        total_duration: 0,
+      }
+    end
 
     before do
       allow(TaricImporter).to receive(:new).with(taric_update).and_return(taric_importer)
-      allow(taric_importer).to receive(:import)
+      allow(taric_importer).to receive(:import).and_return(inserted_oplog_records)
       allow(taric_update).to receive(:file_path).and_return('spec/fixtures/taric_samples/insert_record.xml')
     end
 
@@ -51,6 +57,11 @@ RSpec.describe TariffSynchronizer::TaricUpdate do
     it 'marks the Taric update as applied' do
       taric_update.import!
       expect(taric_update.reload).to be_applied
+    end
+
+    it 'stores the inserts on the update' do
+      taric_update.import!
+      expect(taric_update.reload.inserts).to include('"total_count":1')
     end
 
     it 'emits a file_import_completed instrumentation event' do


### PR DESCRIPTION
## What:
Enables saving off the `oplog_inserts` for TARIC updates.
Converts entity class to string which fixes bug that previously caused this to crash the import

## Why:
Operators should be able to inspect TARIC imports to see what has changed

## Ticket:
[HMRC-2041](https://transformuk.atlassian.net/browse/HMRC-2041)

## Risk:
🟢 / 🟠 

**Reason for rating:**
Tiny change but a change to the sync pipeline
