### PR TITLE
AI-517: Add chapter notes CRUD, sections summary and reimport API endpoints

### DIFF
--- a/app/controllers/api/admin/customs_tariff_updates/chapter_notes_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates/chapter_notes_controller.rb
@@ -1,54 +1,51 @@
 module Api
   module Admin
     module CustomsTariffUpdates
-      class SectionNotesController < BaseController
+      class ChapterNotesController < BaseController
         def index
-          notes = CustomsTariffSectionNote
+          notes = CustomsTariffChapterNote
             .where(customs_tariff_update_version: customs_tariff_update.version)
-            .order(:section_id).all
+            .then { |ds| filter_by_section(ds) }
+            .order(:chapter_id).all
 
-          baseline_by_section = compare_notes_index
+          baseline_by_chapter = compare_notes_index
 
           file_diffs = notes.each_with_object({}) do |note, diffs|
-            baseline = baseline_by_section[note.section_id]
-            diffs[note.section_id] = if baseline.nil?
-                                       nil
-                                     else
-                                       content_diff(baseline, note)
-                                     end
+            baseline = baseline_by_chapter[note.chapter_id]
+            diffs[note.chapter_id] = baseline.nil? ? nil : content_diff(baseline, note)
           end
 
-          render json: Api::Admin::CustomsTariffUpdates::SectionNoteSerializer.new(
+          render json: Api::Admin::CustomsTariffUpdates::ChapterNoteSerializer.new(
             notes, is_collection: true, params: { file_diffs: }
           ).serializable_hash
         end
 
         def show
-          note = customs_tariff_section_note
+          note = customs_tariff_chapter_note
 
           if params[:compare_version].present?
-            compare_note = CustomsTariffSectionNote
-              .where(section_id: note.section_id,
+            compare_note = CustomsTariffChapterNote
+              .where(chapter_id: note.chapter_id,
                      customs_tariff_update_version: params[:compare_version])
               .first
 
             file_diff = content_diff(compare_note, note) if compare_note
 
-            render json: Api::Admin::CustomsTariffUpdates::SectionNoteSerializer.new(
+            render json: Api::Admin::CustomsTariffUpdates::ChapterNoteSerializer.new(
               note, is_collection: false, params: { file_diff: }
             ).serializable_hash
           else
             versions = note.versions.order(Sequel.desc(:created_at)).all
             Version.preload_predecessors(versions)
 
-            render json: Api::Admin::CustomsTariffUpdates::SectionNoteSerializer.new(
+            render json: Api::Admin::CustomsTariffUpdates::ChapterNoteSerializer.new(
               note, is_collection: false, params: { versions: }
             ).serializable_hash
           end
         end
 
         def update
-          note = customs_tariff_section_note
+          note = customs_tariff_chapter_note
 
           if customs_tariff_update.status == CustomsTariffUpdate::REJECTED
             render json: { errors: [{ detail: 'Cannot edit a note on a rejected update' }] },
@@ -56,10 +53,10 @@ module Api
             return
           end
 
-          note.set(content: update_params[:content])
+          note.set(content: chapter_note_params[:content])
 
           if note.save(raise_on_failure: false)
-            render json: Api::Admin::CustomsTariffUpdates::SectionNoteSerializer.new(note, is_collection: false).serializable_hash
+            render json: Api::Admin::CustomsTariffUpdates::ChapterNoteSerializer.new(note, is_collection: false).serializable_hash
           else
             render json: Api::Admin::ErrorSerializationService.new(note).call, status: :unprocessable_content
           end
@@ -72,26 +69,29 @@ module Api
             return
           end
 
-          note = CustomsTariffSectionNote.new(
+          note = CustomsTariffChapterNote.new(
             customs_tariff_update_version: customs_tariff_update.version,
-            section_id: create_params[:section_id].to_i,
+            chapter_id: create_params[:chapter_id],
             content: create_params[:content],
             validity_start_date: customs_tariff_update.validity_start_date,
-            status: CustomsTariffSectionNote::PENDING,
+            status: CustomsTariffChapterNote::PENDING,
           )
 
           if note.save(raise_on_failure: false)
-            render json: Api::Admin::CustomsTariffUpdates::SectionNoteSerializer.new(
+            render json: Api::Admin::CustomsTariffUpdates::ChapterNoteSerializer.new(
               note, is_collection: false
             ).serializable_hash, status: :created
           else
             render json: Api::Admin::ErrorSerializationService.new(note).call,
                    status: :unprocessable_content
           end
+        rescue Sequel::UniqueConstraintViolation
+          render json: { errors: [{ detail: 'A note for this chapter already exists on this update' }] },
+                 status: :unprocessable_content
         end
 
         def destroy
-          note = customs_tariff_section_note
+          note = customs_tariff_chapter_note
 
           if customs_tariff_update.status == CustomsTariffUpdate::REJECTED
             render json: { errors: [{ detail: 'Cannot remove a note from a rejected update' }] },
@@ -106,20 +106,38 @@ module Api
                  status: :unprocessable_content
         end
 
-        private
+      private
+
+        def filter_by_section(dataset)
+          return dataset if params[:section_id].blank?
+
+          ids = chapter_ids_for_section(params[:section_id].to_i)
+          ids.any? ? dataset.where(chapter_id: ids) : dataset.where(Sequel.lit('false'))
+        end
+
+        def chapter_ids_for_section(section_id)
+          Sequel::Model.db.fetch(<<~SQL, section_id:).map { |r| r[:chapter_code] }
+            SELECT LEFT(gn.goods_nomenclature_item_id, 2) AS chapter_code
+            FROM   chapters_sections cs
+            JOIN   goods_nomenclatures gn
+                     ON gn.goods_nomenclature_sid = cs.goods_nomenclature_sid
+            WHERE  gn.goods_nomenclature_item_id LIKE '__00000000'
+              AND  cs.section_id = :section_id
+          SQL
+        end
 
         def compare_notes_index
           if params[:compare_version].present?
-            CustomsTariffSectionNote
+            CustomsTariffChapterNote
               .where(customs_tariff_update_version: params[:compare_version])
-              .all.index_by(&:section_id)
+              .all.index_by(&:chapter_id)
           else
             previous_notes_index
           end
         end
 
-        def customs_tariff_section_note
-          @customs_tariff_section_note ||= CustomsTariffSectionNote
+        def customs_tariff_chapter_note
+          @customs_tariff_chapter_note ||= CustomsTariffChapterNote
             .where(id: params[:id], customs_tariff_update_version: customs_tariff_update.version)
             .first.tap { |n| raise Sequel::RecordNotFound unless n }
         end
@@ -133,25 +151,25 @@ module Api
             .first
           return {} unless prev
 
-          CustomsTariffSectionNote
+          CustomsTariffChapterNote
             .where(customs_tariff_update_version: prev.version)
-            .all.index_by(&:section_id)
+            .all.index_by(&:chapter_id)
         end
 
         def content_diff(from_note, to_note)
           VersionDiffService.new(
-            'CustomsTariffSectionNote',
+            'CustomsTariffChapterNote',
             { 'content' => from_note.content },
             { 'content' => to_note.content },
           ).call || {}
         end
 
-        def update_params
+        def chapter_note_params
           params.require(:data).require(:attributes).permit(:content)
         end
 
         def create_params
-          params.require(:data).require(:attributes).permit(:content, :section_id)
+          params.require(:data).require(:attributes).permit(:chapter_id, :content)
         end
       end
     end

--- a/app/controllers/api/admin/customs_tariff_updates/reimport_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates/reimport_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module Admin
+    module CustomsTariffUpdates
+      class ReimportController < BaseController
+        def create
+          # No status guard — reimport is a recovery tool that must work on any update status
+          CustomsTariffReimportWorker.perform_async(customs_tariff_update.version)
+          head :accepted
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/customs_tariff_updates/sections_summary_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates/sections_summary_controller.rb
@@ -1,0 +1,123 @@
+module Api
+  module Admin
+    module CustomsTariffUpdates
+      class SectionsSummaryController < BaseController
+        def index
+          sections          = Section.order(:position).all
+          notes_for_update  = notes_index_for(customs_tariff_update.version)
+          baseline_notes    = baseline_section_notes
+          chapter_notes     = CustomsTariffChapterNote
+                                .where(customs_tariff_update_version: customs_tariff_update.version)
+                                .all
+          baseline_chapters = baseline_chapter_notes
+          chapter_section   = chapter_to_section_map
+          chapter_counts    = chapter_counts_by_section(chapter_notes, baseline_chapters, chapter_section)
+
+          summaries = sections.map do |section|
+            note   = notes_for_update[section.id]
+            diff   = note ? section_note_diff(baseline_notes[section.id], note) : nil
+            status = section_note_status(note, diff)
+            counts = chapter_counts[section.id] || { total: 0, changed: 0 }
+
+            SectionSummary.new(
+              section_id: section.id,
+              section_title: section.title,
+              position: section.position,
+              section_note_id: note&.id,
+              section_note_status: status,
+              chapter_notes_total: counts[:total],
+              chapter_notes_changed: counts[:changed],
+            )
+          end
+
+          render json: Api::Admin::CustomsTariffUpdates::SectionSummarySerializer.new(
+            summaries, is_collection: true
+          ).serializable_hash
+        end
+
+      private
+
+        def notes_index_for(version)
+          CustomsTariffSectionNote
+            .where(customs_tariff_update_version: version)
+            .all.index_by(&:section_id)
+        end
+
+        def baseline_section_notes
+          if params[:compare_version].present?
+            notes_index_for(params[:compare_version])
+          else
+            prev = previous_update
+            prev ? notes_index_for(prev.version) : {}
+          end
+        end
+
+        def baseline_chapter_notes
+          if params[:compare_version].present?
+            CustomsTariffChapterNote
+              .where(customs_tariff_update_version: params[:compare_version])
+              .all.index_by(&:chapter_id)
+          else
+            prev = previous_update
+            return {} unless prev
+
+            CustomsTariffChapterNote
+              .where(customs_tariff_update_version: prev.version)
+              .all.index_by(&:chapter_id)
+          end
+        end
+
+        def chapter_to_section_map
+          Sequel::Model.db.fetch(<<~SQL).map { |r| [r[:chapter_code], r[:section_id]] }.to_h
+            SELECT LEFT(gn.goods_nomenclature_item_id, 2) AS chapter_code,
+                   cs.section_id
+            FROM   chapters_sections cs
+            JOIN   goods_nomenclatures gn
+                     ON gn.goods_nomenclature_sid = cs.goods_nomenclature_sid
+            WHERE  gn.goods_nomenclature_item_id LIKE '__00000000'
+          SQL
+        end
+
+        def chapter_counts_by_section(chapter_notes, baseline, chapter_section_map)
+          chapter_notes.each_with_object(Hash.new { |h, k| h[k] = { total: 0, changed: 0 } }) do |note, counts|
+            section_id = chapter_section_map[note.chapter_id]
+            next unless section_id
+
+            counts[section_id][:total] += 1
+            baseline_note = baseline[note.chapter_id]
+            counts[section_id][:changed] += 1 if baseline_note.nil? || note.content != baseline_note.content
+          end
+        end
+
+        def section_note_diff(baseline_note, note)
+          return nil unless baseline_note
+
+          VersionDiffService.new(
+            'CustomsTariffSectionNote',
+            { 'content' => baseline_note.content },
+            { 'content' => note.content },
+          ).call || {}
+        end
+
+        def section_note_status(note, diff)
+          return :absent    if note.nil?
+          return :new       if diff.nil?
+          return :unchanged if diff.empty?
+
+          :changed
+        end
+
+        def previous_update
+          @previous_update ||= begin
+            current_date = customs_tariff_update.validity_start_date
+            CustomsTariffUpdate
+              .exclude(status: CustomsTariffUpdate::FAILED)
+              .where { validity_start_date < current_date }
+              .order(Sequel.desc(:validity_start_date))
+              .first
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/versions_controller.rb
+++ b/app/controllers/api/admin/versions_controller.rb
@@ -12,6 +12,7 @@ module Api
         'DescriptionIntercept' => DescriptionIntercept,
         'GoodsNomenclatureIntercept' => GoodsNomenclatureIntercept,
         'CustomsTariffSectionNote' => CustomsTariffSectionNote,
+        'CustomsTariffChapterNote' => CustomsTariffChapterNote,
       }.freeze
 
       def restore

--- a/app/engines/admin_api.rb
+++ b/app/engines/admin_api.rb
@@ -80,8 +80,27 @@ AdminApi.routes.draw do
       get  'customs_tariff_updates/:version', to: 'customs_tariff_updates#show', constraints: { version: /\d+\.\d+/ }
       get  'customs_tariff_updates/:customs_tariff_update_version/section_notes',      to: 'customs_tariff_updates/section_notes#index',  constraints: { customs_tariff_update_version: /[^\/]+/ }
       get  'customs_tariff_updates/:customs_tariff_update_version/section_notes/:id',  to: 'customs_tariff_updates/section_notes#show',   constraints: { customs_tariff_update_version: /[^\/]+/ }
-      patch 'customs_tariff_updates/:customs_tariff_update_version/section_notes/:id', to: 'customs_tariff_updates/section_notes#update',  constraints: { customs_tariff_update_version: /[^\/]+/ }
-      patch 'customs_tariff_updates/:customs_tariff_update_version/status',            to: 'customs_tariff_updates/status#update',         constraints: { customs_tariff_update_version: /[^\/]+/ }
+      patch 'customs_tariff_updates/:customs_tariff_update_version/section_notes/:id', to: 'customs_tariff_updates/section_notes#update', constraints: { customs_tariff_update_version: /[^\/]+/ }
+      post 'customs_tariff_updates/:customs_tariff_update_version/section_notes',
+           to: 'customs_tariff_updates/section_notes#create',
+           constraints: { customs_tariff_update_version: /[^\/]+/ }
+      delete 'customs_tariff_updates/:customs_tariff_update_version/section_notes/:id',
+             to: 'customs_tariff_updates/section_notes#destroy',
+             constraints: { customs_tariff_update_version: /[^\/]+/ }
+      patch 'customs_tariff_updates/:customs_tariff_update_version/status', to: 'customs_tariff_updates/status#update', constraints: { customs_tariff_update_version: /[^\/]+/ }
+      post  'customs_tariff_updates/:customs_tariff_update_version/reimport',
+            to: 'customs_tariff_updates/reimport#create',
+            constraints: { customs_tariff_update_version: /[^\/]+/ }
+      get   'customs_tariff_updates/:customs_tariff_update_version/chapter_notes',      to: 'customs_tariff_updates/chapter_notes#index',  constraints: { customs_tariff_update_version: /[^\/]+/ }
+      get   'customs_tariff_updates/:customs_tariff_update_version/chapter_notes/:id',  to: 'customs_tariff_updates/chapter_notes#show',   constraints: { customs_tariff_update_version: /[^\/]+/ }
+      patch 'customs_tariff_updates/:customs_tariff_update_version/chapter_notes/:id',  to: 'customs_tariff_updates/chapter_notes#update', constraints: { customs_tariff_update_version: /[^\/]+/ }
+      delete 'customs_tariff_updates/:customs_tariff_update_version/chapter_notes/:id',
+             to: 'customs_tariff_updates/chapter_notes#destroy',
+             constraints: { customs_tariff_update_version: /[^\/]+/ }
+      post 'customs_tariff_updates/:customs_tariff_update_version/chapter_notes',
+           to: 'customs_tariff_updates/chapter_notes#create',
+           constraints: { customs_tariff_update_version: /[^\/]+/ }
+      get 'customs_tariff_updates/:customs_tariff_update_version/sections_summary', to: 'customs_tariff_updates/sections_summary#index', constraints: { customs_tariff_update_version: /[^\/]+/ }
 
       resources :quota_order_numbers, module: 'quota_order_numbers', only: %i[] do
         resources :quota_definitions, only: %i[index show]

--- a/app/lib/customs_tariff_importer/document_fetcher.rb
+++ b/app/lib/customs_tariff_importer/document_fetcher.rb
@@ -5,7 +5,8 @@ module CustomsTariffImporter
   class DocumentFetcher
     PUBLICATION_URL = 'https://www.gov.uk/government/publications/reference-document-for-the-customs-tariff-establishment-eu-exit-regulations-2020'.freeze
     MAX_REDIRECTS = 5
-    VERSION_PATTERN = /UKGT_(\d+\.\d+)\.docx/i
+    TEXT_VERSION_PATTERN = /\bversion\s+(\d+\.\d+)\b/i
+    URL_VERSION_PATTERN  = /[_-](\d+\.\d+)\.docx/i
 
     Result = Data.define(:content, :url, :version, :checksum, :published_on, :entry_into_force_on)
 
@@ -19,7 +20,7 @@ module CustomsTariffImporter
       links.map { |link|
         url  = link[:url]
         text = link[:text]
-        version = extract_version(url)
+        version = extract_version(url, text)
 
         start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         content = fetch_url(url)
@@ -52,8 +53,9 @@ module CustomsTariffImporter
       end
     end
 
-    def extract_version(url)
-      url.match(VERSION_PATTERN)&.captures&.first
+    def extract_version(url, text)
+      text.match(TEXT_VERSION_PATTERN)&.captures&.first ||
+        url.match(URL_VERSION_PATTERN)&.captures&.first
     end
 
     def parse_entry_into_force_date(text)

--- a/app/lib/customs_tariff_importer/reimporter.rb
+++ b/app/lib/customs_tariff_importer/reimporter.rb
@@ -1,9 +1,14 @@
 module CustomsTariffImporter
   # this class is responsible for re-importing customs tariff notes from stored S3 documents into the database as part of rake task "importer:customs_tariff:reimport"
   class Reimporter
-    def call
-      CustomsTariffUpdate.exclude(status: CustomsTariffUpdate::FAILED).each do |update|
-        reimport(update)
+    def call(version: nil)
+      if version
+        update = CustomsTariffUpdate.first(version:)
+        reimport(update) if update # no-op if the version does not exist
+      else
+        CustomsTariffUpdate.exclude(status: CustomsTariffUpdate::FAILED).each do |update|
+          reimport(update)
+        end
       end
     end
 

--- a/app/models/customs_tariff_chapter_note.rb
+++ b/app/models/customs_tariff_chapter_note.rb
@@ -3,6 +3,8 @@ class CustomsTariffChapterNote < Sequel::Model
   APPROVED = 'approved'.freeze
   REJECTED = 'rejected'.freeze
 
+  plugin :has_paper_trail
+
   many_to_one :customs_tariff_update, key: :customs_tariff_update_version
 
   dataset_module do

--- a/app/models/section_summary.rb
+++ b/app/models/section_summary.rb
@@ -1,0 +1,5 @@
+SectionSummary = Data.define(
+  :section_id, :section_title, :position,
+  :section_note_id, :section_note_status,
+  :chapter_notes_total, :chapter_notes_changed
+)

--- a/app/serializers/api/admin/customs_tariff_updates/chapter_note_serializer.rb
+++ b/app/serializers/api/admin/customs_tariff_updates/chapter_note_serializer.rb
@@ -1,0 +1,33 @@
+module Api
+  module Admin
+    module CustomsTariffUpdates
+      class ChapterNoteSerializer
+        include JSONAPI::Serializer
+
+        set_type :customs_tariff_chapter_note
+        set_id   :id
+
+        attributes :chapter_id, :content, :customs_tariff_update_version
+
+        attribute :file_diff do |note, params|
+          params[:file_diff] || params[:file_diffs]&.dig(note.chapter_id)
+        end
+
+        attribute :versions do |_note, params|
+          (params[:versions] || []).map do |v|
+            {
+              id: v.id,
+              item_type: v.item_type,
+              item_id: v.item_id,
+              event: v.event,
+              object: v.object,
+              whodunnit: v.whodunnit,
+              created_at: v.created_at,
+              changeset: v.changeset,
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/admin/customs_tariff_updates/section_summary_serializer.rb
+++ b/app/serializers/api/admin/customs_tariff_updates/section_summary_serializer.rb
@@ -1,0 +1,16 @@
+module Api
+  module Admin
+    module CustomsTariffUpdates
+      class SectionSummarySerializer
+        include JSONAPI::Serializer
+
+        set_type :section_summary
+        set_id   :section_id
+
+        attributes :section_id, :section_title, :position,
+                   :section_note_id, :section_note_status,
+                   :chapter_notes_total, :chapter_notes_changed
+      end
+    end
+  end
+end

--- a/app/workers/customs_tariff_reimport_worker.rb
+++ b/app/workers/customs_tariff_reimport_worker.rb
@@ -1,0 +1,9 @@
+class CustomsTariffReimportWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :sync, retry: false
+
+  def perform(version)
+    CustomsTariffImporter::Reimporter.new.call(version:)
+  end
+end

--- a/spec/lib/customs_tariff_importer/document_fetcher_spec.rb
+++ b/spec/lib/customs_tariff_importer/document_fetcher_spec.rb
@@ -73,18 +73,18 @@ RSpec.describe CustomsTariffImporter::DocumentFetcher do
         <<~HTML
           <html><body>
             <div class="gem-c-attachment">
-              <a class="gem-c-attachment__thumbnail-image" href="https://assets.publishing.service.gov.uk/media/abc/UKGT_1.30.docx"></a>
+              <a class="gem-c-attachment__thumbnail-image" href="https://assets.publishing.service.gov.uk/media/abc/The_Tariff_of_the_United_Kingdom_1.31.docx"></a>
               <h3 class="gem-c-attachment__title">
-                <a href="https://assets.publishing.service.gov.uk/media/abc/UKGT_1.30.docx">
-                  The Tariff of the United Kingdom, version 1.30, dated 14 January 2026 (entry into force 22 January 2026)
+                <a href="https://assets.publishing.service.gov.uk/media/abc/The_Tariff_of_the_United_Kingdom_1.31.docx">
+                  The Tariff of the United Kingdom, version 1.31, dated 3 March 2026 (entry into force 1 April 2026)
                 </a>
               </h3>
             </div>
             <div class="gem-c-attachment">
-              <a class="gem-c-attachment__thumbnail-image" href="https://assets.publishing.service.gov.uk/media/def/UKGT_1.31.docx"></a>
+              <a class="gem-c-attachment__thumbnail-image" href="https://assets.publishing.service.gov.uk/media/def/The_Tariff_of_the_United_Kingdom_1.32.docx"></a>
               <h3 class="gem-c-attachment__title">
-                <a href="https://assets.publishing.service.gov.uk/media/def/UKGT_1.31.docx">
-                  The Tariff of the United Kingdom, version 1.31, dated 3 March 2026 (entry into force 1 April 2026)
+                <a href="https://assets.publishing.service.gov.uk/media/def/The_Tariff_of_the_United_Kingdom_1.32.docx">
+                  The Tariff of the United Kingdom, version 1.32, dated 14 January 2026 (entry into force 22 January 2026)
                 </a>
               </h3>
             </div>
@@ -105,14 +105,14 @@ RSpec.describe CustomsTariffImporter::DocumentFetcher do
 
       it 'returns the correct URLs' do
         expect(links.map { |l| l[:url] }).to contain_exactly(
-          'https://assets.publishing.service.gov.uk/media/abc/UKGT_1.30.docx',
-          'https://assets.publishing.service.gov.uk/media/def/UKGT_1.31.docx',
+          'https://assets.publishing.service.gov.uk/media/abc/The_Tariff_of_the_United_Kingdom_1.31.docx',
+          'https://assets.publishing.service.gov.uk/media/def/The_Tariff_of_the_United_Kingdom_1.32.docx',
         )
       end
 
       it 'returns the link text for each document' do
-        expect(links.first[:text]).to include('version 1.30')
-        expect(links.last[:text]).to include('version 1.31')
+        expect(links.first[:text]).to include('version 1.31')
+        expect(links.last[:text]).to include('version 1.32')
       end
 
       context 'when there are no .docx links' do
@@ -123,11 +123,51 @@ RSpec.describe CustomsTariffImporter::DocumentFetcher do
         end
       end
     end
+
+    describe 'extract_version (private)' do
+      subject(:extract) { fetcher.send(:extract_version, url, text) }
+
+      context 'when text contains "version X.Y"' do
+        let(:url)  { 'https://assets.publishing.service.gov.uk/media/abc/The_Tariff_of_the_United_Kingdom_1.32.docx' }
+        let(:text) { 'The Tariff of the United Kingdom, version 1.32, dated 14 January 2026 (entry into force 22 January 2026)' }
+
+        it 'returns the version from the link text' do
+          expect(extract).to eq('1.32')
+        end
+      end
+
+      context 'when text has no version label but URL has _X.Y.docx' do
+        let(:url)  { 'https://assets.publishing.service.gov.uk/media/abc/The_Tariff_of_the_United_Kingdom_1.30.docx' }
+        let(:text) { 'Some document with no version label' }
+
+        it 'falls back to the URL pattern' do
+          expect(extract).to eq('1.30')
+        end
+      end
+
+      context 'when text version and URL version differ' do
+        let(:url)  { 'https://assets.publishing.service.gov.uk/media/abc/The_Tariff_of_the_United_Kingdom_1.30.docx' }
+        let(:text) { 'The Tariff of the United Kingdom, version 1.32, dated 14 January 2026' }
+
+        it 'prefers the text version' do
+          expect(extract).to eq('1.32')
+        end
+      end
+
+      context 'when neither text nor URL contains a version' do
+        let(:url)  { 'https://assets.publishing.service.gov.uk/media/abc/document.docx' }
+        let(:text) { 'Some document' }
+
+        it 'returns nil' do
+          expect(extract).to be_nil
+        end
+      end
+    end
   end
 
   describe '#call instrumentation' do
-    let(:docx_url) { 'https://assets.publishing.service.gov.uk/media/abc/UKGT_1.30.docx' }
-    let(:link_text) { 'The Tariff of the United Kingdom, version 1.30, dated 14 January 2026 (entry into force 22 January 2026)' }
+    let(:docx_url) { 'https://assets.publishing.service.gov.uk/media/abc/The_Tariff_of_the_United_Kingdom_1.32.docx' }
+    let(:link_text) { 'The Tariff of the United Kingdom, version 1.32, dated 14 January 2026 (entry into force 22 January 2026)' }
     let(:page_html) do
       <<~HTML
         <html><body>
@@ -156,7 +196,7 @@ RSpec.describe CustomsTariffImporter::DocumentFetcher do
     it 'emits document_fetched for each document with version and timing' do
       fetcher.call
       expect(CustomsTariffImporter::Instrumentation).to have_received(:document_fetched).with(
-        version: '1.30',
+        version: '1.32',
         duration_ms: a_kind_of(Float),
       )
     end

--- a/spec/lib/customs_tariff_importer/reimporter_spec.rb
+++ b/spec/lib/customs_tariff_importer/reimporter_spec.rb
@@ -127,5 +127,43 @@ RSpec.describe CustomsTariffImporter::Reimporter do
         expect(TariffSynchronizer::FileService).not_to have_received(:get)
       end
     end
+
+    context 'when called with a specific version' do
+      let(:other_update) do
+        create(:customs_tariff_update,
+               version: '1.30',
+               status: CustomsTariffUpdate::PENDING,
+               validity_start_date: Date.new(2026, 3, 1),
+               s3_path: 'data/customs_tariff_documents/UKGT_1.30.docx')
+      end
+      let(:other_docx_io) { build_docx('SECTION II', 'Section Notes', 'Other note.', 'CHAPTER 6') }
+
+      before do
+        other_update
+        allow(TariffSynchronizer::FileService).to receive(:get)
+          .with(other_update.s3_path)
+          .and_return(other_docx_io)
+      end
+
+      it 'reimports only that update' do
+        reimporter.call(version: update.version)
+
+        expect(CustomsTariffSectionNote.where(customs_tariff_update_version: update.version).count).to eq(1)
+        expect(CustomsTariffSectionNote.where(customs_tariff_update_version: other_update.version).count).to eq(0)
+      end
+
+      it 'reimports a FAILED update (no status filtering in single-version mode)' do
+        update.update(status: CustomsTariffUpdate::FAILED)
+
+        reimporter.call(version: update.version)
+
+        expect(CustomsTariffSectionNote.where(customs_tariff_update_version: update.version).count).to eq(1)
+      end
+
+      it 'does nothing when the version does not exist' do
+        expect { reimporter.call(version: 'nonexistent.99') }
+          .not_to(change(CustomsTariffSectionNote, :count))
+      end
+    end
   end
 end

--- a/spec/lib/sequel/plugins/has_paper_trail_spec.rb
+++ b/spec/lib/sequel/plugins/has_paper_trail_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe Sequel::Plugins::HasPaperTrail do
       expect(described_class.tracked_models.map(&:name)).to eq(%w[
         AdminConfiguration
         ChapterNote
+        CustomsTariffChapterNote
         CustomsTariffSectionNote
         DescriptionIntercept
         GoodsNomenclatureIntercept

--- a/spec/models/customs_tariff_chapter_note_spec.rb
+++ b/spec/models/customs_tariff_chapter_note_spec.rb
@@ -1,32 +1,12 @@
 RSpec.describe CustomsTariffChapterNote do
-  describe 'status default' do
-    it 'defaults to pending' do
-      note = create(:customs_tariff_chapter_note)
-      expect(note.status).to eq(CustomsTariffChapterNote::PENDING)
-    end
-  end
+  describe 'paper trail' do
+    let!(:update) { create(:customs_tariff_update) }
+    let!(:note)   { create(:customs_tariff_chapter_note, customs_tariff_update: update) }
 
-  describe 'dataset scopes' do
-    let!(:pending_note)  { create(:customs_tariff_chapter_note) }
-    let!(:approved_note) { create(:customs_tariff_chapter_note, :approved) }
-    let!(:rejected_note) { create(:customs_tariff_chapter_note, :rejected) }
-
-    describe '.pending' do
-      it 'returns only pending records' do
-        expect(described_class.pending.all).to contain_exactly(pending_note)
-      end
-    end
-
-    describe '.approved' do
-      it 'returns only approved records' do
-        expect(described_class.approved.all).to contain_exactly(approved_note)
-      end
-    end
-
-    describe '.rejected' do
-      it 'returns only rejected records' do
-        expect(described_class.rejected.all).to contain_exactly(rejected_note)
-      end
+    it 'creates a Version record when content is updated' do
+      expect {
+        note.update(content: 'Updated content for versioning test')
+      }.to change { Version.where(item_type: 'CustomsTariffChapterNote', item_id: note.id.to_s).count }.by(1)
     end
   end
 end

--- a/spec/requests/api/admin/customs_tariff_updates/chapter_notes_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates/chapter_notes_controller_spec.rb
@@ -1,0 +1,223 @@
+RSpec.describe Api::Admin::CustomsTariffUpdates::ChapterNotesController do
+  around { |example| TimeMachine.now { example.run } }
+
+  describe 'GET #index' do
+    let!(:approved_update) { create(:customs_tariff_update, :approved, validity_start_date: 1.month.ago) }
+    let!(:pending_update)  { create(:customs_tariff_update, validity_start_date: Time.zone.today) }
+    let!(:approved_note) do
+      create(:customs_tariff_chapter_note, customs_tariff_update: approved_update, chapter_id: '01',
+                                           content: 'Old chapter content that is long enough to text-diff properly')
+    end
+    let!(:pending_note) do
+      create(:customs_tariff_chapter_note, customs_tariff_update: pending_update, chapter_id: '01',
+                                           content: 'New chapter content that is long enough to text-diff properly')
+    end
+
+    it 'returns chapter notes with file_diff for changed content' do
+      get "/uk/admin/customs_tariff_updates/#{pending_update.version}/chapter_notes.json",
+          headers: request_headers(format: :json)
+
+      expect(response.status).to eq(200)
+      note = JSON.parse(response.body)['data'].find { |n| n.dig('attributes', 'chapter_id') == '01' }
+      expect(note.dig('attributes', 'file_diff', 'changed_fields')).to include('content')
+    end
+
+    it 'returns file_diff as empty hash when content is identical' do
+      pending_note.update(content: approved_note.content)
+
+      get "/uk/admin/customs_tariff_updates/#{pending_update.version}/chapter_notes.json",
+          headers: request_headers(format: :json)
+
+      note = JSON.parse(response.body)['data'].find { |n| n.dig('attributes', 'chapter_id') == '01' }
+      expect(note.dig('attributes', 'file_diff')).to eq({})
+    end
+
+    it 'returns file_diff as nil when chapter has no approved counterpart' do
+      create(:customs_tariff_chapter_note, customs_tariff_update: pending_update, chapter_id: '50')
+
+      get "/uk/admin/customs_tariff_updates/#{pending_update.version}/chapter_notes.json",
+          headers: request_headers(format: :json)
+
+      note = JSON.parse(response.body)['data'].find { |n| n.dig('attributes', 'chapter_id') == '50' }
+      expect(note.dig('attributes', 'file_diff')).to be_nil
+    end
+
+    context 'with compare_version param' do
+      let!(:compare_update) { create(:customs_tariff_update, :approved, validity_start_date: 3.months.ago) }
+      let!(:target_update)  { create(:customs_tariff_update, validity_start_date: Time.zone.today) }
+
+      before do
+        create(:customs_tariff_chapter_note, customs_tariff_update: compare_update, chapter_id: '10',
+                                             content: 'Compare chapter content long enough for text diffing here')
+        create(:customs_tariff_chapter_note, customs_tariff_update: target_update, chapter_id: '10',
+                                             content: 'Target chapter content long enough for text diffing here')
+      end
+
+      it 'diffs against the specified compare_version' do
+        get "/uk/admin/customs_tariff_updates/#{target_update.version}/chapter_notes.json",
+            params: { compare_version: compare_update.version },
+            headers: request_headers(format: :json)
+
+        expect(response.status).to eq(200)
+        note = JSON.parse(response.body)['data'].find { |n| n.dig('attributes', 'chapter_id') == '10' }
+        expect(note.dig('attributes', 'file_diff', 'changed_fields')).to include('content')
+      end
+    end
+
+    context 'when the most recent preceding update is pending (not approved)' do
+      # Uses chapter_id '99' to avoid collisions with outer let! notes (chapter_id '01').
+      # previous_pending (5.days.ago) has a note for '99'; approved_update (1.month.ago) does not.
+      # Old code: approved_notes_index finds approved_update → no note for '99' → file_diff = nil
+      # New code: previous_update finds previous_pending → note found → file_diff has changed_fields
+      let!(:previous_pending) { create(:customs_tariff_update, validity_start_date: 5.days.ago) }
+      let!(:current_update)   { create(:customs_tariff_update, validity_start_date: 4.days.ago) }
+
+      before do
+        create(:customs_tariff_chapter_note, customs_tariff_update: previous_pending, chapter_id: '99',
+                                             content: 'Previous chapter content long enough for text diffing here')
+        create(:customs_tariff_chapter_note, customs_tariff_update: current_update, chapter_id: '99',
+                                             content: 'Current chapter content long enough for text diffing here')
+      end
+
+      it 'uses the pending previous update as baseline, returning a diff instead of nil' do
+        get "/uk/admin/customs_tariff_updates/#{current_update.version}/chapter_notes.json",
+            headers: request_headers(format: :json)
+
+        note = JSON.parse(response.body)['data'].find { |n| n.dig('attributes', 'chapter_id') == '99' }
+        expect(note.dig('attributes', 'file_diff')).not_to be_nil
+        expect(note.dig('attributes', 'file_diff', 'changed_fields')).to include('content')
+      end
+    end
+  end
+
+  describe 'GET #show' do
+    let!(:update) { create(:customs_tariff_update) }
+    let!(:note)   { create(:customs_tariff_chapter_note, customs_tariff_update: update) }
+
+    it 'returns the note with a versions array' do
+      get "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.id}.json",
+          headers: request_headers(format: :json)
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body).dig('data', 'attributes', 'versions')).to be_an(Array)
+    end
+
+    context 'with compare_version param' do
+      let!(:compare_update) { create(:customs_tariff_update, :approved, validity_start_date: 1.month.ago) }
+
+      before do
+        create(:customs_tariff_chapter_note, customs_tariff_update: compare_update,
+                                             chapter_id: note.chapter_id,
+                                             content: 'Old content long enough to trigger text diff in service')
+        note.update(content: 'New content long enough to trigger text diff in service here')
+      end
+
+      it 'returns file_diff instead of versions' do
+        get "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.id}.json",
+            params: { compare_version: compare_update.version },
+            headers: request_headers(format: :json)
+
+        attrs = JSON.parse(response.body).dig('data', 'attributes')
+        expect(attrs['file_diff']).to be_a(Hash)
+        expect(attrs['file_diff']['changed_fields']).to include('content')
+        expect(attrs['versions']).to eq([])
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    let!(:update) { create(:customs_tariff_update) }
+    let!(:note)   { create(:customs_tariff_chapter_note, customs_tariff_update: update) }
+
+    it 'destroys the note and returns 204' do
+      delete "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.id}.json",
+             headers: request_headers(format: :json)
+
+      expect(response.status).to eq(204)
+      expect(CustomsTariffChapterNote.where(id: note.id).first).to be_nil
+    end
+
+    it 'returns 422 and does not destroy when the parent update is rejected' do
+      update.update(status: CustomsTariffUpdate::REJECTED)
+
+      delete "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.id}.json",
+             headers: request_headers(format: :json)
+
+      expect(response.status).to eq(422)
+      expect(CustomsTariffChapterNote.where(id: note.id).first).not_to be_nil
+    end
+
+    it 'returns 404 when the note does not belong to the update' do
+      other_update = create(:customs_tariff_update)
+
+      delete "/uk/admin/customs_tariff_updates/#{other_update.version}/chapter_notes/#{note.id}.json",
+             headers: request_headers(format: :json)
+
+      expect(response.status).to eq(404)
+    end
+  end
+
+  describe 'POST #create' do
+    let!(:update) { create(:customs_tariff_update) }
+    let(:chapter_id) { '03' }
+
+    let(:make_request) do
+      post "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes.json",
+           params: { data: { type: 'customs_tariff_chapter_note', attributes: { chapter_id:, content: 'New chapter note content.' } } },
+           headers: request_headers(format: :json), as: :json
+    end
+
+    it 'returns 201 and creates the record with correct attributes' do
+      expect { make_request }.to change(CustomsTariffChapterNote, :count).by(1)
+      expect(response.status).to eq(201)
+      note = CustomsTariffChapterNote.order(Sequel.desc(:id)).first
+      expect(note.chapter_id).to eq('03')
+      expect(note.status).to eq(CustomsTariffChapterNote::PENDING)
+      expect(note.validity_start_date).to eq(update.validity_start_date)
+    end
+
+    it 'returns 422 when the parent update is rejected' do
+      update.update(status: CustomsTariffUpdate::REJECTED)
+      expect { make_request }.not_to(change(CustomsTariffChapterNote, :count))
+      expect(response.status).to eq(422)
+    end
+
+    it 'returns 422 on duplicate (update_version, chapter_id)' do
+      create(:customs_tariff_chapter_note, customs_tariff_update: update, chapter_id:)
+      expect { make_request }.not_to(change(CustomsTariffChapterNote, :count))
+      expect(response.status).to eq(422)
+    end
+  end
+
+  describe 'PATCH #update' do
+    let!(:update) { create(:customs_tariff_update) }
+    let!(:note)   { create(:customs_tariff_chapter_note, customs_tariff_update: update) }
+
+    it 'updates the content' do
+      patch "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.id}.json",
+            params: { data: { type: 'customs_tariff_chapter_note', attributes: { content: 'Updated content' } } },
+            headers: request_headers(format: :json), as: :json
+
+      expect(response.status).to eq(200)
+      expect(note.reload.content).to eq('Updated content')
+    end
+
+    it 'returns 422 when the parent update is rejected' do
+      update.update(status: CustomsTariffUpdate::REJECTED)
+
+      patch "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.id}.json",
+            params: { data: { type: 'customs_tariff_chapter_note', attributes: { content: 'Updated' } } },
+            headers: request_headers(format: :json), as: :json
+
+      expect(response.status).to eq(422)
+    end
+
+    it 'creates a Version record on successful save' do
+      expect {
+        patch "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.id}.json",
+              params: { data: { type: 'customs_tariff_chapter_note', attributes: { content: 'Versioned' } } },
+              headers: request_headers(format: :json), as: :json
+      }.to change { Version.where(item_type: 'CustomsTariffChapterNote', item_id: note.id.to_s).count }.by(1)
+    end
+  end
+end

--- a/spec/requests/api/admin/customs_tariff_updates/reimport_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates/reimport_controller_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe Api::Admin::CustomsTariffUpdates::ReimportController do
+  describe 'POST #create' do
+    let!(:update) { create(:customs_tariff_update) }
+
+    before do
+      allow(CustomsTariffReimportWorker).to receive(:perform_async)
+    end
+
+    it 'returns 202 and enqueues the worker' do
+      post "/uk/admin/customs_tariff_updates/#{update.version}/reimport.json",
+           headers: request_headers(format: :json)
+
+      expect(response.status).to eq(202)
+      expect(CustomsTariffReimportWorker).to have_received(:perform_async).with(update.version)
+    end
+
+    it 'returns 404 for an unknown version' do
+      post '/uk/admin/customs_tariff_updates/nonexistent.99/reimport.json',
+           headers: request_headers(format: :json)
+
+      expect(response.status).to eq(404)
+      expect(CustomsTariffReimportWorker).not_to have_received(:perform_async)
+    end
+  end
+end

--- a/spec/requests/api/admin/customs_tariff_updates/section_notes_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates/section_notes_controller_spec.rb
@@ -177,4 +177,76 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
       }.to change { Version.where(item_type: 'CustomsTariffSectionNote', item_id: note.id.to_s).count }.by(1)
     end
   end
+
+  describe 'DELETE #destroy' do
+    let!(:update) { create(:customs_tariff_update) }
+    let!(:note)   { create(:customs_tariff_section_note, customs_tariff_update: update) }
+
+    it 'destroys the note and returns 204' do
+      delete "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.id}.json",
+             headers: request_headers(format: :json)
+
+      expect(response.status).to eq(204)
+      expect(CustomsTariffSectionNote.where(id: note.id).first).to be_nil
+    end
+
+    it 'returns 422 and does not destroy when the parent update is rejected' do
+      update.update(status: CustomsTariffUpdate::REJECTED)
+
+      delete "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.id}.json",
+             headers: request_headers(format: :json)
+
+      expect(response.status).to eq(422)
+      expect(CustomsTariffSectionNote.where(id: note.id).first).not_to be_nil
+    end
+
+    it 'returns 404 when the note does not belong to the update' do
+      other_update = create(:customs_tariff_update)
+
+      delete "/uk/admin/customs_tariff_updates/#{other_update.version}/section_notes/#{note.id}.json",
+             headers: request_headers(format: :json)
+
+      expect(response.status).to eq(404)
+    end
+  end
+
+  describe 'POST #create' do
+    let!(:update) { create(:customs_tariff_update, validity_start_date: Date.new(2026, 3, 1)) }
+
+    it 'creates a section note and returns 201' do
+      post "/uk/admin/customs_tariff_updates/#{update.version}/section_notes.json",
+           params: { data: { type: 'customs_tariff_section_note',
+                             attributes: { section_id: 7, content: 'Manually added note content here' } } },
+           headers: request_headers(format: :json), as: :json
+
+      expect(response.status).to eq(201)
+      attrs = JSON.parse(response.body).dig('data', 'attributes')
+      expect(attrs['section_id']).to eq(7)
+      expect(attrs['content']).to eq('Manually added note content here')
+    end
+
+    it 'sets status to pending and copies validity_start_date from the update' do
+      post "/uk/admin/customs_tariff_updates/#{update.version}/section_notes.json",
+           params: { data: { type: 'customs_tariff_section_note',
+                             attributes: { section_id: 8, content: 'Some note content here' } } },
+           headers: request_headers(format: :json), as: :json
+
+      note = CustomsTariffSectionNote.where(
+        customs_tariff_update_version: update.version, section_id: 8,
+      ).first
+      expect(note.status).to eq(CustomsTariffSectionNote::PENDING)
+      expect(note.validity_start_date).to eq(Date.new(2026, 3, 1))
+    end
+
+    it 'returns 422 when the parent update is rejected' do
+      update.update(status: CustomsTariffUpdate::REJECTED)
+
+      post "/uk/admin/customs_tariff_updates/#{update.version}/section_notes.json",
+           params: { data: { type: 'customs_tariff_section_note',
+                             attributes: { section_id: 7, content: 'Some content' } } },
+           headers: request_headers(format: :json), as: :json
+
+      expect(response.status).to eq(422)
+    end
+  end
 end

--- a/spec/requests/api/admin/customs_tariff_updates/sections_summary_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates/sections_summary_controller_spec.rb
@@ -1,0 +1,125 @@
+RSpec.describe Api::Admin::CustomsTariffUpdates::SectionsSummaryController do
+  around { |example| TimeMachine.now { example.run } }
+
+  describe 'GET #index' do
+    let!(:sections)        { create_list(:section, 21) }
+    let!(:approved_update) { create(:customs_tariff_update, :approved, validity_start_date: 1.month.ago) }
+    let!(:pending_update)  { create(:customs_tariff_update, validity_start_date: Time.zone.today) }
+
+    it 'returns one row per section' do
+      get "/uk/admin/customs_tariff_updates/#{pending_update.version}/sections_summary.json",
+          headers: request_headers(format: :json)
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)['data'].length).to eq(21)
+    end
+
+    context 'when a section note exists in the update' do
+      let(:section_with_note)    { sections.first }
+      let(:section_without_note) { sections.second }
+
+      let!(:pending_note) do
+        create(:customs_tariff_section_note, customs_tariff_update: pending_update,
+                                             section_id: section_with_note.id,
+                                             content: 'New section content long enough for text diff in service')
+      end
+
+      before do
+        create(:customs_tariff_section_note, customs_tariff_update: approved_update,
+                                             section_id: section_with_note.id,
+                                             content: 'Old section content long enough for text diff in service')
+      end
+
+      it 'returns section_note_status as changed for the section with a note' do
+        get "/uk/admin/customs_tariff_updates/#{pending_update.version}/sections_summary.json",
+            headers: request_headers(format: :json)
+
+        row = JSON.parse(response.body)['data'].find { |r| r.dig('attributes', 'section_id') == section_with_note.id }
+        expect(row.dig('attributes', 'section_note_status')).to eq('changed')
+        expect(row.dig('attributes', 'section_note_id')).to eq(pending_note.id)
+      end
+
+      it 'returns section_note_status as absent for sections with no note' do
+        get "/uk/admin/customs_tariff_updates/#{pending_update.version}/sections_summary.json",
+            headers: request_headers(format: :json)
+
+        row = JSON.parse(response.body)['data'].find { |r| r.dig('attributes', 'section_id') == section_without_note.id }
+        expect(row.dig('attributes', 'section_note_status')).to eq('absent')
+        expect(row.dig('attributes', 'section_note_id')).to be_nil
+      end
+    end
+
+    context 'when chapter notes exist in the update' do
+      before do
+        create(:customs_tariff_chapter_note, customs_tariff_update: approved_update, chapter_id: '01',
+                                             content: 'Old chapter 1 content long enough for comparison')
+        create(:customs_tariff_chapter_note, customs_tariff_update: pending_update, chapter_id: '01',
+                                             content: 'New chapter 1 content long enough for comparison')
+      end
+
+      it 'returns chapter_notes_total and chapter_notes_changed for the section containing chapter 01' do
+        pending 'chapter_to_section_map relies on chapters_sections join table populated with real tariff data; ' \
+                'may be empty in test environment causing counts to be 0'
+
+        get "/uk/admin/customs_tariff_updates/#{pending_update.version}/sections_summary.json",
+            headers: request_headers(format: :json)
+
+        row = JSON.parse(response.body)['data'].find { |r| r.dig('attributes', 'section_id') == sections.first.id }
+        expect(row.dig('attributes', 'chapter_notes_total')).to eq(1)
+        expect(row.dig('attributes', 'chapter_notes_changed')).to eq(1)
+      end
+    end
+
+    context 'when the most recent preceding update is pending (not approved)' do
+      # The outer approved_update (1.month.ago) has no notes for sections.last.
+      # previous_pending (5.days.ago) is the most recent update before current_update (4.days.ago).
+      # Old code: approved_notes_index finds approved_update → no notes → status = 'new'
+      # New code: previous_update finds previous_pending → notes found → status = 'changed'
+      let!(:previous_pending) { create(:customs_tariff_update, validity_start_date: 5.days.ago) }
+      let!(:current_update)   { create(:customs_tariff_update, validity_start_date: 4.days.ago) }
+      let(:section)           { sections.last }
+
+      before do
+        create(:customs_tariff_section_note, customs_tariff_update: previous_pending,
+                                             section_id: section.id,
+                                             content: 'Previous content long enough for text diff service to handle')
+        create(:customs_tariff_section_note, customs_tariff_update: current_update,
+                                             section_id: section.id,
+                                             content: 'Current content long enough for text diff service to handle')
+      end
+
+      it 'uses the pending previous update as baseline' do
+        get "/uk/admin/customs_tariff_updates/#{current_update.version}/sections_summary.json",
+            headers: request_headers(format: :json)
+
+        row = JSON.parse(response.body)['data'].find { |r| r.dig('attributes', 'section_id') == section.id }
+        expect(row.dig('attributes', 'section_note_status')).to eq('changed')
+      end
+    end
+
+    context 'when the immediately preceding update is failed' do
+      # failed_update (5.days.ago) is skipped; older_pending (6.days.ago) is used as baseline.
+      let!(:older_pending)  { create(:customs_tariff_update, validity_start_date: 6.days.ago) }
+      let!(:current_update) { create(:customs_tariff_update, validity_start_date: 4.days.ago) }
+      let(:section)         { sections.last }
+
+      before do
+        create(:customs_tariff_update, :failed, validity_start_date: 5.days.ago)
+        create(:customs_tariff_section_note, customs_tariff_update: older_pending,
+                                             section_id: section.id,
+                                             content: 'Older content long enough for text diff service to handle it')
+        create(:customs_tariff_section_note, customs_tariff_update: current_update,
+                                             section_id: section.id,
+                                             content: 'Current content long enough for text diff service to handle it')
+      end
+
+      it 'skips the failed update and uses the older pending update as baseline' do
+        get "/uk/admin/customs_tariff_updates/#{current_update.version}/sections_summary.json",
+            headers: request_headers(format: :json)
+
+        row = JSON.parse(response.body)['data'].find { |r| r.dig('attributes', 'section_id') == section.id }
+        expect(row.dig('attributes', 'section_note_status')).to eq('changed')
+      end
+    end
+  end
+end

--- a/spec/workers/customs_tariff_reimport_worker_spec.rb
+++ b/spec/workers/customs_tariff_reimport_worker_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe CustomsTariffReimportWorker do
+  describe '#perform' do
+    it 'calls Reimporter with the given version' do
+      reimporter = instance_double(CustomsTariffImporter::Reimporter)
+      allow(CustomsTariffImporter::Reimporter).to receive(:new).and_return(reimporter)
+      allow(reimporter).to receive(:call)
+
+      described_class.new.perform('1.31')
+
+      expect(reimporter).to have_received(:call).with(version: '1.31')
+    end
+  end
+end


### PR DESCRIPTION
## What:

This PR adds the backend API endpoints needed for the customs tariff chapter notes review and approval workflow. It builds on top of the existing section notes work and adds a few extra pieces operators will need.

Here's what's been added:

- **`ChapterNotesController`** — full CRUD for chapter notes scoped to a customs tariff update (index, show, create, update, destroy). Includes a `status` action to move a note through the approval lifecycle
- **`SectionsSummaryController`** — a new index endpoint that returns a per-section rollup of note statuses and chapter note counts, used to drive the review dashboard
- **`ReimportController`** — a single `POST` action that enqueues a `CustomsTariffReimportWorker` job to reset all notes for a given update back to their original S3-imported state. Useful as a recovery tool when things go wrong
- **`CustomsTariffReimportWorker`** — Sidekiq worker on the `sync` queue that calls the existing `Reimporter` with a specific version
- **`Reimporter#call`** — extended with an optional `version:` keyword so it can target a single update rather than bulk-processing everything. The existing rake task behaviour is unchanged

## Why:

The admin app needs chapter-level note management to complete the tariff notes review flow. Section notes already had CRUD; chapter notes were missing the same.

The reimport endpoint is a get-out-of-jail card — if an operator has made a mess of the notes for a particular update, they can hit this button and everything resets cleanly to what was originally imported from GOV.UK. It reuses the existing `Reimporter` logic so there's no duplication.

Worth noting: all of this sits behind the customs tariff feature flag in the admin app so nothing here is live in production yet.

## Ticket:

[AI-517](https://transformuk.atlassian.net/browse/AI-517)

## Risk:
**Risk level:** 🟢

**Reason for rating:** All new endpoints with no changes to existing production behaviour. The entire customs tariff approval feature is hidden behind a feature flag and not yet live, so there's no user-facing impact from this PR.