### PR TITLE
OTTIMP-640 Improve commodity end date removal tariff change information

### DIFF
--- a/app/models/tariff_change.rb
+++ b/app/models/tariff_change.rb
@@ -119,9 +119,8 @@ class TariffChange < Sequel::Model
     measure_metadata['quota_order_number']
   end
 
-  def measure_end_date_removed?
-    type == 'Measure' &&
-      action == TariffChangesService::BaseChanges::ENDING &&
+  def end_date_removed?
+    action == TariffChangesService::BaseChanges::ENDING &&
       validity_end_date.nil?
   end
 
@@ -141,7 +140,7 @@ class TariffChange < Sequel::Model
   # When this change becomes effective to the public.
   # e.g. for ENDING measures, it is no longer visible the day after its end date
   def date_of_effect_visible
-    return if measure_end_date_removed?
+    return if end_date_removed?
 
     action == TariffChangesService::BaseChanges::ENDING ? date_of_effect + 1.day : date_of_effect
   end

--- a/app/models/tariff_changes/grouped_measure_commodity_change.rb
+++ b/app/models/tariff_changes/grouped_measure_commodity_change.rb
@@ -63,7 +63,7 @@ module TariffChanges
         changes.sort_by(&:date_of_effect).map do |change|
           {
             measure_sid: change.object_sid,
-            date_of_effect: change.measure_end_date_removed? ? TariffChange::END_DATE_REMOVED_DISPLAY : change.date_of_effect,
+            date_of_effect: change.end_date_removed? ? TariffChange::END_DATE_REMOVED_DISPLAY : change.date_of_effect,
             date_of_effect_visible: change.date_of_effect_visible,
             change_type: change.description,
             additional_code: change.additional_code,

--- a/app/serializers/api/user/tariff_change_serializer.rb
+++ b/app/serializers/api/user/tariff_change_serializer.rb
@@ -9,7 +9,11 @@ module Api
 
       attributes :description, :goods_nomenclature_item_id
       attribute :date_of_effect do |tariff_change|
-        tariff_change.date_of_effect.strftime('%d/%m/%Y')
+        if tariff_change.end_date_removed?
+          TariffChange::END_DATE_REMOVED_DISPLAY
+        else
+          tariff_change.date_of_effect.strftime('%d/%m/%Y')
+        end
       end
       attribute :classification_description do |tariff_change|
         TimeMachine.at(tariff_change.date_of_effect) do

--- a/app/services/tariff_changes_service/presenter.rb
+++ b/app/services/tariff_changes_service/presenter.rb
@@ -72,13 +72,13 @@ class TariffChangesService
     end
 
     def date_of_effect
-      return TariffChange::END_DATE_REMOVED_DISPLAY if measure_end_date_removed?
+      return TariffChange::END_DATE_REMOVED_DISPLAY if end_date_removed?
 
       super.strftime('%d/%m/%Y')
     end
 
     def ott_url
-      query = measure_end_date_removed? ? UTM_TAGS : "#{ott_date_query}&#{UTM_TAGS}"
+      query = end_date_removed? ? UTM_TAGS : "#{ott_date_query}&#{UTM_TAGS}"
       url = "#{commodity_base_url}?#{query}"
       url += '#export' if trade_movement_code == 1
       url += '#import' if trade_movement_code.in?([0, 2])
@@ -87,7 +87,7 @@ class TariffChangesService
     end
 
     def api_url
-      query = measure_end_date_removed? ? UTM_TAGS : "as_of=#{date_of_effect_visible.strftime('%Y-%m-%d')}&#{UTM_TAGS}"
+      query = end_date_removed? ? UTM_TAGS : "as_of=#{date_of_effect_visible.strftime('%Y-%m-%d')}&#{UTM_TAGS}"
       "#{commodity_api_base_url}?#{query}"
     end
 

--- a/spec/models/tariff_change_spec.rb
+++ b/spec/models/tariff_change_spec.rb
@@ -590,7 +590,7 @@ RSpec.describe TariffChange do
     end
   end
 
-  describe '#measure_end_date_removed?' do
+  describe '#end_date_removed?' do
     context 'when Commodity and action is ending and validity_end_date is nil' do
       let(:tariff_change) do
         described_class.new(
@@ -602,8 +602,8 @@ RSpec.describe TariffChange do
         )
       end
 
-      it 'returns false' do
-        expect(tariff_change.measure_end_date_removed?).to be(false)
+      it 'returns true' do
+        expect(tariff_change.end_date_removed?).to be(true)
       end
     end
 
@@ -619,7 +619,7 @@ RSpec.describe TariffChange do
       end
 
       it 'returns true' do
-        expect(tariff_change.measure_end_date_removed?).to be(true)
+        expect(tariff_change.end_date_removed?).to be(true)
       end
     end
 
@@ -635,7 +635,7 @@ RSpec.describe TariffChange do
       end
 
       it 'returns false' do
-        expect(tariff_change.measure_end_date_removed?).to be(false)
+        expect(tariff_change.end_date_removed?).to be(false)
       end
     end
 
@@ -650,7 +650,7 @@ RSpec.describe TariffChange do
       end
 
       it 'returns false' do
-        expect(tariff_change.measure_end_date_removed?).to be(false)
+        expect(tariff_change.end_date_removed?).to be(false)
       end
     end
   end

--- a/spec/serializers/api/user/tariff_change_serializer_spec.rb
+++ b/spec/serializers/api/user/tariff_change_serializer_spec.rb
@@ -28,4 +28,19 @@ RSpec.describe Api::User::TariffChangeSerializer do
     data = result[:data].first
     expect(data[:attributes][:classification_description]).to eq('Test Classification Description')
   end
+
+  it 'serializes date_of_effect as end date removed when end date is removed' do
+    removed_end_date_change = create(
+      :tariff_change,
+      action: TariffChangesService::BaseChanges::ENDING,
+      validity_end_date: nil,
+      date_of_effect: Date.new(2025, 10, 17),
+      goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
+    )
+
+    result = described_class.new([removed_end_date_change]).serializable_hash
+    data = result[:data].first
+
+    expect(data[:attributes][:date_of_effect]).to eq(TariffChange::END_DATE_REMOVED_DISPLAY)
+  end
 end

--- a/spec/services/tariff_changes_service/presenter_spec.rb
+++ b/spec/services/tariff_changes_service/presenter_spec.rb
@@ -547,6 +547,23 @@ RSpec.describe TariffChangesService::Presenter do
         expect(presenter.date_of_effect).to eq('end date removed')
       end
     end
+
+    context 'when commodity end date has been removed' do
+      let(:tariff_change) do
+        create(:tariff_change,
+               action: 'ending',
+               type: 'Commodity',
+               operation_date: Date.parse('2024-08-14'),
+               validity_end_date: nil,
+               goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
+               goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
+               date_of_effect: Date.parse('2024-08-15'))
+      end
+
+      it 'returns end date removed' do
+        expect(presenter.date_of_effect).to eq('end date removed')
+      end
+    end
   end
 
   describe '#ott_url' do


### PR DESCRIPTION
## What:
If a commodity end date is removed then we should tell users with CCWL subscriptions this information more accurately.
This matches the change in https://github.com/trade-tariff/trade-tariff-backend/pull/3212 that was made for measures.

The `measure_end_date_removed?` method has been changed to `end_date_removed?` and now also applies to commodities.

This change will show up in the JSON API, and when a spreadsheet with tariff changes is requested.

## Why:
Currently when an end date is removed, this is not made obvious to the user.

## Ticket:
https://transformuk.atlassian.net/browse/OTTIMP-640

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Small API change
