### PR TITLE
BAU: Log search type for selected results

### DIFF
--- a/app/controllers/concerns/search_result_tracking.rb
+++ b/app/controllers/concerns/search_result_tracking.rb
@@ -11,6 +11,7 @@ module SearchResultTracking
 
     ::Search::Instrumentation.result_selected(
       request_id: rid,
+      search_type: 'classic',
       goods_nomenclature_item_id: params[:id],
       goods_nomenclature_class: controller_name.classify,
     )

--- a/app/lib/search/instrumentation.rb
+++ b/app/lib/search/instrumentation.rb
@@ -196,8 +196,8 @@ module Search
       )
     end
 
-    def result_selected(request_id:, goods_nomenclature_item_id:, goods_nomenclature_class:)
-      instrument('result_selected', request_id:, goods_nomenclature_item_id:, goods_nomenclature_class:)
+    def result_selected(request_id:, search_type:, goods_nomenclature_item_id:, goods_nomenclature_class:)
+      instrument('result_selected', request_id:, search_type:, goods_nomenclature_item_id:, goods_nomenclature_class:)
     end
 
     def search_failed(request_id:, error_type:, error_message:, search_type:)

--- a/app/lib/search/logger.rb
+++ b/app/lib/search/logger.rb
@@ -177,6 +177,7 @@ module Search
       info log_entry(
         event: 'result_selected',
         request_id: event.payload[:request_id],
+        search_type: event.payload[:search_type],
         goods_nomenclature_item_id: event.payload[:goods_nomenclature_item_id],
         goods_nomenclature_class: event.payload[:goods_nomenclature_class],
       )

--- a/spec/lib/search/instrumentation_spec.rb
+++ b/spec/lib/search/instrumentation_spec.rb
@@ -620,6 +620,7 @@ RSpec.describe Search::Instrumentation do
 
       described_class.result_selected(
         request_id: 'req-1',
+        search_type: 'classic',
         goods_nomenclature_item_id: '4202210000',
         goods_nomenclature_class: 'Commodity',
       )
@@ -627,6 +628,7 @@ RSpec.describe Search::Instrumentation do
       expect(ActiveSupport::Notifications).to have_received(:instrument).with(
         'result_selected.search',
         request_id: 'req-1',
+        search_type: 'classic',
         goods_nomenclature_item_id: '4202210000',
         goods_nomenclature_class: 'Commodity',
       )

--- a/spec/lib/search/logger_spec.rb
+++ b/spec/lib/search/logger_spec.rb
@@ -350,15 +350,16 @@ RSpec.describe Search::Logger do
   end
 
   describe '#result_selected' do
-    let(:payload) { { request_id: 'req-1', goods_nomenclature_item_id: '4202210000', goods_nomenclature_class: 'Commodity' } }
+    let(:payload) { { request_id: 'req-1', search_type: 'classic', goods_nomenclature_item_id: '4202210000', goods_nomenclature_class: 'Commodity' } }
 
     it_behaves_like 'a search log entry', :result_selected, 'result_selected',
-                    { request_id: 'req-1', goods_nomenclature_item_id: '4202210000', goods_nomenclature_class: 'Commodity' }
+                    { request_id: 'req-1', search_type: 'classic', goods_nomenclature_item_id: '4202210000', goods_nomenclature_class: 'Commodity' }
 
     it 'logs correct fields' do
       logger_instance.result_selected(build_event('result_selected', payload))
       json = parsed_log_output
       expect(json['event']).to eq('result_selected')
+      expect(json['search_type']).to eq('classic')
       expect(json['goods_nomenclature_item_id']).to eq('4202210000')
       expect(json['goods_nomenclature_class']).to eq('Commodity')
     end

--- a/spec/requests/concerns/search_result_tracking_spec.rb
+++ b/spec/requests/concerns/search_result_tracking_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe SearchResultTracking, :v2, type: :request do
 
         expect(Search::Instrumentation).to have_received(:result_selected).with(
           request_id: 'req-abc-123',
+          search_type: 'classic',
           goods_nomenclature_item_id: commodity.code,
           goods_nomenclature_class: 'Commodity',
         )
@@ -33,6 +34,7 @@ RSpec.describe SearchResultTracking, :v2, type: :request do
 
         expect(Search::Instrumentation).to have_received(:result_selected).with(
           request_id: 'req-def-456',
+          search_type: 'classic',
           goods_nomenclature_item_id: commodity.code,
           goods_nomenclature_class: 'Commodity',
         )


### PR DESCRIPTION
## What

Adds `search_type: classic` to the `result_selected` search instrumentation path for public tariff entity selections, and includes it in the structured search log output.

## Why

Search diagnostics in admin showed `-` in the Type column for selected-result rows. The admin UI was reading the top-level `search_type` field correctly, but backend logs were not emitting that field for `result_selected` events.

## Impact

New selected-result logs will include the classic search type, so diagnostics can show a complete Type value for clicked results. Existing historical logs will remain unchanged.

## Verification

- `PGHOST=/home/william/Repositories/hmrc/trade-tariff-backend/.nix/postgres DB_USER= bundle exec rspec spec/requests/concerns/search_result_tracking_spec.rb spec/lib/search/instrumentation_spec.rb spec/lib/search/logger_spec.rb`
- `PGHOST=/home/william/Repositories/hmrc/trade-tariff-backend/.nix/postgres DB_USER= bundle exec rubocop app/controllers/concerns/search_result_tracking.rb app/lib/search/instrumentation.rb app/lib/search/logger.rb spec/requests/concerns/search_result_tracking_spec.rb spec/lib/search/instrumentation_spec.rb spec/lib/search/logger_spec.rb`