### PR TITLE
AI-868: Add tariff knowledge operational tasks

### DIFF
--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -3,26 +3,27 @@ module TariffKnowledge
     BATCH_SIZE = 500
 
     RangeReference = Data.define(:type, :code)
+    SourceAssociation = Data.define(:association, :label, :identifier, :title)
 
-    SOURCE_TYPES = [
-      {
-        model: CustomsTariffChapterNote,
+    SOURCE_ASSOCIATIONS = [
+      SourceAssociation.new(
+        association: :customs_tariff_chapter_notes,
         label: 'customs_tariff_chapter_note',
         identifier: :chapter_id,
-        title: ->(note) { "Chapter #{note.chapter_id} notes" },
-      },
-      {
-        model: CustomsTariffSectionNote,
+        title: ->(source) { "Chapter #{source.chapter_id} notes" },
+      ),
+      SourceAssociation.new(
+        association: :customs_tariff_section_notes,
         label: 'customs_tariff_section_note',
         identifier: :section_id,
-        title: ->(note) { "Section #{note.section_id} notes" },
-      },
-      {
-        model: CustomsTariffGeneralRule,
+        title: ->(source) { "Section #{source.section_id} notes" },
+      ),
+      SourceAssociation.new(
+        association: :customs_tariff_general_rules,
         label: 'customs_tariff_general_rule',
         identifier: :rule_label,
-        title: ->(note) { "GIR #{note.rule_label}" },
-      },
+        title: ->(source) { "GIR #{source.rule_label}" },
+      ),
     ].freeze
 
     def self.call
@@ -33,9 +34,9 @@ module TariffKnowledge
       update = latest_approved_update
       return unless update
 
-      SOURCE_TYPES.each do |source_type|
-        sources_for(source_type, update).each do |source|
-          load_source(source_type, source)
+      SOURCE_ASSOCIATIONS.each do |source_association|
+        sources_for(source_association, update).each do |source|
+          load_source(source_association, source)
         end
       end
     end
@@ -43,34 +44,48 @@ module TariffKnowledge
   private
 
     def latest_approved_update
-      TimeMachine.now do
-        CustomsTariffUpdate
-          .actual
-          .approved
-          .order(Sequel.desc(:validity_start_date))
-          .first
+      if TimeMachine.date_is_set?
+        latest_approved_update_at_time_machine_date
+      else
+        TimeMachine.now { latest_approved_update_at_time_machine_date }
       end
     end
 
-    def sources_for(source_type, update)
-      source_type[:model]
+    def latest_approved_update_at_time_machine_date
+      CustomsTariffUpdate
+        .actual
         .approved
-        .where(customs_tariff_update_version: update.version)
+        .order(Sequel.desc(:validity_start_date))
+        .first
     end
 
-    def load_source(source_type, source)
+    def sources_for(source_association, update)
+      if TimeMachine.date_is_set?
+        sources_for_at_time_machine_date(source_association, update)
+      else
+        TimeMachine.now { sources_for_at_time_machine_date(source_association, update) }
+      end
+    end
+
+    def sources_for_at_time_machine_date(source_association, update)
+      update
+        .public_send(:"#{source_association.association}_dataset")
+        .approved
+    end
+
+    def load_source(source_association, source)
       source_node = upsert_node(
         node_type: Node::NOTE_SOURCE,
-        key: source_key(source_type, source),
-        title: source_type[:title].call(source),
+        key: source_key(source_association, source),
+        title: source_association.title.call(source),
         content: source.content,
-        source_type: source_type[:label],
-        source_id: source.public_send(source_type[:identifier]).to_s,
+        source_type: source_association.label,
+        source_id: source.public_send(source_association.identifier).to_s,
         source_version: source.customs_tariff_update_version,
       )
 
       fragment_nodes = fragments(source.content).map.with_index(1) do |fragment_content, index|
-        load_fragment(source_type, source, source_node, fragment_content, index)
+        load_fragment(source_association, source, source_node, fragment_content, index)
       end
 
       delete_stale_edges(
@@ -80,13 +95,13 @@ module TariffKnowledge
       )
     end
 
-    def load_fragment(source_type, source, source_node, content, index)
+    def load_fragment(source_association, source, source_node, content, index)
       fragment_node = upsert_node(
         node_type: Node::NOTE_FRAGMENT,
-        key: "#{source_key(source_type, source)}:#{sprintf('%04d', index)}".sub('note_source:', 'note_fragment:'),
+        key: "#{source_key(source_association, source)}:#{sprintf('%04d', index)}".sub('note_source:', 'note_fragment:'),
         title: "#{source_node.title} fragment #{index}",
         content:,
-        source_type: source_type[:label],
+        source_type: source_association.label,
         source_id: source_node.source_id,
         source_version: source.customs_tariff_update_version,
       )
@@ -153,9 +168,9 @@ module TariffKnowledge
           .where(Sequel.like(:goods_nomenclature_item_id, "#{reference.code}%"))
     end
 
-    def source_key(source_type, source)
-      identifier = source.public_send(source_type[:identifier])
-      "note_source:#{source_type[:label]}:#{source.customs_tariff_update_version}:#{identifier}"
+    def source_key(source_association, source)
+      identifier = source.public_send(source_association.identifier)
+      "note_source:#{source_association.label}:#{source.customs_tariff_update_version}:#{identifier}"
     end
 
     def upsert_node(attributes)

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -43,11 +43,13 @@ module TariffKnowledge
   private
 
     def latest_approved_update
-      CustomsTariffUpdate
-        .actual
-        .approved
-        .order(Sequel.desc(:validity_start_date))
-        .first
+      TimeMachine.now do
+        CustomsTariffUpdate
+          .actual
+          .approved
+          .order(Sequel.desc(:validity_start_date))
+          .first
+      end
     end
 
     def sources_for(source_type, update)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -87,3 +87,15 @@
       cron: "0 9 * * *"
       description: "Checks GOV.UK for a new Customs Tariff document version and imports it"
       enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' %>
+    CreateTariffKnowledgeSourceGraphWorker:
+      cron: "0 2 * * *"
+      description: "Builds the tariff knowledge source graph from current approved chapter and section notes"
+      enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' && ENV.fetch('ENVIRONMENT', 'local') == 'staging' %>
+    CreateTariffKnowledgeDeclarableNodesWorker:
+      cron: "30 2 * * *"
+      description: "Builds current declarable tariff knowledge graph nodes"
+      enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' && ENV.fetch('ENVIRONMENT', 'local') == 'staging' %>
+    RefreshTariffKnowledgeCompressedNotesWorker:
+      cron: "0 3 * * *"
+      description: "Refreshes tariff knowledge compressed notes for current declarable goods"
+      enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' && ENV.fetch('ENVIRONMENT', 'local') == 'staging' %>

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -87,15 +87,7 @@
       cron: "0 9 * * *"
       description: "Checks GOV.UK for a new Customs Tariff document version and imports it"
       enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' %>
-    CreateTariffKnowledgeSourceGraphWorker:
-      cron: "0 2 * * *"
-      description: "Builds the tariff knowledge source graph from current approved chapter and section notes"
-      enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' && ENV.fetch('ENVIRONMENT', 'local') == 'staging' %>
-    CreateTariffKnowledgeDeclarableNodesWorker:
-      cron: "30 2 * * *"
-      description: "Builds current declarable tariff knowledge graph nodes"
-      enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' && ENV.fetch('ENVIRONMENT', 'local') == 'staging' %>
     RefreshTariffKnowledgeCompressedNotesWorker:
       cron: "0 3 * * *"
-      description: "Refreshes tariff knowledge compressed notes for current declarable goods"
+      description: "Refreshes tariff knowledge graph and compressed notes for current declarable goods"
       enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' && ENV.fetch('ENVIRONMENT', 'local') == 'staging' %>

--- a/lib/tasks/tariff_knowledge.rake
+++ b/lib/tasks/tariff_knowledge.rake
@@ -1,14 +1,8 @@
 namespace :tariff_knowledge do
   desc 'Enqueue the full tariff knowledge graph population pipeline'
   task populate: :environment do
-    CreateTariffKnowledgeSourceGraphWorker.perform_async
-    puts 'Enqueued source graph loading.'
-
-    CreateTariffKnowledgeDeclarableNodesWorker.perform_async
-    puts 'Enqueued declarable node loading.'
-
     RefreshTariffKnowledgeCompressedNotesWorker.perform_async
-    puts 'Enqueued compressed note refresh. Check Sidekiq for progress.'
+    puts 'Enqueued compressed note refresh, including source graph and declarable node loading. Check Sidekiq for progress.'
   end
 
   namespace :source_graph do

--- a/lib/tasks/tariff_knowledge.rake
+++ b/lib/tasks/tariff_knowledge.rake
@@ -1,0 +1,57 @@
+namespace :tariff_knowledge do
+  desc 'Enqueue the full tariff knowledge graph population pipeline'
+  task populate: :environment do
+    CreateTariffKnowledgeSourceGraphWorker.perform_async
+    puts 'Enqueued source graph loading.'
+
+    CreateTariffKnowledgeDeclarableNodesWorker.perform_async
+    puts 'Enqueued declarable node loading.'
+
+    RefreshTariffKnowledgeCompressedNotesWorker.perform_async
+    puts 'Enqueued compressed note refresh. Check Sidekiq for progress.'
+  end
+
+  namespace :source_graph do
+    desc 'Enqueue tariff knowledge source graph loading'
+    task enqueue: :environment do
+      CreateTariffKnowledgeSourceGraphWorker.perform_async
+      puts 'Enqueued source graph loading. Check Sidekiq for progress.'
+    end
+
+    desc 'Run tariff knowledge source graph loading inline'
+    task run: :environment do
+      TariffKnowledge::SourceGraphLoader.call
+      puts 'Source graph loading complete.'
+    end
+  end
+
+  namespace :declarable_nodes do
+    desc 'Enqueue tariff knowledge declarable node loading'
+    task enqueue: :environment do
+      CreateTariffKnowledgeDeclarableNodesWorker.perform_async
+      puts 'Enqueued declarable node loading. Check Sidekiq for progress.'
+    end
+
+    desc 'Run tariff knowledge declarable node loading inline'
+    task run: :environment do
+      TariffKnowledge::DeclarableNodeLoader.call
+      puts 'Declarable node loading complete.'
+    end
+  end
+
+  namespace :compressed_notes do
+    namespace :refresh do
+      desc 'Enqueue tariff knowledge compressed note refresh'
+      task enqueue: :environment do
+        RefreshTariffKnowledgeCompressedNotesWorker.perform_async
+        puts 'Enqueued compressed note refresh. Check Sidekiq for progress.'
+      end
+
+      desc 'Run tariff knowledge compressed note refresh inline'
+      task run: :environment do
+        result = TariffKnowledge::CompressedNoteRefresh.call
+        puts "Compressed note refresh complete: #{result.goods_nomenclature_count} current goods nomenclatures, #{result.expired_note_count} expired notes."
+      end
+    end
+  end
+end

--- a/spec/config/sidekiq_schedule_spec.rb
+++ b/spec/config/sidekiq_schedule_spec.rb
@@ -1,0 +1,51 @@
+require 'erb'
+require 'yaml'
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'config/sidekiq.yml' do
+  def sidekiq_schedule(environment:, service: 'uk')
+    original_environment = ENV.fetch('ENVIRONMENT', nil)
+    original_service = ENV.fetch('SERVICE', nil)
+    ENV['ENVIRONMENT'] = environment
+    ENV['SERVICE'] = service
+
+    begin
+      YAML.safe_load(ERB.new(Rails.root.join('config/sidekiq.yml').read).result, permitted_classes: [Symbol], aliases: true)
+        .fetch(:scheduler)
+        .fetch(:schedule)
+    ensure
+      ENV['ENVIRONMENT'] = original_environment
+      ENV['SERVICE'] = original_service
+    end
+  end
+
+  it 'schedules tariff knowledge graph population jobs in staging' do
+    schedule = sidekiq_schedule(environment: 'staging')
+
+    expect(schedule).to include(
+      'CreateTariffKnowledgeSourceGraphWorker' => include(
+        'cron' => '0 2 * * *',
+        'enabled' => true,
+      ),
+      'CreateTariffKnowledgeDeclarableNodesWorker' => include(
+        'cron' => '30 2 * * *',
+        'enabled' => true,
+      ),
+      'RefreshTariffKnowledgeCompressedNotesWorker' => include(
+        'cron' => '0 3 * * *',
+        'enabled' => true,
+      ),
+    )
+  end
+
+  it 'keeps tariff knowledge graph schedules disabled outside staging' do
+    schedule = sidekiq_schedule(environment: 'production')
+
+    expect(schedule).to include(
+      'CreateTariffKnowledgeSourceGraphWorker' => include('enabled' => false),
+      'CreateTariffKnowledgeDeclarableNodesWorker' => include('enabled' => false),
+      'RefreshTariffKnowledgeCompressedNotesWorker' => include('enabled' => false),
+    )
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/config/sidekiq_schedule_spec.rb
+++ b/spec/config/sidekiq_schedule_spec.rb
@@ -19,31 +19,23 @@ RSpec.describe 'config/sidekiq.yml' do
     end
   end
 
-  it 'schedules tariff knowledge graph population jobs in staging' do
+  it 'schedules the tariff knowledge compressed note refresh pipeline in staging' do
     schedule = sidekiq_schedule(environment: 'staging')
 
     expect(schedule).to include(
-      'CreateTariffKnowledgeSourceGraphWorker' => include(
-        'cron' => '0 2 * * *',
-        'enabled' => true,
-      ),
-      'CreateTariffKnowledgeDeclarableNodesWorker' => include(
-        'cron' => '30 2 * * *',
-        'enabled' => true,
-      ),
       'RefreshTariffKnowledgeCompressedNotesWorker' => include(
         'cron' => '0 3 * * *',
         'enabled' => true,
       ),
     )
+    expect(schedule).not_to include('CreateTariffKnowledgeSourceGraphWorker')
+    expect(schedule).not_to include('CreateTariffKnowledgeDeclarableNodesWorker')
   end
 
-  it 'keeps tariff knowledge graph schedules disabled outside staging' do
+  it 'keeps tariff knowledge compressed note refresh disabled outside staging' do
     schedule = sidekiq_schedule(environment: 'production')
 
     expect(schedule).to include(
-      'CreateTariffKnowledgeSourceGraphWorker' => include('enabled' => false),
-      'CreateTariffKnowledgeDeclarableNodesWorker' => include('enabled' => false),
       'RefreshTariffKnowledgeCompressedNotesWorker' => include('enabled' => false),
     )
   end

--- a/spec/lib/tasks/tariff_knowledge_rake_spec.rb
+++ b/spec/lib/tasks/tariff_knowledge_rake_spec.rb
@@ -13,16 +13,16 @@ RSpec.describe 'tariff_knowledge rake tasks' do
   end
 
   describe 'tariff_knowledge:populate' do
-    it 'enqueues the full tariff knowledge graph pipeline' do
+    it 'enqueues the compressed note refresh pipeline' do
       allow(CreateTariffKnowledgeSourceGraphWorker).to receive(:perform_async)
       allow(CreateTariffKnowledgeDeclarableNodesWorker).to receive(:perform_async)
       allow(RefreshTariffKnowledgeCompressedNotesWorker).to receive(:perform_async)
 
       suppress_output { Rake::Task['tariff_knowledge:populate'].invoke }
 
-      expect(CreateTariffKnowledgeSourceGraphWorker).to have_received(:perform_async).ordered
-      expect(CreateTariffKnowledgeDeclarableNodesWorker).to have_received(:perform_async).ordered
-      expect(RefreshTariffKnowledgeCompressedNotesWorker).to have_received(:perform_async).ordered
+      expect(RefreshTariffKnowledgeCompressedNotesWorker).to have_received(:perform_async)
+      expect(CreateTariffKnowledgeSourceGraphWorker).not_to have_received(:perform_async)
+      expect(CreateTariffKnowledgeDeclarableNodesWorker).not_to have_received(:perform_async)
     end
   end
 

--- a/spec/lib/tasks/tariff_knowledge_rake_spec.rb
+++ b/spec/lib/tasks/tariff_knowledge_rake_spec.rb
@@ -1,0 +1,91 @@
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'tariff_knowledge rake tasks' do
+  after do
+    %w[
+      tariff_knowledge:populate
+      tariff_knowledge:source_graph:enqueue
+      tariff_knowledge:source_graph:run
+      tariff_knowledge:declarable_nodes:enqueue
+      tariff_knowledge:declarable_nodes:run
+      tariff_knowledge:compressed_notes:refresh:enqueue
+      tariff_knowledge:compressed_notes:refresh:run
+    ].each { |task| Rake::Task[task].reenable if Rake::Task.task_defined?(task) }
+  end
+
+  describe 'tariff_knowledge:populate' do
+    it 'enqueues the full tariff knowledge graph pipeline' do
+      allow(CreateTariffKnowledgeSourceGraphWorker).to receive(:perform_async)
+      allow(CreateTariffKnowledgeDeclarableNodesWorker).to receive(:perform_async)
+      allow(RefreshTariffKnowledgeCompressedNotesWorker).to receive(:perform_async)
+
+      suppress_output { Rake::Task['tariff_knowledge:populate'].invoke }
+
+      expect(CreateTariffKnowledgeSourceGraphWorker).to have_received(:perform_async).ordered
+      expect(CreateTariffKnowledgeDeclarableNodesWorker).to have_received(:perform_async).ordered
+      expect(RefreshTariffKnowledgeCompressedNotesWorker).to have_received(:perform_async).ordered
+    end
+  end
+
+  describe 'tariff_knowledge:source_graph:enqueue' do
+    it 'enqueues source graph loading' do
+      allow(CreateTariffKnowledgeSourceGraphWorker).to receive(:perform_async)
+
+      suppress_output { Rake::Task['tariff_knowledge:source_graph:enqueue'].invoke }
+
+      expect(CreateTariffKnowledgeSourceGraphWorker).to have_received(:perform_async)
+    end
+  end
+
+  describe 'tariff_knowledge:source_graph:run' do
+    it 'runs source graph loading inline' do
+      allow(TariffKnowledge::SourceGraphLoader).to receive(:call)
+
+      suppress_output { Rake::Task['tariff_knowledge:source_graph:run'].invoke }
+
+      expect(TariffKnowledge::SourceGraphLoader).to have_received(:call)
+    end
+  end
+
+  describe 'tariff_knowledge:declarable_nodes:enqueue' do
+    it 'enqueues declarable node loading' do
+      allow(CreateTariffKnowledgeDeclarableNodesWorker).to receive(:perform_async)
+
+      suppress_output { Rake::Task['tariff_knowledge:declarable_nodes:enqueue'].invoke }
+
+      expect(CreateTariffKnowledgeDeclarableNodesWorker).to have_received(:perform_async)
+    end
+  end
+
+  describe 'tariff_knowledge:declarable_nodes:run' do
+    it 'runs declarable node loading inline' do
+      allow(TariffKnowledge::DeclarableNodeLoader).to receive(:call)
+
+      suppress_output { Rake::Task['tariff_knowledge:declarable_nodes:run'].invoke }
+
+      expect(TariffKnowledge::DeclarableNodeLoader).to have_received(:call)
+    end
+  end
+
+  describe 'tariff_knowledge:compressed_notes:refresh:enqueue' do
+    it 'enqueues compressed note refresh' do
+      allow(RefreshTariffKnowledgeCompressedNotesWorker).to receive(:perform_async)
+
+      suppress_output { Rake::Task['tariff_knowledge:compressed_notes:refresh:enqueue'].invoke }
+
+      expect(RefreshTariffKnowledgeCompressedNotesWorker).to have_received(:perform_async)
+    end
+  end
+
+  describe 'tariff_knowledge:compressed_notes:refresh:run' do
+    it 'runs compressed note refresh inline' do
+      allow(TariffKnowledge::CompressedNoteRefresh)
+        .to receive(:call)
+        .and_return(TariffKnowledge::CompressedNoteRefresh::Result.new(goods_nomenclature_count: 2, expired_note_count: 1))
+
+      suppress_output { Rake::Task['tariff_knowledge:compressed_notes:refresh:run'].invoke }
+
+      expect(TariffKnowledge::CompressedNoteRefresh).to have_received(:call)
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/services/tariff_knowledge/source_graph_loader_spec.rb
+++ b/spec/services/tariff_knowledge/source_graph_loader_spec.rb
@@ -75,6 +75,51 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       expect(TariffKnowledge::Edge.count).to eq(edge_count)
     end
 
+    it 'loads approved chapter, section, and general rule source associations from the latest approved update' do
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers chapter note horses.',
+      )
+      create(
+        :customs_tariff_section_note,
+        :approved,
+        customs_tariff_update: update,
+        section_id: 1,
+        content: 'Heading 0101 covers section note horses.',
+      )
+      create(
+        :customs_tariff_general_rule,
+        :approved,
+        customs_tariff_update: update,
+        rule_label: '1',
+        content: 'Heading 0101 covers general rule horses.',
+      )
+      create(
+        :customs_tariff_chapter_note,
+        customs_tariff_update: update,
+        chapter_id: '02',
+        content: 'Heading 0201 is pending.',
+      )
+
+      described_class.call
+
+      expect(TariffKnowledge::Node.where(node_type: TariffKnowledge::Node::NOTE_SOURCE).select_order_map(:key))
+        .to contain_exactly(
+          'note_source:customs_tariff_chapter_note:1.31:01',
+          'note_source:customs_tariff_general_rule:1.31:1',
+          'note_source:customs_tariff_section_note:1.31:1',
+        )
+      expect(TariffKnowledge::Node.by_key('note_source:customs_tariff_chapter_note:1.31:01').first.title)
+        .to eq('Chapter 01 notes')
+      expect(TariffKnowledge::Node.by_key('note_source:customs_tariff_section_note:1.31:1').first.title)
+        .to eq('Section 1 notes')
+      expect(TariffKnowledge::Node.by_key('note_source:customs_tariff_general_rule:1.31:1').first.title)
+        .to eq('GIR 1')
+    end
+
     it 'only loads notes from the latest approved update that is actual in TimeMachine' do
       older_update = create(
         :customs_tariff_update,
@@ -117,6 +162,58 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
         .to contain_exactly(update.version)
       expect(TariffKnowledge::Node.by_key('note_source:customs_tariff_chapter_note:1.31:01').first.content)
         .to eq(current_note.content)
+    end
+
+    it 'honours an existing TimeMachine date when choosing the latest approved update and its source associations' do
+      old_update = create(
+        :customs_tariff_update,
+        :approved,
+        version: '1.29',
+        validity_start_date: Date.new(2020, 1, 1),
+        validity_end_date: Date.new(2020, 12, 31),
+      )
+      current_update = create(
+        :customs_tariff_update,
+        :approved,
+        version: '1.31',
+        validity_start_date: Date.new(2021, 1, 1),
+      )
+      old_note = create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: old_update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers historical horses.',
+      )
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: current_update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers current horses.',
+      )
+
+      TimeMachine.at(Date.new(2020, 6, 1)) { described_class.call }
+
+      expect(TariffKnowledge::Node.where(node_type: TariffKnowledge::Node::NOTE_SOURCE).select_map(:source_version))
+        .to contain_exactly(old_update.version)
+      expect(TariffKnowledge::Node.by_key('note_source:customs_tariff_chapter_note:1.29:01').first.content)
+        .to eq(old_note.content)
+    end
+
+    it 'sets TimeMachine.now when called outside an existing TimeMachine context' do
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers current horses.',
+      )
+
+      TimeMachine.no_time_machine { described_class.call }
+
+      expect(TariffKnowledge::Node.by_key('note_source:customs_tariff_chapter_note:1.31:01').first)
+        .to be_present
     end
 
     it 'keeps positive references when another clause in the fragment is negated' do


### PR DESCRIPTION
### Jira link

[AI-868](https://transformuk.atlassian.net/browse/AI-868)

### What?

- [x] Add `tariff_knowledge:populate` to enqueue the full tariff knowledge graph population pipeline.
- [x] Add per-stage rake tasks for source graph loading, declarable node loading, and compressed note refresh.
- [x] Add staging-only Sidekiq schedules for the tariff knowledge async workers.
- [x] Cover the rake tasks and Sidekiq schedule configuration with specs.

### Why?

The compressed notes pipeline needs an operator-friendly way to populate each stage and a scheduled path for keeping staging data refreshed while the feature is evaluated.

### Environment note

Compressed notes are intended to be consumed only in staging. Staging is the only environment where this capability will be enabled; production and other environments should leave the consuming feature disabled.

### Risk

**Risk level:** 🟢

**Reason for rating:** This is staging-only, technical-operator functionality for generating, reviewing, refreshing, exposing, or consuming compressed notes. Production and other environments should leave the consuming feature disabled, so this does not change live trader journeys or production search behaviour.
