### PR TITLE
BAU: Disable CW alarms in staging

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -79,7 +79,7 @@ Terraform to deploy the service into AWS.
 | <a name="input_backend_xi_min_capacity"></a> [backend\_xi\_min\_capacity](#input\_backend\_xi\_min\_capacity) | Smallest number of tasks the backend-xi service can scale-in to. | `number` | `1` | no |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
-| <a name="input_enable_alarms"></a> [enable\_alarms](#input\_enable\_alarms) | Whether to enable CloudWatch alarms for the service. | `bool` | `true` | no |
+| <a name="input_enable_alarms"></a> [enable\_alarms](#input\_enable\_alarms) | Whether to enable CloudWatch alarms for the service. | `bool` | `false` | no |
 | <a name="input_enable_observability_alerts"></a> [enable\_observability\_alerts](#input\_enable\_observability\_alerts) | n/a | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Largest number of tasks the service can scale-out to. | `number` | `5` | no |

--- a/terraform/config_development.tfvars
+++ b/terraform/config_development.tfvars
@@ -5,4 +5,3 @@ memory                  = 2048
 backend_uk_min_capacity = 1
 backend_xi_min_capacity = 1
 max_capacity            = 1
-enable_alarms           = false

--- a/terraform/config_production.tfvars
+++ b/terraform/config_production.tfvars
@@ -11,4 +11,5 @@ max_capacity            = 16
 scale_in_cooldown  = 0
 scale_out_cooldown = 0
 
+enable_alarms               = true
 enable_observability_alerts = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -50,7 +50,7 @@ variable "memory" {
 variable "enable_alarms" {
   description = "Whether to enable CloudWatch alarms for the service."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "enable_observability_alerts" {


### PR DESCRIPTION
## What:
- Disabled ECS CloudWatch alarms in the staging environment.

## Why:
- Staging services are intentionally stopped every night by a scheduled job.
- This expected behaviour triggers ECS alarms and generates unnecessary alerts. Disabling these alarms reduces noise from a known, non-actionable condition.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
- Change is limited to the staging environment only.
- The change only suppresses alerts for an expected and intentional service shutdown.