### PR TITLE
AI-868: Add compressed notes admin API

### DIFF
--- a/app/controllers/api/admin/goods_nomenclatures/tariff_knowledge_compressed_notes_controller.rb
+++ b/app/controllers/api/admin/goods_nomenclatures/tariff_knowledge_compressed_notes_controller.rb
@@ -1,0 +1,96 @@
+module Api
+  module Admin
+    module GoodsNomenclatures
+      class TariffKnowledgeCompressedNotesController < AdminController
+        include Api::Admin::VersionBrowsing
+
+        def show
+          render json: serialize(compressed_note, serializer_options)
+        end
+
+        def update
+          compressed_note.apply_manual_edit!(update_params)
+
+          render json: serialize(compressed_note.reload, serializer_options), status: :ok
+        end
+
+        def approve
+          compressed_note.approve!
+
+          render json: serialize(compressed_note.reload), status: :ok
+        end
+
+        def reject
+          compressed_note.mark_needs_review!
+
+          render json: serialize(compressed_note.reload), status: :ok
+        end
+
+        def regenerate
+          compressed_note.prepare_ui_regeneration!(context_hash: 'invalidated')
+          TariffKnowledge::CompressedNoteGenerator.call(goods_nomenclature_sids: [goods_nomenclature_sid])
+
+          render json: serialize(compressed_note.reload), status: :ok
+        end
+
+        def versions
+          render json: serialize_versions(compressed_note.versions.all)
+        end
+
+      private
+
+        def serialize(note, options = {})
+          Api::Admin::TariffKnowledgeCompressedNoteSerializer
+            .new(note, options)
+            .serializable_hash
+        end
+
+        def serialize_versions(versions)
+          Version.preload_predecessors(versions)
+          Api::Admin::VersionSerializer.new(versions).serializable_hash
+        end
+
+        def compressed_note
+          @compressed_note ||= find_compressed_note
+        end
+
+        def find_compressed_note
+          if filter_version_id.present? && !current_version?
+            find_historical_compressed_note
+          else
+            find_current_compressed_note
+          end
+        end
+
+        def find_current_compressed_note
+          TariffKnowledge::CompressedNote[goods_nomenclature_sid] || raise(Sequel::RecordNotFound)
+        end
+
+        def find_historical_compressed_note
+          version = versions_for_item
+            .where(id: filter_version_id)
+            .first
+
+          raise Sequel::RecordNotFound if version.blank?
+
+          version.reify
+        end
+
+        def versions_for_item
+          Version.where(item_type: 'TariffKnowledge::CompressedNote', item_id: goods_nomenclature_sid.to_s)
+        end
+
+        def goods_nomenclature_sid
+          params[:goods_nomenclature_id].to_i
+        end
+
+        def update_params
+          attributes = params.require(:data).require(:attributes)
+          {
+            content: attributes[:content],
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/goods_nomenclatures/tariff_knowledge_compressed_notes_controller.rb
+++ b/app/controllers/api/admin/goods_nomenclatures/tariff_knowledge_compressed_notes_controller.rb
@@ -5,7 +5,7 @@ module Api
         include Api::Admin::VersionBrowsing
 
         def show
-          render json: serialize(compressed_note, serializer_options)
+          render json: serialize(viewed_compressed_note, serializer_options)
         end
 
         def update
@@ -51,10 +51,10 @@ module Api
         end
 
         def compressed_note
-          @compressed_note ||= find_compressed_note
+          @compressed_note ||= find_current_compressed_note
         end
 
-        def find_compressed_note
+        def viewed_compressed_note
           if filter_version_id.present? && !current_version?
             find_historical_compressed_note
           else

--- a/app/controllers/api/admin/tariff_knowledge_compressed_notes_controller.rb
+++ b/app/controllers/api/admin/tariff_knowledge_compressed_notes_controller.rb
@@ -1,0 +1,71 @@
+module Api
+  module Admin
+    class TariffKnowledgeCompressedNotesController < AdminController
+      def index
+        render json: serializer_class.new(
+          paginated_dataset.all,
+          is_collection: true,
+          meta: pagination_meta,
+        ).serializable_hash
+      end
+
+    private
+
+      def paginated_dataset
+        @paginated_dataset ||= filtered_dataset.paginate(current_page, per_page)
+      end
+
+      def filtered_dataset
+        dataset = TariffKnowledge::CompressedNote.dataset
+        dataset = apply_status_filter(dataset)
+        dataset = apply_search(dataset)
+
+        dataset.order(Sequel.asc(:goods_nomenclature_item_id))
+      end
+
+      def apply_status_filter(dataset)
+        case params[:status]
+        when 'expired'
+          dataset.where(expired: true)
+        when 'approved'
+          dataset.where(approved: true, expired: false)
+        when 'stale'
+          dataset.where(stale: true, expired: false)
+        when 'manually_edited'
+          dataset.where(manually_edited: true, expired: false)
+        when 'needs_review'
+          dataset.where(needs_review: true, expired: false)
+        else
+          dataset.where(approved: false, expired: false)
+        end
+      end
+
+      def apply_search(dataset)
+        query = params[:q].to_s.strip
+        return dataset if query.blank?
+
+        if query.match?(/\A\d{2,10}\z/)
+          dataset.where(Sequel.like(:goods_nomenclature_item_id, "#{query}%"))
+        elsif query.length >= 2
+          dataset.where(Sequel.ilike(:content, "%#{query}%"))
+        else
+          dataset
+        end
+      end
+
+      def pagination_meta
+        {
+          pagination: {
+            page: current_page,
+            per_page:,
+            total_count: paginated_dataset.pagination_record_count,
+          },
+        }
+      end
+
+      def serializer_class
+        Api::Admin::TariffKnowledgeCompressedNoteSerializer
+      end
+    end
+  end
+end

--- a/app/engines/admin_api.rb
+++ b/app/engines/admin_api.rb
@@ -62,6 +62,12 @@ AdminApi.routes.draw do
             post :reject
             get :versions
           end
+          resource :tariff_knowledge_compressed_note, only: %i[show update] do
+            post :regenerate
+            post :approve
+            post :reject
+            get :versions
+          end
         end
       end
 
@@ -71,6 +77,7 @@ AdminApi.routes.draw do
 
       resources :goods_nomenclature_labels, only: [:index]
       resources :goods_nomenclature_self_texts, only: [:index]
+      resources :tariff_knowledge_compressed_notes, only: [:index]
       resources :versions, only: [:index] do
         member do
           post :restore

--- a/app/serializers/api/admin/tariff_knowledge_compressed_note_serializer.rb
+++ b/app/serializers/api/admin/tariff_knowledge_compressed_note_serializer.rb
@@ -1,0 +1,26 @@
+module Api
+  module Admin
+    class TariffKnowledgeCompressedNoteSerializer
+      include JSONAPI::Serializer
+
+      set_type :tariff_knowledge_compressed_note
+      set_id :goods_nomenclature_sid
+
+      attributes :goods_nomenclature_sid,
+                 :goods_nomenclature_item_id,
+                 :producline_suffix,
+                 :goods_nomenclature_type,
+                 :content,
+                 :metadata,
+                 :context_hash,
+                 :needs_review,
+                 :approved,
+                 :manually_edited,
+                 :stale,
+                 :expired,
+                 :generated_at,
+                 :created_at,
+                 :updated_at
+    end
+  end
+end

--- a/spec/requests/api/admin/goods_nomenclatures/tariff_knowledge_compressed_notes_controller_spec.rb
+++ b/spec/requests/api/admin/goods_nomenclatures/tariff_knowledge_compressed_notes_controller_spec.rb
@@ -48,6 +48,19 @@ RSpec.describe Api::Admin::GoodsNomenclatures::TariffKnowledgeCompressedNotesCon
       expect(response).to have_http_status(:ok)
       expect(note.reload).to have_attributes(approved: true, needs_review: false)
     end
+
+    it 'approves the current compressed note when a historical version is selected' do
+      note.update(content: 'Historical note')
+      historical_version_id = note.versions.order(:id).first.id
+
+      post '/uk/admin/goods_nomenclatures/123/tariff_knowledge_compressed_note/approve.json',
+           params: { filter: { oid: historical_version_id } },
+           headers: request_headers(format: :json),
+           as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(note.reload).to have_attributes(approved: true, needs_review: false)
+    end
   end
 
   describe '#reject' do

--- a/spec/requests/api/admin/goods_nomenclatures/tariff_knowledge_compressed_notes_controller_spec.rb
+++ b/spec/requests/api/admin/goods_nomenclatures/tariff_knowledge_compressed_notes_controller_spec.rb
@@ -1,0 +1,89 @@
+RSpec.describe Api::Admin::GoodsNomenclatures::TariffKnowledgeCompressedNotesController do
+  let!(:note) do
+    create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_sid: 123,
+      goods_nomenclature_item_id: '0101210000',
+      content: 'Heading 0101 covers live horses.',
+      needs_review: true,
+      approved: false,
+    )
+  end
+
+  describe '#show' do
+    it 'returns compressed note review content' do
+      get '/uk/admin/goods_nomenclatures/123/tariff_knowledge_compressed_note.json', headers: request_headers(format: :json)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.dig('data', 'attributes')).to include(
+        'goods_nomenclature_sid' => 123,
+        'goods_nomenclature_item_id' => '0101210000',
+        'content' => 'Heading 0101 covers live horses.',
+        'needs_review' => true,
+      )
+    end
+  end
+
+  describe '#update' do
+    it 'applies a manual edit' do
+      put '/uk/admin/goods_nomenclatures/123/tariff_knowledge_compressed_note.json',
+          params: { data: { type: 'tariff_knowledge_compressed_note', attributes: { content: 'Reviewed note' } } },
+          headers: request_headers(format: :json),
+          as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(note.reload).to have_attributes(
+        content: 'Reviewed note',
+        manually_edited: true,
+        approved: true,
+        needs_review: false,
+      )
+    end
+  end
+
+  describe '#approve' do
+    it 'approves the compressed note' do
+      post '/uk/admin/goods_nomenclatures/123/tariff_knowledge_compressed_note/approve.json', headers: request_headers(format: :json), as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(note.reload).to have_attributes(approved: true, needs_review: false)
+    end
+  end
+
+  describe '#reject' do
+    it 'marks the compressed note as needing review' do
+      note.update(approved: true, needs_review: false)
+
+      post '/uk/admin/goods_nomenclatures/123/tariff_knowledge_compressed_note/reject.json', headers: request_headers(format: :json), as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(note.reload).to have_attributes(approved: false, needs_review: true)
+    end
+  end
+
+  describe '#versions' do
+    it 'returns compressed note versions' do
+      note.update(content: 'Changed note')
+
+      get '/uk/admin/goods_nomenclatures/123/tariff_knowledge_compressed_note/versions.json', headers: request_headers(format: :json)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['data'].first['type']).to eq('version')
+    end
+  end
+
+  describe '#regenerate' do
+    it 'delegates regeneration for this goods nomenclature sid' do
+      allow(TariffKnowledge::CompressedNoteGenerator).to receive(:call) do
+        note.update(content: 'Regenerated note')
+      end
+
+      post '/uk/admin/goods_nomenclatures/123/tariff_knowledge_compressed_note/regenerate.json', headers: request_headers(format: :json), as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(TariffKnowledge::CompressedNoteGenerator)
+        .to have_received(:call).with(goods_nomenclature_sids: [123])
+      expect(response.parsed_body.dig('data', 'attributes', 'content')).to eq('Regenerated note')
+    end
+  end
+end

--- a/spec/requests/api/admin/tariff_knowledge_compressed_notes_controller_spec.rb
+++ b/spec/requests/api/admin/tariff_knowledge_compressed_notes_controller_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Api::Admin::TariffKnowledgeCompressedNotesController do
+  describe '#index' do
+    before do
+      create(:tariff_knowledge_compressed_note, goods_nomenclature_sid: 123, goods_nomenclature_item_id: '0101210000', needs_review: true, approved: false)
+      create(:tariff_knowledge_compressed_note, goods_nomenclature_sid: 456, goods_nomenclature_item_id: '0101290000', needs_review: false, approved: true)
+      create(:tariff_knowledge_compressed_note, goods_nomenclature_sid: 789, goods_nomenclature_item_id: '0201100000', needs_review: true, expired: true)
+    end
+
+    it 'lists non-approved current compressed notes by default' do
+      get '/uk/admin/tariff_knowledge_compressed_notes.json', headers: request_headers(format: :json)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['data'].map { |record| record['id'] }).to eq(%w[123])
+      expect(response.parsed_body.dig('meta', 'pagination', 'total_count')).to eq(1)
+    end
+
+    it 'can list expired compressed notes' do
+      get '/uk/admin/tariff_knowledge_compressed_notes.json', params: { status: 'expired' }, headers: request_headers(format: :json)
+
+      expect(response.parsed_body['data'].map { |record| record['id'] }).to eq(%w[789])
+    end
+  end
+end


### PR DESCRIPTION
## What:
- [x] Add admin review collection endpoint for tariff knowledge compressed notes
- [x] Add nested compressed-note show/update/approve/reject/regenerate/versions endpoints under goods nomenclatures
- [x] Add JSON:API serializer and request coverage for the review workflow

## Why:
The admin UI needs backend endpoints to review, edit, approve, reject, regenerate, and inspect versions for generated compressed notes.

## Ticket:
[AI-868](https://transformuk.atlassian.net/browse/AI-868)

## Risk:
**Risk level:** 🟢

**Reason for rating:** This is staging-only, technical-operator functionality for generating, reviewing, refreshing, exposing, or consuming compressed notes. Production and other environments should leave the consuming feature disabled, so this does not change live trader journeys or production search behaviour.

### Environment note
Compressed notes are intended to be consumed only in staging. Staging is the only environment where this capability will be enabled; production and other environments should leave the consuming feature disabled.
