### PR TITLE
AI-868: Add declarable knowledge graph loader

### DIFF
--- a/app/services/tariff_knowledge/declarable_node_loader.rb
+++ b/app/services/tariff_knowledge/declarable_node_loader.rb
@@ -1,0 +1,67 @@
+module TariffKnowledge
+  class DeclarableNodeLoader
+    BATCH_SIZE = 500
+
+    def self.call
+      new.call
+    end
+
+    def call
+      TimeMachine.now do
+        GoodsNomenclature.actual
+                         .with_leaf_column
+                         .declarable
+                         .paged_each(rows_per_fetch: BATCH_SIZE)
+                         .each_slice(BATCH_SIZE) do |goods_nomenclatures|
+          upsert_goods_nomenclature_nodes(goods_nomenclatures.map(&:sti_cast))
+        end
+      end
+    end
+
+  private
+
+    def upsert_goods_nomenclature_nodes(goods_nomenclatures)
+      rows = goods_nomenclatures.map { |goods_nomenclature| node_row(goods_nomenclature) }
+      return if rows.empty?
+
+      Node.dataset
+          .insert_conflict(target: :key, update: update_values)
+          .multi_insert(rows)
+    end
+
+    def node_row(goods_nomenclature)
+      now = Time.zone.now
+
+      {
+        node_type: Node::GOODS_NOMENCLATURE,
+        key: "goods_nomenclature:#{goods_nomenclature.goods_nomenclature_sid}",
+        title: goods_nomenclature.goods_nomenclature_item_id,
+        content: goods_nomenclature.description,
+        metadata: Sequel.pg_jsonb({}),
+        goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
+        goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
+        producline_suffix: goods_nomenclature.producline_suffix,
+        goods_nomenclature_type: goods_nomenclature.goods_nomenclature_class,
+        validity_start_date: goods_nomenclature.validity_start_date,
+        validity_end_date: goods_nomenclature.validity_end_date,
+        created_at: now,
+        updated_at: now,
+      }
+    end
+
+    def update_values
+      {
+        title: Sequel[:excluded][:title],
+        content: Sequel[:excluded][:content],
+        metadata: Sequel[:excluded][:metadata],
+        goods_nomenclature_sid: Sequel[:excluded][:goods_nomenclature_sid],
+        goods_nomenclature_item_id: Sequel[:excluded][:goods_nomenclature_item_id],
+        producline_suffix: Sequel[:excluded][:producline_suffix],
+        goods_nomenclature_type: Sequel[:excluded][:goods_nomenclature_type],
+        validity_start_date: Sequel[:excluded][:validity_start_date],
+        validity_end_date: Sequel[:excluded][:validity_end_date],
+        updated_at: Sequel[:excluded][:updated_at],
+      }
+    end
+  end
+end

--- a/app/workers/create_tariff_knowledge_declarable_nodes_worker.rb
+++ b/app/workers/create_tariff_knowledge_declarable_nodes_worker.rb
@@ -1,0 +1,9 @@
+class CreateTariffKnowledgeDeclarableNodesWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :sync, retry: false
+
+  def perform
+    TariffKnowledge::DeclarableNodeLoader.call
+  end
+end

--- a/spec/services/tariff_knowledge/declarable_node_loader_spec.rb
+++ b/spec/services/tariff_knowledge/declarable_node_loader_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe TariffKnowledge::DeclarableNodeLoader do
+  describe '.call' do
+    let(:chapter) { create(:chapter, goods_nomenclature_item_id: '0100000000') }
+    let(:heading) { create(:heading, parent: chapter, goods_nomenclature_item_id: '0101000000') }
+
+    before do
+      create(:commodity, parent: heading, goods_nomenclature_item_id: '0101210000')
+      create(:commodity, parent: heading, goods_nomenclature_item_id: '0101290000')
+      GoodsNomenclatures::TreeNode.refresh!
+    end
+
+    it 'creates a goods nomenclature node for each current declarable' do
+      described_class.call
+
+      expect(TariffKnowledge::Node.goods_nomenclatures.map(:goods_nomenclature_item_id))
+        .to include('0101210000', '0101290000')
+    end
+
+    it 'is idempotent' do
+      described_class.call
+
+      expect { described_class.call }
+        .not_to change(TariffKnowledge::Node.goods_nomenclatures, :count)
+    end
+
+    it 'updates existing declarable nodes when tariff metadata changes' do
+      commodity = Commodity.where(goods_nomenclature_item_id: '0101210000').first
+      create(
+        :tariff_knowledge_node,
+        key: "goods_nomenclature:#{commodity.goods_nomenclature_sid}",
+        goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+        goods_nomenclature_item_id: 'stale-code',
+      )
+
+      described_class.call
+
+      node = TariffKnowledge::Node.goods_nomenclatures
+                                  .where(goods_nomenclature_sid: commodity.goods_nomenclature_sid)
+                                  .first
+      expect(node.goods_nomenclature_item_id).to eq('0101210000')
+    end
+  end
+end

--- a/spec/workers/create_tariff_knowledge_declarable_nodes_worker_spec.rb
+++ b/spec/workers/create_tariff_knowledge_declarable_nodes_worker_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe CreateTariffKnowledgeDeclarableNodesWorker, type: :worker do
+  describe '#perform' do
+    it 'loads declarable goods nomenclature graph nodes' do
+      allow(TariffKnowledge::DeclarableNodeLoader).to receive(:call)
+
+      described_class.new.perform
+
+      expect(TariffKnowledge::DeclarableNodeLoader).to have_received(:call)
+    end
+  end
+
+  describe 'sidekiq options' do
+    it 'uses the sync queue' do
+      expect(described_class.sidekiq_options['queue']).to eq(:sync)
+    end
+
+    it 'disables retries' do
+      expect(described_class.sidekiq_options['retry']).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
## What:

- [x] Add `TariffKnowledge::DeclarableNodeLoader` to load current declarable goods nomenclatures into KG reference nodes
- [x] Add `CreateTariffKnowledgeDeclarableNodesWorker` to run the loader asynchronously
- [x] Cover idempotency, metadata refresh, and worker delegation

## Why:

The KG implementation needs a current declarable reference set before source/rule ingestion can attach narrow, source-evidenced relationships. This keeps declarable node loading separate from rule extraction and avoids recreating the spike's broad rule-to-declarable expansion in the core graph.

## Ticket:

[AI-868](https://transformuk.atlassian.net/browse/AI-868)

## Risk:
**Risk level:** 🟢

**Reason for rating:** Isolated additive worker/service with focused test coverage. The worker is not scheduled here and no API, migration, sync, search, or trader-facing behaviour changes are introduced.
