### PR TITLE
AI-521: Add tariff note pipeline RED dashboard

### DIFF
--- a/app/controllers/api/admin/customs_tariff_updates/section_notes_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates/section_notes_controller.rb
@@ -59,6 +59,13 @@ module Api
           note.set(content: section_note_params[:content])
 
           if note.save(raise_on_failure: false)
+            CustomsTariffImporter::Instrumentation.section_note_updated(
+              version: customs_tariff_update.version,
+              section_id: note.section_id,
+              note_id: note.id,
+              whodunnit: TradeTariffRequest.whodunnit,
+            )
+
             render json: Api::Admin::CustomsTariffUpdates::SectionNoteSerializer.new(note, is_collection: false).serializable_hash
           else
             render json: Api::Admin::ErrorSerializationService.new(note).call, status: :unprocessable_content

--- a/app/controllers/api/admin/customs_tariff_updates/status_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates/status_controller.rb
@@ -19,7 +19,15 @@ module Api
             return
           end
 
+          previous_status = customs_tariff_update.status
           customs_tariff_update.update(status: new_status)
+          CustomsTariffImporter::Instrumentation.status_changed(
+            version: customs_tariff_update.version,
+            from_status: previous_status,
+            to_status: new_status,
+            whodunnit: TradeTariffRequest.whodunnit,
+          )
+
           render json: Api::Admin::CustomsTariffUpdateSerializer.new(customs_tariff_update, is_collection: false).serializable_hash
         end
 

--- a/app/controllers/api/admin/customs_tariff_updates/status_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates/status_controller.rb
@@ -26,6 +26,7 @@ module Api
             from_status: previous_status,
             to_status: new_status,
             whodunnit: TradeTariffRequest.whodunnit,
+            review_backlog: CustomsTariffUpdate.pending.count,
           )
 
           render json: Api::Admin::CustomsTariffUpdateSerializer.new(customs_tariff_update, is_collection: false).serializable_hash

--- a/app/lib/customs_tariff_importer/instrumentation.rb
+++ b/app/lib/customs_tariff_importer/instrumentation.rb
@@ -12,8 +12,8 @@ module CustomsTariffImporter
       instrument('import_run_started')
     end
 
-    def import_run_completed(imported:, skipped:, failed:, duration_ms:)
-      instrument('import_run_completed', imported:, skipped:, failed:, duration_ms:)
+    def import_run_completed(imported:, skipped:, failed:, duration_ms:, review_backlog:)
+      instrument('import_run_completed', imported:, skipped:, failed:, duration_ms:, review_backlog:)
     end
 
     def import_run_failed(error_class:, error_message:)
@@ -56,8 +56,8 @@ module CustomsTariffImporter
       instrument('document_import_failed', version:, error_class:, error_message:)
     end
 
-    def status_changed(version:, from_status:, to_status:, whodunnit:)
-      instrument('status_changed', version:, from_status:, to_status:, whodunnit:)
+    def status_changed(version:, from_status:, to_status:, whodunnit:, review_backlog:)
+      instrument('status_changed', version:, from_status:, to_status:, whodunnit:, review_backlog:)
     end
 
     def section_note_updated(version:, section_id:, note_id:, whodunnit:)

--- a/app/lib/customs_tariff_importer/instrumentation.rb
+++ b/app/lib/customs_tariff_importer/instrumentation.rb
@@ -55,5 +55,13 @@ module CustomsTariffImporter
     def document_import_failed(version:, error_class:, error_message:)
       instrument('document_import_failed', version:, error_class:, error_message:)
     end
+
+    def status_changed(version:, from_status:, to_status:, whodunnit:)
+      instrument('status_changed', version:, from_status:, to_status:, whodunnit:)
+    end
+
+    def section_note_updated(version:, section_id:, note_id:, whodunnit:)
+      instrument('section_note_updated', version:, section_id:, note_id:, whodunnit:)
+    end
   end
 end

--- a/app/lib/customs_tariff_importer/logger.rb
+++ b/app/lib/customs_tariff_importer/logger.rb
@@ -94,6 +94,26 @@ module CustomsTariffImporter
       )
     end
 
+    def status_changed(event)
+      info log_entry(
+        event: 'status_changed',
+        version: event.payload[:version],
+        from_status: event.payload[:from_status],
+        to_status: event.payload[:to_status],
+        whodunnit: event.payload[:whodunnit],
+      )
+    end
+
+    def section_note_updated(event)
+      info log_entry(
+        event: 'section_note_updated',
+        version: event.payload[:version],
+        section_id: event.payload[:section_id],
+        note_id: event.payload[:note_id],
+        whodunnit: event.payload[:whodunnit],
+      )
+    end
+
     private
 
     def log_entry(data)

--- a/app/lib/customs_tariff_importer/logger.rb
+++ b/app/lib/customs_tariff_importer/logger.rb
@@ -13,6 +13,7 @@ module CustomsTariffImporter
         skipped: event.payload[:skipped],
         failed: event.payload[:failed],
         duration_ms: event.payload[:duration_ms],
+        review_backlog: event.payload[:review_backlog],
       )
     end
 
@@ -101,6 +102,7 @@ module CustomsTariffImporter
         from_status: event.payload[:from_status],
         to_status: event.payload[:to_status],
         whodunnit: event.payload[:whodunnit],
+        review_backlog: event.payload[:review_backlog],
       )
     end
 

--- a/app/workers/import_customs_tariff_document_worker.rb
+++ b/app/workers/import_customs_tariff_document_worker.rb
@@ -18,6 +18,7 @@ class ImportCustomsTariffDocumentWorker
       skipped: results.count { |r| %i[skipped duplicate_content].include?(r.status) },
       failed: results.count { |r| r.status == :failed },
       duration_ms:,
+      review_backlog: CustomsTariffUpdate.pending.count,
     )
   rescue StandardError => e
     CustomsTariffImporter::Instrumentation.import_run_failed(

--- a/spec/lib/customs_tariff_importer/instrumentation_spec.rb
+++ b/spec/lib/customs_tariff_importer/instrumentation_spec.rb
@@ -120,4 +120,26 @@ RSpec.describe CustomsTariffImporter::Instrumentation do
       )
     end
   end
+
+  describe '.status_changed' do
+    it 'emits status_changed with the operator and status transition' do
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+      described_class.status_changed(version: '1.30', from_status: 'pending', to_status: 'approved', whodunnit: 'user-1')
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'status_changed.customs_tariff_importer',
+        hash_including(version: '1.30', from_status: 'pending', to_status: 'approved', whodunnit: 'user-1'),
+      )
+    end
+  end
+
+  describe '.section_note_updated' do
+    it 'emits section_note_updated with the operator and note identifiers' do
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+      described_class.section_note_updated(version: '1.30', section_id: 1, note_id: 12, whodunnit: 'user-1')
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'section_note_updated.customs_tariff_importer',
+        hash_including(version: '1.30', section_id: 1, note_id: 12, whodunnit: 'user-1'),
+      )
+    end
+  end
 end

--- a/spec/lib/customs_tariff_importer/instrumentation_spec.rb
+++ b/spec/lib/customs_tariff_importer/instrumentation_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe CustomsTariffImporter::Instrumentation do
   describe '.import_run_completed' do
     it 'emits import_run_completed with counts and duration' do
       allow(ActiveSupport::Notifications).to receive(:instrument)
-      described_class.import_run_completed(imported: 2, skipped: 1, failed: 0, duration_ms: 1500.0)
+      described_class.import_run_completed(imported: 2, skipped: 1, failed: 0, duration_ms: 1500.0, review_backlog: 3)
       expect(ActiveSupport::Notifications).to have_received(:instrument).with(
         'import_run_completed.customs_tariff_importer',
-        hash_including(imported: 2, skipped: 1, failed: 0, duration_ms: 1500.0),
+        hash_including(imported: 2, skipped: 1, failed: 0, duration_ms: 1500.0, review_backlog: 3),
       )
     end
   end
@@ -124,10 +124,10 @@ RSpec.describe CustomsTariffImporter::Instrumentation do
   describe '.status_changed' do
     it 'emits status_changed with the operator and status transition' do
       allow(ActiveSupport::Notifications).to receive(:instrument)
-      described_class.status_changed(version: '1.30', from_status: 'pending', to_status: 'approved', whodunnit: 'user-1')
+      described_class.status_changed(version: '1.30', from_status: 'pending', to_status: 'approved', whodunnit: 'user-1', review_backlog: 2)
       expect(ActiveSupport::Notifications).to have_received(:instrument).with(
         'status_changed.customs_tariff_importer',
-        hash_including(version: '1.30', from_status: 'pending', to_status: 'approved', whodunnit: 'user-1'),
+        hash_including(version: '1.30', from_status: 'pending', to_status: 'approved', whodunnit: 'user-1', review_backlog: 2),
       )
     end
   end

--- a/spec/lib/customs_tariff_importer/logger_spec.rb
+++ b/spec/lib/customs_tariff_importer/logger_spec.rb
@@ -184,4 +184,48 @@ RSpec.describe CustomsTariffImporter::Logger do
       end
     end
   end
+
+  describe '#status_changed' do
+    it 'logs the status transition and operator' do
+      allow(log_subscriber).to receive(:info)
+
+      log_subscriber.status_changed(build_event(
+                                      'status_changed',
+                                      payload: { version: '1.30', from_status: 'pending', to_status: 'approved', whodunnit: 'user-1' },
+                                    ))
+
+      expect(log_subscriber).to have_received(:info) do |json|
+        entry = JSON.parse(json)
+        expect(entry).to include(
+          'event' => 'status_changed',
+          'version' => '1.30',
+          'from_status' => 'pending',
+          'to_status' => 'approved',
+          'whodunnit' => 'user-1',
+        )
+      end
+    end
+  end
+
+  describe '#section_note_updated' do
+    it 'logs the note identifiers and operator' do
+      allow(log_subscriber).to receive(:info)
+
+      log_subscriber.section_note_updated(build_event(
+                                            'section_note_updated',
+                                            payload: { version: '1.30', section_id: 1, note_id: 12, whodunnit: 'user-1' },
+                                          ))
+
+      expect(log_subscriber).to have_received(:info) do |json|
+        entry = JSON.parse(json)
+        expect(entry).to include(
+          'event' => 'section_note_updated',
+          'version' => '1.30',
+          'section_id' => 1,
+          'note_id' => 12,
+          'whodunnit' => 'user-1',
+        )
+      end
+    end
+  end
 end

--- a/spec/lib/customs_tariff_importer/logger_spec.rb
+++ b/spec/lib/customs_tariff_importer/logger_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe CustomsTariffImporter::Logger do
 
       log_subscriber.import_run_completed(build_event(
                                             'import_run_completed',
-                                            payload: { imported: 2, skipped: 1, failed: 0, duration_ms: 3500.0 },
+                                            payload: { imported: 2, skipped: 1, failed: 0, duration_ms: 3500.0, review_backlog: 3 },
                                           ))
 
       expect(log_subscriber).to have_received(:info) do |json|
         entry = JSON.parse(json)
-        expect(entry).to include('imported' => 2, 'skipped' => 1, 'failed' => 0, 'duration_ms' => 3500.0)
+        expect(entry).to include('imported' => 2, 'skipped' => 1, 'failed' => 0, 'duration_ms' => 3500.0, 'review_backlog' => 3)
       end
     end
   end
@@ -191,7 +191,7 @@ RSpec.describe CustomsTariffImporter::Logger do
 
       log_subscriber.status_changed(build_event(
                                       'status_changed',
-                                      payload: { version: '1.30', from_status: 'pending', to_status: 'approved', whodunnit: 'user-1' },
+                                      payload: { version: '1.30', from_status: 'pending', to_status: 'approved', whodunnit: 'user-1', review_backlog: 2 },
                                     ))
 
       expect(log_subscriber).to have_received(:info) do |json|
@@ -202,6 +202,7 @@ RSpec.describe CustomsTariffImporter::Logger do
           'from_status' => 'pending',
           'to_status' => 'approved',
           'whodunnit' => 'user-1',
+          'review_backlog' => 2,
         )
       end
     end

--- a/spec/requests/api/admin/customs_tariff_updates/section_notes_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates/section_notes_controller_spec.rb
@@ -150,13 +150,23 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
     let!(:update) { create(:customs_tariff_update) }
     let!(:note)   { create(:customs_tariff_section_note, customs_tariff_update: update) }
 
+    before do
+      allow(CustomsTariffImporter::Instrumentation).to receive(:section_note_updated)
+    end
+
     it 'updates the content' do
       patch "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.id}.json",
             params: { data: { type: 'customs_tariff_section_note', attributes: { content: 'Updated content' } } },
-            headers: request_headers(format: :json), as: :json
+            headers: request_headers({ 'X-Whodunnit' => 'operator-1' }, format: :json), as: :json
 
       expect(response.status).to eq(200)
       expect(note.reload.content).to eq('Updated content')
+      expect(CustomsTariffImporter::Instrumentation).to have_received(:section_note_updated).with(
+        version: update.version,
+        section_id: note.section_id,
+        note_id: note.id,
+        whodunnit: 'operator-1',
+      )
     end
 
     it 'returns 422 when the parent update is rejected' do
@@ -167,6 +177,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
             headers: request_headers(format: :json), as: :json
 
       expect(response.status).to eq(422)
+      expect(CustomsTariffImporter::Instrumentation).not_to have_received(:section_note_updated)
     end
 
     it 'creates a Version record on successful save' do

--- a/spec/requests/api/admin/customs_tariff_updates/status_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates/status_controller_spec.rb
@@ -2,13 +2,23 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::StatusController do
   describe 'PATCH #update' do
     let!(:update) { create(:customs_tariff_update) }
 
+    before do
+      allow(CustomsTariffImporter::Instrumentation).to receive(:status_changed)
+    end
+
     it 'changes status to approved' do
       patch "/uk/admin/customs_tariff_updates/#{update.version}/status.json",
             params: { data: { attributes: { status: 'approved' } } },
-            headers: request_headers(format: :json), as: :json
+            headers: request_headers({ 'X-Whodunnit' => 'operator-1' }, format: :json), as: :json
 
       expect(response.status).to eq(200)
       expect(update.reload.status).to eq('approved')
+      expect(CustomsTariffImporter::Instrumentation).to have_received(:status_changed).with(
+        version: update.version,
+        from_status: 'pending',
+        to_status: 'approved',
+        whodunnit: 'operator-1',
+      )
     end
 
     it 'returns 422 when status is already the same' do
@@ -17,6 +27,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::StatusController do
             headers: request_headers(format: :json), as: :json
 
       expect(response.status).to eq(422)
+      expect(CustomsTariffImporter::Instrumentation).not_to have_received(:status_changed)
     end
 
     it 'returns 422 for an invalid status value' do
@@ -25,6 +36,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::StatusController do
             headers: request_headers(format: :json), as: :json
 
       expect(response.status).to eq(422)
+      expect(CustomsTariffImporter::Instrumentation).not_to have_received(:status_changed)
     end
 
     it 'allows changing the status of any update, not just the latest' do

--- a/spec/requests/api/admin/customs_tariff_updates/status_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates/status_controller_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::StatusController do
     end
 
     it 'changes status to approved' do
+      create(:customs_tariff_update)
+
       patch "/uk/admin/customs_tariff_updates/#{update.version}/status.json",
             params: { data: { attributes: { status: 'approved' } } },
             headers: request_headers({ 'X-Whodunnit' => 'operator-1' }, format: :json), as: :json
@@ -18,6 +20,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::StatusController do
         from_status: 'pending',
         to_status: 'approved',
         whodunnit: 'operator-1',
+        review_backlog: 1,
       )
     end
 

--- a/spec/workers/import_customs_tariff_document_worker_spec.rb
+++ b/spec/workers/import_customs_tariff_document_worker_spec.rb
@@ -25,12 +25,15 @@ RSpec.describe ImportCustomsTariffDocumentWorker, type: :worker do
     end
 
     it 'emits import_run_completed with correct counts' do
+      create(:customs_tariff_update)
+
       perform
       expect(CustomsTariffImporter::Instrumentation).to have_received(:import_run_completed).with(
         imported: 1,
         skipped: 0,
         failed: 0,
         duration_ms: a_kind_of(Float),
+        review_backlog: 1,
       )
     end
   end

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -28,6 +28,7 @@ Terraform to deploy the service into AWS.
 | <a name="module_search_operations_dashboard"></a> [search\_operations\_dashboard](#module\_search\_operations\_dashboard) | ./modules/search_operations_dashboard | n/a |
 | <a name="module_search_quality_dashboard"></a> [search\_quality\_dashboard](#module\_search\_quality\_dashboard) | ./modules/search_quality_dashboard | n/a |
 | <a name="module_self_text_generator_dashboard"></a> [self\_text\_generator\_dashboard](#module\_self\_text\_generator\_dashboard) | ./modules/self_text_generator_dashboard | n/a |
+| <a name="module_tariff_note_pipeline_dashboard"></a> [tariff\_note\_pipeline\_dashboard](#module\_tariff\_note\_pipeline\_dashboard) | ./modules/tariff_note_pipeline_dashboard | n/a |
 | <a name="module_tariff_sync_dashboard"></a> [tariff\_sync\_dashboard](#module\_tariff\_sync\_dashboard) | ./modules/tariff_sync_dashboard | n/a |
 | <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.1.0 |
 | <a name="module_worker_xi"></a> [worker\_xi](#module\_worker\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.1.0 |
@@ -98,5 +99,6 @@ Terraform to deploy the service into AWS.
 | <a name="output_search_operations_dashboard_url"></a> [search\_operations\_dashboard\_url](#output\_search\_operations\_dashboard\_url) | URL to the Search Operations CloudWatch dashboard |
 | <a name="output_search_quality_dashboard_url"></a> [search\_quality\_dashboard\_url](#output\_search\_quality\_dashboard\_url) | URL to the Search Quality CloudWatch dashboard |
 | <a name="output_self_text_generator_dashboard_url"></a> [self\_text\_generator\_dashboard\_url](#output\_self\_text\_generator\_dashboard\_url) | URL to the Self-Text Generator CloudWatch dashboard |
+| <a name="output_tariff_note_pipeline_dashboard_url"></a> [tariff\_note\_pipeline\_dashboard\_url](#output\_tariff\_note\_pipeline\_dashboard\_url) | URL to the Tariff Note Pipeline CloudWatch dashboard |
 | <a name="output_tariff_sync_dashboard_url"></a> [tariff\_sync\_dashboard\_url](#output\_tariff\_sync\_dashboard\_url) | URL to the Tariff Sync CloudWatch dashboard |
 <!-- END_TF_DOCS -->

--- a/terraform/dashboards.tf
+++ b/terraform/dashboards.tf
@@ -75,3 +75,16 @@ output "tariff_sync_dashboard_url" {
   description = "URL to the Tariff Sync CloudWatch dashboard"
   value       = module.tariff_sync_dashboard.dashboard_url
 }
+
+module "tariff_note_pipeline_dashboard" {
+  source = "./modules/tariff_note_pipeline_dashboard"
+
+  environment    = var.environment
+  log_group_name = "platform-logs-${var.environment}"
+  region         = var.region
+}
+
+output "tariff_note_pipeline_dashboard_url" {
+  description = "URL to the Tariff Note Pipeline CloudWatch dashboard"
+  value       = module.tariff_note_pipeline_dashboard.dashboard_url
+}

--- a/terraform/modules/tariff_note_pipeline_dashboard/README.md
+++ b/terraform/modules/tariff_note_pipeline_dashboard/README.md
@@ -1,0 +1,53 @@
+# tariff_note_pipeline_dashboard
+
+CloudWatch Logs Insights dashboard for the tariff note pipeline.
+
+The dashboard follows the RED model:
+
+- **Rate**: import runs, document outcomes, status changes and note edits.
+- **Errors**: failed import runs, fetches, parses and document imports.
+- **Duration**: import run, fetch, parse and document import latency percentiles.
+
+It reads structured JSON logs emitted by `CustomsTariffImporter::Logger` with `service = "customs_tariff_importer"`.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.12.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [aws_cloudwatch_dashboard.tariff_note_pipeline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_dashboard) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_dashboard_name"></a> [dashboard\_name](#input\_dashboard\_name) | Name of the CloudWatch dashboard | `string` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (e.g., development, staging, production) | `string` | n/a | yes |
+| <a name="input_log_group_name"></a> [log\_group\_name](#input\_log\_group\_name) | CloudWatch Log Group name where tariff note pipeline logs are sent | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | `"eu-west-2"` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_dashboard_arn"></a> [dashboard\_arn](#output\_dashboard\_arn) | ARN of the CloudWatch dashboard |
+| <a name="output_dashboard_name"></a> [dashboard\_name](#output\_dashboard\_name) | Name of the CloudWatch dashboard |
+| <a name="output_dashboard_url"></a> [dashboard\_url](#output\_dashboard\_url) | URL to the CloudWatch dashboard |
+<!-- END_TF_DOCS -->

--- a/terraform/modules/tariff_note_pipeline_dashboard/README.md
+++ b/terraform/modules/tariff_note_pipeline_dashboard/README.md
@@ -7,6 +7,7 @@ The dashboard follows the RED model:
 - **Rate**: import runs, document outcomes, status changes and note edits.
 - **Errors**: failed import runs, fetches, parses and document imports.
 - **Duration**: import run, fetch, parse and document import latency percentiles.
+- **Review backlog**: pending tariff note updates recorded on import completion and status changes.
 
 It reads structured JSON logs emitted by `CustomsTariffImporter::Logger` with `service = "customs_tariff_importer"`.
 

--- a/terraform/modules/tariff_note_pipeline_dashboard/main.tf
+++ b/terraform/modules/tariff_note_pipeline_dashboard/main.tf
@@ -22,8 +22,8 @@ resource "aws_cloudwatch_dashboard" "tariff_note_pipeline" {
             markdown = join("\n", [
               "## Tariff Note Pipeline RED Dashboard",
               "CloudWatch Logs Insights dashboard for the tariff note document import and admin review pipeline.",
-              "**Healthy:** import runs complete, failed event volume stays at zero, and p90 import/parse/fetch duration remains stable.",
-              "**Start here:** check Rate, Errors, and Duration in the first row. Use the drill-down tables for failed documents and operator status changes.",
+              "**Healthy:** import runs complete, failed event volume stays at zero, p90 import/parse/fetch duration remains stable, and review backlog does not grow unexpectedly.",
+              "**Start here:** check Rate, Errors, Duration, and Review Backlog in the first row. Use the drill-down tables for failed documents and operator status changes.",
               "**Related:** [Tariff Sync](${local.tariff_sync_dashboard_url})",
             ])
           }
@@ -95,7 +95,7 @@ resource "aws_cloudwatch_dashboard" "tariff_note_pipeline" {
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "import_run_completed"
-              | fields @timestamp, imported, skipped, failed, duration_ms
+              | fields @timestamp, imported, skipped, failed, review_backlog, duration_ms
               | sort @timestamp desc
               | limit 20
             EOT
@@ -184,13 +184,13 @@ resource "aws_cloudwatch_dashboard" "tariff_note_pipeline" {
           width  = 8
           height = 6
           properties = {
-            title  = "Admin Status Changes"
+            title  = "Review Backlog"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
-              | ${local.service_filter} and event = "status_changed"
-              | stats count(*) as changes by from_status, to_status, bin(1h)
+              | ${local.service_filter} and event in ["import_run_completed", "status_changed"] and ispresent(review_backlog)
+              | stats latest(review_backlog) as pending_updates by bin(1h)
             EOT
           }
         },
@@ -263,7 +263,7 @@ resource "aws_cloudwatch_dashboard" "tariff_note_pipeline" {
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event in ["status_changed", "section_note_updated"]
-              | fields @timestamp, event, version, from_status, to_status, section_id, note_id, whodunnit
+              | fields @timestamp, event, version, from_status, to_status, review_backlog, section_id, note_id, whodunnit
               | sort @timestamp desc
               | limit 30
             EOT

--- a/terraform/modules/tariff_note_pipeline_dashboard/main.tf
+++ b/terraform/modules/tariff_note_pipeline_dashboard/main.tf
@@ -1,0 +1,275 @@
+locals {
+  dashboard_name = var.dashboard_name != null ? var.dashboard_name : "TariffNotePipeline-${var.environment}"
+  source         = "SOURCE '${var.log_group_name}'"
+  service_filter = "filter service = \"customs_tariff_importer\""
+
+  tariff_sync_dashboard_url = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=TariffSync-${var.environment}"
+}
+
+resource "aws_cloudwatch_dashboard" "tariff_note_pipeline" {
+  dashboard_name = local.dashboard_name
+
+  dashboard_body = jsonencode({
+    widgets = concat(
+      [
+        {
+          type   = "text"
+          x      = 0
+          y      = 0
+          width  = 24
+          height = 2
+          properties = {
+            markdown = join("\n", [
+              "## Tariff Note Pipeline RED Dashboard",
+              "CloudWatch Logs Insights dashboard for the tariff note document import and admin review pipeline.",
+              "**Healthy:** import runs complete, failed event volume stays at zero, and p90 import/parse/fetch duration remains stable.",
+              "**Start here:** check Rate, Errors, and Duration in the first row. Use the drill-down tables for failed documents and operator status changes.",
+              "**Related:** [Tariff Sync](${local.tariff_sync_dashboard_url})",
+            ])
+          }
+        }
+      ],
+
+      # RED row: request rate, errors and duration.
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 2
+          width  = 6
+          height = 6
+          properties = {
+            title  = "Rate: Pipeline Events"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event in ["import_run_started", "import_run_completed", "document_imported", "document_skipped", "status_changed", "section_note_updated"]
+              | stats count(*) as count by event, bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 6
+          y      = 2
+          width  = 6
+          height = 6
+          properties = {
+            title  = "Errors: Failed Events"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event in ["import_run_failed", "fetch_failed", "parse_failed", "document_import_failed"]
+              | stats count(*) as errors by event, bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 12
+          y      = 2
+          width  = 6
+          height = 6
+          properties = {
+            title  = "Duration: Run p50/p90/p99 (ms)"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "import_run_completed"
+              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90, pct(duration_ms, 99) as p99 by bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 18
+          y      = 2
+          width  = 6
+          height = 6
+          properties = {
+            title  = "Recent Import Runs"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "import_run_completed"
+              | fields @timestamp, imported, skipped, failed, duration_ms
+              | sort @timestamp desc
+              | limit 20
+            EOT
+          }
+        }
+      ],
+
+      # Import phase breakdown.
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 8
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Fetch Duration p50/p90/p99 (ms)"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "document_fetched"
+              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90, pct(duration_ms, 99) as p99 by bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 8
+          y      = 8
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Parse Duration p50/p90/p99 (ms)"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "document_parsed"
+              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90, pct(duration_ms, 99) as p99 by bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 16
+          y      = 8
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Document Import Duration p50/p90/p99 (ms)"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "document_imported"
+              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90, pct(duration_ms, 99) as p99 by bin(1h)
+            EOT
+          }
+        }
+      ],
+
+      # Content and review activity.
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 14
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Extracted Content Counts"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "document_parsed"
+              | stats max(chapters) as chapters, max(sections) as sections, max(rules) as rules by version, bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 8
+          y      = 14
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Admin Status Changes"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "status_changed"
+              | stats count(*) as changes by from_status, to_status, bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 16
+          y      = 14
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Section Note Edits"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "section_note_updated"
+              | stats count(*) as edits by version, bin(1h)
+            EOT
+          }
+        }
+      ],
+
+      # Drill-down tables.
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 20
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Recent Failures"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event in ["import_run_failed", "fetch_failed", "parse_failed", "document_import_failed"]
+              | fields @timestamp, event, version, url, error_class, error_message
+              | sort @timestamp desc
+              | limit 30
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 8
+          y      = 20
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Recent Document Outcomes"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event in ["document_imported", "document_skipped", "document_import_failed"]
+              | fields @timestamp, event, version, reason, duration_ms, error_class, error_message
+              | sort @timestamp desc
+              | limit 30
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 16
+          y      = 20
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Recent Admin Changes"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event in ["status_changed", "section_note_updated"]
+              | fields @timestamp, event, version, from_status, to_status, section_id, note_id, whodunnit
+              | sort @timestamp desc
+              | limit 30
+            EOT
+          }
+        }
+      ]
+    )
+  })
+}

--- a/terraform/modules/tariff_note_pipeline_dashboard/outputs.tf
+++ b/terraform/modules/tariff_note_pipeline_dashboard/outputs.tf
@@ -1,0 +1,14 @@
+output "dashboard_arn" {
+  description = "ARN of the CloudWatch dashboard"
+  value       = aws_cloudwatch_dashboard.tariff_note_pipeline.dashboard_arn
+}
+
+output "dashboard_name" {
+  description = "Name of the CloudWatch dashboard"
+  value       = aws_cloudwatch_dashboard.tariff_note_pipeline.dashboard_name
+}
+
+output "dashboard_url" {
+  description = "URL to the CloudWatch dashboard"
+  value       = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${local.dashboard_name}"
+}

--- a/terraform/modules/tariff_note_pipeline_dashboard/variables.tf
+++ b/terraform/modules/tariff_note_pipeline_dashboard/variables.tf
@@ -1,0 +1,21 @@
+variable "environment" {
+  description = "Environment name (e.g., development, staging, production)"
+  type        = string
+}
+
+variable "log_group_name" {
+  description = "CloudWatch Log Group name where tariff note pipeline logs are sent"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "eu-west-2"
+}
+
+variable "dashboard_name" {
+  description = "Name of the CloudWatch dashboard"
+  type        = string
+  default     = null
+}

--- a/terraform/modules/tariff_note_pipeline_dashboard/versions.tf
+++ b/terraform/modules/tariff_note_pipeline_dashboard/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">=1.12.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5"
+    }
+  }
+}


### PR DESCRIPTION
## What:
- Add a Tariff Note Pipeline CloudWatch RED dashboard for pipeline rate, errors and duration.
- Surface import run, fetch, parse, document import, status change and section-note edit events from structured `customs_tariff_importer` logs.
- Add admin status-change and section-note edit instrumentation so review activity is visible in the dashboard.
- Close out the earlier DB/API direction in favour of additive observability through Terraform and standard instrumentation.

## Why:
AI-521 asks for audit, monitoring and alerting for the tariff note pipeline. The story wording points at operational dashboards and alerts rather than new backend storage/API tables, so this follows the existing CloudWatch dashboard pattern used by Search, Label Generator, Self Text Generator and Tariff Sync.

## Ticket:
https://transformuk.atlassian.net/browse/AI-521

## Risk:
**Risk level:** 🟢

**Reason for rating:**
This is additive read-only observability plus structured logging for successful admin state changes. It does not change trader-facing content, tariff calculation, database schema, API contracts, IAM, networking or resource replacement semantics.