### PR TITLE
AI-868: Generate tariff knowledge compressed notes

### DIFF
--- a/app/services/tariff_knowledge/compressed_note_generator.rb
+++ b/app/services/tariff_knowledge/compressed_note_generator.rb
@@ -1,0 +1,122 @@
+module TariffKnowledge
+  class CompressedNoteGenerator
+    def self.call(goods_nomenclature_sids:)
+      new(goods_nomenclature_sids).call
+    end
+
+    def initialize(goods_nomenclature_sids)
+      @goods_nomenclature_sids = goods_nomenclature_sids
+    end
+
+    def call
+      declarable_nodes.filter_map do |declarable_node|
+        generate_for(declarable_node)
+      end
+    end
+
+  private
+
+    attr_reader :goods_nomenclature_sids
+
+    def declarable_nodes
+      Node.goods_nomenclatures
+          .where(goods_nomenclature_sid: goods_nomenclature_sids)
+          .all
+    end
+
+    def generate_for(declarable_node)
+      evidence = evidence_for(declarable_node)
+      return if evidence.empty?
+
+      content = content_for(evidence)
+      attributes = {
+        goods_nomenclature_item_id: declarable_node.goods_nomenclature_item_id,
+        producline_suffix: declarable_node.producline_suffix,
+        goods_nomenclature_type: declarable_node.goods_nomenclature_type,
+        content:,
+        metadata: Sequel.pg_jsonb(metadata_for(evidence)),
+        context_hash: Digest::SHA256.hexdigest(content),
+        generated_at: Time.zone.now,
+        needs_review: true,
+        approved: false,
+        manually_edited: false,
+        stale: false,
+        expired: false,
+      }
+
+      upsert_note(declarable_node, attributes)
+    end
+
+    def evidence_for(declarable_node)
+      range_nodes = range_nodes_for(declarable_node)
+      indexed_range_nodes = range_nodes_by_id(range_nodes)
+      evidence = fragment_nodes_by_range_node_id(range_nodes).flat_map do |range_node_id, fragment_nodes|
+        range_node = indexed_range_nodes[range_node_id]
+        fragment_nodes.map { |fragment_node| [fragment_node, range_node] }
+      end
+
+      evidence.sort_by { |fragment_node, range_node| [fragment_node.source_type.to_s, fragment_node.source_id.to_s, fragment_node.key, range_node.key] }
+    end
+
+    def range_nodes_for(declarable_node)
+      range_node_ids = Edge
+        .by_relationship(Edge::EXPANDS_TO)
+        .where(target_node_id: declarable_node.id)
+        .select_map(:source_node_id)
+      return [] if range_node_ids.empty?
+
+      Node.where(id: range_node_ids, node_type: Node::RANGE).all
+    end
+
+    def fragment_nodes_by_range_node_id(range_nodes)
+      range_node_ids = range_nodes.map(&:id)
+      return {} if range_node_ids.empty?
+
+      reference_edges = Edge
+        .by_relationship(Edge::REFERENCES)
+        .where(target_node_id: range_node_ids)
+        .all
+      fragment_nodes = Node
+        .note_fragments
+        .where(id: reference_edges.map(&:source_node_id).uniq)
+        .all
+        .index_by(&:id)
+
+      reference_edges.each_with_object({}) do |edge, grouped|
+        fragment_node = fragment_nodes[edge.source_node_id]
+        next unless fragment_node
+
+        grouped[edge.target_node_id] ||= []
+        grouped[edge.target_node_id] << fragment_node
+      end
+    end
+
+    def range_nodes_by_id(range_nodes)
+      range_nodes.index_by(&:id)
+    end
+
+    def content_for(evidence)
+      evidence.map { |fragment_node, _range_node|
+        "#{fragment_node.title}\n#{fragment_node.content}"
+      }.uniq.join("\n\n")
+    end
+
+    def metadata_for(evidence)
+      {
+        'source_node_keys' => evidence.map { |fragment_node, _range_node| fragment_node.key }.uniq,
+        'range_node_keys' => evidence.map { |_fragment_node, range_node| range_node.key }.uniq,
+      }
+    end
+
+    def upsert_note(declarable_node, attributes)
+      note = CompressedNote[declarable_node.goods_nomenclature_sid]
+      return note if note&.manually_edited
+
+      if note
+        note.update(attributes)
+      else
+        CompressedNote.create(attributes.merge(goods_nomenclature_sid: declarable_node.goods_nomenclature_sid))
+      end
+    end
+  end
+end

--- a/app/workers/generate_tariff_knowledge_compressed_notes_worker.rb
+++ b/app/workers/generate_tariff_knowledge_compressed_notes_worker.rb
@@ -1,0 +1,9 @@
+class GenerateTariffKnowledgeCompressedNotesWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :sync, retry: false
+
+  def perform(goods_nomenclature_sids)
+    TariffKnowledge::CompressedNoteGenerator.call(goods_nomenclature_sids:)
+  end
+end

--- a/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
+++ b/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
@@ -1,0 +1,91 @@
+RSpec.describe TariffKnowledge::CompressedNoteGenerator do
+  describe '.call' do
+    let(:declarable_node) do
+      create(
+        :tariff_knowledge_node,
+        key: 'goods_nomenclature:123',
+        goods_nomenclature_sid: 123,
+        goods_nomenclature_item_id: '0101210000',
+      )
+    end
+    let(:range_node) do
+      create(
+        :tariff_knowledge_node,
+        node_type: TariffKnowledge::Node::RANGE,
+        key: 'range:heading:0101',
+        title: 'Heading 0101',
+        goods_nomenclature_sid: nil,
+        goods_nomenclature_item_id: nil,
+        producline_suffix: nil,
+        goods_nomenclature_type: nil,
+      )
+    end
+    let(:fragment_node) do
+      create(
+        :tariff_knowledge_node,
+        :note_fragment,
+        key: 'note_fragment:customs_tariff_chapter_note:1.31:01:0001',
+        title: 'Chapter 01 notes fragment 1',
+        content: 'Heading 0101 covers live horses.',
+      )
+    end
+
+    before do
+      create(
+        :tariff_knowledge_edge,
+        source_node: fragment_node,
+        target_node: range_node,
+        relationship_type: TariffKnowledge::Edge::REFERENCES,
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: range_node,
+        target_node: declarable_node,
+        relationship_type: TariffKnowledge::Edge::EXPANDS_TO,
+      )
+    end
+
+    it 'creates reviewable compressed notes from source-evidenced graph fragments' do
+      described_class.call(goods_nomenclature_sids: [123])
+
+      note = TariffKnowledge::CompressedNote[123]
+      expect(note).to have_attributes(
+        goods_nomenclature_item_id: '0101210000',
+        content: "Chapter 01 notes fragment 1\nHeading 0101 covers live horses.",
+        needs_review: true,
+        approved: false,
+        stale: false,
+      )
+      expect(note.metadata.to_hash).to include(
+        'source_node_keys' => ['note_fragment:customs_tariff_chapter_note:1.31:01:0001'],
+        'range_node_keys' => ['range:heading:0101'],
+      )
+      expect(note.context_hash).to eq(Digest::SHA256.hexdigest(note.content))
+    end
+
+    it 'updates generated notes when the graph context changes' do
+      described_class.call(goods_nomenclature_sids: [123])
+      fragment_node.update(content: 'Heading 0101 covers live horses and asses.')
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      expect(TariffKnowledge::CompressedNote[123].content)
+        .to include('horses and asses')
+    end
+
+    it 'does not overwrite manually edited notes' do
+      create(
+        :tariff_knowledge_compressed_note,
+        goods_nomenclature_sid: 123,
+        content: 'Reviewed human content',
+        manually_edited: true,
+        approved: true,
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      expect(TariffKnowledge::CompressedNote[123].content)
+        .to eq('Reviewed human content')
+    end
+  end
+end

--- a/spec/workers/generate_tariff_knowledge_compressed_notes_worker_spec.rb
+++ b/spec/workers/generate_tariff_knowledge_compressed_notes_worker_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe GenerateTariffKnowledgeCompressedNotesWorker, type: :worker do
+  describe '#perform' do
+    it 'delegates compressed note generation for the supplied goods nomenclature sids' do
+      allow(TariffKnowledge::CompressedNoteGenerator).to receive(:call)
+
+      described_class.new.perform([123, 456])
+
+      expect(TariffKnowledge::CompressedNoteGenerator)
+        .to have_received(:call).with(goods_nomenclature_sids: [123, 456])
+    end
+  end
+
+  it 'uses the sync queue' do
+    expect(described_class.sidekiq_options['queue']).to eq(:sync)
+  end
+
+  it 'does not retry failures' do
+    expect(described_class.sidekiq_options['retry']).to be(false)
+  end
+end


### PR DESCRIPTION
## What:
- [x] Add `TariffKnowledge::CompressedNoteGenerator` to build reviewable compressed notes for supplied declarable SIDs
- [x] Use fragment -> range -> declarable evidence instead of broad `APPLIES_TO` edges
- [x] Preserve manually edited compressed notes
- [x] Add `GenerateTariffKnowledgeCompressedNotesWorker` as an unscheduled sync worker entry point

## Why:
The archive comparison showed the spike made reproducibility difficult by collapsing rule scope directly into declarable links. This slice generates compressed notes from explicit source fragment and range evidence, and stores the contributing node keys in metadata so the generated output can be compared and reviewed.

## Ticket:
[AI-868](https://transformuk.atlassian.net/browse/AI-868)

## Risk:
**Risk level:** 🟢

**Reason for rating:** This is staging-only, technical-operator functionality for generating, reviewing, refreshing, exposing, or consuming compressed notes. Production and other environments should leave the consuming feature disabled, so this does not change live trader journeys or production search behaviour.

### Environment note
Compressed notes are intended to be consumed only in staging. Staging is the only environment where this capability will be enabled; production and other environments should leave the consuming feature disabled.
