### PR TITLE
AI-521: Add pipeline observability APIs

### DIFF
--- a/app/controllers/api/admin/customs_tariff_pipeline/alerts_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_pipeline/alerts_controller.rb
@@ -1,0 +1,32 @@
+module Api
+  module Admin
+    module CustomsTariffPipeline
+      class AlertsController < BaseController
+        def index
+          page = filtered_alerts.paginate(current_page, per_page)
+
+          render json: AlertSerializer.new(
+            page.all,
+            is_collection: true,
+            meta: pagination_meta(page),
+          ).serializable_hash
+        end
+
+        private
+
+        def filtered_alerts
+          dataset = CustomsTariffPipelineAlert.most_recent_first
+          dataset = apply_time_range(dataset)
+          apply_exact_filters(
+            dataset,
+            :alert_type,
+            :severity,
+            :status,
+            :customs_tariff_update_version,
+            :metric_name,
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/customs_tariff_pipeline/base_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_pipeline/base_controller.rb
@@ -1,0 +1,44 @@
+module Api
+  module Admin
+    module CustomsTariffPipeline
+      class BaseController < AdminController
+        private
+
+        def pagination_meta(dataset)
+          {
+            pagination: {
+              page: current_page,
+              per_page:,
+              total_count: dataset.pagination_record_count,
+            },
+          }
+        end
+
+        def parsed_time_param(name)
+          return if params[name].blank?
+
+          Time.zone.parse(params[name])
+        rescue ArgumentError, TypeError
+          raise ActionController::BadRequest, "#{name} must be a valid ISO 8601 time"
+        end
+
+        def apply_time_range(dataset, column: nil)
+          from_time = parsed_time_param(:from)
+          to_time = parsed_time_param(:to)
+
+          dataset = column ? dataset.where { Sequel[column] >= from_time } : dataset.from_time(from_time) if from_time
+          dataset = column ? dataset.where { Sequel[column] <= to_time } : dataset.to_time(to_time) if to_time
+          dataset
+        end
+
+        def apply_exact_filters(dataset, *names)
+          names.each do |name|
+            dataset = dataset.where(name => params[name]) if params[name].present?
+          end
+
+          dataset
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/customs_tariff_pipeline/dashboard_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_pipeline/dashboard_controller.rb
@@ -1,0 +1,74 @@
+module Api
+  module Admin
+    module CustomsTariffPipeline
+      class DashboardController < BaseController
+        def show
+          render json: {
+            data: {
+              id: 'current',
+              type: 'customs_tariff_pipeline_dashboard',
+              attributes: dashboard_attributes,
+            },
+          }
+        end
+
+        private
+
+        def dashboard_attributes
+          {
+            latest_import_event: serialize_event(latest_event('import')),
+            latest_publication_event: serialize_event(latest_event('publish')),
+            review_backlog: serialize_metric_bin(latest_metric_bin('review_backlog')),
+            open_alerts_count: filtered_alerts.open.count,
+            metric_bins: filtered_metric_bins.all.map { |bin| serialize_metric_bin(bin) },
+            open_alerts: filtered_alerts.open.limit(10).all.map { |alert| serialize_alert(alert) },
+          }
+        end
+
+        def latest_event(event_type)
+          filtered_events.where(event_type:).first
+        end
+
+        def latest_metric_bin(metric_name)
+          filtered_metric_bins
+            .where(metric_name:)
+            .reverse(:bucket_start_at, :id)
+            .first
+        end
+
+        def filtered_events
+          @filtered_events ||= apply_time_range(CustomsTariffPipelineEvent.most_recent_first)
+        end
+
+        def filtered_metric_bins
+          @filtered_metric_bins ||= begin
+            dataset = CustomsTariffPipelineMetricBin.earliest_first
+            dataset = apply_time_range(dataset)
+            dataset = dataset.where(bucket_size: params[:bucket_size]) if params[:bucket_size].present?
+            dataset
+          end
+        end
+
+        def filtered_alerts
+          @filtered_alerts ||= apply_time_range(CustomsTariffPipelineAlert.most_recent_first)
+        end
+
+        def serialize_event(event)
+          return unless event
+
+          EventSerializer.new(event).serializable_hash[:data][:attributes]
+        end
+
+        def serialize_metric_bin(metric_bin)
+          return unless metric_bin
+
+          MetricBinSerializer.new(metric_bin).serializable_hash[:data][:attributes]
+        end
+
+        def serialize_alert(alert)
+          AlertSerializer.new(alert).serializable_hash[:data][:attributes]
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/customs_tariff_pipeline/events_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_pipeline/events_controller.rb
@@ -1,0 +1,32 @@
+module Api
+  module Admin
+    module CustomsTariffPipeline
+      class EventsController < BaseController
+        def index
+          page = filtered_events.paginate(current_page, per_page)
+
+          render json: EventSerializer.new(
+            page.all,
+            is_collection: true,
+            meta: pagination_meta(page),
+          ).serializable_hash
+        end
+
+        private
+
+        def filtered_events
+          dataset = CustomsTariffPipelineEvent.most_recent_first
+          dataset = apply_time_range(dataset)
+          apply_exact_filters(
+            dataset,
+            :event_type,
+            :outcome,
+            :customs_tariff_update_version,
+            :subject_type,
+            :subject_id,
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/customs_tariff_pipeline/metric_bins_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_pipeline/metric_bins_controller.rb
@@ -1,0 +1,33 @@
+module Api
+  module Admin
+    module CustomsTariffPipeline
+      class MetricBinsController < BaseController
+        def index
+          page = filtered_metric_bins.paginate(current_page, per_page)
+
+          render json: MetricBinSerializer.new(
+            page.all,
+            is_collection: true,
+            meta: pagination_meta(page),
+          ).serializable_hash
+        end
+
+        private
+
+        def filtered_metric_bins
+          dataset = CustomsTariffPipelineMetricBin.earliest_first
+          dataset = apply_time_range(dataset)
+          apply_exact_filters(
+            dataset,
+            :bucket_size,
+            :metric_name,
+            :customs_tariff_update_version,
+            :event_type,
+            :outcome,
+            :note_type,
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/engines/admin_api.rb
+++ b/app/engines/admin_api.rb
@@ -83,6 +83,13 @@ AdminApi.routes.draw do
       patch 'customs_tariff_updates/:customs_tariff_update_version/section_notes/:id', to: 'customs_tariff_updates/section_notes#update',  constraints: { customs_tariff_update_version: /[^\/]+/ }
       patch 'customs_tariff_updates/:customs_tariff_update_version/status',            to: 'customs_tariff_updates/status#update',         constraints: { customs_tariff_update_version: /[^\/]+/ }
 
+      namespace :customs_tariff_pipeline do
+        resources :events, only: [:index]
+        resources :metric_bins, only: [:index]
+        resources :alerts, only: [:index]
+        resource :dashboard, only: [:show], controller: :dashboard
+      end
+
       resources :quota_order_numbers, module: 'quota_order_numbers', only: %i[] do
         resources :quota_definitions, only: %i[index show]
       end

--- a/app/models/customs_tariff_pipeline_alert.rb
+++ b/app/models/customs_tariff_pipeline_alert.rb
@@ -1,0 +1,19 @@
+class CustomsTariffPipelineAlert < Sequel::Model
+  dataset_module do
+    def most_recent_first
+      order(Sequel.desc(:triggered_at), Sequel.desc(:id))
+    end
+
+    def from_time(time)
+      where { triggered_at >= time }
+    end
+
+    def to_time(time)
+      where { triggered_at <= time }
+    end
+
+    def open
+      where(status: 'open')
+    end
+  end
+end

--- a/app/models/customs_tariff_pipeline_event.rb
+++ b/app/models/customs_tariff_pipeline_event.rb
@@ -1,0 +1,15 @@
+class CustomsTariffPipelineEvent < Sequel::Model
+  dataset_module do
+    def most_recent_first
+      order(Sequel.desc(:occurred_at), Sequel.desc(:id))
+    end
+
+    def from_time(time)
+      where { occurred_at >= time }
+    end
+
+    def to_time(time)
+      where { occurred_at <= time }
+    end
+  end
+end

--- a/app/models/customs_tariff_pipeline_metric_bin.rb
+++ b/app/models/customs_tariff_pipeline_metric_bin.rb
@@ -1,0 +1,15 @@
+class CustomsTariffPipelineMetricBin < Sequel::Model
+  dataset_module do
+    def earliest_first
+      order(:bucket_start_at, :metric_name, :id)
+    end
+
+    def from_time(time)
+      where { bucket_start_at >= time }
+    end
+
+    def to_time(time)
+      where { bucket_start_at <= time }
+    end
+  end
+end

--- a/app/serializers/api/admin/customs_tariff_pipeline/alert_serializer.rb
+++ b/app/serializers/api/admin/customs_tariff_pipeline/alert_serializer.rb
@@ -1,0 +1,18 @@
+module Api
+  module Admin
+    module CustomsTariffPipeline
+      class AlertSerializer
+        include JSONAPI::Serializer
+
+        set_type :customs_tariff_pipeline_alert
+
+        attributes :alert_type, :severity, :status,
+                   :customs_tariff_update_version, :metric_name,
+                   :bucket_start_at, :triggered_at, :acknowledged_at,
+                   :resolved_at, :acknowledged_by, :resolved_by,
+                   :threshold_value, :observed_value, :message, :metadata,
+                   :created_at, :updated_at
+      end
+    end
+  end
+end

--- a/app/serializers/api/admin/customs_tariff_pipeline/event_serializer.rb
+++ b/app/serializers/api/admin/customs_tariff_pipeline/event_serializer.rb
@@ -1,0 +1,17 @@
+module Api
+  module Admin
+    module CustomsTariffPipeline
+      class EventSerializer
+        include JSONAPI::Serializer
+
+        set_type :customs_tariff_pipeline_event
+
+        attributes :event_type, :outcome, :customs_tariff_update_version,
+                   :subject_type, :subject_id, :whodunnit, :occurred_at,
+                   :duration_ms, :records_total, :records_succeeded,
+                   :records_failed, :records_pending, :error_code,
+                   :error_message, :metadata, :created_at
+      end
+    end
+  end
+end

--- a/app/serializers/api/admin/customs_tariff_pipeline/metric_bin_serializer.rb
+++ b/app/serializers/api/admin/customs_tariff_pipeline/metric_bin_serializer.rb
@@ -1,0 +1,16 @@
+module Api
+  module Admin
+    module CustomsTariffPipeline
+      class MetricBinSerializer
+        include JSONAPI::Serializer
+
+        set_type :customs_tariff_pipeline_metric_bin
+
+        attributes :bucket_size, :bucket_start_at, :metric_name,
+                   :customs_tariff_update_version, :event_type, :outcome,
+                   :note_type, :count, :value_sum, :value_min, :value_max,
+                   :value_last, :metadata, :created_at, :updated_at
+      end
+    end
+  end
+end

--- a/spec/factories/customs_tariff_pipeline_observability_factory.rb
+++ b/spec/factories/customs_tariff_pipeline_observability_factory.rb
@@ -1,0 +1,47 @@
+FactoryBot.define do
+  factory :customs_tariff_pipeline_event do
+    event_type { 'import' }
+    outcome { 'succeeded' }
+    customs_tariff_update_version { '1.1' }
+    subject_type { 'CustomsTariffUpdate' }
+    subject_id { customs_tariff_update_version }
+    whodunnit { 'operator@example.gov.uk' }
+    occurred_at { Time.zone.local(2026, 6, 5, 10, 0, 0) }
+    duration_ms { 1250 }
+    records_total { 10 }
+    records_succeeded { 10 }
+    records_failed { 0 }
+    records_pending { 0 }
+    metadata { { 'source_url' => 'https://example.com/tariff.docx' } }
+  end
+
+  factory :customs_tariff_pipeline_metric_bin do
+    bucket_size { 'hour' }
+    bucket_start_at { Time.zone.local(2026, 6, 5, 10, 0, 0) }
+    metric_name { 'import_runs' }
+    customs_tariff_update_version { 'all' }
+    event_type { 'import' }
+    outcome { 'succeeded' }
+    note_type { 'all' }
+    count { 1 }
+    value_sum { 1250 }
+    value_min { 1250 }
+    value_max { 1250 }
+    value_last { 1250 }
+    metadata { { 'unit' => 'milliseconds' } }
+  end
+
+  factory :customs_tariff_pipeline_alert do
+    alert_type { 'failed_import' }
+    severity { 'critical' }
+    status { 'open' }
+    customs_tariff_update_version { '1.1' }
+    metric_name { 'import_runs' }
+    bucket_start_at { Time.zone.local(2026, 6, 5, 10, 0, 0) }
+    triggered_at { Time.zone.local(2026, 6, 5, 10, 5, 0) }
+    threshold_value { 0 }
+    observed_value { 1 }
+    message { 'Customs tariff document import failed' }
+    metadata { { 'error_code' => 'document_parse_failed' } }
+  end
+end

--- a/spec/requests/api/admin/customs_tariff_pipeline/alerts_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_pipeline/alerts_controller_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe Api::Admin::CustomsTariffPipeline::AlertsController do
+  describe 'GET #index' do
+    before do
+      create(:customs_tariff_pipeline_alert,
+             alert_type: 'failed_import',
+             severity: 'critical',
+             status: 'open',
+             triggered_at: Time.zone.local(2026, 6, 5, 10, 0, 0))
+      create(:customs_tariff_pipeline_alert,
+             alert_type: 'review_backlog_growth',
+             severity: 'warning',
+             status: 'resolved',
+             triggered_at: Time.zone.local(2026, 6, 5, 9, 0, 0))
+    end
+
+    it 'returns alerts most recent first' do
+      get '/uk/admin/customs_tariff_pipeline/alerts.json', headers: request_headers(format: :json)
+
+      json = JSON.parse(response.body)
+      expect(response).to have_http_status(:ok)
+      expect(json['data'].map { |row| row.dig('attributes', 'alert_type') }).to eq(%w[failed_import review_backlog_growth])
+    end
+
+    it 'filters open critical alerts' do
+      get '/uk/admin/customs_tariff_pipeline/alerts.json',
+          params: { status: 'open', severity: 'critical' },
+          headers: request_headers(format: :json)
+
+      json = JSON.parse(response.body)
+      expect(json['data'].length).to eq(1)
+      expect(json['data'].first.dig('attributes', 'alert_type')).to eq('failed_import')
+    end
+  end
+end

--- a/spec/requests/api/admin/customs_tariff_pipeline/dashboard_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_pipeline/dashboard_controller_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe Api::Admin::CustomsTariffPipeline::DashboardController do
+  describe 'GET #show' do
+    before do
+      create(:customs_tariff_pipeline_event,
+             event_type: 'import',
+             outcome: 'succeeded',
+             occurred_at: Time.zone.local(2026, 6, 5, 9, 0, 0))
+      create(:customs_tariff_pipeline_event,
+             event_type: 'publish',
+             outcome: 'failed',
+             occurred_at: Time.zone.local(2026, 6, 5, 10, 0, 0))
+      create(:customs_tariff_pipeline_metric_bin,
+             metric_name: 'review_backlog',
+             bucket_size: 'hour',
+             count: 0,
+             value_last: 7,
+             bucket_start_at: Time.zone.local(2026, 6, 5, 10, 0, 0))
+      create(:customs_tariff_pipeline_metric_bin,
+             metric_name: 'import_runs',
+             bucket_size: 'hour',
+             bucket_start_at: Time.zone.local(2026, 6, 5, 10, 0, 0))
+      create(:customs_tariff_pipeline_alert,
+             alert_type: 'failed_publication',
+             status: 'open',
+             triggered_at: Time.zone.local(2026, 6, 5, 10, 5, 0))
+    end
+
+    it 'returns the dashboard summary' do
+      get '/uk/admin/customs_tariff_pipeline/dashboard.json',
+          params: { bucket_size: 'hour', from: '2026-06-05T08:00:00Z', to: '2026-06-05T11:00:00Z' },
+          headers: request_headers(format: :json)
+
+      json = JSON.parse(response.body)
+      attributes = json.dig('data', 'attributes')
+
+      expect(response).to have_http_status(:ok)
+      expect(json.dig('data', 'type')).to eq('customs_tariff_pipeline_dashboard')
+      expect(attributes.dig('latest_import_event', 'outcome')).to eq('succeeded')
+      expect(attributes.dig('latest_publication_event', 'outcome')).to eq('failed')
+      expect(attributes.dig('review_backlog', 'value_last')).to eq(7)
+      expect(attributes['open_alerts_count']).to eq(1)
+      expect(attributes['metric_bins'].length).to eq(2)
+    end
+  end
+end

--- a/spec/requests/api/admin/customs_tariff_pipeline/events_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_pipeline/events_controller_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe Api::Admin::CustomsTariffPipeline::EventsController do
+  describe 'GET #index' do
+    let!(:import_event) do
+      create(:customs_tariff_pipeline_event,
+             event_type: 'import',
+             outcome: 'succeeded',
+             customs_tariff_update_version: '1.1',
+             occurred_at: Time.zone.local(2026, 6, 5, 10, 0, 0))
+    end
+    let!(:publish_event) do
+      create(:customs_tariff_pipeline_event,
+             event_type: 'publish',
+             outcome: 'failed',
+             customs_tariff_update_version: '1.2',
+             occurred_at: Time.zone.local(2026, 6, 5, 11, 0, 0))
+    end
+
+    it 'returns pipeline events most recent first' do
+      get '/uk/admin/customs_tariff_pipeline/events.json', headers: request_headers(format: :json)
+
+      json = JSON.parse(response.body)
+      expect(response).to have_http_status(:ok)
+      expect(json['data'].map { |row| row.dig('attributes', 'event_type') }).to eq(%w[publish import])
+      expect(json.dig('meta', 'pagination')).to include('page' => 1, 'total_count' => 2)
+    end
+
+    it 'filters by event type and time range' do
+      get '/uk/admin/customs_tariff_pipeline/events.json',
+          params: { event_type: 'import', from: '2026-06-05T09:30:00Z', to: '2026-06-05T10:30:00Z' },
+          headers: request_headers(format: :json)
+
+      json = JSON.parse(response.body)
+      expect(json['data'].length).to eq(1)
+      expect(json['data'].first.dig('attributes', 'customs_tariff_update_version')).to eq(import_event.customs_tariff_update_version)
+    end
+
+    it 'filters by outcome and source document version' do
+      get '/uk/admin/customs_tariff_pipeline/events.json',
+          params: { outcome: 'failed', customs_tariff_update_version: publish_event.customs_tariff_update_version },
+          headers: request_headers(format: :json)
+
+      json = JSON.parse(response.body)
+      expect(json['data'].length).to eq(1)
+      expect(json['data'].first.dig('attributes', 'event_type')).to eq('publish')
+    end
+  end
+end

--- a/spec/requests/api/admin/customs_tariff_pipeline/metric_bins_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_pipeline/metric_bins_controller_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe Api::Admin::CustomsTariffPipeline::MetricBinsController do
+  describe 'GET #index' do
+    before do
+      create(:customs_tariff_pipeline_metric_bin,
+             metric_name: 'import_runs',
+             bucket_size: 'hour',
+             bucket_start_at: Time.zone.local(2026, 6, 5, 9, 0, 0))
+      create(:customs_tariff_pipeline_metric_bin,
+             metric_name: 'review_backlog',
+             bucket_size: 'hour',
+             event_type: 'review',
+             outcome: 'pending',
+             count: 0,
+             value_last: 12,
+             bucket_start_at: Time.zone.local(2026, 6, 5, 10, 0, 0))
+    end
+
+    it 'returns metric bins earliest first' do
+      get '/uk/admin/customs_tariff_pipeline/metric_bins.json', headers: request_headers(format: :json)
+
+      json = JSON.parse(response.body)
+      expect(response).to have_http_status(:ok)
+      expect(json['data'].map { |row| row.dig('attributes', 'metric_name') }).to eq(%w[import_runs review_backlog])
+    end
+
+    it 'filters by metric name and bucket size' do
+      get '/uk/admin/customs_tariff_pipeline/metric_bins.json',
+          params: { metric_name: 'review_backlog', bucket_size: 'hour' },
+          headers: request_headers(format: :json)
+
+      json = JSON.parse(response.body)
+      expect(json['data'].length).to eq(1)
+      expect(json['data'].first.dig('attributes', 'value_last')).to eq(12)
+    end
+  end
+end


### PR DESCRIPTION
## What:
- [x] Add read-only admin endpoints for customs tariff pipeline events, metric bins and alerts
- [x] Add a customs tariff pipeline dashboard resource that returns latest import status, latest publication status, review backlog, open alert count, recent open alerts and time-series metric bins
- [x] Add filter support for admin UI time ranges and drill-downs: `from`, `to`, `event_type`, `outcome`, `status`, `severity`, `metric_name`, `bucket_size`, `note_type` and `customs_tariff_update_version`
- [x] Add request specs and factories for the new API resources

## Why:
AI-521 needs operators to see import status, review backlog, publication status, failures, alert state and source-document context efficiently in the admin UI. These endpoints expose the binned observability schema from the parent PR without forcing the UI to scan raw event rows for every dashboard view.

## Ticket:
[AI-521](https://transformuk.atlassian.net/browse/AI-521)

## Risk:
**Risk level:** 🟠

**Reason for rating:**
This adds new read-only admin API endpoints intended for the admin UI. It does not change existing tariff note publication behaviour, but new consumed API surface is amber under the repo risk decision tree.
