### PR TITLE
BAU_: Remove redundant .presence || nil

### DIFF
--- a/app/lib/reporting/declarable_duties/presented_measure.rb
+++ b/app/lib/reporting/declarable_duties/presented_measure.rb
@@ -66,7 +66,7 @@ module Reporting
           condition << "certificate:#{measure_condition.document_code}" if measure_condition.document_code.present?
           condition << "action:#{measure_condition.action_code}"
           condition.join(',')
-        }.join('|').presence || nil
+        }.join('|').presence
       end
 
       def measure__geographical_area__sid

--- a/app/lib/reporting/differences/loaders/me16.rb
+++ b/app/lib/reporting/differences/loaders/me16.rb
@@ -79,7 +79,7 @@ module Reporting
           end
 
           def additional_code
-            "#{additional_code_type_id}#{additional_code_id}".presence || nil
+            "#{additional_code_type_id}#{additional_code_id}".presence
           end
 
           def measure_type_description

--- a/app/lib/reporting/differences/loaders/me32.rb
+++ b/app/lib/reporting/differences/loaders/me32.rb
@@ -80,7 +80,7 @@ module Reporting
           end
 
           def additional_code
-            "#{additional_code_type_id}#{additional_code_id}".presence || nil
+            "#{additional_code_type_id}#{additional_code_id}".presence
           end
         end
       end

--- a/app/lib/reporting/differences/loaders/omitted_duty_measures.rb
+++ b/app/lib/reporting/differences/loaders/omitted_duty_measures.rb
@@ -168,7 +168,7 @@ module Reporting
           end
 
           def additional_code
-            "#{additional_code_type_id}#{additional_code_id}".presence || nil
+            "#{additional_code_type_id}#{additional_code_id}".presence
           end
         end
       end


### PR DESCRIPTION
## What:
Remove redundant .presence || nil

## Why:
.presence already returns nil for blank strings, so || nil does nothing.

## Ticket:
BAU

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
Small refactoring which doesn't have functional affect
