### PR TITLE
BAU: Notify on customs tariff document imports

### DIFF
--- a/app/workers/import_customs_tariff_document_worker.rb
+++ b/app/workers/import_customs_tariff_document_worker.rb
@@ -13,18 +13,54 @@ class ImportCustomsTariffDocumentWorker
     results = CustomsTariffImporter::Importer.new.call
 
     duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
+    imported_count = results.count { |r| r.status == :imported }
+    skipped_count = results.count { |r| %i[skipped duplicate_content].include?(r.status) }
+    failed_count = results.count { |r| r.status == :failed }
+    review_backlog = CustomsTariffUpdate.pending.count
+
     CustomsTariffImporter::Instrumentation.import_run_completed(
-      imported: results.count { |r| r.status == :imported },
-      skipped: results.count { |r| %i[skipped duplicate_content].include?(r.status) },
-      failed: results.count { |r| r.status == :failed },
+      imported: imported_count,
+      skipped: skipped_count,
+      failed: failed_count,
       duration_ms:,
-      review_backlog: CustomsTariffUpdate.pending.count,
+      review_backlog:,
     )
+
+    notify_completed(imported_count:, skipped_count:, failed_count:, review_backlog:)
   rescue StandardError => e
     CustomsTariffImporter::Instrumentation.import_run_failed(
       error_class: e.class.name,
       error_message: e.message,
     )
+    notify_failed(e)
     raise
+  end
+
+  private
+
+  def notify_completed(imported_count:, skipped_count:, failed_count:, review_backlog:)
+    return unless imported_count.positive? || failed_count.positive?
+
+    status = failed_count.positive? ? 'completed with failures' : 'completed'
+
+    notify_slack(
+      "Customs tariff document import #{status}. " \
+      "imported: #{imported_count}, skipped: #{skipped_count}, failed: #{failed_count}, " \
+      "pending review: #{review_backlog}",
+    )
+  end
+
+  def notify_failed(error)
+    notify_slack(
+      "Customs tariff document import failed. #{error.class}: #{error.message}",
+    )
+  end
+
+  def notify_slack(message)
+    SlackNotifierService.call(message)
+  rescue StandardError => e
+    Rails.logger.error(
+      "Failed to send customs tariff document import Slack notification: #{e.class}: #{e.message}",
+    )
   end
 end

--- a/spec/workers/import_customs_tariff_document_worker_spec.rb
+++ b/spec/workers/import_customs_tariff_document_worker_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe ImportCustomsTariffDocumentWorker, type: :worker do
   subject(:perform) { described_class.new.perform }
 
   before do
+    allow(SlackNotifierService).to receive(:call)
     allow(CustomsTariffImporter::Instrumentation).to receive(:import_run_started)
     allow(CustomsTariffImporter::Instrumentation).to receive(:import_run_completed)
     allow(CustomsTariffImporter::Instrumentation).to receive(:import_run_failed)
@@ -36,6 +37,26 @@ RSpec.describe ImportCustomsTariffDocumentWorker, type: :worker do
         review_backlog: 1,
       )
     end
+
+    it 'notifies Slack that the import completed successfully' do
+      perform
+
+      expect(SlackNotifierService).to have_received(:call).with(
+        include('Customs tariff document import completed', 'imported: 1', 'skipped: 0', 'failed: 0'),
+      )
+    end
+
+    context 'when Slack notification fails' do
+      before do
+        allow(SlackNotifierService).to receive(:call).and_raise(Slack::Notifier::APIError, 'Slack timeout')
+      end
+
+      it 'does not fail the import job' do
+        expect { perform }.not_to raise_error
+
+        expect(CustomsTariffImporter::Instrumentation).to have_received(:import_run_completed)
+      end
+    end
   end
 
   context 'when all documents are skipped' do
@@ -52,6 +73,12 @@ RSpec.describe ImportCustomsTariffDocumentWorker, type: :worker do
         hash_including(imported: 0, skipped: 1, failed: 0),
       )
     end
+
+    it 'does not notify Slack' do
+      perform
+
+      expect(SlackNotifierService).not_to have_received(:call)
+    end
   end
 
   context 'when a document import fails' do
@@ -66,6 +93,14 @@ RSpec.describe ImportCustomsTariffDocumentWorker, type: :worker do
       perform
       expect(CustomsTariffImporter::Instrumentation).to have_received(:import_run_completed).with(
         hash_including(imported: 0, skipped: 0, failed: 1),
+      )
+    end
+
+    it 'notifies Slack that the import completed with failures' do
+      perform
+
+      expect(SlackNotifierService).to have_received(:call).with(
+        include('Customs tariff document import completed with failures', 'failed: 1'),
       )
     end
   end
@@ -85,6 +120,24 @@ RSpec.describe ImportCustomsTariffDocumentWorker, type: :worker do
         error_class: 'RuntimeError',
         error_message: 'catastrophic failure',
       )
+    end
+
+    it 'notifies Slack that the import failed unexpectedly' do
+      expect { perform }.to raise_error(RuntimeError)
+
+      expect(SlackNotifierService).to have_received(:call).with(
+        include('Customs tariff document import failed', 'RuntimeError', 'catastrophic failure'),
+      )
+    end
+
+    context 'when Slack notification fails' do
+      before do
+        allow(SlackNotifierService).to receive(:call).and_raise(Slack::Notifier::APIError, 'Slack timeout')
+      end
+
+      it 're-raises the original import error' do
+        expect { perform }.to raise_error(RuntimeError, 'catastrophic failure')
+      end
     end
   end
 end


### PR DESCRIPTION
### Jira link

N/A

### What?

- [x] Notify Slack when the customs tariff document import loads new chapter notes, section notes, or general rules
- [x] Notify Slack when the import completes with handled document failures
- [x] Notify Slack before re-raising unexpected import job failures
- [x] Keep all-skipped runs quiet to avoid daily Slack noise when there is no new document to load
- [x] Add worker specs for success, handled failure, unexpected failure, and skipped-only runs

### Why?

Operators need a clear Slack signal when the scheduled customs tariff document import loads reference notes or fails while loading them. This matches the operational visibility already expected for similar data refresh jobs without changing the import behaviour or approval flow.

### Risk

**Risk level:** 🟢

**Reason for rating:** Low-risk additive observability. The change only sends Slack messages around the existing import worker outcome and keeps the underlying customs tariff import, persistence, and approval behaviour unchanged.