### PR TITLE
AI-868: Refresh tariff knowledge compressed notes

### DIFF
--- a/app/services/tariff_knowledge/compressed_note_refresh.rb
+++ b/app/services/tariff_knowledge/compressed_note_refresh.rb
@@ -1,0 +1,40 @@
+module TariffKnowledge
+  class CompressedNoteRefresh
+    Result = Data.define(:goods_nomenclature_count, :expired_note_count)
+
+    def self.call
+      new.call
+    end
+
+    def call
+      DeclarableNodeLoader.call
+      SourceGraphLoader.call
+
+      current_sids = current_goods_nomenclature_sids
+      CompressedNoteGenerator.call(goods_nomenclature_sids: current_sids)
+
+      Result.new(
+        goods_nomenclature_count: current_sids.size,
+        expired_note_count: expire_non_current_notes(current_sids),
+      )
+    end
+
+  private
+
+    def current_goods_nomenclature_sids
+      Node.goods_nomenclatures
+          .select_map(:goods_nomenclature_sid)
+          .compact
+          .uniq
+          .sort
+    end
+
+    def expire_non_current_notes(current_sids)
+      dataset = CompressedNote.exclude(goods_nomenclature_sid: current_sids)
+                              .where(expired: false)
+      count = dataset.count
+      dataset.update(expired: true) if count.positive?
+      count
+    end
+  end
+end

--- a/app/services/tariff_knowledge/compressed_note_refresh.rb
+++ b/app/services/tariff_knowledge/compressed_note_refresh.rb
@@ -1,5 +1,7 @@
 module TariffKnowledge
   class CompressedNoteRefresh
+    BATCH_SIZE = 500
+
     Result = Data.define(:goods_nomenclature_count, :expired_note_count)
 
     def self.call
@@ -11,7 +13,9 @@ module TariffKnowledge
       SourceGraphLoader.call
 
       current_sids = current_goods_nomenclature_sids
-      CompressedNoteGenerator.call(goods_nomenclature_sids: current_sids)
+      current_sids.each_slice(BATCH_SIZE) do |sids|
+        CompressedNoteGenerator.call(goods_nomenclature_sids: sids)
+      end
 
       Result.new(
         goods_nomenclature_count: current_sids.size,
@@ -22,19 +26,30 @@ module TariffKnowledge
   private
 
     def current_goods_nomenclature_sids
-      Node.goods_nomenclatures
-          .select_map(:goods_nomenclature_sid)
-          .compact
-          .uniq
-          .sort
+      if TimeMachine.date_is_set?
+        current_goods_nomenclature_sids_at_time_machine_date
+      else
+        TimeMachine.now { current_goods_nomenclature_sids_at_time_machine_date }
+      end
+    end
+
+    def current_goods_nomenclature_sids_at_time_machine_date
+      GoodsNomenclature
+        .actual
+        .with_leaf_column
+        .declarable
+        .unordered
+        .select_map(Sequel[:goods_nomenclatures][:goods_nomenclature_sid])
+        .compact
+        .uniq
+        .sort
     end
 
     def expire_non_current_notes(current_sids)
-      dataset = CompressedNote.exclude(goods_nomenclature_sid: current_sids)
-                              .where(expired: false)
-      count = dataset.count
-      dataset.update(expired: true) if count.positive?
-      count
+      dataset = CompressedNote.where(expired: false)
+      dataset = dataset.exclude(goods_nomenclature_sid: current_sids) if current_sids.any?
+
+      dataset.update(expired: true)
     end
   end
 end

--- a/app/workers/refresh_tariff_knowledge_compressed_notes_worker.rb
+++ b/app/workers/refresh_tariff_knowledge_compressed_notes_worker.rb
@@ -1,0 +1,9 @@
+class RefreshTariffKnowledgeCompressedNotesWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :sync, retry: false
+
+  def perform
+    TariffKnowledge::CompressedNoteRefresh.call
+  end
+end

--- a/spec/services/tariff_knowledge/compressed_note_refresh_spec.rb
+++ b/spec/services/tariff_knowledge/compressed_note_refresh_spec.rb
@@ -1,12 +1,9 @@
 RSpec.describe TariffKnowledge::CompressedNoteRefresh do
   describe '.call' do
+    let(:chapter) { create(:chapter, goods_nomenclature_item_id: '0100000000') }
+    let(:heading) { create(:heading, parent: chapter, goods_nomenclature_item_id: '0101000000') }
+
     before do
-      create(
-        :tariff_knowledge_node,
-        key: 'goods_nomenclature:123',
-        goods_nomenclature_sid: 123,
-        goods_nomenclature_item_id: '0101210000',
-      )
       create(
         :tariff_knowledge_compressed_note,
         goods_nomenclature_sid: 999,
@@ -20,6 +17,15 @@ RSpec.describe TariffKnowledge::CompressedNoteRefresh do
     end
 
     it 'regenerates compressed notes for current declarables and expires old notes' do
+      create(:commodity, parent: heading, goods_nomenclature_sid: 123, goods_nomenclature_item_id: '0101210000')
+      create(
+        :tariff_knowledge_node,
+        key: 'goods_nomenclature:456',
+        goods_nomenclature_sid: 456,
+        goods_nomenclature_item_id: '0101290000',
+      )
+      GoodsNomenclatures::TreeNode.refresh!
+
       result = described_class.call
 
       expect(TariffKnowledge::DeclarableNodeLoader).to have_received(:call).ordered
@@ -31,6 +37,26 @@ RSpec.describe TariffKnowledge::CompressedNoteRefresh do
         goods_nomenclature_count: 1,
         expired_note_count: 1,
       )
+    end
+
+    it 'processes current declarables in batches' do
+      stub_const("#{described_class}::BATCH_SIZE", 1)
+      create(:commodity, parent: heading, goods_nomenclature_sid: 123, goods_nomenclature_item_id: '0101210000')
+      create(:commodity, parent: heading, goods_nomenclature_sid: 124, goods_nomenclature_item_id: '0101290000')
+      GoodsNomenclatures::TreeNode.refresh!
+
+      described_class.call
+
+      expect(TariffKnowledge::CompressedNoteGenerator)
+        .to have_received(:call).with(goods_nomenclature_sids: [123]).ordered
+      expect(TariffKnowledge::CompressedNoteGenerator)
+        .to have_received(:call).with(goods_nomenclature_sids: [124]).ordered
+    end
+
+    it 'expires all unexpired notes when there are no current declarables' do
+      described_class.call
+
+      expect(TariffKnowledge::CompressedNote[999].expired).to be(true)
     end
   end
 end

--- a/spec/services/tariff_knowledge/compressed_note_refresh_spec.rb
+++ b/spec/services/tariff_knowledge/compressed_note_refresh_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe TariffKnowledge::CompressedNoteRefresh do
+  describe '.call' do
+    before do
+      create(
+        :tariff_knowledge_node,
+        key: 'goods_nomenclature:123',
+        goods_nomenclature_sid: 123,
+        goods_nomenclature_item_id: '0101210000',
+      )
+      create(
+        :tariff_knowledge_compressed_note,
+        goods_nomenclature_sid: 999,
+        goods_nomenclature_item_id: '9999999999',
+        expired: false,
+      )
+
+      allow(TariffKnowledge::DeclarableNodeLoader).to receive(:call)
+      allow(TariffKnowledge::SourceGraphLoader).to receive(:call)
+      allow(TariffKnowledge::CompressedNoteGenerator).to receive(:call)
+    end
+
+    it 'regenerates compressed notes for current declarables and expires old notes' do
+      result = described_class.call
+
+      expect(TariffKnowledge::DeclarableNodeLoader).to have_received(:call).ordered
+      expect(TariffKnowledge::SourceGraphLoader).to have_received(:call).ordered
+      expect(TariffKnowledge::CompressedNoteGenerator)
+        .to have_received(:call).with(goods_nomenclature_sids: [123]).ordered
+      expect(TariffKnowledge::CompressedNote[999].expired).to be(true)
+      expect(result).to have_attributes(
+        goods_nomenclature_count: 1,
+        expired_note_count: 1,
+      )
+    end
+  end
+end

--- a/spec/workers/refresh_tariff_knowledge_compressed_notes_worker_spec.rb
+++ b/spec/workers/refresh_tariff_knowledge_compressed_notes_worker_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe RefreshTariffKnowledgeCompressedNotesWorker, type: :worker do
+  describe '#perform' do
+    it 'delegates compressed note refresh' do
+      allow(TariffKnowledge::CompressedNoteRefresh).to receive(:call)
+
+      described_class.new.perform
+
+      expect(TariffKnowledge::CompressedNoteRefresh).to have_received(:call)
+    end
+  end
+
+  it 'uses the sync queue' do
+    expect(described_class.sidekiq_options['queue']).to eq(:sync)
+  end
+
+  it 'does not retry failures' do
+    expect(described_class.sidekiq_options['retry']).to be(false)
+  end
+end


### PR DESCRIPTION
## What:
- [x] Add `TariffKnowledge::CompressedNoteRefresh` to refresh the KG compressed note pipeline
- [x] Regenerate notes for the current declarable node set
- [x] Mark compressed notes for non-current declarables as expired
- [x] Add `RefreshTariffKnowledgeCompressedNotesWorker` as an unscheduled sync worker entry point

## Why:
We need a lightweight repeatable entry point for data changes so current compressed notes can be regenerated and old notes do not remain visible as current review content.

## Ticket:
[AI-868](https://transformuk.atlassian.net/browse/AI-868)

## Risk:
**Risk level:** 🟢

**Reason for rating:** This is staging-only, technical-operator functionality for generating, reviewing, refreshing, exposing, or consuming compressed notes. Production and other environments should leave the consuming feature disabled, so this does not change live trader journeys or production search behaviour.

### Environment note
Compressed notes are intended to be consumed only in staging. Staging is the only environment where this capability will be enabled; production and other environments should leave the consuming feature disabled.
