### PR TITLE
AI-868: Add compressed notes to internal search context

### DIFF
--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -108,6 +108,7 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
     'expand_search_min_results' => 5,
     'expand_search_min_score' => 5,
     'expand_search_when_needed_enabled' => false,
+    'search_compressed_notes_enabled' => false,
     'expand_model' => NESTED_OPTION_DEFAULTS['expand_model'][:selected],
     'interactive_search_enabled' => true,
     'interactive_search_excluded_chapters' => %w[98 99].freeze,

--- a/app/services/interactive_search_service.rb
+++ b/app/services/interactive_search_service.rb
@@ -121,13 +121,31 @@ class InteractiveSearchService
 
   def format_opensearch_results
     results = opensearch_results.map do |result|
-      {
+      formatted_result = {
         commodity_code: result.goods_nomenclature_item_id,
         description: result.full_description.presence || result.description,
         score: result.score,
       }
+      compressed_note = compressed_notes_by_item_id[result.goods_nomenclature_item_id]
+      formatted_result[:compressed_note] = compressed_note.content if compressed_note
+      formatted_result
     end
     results.to_json
+  end
+
+  def compressed_notes_by_item_id
+    return {} unless AdminConfiguration.enabled?('search_compressed_notes_enabled')
+
+    @compressed_notes_by_item_id ||= begin
+      item_ids = opensearch_results.map(&:goods_nomenclature_item_id).compact_blank.uniq
+      notes = TariffKnowledge::CompressedNote
+        .where(approved: true, stale: false, expired: false)
+        .by_item_ids(item_ids)
+
+      notes.each_with_object({}) do |note, by_item_id|
+        by_item_id[note.goods_nomenclature_item_id] ||= note
+      end
+    end
   end
 
   def format_questions_and_answers

--- a/lib/tasks/admin_configurations.rake
+++ b/lib/tasks/admin_configurations.rake
@@ -447,6 +447,12 @@ namespace :admin_configurations do
         value: AdminConfigurationSeeder.expand_query_context_markdown,
       },
       {
+        name: 'search_compressed_notes_enabled',
+        config_type: 'boolean',
+        description: 'Include current approved compressed notes in the internal search LLM context. Only enable this in staging.',
+        value: AdminConfiguration.default_for('search_compressed_notes_enabled'),
+      },
+      {
         name: 'interactive_search_enabled',
         config_type: 'boolean',
         description: 'Enable interactive Q&A to help traders narrow down commodity codes through clarifying questions',

--- a/spec/lib/tasks/admin_configurations_rake_spec.rb
+++ b/spec/lib/tasks/admin_configurations_rake_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe 'admin_configurations:seed' do
     Rake::Task['admin_configurations:seed'].reenable
   end
 
-  it 'creates all 41 admin configurations', :aggregate_failures do
-    expect { seed }.to change(AdminConfiguration, :count).by(41)
+  it 'creates all 42 admin configurations', :aggregate_failures do
+    expect { seed }.to change(AdminConfiguration, :count).by(42)
 
     names = AdminConfiguration.order(:name).select_map(:name)
     expect(names).to eq(%w[
@@ -41,6 +41,7 @@ RSpec.describe 'admin_configurations:seed' do
       refine_search_with_answers_enabled
       retrieval_method
       rrf_k
+      search_compressed_notes_enabled
       search_context
       search_labels_enabled
       search_model
@@ -357,7 +358,7 @@ RSpec.describe 'admin_configurations:seed' do
   it 'patches existing configurations when their type changes' do
     create(:admin_configuration, name: 'description_intercept_templates', config_type: 'string', value: 'legacy')
 
-    expect { seed }.to change(AdminConfiguration, :count).by(40)
+    expect { seed }.to change(AdminConfiguration, :count).by(41)
     expect(AdminConfiguration.where(name: 'description_intercept_templates').first.config_type).to eq('object_template')
   end
 end

--- a/spec/services/interactive_search_service_spec.rb
+++ b/spec/services/interactive_search_service_spec.rb
@@ -425,6 +425,44 @@ RSpec.describe InteractiveSearchService do
       allow(OpenaiClient).to receive(:call).and_return(ai_response)
     end
 
+    context 'when compressed note context is enabled' do
+      before do
+        create(:admin_configuration,
+               :boolean,
+               name: 'search_compressed_notes_enabled',
+               value: true,
+               area: 'classification')
+        create(:tariff_knowledge_compressed_note,
+               goods_nomenclature_item_id: '4202210000',
+               content: 'Includes handbags with outer surface of leather. Excludes plastic sheeting.',
+               approved: true,
+               stale: false,
+               expired: false)
+        create(:tariff_knowledge_compressed_note,
+               goods_nomenclature_item_id: '4202220000',
+               content: 'Stale notes should not be consumed.',
+               approved: true,
+               stale: true,
+               expired: false)
+      end
+
+      it 'adds current approved compressed notes to matching OpenSearch results' do
+        result
+
+        context_arg = nil
+        expect(OpenaiClient).to have_received(:call) do |context, **_opts|
+          context_arg = context
+        end
+
+        parsed_results = JSON.parse(context_arg.match(/OpenSearch results: (.+?)Previous/m)[1])
+        expect(parsed_results.first).to include(
+          'commodity_code' => '4202210000',
+          'compressed_note' => 'Includes handbags with outer surface of leather. Excludes plastic sheeting.',
+        )
+        expect(parsed_results.second).not_to include('compressed_note')
+      end
+    end
+
     context 'when results have full_description' do
       let(:opensearch_results) do
         [


### PR DESCRIPTION
### Jira link

[AI-868](https://transformuk.atlassian.net/browse/AI-868)

### What?

- [x] Add a default-off `search_compressed_notes_enabled` admin configuration.
- [x] Seed the configuration as a boolean so staging can opt in explicitly.
- [x] Include current approved compressed notes in the internal search LLM context when the flag is enabled.
- [x] Exclude stale, expired, and unapproved compressed notes from the LLM context.

### Why?

The compressed notes pipeline produces concise tariff note context, but internal search was not yet consuming it when calling the search LLM. This change lets staging include that context in the OpenSearch result payload sent to the LLM while keeping the consuming feature disabled everywhere else by default.

### Environment note

Compressed notes are intended to be consumed only in staging. Staging is the only environment where this capability will be enabled; production and other environments should leave the consuming feature disabled.

### Risk

**Risk level:** 🟢

**Reason for rating:** This is staging-only, technical-operator functionality for consuming compressed notes in the internal search LLM context. Production and other environments should leave the consuming feature disabled, so this does not change live trader journeys or production search behaviour.
