### PR TITLE
AI-868: Add source knowledge graph loader

### DIFF
--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -136,34 +136,60 @@ module TariffKnowledge
 
     def upsert_node(attributes)
       key = attributes.fetch(:key)
-      node = Node.by_key(key).first
       now = Time.zone.now
       values = attributes.merge(
         metadata: Sequel.pg_jsonb(attributes.fetch(:metadata, { 'loader' => self.class.name })),
+        created_at: now,
         updated_at: now,
       )
 
-      if node
-        node.update(values)
-      else
-        Node.create(values.merge(created_at: now))
-      end
+      Node.dataset
+          .insert_conflict(target: :key, update: node_update_values)
+          .insert(values)
+
+      Node.by_key(key).first
     end
 
     def upsert_edge(source_node, target_node, relationship_type)
-      edge = Edge.where(
+      now = Time.zone.now
+      values = {
         source_node_id: source_node.id,
         target_node_id: target_node.id,
         relationship_type:,
-      ).first
-      now = Time.zone.now
-      values = { metadata: Sequel.pg_jsonb({ 'loader' => self.class.name }), updated_at: now }
+        metadata: Sequel.pg_jsonb({ 'loader' => self.class.name }),
+        created_at: now,
+        updated_at: now,
+      }
 
-      if edge
-        edge.update(values)
-      else
-        Edge.create(values.merge(source_node_id: source_node.id, target_node_id: target_node.id, relationship_type:, created_at: now))
-      end
+      Edge.dataset
+          .insert_conflict(target: %i[source_node_id target_node_id relationship_type], update: edge_update_values)
+          .insert(values)
+    end
+
+    def node_update_values
+      {
+        node_type: Sequel[:excluded][:node_type],
+        title: Sequel[:excluded][:title],
+        content: Sequel[:excluded][:content],
+        metadata: Sequel[:excluded][:metadata],
+        source_type: Sequel[:excluded][:source_type],
+        source_id: Sequel[:excluded][:source_id],
+        source_version: Sequel[:excluded][:source_version],
+        goods_nomenclature_sid: Sequel[:excluded][:goods_nomenclature_sid],
+        goods_nomenclature_item_id: Sequel[:excluded][:goods_nomenclature_item_id],
+        producline_suffix: Sequel[:excluded][:producline_suffix],
+        goods_nomenclature_type: Sequel[:excluded][:goods_nomenclature_type],
+        validity_start_date: Sequel[:excluded][:validity_start_date],
+        validity_end_date: Sequel[:excluded][:validity_end_date],
+        updated_at: Sequel[:excluded][:updated_at],
+      }
+    end
+
+    def edge_update_values
+      {
+        metadata: Sequel[:excluded][:metadata],
+        updated_at: Sequel[:excluded][:updated_at],
+      }
     end
   end
 end

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -67,9 +67,15 @@ module TariffKnowledge
         source_version: source.customs_tariff_update_version,
       )
 
-      fragments(source.content).each.with_index(1) do |fragment_content, index|
+      fragment_nodes = fragments(source.content).map.with_index(1) do |fragment_content, index|
         load_fragment(source_type, source, source_node, fragment_content, index)
       end
+
+      delete_stale_edges(
+        source_node:,
+        relationship_type: Edge::CONTAINS,
+        current_target_node_ids: fragment_nodes.map(&:id),
+      )
     end
 
     def load_fragment(source_type, source, source_node, content, index)
@@ -84,11 +90,20 @@ module TariffKnowledge
       )
       upsert_edge(source_node, fragment_node, Edge::CONTAINS)
 
-      range_references(content).each do |reference|
+      range_nodes = range_references(content).map do |reference|
         range_node = upsert_range_node(reference)
         upsert_edge(fragment_node, range_node, Edge::REFERENCES)
         expand_range(range_node, reference)
+        range_node
       end
+
+      delete_stale_edges(
+        source_node: fragment_node,
+        relationship_type: Edge::REFERENCES,
+        current_target_node_ids: range_nodes.map(&:id),
+      )
+
+      fragment_node
     end
 
     def fragments(content)
@@ -171,6 +186,15 @@ module TariffKnowledge
       Edge.dataset
           .insert_conflict(target: %i[source_node_id target_node_id relationship_type], update: edge_update_values)
           .insert(values)
+    end
+
+    def delete_stale_edges(source_node:, relationship_type:, current_target_node_ids:)
+      dataset = Edge.where(
+        source_node_id: source_node.id,
+        relationship_type:,
+      )
+      dataset = dataset.exclude(target_node_id: current_target_node_ids) if current_target_node_ids.any?
+      dataset.delete
     end
 
     def node_update_values

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -28,14 +28,31 @@ module TariffKnowledge
     end
 
     def call
+      update = latest_approved_update
+      return unless update
+
       SOURCE_TYPES.each do |source_type|
-        source_type[:model].approved.each do |source|
+        sources_for(source_type, update).each do |source|
           load_source(source_type, source)
         end
       end
     end
 
   private
+
+    def latest_approved_update
+      CustomsTariffUpdate
+        .actual
+        .approved
+        .order(Sequel.desc(:validity_start_date))
+        .first
+    end
+
+    def sources_for(source_type, update)
+      source_type[:model]
+        .approved
+        .where(customs_tariff_update_version: update.version)
+    end
 
     def load_source(source_type, source)
       source_node = upsert_node(

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -1,0 +1,152 @@
+module TariffKnowledge
+  class SourceGraphLoader
+    RangeReference = Data.define(:type, :code)
+
+    SOURCE_TYPES = [
+      {
+        model: CustomsTariffChapterNote,
+        label: 'customs_tariff_chapter_note',
+        identifier: :chapter_id,
+        title: ->(note) { "Chapter #{note.chapter_id} notes" },
+      },
+      {
+        model: CustomsTariffSectionNote,
+        label: 'customs_tariff_section_note',
+        identifier: :section_id,
+        title: ->(note) { "Section #{note.section_id} notes" },
+      },
+      {
+        model: CustomsTariffGeneralRule,
+        label: 'customs_tariff_general_rule',
+        identifier: :rule_label,
+        title: ->(note) { "GIR #{note.rule_label}" },
+      },
+    ].freeze
+
+    def self.call
+      new.call
+    end
+
+    def call
+      SOURCE_TYPES.each do |source_type|
+        source_type[:model].approved.each do |source|
+          load_source(source_type, source)
+        end
+      end
+    end
+
+  private
+
+    def load_source(source_type, source)
+      source_node = upsert_node(
+        node_type: Node::NOTE_SOURCE,
+        key: source_key(source_type, source),
+        title: source_type[:title].call(source),
+        content: source.content,
+        source_type: source_type[:label],
+        source_id: source.public_send(source_type[:identifier]).to_s,
+        source_version: source.customs_tariff_update_version,
+      )
+
+      fragments(source.content).each.with_index(1) do |fragment_content, index|
+        load_fragment(source_type, source, source_node, fragment_content, index)
+      end
+    end
+
+    def load_fragment(source_type, source, source_node, content, index)
+      fragment_node = upsert_node(
+        node_type: Node::NOTE_FRAGMENT,
+        key: "#{source_key(source_type, source)}:#{sprintf('%04d', index)}".sub('note_source:', 'note_fragment:'),
+        title: "#{source_node.title} fragment #{index}",
+        content:,
+        source_type: source_type[:label],
+        source_id: source_node.source_id,
+        source_version: source.customs_tariff_update_version,
+      )
+      upsert_edge(source_node, fragment_node, Edge::CONTAINS)
+
+      range_references(content).each do |reference|
+        range_node = upsert_range_node(reference)
+        upsert_edge(fragment_node, range_node, Edge::REFERENCES)
+        expand_range(range_node, reference)
+      end
+    end
+
+    def fragments(content)
+      content.to_s.split(/\n{2,}|(?<=[.!?])\s+/).map(&:strip).reject(&:blank?)
+    end
+
+    def range_references(content)
+      references = content.to_s.scan(/\b(chapter|heading)\s+(\d{2}|\d{4})\b/i).filter_map do |type, code|
+        next if negated_reference?(content)
+
+        RangeReference.new(type: type.downcase, code:)
+      end
+
+      references.uniq
+    end
+
+    def negated_reference?(content)
+      content.match?(/\b(excluded|excluding|does not include|do not include)\b/i)
+    end
+
+    def upsert_range_node(reference)
+      upsert_node(
+        node_type: Node::RANGE,
+        key: "range:#{reference.type}:#{reference.code}",
+        title: "#{reference.type.titleize} #{reference.code}",
+        content: nil,
+        metadata: { 'range_type' => reference.type, 'code' => reference.code },
+      )
+    end
+
+    def expand_range(range_node, reference)
+      matching_declarable_nodes(reference).each do |declarable_node|
+        upsert_edge(range_node, declarable_node, Edge::EXPANDS_TO)
+      end
+    end
+
+    def matching_declarable_nodes(reference)
+      Node.goods_nomenclatures
+          .where(Sequel.like(:goods_nomenclature_item_id, "#{reference.code}%"))
+          .all
+    end
+
+    def source_key(source_type, source)
+      identifier = source.public_send(source_type[:identifier])
+      "note_source:#{source_type[:label]}:#{source.customs_tariff_update_version}:#{identifier}"
+    end
+
+    def upsert_node(attributes)
+      key = attributes.fetch(:key)
+      node = Node.by_key(key).first
+      now = Time.zone.now
+      values = attributes.merge(
+        metadata: Sequel.pg_jsonb(attributes.fetch(:metadata, {})),
+        updated_at: now,
+      )
+
+      if node
+        node.update(values)
+      else
+        Node.create(values.merge(created_at: now))
+      end
+    end
+
+    def upsert_edge(source_node, target_node, relationship_type)
+      edge = Edge.where(
+        source_node_id: source_node.id,
+        target_node_id: target_node.id,
+        relationship_type:,
+      ).first
+      now = Time.zone.now
+      values = { metadata: Sequel.pg_jsonb({}), updated_at: now }
+
+      if edge
+        edge.update(values)
+      else
+        Edge.create(values.merge(source_node_id: source_node.id, target_node_id: target_node.id, relationship_type:, created_at: now))
+      end
+    end
+  end
+end

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -122,7 +122,7 @@ module TariffKnowledge
       node = Node.by_key(key).first
       now = Time.zone.now
       values = attributes.merge(
-        metadata: Sequel.pg_jsonb(attributes.fetch(:metadata, {})),
+        metadata: Sequel.pg_jsonb(attributes.fetch(:metadata, { 'loader' => self.class.name })),
         updated_at: now,
       )
 
@@ -140,7 +140,7 @@ module TariffKnowledge
         relationship_type:,
       ).first
       now = Time.zone.now
-      values = { metadata: Sequel.pg_jsonb({}), updated_at: now }
+      values = { metadata: Sequel.pg_jsonb({ 'loader' => self.class.name }), updated_at: now }
 
       if edge
         edge.update(values)

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -1,5 +1,7 @@
 module TariffKnowledge
   class SourceGraphLoader
+    BATCH_SIZE = 500
+
     RangeReference = Data.define(:type, :code)
 
     SOURCE_TYPES = [
@@ -94,13 +96,19 @@ module TariffKnowledge
     end
 
     def range_references(content)
-      references = content.to_s.scan(/\b(chapter|heading)\s+(\d{2}|\d{4})\b/i).filter_map do |type, code|
-        next if negated_reference?(content)
+      references = reference_clauses(content).flat_map do |clause|
+        next [] if negated_reference?(clause)
 
-        RangeReference.new(type: type.downcase, code:)
+        clause.scan(/\b(chapter|heading)\s+(\d{2}|\d{4})\b/i).map do |type, code|
+          RangeReference.new(type: type.downcase, code:)
+        end
       end
 
       references.uniq
+    end
+
+    def reference_clauses(content)
+      content.to_s.split(/[.;]/).map(&:strip).reject(&:blank?)
     end
 
     def negated_reference?(content)
@@ -118,7 +126,7 @@ module TariffKnowledge
     end
 
     def expand_range(range_node, reference)
-      matching_declarable_nodes(reference).each do |declarable_node|
+      matching_declarable_nodes(reference).paged_each(rows_per_fetch: BATCH_SIZE) do |declarable_node|
         upsert_edge(range_node, declarable_node, Edge::EXPANDS_TO)
       end
     end
@@ -126,7 +134,6 @@ module TariffKnowledge
     def matching_declarable_nodes(reference)
       Node.goods_nomenclatures
           .where(Sequel.like(:goods_nomenclature_item_id, "#{reference.code}%"))
-          .all
     end
 
     def source_key(source_type, source)

--- a/app/workers/create_tariff_knowledge_source_graph_worker.rb
+++ b/app/workers/create_tariff_knowledge_source_graph_worker.rb
@@ -1,0 +1,9 @@
+class CreateTariffKnowledgeSourceGraphWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :sync, retry: false
+
+  def perform
+    TariffKnowledge::SourceGraphLoader.call
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -14074,6 +14074,12 @@ CREATE INDEX tariff_knowledge_edges_target_node_id_index ON uk.tariff_knowledge_
 
 CREATE INDEX tariff_knowledge_edges_target_node_id_relationship_type_index ON uk.tariff_knowledge_edges USING btree (target_node_id, relationship_type);
 
+--
+-- Name: idx_tariff_knowledge_edges_unique; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_tariff_knowledge_edges_unique ON uk.tariff_knowledge_edges USING btree (source_node_id, target_node_id, relationship_type);
+
 
 --
 -- Name: tariff_knowledge_nodes_goods_nomenclature_item_id_index; Type: INDEX; Schema: uk; Owner: -

--- a/spec/services/tariff_knowledge/source_graph_loader_spec.rb
+++ b/spec/services/tariff_knowledge/source_graph_loader_spec.rb
@@ -74,6 +74,50 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       expect(TariffKnowledge::Node.count).to eq(node_count)
       expect(TariffKnowledge::Edge.count).to eq(edge_count)
     end
+
+    it 'only loads notes from the latest approved update that is actual in TimeMachine' do
+      older_update = create(
+        :customs_tariff_update,
+        :approved,
+        version: '1.30',
+        validity_start_date: 2.months.ago,
+        validity_end_date: 1.month.ago,
+      )
+      future_update = create(
+        :customs_tariff_update,
+        :approved,
+        version: '1.32',
+        validity_start_date: 1.month.from_now,
+      )
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: older_update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers older horses.',
+      )
+      current_note = create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers current horses.',
+      )
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: future_update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers future horses.',
+      )
+
+      described_class.call
+
+      expect(TariffKnowledge::Node.where(node_type: TariffKnowledge::Node::NOTE_SOURCE).select_map(:source_version))
+        .to contain_exactly(update.version)
+      expect(TariffKnowledge::Node.by_key('note_source:customs_tariff_chapter_note:1.31:01').first.content)
+        .to eq(current_note.content)
+    end
   end
 
   def edge_exists?(source_node, target_node, relationship_type)

--- a/spec/services/tariff_knowledge/source_graph_loader_spec.rb
+++ b/spec/services/tariff_knowledge/source_graph_loader_spec.rb
@@ -133,6 +133,50 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       expect(TariffKnowledge::Node.where(node_type: TariffKnowledge::Node::RANGE).select_map(:key))
         .to contain_exactly('range:heading:0101')
     end
+
+    it 'removes stale fragment links when source content has fewer fragments' do
+      note = create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers live horses. Heading 0201 covers bovine animals.',
+      )
+
+      described_class.call
+
+      note.update(content: 'Heading 0101 covers live horses.')
+      described_class.call
+
+      source_node = TariffKnowledge::Node.by_key('note_source:customs_tariff_chapter_note:1.31:01').first
+      current_fragment_node = TariffKnowledge::Node.by_key('note_fragment:customs_tariff_chapter_note:1.31:01:0001').first
+      stale_fragment_node = TariffKnowledge::Node.by_key('note_fragment:customs_tariff_chapter_note:1.31:01:0002').first
+
+      expect(edge_exists?(source_node, current_fragment_node, TariffKnowledge::Edge::CONTAINS)).to be(true)
+      expect(edge_exists?(source_node, stale_fragment_node, TariffKnowledge::Edge::CONTAINS)).to be(false)
+    end
+
+    it 'removes stale range references when fragment content changes' do
+      note = create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers live horses.',
+      )
+
+      described_class.call
+
+      note.update(content: 'Heading 0201 covers bovine animals.')
+      described_class.call
+
+      fragment_node = TariffKnowledge::Node.by_key('note_fragment:customs_tariff_chapter_note:1.31:01:0001').first
+      current_range_node = TariffKnowledge::Node.by_key('range:heading:0201').first
+      stale_range_node = TariffKnowledge::Node.by_key('range:heading:0101').first
+
+      expect(edge_exists?(fragment_node, current_range_node, TariffKnowledge::Edge::REFERENCES)).to be(true)
+      expect(edge_exists?(fragment_node, stale_range_node, TariffKnowledge::Edge::REFERENCES)).to be(false)
+    end
   end
 
   def edge_exists?(source_node, target_node, relationship_type)

--- a/spec/services/tariff_knowledge/source_graph_loader_spec.rb
+++ b/spec/services/tariff_knowledge/source_graph_loader_spec.rb
@@ -1,0 +1,86 @@
+RSpec.describe TariffKnowledge::SourceGraphLoader do
+  describe '.call' do
+    let(:update) { create(:customs_tariff_update, :approved, version: '1.31') }
+    let(:chapter) { create(:chapter, goods_nomenclature_item_id: '0100000000') }
+    let(:heading) { create(:heading, parent: chapter, goods_nomenclature_item_id: '0101000000') }
+
+    before do
+      create(:commodity, parent: heading, goods_nomenclature_item_id: '0101210000')
+      create(:commodity, parent: heading, goods_nomenclature_item_id: '0101290000')
+      create(:chapter, goods_nomenclature_item_id: '0200000000')
+      GoodsNomenclatures::TreeNode.refresh!
+      TariffKnowledge::DeclarableNodeLoader.call
+    end
+
+    it 'builds source, fragment, range, and expansion edges for explicit references only' do
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers live horses. Chapter 02 is excluded.',
+      )
+
+      described_class.call
+
+      source_node = TariffKnowledge::Node.by_key('note_source:customs_tariff_chapter_note:1.31:01').first
+      fragment_node = TariffKnowledge::Node.by_key('note_fragment:customs_tariff_chapter_note:1.31:01:0001').first
+      range_node = TariffKnowledge::Node.by_key('range:heading:0101').first
+
+      expect(source_node).to have_attributes(
+        node_type: TariffKnowledge::Node::NOTE_SOURCE,
+        title: 'Chapter 01 notes',
+      )
+      expect(fragment_node).to have_attributes(
+        node_type: TariffKnowledge::Node::NOTE_FRAGMENT,
+        content: 'Heading 0101 covers live horses.',
+      )
+      expect(range_node).to have_attributes(
+        node_type: TariffKnowledge::Node::RANGE,
+        title: 'Heading 0101',
+      )
+
+      expect(edge_exists?(source_node, fragment_node, TariffKnowledge::Edge::CONTAINS)).to be(true)
+      expect(edge_exists?(fragment_node, range_node, TariffKnowledge::Edge::REFERENCES)).to be(true)
+
+      expanded_codes = TariffKnowledge::Edge
+        .by_relationship(TariffKnowledge::Edge::EXPANDS_TO)
+        .where(source_node_id: range_node.id)
+        .association_join(:target_node)
+        .select_map(Sequel[:target_node][:goods_nomenclature_item_id])
+
+      expect(expanded_codes).to contain_exactly('0101210000', '0101290000')
+      expect(TariffKnowledge::Node.where(node_type: TariffKnowledge::Node::RANGE).map(:key))
+        .not_to include('range:chapter:02')
+      expect(TariffKnowledge::Edge.by_relationship(TariffKnowledge::Edge::APPLIES_TO).count)
+        .to be_zero
+    end
+
+    it 'is idempotent' do
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers live horses.',
+      )
+
+      described_class.call
+
+      node_count = TariffKnowledge::Node.count
+      edge_count = TariffKnowledge::Edge.count
+      described_class.call
+
+      expect(TariffKnowledge::Node.count).to eq(node_count)
+      expect(TariffKnowledge::Edge.count).to eq(edge_count)
+    end
+  end
+
+  def edge_exists?(source_node, target_node, relationship_type)
+    TariffKnowledge::Edge.where(
+      source_node_id: source_node.id,
+      target_node_id: target_node.id,
+      relationship_type:,
+    ).any?
+  end
+end

--- a/spec/services/tariff_knowledge/source_graph_loader_spec.rb
+++ b/spec/services/tariff_knowledge/source_graph_loader_spec.rb
@@ -118,6 +118,21 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       expect(TariffKnowledge::Node.by_key('note_source:customs_tariff_chapter_note:1.31:01').first.content)
         .to eq(current_note.content)
     end
+
+    it 'keeps positive references when another clause in the fragment is negated' do
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers live horses; Chapter 02 is excluded.',
+      )
+
+      described_class.call
+
+      expect(TariffKnowledge::Node.where(node_type: TariffKnowledge::Node::RANGE).select_map(:key))
+        .to contain_exactly('range:heading:0101')
+    end
   end
 
   def edge_exists?(source_node, target_node, relationship_type)

--- a/spec/workers/create_tariff_knowledge_source_graph_worker_spec.rb
+++ b/spec/workers/create_tariff_knowledge_source_graph_worker_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe CreateTariffKnowledgeSourceGraphWorker, type: :worker do
+  describe '#perform' do
+    it 'delegates source graph loading' do
+      allow(TariffKnowledge::SourceGraphLoader).to receive(:call)
+
+      described_class.new.perform
+
+      expect(TariffKnowledge::SourceGraphLoader).to have_received(:call)
+    end
+  end
+
+  it 'uses the sync queue' do
+    expect(described_class.sidekiq_options['queue']).to eq(:sync)
+  end
+
+  it 'does not retry failures' do
+    expect(described_class.sidekiq_options['retry']).to be(false)
+  end
+end


### PR DESCRIPTION
## What:
- [x] Add `TariffKnowledge::SourceGraphLoader` for approved chapter notes, section notes, and GIR sources
- [x] Store source nodes, sentence-level note fragments, explicit range nodes, and `EXPANDS_TO` edges to declarable nodes
- [x] Add `CreateTariffKnowledgeSourceGraphWorker` as an unscheduled sync worker entry point

## Why:
The archive comparison showed the spike was not reproducible because it expanded source-scope rules directly across declarables. This slice keeps the core graph source-evidenced: fragments `REFERENCES` explicit chapter/heading ranges, and ranges separately `EXPANDS_TO` matching declarable nodes. It also loads GIR/global source rows instead of limiting the graph to chapter notes.

## Ticket:
[AI-868](https://transformuk.atlassian.net/browse/AI-868)

## Risk:
**Risk level:** 🟢

**Reason for rating:** This is staging-only, technical-operator functionality for generating, reviewing, refreshing, exposing, or consuming compressed notes. Production and other environments should leave the consuming feature disabled, so this does not change live trader journeys or production search behaviour.

### Environment note
Compressed notes are intended to be consumed only in staging. Staging is the only environment where this capability will be enabled; production and other environments should leave the consuming feature disabled.
