### PR TITLE
Add risk label workflow

### DIFF
--- a/.github/workflows/risk-label.yml
+++ b/.github/workflows/risk-label.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Detect risk level and apply label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const body = context.payload.pull_request.body || '';

--- a/.github/workflows/risk-label.yml
+++ b/.github/workflows/risk-label.yml
@@ -1,0 +1,97 @@
+name: "Risk Label"
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+jobs:
+  risk-label:
+    name: Apply risk label
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Detect risk level and apply label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const prNumber = context.payload.pull_request.number;
+
+            const GREEN = '🟢';
+            const AMBER = '🟠';
+            const RED   = '🔴';
+
+            const LABEL_LOW    = 'low-risk';
+            const LABEL_MEDIUM = 'medium-risk';
+            const LABEL_HIGH   = 'high-risk';
+            const RISK_LABELS  = [LABEL_LOW, LABEL_MEDIUM, LABEL_HIGH];
+
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existingRiskLabel = currentLabels.find(l => RISK_LABELS.includes(l.name));
+
+            // Prefer emoji in the body; fall back to an already-applied risk label.
+            const hasGreen = body.includes(GREEN);
+            const hasAmber = body.includes(AMBER);
+            const hasRed   = body.includes(RED);
+
+            let detectedLabel = null;
+
+            if (hasRed) {
+              detectedLabel = LABEL_HIGH;
+            } else if (hasAmber) {
+              detectedLabel = LABEL_MEDIUM;
+            } else if (hasGreen) {
+              detectedLabel = LABEL_LOW;
+            } else if (existingRiskLabel) {
+              detectedLabel = existingRiskLabel.name;
+            }
+
+            if (!detectedLabel) {
+              core.setFailed(
+                'No risk level found. Add 🟢, 🟠, or 🔴 to the PR description, or apply a risk label manually.'
+              );
+              return;
+            }
+
+            // Remove stale risk labels before applying the detected one.
+            for (const label of currentLabels) {
+              if (RISK_LABELS.includes(label.name) && label.name !== detectedLabel) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo:  context.repo.repo,
+                  issue_number: prNumber,
+                  name: label.name,
+                });
+              }
+            }
+
+            if (!existingRiskLabel || existingRiskLabel.name !== detectedLabel) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: prNumber,
+                labels: [detectedLabel],
+              });
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              issue_number: prNumber,
+              labels: [detectedLabel],
+            });
+
+            if (detectedLabel === LABEL_HIGH) {
+              core.setFailed(
+                '🔴 This PR is rated HIGH RISK. An admin must bypass branch protection to merge it.'
+              );
+            }


### PR DESCRIPTION
## What:
Adds a GitHub Actions workflow (`.github/workflows/risk-label.yml`) that automatically applies `low-risk`, `medium-risk`, or `high-risk` labels to PRs based on the risk emoji in the description.

## Why:
Developers are already asked to rate risk in the PR template. This workflow enforces that they do so and surfaces the rating as a visible label. High-risk PRs fail the check, requiring an admin branch protection bypass to merge.

## How it works:
- Triggers on PR `opened`, `edited`, and `synchronize` events
- Scans the PR body for 🟢 (low), 🟠 (medium), or 🔴 (high) emoji — red takes priority if multiple are present
- Falls back to an already-applied risk label if no emoji are found
- Fails the check if no risk level is expressed at all
- Fails the check for high-risk PRs so an admin must bypass to merge

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
New workflow file only — no application code changed.